### PR TITLE
CDAP-16711 implement null safe keys as an option

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinCondition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinCondition.java
@@ -70,20 +70,20 @@ public class JoinCondition {
    */
   public static class OnKeys extends JoinCondition {
     private final Set<JoinKey> keys;
-    private final boolean dropNullKeys;
+    private final boolean nullSafe;
 
-    private OnKeys(Set<JoinKey> keys, boolean dropNullKeys) {
+    private OnKeys(Set<JoinKey> keys, boolean nullSafe) {
       super(Op.KEY_EQUALITY);
       this.keys = Collections.unmodifiableSet(new HashSet<>(keys));
-      this.dropNullKeys = dropNullKeys;
+      this.nullSafe = nullSafe;
     }
 
     public Set<JoinKey> getKeys() {
       return keys;
     }
 
-    public boolean isDropNullKeys() {
-      return dropNullKeys;
+    public boolean isNullSafe() {
+      return nullSafe;
     }
 
     @Override
@@ -170,11 +170,11 @@ public class JoinCondition {
      */
     public static class Builder {
       private final Set<JoinKey> keys;
-      private boolean dropNullKeys;
+      private boolean nullSafe;
 
       private Builder() {
         this.keys = new HashSet<>();
-        this.dropNullKeys = false;
+        this.nullSafe = true;
       }
 
       public Builder addKey(JoinKey key) {
@@ -188,8 +188,15 @@ public class JoinCondition {
         return this;
       }
 
-      public Builder setDropNullKeys(boolean dropNullKeys) {
-        this.dropNullKeys = dropNullKeys;
+      /**
+       * Whether to perform null safe equality on the join keys. Null safe means a null value equals another null value.
+       * For example, when joining on A.id = B.id, if there are rows in both A and B with null ids, they will be
+       * joined together. When not performing a null-safe join, rows with null ids would not get joined.
+       *
+       * Note that the behavior of traditional SQL systems is *not* to perform null safe joins. T
+       */
+      public Builder setNullSafe(boolean nullSafe) {
+        this.nullSafe = nullSafe;
         return this;
       }
 
@@ -219,7 +226,7 @@ public class JoinCondition {
           }
           throw new InvalidJoinConditionException(message.toString());
         }
-        return new OnKeys(keys, dropNullKeys);
+        return new OnKeys(keys, nullSafe);
       }
     }
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -397,7 +397,8 @@ public abstract class SparkPipelineRunner {
 
     // JoinRequest contains the left side of the join, plus 1 or more other stages to join to.
     JoinRequest joinRequest = new JoinRequest(left.getStageName(), stageKeys.get(left.getStageName()), leftSchema,
-                                              left.isRequired(), joinDefinition.getSelectedFields(),
+                                              left.isRequired(), onKeys.isNullSafe(),
+                                              joinDefinition.getSelectedFields(),
                                               joinDefinition.getOutputSchema(), toJoin);
     return leftCollection.join(joinRequest);
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/join/JoinRequest.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/join/JoinRequest.java
@@ -29,15 +29,17 @@ public class JoinRequest {
   private final List<String> leftKey;
   private final Schema leftSchema;
   private final boolean leftRequired;
+  private final boolean nullSafe;
   private final List<JoinField> fields;
   private final Schema outputSchema;
   private final List<JoinCollection> toJoin;
 
   public JoinRequest(String leftStage, List<String> leftKey, Schema leftSchema, boolean leftRequired,
-                     List<JoinField> fields, Schema outputSchema, List<JoinCollection> toJoin) {
+                     boolean nullSafe, List<JoinField> fields, Schema outputSchema, List<JoinCollection> toJoin) {
     this.leftStage = leftStage;
     this.leftKey = leftKey;
     this.leftRequired = leftRequired;
+    this.nullSafe = nullSafe;
     this.fields = fields;
     this.leftSchema = leftSchema;
     this.outputSchema = outputSchema;
@@ -58,6 +60,10 @@ public class JoinRequest {
 
   public boolean isLeftRequired() {
     return leftRequired;
+  }
+
+  public boolean isNullSafe() {
+    return nullSafe;
   }
 
   public List<JoinField> getFields() {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -96,9 +96,9 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
 
       Iterator<Column> leftIter = leftJoinColumns.iterator();
       Iterator<Column> rightIter = rightJoinColumns.iterator();
-      Column joinOn = leftIter.next().equalTo(rightIter.next());
+      Column joinOn = eq(leftIter.next(), rightIter.next(), joinRequest.isNullSafe());
       while (leftIter.hasNext()) {
-        joinOn = joinOn.and(leftIter.next().equalTo(rightIter.next()));
+        joinOn = joinOn.and(eq(leftIter.next(), rightIter.next(), joinRequest.isNullSafe()));
       }
 
       String joinType;
@@ -160,6 +160,13 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
     Schema outputSchema = joinRequest.getOutputSchema();
     JavaRDD<StructuredRecord> output = joined.javaRDD().map(r -> DataFrames.fromRow(r, outputSchema));
     return (SparkCollection<T>) wrap(output);
+  }
+
+  private Column eq(Column left, Column right, boolean isNullSafe) {
+    if (isNullSafe) {
+      return left.eqNullSafe(right);
+    }
+    return left.equalTo(right);
   }
 
   private Dataset<Row> toDataset(JavaRDD<StructuredRecord> rdd, Schema schema) {


### PR DESCRIPTION
Changed the 'dropNullKeys' property to 'nullSafe' since it more
accurately describes what is happening. Null keys are not dropped
in outer joins, they just do not count as being equal to a null
key on the other side.

Implemented by using Spark's null safe equality when configured
to do so and normal equality otherwise.