### PR TITLE
Feature release/cdap 16855 spark impl aggregator1

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/ReducibleAggregatorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/ReducibleAggregatorTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.dataset.table.Table;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.etl.api.Engine;
+import io.cdap.cdap.etl.mock.batch.MockSink;
+import io.cdap.cdap.etl.mock.batch.MockSource;
+import io.cdap.cdap.etl.mock.batch.aggregator.DistinctReducibleAggregator;
+import io.cdap.cdap.etl.mock.batch.aggregator.FieldCountReducibleAggregator;
+import io.cdap.cdap.etl.mock.test.HydratorTestBase;
+import io.cdap.cdap.etl.proto.v2.ETLBatchConfig;
+import io.cdap.cdap.etl.proto.v2.ETLStage;
+import io.cdap.cdap.etl.spark.Compat;
+import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.artifact.AppRequest;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.test.ApplicationManager;
+import io.cdap.cdap.test.DataSetManager;
+import io.cdap.cdap.test.TestConfiguration;
+import io.cdap.cdap.test.WorkflowManager;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Tests for BatchReducibleAggregator plugins.
+ */
+public class ReducibleAggregatorTest extends HydratorTestBase {
+  private static final ArtifactId APP_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("app", "1.0.0");
+  private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
+
+  private static int startCount = 0;
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false,
+                                                                       Constants.Security.Store.PROVIDER, "file",
+                                                                       Constants.AppFabric.SPARK_COMPAT,
+                                                                       Compat.SPARK_COMPAT);
+
+  @BeforeClass
+  public static void setupTest() throws Exception {
+    if (startCount++ > 0) {
+      return;
+    }
+    setupBatchArtifacts(APP_ARTIFACT_ID, DataPipelineApp.class);
+  }
+
+
+  @Test
+  public void testSimpleAggregator() throws Exception {
+    Schema inputSchema = Schema.recordOf(
+      "input",
+      Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("used_name", Schema.of(Schema.Type.STRING)));
+    String userInput = "inputSource";
+    String output = "outputSink";
+    ETLBatchConfig config = ETLBatchConfig.builder()
+      .addStage(new ETLStage("users", MockSource.getPlugin(userInput, inputSchema)))
+      .addStage(new ETLStage("aggregator", DistinctReducibleAggregator.getPlugin("id,name")))
+      .addStage(new ETLStage("sink", MockSink.getPlugin(output)))
+      .addConnection("users", "aggregator")
+      .addConnection("aggregator", "sink")
+      .setEngine(Engine.SPARK)
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, config);
+    ApplicationId appId = NamespaceId.DEFAULT.app(UUID.randomUUID().toString());
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    List<StructuredRecord> userData = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      StructuredRecord record1 = StructuredRecord.builder(inputSchema)
+        .set("id", 1).set("name", "test").set("used_name", "test" + i).build();
+      StructuredRecord record2 = StructuredRecord.builder(inputSchema)
+        .set("id", 2).set("name", "test2").set("used_name", "test2" + i).build();
+      userData.add(record1);
+      userData.add(record2);
+    }
+
+    // write input data
+    DataSetManager<Table> inputManager = getDataset(userInput);
+    MockSource.writeInput(inputManager, userData);
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+
+    DataSetManager<Table> outputManager = getDataset(output);
+    List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
+
+    Schema expectedSchema = Schema.recordOf(
+      "record",
+      Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    Set<StructuredRecord> expected = ImmutableSet.of(
+      StructuredRecord.builder(expectedSchema).set("id", 1).set("name", "test").build(),
+      StructuredRecord.builder(expectedSchema).set("id", 2).set("name", "test2").build()
+    );
+    Assert.assertEquals(expected, new HashSet<>(outputRecords));
+  }
+
+  @Test
+  public void testFieldCountAgg() throws Exception {
+    Engine engine = Engine.SPARK;
+    String source1Name = "pAggInput1-" + engine.name();
+    String source2Name = "pAggInput2-" + engine.name();
+    String sink1Name = "pAggOutput1-" + engine.name();
+    String sink2Name = "pAggOutput2-" + engine.name();
+    Schema inputSchema = Schema.recordOf(
+      "testRecord",
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("item", Schema.of(Schema.Type.LONG))
+    );
+    /*
+       source1 --|--> agg1 --> sink1
+                 |
+       source2 --|--> agg2 --> sink2
+     */
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
+      .setEngine(engine)
+      .addStage(new ETLStage("source1", MockSource.getPlugin(source1Name, inputSchema)))
+      .addStage(new ETLStage("source2", MockSource.getPlugin(source2Name, inputSchema)))
+      .addStage(new ETLStage("sink1", MockSink.getPlugin(sink1Name)))
+      .addStage(new ETLStage("sink2", MockSink.getPlugin(sink2Name)))
+      .addStage(new ETLStage("agg1", FieldCountReducibleAggregator.getPlugin("user", "string")))
+      .addStage(new ETLStage("agg2", FieldCountReducibleAggregator.getPlugin("item", "long")))
+      .addConnection("source1", "agg1")
+      .addConnection("source1", "agg2")
+      .addConnection("source2", "agg1")
+      .addConnection("source2", "agg2")
+      .addConnection("agg1", "sink1")
+      .addConnection("agg2", "sink2")
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("ParallelAggApp-" + engine);
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    // write few records to each source
+    DataSetManager<Table> inputManager = getDataset(NamespaceId.DEFAULT.dataset(source1Name));
+    MockSource.writeInput(inputManager, ImmutableList.of(
+      StructuredRecord.builder(inputSchema).set("user", "samuel").set("item", 1L).build(),
+      StructuredRecord.builder(inputSchema).set("user", "samuel").set("item", 2L).build()));
+
+    inputManager = getDataset(NamespaceId.DEFAULT.dataset(source2Name));
+    MockSource.writeInput(inputManager, ImmutableList.of(
+      StructuredRecord.builder(inputSchema).set("user", "samuel").set("item", 3L).build(),
+      StructuredRecord.builder(inputSchema).set("user", "john").set("item", 4L).build(),
+      StructuredRecord.builder(inputSchema).set("user", "john").set("item", 3L).build()));
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start();
+    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+
+    Schema outputSchema1 = Schema.recordOf(
+      "user.count",
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("ct", Schema.of(Schema.Type.LONG))
+    );
+    Schema outputSchema2 = Schema.recordOf(
+      "item.count",
+      Schema.Field.of("item", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("ct", Schema.of(Schema.Type.LONG))
+    );
+
+    // check output
+    DataSetManager<Table> sinkManager = getDataset(sink1Name);
+    Set<StructuredRecord> expected = ImmutableSet.of(
+      StructuredRecord.builder(outputSchema1).set("user", "all").set("ct", 5L).build(),
+      StructuredRecord.builder(outputSchema1).set("user", "samuel").set("ct", 3L).build(),
+      StructuredRecord.builder(outputSchema1).set("user", "john").set("ct", 2L).build());
+    Set<StructuredRecord> actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
+    Assert.assertEquals(expected, actual);
+
+    sinkManager = getDataset(sink2Name);
+    expected = ImmutableSet.of(
+      StructuredRecord.builder(outputSchema2).set("item", 0L).set("ct", 5L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 1L).set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 2L).set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 3L).set("ct", 2L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 4L).set("ct", 1L).build());
+    actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
+    Assert.assertEquals(expected, actual);
+
+    validateMetric(2, appId, "source1.records.out");
+    validateMetric(3, appId, "source2.records.out");
+    validateMetric(5, appId, "agg1.records.in");
+    // 2 users, but FieldCountReduceAggregator always emits an 'all' group
+    validateMetric(3, appId, "agg1.aggregator.groups");
+    validateMetric(3, appId, "agg1.records.out");
+    validateMetric(5, appId, "agg2.records.in");
+    // 4 items, but FieldCountReduceAggregator always emits an 'all' group
+    validateMetric(5, appId, "agg2.aggregator.groups");
+    validateMetric(5, appId, "agg2.records.out");
+    validateMetric(3, appId, "sink1.records.in");
+    validateMetric(5, appId, "sink2.records.in");
+  }
+
+  private void validateMetric(long expected, ApplicationId appId,
+                              String metric) throws TimeoutException, InterruptedException {
+    Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, appId.getNamespace(),
+                                               Constants.Metrics.Tag.APP, appId.getEntityName(),
+                                               Constants.Metrics.Tag.WORKFLOW, SmartWorkflow.NAME);
+    getMetricsManager().waitForTotalMetricCount(tags, "user." + metric, expected, 20, TimeUnit.SECONDS);
+    // wait for won't throw an exception if the metric count is greater than expected
+    Assert.assertEquals(expected, getMetricsManager().getTotalMetric(tags, "user." + metric));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/ReducibleAggregator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/ReducibleAggregator.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api;
+
+import io.cdap.cdap.api.annotation.Beta;
+
+/**
+ * Groups all input objects into collections and performs an aggregation on the entire group.
+ * Objects that have the same group key are placed into the same group for aggregation.
+ * When possible, this interface should be used over the {@link Aggregator} interface because this performs better.
+ * An {@link Aggregator} will shuffle all data across the cluster before aggregating, whereas
+ * this will aggregate both before and after the shuffle.
+ * This reduces the amount of data that needs to be sent over the network, as well as reducing the amount
+ * of memory required to perform the aggregation.
+ *
+ * For example, to aggregate and compute the average for the values, the plugin will first group all the values based
+ * on the group key, considering it generates following splits:
+ * Split 1: (key1, 1), (key1, 2), (key1, 3), (key2, 4)
+ * Split 2: (key1, 2), (key1, 3), (key1, 4), (key2, 4)
+ * Split 3: (key1, 3), (key1, 4), (key1, 5), (key2, 4)
+ *
+ * First, the initializeValue method will be called in each split to generate an agg value with following info:
+ * (sum: value, count: num)
+ *
+ * The mergeValues function will be called in each split to generate following:
+ * Split 1: (key1, sum: 6, count: 3), (key2, sum: 4, count: 1)
+ * Split 2: (key1, sum: 9, count: 3), (key2, sum: 4, count: 1)
+ * Split 3: (key1, sum: 12, count: 3), (key2, sum: 4, count: 1)
+ *
+ * Data is then shuffled across the cluster such that records with the same key are handled by the same executor:
+ * Split 4: (key1, sum: 6, count: 3), (key1, sum:9, count:3), (key1, sum:12, count:3)
+ * Split 5: (key2, sum:4, count:1), (key2, sum:4, count:1), (key2, sum:4, count:1)
+ *
+ * The mergePartitions function is called to generate:
+ * Split 4: (key1, sum:27, count:9)
+ * Split 5: (key2, sum:12, count:3)
+ *
+ * Finally, the finalize method is called to generate the final output value(s):
+ * Split 4: (key1, avg: 3)
+ * Split 5: (key2, avg: 4)
+ *
+ * @param <GROUP_KEY> Type of group key
+ * @param <GROUP_VALUE> Type of values to group
+ * @param <AGG_VALUE> Type of agg values to group
+ * @param <OUT> Type of output object
+ */
+@Beta
+public interface ReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT> {
+
+  /**
+   * Emit the group key(s) for a given input value. If no group key is emitted, the input value
+   * is filtered out. If multiple group keys are emitted, the input value will be present in multiple groups.
+   *
+   * @param groupValue the value to group
+   * @param emitter the emitter to emit zero or more group keys for the input
+   * @throws Exception if there is some error getting the group
+   */
+  void groupBy(GROUP_VALUE groupValue, Emitter<GROUP_KEY> emitter) throws Exception;
+
+  /**
+   * Initialize the aggregated value based on the given value. This method is called before mergeValues.
+   * For example, to compute the average, the aggregated value will be (sum: value of the group value, count: 1)
+   *
+   * @param val the value to group
+   * @return the aggregated value
+   */
+  AGG_VALUE initializeAggregateValue(GROUP_VALUE val) throws Exception;
+
+  /**
+   * Merge the given values to a single value. This method is called before grouping of the keys.
+   * For example, to compute the sum, the returned value will be the sum of two given values.
+   * To compute average, the returned value will contain the sum and count for the two given values.
+   *
+   * @param aggValue the aggregated value which contains the current aggregated information
+   * @param value the value to merge
+   * @return the aggregated value of two given values
+   */
+  AGG_VALUE mergeValues(AGG_VALUE aggValue, GROUP_VALUE value) throws Exception;
+
+  /**
+   * Merge the given aggregated values from each split to a final aggregated value. This method is called after
+   * grouping of the keys.
+   *
+   * @param value1 the aggregated value to merge
+   * @param value2 the aggregated value to merge
+   * @return the aggregated value of two given values
+   */
+  AGG_VALUE mergePartitions(AGG_VALUE value1, AGG_VALUE value2) throws Exception;
+
+  /**
+   * Finalize the grouped object for the group key into zero or more output objects.
+   * The group value will only contain one value which contains the aggregated stats for
+   * all the values, this method can use this stat to compute the desired result, i.e, average, standard deviation
+   *
+   * @param groupKey the key for the group
+   * @param groupValue the group value associated with the group key
+   * @param emitter the emitter to emit finalized values for the group
+   * @throws Exception if there is some error aggregating
+   */
+  void finalize(GROUP_KEY groupKey, AGG_VALUE groupValue, Emitter<OUT> emitter) throws Exception;
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/batch/BatchReducibleAggregator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/batch/BatchReducibleAggregator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.batch;
+
+import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.PipelineConfigurable;
+import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.ReducibleAggregator;
+import io.cdap.cdap.etl.api.StageLifecycle;
+import io.cdap.cdap.etl.api.validation.ValidationException;
+
+/**
+ * A {@link ReducibleAggregator} used in batch programs.
+ * As it is used in batch programs, a BatchReducibleAggregator must be parameterized
+ * with supported group key and value classes. Group keys and values can be a
+ * byte[], Boolean, Integer, Long, Float, Double, String, or StructuredRecord.
+ * If the group key is not one of those types and is being used in mapreduce,
+ * it must implement Hadoop's org.apache.hadoop.io.WritableComparable interface.
+ * If the group value is not one of those types and is being used in mapreduce,
+ * it must implement Hadoop's org.apache.hadoop.io.Writable interface.
+ * If the aggregator is being used in spark, both the group key and value must implement the
+ * {@link java.io.Serializable} interface.
+ *
+ * @param <GROUP_KEY> group key type. Must be a supported type
+ * @param <GROUP_VALUE> group value type. Must be a supported type
+ * @param <AGG_VALUE> agg value type
+ * @param <OUT> output object type
+ */
+@Beta
+public abstract class BatchReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT>
+  extends BatchConfigurable<BatchAggregatorContext>
+  implements ReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT>,
+  PipelineConfigurable, StageLifecycle<BatchRuntimeContext> {
+
+  public static final String PLUGIN_TYPE = BatchAggregator.PLUGIN_TYPE;
+
+  /**
+   * Configure the pipeline. This is run once when the pipeline is being published.
+   * This is where you perform any static logic, like creating required datasets, performing schema validation,
+   * setting output schema, and things of that nature.
+   *
+   * @param pipelineConfigurer the configurer used to add required datasets and streams
+   * @throws ValidationException if the given config is invalid
+   */
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    // no-op
+  }
+
+  /**
+   * Prepare a pipeline run. This is run every time before a pipeline runs in order to help set up the run.
+   * This is where you would set things like the number of partitions to use when grouping, and setting the
+   * group key and value classes if they are not known at compile time.
+   *
+   * @param context batch execution context
+   * @throws Exception
+   */
+  @Override
+  public void prepareRun(BatchAggregatorContext context) throws Exception {
+    // no-op
+  }
+
+  /**
+   * Initialize the Batch Reduce Aggregator. Executed inside the Batch Run. This method is guaranteed to be invoked
+   * before any calls to {@link #groupBy(Object, Emitter)} and {@link #finalize(Object, Object, Emitter)} are made.
+   *
+   * @param context {@link BatchRuntimeContext}
+   * @throws Exception if there is any error during initialization
+   */
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    // no-op
+  }
+
+  /**
+   * Destroy the Batch Aggregator. Executed at the end of the Batch Run.
+   */
+  @Override
+  public void destroy() {
+    // no-op
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/MapReducePreparer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/MapReducePreparer.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.etl.api.batch.BatchAggregator;
 import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchConfigurable;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
 import io.cdap.cdap.etl.batch.BatchPhaseSpec;
@@ -165,6 +166,33 @@ public class MapReducePreparer extends PipelinePhasePreparer {
 
   @Override
   protected SubmitterPlugin createAggregator(BatchAggregator<?, ?, ?> aggregator, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<DefaultAggregatorContext> contextProvider =
+      new AggregatorContextProvider(pipelineRuntime, stageSpec, context.getAdmin());
+    return new SubmitterPlugin<>(stageName, context, aggregator, contextProvider, aggregatorContext -> {
+      if (aggregatorContext.getNumPartitions() != null) {
+        job.setNumReduceTasks(aggregatorContext.getNumPartitions());
+      }
+      Class<?> outputKeyClass = aggregatorContext.getGroupKeyClass();
+      Class<?> outputValClass = aggregatorContext.getGroupValueClass();
+
+      if (outputKeyClass == null) {
+        outputKeyClass = TypeChecker.getGroupKeyClass(aggregator);
+      }
+      if (outputValClass == null) {
+        outputValClass = TypeChecker.getGroupValueClass(aggregator);
+      }
+      hConf.set(ETLMapReduce.MAP_KEY_CLASS, outputKeyClass.getName());
+      hConf.set(ETLMapReduce.MAP_VAL_CLASS, outputValClass.getName());
+      job.setMapOutputKeyClass(getOutputKeyClass(stageName, outputKeyClass));
+      job.setMapOutputValueClass(getOutputValClass(stageName, outputValClass));
+      stageOperations.put(stageName, aggregatorContext.getFieldOperations());
+    });
+  }
+
+  @Override
+  protected SubmitterPlugin createReducibleAggregator(BatchReducibleAggregator<?, ?, ?, ?> aggregator,
+                                                      StageSpec stageSpec) {
     String stageName = stageSpec.getName();
     ContextProvider<DefaultAggregatorContext> contextProvider =
       new AggregatorContextProvider(pipelineRuntime, stageSpec, context.getAdmin());

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/TypeChecker.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/TypeChecker.java
@@ -20,6 +20,7 @@ import com.google.common.reflect.TypeToken;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.etl.api.Aggregator;
 import io.cdap.cdap.etl.api.Joiner;
+import io.cdap.cdap.etl.api.ReducibleAggregator;
 
 /**
  * Helper for checking parameter types.
@@ -31,10 +32,18 @@ public class TypeChecker {
 
   public static Class<?> getGroupKeyClass(Aggregator aggregator) {
     return getParameterClass(aggregator, Aggregator.class, 0);
-}
+  }
 
   public static Class<?> getGroupValueClass(Aggregator aggregator) {
     return getParameterClass(aggregator, Aggregator.class, 1);
+  }
+
+  public static Class<?> getGroupKeyClass(ReducibleAggregator aggregator) {
+    return getParameterClass(aggregator, ReducibleAggregator.class, 0);
+  }
+
+  public static Class<?> getGroupValueClass(ReducibleAggregator aggregator) {
+    return getParameterClass(aggregator, ReducibleAggregator.class, 1);
   }
 
   public static Class<?> getJoinKeyClass(Joiner joiner) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/PipelinePluginContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/PipelinePluginContext.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.action.Action;
 import io.cdap.cdap.etl.api.batch.BatchAggregator;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.PostAction;
@@ -94,6 +95,8 @@ public class PipelinePluginContext implements PluginContext {
       return new WrappedErrorTransform<>((ErrorTransform) plugin, caller, operationTimer);
     } else if (plugin instanceof Transform) {
       return new WrappedTransform<>((Transform) plugin, caller, operationTimer);
+    } else if (plugin instanceof BatchReducibleAggregator) {
+      return new WrappedReduceAggregator<>((BatchReducibleAggregator) plugin, caller, operationTimer);
     } else if (plugin instanceof BatchAggregator) {
       return new WrappedBatchAggregator<>((BatchAggregator) plugin, caller, operationTimer);
     } else if (plugin instanceof BatchJoiner) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedReduceAggregator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedReduceAggregator.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common.plugin;
+
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.batch.BatchAggregatorContext;
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
+import io.cdap.cdap.etl.api.batch.BatchRuntimeContext;
+import io.cdap.cdap.etl.common.TypeChecker;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Wrapper around {@link BatchReducibleAggregator} that makes sure logging, classloading, and other pipeline
+ * capabilities are setup correctly.
+ *
+ * @param <GROUP_KEY> group key type. Must be a supported type
+ * @param <GROUP_VALUE> group value type. Must be a supported type
+ * @param <AGG_VALUE> agg value type
+ * @param <OUT> output object type
+ */
+public class WrappedReduceAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT>
+  extends BatchReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT> {
+  private final BatchReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT> aggregator;
+  private final Caller caller;
+  private final OperationTimer operationTimer;
+
+  public WrappedReduceAggregator(BatchReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT> aggregator,
+                                 Caller caller, OperationTimer operationTimer) {
+    this.aggregator = aggregator;
+    this.caller = caller;
+    this.operationTimer = operationTimer;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    caller.callUnchecked((Callable<Void>) () -> {
+      aggregator.configurePipeline(pipelineConfigurer);
+      return null;
+    });
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    caller.call((Callable<Void>) () -> {
+      aggregator.initialize(context);
+      return null;
+    });
+  }
+
+  @Override
+  public void destroy() {
+    caller.callUnchecked((Callable<Void>) () -> {
+      aggregator.destroy();
+      return null;
+    });
+  }
+
+  @Override
+  public void prepareRun(BatchAggregatorContext context) throws Exception {
+    context.setGroupKeyClass(TypeChecker.getGroupKeyClass(aggregator));
+    context.setGroupValueClass(TypeChecker.getGroupValueClass(aggregator));
+    caller.call((Callable<Void>) () -> {
+      aggregator.prepareRun(context);
+      return null;
+    });
+  }
+
+  @Override
+  public void onRunFinish(boolean succeeded, BatchAggregatorContext context) {
+    caller.callUnchecked((Callable<Void>) () -> {
+      aggregator.onRunFinish(succeeded, context);
+      return null;
+    });
+  }
+
+  @Override
+  public void groupBy(GROUP_VALUE groupValue, Emitter<GROUP_KEY> emitter) throws Exception {
+    operationTimer.start();
+    try {
+      caller.call((Callable<Void>) () -> {
+        aggregator.groupBy(groupValue, new UntimedEmitter<>(emitter, operationTimer));
+        return null;
+      });
+    } finally {
+      operationTimer.reset();
+    }
+  }
+
+  @Override
+  public AGG_VALUE initializeAggregateValue(GROUP_VALUE val) throws Exception {
+    operationTimer.start();
+    try {
+      return caller.call(() -> aggregator.initializeAggregateValue(val));
+    } finally {
+      operationTimer.reset();
+    }
+  }
+
+  @Override
+  public AGG_VALUE mergeValues(AGG_VALUE aggValue, GROUP_VALUE value) throws Exception {
+    operationTimer.start();
+    try {
+      return caller.call(() -> aggregator.mergeValues(aggValue, value));
+    } finally {
+      operationTimer.reset();
+    }
+  }
+
+  @Override
+  public AGG_VALUE mergePartitions(AGG_VALUE value1, AGG_VALUE value2) throws Exception {
+    operationTimer.start();
+    try {
+      return caller.call(() -> aggregator.mergePartitions(value1, value2));
+    } finally {
+      operationTimer.reset();
+    }
+  }
+
+  @Override
+  public void finalize(GROUP_KEY groupKey, AGG_VALUE groupValue, Emitter<OUT> emitter) throws Exception {
+    operationTimer.start();
+    try {
+      caller.call((Callable<Void>) () -> {
+        aggregator.finalize(groupKey, groupValue, new UntimedEmitter<>(emitter, operationTimer));
+        return null;
+      });
+    } finally {
+      operationTimer.reset();
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/AbstractSparkPreparer.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/AbstractSparkPreparer.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.etl.api.batch.BatchAggregator;
 import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchConfigurable;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkPluginContext;
@@ -138,6 +139,16 @@ public abstract class AbstractSparkPreparer extends PipelinePhasePreparer {
 
   @Override
   protected SubmitterPlugin createAggregator(BatchAggregator<?, ?, ?> aggregator, StageSpec stageSpec) {
+    String stageName = stageSpec.getName();
+    ContextProvider<DefaultAggregatorContext> contextProvider =
+      new AggregatorContextProvider(pipelineRuntime, stageSpec, admin);
+    return new SubmitterPlugin<>(stageName, transactional, aggregator, contextProvider,
+                                 ctx -> stageOperations.put(stageName, ctx.getFieldOperations()));
+  }
+
+  @Override
+  protected SubmitterPlugin createReducibleAggregator(BatchReducibleAggregator<?, ?, ?, ?> aggregator,
+                                                      StageSpec stageSpec) {
     String stageName = stageSpec.getName();
     ContextProvider<DefaultAggregatorContext> contextProvider =
       new AggregatorContextProvider(pipelineRuntime, stageSpec, admin);

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
@@ -58,6 +58,9 @@ public interface SparkCollection<T> {
   SparkCollection<RecordInfo<Object>> aggregate(StageSpec stageSpec, @Nullable Integer partitions,
                                                 StageStatisticsCollector collector);
 
+  SparkCollection<RecordInfo<Object>> reduceAggregate(StageSpec stageSpec, @Nullable Integer partitions,
+                                                      StageStatisticsCollector collector);
+
   <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function);
 
   <U> SparkCollection<U> compute(StageSpec stageSpec, SparkCompute<T, U> compute) throws Exception;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -32,6 +32,7 @@ import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.batch.BatchAggregator;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoinerRuntimeContext;
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
@@ -252,10 +253,19 @@ public abstract class SparkPipelineRunner {
 
       } else if (BatchAggregator.PLUGIN_TYPE.equals(pluginType)) {
 
+        Object plugin = pluginContext.newPluginInstance(stageName, macroEvaluator);
         Integer partitions = stagePartitions.get(stageName);
-        SparkCollection<RecordInfo<Object>> combinedData = stageData.aggregate(stageSpec, partitions, collector);
-        emittedBuilder = addEmitted(emittedBuilder, pipelinePhase, stageSpec,
-                                    combinedData, hasErrorOutput, hasAlertOutput);
+
+        if (plugin instanceof BatchReducibleAggregator) {
+          SparkCollection<RecordInfo<Object>> combinedData = stageData.reduceAggregate(stageSpec, partitions,
+                                                                                       collector);
+          emittedBuilder = addEmitted(emittedBuilder, pipelinePhase, stageSpec,
+                                      combinedData, hasErrorOutput, hasAlertOutput);
+        } else {
+          SparkCollection<RecordInfo<Object>> combinedData = stageData.aggregate(stageSpec, partitions, collector);
+          emittedBuilder = addEmitted(emittedBuilder, pipelinePhase, stageSpec,
+                                      combinedData, hasErrorOutput, hasAlertOutput);
+        }
 
       } else if (BatchJoiner.PLUGIN_TYPE.equals(pluginType)) {
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorFinalizeFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorFinalizeFunction.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.Transformation;
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
+import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.common.RecordInfo;
+import io.cdap.cdap.etl.common.TrackedTransform;
+import io.cdap.cdap.etl.spark.CombinedEmitter;
+import scala.Tuple2;
+
+/**
+ * Function that uses a BatchReducibleAggregator to perform the finalize part of the aggregator.
+ * Non-serializable fields are lazily created since this is used in a Spark closure.
+ *
+ * @param <GROUP_KEY> type of group key
+ * @param <GROUP_VAL> type of group value
+ * @param <AGG_VAL> type of agg value
+ * @param <OUT> type of aggregate output
+ */
+public class AggregatorFinalizeFunction<GROUP_KEY, GROUP_VAL, AGG_VAL, OUT>
+  implements FlatMapFunc<Tuple2<GROUP_KEY, AGG_VAL>, RecordInfo<Object>> {
+  private final PluginFunctionContext pluginFunctionContext;
+  private transient TrackedTransform<Tuple2<GROUP_KEY, AGG_VAL>, OUT> aggregateTransform;
+  private transient CombinedEmitter<OUT> emitter;
+
+  public AggregatorFinalizeFunction(PluginFunctionContext pluginFunctionContext) {
+    this.pluginFunctionContext = pluginFunctionContext;
+  }
+
+  @Override
+  public Iterable<RecordInfo<Object>> call(Tuple2<GROUP_KEY, AGG_VAL> input) throws Exception {
+    if (aggregateTransform == null) {
+      BatchReducibleAggregator<GROUP_KEY, GROUP_VAL, AGG_VAL, OUT> aggregator = pluginFunctionContext.createPlugin();
+      aggregator.initialize(pluginFunctionContext.createBatchRuntimeContext());
+      aggregateTransform = new TrackedTransform<>(new AggregateTransform<>(aggregator),
+                                                  pluginFunctionContext.createStageMetrics(),
+                                                  Constants.Metrics.AGG_GROUPS,
+                                                  Constants.Metrics.RECORDS_OUT, pluginFunctionContext.getDataTracer(),
+                                                  pluginFunctionContext.getStageStatisticsCollector());
+      emitter = new CombinedEmitter<>(pluginFunctionContext.getStageName());
+    }
+    emitter.reset();
+    aggregateTransform.transform(input, emitter);
+    return emitter.getEmitted();
+  }
+
+  private static class AggregateTransform<GROUP_KEY, GROUP_VAL, AGG_VAL, OUT_VAL>
+    implements Transformation<Tuple2<GROUP_KEY, AGG_VAL>, OUT_VAL> {
+    private final BatchReducibleAggregator<GROUP_KEY, GROUP_VAL, AGG_VAL, OUT_VAL> aggregator;
+
+    AggregateTransform(BatchReducibleAggregator<GROUP_KEY, GROUP_VAL, AGG_VAL, OUT_VAL> aggregator) {
+      this.aggregator = aggregator;
+    }
+
+    @Override
+    public void transform(Tuple2<GROUP_KEY, AGG_VAL> input, Emitter<OUT_VAL> emitter) throws Exception {
+      aggregator.finalize(input._1(), input._2, emitter);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorInitializeFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorInitializeFunction.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
+import org.apache.spark.api.java.function.Function;
+
+/**
+ * Function that uses a BatchReducibleAggregator to initialize the aggregated value.
+ * Non-serializable fields are lazily created since this is used in a Spark closure.
+ *
+ * @param <GROUP_VALUE> type of group value
+ * @param <AGG_VALUE> type of the agg value
+ */
+public class AggregatorInitializeFunction<GROUP_VALUE, AGG_VALUE> implements Function<GROUP_VALUE, AGG_VALUE> {
+
+  private final PluginFunctionContext pluginFunctionContext;
+  private transient BatchReducibleAggregator<?, GROUP_VALUE, AGG_VALUE, ?> aggregator;
+
+  public AggregatorInitializeFunction(PluginFunctionContext pluginFunctionContext) {
+    this.pluginFunctionContext = pluginFunctionContext;
+  }
+
+  @Override
+  public AGG_VALUE call(GROUP_VALUE value) throws Exception {
+    if (aggregator == null) {
+      aggregator = pluginFunctionContext.createPlugin();
+      aggregator.initialize(pluginFunctionContext.createBatchRuntimeContext());
+    }
+    return aggregator.initializeAggregateValue(value);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorMergePartitionFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorMergePartitionFunction.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
+import org.apache.spark.api.java.function.Function2;
+
+/**
+ * Function that uses a BatchReducibleAggregator to initialize the aggregated value.
+ * Non-serializable fields are lazily created since this is used in a Spark closure.
+ *
+ * @param <AGG_VALUE> type of the agg value
+ */
+public class AggregatorMergePartitionFunction<AGG_VALUE> implements Function2<AGG_VALUE, AGG_VALUE, AGG_VALUE> {
+
+  private final PluginFunctionContext pluginFunctionContext;
+  private transient BatchReducibleAggregator<?, ?, AGG_VALUE, ?> aggregator;
+
+  public AggregatorMergePartitionFunction(PluginFunctionContext pluginFunctionContext) {
+    this.pluginFunctionContext = pluginFunctionContext;
+  }
+
+  @Override
+  public AGG_VALUE call(AGG_VALUE value1, AGG_VALUE value2) throws Exception {
+    if (aggregator == null) {
+      aggregator = pluginFunctionContext.createPlugin();
+      aggregator.initialize(pluginFunctionContext.createBatchRuntimeContext());
+    }
+    return aggregator.mergePartitions(value1, value2);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorMergeValueFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorMergeValueFunction.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
+import org.apache.spark.api.java.function.Function2;
+
+/**
+ * Function that uses a BatchReducibleAggregator to perform the reduce part of the aggregator.
+ * Non-serializable fields are lazily created since this is used in a Spark closure.
+ *
+ * @param <GROUP_VALUE> type of group value
+ * @param <AGG_VALUE> type of the agg value
+ */
+public class AggregatorMergeValueFunction<AGG_VALUE, GROUP_VALUE>
+  implements Function2<AGG_VALUE, GROUP_VALUE, AGG_VALUE> {
+  private final PluginFunctionContext pluginFunctionContext;
+  private transient BatchReducibleAggregator<?, GROUP_VALUE, AGG_VALUE, ?> aggregator;
+
+  public AggregatorMergeValueFunction(PluginFunctionContext pluginFunctionContext) {
+    this.pluginFunctionContext = pluginFunctionContext;
+  }
+
+  @Override
+  public AGG_VALUE call(AGG_VALUE aggValue, GROUP_VALUE groupValue) throws Exception {
+    if (aggregator == null) {
+      aggregator = pluginFunctionContext.createPlugin();
+      aggregator.initialize(pluginFunctionContext.createBatchRuntimeContext());
+    }
+    return aggregator.mergeValues(aggValue, groupValue);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorReduceGroupByFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorReduceGroupByFunction.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.Transformation;
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
+import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.common.DefaultEmitter;
+import io.cdap.cdap.etl.common.NoErrorEmitter;
+import io.cdap.cdap.etl.common.TrackedTransform;
+import scala.Tuple2;
+
+/**
+ * Function that uses a BatchReduceAggregator to perform the groupBy part of the aggregator.
+ * Non-serializable fields are lazily created since this is used in a Spark closure.
+ *
+ * @param <GROUP_KEY> type of group key
+ * @param <GROUP_VAL> type of group val
+ */
+public class AggregatorReduceGroupByFunction<GROUP_KEY, GROUP_VAL>
+  implements PairFlatMapFunc<GROUP_VAL, GROUP_KEY, GROUP_VAL> {
+  private final PluginFunctionContext pluginFunctionContext;
+  private transient TrackedTransform<GROUP_VAL, Tuple2<GROUP_KEY, GROUP_VAL>> groupByFunction;
+  private transient DefaultEmitter<Tuple2<GROUP_KEY, GROUP_VAL>> emitter;
+
+  public AggregatorReduceGroupByFunction(PluginFunctionContext pluginFunctionContext) {
+    this.pluginFunctionContext = pluginFunctionContext;
+  }
+
+  @Override
+  public Iterable<Tuple2<GROUP_KEY, GROUP_VAL>> call(GROUP_VAL input) throws Exception {
+    if (groupByFunction == null) {
+      BatchReducibleAggregator<GROUP_KEY, GROUP_VAL, ?, ?> aggregator = pluginFunctionContext.createPlugin();
+      aggregator.initialize(pluginFunctionContext.createBatchRuntimeContext());
+      groupByFunction = new TrackedTransform<>(new GroupByTransform<>(aggregator),
+                                               pluginFunctionContext.createStageMetrics(),
+                                               Constants.Metrics.RECORDS_IN,
+                                               null, pluginFunctionContext.getDataTracer(),
+                                               pluginFunctionContext.getStageStatisticsCollector());
+      emitter = new DefaultEmitter<>();
+    }
+    emitter.reset();
+    groupByFunction.transform(input, emitter);
+    return emitter.getEntries();
+  }
+
+  private static class GroupByTransform<GROUP_KEY, GROUP_VAL>
+    implements Transformation<GROUP_VAL, Tuple2<GROUP_KEY, GROUP_VAL>> {
+    private final BatchReducibleAggregator<GROUP_KEY, GROUP_VAL, ?, ?> aggregator;
+    private final NoErrorEmitter<GROUP_KEY> keyEmitter;
+
+    GroupByTransform(BatchReducibleAggregator<GROUP_KEY, GROUP_VAL, ?, ?> aggregator) {
+      this.aggregator = aggregator;
+      this.keyEmitter =
+        new NoErrorEmitter<>("Errors and Alerts cannot be emitted from the groupBy method of an aggregator");
+    }
+
+    @Override
+    public void transform(final GROUP_VAL inputValue, Emitter<Tuple2<GROUP_KEY, GROUP_VAL>> emitter) throws Exception {
+      keyEmitter.reset();
+      aggregator.groupBy(inputValue, keyEmitter);
+      for (GROUP_KEY key : keyEmitter.getEntries()) {
+        emitter.emit(new Tuple2<>(key, inputValue));
+      }
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
@@ -132,6 +132,14 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   }
 
   @Override
+  public SparkCollection<RecordInfo<Object>> reduceAggregate(StageSpec stageSpec, @Nullable Integer partitions,
+                                                             StageStatisticsCollector collector) {
+    // TODO: implement
+    throw new UnsupportedOperationException("reduce aggregator not supported");
+  }
+
+
+  @Override
   public <U> SparkCollection<U> compute(final StageSpec stageSpec, SparkCompute<T, U> compute) throws Exception {
     final SparkCompute<T, U> wrappedCompute =
       new DynamicSparkCompute<>(new DynamicDriverContext(stageSpec, sec, new NoopStageStatisticsCollector()), compute);

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/aggregator/FieldCountReducibleAggregator.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/aggregator/FieldCountReducibleAggregator.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.mock.batch.aggregator;
+
+import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.api.plugin.PluginConfig;
+import io.cdap.cdap.api.plugin.PluginPropertyField;
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.StageConfigurer;
+import io.cdap.cdap.etl.api.batch.BatchAggregatorContext;
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
+import io.cdap.cdap.etl.api.batch.BatchRuntimeContext;
+import io.cdap.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Groups on a specific field and adds count field. Used to test that the right values are going to the
+ * right groups, to test multiple group keys for the same value, and to test setting the group key class
+ * at runtime, and to test setting a supported non-writable class.
+ */
+@Plugin(type = BatchReducibleAggregator.PLUGIN_TYPE)
+@Name(FieldCountReducibleAggregator.NAME)
+public class FieldCountReducibleAggregator
+  extends BatchReducibleAggregator<Object, StructuredRecord, StructuredRecord, StructuredRecord> {
+  public static final String NAME = "FieldCount Aggregator";
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private static final Schema REDUCE_SCHEMA =
+    Schema.recordOf("record", Schema.Field.of("fc", Schema.of(Schema.Type.LONG)));
+  private final Config config;
+  private Schema schema;
+
+  public FieldCountReducibleAggregator(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    StageConfigurer stageConfigurer = pipelineConfigurer.getStageConfigurer();
+    if (!config.containsMacro("fieldType") && !config.containsMacro("fieldName")) {
+      stageConfigurer.setOutputSchema(config.getSchema());
+    }
+  }
+
+  @Override
+  public void prepareRun(BatchAggregatorContext context) throws Exception {
+    if ("long".equalsIgnoreCase(config.fieldType)) {
+      context.setGroupKeyClass(Long.class);
+    } else {
+      context.setGroupKeyClass(String.class);
+    }
+  }
+
+  @Override
+  public void groupBy(StructuredRecord input, Emitter<Object> emitter) throws Exception {
+    if ("long".equalsIgnoreCase(config.fieldType)) {
+      emitter.emit(input.get(config.fieldName));
+      emitter.emit(0L);
+    } else {
+      emitter.emit(input.get(config.fieldName).toString());
+      emitter.emit("all");
+    }
+  }
+
+  @Override
+  public StructuredRecord initializeAggregateValue(StructuredRecord val) throws Exception {
+    return StructuredRecord.builder(REDUCE_SCHEMA).set("fc", 1L).build();
+  }
+
+  @Override
+  public StructuredRecord mergeValues(StructuredRecord aggValue, StructuredRecord groupValue) throws Exception {
+    return combine(aggValue, groupValue);
+  }
+
+  @Override
+  public StructuredRecord mergePartitions(StructuredRecord value1, StructuredRecord value2) throws Exception {
+    return combine(value1, value2);
+  }
+
+  @Override
+  public void finalize(Object groupKey, StructuredRecord groupValue,
+                       Emitter<StructuredRecord> emitter) throws Exception {
+    emitter.emit(StructuredRecord.builder(schema)
+                   .set(config.fieldName, groupKey)
+                   .set("ct", groupValue.get("fc") == null ? 1L : groupValue.get("fc"))
+                   .build());
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    schema = config.getSchema();
+    // should never happen, just done to test App correctness in unit tests
+    if (context.getOutputSchema() != null && !schema.equals(context.getOutputSchema())) {
+      throw new IllegalStateException("Output schema does not match what was set at configure time.");
+    }
+  }
+
+  private StructuredRecord combine(StructuredRecord value1, StructuredRecord value2) {
+    Long v1Ct = value1.get("fc");
+    Long v2Ct = value2.get("fc");
+    long count = (v1Ct == null ? 1L : v1Ct) + (v2Ct == null ? 1L : v2Ct);
+    return StructuredRecord.builder(REDUCE_SCHEMA).set("fc", count).build();
+  }
+
+  /**
+   * Conf for the aggregator.
+   */
+  public static class Config extends PluginConfig {
+    @Macro
+    private final String fieldName;
+
+    @Macro
+    private final String fieldType;
+
+    public Config() {
+      this.fieldName = "field";
+      this.fieldType = "string";
+    }
+
+    private Schema getSchema() {
+      Schema.Field fieldSchema;
+      if ("string".equalsIgnoreCase(fieldType)) {
+        fieldSchema = Schema.Field.of(fieldName, Schema.of(Schema.Type.STRING));
+      } else if ("long".equalsIgnoreCase(fieldType)) {
+        fieldSchema = Schema.Field.of(fieldName, Schema.of(Schema.Type.LONG));
+      } else {
+        throw new IllegalArgumentException("Unsupported field type " + fieldType);
+      }
+
+      return Schema.recordOf(
+        fieldName + ".count",
+        fieldSchema,
+        Schema.Field.of("ct", Schema.of(Schema.Type.LONG)));
+    }
+  }
+
+  public static ETLPlugin getPlugin(String fieldName, String fieldType) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("fieldName", fieldName);
+    properties.put("fieldType", fieldType);
+    return new ETLPlugin(NAME, BatchReducibleAggregator.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("fieldName", new PluginPropertyField("fieldName", "", "string", true, true));
+    properties.put("fieldType", new PluginPropertyField("fieldType", "", "string", true, true));
+    return new PluginClass(BatchReducibleAggregator.PLUGIN_TYPE, NAME, "",
+                           FieldCountReducibleAggregator.class.getName(), "config", properties);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -45,7 +45,9 @@ import io.cdap.cdap.etl.mock.batch.MockRuntimeDatasetSource;
 import io.cdap.cdap.etl.mock.batch.MockSink;
 import io.cdap.cdap.etl.mock.batch.MockSource;
 import io.cdap.cdap.etl.mock.batch.NodeStatesAction;
+import io.cdap.cdap.etl.mock.batch.aggregator.DistinctReducibleAggregator;
 import io.cdap.cdap.etl.mock.batch.aggregator.FieldCountAggregator;
+import io.cdap.cdap.etl.mock.batch.aggregator.FieldCountReducibleAggregator;
 import io.cdap.cdap.etl.mock.batch.aggregator.GroupFilterAggregator;
 import io.cdap.cdap.etl.mock.batch.aggregator.IdentityAggregator;
 import io.cdap.cdap.etl.mock.batch.joiner.DupeFlagger;
@@ -90,7 +92,8 @@ public class HydratorTestBase extends TestBase {
     MockAction.PLUGIN_CLASS, FileMoveAction.PLUGIN_CLASS, FieldLineageAction.PLUGIN_CLASS,
     StringValueFilterCompute.PLUGIN_CLASS, FlattenErrorTransform.PLUGIN_CLASS, FilterErrorTransform.PLUGIN_CLASS,
     NullFieldSplitterTransform.PLUGIN_CLASS, TMSAlertPublisher.PLUGIN_CLASS, NullAlertTransform.PLUGIN_CLASS,
-    MockCondition.PLUGIN_CLASS, MockSource.PLUGIN_CLASS, MockSink.PLUGIN_CLASS
+    MockCondition.PLUGIN_CLASS, MockSource.PLUGIN_CLASS, MockSink.PLUGIN_CLASS,
+    DistinctReducibleAggregator.PLUGIN_CLASS, FieldCountReducibleAggregator.PLUGIN_CLASS
   );
   private static final Set<PluginClass> STREAMING_MOCK_PLUGINS = ImmutableSet.of(
     io.cdap.cdap.etl.mock.spark.streaming.MockSource.PLUGIN_CLASS,


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16855
build: https://builds.cask.co/browse/CDAP-RUT1786-1

Reopen #12204  with conflicts resolved
Implemented reducer as aggregator improvement for batch spark pipelines. This changes the use of groupByKey to reduceByKey which will do a map side reduce before do the aggregation. A reduce function will need to be provided to achieve this