### PR TITLE
[CDAP-16863] Show the live JSON view (plugin JSON Creator)

### DIFF
--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/BasicPluginInfo/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/BasicPluginInfo/index.tsx
@@ -17,6 +17,7 @@
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import Heading, { HeadingTypes } from 'components/Heading';
 import { PluginTypes } from 'components/PluginJSONCreator/constants';
+import JsonMenu from 'components/PluginJSONCreator/Create/Content/JsonMenu';
 import PluginInput from 'components/PluginJSONCreator/Create/Content/PluginInput';
 import StepButtons from 'components/PluginJSONCreator/Create/Content/StepButtons';
 import {
@@ -44,6 +45,12 @@ const BasicPluginInfoView: React.FC<ICreateContext & WithStyles<typeof styles>> 
   emitAlerts,
   emitErrors,
   setBasicPluginInfo,
+  configurationGroups,
+  groupToInfo,
+  groupToWidgets,
+  widgetInfo,
+  jsonView,
+  setJsonView,
 }) => {
   const [localPluginName, setLocalPluginName] = React.useState(pluginName);
   const [localPluginType, setLocalPluginType] = React.useState(pluginType);
@@ -66,6 +73,19 @@ const BasicPluginInfoView: React.FC<ICreateContext & WithStyles<typeof styles>> 
 
   return (
     <div>
+      <JsonMenu
+        pluginName={localPluginName}
+        pluginType={localPluginType}
+        displayName={localDisplayName}
+        emitAlerts={localEmitAlerts}
+        emitErrors={localEmitErrors}
+        configurationGroups={configurationGroups}
+        groupToInfo={groupToInfo}
+        groupToWidgets={groupToWidgets}
+        widgetInfo={widgetInfo}
+        jsonView={jsonView}
+        setJsonView={setJsonView}
+      />
       <Heading type={HeadingTypes.h3} label="Basic Plugin Information" />
       <div className={classes.basicPluginInput}>
         <PluginInput

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/GroupActionButtons/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/GroupActionButtons/index.tsx
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import { IconButton } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import AddIcon from '@material-ui/icons/Add';
 import DeleteIcon from '@material-ui/icons/Delete';

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/index.tsx
@@ -25,6 +25,7 @@ import Heading, { HeadingTypes } from 'components/Heading';
 import If from 'components/If';
 import GroupActionButtons from 'components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/GroupActionButtons';
 import GroupInfoInput from 'components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/GroupInfoInput';
+import JsonMenu from 'components/PluginJSONCreator/Create/Content/JsonMenu';
 import StepButtons from 'components/PluginJSONCreator/Create/Content/StepButtons';
 import WidgetCollection from 'components/PluginJSONCreator/Create/Content/WidgetCollection';
 import {
@@ -52,14 +53,21 @@ const styles = (): StyleRules => {
 
 const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
   classes,
+  pluginName,
+  pluginType,
+  displayName,
+  emitAlerts,
+  emitErrors,
   configurationGroups,
   setConfigurationGroups,
   groupToInfo,
   setGroupToInfo,
   groupToWidgets,
   setGroupToWidgets,
-  widgetToInfo,
-  setWidgetToInfo,
+  widgetInfo,
+  setWidgetInfo,
+  jsonView,
+  setJsonView,
 }) => {
   const [activeGroupIndex, setActiveGroupIndex] = React.useState(null);
   const [localConfigurationGroups, setLocalConfigurationGroups] = React.useState(
@@ -67,7 +75,7 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
   );
   const [localGroupToInfo, setLocalGroupToInfo] = React.useState(groupToInfo);
   const [localGroupToWidgets, setLocalGroupToWidgets] = React.useState(groupToWidgets);
-  const [localWidgetToInfo, setLocalWidgetToInfo] = React.useState(widgetToInfo);
+  const [localWidgetInfo, setLocalWidgetInfo] = React.useState(widgetInfo);
 
   function addConfigurationGroup(index: number) {
     return () => {
@@ -118,11 +126,11 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
       setLocalGroupToWidgets(restGroupToWidgets);
 
       // Delete all the widget information that belong to the group
-      const newWidgetToInfo = localWidgetToInfo;
+      const newWidgetInfo = localWidgetInfo;
       widgets.forEach((widget) => {
-        delete newWidgetToInfo[widget];
+        delete newWidgetInfo[widget];
       });
-      setLocalWidgetToInfo(newWidgetToInfo);
+      setLocalWidgetInfo(newWidgetInfo);
     };
   }
 
@@ -138,11 +146,24 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
     setConfigurationGroups(localConfigurationGroups);
     setGroupToInfo(localGroupToInfo);
     setGroupToWidgets(localGroupToWidgets);
-    setWidgetToInfo(localWidgetToInfo);
+    setWidgetInfo(localWidgetInfo);
   }
 
   return (
     <div>
+      <JsonMenu
+        pluginName={pluginName}
+        pluginType={pluginType}
+        displayName={displayName}
+        emitAlerts={emitAlerts}
+        emitErrors={emitErrors}
+        configurationGroups={localConfigurationGroups}
+        groupToInfo={localGroupToInfo}
+        groupToWidgets={localGroupToWidgets}
+        widgetInfo={localWidgetInfo}
+        jsonView={jsonView}
+        setJsonView={setJsonView}
+      />
       <Heading type={HeadingTypes.h3} label="Configuration Groups" />
       <br />
       <If condition={localConfigurationGroups.length === 0}>
@@ -171,7 +192,6 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
               </ExpansionPanelSummary>
               <ExpansionPanelActions className={classes.groupContent}>
                 <GroupInfoInput
-                  classes={classes}
                   groupID={groupID}
                   groupToInfo={localGroupToInfo}
                   setGroupToInfo={setLocalGroupToInfo}
@@ -180,8 +200,8 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
                   groupID={groupID}
                   groupToWidgets={localGroupToWidgets}
                   setGroupToWidgets={setLocalGroupToWidgets}
-                  widgetToInfo={localWidgetToInfo}
-                  setWidgetToInfo={setLocalWidgetToInfo}
+                  widgetInfo={localWidgetInfo}
+                  setWidgetInfo={setLocalWidgetInfo}
                 />
               </ExpansionPanelActions>
             </ExpansionPanel>

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/ClosedJsonMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/ClosedJsonMenu/index.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Divider from '@material-ui/core/Divider';
+import Drawer from '@material-ui/core/Drawer';
+import IconButton from '@material-ui/core/IconButton';
+import List from '@material-ui/core/List';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import Tooltip from '@material-ui/core/Tooltip';
+import CodeIcon from '@material-ui/icons/Code';
+import GetAppIcon from '@material-ui/icons/GetApp';
+import { downloadPluginJSON } from 'components/PluginJSONCreator/Create/Content/JsonMenu/utilities';
+import { ICreateContext } from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+
+const styles = (theme): StyleRules => {
+  return {
+    closedJsonMenu: {
+      zIndex: theme.zIndex.drawer,
+    },
+    closedJsonMenuPaper: {
+      backgroundColor: theme.palette.white[50],
+    },
+    toolbar: {
+      minHeight: '48px',
+    },
+    mainMenu: {
+      borderTop: `1px solid ${theme.palette.grey['500']}`,
+      paddingTop: theme.Spacing(1),
+      paddingBottom: theme.Spacing(1),
+    },
+    jsonCollapseActionButtons: {
+      padding: '15px',
+      flexDirection: 'column',
+    },
+    jsonViewerTooltip: {
+      fontSize: '14px',
+      backgroundColor: theme.palette.grey[500],
+    },
+  };
+};
+
+const ClosedJsonMenuView: React.FC<ICreateContext & WithStyles<typeof styles>> = (
+  widgetJSONData
+) => {
+  const { classes, pluginName, pluginType, jsonView, setJsonView } = widgetJSONData;
+  const downloadDisabled = pluginName.length === 0 || pluginType.length === 0;
+  return (
+    <div>
+      <Drawer
+        open={!jsonView}
+        variant="persistent"
+        className={classes.closedJsonMenu}
+        anchor="right"
+        ModalProps={{
+          keepMounted: true,
+        }}
+        classes={{
+          paper: classes.closedJsonMenuPaper,
+        }}
+        data-cy="navbar-jsonViewer"
+      >
+        <div className={classes.toolbar} />
+        <List component="nav" dense={true} className={classes.mainMenu}>
+          <div className={classes.jsonCollapseActionButtons}>
+            <Tooltip
+              title="Open JSON View"
+              classes={{
+                tooltip: classes.jsonViewerTooltip,
+              }}
+            >
+              <IconButton onClick={() => setJsonView(true)}>
+                <CodeIcon />
+              </IconButton>
+            </Tooltip>
+            <Divider />
+
+            <Tooltip
+              title={
+                downloadDisabled
+                  ? 'Download is disabled until the required fields are filled'
+                  : 'Download Plugin JSON'
+              }
+              classes={{
+                tooltip: classes.jsonViewerTooltip,
+              }}
+            >
+              <span>
+                <IconButton
+                  disabled={downloadDisabled}
+                  onClick={() => downloadPluginJSON(widgetJSONData)}
+                >
+                  <GetAppIcon />
+                </IconButton>
+              </span>
+            </Tooltip>
+          </div>
+        </List>
+      </Drawer>
+    </div>
+  );
+};
+
+const ClosedJsonMenu = withStyles(styles)(ClosedJsonMenuView);
+export default ClosedJsonMenu;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/JsonLiveViewer/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/JsonLiveViewer/index.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Button from '@material-ui/core/Button';
+import Drawer from '@material-ui/core/Drawer';
+import List from '@material-ui/core/List';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import Tooltip from '@material-ui/core/Tooltip';
+import FullscreenExitIcon from '@material-ui/icons/FullscreenExit';
+import SaveAltIcon from '@material-ui/icons/SaveAlt';
+import {
+  downloadPluginJSON,
+  getJSONConfig,
+} from 'components/PluginJSONCreator/Create/Content/JsonMenu/utilities';
+import { ICreateContext } from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+
+const JSON_VIEWER_WIDTH = '600px';
+
+const styles = (theme): StyleRules => {
+  return {
+    jsonViewer: {
+      zIndex: theme.zIndex.drawer,
+      width: JSON_VIEWER_WIDTH,
+    },
+    jsonViewerPaper: {
+      width: JSON_VIEWER_WIDTH,
+      backgroundColor: theme.palette.white[50],
+    },
+    toolbar: {
+      minHeight: '48px',
+    },
+    mainMenu: {
+      borderTop: `1px solid ${theme.palette.grey['500']}`,
+      paddingTop: theme.Spacing(1),
+      paddingBottom: theme.Spacing(1),
+    },
+    jsonActionButtons: {
+      padding: '5px',
+      display: 'flex',
+    },
+    closeJSONViewerButon: {
+      marginLeft: 'auto',
+    },
+    jsonViewerTooltip: {
+      fontSize: '14px',
+      backgroundColor: theme.palette.grey[500],
+    },
+    jsonLiveCode: {
+      padding: '14px',
+    },
+  };
+};
+
+const JsonLiveViewerView: React.FC<ICreateContext & WithStyles<typeof styles>> = (
+  widgetJSONData
+) => {
+  const { classes, pluginName, pluginType, jsonView, setJsonView } = widgetJSONData;
+  const JSONConfig = getJSONConfig(widgetJSONData);
+  const downloadDisabled = pluginName.length === 0 || pluginType.length === 0;
+  return (
+    <div>
+      <Drawer
+        open={jsonView}
+        variant="persistent"
+        className={classes.jsonViewer}
+        anchor="right"
+        ModalProps={{
+          keepMounted: true,
+        }}
+        classes={{
+          paper: classes.jsonViewerPaper,
+        }}
+        data-cy="navbar-drawer"
+      >
+        <div className={classes.toolbar} />
+        <List component="nav" dense={true} className={classes.mainMenu}>
+          <div className={classes.jsonActionButtons}>
+            <Tooltip
+              classes={{
+                tooltip: classes.jsonViewerTooltip,
+              }}
+              title={
+                downloadDisabled
+                  ? 'Download is disabled until the required fields are filled in'
+                  : 'Download Plugin JSON'
+              }
+            >
+              <span>
+                <Button
+                  disabled={downloadDisabled}
+                  onClick={() => downloadPluginJSON(widgetJSONData)}
+                >
+                  <SaveAltIcon />
+                </Button>
+              </span>
+            </Tooltip>
+            <Tooltip
+              classes={{
+                tooltip: classes.jsonViewerTooltip,
+              }}
+              title="Close JSON View"
+            >
+              <Button className={classes.closeJSONViewerButon} onClick={() => setJsonView(false)}>
+                <FullscreenExitIcon />
+              </Button>
+            </Tooltip>
+          </div>
+          <div className={classes.jsonLiveCode}>
+            <pre>{JSON.stringify(JSONConfig, undefined, 2)}</pre>
+          </div>
+        </List>
+      </Drawer>
+    </div>
+  );
+};
+
+const JsonLiveViewer = withStyles(styles)(JsonLiveViewerView);
+export default JsonLiveViewer;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/index.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import If from 'components/If';
+import ClosedJsonMenu from 'components/PluginJSONCreator/Create/Content/JsonMenu/ClosedJsonMenu';
+import JsonLiveViewer from 'components/PluginJSONCreator/Create/Content/JsonMenu/JsonLiveViewer';
+import {
+  CreateContext,
+  createContextConnect,
+  ICreateContext,
+} from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+
+const JsonMenuView: React.FC<ICreateContext> = ({
+  pluginName,
+  pluginType,
+  displayName,
+  emitAlerts,
+  emitErrors,
+  configurationGroups,
+  groupToInfo,
+  groupToWidgets,
+  widgetInfo,
+  jsonView,
+  setJsonView,
+}) => {
+  return (
+    <div>
+      <If condition={jsonView}>
+        <JsonLiveViewer
+          pluginName={pluginName}
+          pluginType={pluginType}
+          displayName={displayName}
+          emitAlerts={emitAlerts}
+          emitErrors={emitErrors}
+          configurationGroups={configurationGroups}
+          groupToInfo={groupToInfo}
+          groupToWidgets={groupToWidgets}
+          widgetInfo={widgetInfo}
+          jsonView={jsonView}
+          setJsonView={setJsonView}
+        />
+      </If>
+      <If condition={!jsonView}>
+        <ClosedJsonMenu
+          pluginName={pluginName}
+          pluginType={pluginType}
+          displayName={displayName}
+          emitAlerts={emitAlerts}
+          emitErrors={emitErrors}
+          configurationGroups={configurationGroups}
+          groupToInfo={groupToInfo}
+          groupToWidgets={groupToWidgets}
+          widgetInfo={widgetInfo}
+          jsonView={jsonView}
+          setJsonView={setJsonView}
+        />
+      </If>
+    </div>
+  );
+};
+
+const JsonMenu = createContextConnect(CreateContext, JsonMenuView);
+export default JsonMenu;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/utilities.ts
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/utilities.ts
@@ -1,0 +1,53 @@
+import { SPEC_VERSION } from 'components/PluginJSONCreator/constants';
+import { IWidgetInfo } from 'components/PluginJSONCreator/CreateContextConnect';
+import fileDownload from 'js-file-download';
+
+function getJSONConfig(widgetJSONData) {
+  const {
+    displayName,
+    emitAlerts,
+    emitErrors,
+    configurationGroups,
+    groupToInfo,
+    groupToWidgets,
+    widgetInfo,
+  } = widgetJSONData;
+
+  const configurationGroupsData = configurationGroups.map((groupID: string) => {
+    const groupLabel = groupToInfo[groupID].label;
+    const widgetData = groupToWidgets[groupID].map((widgetID: string) => {
+      const info: IWidgetInfo = widgetInfo[widgetID];
+
+      return {
+        'widget-type': info.widgetType,
+        label: info.label,
+        name: info.name,
+        ...(info.widgetCategory && { 'widget-category': info.widgetCategory }),
+      };
+    });
+    return {
+      label: groupLabel,
+      properties: widgetData,
+    };
+  });
+
+  const config = {
+    metadata: {
+      'spec-version': SPEC_VERSION,
+    },
+    ...(displayName && { 'display-name': displayName }),
+    ...(emitAlerts && { 'emit-alerts': emitAlerts }),
+    ...(emitErrors && { 'emit-errors': emitErrors }),
+    'configuration-groups': configurationGroupsData,
+  };
+
+  return config;
+}
+
+function downloadPluginJSON(widgetJSONData) {
+  const JSONConfig = getJSONConfig(widgetJSONData);
+  const { pluginName, pluginType } = widgetJSONData;
+  fileDownload(JSON.stringify(JSONConfig, undefined, 4), `${pluginName}-${pluginType}.json`);
+}
+
+export { getJSONConfig, downloadPluginJSON };

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetActionButtons/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetActionButtons/index.tsx
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import { IconButton } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import AddIcon from '@material-ui/icons/Add';
 import DeleteIcon from '@material-ui/icons/Delete';

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetInput/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetInput/index.tsx
@@ -24,6 +24,7 @@ import * as React from 'react';
 const styles = (): StyleRules => {
   return {
     widgetInput: {
+      width: '100%',
       marginTop: '20px',
       marginBottom: '20px',
     },
@@ -42,43 +43,53 @@ interface IWidgetInputProps extends WithStyles<typeof styles>, ICreateContext {
 const WidgetInputView: React.FC<IWidgetInputProps> = ({
   classes,
   widgetID,
-  widgetToInfo,
-  setWidgetToInfo,
+  widgetInfo,
+  setWidgetInfo,
 }) => {
-  function onNameChange(obj, id) {
+  function onNameChange() {
     return (name) => {
-      setWidgetToInfo((prevObjs) => ({ ...prevObjs, [id]: { ...obj, name } }));
+      setWidgetInfo((prevObjs) => ({
+        ...prevObjs,
+        [widgetID]: { ...prevObjs[widgetID], name },
+      }));
     };
   }
 
-  function onLabelChange(obj, id) {
+  function onLabelChange() {
     return (label) => {
-      setWidgetToInfo((prevObjs) => ({ ...prevObjs, [id]: { ...obj, label } }));
+      setWidgetInfo((prevObjs) => ({
+        ...prevObjs,
+        [widgetID]: { ...prevObjs[widgetID], label },
+      }));
     };
   }
 
-  function onWidgetTypeChange(obj, id) {
+  function onWidgetTypeChange() {
     return (widgetType) => {
-      setWidgetToInfo((prevObjs) => ({ ...prevObjs, [id]: { ...obj, widgetType } }));
+      setWidgetInfo((prevObjs) => ({
+        ...prevObjs,
+        [widgetID]: { ...prevObjs[widgetID], widgetType },
+      }));
     };
   }
 
-  function onWidgetCategoryChange(obj, id) {
+  function onWidgetCategoryChange() {
     return (widgetCategory) => {
-      setWidgetToInfo((prevObjs) => ({ ...prevObjs, [id]: { ...obj, widgetCategory } }));
+      setWidgetInfo((prevObjs) => ({
+        ...prevObjs,
+        [widgetID]: { ...prevObjs[widgetID], widgetCategory },
+      }));
     };
   }
-
-  const widgetInfo = widgetToInfo[widgetID];
 
   return (
-    <If condition={widgetInfo}>
+    <If condition={widgetInfo[widgetID]}>
       <div className={classes.widgetInput}>
         <div className={classes.widgetField}>
           <PluginInput
             widgetType={'textbox'}
-            value={widgetInfo.name}
-            onChange={onNameChange(widgetInfo, widgetID)}
+            value={widgetInfo[widgetID].name}
+            onChange={onNameChange()}
             label={'Name'}
             placeholder={'Name a Widget'}
             required={false}
@@ -87,8 +98,8 @@ const WidgetInputView: React.FC<IWidgetInputProps> = ({
         <div className={classes.widgetField}>
           <PluginInput
             widgetType={'textbox'}
-            value={widgetInfo.label}
-            onChange={onLabelChange(widgetInfo, widgetID)}
+            value={widgetInfo[widgetID].label}
+            onChange={onLabelChange()}
             label={'Label'}
             placeholder={'Label a Widget'}
             required={false}
@@ -97,8 +108,8 @@ const WidgetInputView: React.FC<IWidgetInputProps> = ({
         <div className={classes.widgetField}>
           <PluginInput
             widgetType={'select'}
-            value={widgetInfo.widgetCategory}
-            onChange={onWidgetCategoryChange(widgetInfo, widgetID)}
+            value={widgetInfo[widgetID].widgetCategory}
+            onChange={onWidgetCategoryChange()}
             label={'Category'}
             options={WIDGET_CATEGORY}
             required={false}
@@ -107,8 +118,8 @@ const WidgetInputView: React.FC<IWidgetInputProps> = ({
         <div className={classes.widgetField}>
           <PluginInput
             widgetType={'select'}
-            value={widgetInfo.widgetType}
-            onChange={onWidgetTypeChange(widgetInfo, widgetID)}
+            value={widgetInfo[widgetID].widgetType}
+            onChange={onWidgetTypeChange()}
             label={'Widget Type'}
             options={WIDGET_TYPES}
             required={true}

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/index.tsx
@@ -14,7 +14,8 @@
  * the License.
  */
 
-import { Button, Divider } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
+import Divider from '@material-ui/core/Divider';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import If from 'components/If';
 import WidgetActionButtons from 'components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetActionButtons';
@@ -72,12 +73,13 @@ interface IWidgetCollectionProps extends WithStyles<typeof styles>, ICreateConte
 const WidgetCollectionView: React.FC<IWidgetCollectionProps> = ({
   classes,
   groupID,
-  widgetToInfo,
+  widgetInfo,
   groupToWidgets,
-  setWidgetToInfo,
+  setWidgetInfo,
   setGroupToWidgets,
 }) => {
   const [activeWidgets, setActiveWidgets] = React.useState(groupID ? groupToWidgets[groupID] : []);
+  const [openWidgetIndex, setOpenWidgetIndex] = React.useState(null);
 
   React.useEffect(() => {
     if (groupID) {
@@ -104,8 +106,8 @@ const WidgetCollectionView: React.FC<IWidgetCollectionProps> = ({
       });
 
       // Set the default empty properties of the widget
-      setWidgetToInfo({
-        ...widgetToInfo,
+      setWidgetInfo({
+        ...widgetInfo,
         [newWidgetID]: {
           widgetType: '',
           label: '',
@@ -127,8 +129,8 @@ const WidgetCollectionView: React.FC<IWidgetCollectionProps> = ({
         [groupID]: newWidgets,
       });
 
-      const { [widgetToDelete]: info, ...restWidgetToInfo } = widgetToInfo;
-      setWidgetToInfo(restWidgetToInfo);
+      const { [widgetToDelete]: info, ...restWidgetInfo } = widgetInfo;
+      setWidgetInfo(restWidgetInfo);
     };
   }
 
@@ -141,12 +143,12 @@ const WidgetCollectionView: React.FC<IWidgetCollectionProps> = ({
       <div className={classes.widgetContainer}>
         {activeWidgets.map((widgetID, widgetIndex) => {
           return (
-            <If condition={widgetToInfo[widgetID]}>
+            <If condition={widgetInfo[widgetID]} key={widgetIndex}>
               <div className={classes.eachWidget}>
                 <WidgetInput
-                  widgetToInfo={widgetToInfo}
+                  widgetInfo={widgetInfo}
                   widgetID={widgetID}
-                  setWidgetToInfo={setWidgetToInfo}
+                  setWidgetInfo={setWidgetInfo}
                 />
                 <WidgetActionButtons
                   onAddWidgetToGroup={addWidgetToGroup(widgetIndex)}

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
@@ -71,8 +71,12 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     this.setState({ groupToWidgets });
   };
 
-  public setWidgetToInfo = (widgetToInfo: any) => {
-    this.setState({ widgetToInfo });
+  public setWidgetInfo = (widgetInfo: any) => {
+    this.setState({ widgetInfo });
+  };
+
+  public setJsonView = (jsonView: boolean) => {
+    this.setState({ jsonView });
   };
 
   public state = {
@@ -85,14 +89,16 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     configurationGroups: [],
     groupToInfo: {},
     groupToWidgets: {},
-    widgetToInfo: {},
+    widgetInfo: {},
+    jsonView: true,
 
     setActiveStep: this.setActiveStep,
     setBasicPluginInfo: this.setBasicPluginInfo,
     setConfigurationGroups: this.setConfigurationGroups,
     setGroupToInfo: this.setGroupToInfo,
     setGroupToWidgets: this.setGroupToWidgets,
-    setWidgetToInfo: this.setWidgetToInfo,
+    setWidgetInfo: this.setWidgetInfo,
+    setJsonView: this.setJsonView,
   };
 
   public render() {

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
@@ -28,14 +28,16 @@ interface ICreateState {
   configurationGroups: string[];
   groupToInfo: any;
   groupToWidgets: any;
-  widgetToInfo: any;
+  widgetInfo: any;
+  jsonView: boolean;
 
   setActiveStep: (step: number) => void;
   setBasicPluginInfo: (basicPluginInfo: IBasicPluginInfo) => void;
   setConfigurationGroups: (groups: string[]) => void;
   setGroupToInfo: (groupToInfo: any) => void;
   setGroupToWidgets: (groupToWidgets: any) => void;
-  setWidgetToInfo: (widgetToInfo: any) => void;
+  setWidgetInfo: (widgetInfo: any) => void;
+  setJsonView: (jsonView: boolean) => void;
 }
 
 export interface IBasicPluginInfo {

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/constants.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/constants.tsx
@@ -23,3 +23,5 @@ export const PluginTypes = Object.keys(GLOBALS.pluginTypeToLabel).filter(
 
 export const WIDGET_TYPES = Object.keys(WIDGET_FACTORY);
 export const WIDGET_CATEGORY = ['plugin'];
+
+export const SPEC_VERSION = '1.5';


### PR DESCRIPTION

JIRA: https://issues.cask.co/browse/CDAP-16863

Any changes that users make in the system will be reflected in the JSON view in real-time. This way, users will be able to see their current progress on creating the plugin JSON file.

- Show the JSON output in real-time
- Enable the toggle of the JSON viewer

**1st page (Basic Plugin Information)** 

<img width="1786" alt="Screen Shot 2020-05-27 at 5 02 16 PM" src="https://user-images.githubusercontent.com/14116152/83071894-d5e09000-a03b-11ea-9d99-939f6835168c.png">

**2nd page (Configuration Groups)**

<img width="926" alt="json-live" src="https://user-images.githubusercontent.com/14116152/83071010-61592180-a03a-11ea-8777-ef17d135af76.png">
