### PR TITLE
CDAP-16709 implemented auto-join for spark streaming

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/JoinOnFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/JoinOnFunction.java
@@ -16,13 +16,21 @@
 
 package io.cdap.cdap.etl.spark.function;
 
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.Emitter;
 import io.cdap.cdap.etl.api.Transformation;
+import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoinerRuntimeContext;
+import io.cdap.cdap.etl.api.join.AutoJoinerContext;
+import io.cdap.cdap.etl.api.join.JoinCondition;
+import io.cdap.cdap.etl.api.join.JoinDefinition;
+import io.cdap.cdap.etl.api.join.JoinStage;
 import io.cdap.cdap.etl.common.Constants;
 import io.cdap.cdap.etl.common.DefaultEmitter;
 import io.cdap.cdap.etl.common.TrackedTransform;
+import io.cdap.cdap.etl.common.plugin.JoinerBridge;
 import scala.Tuple2;
 
 /**
@@ -48,12 +56,49 @@ public class JoinOnFunction<JOIN_KEY, INPUT_RECORD>
   @Override
   public Iterable<Tuple2<JOIN_KEY, INPUT_RECORD>> call(INPUT_RECORD input) throws Exception {
     if (joinFunction == null) {
-      BatchJoiner<JOIN_KEY, INPUT_RECORD, Object> joiner = pluginFunctionContext.createPlugin();
-      BatchJoinerRuntimeContext context = pluginFunctionContext.createBatchRuntimeContext();
-      joiner.initialize(context);
-      // TODO: CDAP-16709 pass in the right flag for filtering based on if the joiner is an auto-join or not
-      //   The plugin should only potentially be an auto-joiner in streaming pipelines
-      joinFunction = new TrackedTransform<>(new JoinOnTransform<>(joiner, inputStageName, false),
+      Object plugin = pluginFunctionContext.createPlugin();
+      BatchJoiner<JOIN_KEY, INPUT_RECORD, Object> joiner;
+      boolean filterNullKeys = false;
+      if (plugin instanceof BatchAutoJoiner) {
+        BatchAutoJoiner autoJoiner = (BatchAutoJoiner) plugin;
+        AutoJoinerContext autoJoinerContext = pluginFunctionContext.createAutoJoinerContext();
+        JoinDefinition joinDefinition = autoJoiner.define(autoJoinerContext);
+        if (joinDefinition == null) {
+          throw new IllegalStateException(String.format(
+            "Join stage '%s' did not specify a join definition. " +
+              "Check with the plugin developer to ensure it is implemented correctly.",
+            pluginFunctionContext.getStageSpec().getName()));
+        }
+        JoinCondition condition = joinDefinition.getCondition();
+        /*
+           Filter out the record if it comes from an optional stage
+           and the key is null, or if any of the fields in the key is null.
+           For example, suppose we are performing a left outer join on:
+
+            A (id, name) = (0, alice), (null, bob)
+            B (id, email) = (0, alice@example.com), (null, placeholder@example.com)
+
+           The final output should be:
+
+           joined (A.id, A.name, B.email) = (0, alice, alice@example.com), (null, bob, null, null)
+
+           that is, the bob record should not be joined to the placeholder@example email, even though both their
+           ids are null.
+         */
+        if (condition.getOp() == JoinCondition.Op.KEY_EQUALITY && !((JoinCondition.OnKeys) condition).isNullSafe()) {
+          filterNullKeys = joinDefinition.getStages().stream()
+            .filter(s -> !s.isRequired())
+            .map(JoinStage::getStageName)
+            .anyMatch(s -> s.equals(inputStageName));
+        }
+        joiner = new JoinerBridge(autoJoiner, joinDefinition);
+      } else {
+        joiner = (BatchJoiner<JOIN_KEY, INPUT_RECORD, Object>) plugin;
+        BatchJoinerRuntimeContext context = pluginFunctionContext.createBatchRuntimeContext();
+        joiner.initialize(context);
+      }
+
+      joinFunction = new TrackedTransform<>(new JoinOnTransform<>(joiner, inputStageName, filterNullKeys),
                                             pluginFunctionContext.createStageMetrics(),
                                             Constants.Metrics.RECORDS_IN,
                                             null, pluginFunctionContext.getDataTracer(),
@@ -77,11 +122,22 @@ public class JoinOnFunction<JOIN_KEY, INPUT_RECORD>
     }
 
     @Override
-    public void transform(final INPUT inputValue, Emitter<Tuple2<JOIN_KEY, INPUT>> emitter) throws Exception {
-      if (filterNullKeys && inputValue == null) {
-        return;
+    public void transform(INPUT inputValue, Emitter<Tuple2<JOIN_KEY, INPUT>> emitter) throws Exception {
+      JOIN_KEY key = joiner.joinOn(inputStageName, inputValue);
+      if (filterNullKeys) {
+        if (key == null) {
+          return;
+        }
+        if (key instanceof StructuredRecord) {
+          StructuredRecord keyRecord = (StructuredRecord) key;
+          for (Schema.Field field : keyRecord.getSchema().getFields()) {
+            if (keyRecord.get(field.getName()) == null) {
+              return;
+            }
+          }
+        }
       }
-      emitter.emit(new Tuple2<>(joiner.joinOn(inputStageName, inputValue), inputValue));
+      emitter.emit(new Tuple2<>(key, inputValue));
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/joiner/MockAutoJoiner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/joiner/MockAutoJoiner.java
@@ -153,12 +153,12 @@ public class MockAutoJoiner extends BatchAutoJoiner {
   }
 
   public static ETLPlugin getPlugin(List<String> stages, List<String> key, List<String> required,
-                                    boolean filterNullKeys) {
+                                    boolean nullSafe) {
     Map<String, String> properties = new HashMap<>();
     properties.put("stages", GSON.toJson(stages));
     properties.put("required", GSON.toJson(required));
     properties.put("key", GSON.toJson(key));
-    properties.put("nullSafe", Boolean.toString(filterNullKeys));
+    properties.put("nullSafe", Boolean.toString(nullSafe));
     return new ETLPlugin(NAME, BatchJoiner.PLUGIN_TYPE, properties, null);
   }
 


### PR DESCRIPTION
Implemented auto-join for spark streaming by using the same
JoinerBridge that is used for MapReduce. This means auto-joins
in streaming pipelines will have the same characteristics as normal
joins, meaning they will be executed as shuffle hash joins.

This is probably ok, as only data within the micro batch is being
joined, which means it shouldn't be too likely to go OOM assuming
there is enough executor memory.