### PR TITLE
[CDAP-16876] Remove leftover 'provided' header in preview for 6.1.x

### DIFF
--- a/cdap-ui/app/directives/my-pipeline-runtime-args/my-pipeline-runtime-args.html
+++ b/cdap-ui/app/directives/my-pipeline-runtime-args/my-pipeline-runtime-args.html
@@ -17,32 +17,12 @@
 <div class="step-content-heading">
   Specify runtime arguments or update the ones derived from preferences
   <div class="step-content-subtitle">
-    By default, values for all runtime arguments must be provided before running the pipeline. If a stage in your pipeline provides the value of an argument, you can skip that argument by marking it as provided.
+    By default, values for all runtime arguments must be provided before running the pipeline. If a stage in your pipeline provides the value of an argument, it needs to be left empty.
   </div>
 </div>
 <div class="runtime-arguments-labels key-value-pair-labels">
   <span class="key-label">Name</span>
   <span class="value-label">Value</span>
-  <span></span>
-  <span class="provided-label"
-        ng-if="RuntimeArgsCtrl.containsMacros">
-    <span uib-dropdown
-      class="dropdown"
-      is-open="RuntimeArgsCtrl.providedPopoverOpen">
-      <span uib-dropdown-toggle>
-        Provided
-        <span class="fa fa-caret-square-o-down">
-      </span>
-      <ul uib-dropdown-menu ng-click="$event.stopPropagation();">
-        <li ng-click="RuntimeArgsCtrl.toggleAllProvided(false)">
-          Clear All
-        </li>
-        <li ng-click="RuntimeArgsCtrl.toggleAllProvided(true)">
-          Select All
-        </li>
-      </ul>
-    </span>
-  </span>
 </div>
 <div class="runtime-arguments-values key-value-pair-values">
   <key-value-pairs

--- a/cdap-ui/app/directives/my-pipeline-runtime-args/my-pipeline-runtime-args.less
+++ b/cdap-ui/app/directives/my-pipeline-runtime-args/my-pipeline-runtime-args.less
@@ -40,7 +40,7 @@ my-pipeline-runtime-args {
     }
     &.key-value-pair-labels {
       display: grid;
-      grid-template-columns: 1fr 1fr 62px 100px;
+      grid-template-columns: 1fr 1fr 62px;
       grid-gap: 10px;
       margin-right: -25px;
     }
@@ -57,7 +57,7 @@ my-pipeline-runtime-args {
       margin-bottom: 15px;
       justify-content: initial;
       display: grid;
-      grid-template-columns: 1fr 1fr auto 100px;
+      grid-template-columns: 1fr 1fr auto;
       grid-gap: 10px;
       input {
         width: 100%;


### PR DESCRIPTION
After we removed provided arguments in preview, the table header for it was leftover. This was fixed in develop/6.2 with the revamped key value pairs but the hanging header is present in 6.1.x.

JIRA: https://issues.cask.co/browse/CDAP-16876