### PR TITLE
CDAP-16855 aggregator spark streaming

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
@@ -134,8 +134,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   @Override
   public SparkCollection<RecordInfo<Object>> reduceAggregate(StageSpec stageSpec, @Nullable Integer partitions,
                                                              StageStatisticsCollector collector) {
-    // TODO: implement
-    throw new UnsupportedOperationException("reduce aggregator not supported");
+    return aggregate(stageSpec, partitions, collector);
   }
 
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/DynamicAggregatorAggregate.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/DynamicAggregatorAggregate.java
@@ -46,7 +46,7 @@ public class DynamicAggregatorAggregate<GROUP_KEY, GROUP_VAL, OUT>
 
   @Override
   public JavaRDD<RecordInfo<Object>> call(JavaPairRDD<GROUP_KEY, Iterable<GROUP_VAL>> input,
-                                               Time batchTime) throws Exception {
+                                          Time batchTime) throws Exception {
     if (function == null) {
       function = Compat.convert(
         new AggregatorAggregateFunction<GROUP_KEY, GROUP_VAL, OUT>(dynamicDriverContext.getPluginFunctionContext()));

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -103,6 +103,7 @@ public class HydratorTestBase extends TestBase {
     IntValueFilterTransform.PLUGIN_CLASS, StringValueFilterTransform.PLUGIN_CLASS, DropNullTransform.PLUGIN_CLASS,
     FilterTransform.PLUGIN_CLASS,
     FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS,
+    FieldCountReducibleAggregator.PLUGIN_CLASS,
     GroupFilterAggregator.PLUGIN_CLASS, MockJoiner.PLUGIN_CLASS, MockAutoJoiner.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
     StringValueFilterCompute.PLUGIN_CLASS, Window.PLUGIN_CLASS,
     FlattenErrorTransform.PLUGIN_CLASS, FilterErrorTransform.PLUGIN_CLASS,


### PR DESCRIPTION
Implemented reducible aggregator for spark streaming by using the same
AggregatorBridge that is used for MapReduce, which means it will behave same as the old aggregator. This is due to the checkpointing in spark streaming and we need more thorough testing on whether macro will work using combineByKey. 

build: https://builds.cask.co/browse/CDAP-RUT1796-1