### PR TITLE
CDAP-16711 implemented null safe equality in mapreduce

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/AutoJoinerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/AutoJoinerTest.java
@@ -526,6 +526,7 @@ public class AutoJoinerTest extends HydratorTestBase {
     expected.add(StructuredRecord.builder(expectedSchema).set("items_region", "us").build());
 
     testNullEquality(Engine.SPARK, false, expected);
+    testNullEquality(Engine.MAPREDUCE, false, expected);
   }
 
   @Test
@@ -556,6 +557,7 @@ public class AutoJoinerTest extends HydratorTestBase {
                    .set("attributes_region", "us").build());
 
     testNullEquality(Engine.SPARK, true, expected);
+    testNullEquality(Engine.MAPREDUCE, true, expected);
   }
 
   private void testNullEquality(Engine engine, boolean nullIsEqual, Set<StructuredRecord> expected) throws Exception {

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/Joiner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/Joiner.java
@@ -38,7 +38,6 @@ public interface Joiner<JOIN_KEY, INPUT_RECORD, OUT> {
    */
   JOIN_KEY joinOn(String stageName, INPUT_RECORD inputRecord) throws Exception;
 
-
   /**
    * Creates join configuration which holds information about required inputs which are needed to decide
    * type of the join and produce join result.


### PR DESCRIPTION
Implemented the nullSafe flag for mapreduce auto join.
This was done by filtering out records on the map side if they
come from an optional stage and have a null key or a field in
the key that is null.