### PR TITLE
CDAP-16709 implement manual broadcasts

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinDefinition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinDefinition.java
@@ -132,6 +132,10 @@ public class JoinDefinition {
         throw new InvalidJoinException("At least two stages must be specified.");
       }
 
+      if (stages.stream().allMatch(JoinStage::isBroadcast)) {
+        throw new InvalidJoinException("Cannot broadcast all stages.");
+      }
+
       // validate the join condition
       if (condition == null) {
         throw new InvalidJoinException("A join condition must be specified.");

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinStage.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinStage.java
@@ -97,8 +97,11 @@ public class JoinStage {
     }
 
     /**
-     * Set whether the stage data should be broadcast during the join. In order to be broadcast, the stage data must
+     * Hint that the stage data should be broadcast during the join. In order to be broadcast, the stage data must
      * be below 8gb and fit entirely in memory. You cannot broadcast both sides of a join.
+     * This is just a hint and will not always be honored.
+     * MapReduce pipelines will currently ignore this flag. Spark pipelines will hint to Spark to broadcast, but Spark
+     * may still decide to do a normal join depending on the type of join being performed and the datasets involved.
      */
     public Builder setBroadcast(boolean broadcast) {
       this.broadcast = broadcast;

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/join/JoinDefinitionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/join/JoinDefinitionTest.java
@@ -284,6 +284,34 @@ public class JoinDefinitionTest {
     }
   }
 
+  @Test
+  public void testAllBroadcastThrowsException() {
+    JoinStage purchases = JoinStage.builder("purchases", PURCHASE_SCHEMA).setBroadcast(true).build();
+    JoinStage users = JoinStage.builder("users", USER_SCHEMA).setBroadcast(true).build();
+
+    try {
+      JoinDefinition.builder()
+        .select(new JoinField("purchases", "id", "purchase_id"),
+                new JoinField("users", "id", "user_id"),
+                new JoinField("purchases", "ts"),
+                new JoinField("purchases", "price"),
+                new JoinField("purchases", "coupon"),
+                new JoinField("users", "name"),
+                new JoinField("users", "email"),
+                new JoinField("users", "age"),
+                new JoinField("users", "bday"))
+        .from(purchases, users)
+        .on(JoinCondition.onKeys()
+              .addKey(new JoinKey("purchases", Collections.singletonList("user_id")))
+              .addKey(new JoinKey("users", Collections.singletonList("id")))
+              .build())
+        .build();
+      Assert.fail("Invalid join condition did not fail as expected");
+    } catch (InvalidJoinException e) {
+      // expected
+    }
+  }
+
   private void testUserPurchaseSchema(JoinStage purchases, JoinStage users, Schema expected) {
     JoinDefinition definition = JoinDefinition.builder()
       .select(new JoinField("purchases", "id", "purchase_id"),

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
@@ -95,6 +95,9 @@ public class ETLSpark extends AbstractSpark {
 
     SparkConf sparkConf = new SparkConf();
     sparkConf.set("spark.speculation", "false");
+    // turn off auto-broadcast by default until we better understand the implications and can set this to a
+    // value that we are confident is safe.
+    sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1");
     context.setSparkConf(sparkConf);
 
     Map<String, String> properties = context.getSpecification().getProperties();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -31,6 +31,7 @@ import org.apache.spark.sql.Column;
 import org.apache.spark.sql.DataFrame;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.functions;
 import org.apache.spark.sql.types.StructType;
 import scala.collection.JavaConversions;
 import scala.collection.Seq;
@@ -111,6 +112,9 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
       }
       seenRequired = seenRequired || toJoin.isRequired();
 
+      if (toJoin.isBroadcast()) {
+        right = functions.broadcast(right);
+      }
       joined = joined.join(right, joinOn, joinType);
 
       /*

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -32,6 +32,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.catalyst.encoders.RowEncoder;
+import org.apache.spark.sql.functions;
 import org.apache.spark.sql.types.StructType;
 import scala.collection.JavaConversions;
 import scala.collection.Seq;
@@ -112,7 +113,10 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
         joinType = "outer";
       }
       seenRequired = seenRequired || toJoin.isRequired();
-      
+
+      if (toJoin.isBroadcast()) {
+        right = functions.broadcast(right);
+      }
       joined = joined.join(right, joinOn, joinType);
 
       /*


### PR DESCRIPTION
Honor the broadcast flag set in the JoinDefinition when joining
multiple DataFrames. Added a small tweak to the join logic to
join all non-broadcasted datasets first in order to ensure that
both sides of the join are not broadcast, and to reduce the amount
of data that is being shuffled in non-broadcast intermediate joins.