### PR TITLE
[CDAP-16874] Importing existing plugin JSON file (plugin JSON Creator)

### DIFF
--- a/cdap-ui/app/cdap/components/Alert/index.js
+++ b/cdap-ui/app/cdap/components/Alert/index.js
@@ -14,10 +14,10 @@
  * the License.
  */
 
+import IconSVG from 'components/IconSVG';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Modal } from 'reactstrap';
-import IconSVG from 'components/IconSVG';
 
 require('./Alert.scss');
 const SUCCESS_CLOSE_TIMEOUT = 3000;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/BasicPluginInfo/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/BasicPluginInfo/index.tsx
@@ -52,6 +52,10 @@ const BasicPluginInfoView: React.FC<ICreateContext & WithStyles<typeof styles>> 
   widgetToAttributes,
   jsonView,
   setJsonView,
+  outputName,
+  setPluginState,
+  JSONStatus,
+  setJSONStatus,
 }) => {
   const [localPluginName, setLocalPluginName] = React.useState(pluginName);
   const [localPluginType, setLocalPluginType] = React.useState(pluginType);
@@ -87,6 +91,10 @@ const BasicPluginInfoView: React.FC<ICreateContext & WithStyles<typeof styles>> 
         widgetToAttributes={widgetToAttributes}
         jsonView={jsonView}
         setJsonView={setJsonView}
+        outputName={outputName}
+        setPluginState={setPluginState}
+        JSONStatus={JSONStatus}
+        setJSONStatus={setJSONStatus}
       />
       <Heading type={HeadingTypes.h3} label="Basic Plugin Information" />
       <div className={classes.basicPluginInput}>

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/index.tsx
@@ -71,6 +71,9 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
   jsonView,
   setJsonView,
   outputName,
+  setPluginState,
+  JSONStatus,
+  setJSONStatus,
 }) => {
   const [activeGroupIndex, setActiveGroupIndex] = React.useState(null);
   const [localConfigurationGroups, setLocalConfigurationGroups] = React.useState(
@@ -173,6 +176,9 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
         jsonView={jsonView}
         setJsonView={setJsonView}
         outputName={outputName}
+        setPluginState={setPluginState}
+        JSONStatus={JSONStatus}
+        setJSONStatus={setJSONStatus}
       />
       <Heading type={HeadingTypes.h3} label="Configuration Groups" />
       <br />

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/ClosedJsonMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/ClosedJsonMenu/index.tsx
@@ -14,37 +14,25 @@
  * the License.
  */
 
+import Button from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
-import Drawer from '@material-ui/core/Drawer';
-import IconButton from '@material-ui/core/IconButton';
-import List from '@material-ui/core/List';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import Tooltip from '@material-ui/core/Tooltip';
 import CodeIcon from '@material-ui/icons/Code';
 import GetAppIcon from '@material-ui/icons/GetApp';
-import { downloadPluginJSON } from 'components/PluginJSONCreator/Create/Content/JsonMenu/utilities';
+import { JSONStatusMessage } from 'components/PluginJSONCreator/Create/Content/JsonMenu';
+import PluginJSONImporter from 'components/PluginJSONCreator/Create/Content/JsonMenu/PluginJsonImporter';
 import { ICreateContext } from 'components/PluginJSONCreator/CreateContextConnect';
 import * as React from 'react';
 
 const styles = (theme): StyleRules => {
   return {
-    closedJsonMenu: {
-      zIndex: theme.zIndex.drawer,
-    },
-    closedJsonMenuPaper: {
-      backgroundColor: theme.palette.white[50],
-    },
-    toolbar: {
-      minHeight: '48px',
-    },
-    mainMenu: {
-      borderTop: `1px solid ${theme.palette.grey['500']}`,
-      paddingTop: theme.Spacing(1),
-      paddingBottom: theme.Spacing(1),
-    },
-    jsonCollapseActionButtons: {
+    jsonActionButtons: {
       padding: '15px',
       flexDirection: 'column',
+    },
+    jsonActionButton: {
+      margin: '5px',
     },
     jsonViewerTooltip: {
       fontSize: '14px',
@@ -53,63 +41,86 @@ const styles = (theme): StyleRules => {
   };
 };
 
-const ClosedJsonMenuView: React.FC<ICreateContext & WithStyles<typeof styles>> = (
-  widgetJSONData
-) => {
-  const { classes, pluginName, pluginType, jsonView, setJsonView } = widgetJSONData;
-  const downloadDisabled = pluginName.length === 0 || pluginType.length === 0;
+const DownloadJSONButton = ({ classes, downloadDisabled, onDownloadClick }) => {
+  return (
+    <Tooltip
+      title={
+        downloadDisabled
+          ? 'Download is disabled until the required fields are filled'
+          : 'Download Plugin JSON'
+      }
+      classes={{
+        tooltip: classes.jsonViewerTooltip,
+      }}
+    >
+      <div>
+        <Button disabled={downloadDisabled} onClick={onDownloadClick}>
+          <GetAppIcon />
+        </Button>
+      </div>
+    </Tooltip>
+  );
+};
+
+const ExpandJSONViewButton = ({ classes, expandJSONView }) => {
+  return (
+    <Tooltip
+      title="Open JSON View"
+      classes={{
+        tooltip: classes.jsonViewerTooltip,
+      }}
+    >
+      <Button onClick={expandJSONView}>
+        <CodeIcon />
+      </Button>
+    </Tooltip>
+  );
+};
+
+interface IClosedJsonMenuProps extends WithStyles<typeof styles>, ICreateContext {
+  expandJSONView: () => void;
+  onDownloadClick: () => void;
+  populateImportResults: (filename: string, fileContent: string) => void;
+  JSONStatus: JSONStatusMessage;
+  downloadDisabled: boolean;
+}
+
+const ClosedJsonMenuView: React.FC<IClosedJsonMenuProps> = ({
+  classes,
+  expandJSONView,
+  onDownloadClick,
+  populateImportResults,
+  JSONStatus,
+  downloadDisabled,
+}) => {
   return (
     <div>
-      <Drawer
-        open={!jsonView}
-        variant="persistent"
-        className={classes.closedJsonMenu}
-        anchor="right"
-        ModalProps={{
-          keepMounted: true,
-        }}
-        classes={{
-          paper: classes.closedJsonMenuPaper,
-        }}
-        data-cy="navbar-jsonViewer"
-      >
-        <div className={classes.toolbar} />
-        <List component="nav" dense={true} className={classes.mainMenu}>
-          <div className={classes.jsonCollapseActionButtons}>
-            <Tooltip
-              title="Open JSON View"
-              classes={{
-                tooltip: classes.jsonViewerTooltip,
-              }}
-            >
-              <IconButton onClick={() => setJsonView(true)}>
-                <CodeIcon />
-              </IconButton>
-            </Tooltip>
-            <Divider />
-
-            <Tooltip
-              title={
-                downloadDisabled
-                  ? 'Download is disabled until the required fields are filled'
-                  : 'Download Plugin JSON'
-              }
-              classes={{
-                tooltip: classes.jsonViewerTooltip,
-              }}
-            >
-              <span>
-                <IconButton
-                  disabled={downloadDisabled}
-                  onClick={() => downloadPluginJSON(widgetJSONData)}
-                >
-                  <GetAppIcon />
-                </IconButton>
-              </span>
-            </Tooltip>
-          </div>
-        </List>
-      </Drawer>
+      <div className={classes.jsonActionButtons}>
+        <div className={classes.jsonActionButton}>
+          <ExpandJSONViewButton classes={classes} expandJSONView={expandJSONView} />
+        </div>
+        <Divider />
+        <div className={classes.jsonActionButton}>
+          <Tooltip
+            classes={{
+              tooltip: classes.jsonViewerTooltip,
+            }}
+            title="Import JSON"
+          >
+            <PluginJSONImporter
+              populateImportResults={populateImportResults}
+              JSONStatus={JSONStatus}
+            />
+          </Tooltip>
+        </div>
+        <div className={classes.jsonActionButton}>
+          <DownloadJSONButton
+            classes={classes}
+            downloadDisabled={downloadDisabled}
+            onDownloadClick={onDownloadClick}
+          />
+        </div>
+      </div>
     </div>
   );
 };

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/JsonLiveViewer/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/JsonLiveViewer/index.tsx
@@ -15,42 +15,27 @@
  */
 
 import Button from '@material-ui/core/Button';
-import Drawer from '@material-ui/core/Drawer';
-import List from '@material-ui/core/List';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import Tooltip from '@material-ui/core/Tooltip';
 import FullscreenExitIcon from '@material-ui/icons/FullscreenExit';
-import SaveAltIcon from '@material-ui/icons/SaveAlt';
-import {
-  downloadPluginJSON,
-  getJSONConfig,
-} from 'components/PluginJSONCreator/Create/Content/JsonMenu/utilities';
+import GetAppIcon from '@material-ui/icons/GetApp';
+import { JSONStatusMessage } from 'components/PluginJSONCreator/Create/Content/JsonMenu';
+import PluginJSONImporter from 'components/PluginJSONCreator/Create/Content/JsonMenu/PluginJsonImporter';
 import { ICreateContext } from 'components/PluginJSONCreator/CreateContextConnect';
 import * as React from 'react';
 
-const JSON_VIEWER_WIDTH = '600px';
-
 const styles = (theme): StyleRules => {
   return {
-    jsonViewer: {
-      zIndex: theme.zIndex.drawer,
-      width: JSON_VIEWER_WIDTH,
-    },
-    jsonViewerPaper: {
-      width: JSON_VIEWER_WIDTH,
-      backgroundColor: theme.palette.white[50],
-    },
-    toolbar: {
-      minHeight: '48px',
-    },
-    mainMenu: {
-      borderTop: `1px solid ${theme.palette.grey['500']}`,
-      paddingTop: theme.Spacing(1),
-      paddingBottom: theme.Spacing(1),
-    },
     jsonActionButtons: {
-      padding: '5px',
+      padding: '0px',
       display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    currentFilename: {
+      position: 'relative',
+      margin: '0 auto',
+      left: '25px',
     },
     closeJSONViewerButon: {
       marginLeft: 'auto',
@@ -65,65 +50,90 @@ const styles = (theme): StyleRules => {
   };
 };
 
-const JsonLiveViewerView: React.FC<ICreateContext & WithStyles<typeof styles>> = (
-  widgetJSONData
-) => {
-  const { classes, pluginName, pluginType, jsonView, setJsonView } = widgetJSONData;
-  const JSONConfig = getJSONConfig(widgetJSONData);
-  const downloadDisabled = pluginName.length === 0 || pluginType.length === 0;
+const DownloadJSONButton = ({ classes, downloadDisabled, onDownloadClick }) => {
+  return (
+    <Tooltip
+      title={
+        downloadDisabled
+          ? 'Download is disabled until the required fields are filled'
+          : 'Download Plugin JSON'
+      }
+      classes={{
+        tooltip: classes.jsonViewerTooltip,
+      }}
+    >
+      <div>
+        <Button disabled={downloadDisabled} onClick={onDownloadClick}>
+          <GetAppIcon />
+        </Button>
+      </div>
+    </Tooltip>
+  );
+};
+
+const CollapseJSONViewButton = ({ classes, collapseJSONView }) => {
+  return (
+    <Tooltip
+      classes={{
+        tooltip: classes.jsonViewerTooltip,
+      }}
+      title="Close JSON View"
+    >
+      <Button className={classes.closeJSONViewerButon} onClick={collapseJSONView}>
+        <FullscreenExitIcon />
+      </Button>
+    </Tooltip>
+  );
+};
+
+interface IJsonLiveViewerProps extends WithStyles<typeof styles>, ICreateContext {
+  JSONConfig: any;
+  collapseJSONView: () => void;
+  onDownloadClick: () => void;
+  populateImportResults: (filename: string, fileContent: string) => void;
+  jsonFilename: string;
+  JSONStatus: JSONStatusMessage;
+  setJSONStatus: (JSONStatus: JSONStatusMessage) => void;
+  downloadDisabled: boolean;
+  JSONErrorMessage: string;
+}
+
+const JsonLiveViewerView: React.FC<IJsonLiveViewerProps> = ({
+  classes,
+  JSONConfig,
+  collapseJSONView,
+  onDownloadClick,
+  populateImportResults,
+  jsonFilename,
+  JSONStatus,
+  downloadDisabled,
+}) => {
   return (
     <div>
-      <Drawer
-        open={jsonView}
-        variant="persistent"
-        className={classes.jsonViewer}
-        anchor="right"
-        ModalProps={{
-          keepMounted: true,
-        }}
-        classes={{
-          paper: classes.jsonViewerPaper,
-        }}
-        data-cy="navbar-drawer"
-      >
-        <div className={classes.toolbar} />
-        <List component="nav" dense={true} className={classes.mainMenu}>
-          <div className={classes.jsonActionButtons}>
-            <Tooltip
-              classes={{
-                tooltip: classes.jsonViewerTooltip,
-              }}
-              title={
-                downloadDisabled
-                  ? 'Download is disabled until the required fields are filled in'
-                  : 'Download Plugin JSON'
-              }
-            >
-              <span>
-                <Button
-                  disabled={downloadDisabled}
-                  onClick={() => downloadPluginJSON(widgetJSONData)}
-                >
-                  <SaveAltIcon />
-                </Button>
-              </span>
-            </Tooltip>
-            <Tooltip
-              classes={{
-                tooltip: classes.jsonViewerTooltip,
-              }}
-              title="Close JSON View"
-            >
-              <Button className={classes.closeJSONViewerButon} onClick={() => setJsonView(false)}>
-                <FullscreenExitIcon />
-              </Button>
-            </Tooltip>
-          </div>
-          <div className={classes.jsonLiveCode}>
-            <pre>{JSON.stringify(JSONConfig, undefined, 2)}</pre>
-          </div>
-        </List>
-      </Drawer>
+      <div className={classes.jsonActionButtons}>
+        <Tooltip
+          classes={{
+            tooltip: classes.jsonViewerTooltip,
+          }}
+          title="Import JSON"
+        >
+          <PluginJSONImporter
+            populateImportResults={populateImportResults}
+            JSONStatus={JSONStatus}
+          />
+        </Tooltip>
+        <DownloadJSONButton
+          classes={classes}
+          downloadDisabled={downloadDisabled}
+          onDownloadClick={onDownloadClick}
+        />
+        <pre className={classes.currentFilename}>{jsonFilename}</pre>
+
+        <CollapseJSONViewButton classes={classes} collapseJSONView={collapseJSONView} />
+      </div>
+      <div className={classes.jsonLiveCode}>
+        <pre>{JSON.stringify(JSONConfig, undefined, 2)}</pre>
+      </div>
     </div>
   );
 };

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/PluginJsonImporter/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/PluginJsonImporter/index.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Button from '@material-ui/core/Button';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import SaveIcon from '@material-ui/icons/Save';
+import { JSONStatusMessage } from 'components/PluginJSONCreator/Create/Content/JsonMenu';
+import { ICreateContext } from 'components/Replicator/Create';
+import React from 'react';
+
+const styles = (): StyleRules => {
+  return {
+    fileInput: {
+      display: 'none',
+    },
+  };
+};
+
+interface IPluginJSONImporterProps extends WithStyles<typeof styles>, ICreateContext {
+  populateImportResults: (filename: string, fileContent: string) => void;
+  JSONStatus: JSONStatusMessage;
+}
+
+const PluginJSONImporterView: React.FC<IPluginJSONImporterProps> = ({
+  classes,
+  populateImportResults,
+}) => {
+  function processFileUpload() {
+    return (e) => {
+      const files = e.target.files;
+      if (files.length > 0) {
+        const filename = files[0].name;
+        const filenameWithoutExtension =
+          filename.substring(0, filename.lastIndexOf('.')) || filename;
+        const reader = new FileReader();
+        reader.readAsText(files[0]);
+        let fileContent;
+        reader.onload = (r) => {
+          fileContent = r.target.result;
+          renderFileContent(filenameWithoutExtension, fileContent);
+        };
+      }
+    };
+  }
+
+  async function renderFileContent(filename, fileContent) {
+    await populateImportResults(filename, fileContent);
+  }
+
+  return (
+    <div>
+      <input
+        accept="json/*"
+        id="raised-button-file"
+        type="file"
+        className={classes.fileInput}
+        onChange={processFileUpload()}
+      />
+      <label htmlFor="raised-button-file">
+        <Button aria-label="save" component="span" color="primary">
+          <SaveIcon />
+        </Button>
+      </label>
+    </div>
+  );
+};
+
+const PluginJSONImporter = withStyles(styles)(PluginJSONImporterView);
+export default PluginJSONImporter;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/index.tsx
@@ -14,70 +14,174 @@
  * the License.
  */
 
+import Drawer from '@material-ui/core/Drawer';
+import List from '@material-ui/core/List';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import Alert from 'components/Alert';
 import If from 'components/If';
 import ClosedJsonMenu from 'components/PluginJSONCreator/Create/Content/JsonMenu/ClosedJsonMenu';
 import JsonLiveViewer from 'components/PluginJSONCreator/Create/Content/JsonMenu/JsonLiveViewer';
 import {
-  CreateContext,
-  createContextConnect,
-  ICreateContext,
-} from 'components/PluginJSONCreator/CreateContextConnect';
+  downloadPluginJSON,
+  getJSONConfig,
+  parsePluginJSON,
+} from 'components/PluginJSONCreator/Create/Content/JsonMenu/utilities';
+import { ICreateContext } from 'components/PluginJSONCreator/CreateContextConnect';
 import * as React from 'react';
 
-const JsonMenuView: React.FC<ICreateContext> = ({
-  pluginName,
-  pluginType,
-  displayName,
-  emitAlerts,
-  emitErrors,
-  configurationGroups,
-  groupToInfo,
-  groupToWidgets,
-  widgetInfo,
-  widgetToAttributes,
-  jsonView,
-  setJsonView,
-  outputName,
-}) => {
+const JSON_VIEWER_WIDTH = '600px';
+
+const styles = (theme): StyleRules => {
+  return {
+    mainMenu: {
+      borderTop: `1px solid ${theme.palette.grey['500']}`,
+      paddingTop: theme.Spacing(1),
+      paddingBottom: theme.Spacing(1),
+    },
+    toolbar: {
+      minHeight: '48px',
+    },
+    closedJsonMenu: {
+      zIndex: 1000, // lower than '1061', which is Alert component's z-index
+    },
+    closedJsonMenuPaper: {
+      zIndex: 1000, // lower than '1061', which is Alert component's z-index
+      backgroundColor: theme.palette.white[50],
+    },
+    jsonViewer: {
+      zIndex: 1000, // lower than '1061', which is Alert component's z-index
+      width: JSON_VIEWER_WIDTH,
+    },
+    jsonViewerPaper: {
+      zIndex: 1000, // lower than '1061', which is Alert component's z-index
+      width: JSON_VIEWER_WIDTH,
+      backgroundColor: theme.palette.white[50],
+    },
+  };
+};
+
+export enum JSONStatusMessage {
+  Normal = '',
+  Success = 'SUCCESS',
+  Fail = 'FAIL',
+}
+
+const JsonMenuView: React.FC<ICreateContext & WithStyles<typeof styles>> = (widgetJSONProps) => {
+  const {
+    classes,
+    pluginName,
+    pluginType,
+    jsonView,
+    setJsonView,
+    setPluginState,
+    JSONStatus,
+    setJSONStatus,
+  } = widgetJSONProps;
+  const [JSONErrorMessage, setJSONErrorMessage] = React.useState('');
+
+  const jsonFilename = `${pluginName ? pluginName : '<PluginName>'}-${
+    pluginType ? pluginType : '<PluginType>'
+  }.json`;
+
+  const downloadDisabled =
+    !pluginName || pluginName.length === 0 || !pluginType || pluginType.length === 0;
+
+  const onDownloadClick = () => {
+    downloadPluginJSON(widgetJSONProps);
+  };
+
+  const populateImportResults = (filename: string, fileContent: string) => {
+    try {
+      const pluginJSON = JSON.parse(fileContent);
+
+      const {
+        basicPluginInfo,
+        newConfigurationGroups,
+        newGroupToInfo,
+        newGroupToWidgets,
+        newWidgetInfo,
+        newWidgetToAttributes,
+        newOutputName,
+      } = parsePluginJSON(filename, pluginJSON);
+
+      setPluginState({
+        basicPluginInfo,
+        configurationGroups: newConfigurationGroups,
+        groupToInfo: newGroupToInfo,
+        groupToWidgets: newGroupToWidgets,
+        widgetInfo: newWidgetInfo,
+        widgetToAttributes: newWidgetToAttributes,
+        outputName: newOutputName,
+      });
+
+      setJSONStatus(JSONStatusMessage.Success);
+      setJSONErrorMessage(null);
+    } catch (e) {
+      setJSONStatus(JSONStatusMessage.Fail);
+      setJSONErrorMessage(`${e.name}: ${e.message}`);
+    }
+  };
+
+  const expandJSONView = () => {
+    setJsonView(true);
+  };
+
+  const collapseJSONView = () => {
+    setJsonView(false);
+  };
+
+  const resetJSONStatus = () => {
+    // When alert closes, reset JSONStatus
+    setJSONStatus(JSONStatusMessage.Normal);
+  };
+
   return (
     <div>
-      <If condition={jsonView}>
-        <JsonLiveViewer
-          pluginName={pluginName}
-          pluginType={pluginType}
-          displayName={displayName}
-          emitAlerts={emitAlerts}
-          emitErrors={emitErrors}
-          configurationGroups={configurationGroups}
-          groupToInfo={groupToInfo}
-          groupToWidgets={groupToWidgets}
-          widgetInfo={widgetInfo}
-          widgetToAttributes={widgetToAttributes}
-          jsonView={jsonView}
-          setJsonView={setJsonView}
-          outputName={outputName}
-        />
-      </If>
-      <If condition={!jsonView}>
-        <ClosedJsonMenu
-          pluginName={pluginName}
-          pluginType={pluginType}
-          displayName={displayName}
-          emitAlerts={emitAlerts}
-          emitErrors={emitErrors}
-          configurationGroups={configurationGroups}
-          groupToInfo={groupToInfo}
-          groupToWidgets={groupToWidgets}
-          widgetInfo={widgetInfo}
-          widgetToAttributes={widgetToAttributes}
-          jsonView={jsonView}
-          setJsonView={setJsonView}
-          outputName={outputName}
-        />
-      </If>
+      <Drawer
+        open={true}
+        variant="persistent"
+        className={jsonView ? classes.jsonViewer : classes.closedJsonMenu}
+        anchor="right"
+        ModalProps={{
+          keepMounted: true,
+        }}
+        classes={{
+          paperAnchorRight: jsonView ? classes.jsonViewerPaper : classes.closedJsonMenuPaper,
+        }}
+        data-cy="navbar-drawer"
+      >
+        <div className={classes.toolbar} />
+        <List component="nav" dense={true} className={classes.mainMenu}>
+          <If condition={jsonView}>
+            <JsonLiveViewer
+              JSONConfig={getJSONConfig(widgetJSONProps)}
+              downloadDisabled={downloadDisabled}
+              collapseJSONView={collapseJSONView}
+              onDownloadClick={onDownloadClick}
+              populateImportResults={populateImportResults}
+              jsonFilename={jsonFilename}
+              JSONStatus={JSONStatus}
+            />
+          </If>
+          <If condition={!jsonView}>
+            <ClosedJsonMenu
+              downloadDisabled={downloadDisabled}
+              onDownloadClick={onDownloadClick}
+              expandJSONView={expandJSONView}
+              populateImportResults={populateImportResults}
+            />
+          </If>
+        </List>
+      </Drawer>
+      <Alert
+        message={JSONErrorMessage}
+        showAlert={JSONStatus === JSONStatusMessage.Fail}
+        type="error"
+        onClose={resetJSONStatus}
+      />
     </div>
   );
 };
 
-const JsonMenu = createContextConnect(CreateContext, JsonMenuView);
+const JsonMenu = withStyles(styles)(JsonMenuView);
 export default JsonMenu;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/utilities.ts
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/utilities.ts
@@ -1,6 +1,11 @@
 import { SPEC_VERSION } from 'components/PluginJSONCreator/constants';
-import { IWidgetInfo } from 'components/PluginJSONCreator/CreateContextConnect';
+import {
+  IBasicPluginInfo,
+  IConfigurationGroupInfo,
+  IWidgetInfo,
+} from 'components/PluginJSONCreator/CreateContextConnect';
 import fileDownload from 'js-file-download';
+import uuidV4 from 'uuid/v4';
 
 function getJSONConfig(widgetJSONData) {
   const {
@@ -56,10 +61,87 @@ function getJSONConfig(widgetJSONData) {
   return config;
 }
 
+function parsePluginJSON(filename, pluginJSON) {
+  // Parse filename in order to set pluginName and pluginType
+  // Currently the filename is designed to be <pluginName>-<pluginType>.json
+  const [pluginName, pluginType] = filename.split('-');
+
+  // Parse file data in order to populate the rest of properties
+  const basicPluginInfo = {
+    // If the string fields are undefined, set them to empty string
+    displayName: pluginJSON['display-name'] ? pluginJSON['display-name'] : '',
+    pluginName: pluginName ? pluginName : '',
+    pluginType: pluginType ? pluginType : '',
+    emitAlerts: pluginJSON['emit-alerts'],
+    emitErrors: pluginJSON['emit-errors'],
+  } as IBasicPluginInfo;
+
+  const newConfigurationGroups = [];
+  const newGroupToInfo = {};
+  const newGroupToWidgets = {};
+  const newWidgetInfo = {};
+  const newWidgetToAttributes = {};
+
+  pluginJSON['configuration-groups'].forEach((groupObj) => {
+    if (!groupObj || Object.keys(groupObj).length === 0) {
+      return;
+    }
+    const groupLabel = groupObj.label;
+
+    // generate a unique group ID
+    const newGroupID = 'ConfigGroup_' + uuidV4();
+
+    newConfigurationGroups.push(newGroupID);
+
+    newGroupToInfo[newGroupID] = {
+      label: groupLabel,
+    } as IConfigurationGroupInfo;
+
+    newGroupToWidgets[newGroupID] = [];
+
+    const groupWidgets = groupObj.properties;
+    groupWidgets.forEach((widgetObj) => {
+      // generate a unique widget ID
+      const newWidgetID = 'Widget_' + uuidV4();
+
+      newGroupToWidgets[newGroupID].push(newWidgetID);
+
+      const widgetInfo = {
+        widgetType: widgetObj['widget-type'],
+        label: widgetObj.label,
+        name: widgetObj.name,
+        ...(widgetObj['widget-category'] && { widgetCategory: widgetObj['widget-category'] }),
+      } as IWidgetInfo;
+
+      newWidgetInfo[newWidgetID] = widgetInfo;
+
+      if (
+        widgetObj['widget-attributes'] &&
+        Object.keys(widgetObj['widget-attributes']).length > 0
+      ) {
+        newWidgetToAttributes[newWidgetID] = widgetObj['widget-attributes'];
+      }
+    });
+  });
+
+  const newOutputName =
+    pluginJSON.outputs && pluginJSON.outputs.length > 0 ? pluginJSON.outputs[0].name : '';
+
+  return {
+    basicPluginInfo,
+    newConfigurationGroups,
+    newGroupToInfo,
+    newGroupToWidgets,
+    newWidgetInfo,
+    newWidgetToAttributes,
+    newOutputName,
+  };
+}
+
 function downloadPluginJSON(widgetJSONData) {
   const JSONConfig = getJSONConfig(widgetJSONData);
   const { pluginName, pluginType } = widgetJSONData;
   fileDownload(JSON.stringify(JSONConfig, undefined, 4), `${pluginName}-${pluginType}.json`);
 }
 
-export { getJSONConfig, downloadPluginJSON };
+export { getJSONConfig, parsePluginJSON, downloadPluginJSON };

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/Outputs/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/Outputs/index.tsx
@@ -43,6 +43,9 @@ const OutputsView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
   setJsonView,
   outputName,
   setOutputName,
+  setPluginState,
+  JSONStatus,
+  setJSONStatus,
 }) => {
   const [localOutputName, setLocalOutputName] = React.useState(outputName);
 
@@ -65,7 +68,10 @@ const OutputsView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
         widgetToAttributes={widgetToAttributes}
         jsonView={jsonView}
         setJsonView={setJsonView}
-        outputName={localOutputName}
+        outputName={outputName}
+        setPluginState={setPluginState}
+        JSONStatus={JSONStatus}
+        setJSONStatus={setJSONStatus}
       />
       <Heading type={HeadingTypes.h3} label="Output" />
       <br />

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/WidgetAttributeInput/AttributeMultipleValuesInput/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/WidgetAttributeInput/AttributeMultipleValuesInput/index.tsx
@@ -312,7 +312,7 @@ const AttributeMultipleValuesInputView = ({
         </div>
       </If>
 
-      {renderAttributeMultipleValuesInput()}
+      <If condition={currentInput}>{renderAttributeMultipleValuesInput()}</If>
     </div>
   );
 };

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/index.tsx
@@ -15,10 +15,14 @@
  */
 
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import If from 'components/If';
+import LoadingSVGCentered from 'components/LoadingSVGCentered';
+import { JSONStatusMessage } from 'components/PluginJSONCreator/Create/Content/JsonMenu';
 import { STEPS } from 'components/PluginJSONCreator/Create/steps';
 import {
   CreateContext,
   createContextConnect,
+  ICreateContext,
 } from 'components/PluginJSONCreator/CreateContextConnect';
 import * as React from 'react';
 
@@ -40,24 +44,48 @@ const styles = (theme): StyleRules => {
   };
 };
 
-interface IContentProps {
-  activeStep: number;
-}
-
-const ContentView: React.FC<IContentProps & WithStyles<typeof styles>> = ({
+const ContentView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
   classes,
   activeStep,
+  JSONStatus,
+  setJSONStatus,
 }) => {
+  const [loading, setLoading] = React.useState(false);
+
+  // When JSON status was successful, show loading view for 500ms
+  // This is in order to force rerender entire component
+  React.useEffect(() => {
+    if (JSONStatus && JSONStatus === JSONStatusMessage.Success) {
+      setLoading(true);
+
+      const timer = setTimeout(() => {
+        setLoading(false);
+        setJSONStatus(JSONStatusMessage.Normal);
+      }, 500);
+
+      return () => {
+        clearTimeout(timer);
+      };
+    }
+  }, [JSONStatus]);
+
   if (!STEPS[activeStep] || !STEPS[activeStep].component) {
     return null;
   }
 
   const Comp = STEPS[activeStep].component;
   return (
-    <div className={classes.root}>
-      <div className={classes.content}>
-        <Comp className={classes.comp} />
-      </div>
+    <div>
+      <If condition={loading}>
+        <LoadingSVGCentered />
+      </If>
+      <If condition={!loading}>
+        <div className={classes.root}>
+          <div className={classes.content}>
+            <Comp className={classes.comp} />
+          </div>
+        </div>
+      </If>
     </div>
   );
 };

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
@@ -16,6 +16,7 @@
 
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import Content from 'components/PluginJSONCreator/Create/Content';
+import { JSONStatusMessage } from 'components/PluginJSONCreator/Create/Content/JsonMenu';
 import WizardGuideline from 'components/PluginJSONCreator/Create/WizardGuideline';
 import {
   CreateContext,
@@ -87,6 +88,35 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     this.setState({ outputName });
   };
 
+  public setJSONStatus = (JSONStatus: string) => {
+    this.setState({ JSONStatus });
+  };
+
+  public setPluginState = ({
+    basicPluginInfo,
+    configurationGroups,
+    groupToInfo,
+    groupToWidgets,
+    widgetInfo,
+    widgetToAttributes,
+    outputName,
+  }) => {
+    const { pluginName, pluginType, displayName, emitAlerts, emitErrors } = basicPluginInfo;
+    this.setState({
+      pluginName,
+      pluginType,
+      displayName,
+      emitAlerts,
+      emitErrors,
+      configurationGroups,
+      groupToInfo,
+      groupToWidgets,
+      widgetInfo,
+      widgetToAttributes,
+      outputName,
+    });
+  };
+
   public state = {
     activeStep: 0,
     pluginName: '',
@@ -101,6 +131,7 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     widgetToAttributes: {},
     jsonView: true,
     outputName: '',
+    JSONStatus: JSONStatusMessage.Normal,
 
     setActiveStep: this.setActiveStep,
     setBasicPluginInfo: this.setBasicPluginInfo,
@@ -111,6 +142,8 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     setWidgetToAttributes: this.setWidgetToAttributes,
     setJsonView: this.setJsonView,
     setOutputName: this.setOutputName,
+    setPluginState: this.setPluginState,
+    setJSONStatus: this.setJSONStatus,
   };
 
   public render() {

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
@@ -14,6 +14,7 @@
  * the License.
  */
 
+import { JSONStatusMessage } from 'components/PluginJSONCreator/Create/Content/JsonMenu';
 import * as React from 'react';
 
 export const CreateContext = React.createContext({});
@@ -32,6 +33,7 @@ interface ICreateState {
   widgetToAttributes: any;
   jsonView: boolean;
   outputName: string;
+  JSONStatus: JSONStatusMessage;
 
   setActiveStep: (step: number) => void;
   setBasicPluginInfo: (basicPluginInfo: IBasicPluginInfo) => void;
@@ -42,6 +44,8 @@ interface ICreateState {
   setWidgetToAttributes: (widgetToAttributes: any) => void;
   setJsonView: (jsonView: boolean) => void;
   setOutputName: (outputName: string) => void;
+  setPluginState: (pluginState: any) => void;
+  setJSONStatus: (JSONStatus: JSONStatusMessage) => void;
 }
 
 export interface IBasicPluginInfo {


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16874

Currently, the plugin JSON creator supports editing JSON file through the user interface. Users are able to see their live progress and download the output.

This PR implements an additional feature where users can upload their own plugin JSON file. Our system will parse the file content and update the interface accordingly. The users can either further edit the file through our UI or choose to proceed with their current file.

Current Progress:
* Updates the UI based on the file content
* JSON file validation
  * Error handling if `file-content` or `file-name` is invalid -> shows error message in the UI

Things to note:
When we import a file of relatively bigger size, the inputs tend to be a bit more laggy. I'm planning to make a separate PR that addresses this speed issue.

**If user uploads the valid file => updates the UI**
<img width="1792" alt="Screen Shot 2020-05-29 at 2 15 47 PM" src="https://user-images.githubusercontent.com/14116152/83291796-eec18080-a1b6-11ea-9268-c50ea1b341d3.png">

**If user uploads the invalid file => doesn't update the UI and shows error message**
<img width="1486" alt="Screen Shot 2020-05-29 at 2 13 25 PM" src="https://user-images.githubusercontent.com/14116152/83291597-97bbab80-a1b6-11ea-9b98-0667d7a80b71.png">