### PR TITLE
[CDAP-16835] Add new API in application interface for upgrading application config

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/app/Application.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/app/Application.java
@@ -32,4 +32,21 @@ public interface Application<T extends Config> {
    * @param context Used to access the environment, application configuration, and application (deployment) arguments
    */
   void configure(ApplicationConfigurer configurer, ApplicationContext<T> context);
+
+  /**
+   * Returns if application supports config update or not.
+   */
+  default boolean isUpdateSupported() {
+    return false;
+  }
+
+  /**
+   * Updates application configuration based on config and update actions inside applicationUpdateContext.
+   *
+   * @param applicationUpdateContext Used to access methods helpful for operations like upgrading plugin version for
+   * config.
+   */
+  default ApplicationUpdateResult<T> updateConfig(ApplicationUpdateContext applicationUpdateContext) {
+    throw new UnsupportedOperationException("Application config update operation is not supported.");
+  }
 }

--- a/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationConfigUpdateAction.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationConfigUpdateAction.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.app;
+
+/**
+ * Possible update actions for application config.
+ */
+public enum ApplicationConfigUpdateAction {
+  // Upgrade artifacts to latest available versions.
+  UPGRADE_ARTIFACT,
+}

--- a/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationUpdateContext.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationUpdateContext.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.app;
+
+import io.cdap.cdap.api.Config;
+import io.cdap.cdap.api.artifact.ArtifactId;
+
+import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.artifact.ArtifactVersionRange;
+import java.lang.reflect.Type;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Context for updating Application configs. Provides helper methods for application to support operations like config
+ * upgrade.
+ */
+public interface ApplicationUpdateContext {
+
+  /**
+   * @return All update actions application should perform on the config.
+   */
+  List<ApplicationConfigUpdateAction> getUpdateActions();
+
+  /**
+   * Get the old config as an object of the given type. The platform would perform the json deserialization based on
+   * the provided type. This is for the case where an application has the same/compatible/old config class. Application
+   * should decide on how they want to convert config from old to current type.
+   *
+   * @param configType type of the config platform should deserialize to.
+   * @return application config serialized to an object of given configType.
+   */
+  <C extends Config> C getConfig(Type configType);
+
+  /**
+   * Get the application configuration as json string.
+   */
+  String getConfigAsString();
+
+  /**
+   * Gets list of plugin artifacts based on given parameters in sorted in ascending order by version.
+   *
+   * @param pluginType the plugin type.
+   * @param pluginName the plugin name.
+   * @param pluginScope the scope to search plugins in.
+   * @param pluginRange the range of the version candidate plugins should be in.
+   * @return artifact list of plugins which matches with given parameters, sorted in ascending order.
+   *         Returns empty list if no artifact for the plugin found.
+   */
+  default List<ArtifactId> getPluginArtifacts(String pluginType, String pluginName, ArtifactScope pluginScope,
+                                              @Nullable ArtifactVersionRange pluginRange) {
+    return getPluginArtifacts(pluginType, pluginName, pluginScope, pluginRange, Integer.MAX_VALUE);
+  }
+
+  /**
+   * Gets list of plugin artifacts based on given parameters in sorted in ascending order by version.
+   *
+   * @param pluginType the plugin type.
+   * @param pluginName the plugin name.
+   * @param pluginScope the scope to search plugins in.
+   * @param pluginRange the range of the version candidate plugins should be in.
+   * @param limit number of results to return at max, if null, default will be INT_MAX.
+   * @return artifact list of plugins which matches with given parameters, sorted in ascending order.
+   *         Returns empty list if no artifact for the plugin found.
+   */
+  List<ArtifactId> getPluginArtifacts(String pluginType, String pluginName, ArtifactScope pluginScope,
+                                      @Nullable ArtifactVersionRange pluginRange, int limit);
+
+}
+

--- a/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationUpdateResult.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationUpdateResult.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.app;
+
+import io.cdap.cdap.api.Config;
+
+/**
+ * Stores results of upgrading an application config.
+ *
+ * @param <T> {@link Config} config class that represents the configuration type of an Application.
+ */
+public class ApplicationUpdateResult<T extends Config> {
+
+  // Upgraded config.
+  private final T newConfig;
+
+  private ApplicationUpdateResult(T newConfig) {
+    this.newConfig = newConfig;
+  }
+
+  public T getNewConfig() {
+    return newConfig;
+  }
+}


### PR DESCRIPTION
Adding a new API for allowing Application to allow config update operations like upgrade artifacts. Added helper classes for the same. Next PR will include using this new API in DataPipelineApp to upgrade ETLBatchConfig.

It is up to Application to define how it wants to update a given application. In future, we can add more helper methods in ApplicationUpdateContext  as needed.