### PR TITLE
CDAP-16852 handle dynamic schemas in auto join

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineRunner.java
@@ -165,7 +165,7 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
                           "Check with the plugin developer to ensure it is implemented correctly.",
                         stageName));
       }
-      joiner = new JoinerBridge(autoJoiner, joinDefinition);
+      joiner = new JoinerBridge(stageName, autoJoiner, joinDefinition);
     } else if (plugin instanceof BatchJoiner) {
       joiner = (BatchJoiner) plugin;
     } else {

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/io/cdap/cdap/datastreams/DataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/test/java/io/cdap/cdap/datastreams/DataStreamsTest.java
@@ -874,7 +874,8 @@ public class DataStreamsTest extends HydratorTestBase {
       .addStage(new ETLStage("transactions", MockSource.getPlugin(inputSchema2, input2)))
       .addStage(new ETLStage("join", MockAutoJoiner.getPlugin(Arrays.asList("customers", "transactions"),
                                                               Collections.singletonList("customer_id"),
-                                                              Collections.singletonList("transactions"))))
+                                                              Collections.singletonList("transactions"),
+                                                              Collections.emptyList(), Collections.emptyList(), true)))
       .addStage(new ETLStage("sink", MockSink.getPlugin(outputName)))
       .addConnection("customers", "join")
       .addConnection("transactions", "join")
@@ -986,6 +987,7 @@ public class DataStreamsTest extends HydratorTestBase {
       .addStage(new ETLStage("join", MockAutoJoiner.getPlugin(Arrays.asList("customers", "transactions"),
                                                               Collections.singletonList("customer_id"),
                                                               Collections.singletonList("transactions"),
+                                                              Collections.emptyList(), Collections.emptyList(),
                                                               nullSafe)))
       .addStage(new ETLStage("sink", MockSink.getPlugin(outputName)))
       .addConnection("customers", "join")

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/error/JoinError.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/error/JoinError.java
@@ -79,6 +79,7 @@ public class JoinError {
     GENERAL,
     SELECTED_FIELD,
     JOIN_KEY,
-    JOIN_KEY_FIELD
+    JOIN_KEY_FIELD,
+    OUTPUT_SCHEMA
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/error/OutputSchemaError.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/error/OutputSchemaError.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.join.error;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * An error with one of the output schema fields.
+ */
+public class OutputSchemaError extends JoinError {
+  private final String field;
+  private final String expectedType;
+
+  public OutputSchemaError(String field, @Nullable String expectedType, String message) {
+    this(field, expectedType, message, null);
+  }
+
+  public OutputSchemaError(String field, @Nullable String expectedType,
+                           String message, @Nullable String correctiveAction) {
+    super(Type.OUTPUT_SCHEMA, message, correctiveAction);
+    this.field = field;
+    this.expectedType = expectedType;
+  }
+
+  public String getField() {
+    return field;
+  }
+
+  @Nullable
+  public String getExpectedType() {
+    return expectedType;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    OutputSchemaError that = (OutputSchemaError) o;
+    return Objects.equals(field, that.field) &&
+      Objects.equals(expectedType, that.expectedType);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), field, expectedType);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/MapReduceTransformExecutorFactory.java
@@ -75,7 +75,6 @@ import io.cdap.cdap.etl.common.TransformExecutor;
 import io.cdap.cdap.etl.common.plugin.AggregatorBridge;
 import io.cdap.cdap.etl.common.plugin.JoinerBridge;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
-import io.cdap.cdap.etl.validation.DefaultFailureCollector;
 import io.cdap.cdap.etl.validation.LoggingFailureCollector;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Writable;
@@ -201,7 +200,7 @@ public class MapReduceTransformExecutorFactory<T> {
         // definition will be non-null due to validate by PipelinePhasePreparer at the start of the run
         JoinDefinition joinDefinition = autoJoiner.define(context);
         failureCollector.getOrThrowException();
-        batchJoiner = new JoinerBridge(autoJoiner, joinDefinition);
+        batchJoiner = new JoinerBridge(stageName, autoJoiner, joinDefinition);
         JoinCondition condition = joinDefinition.getCondition();
         // null safe equality means A.id = B.id will match when the id is null
         // if it's not null safe, A.id = B.id will not match when the id is null

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/submit/PipelinePhasePreparer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/submit/PipelinePhasePreparer.java
@@ -47,7 +47,6 @@ import io.cdap.cdap.etl.common.PhaseSpec;
 import io.cdap.cdap.etl.common.PipelinePhase;
 import io.cdap.cdap.etl.common.PipelineRuntime;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
-import io.cdap.cdap.etl.validation.DefaultFailureCollector;
 import io.cdap.cdap.etl.validation.LoggingFailureCollector;
 import org.apache.tephra.TransactionFailureException;
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
@@ -340,9 +340,7 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
       .addInputSchemas(pipelineConfigurer.getStageConfigurer().getInputSchemas())
       .setErrorSchema(stageConfigurer.getErrorSchema());
 
-    if (type.equals(SplitterTransform.PLUGIN_TYPE)) {
-      specBuilder.setPortSchemas(stageConfigurer.getOutputPortSchemas());
-    } else {
+    if (!type.equals(SplitterTransform.PLUGIN_TYPE)) {
       specBuilder.setOutputSchema(stageConfigurer.getOutputSchema());
     }
     return specBuilder;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
@@ -19,7 +19,10 @@ package io.cdap.cdap.etl.spark.batch;
 import com.google.common.base.Throwables;
 import com.google.gson.Gson;
 import io.cdap.cdap.api.data.DatasetContext;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.api.spark.sql.DataFrames;
 import io.cdap.cdap.etl.api.Alert;
 import io.cdap.cdap.etl.api.AlertPublisher;
 import io.cdap.cdap.etl.api.AlertPublisherContext;
@@ -61,10 +64,14 @@ import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
+import org.apache.spark.sql.Column;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.storage.StorageLevel;
 import scala.Tuple2;
 
+import java.util.List;
 import javax.annotation.Nullable;
 
 
@@ -266,5 +273,12 @@ public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
 
   protected <U> RDDCollection<U> wrap(JavaRDD<U> rdd) {
     return new RDDCollection<>(sec, jsc, sqlContext, datasetContext, sinkFactory, rdd);
+  }
+
+  protected Column eq(Column left, Column right, boolean isNullSafe) {
+    if (isNullSafe) {
+      return left.eqNullSafe(right);
+    }
+    return left.equalTo(right);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/JoinMergeFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/JoinMergeFunction.java
@@ -70,6 +70,7 @@ public class JoinMergeFunction<JOIN_KEY, INPUT_RECORD, OUT>
     Object plugin = pluginFunctionContext.createPlugin();
     BatchJoiner<K, V, O> joiner;
     if (plugin instanceof BatchAutoJoiner) {
+      String stageName = pluginFunctionContext.getStageName();
       BatchAutoJoiner autoJoiner = (BatchAutoJoiner) plugin;
       AutoJoinerContext autoJoinerContext = pluginFunctionContext.createAutoJoinerContext();
       JoinDefinition joinDefinition = autoJoiner.define(autoJoinerContext);
@@ -77,10 +78,9 @@ public class JoinMergeFunction<JOIN_KEY, INPUT_RECORD, OUT>
       if (joinDefinition == null) {
         throw new IllegalStateException(String.format(
           "Join stage '%s' did not specify a join definition. " +
-            "Check with the plugin developer to ensure it is implemented correctly.",
-          pluginFunctionContext.getStageSpec().getName()));
+            "Check with the plugin developer to ensure it is implemented correctly.", stageName));
       }
-      joiner = new JoinerBridge(autoJoiner, joinDefinition);
+      joiner = new JoinerBridge(stageName, autoJoiner, joinDefinition);
     } else {
       joiner = (BatchJoiner<K, V, O>) plugin;
       BatchJoinerRuntimeContext context = pluginFunctionContext.createBatchRuntimeContext();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/JoinOnFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/JoinOnFunction.java
@@ -64,11 +64,11 @@ public class JoinOnFunction<JOIN_KEY, INPUT_RECORD>
         AutoJoinerContext autoJoinerContext = pluginFunctionContext.createAutoJoinerContext();
         JoinDefinition joinDefinition = autoJoiner.define(autoJoinerContext);
         autoJoinerContext.getFailureCollector().getOrThrowException();
+        String stageName = pluginFunctionContext.getStageName();
         if (joinDefinition == null) {
           throw new IllegalStateException(String.format(
             "Join stage '%s' did not specify a join definition. " +
-              "Check with the plugin developer to ensure it is implemented correctly.",
-            pluginFunctionContext.getStageSpec().getName()));
+              "Check with the plugin developer to ensure it is implemented correctly.", stageName));
         }
         JoinCondition condition = joinDefinition.getCondition();
         /*
@@ -92,7 +92,7 @@ public class JoinOnFunction<JOIN_KEY, INPUT_RECORD>
             .map(JoinStage::getStageName)
             .anyMatch(s -> s.equals(inputStageName));
         }
-        joiner = new JoinerBridge(autoJoiner, joinDefinition);
+        joiner = new JoinerBridge(stageName, autoJoiner, joinDefinition);
       } else {
         joiner = (BatchJoiner<JOIN_KEY, INPUT_RECORD, Object>) plugin;
         BatchJoinerRuntimeContext context = pluginFunctionContext.createBatchRuntimeContext();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Spark1 RDD collection.
@@ -80,7 +81,7 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
 
         Join #1 is a straightforward join between 2 sides.
         Join #2 is a left outer because TMP1 becomes 'required', since it uses required input B.
-        Join #3 is an inner join because even though it contains 2 optional datasets, because 'B' is still required.
+        Join #3 is an inner join even though it contains 2 optional datasets, because 'B' is still required.
      */
     boolean seenRequired = joinRequest.isLeftRequired();
     DataFrame joined = left;
@@ -163,16 +164,10 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
     return (SparkCollection<T>) wrap(output);
   }
 
-  private Column eq(Column left, Column right, boolean isNullSafe) {
-    if (isNullSafe) {
-      return left.eqNullSafe(right);
-    }
-    return left.equalTo(right);
-  }
-
-  private DataFrame toDataFrame(JavaRDD<StructuredRecord> rdd, Schema schema) {
+  private DataFrame toDataFrame(JavaRDD<StructuredRecord> rdd, @Nullable Schema schema) {
     StructType sparkSchema = DataFrames.toDataType(schema);
     JavaRDD<Row> rowRDD = rdd.map(record -> DataFrames.toRow(record, sparkSchema));
     return sqlContext.createDataFrame(rowRDD.rdd(), sparkSchema);
   }
+
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/test/java/io/cdap/cdap/etl/spark/SparkPipelineRunnerTest.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/test/java/io/cdap/cdap/etl/spark/SparkPipelineRunnerTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.join.JoinCondition;
+import io.cdap.cdap.etl.api.join.JoinDefinition;
+import io.cdap.cdap.etl.api.join.JoinField;
+import io.cdap.cdap.etl.api.join.JoinKey;
+import io.cdap.cdap.etl.api.join.JoinStage;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests for SparkPipelineRunner
+ */
+public class SparkPipelineRunnerTest {
+
+  @Test
+  public void testDeriveKeySchema() {
+    /*
+        A: x(int), y(string)
+        B: x(int), yy(string), z(long)
+
+        select A.x as A_x, A.y, B.x as B_x, B.z
+        from A join B on A.x = B.x and A.y = B.yy
+     */
+    Schema outputSchema = Schema.recordOf(
+      "joined",
+      Schema.Field.of("A_x", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("y", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("B_x", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("z", Schema.of(Schema.Type.LONG)));
+
+    JoinStage stageA = JoinStage.builder("A", null).build();
+    JoinStage stageB = JoinStage.builder("B", null).build();
+
+    JoinDefinition joinDefinition = JoinDefinition.builder()
+      .select(new JoinField("A", "x", "A_x"), new JoinField("A", "y"),
+              new JoinField("B", "x", "B_x"), new JoinField("B", "z"))
+      .from(stageA, stageB)
+      .on(JoinCondition.onKeys()
+            .addKey(new JoinKey("A", Arrays.asList("x", "y")))
+            .addKey(new JoinKey("B", Arrays.asList("x", "yy"))).build())
+      .setOutputSchema(outputSchema)
+      .build();
+
+    Map<String, List<String>> keys = new HashMap<>();
+    keys.put("A", Arrays.asList("x", "y"));
+    keys.put("B", Arrays.asList("x", "yy"));
+
+    List<Schema> keySchema = SparkPipelineRunner.deriveKeySchema("joiner", keys, joinDefinition);
+    List<Schema> expected = Arrays.asList(
+      Schema.nullableOf(Schema.of(Schema.Type.INT)),
+      Schema.nullableOf(Schema.of(Schema.Type.STRING)));
+    Assert.assertEquals(expected, keySchema);
+  }
+
+  @Test
+  public void testDeriveInputSchema() {
+    /*
+        A: x(int), y(string)
+        B: x(int), yy(string), z(long)
+
+        select A.x as A_x, A.y, B.x as B_x, B.z as zzz
+        from A join B on A.x = B.x and A.y = B.yy
+     */
+    Schema outputSchema = Schema.recordOf(
+      "joined",
+      Schema.Field.of("A_x", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("y", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("B_x", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("zzz", Schema.of(Schema.Type.LONG)));
+
+    List<JoinField> selectedFields = Arrays.asList(new JoinField("A", "x", "A_x"), new JoinField("A", "y"),
+                                                   new JoinField("B", "x", "B_x"), new JoinField("B", "z", "zzz"));
+
+    List<Schema> keySchema = Arrays.asList(
+      Schema.nullableOf(Schema.of(Schema.Type.INT)),
+      Schema.nullableOf(Schema.of(Schema.Type.STRING)));
+    Schema derived = SparkPipelineRunner.deriveInputSchema("joiner", "A", Arrays.asList("x", "y"), keySchema,
+                                                           selectedFields, outputSchema);
+    Schema expected = Schema.recordOf(
+      "A",
+      Schema.Field.of("x", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+      Schema.Field.of("y", Schema.nullableOf(Schema.of(Schema.Type.STRING))));
+    Assert.assertEquals(expected, derived);
+
+    derived = SparkPipelineRunner.deriveInputSchema("joiner", "B", Arrays.asList("x", "yy"), keySchema,
+                                                    selectedFields, outputSchema);
+    expected = Schema.recordOf(
+      "B",
+      Schema.Field.of("x", Schema.nullableOf(Schema.of(Schema.Type.INT))),
+      Schema.Field.of("yy", Schema.nullableOf(Schema.of(Schema.Type.STRING))),
+      Schema.Field.of("z", Schema.of(Schema.Type.LONG)));
+    Assert.assertEquals(expected, derived);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -43,6 +43,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Spark2 RDD collection.
@@ -82,7 +83,7 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
 
         Join #1 is a straightforward join between 2 sides.
         Join #2 is a left outer because TMP1 becomes 'required', since it uses required input B.
-        Join #3 is an inner join because even though it contains 2 optional datasets, because 'B' is still required.
+        Join #3 is an inner join even though it contains 2 optional datasets, because 'B' is still required.
      */
     boolean seenRequired = joinRequest.isLeftRequired();
     Dataset<Row> joined = left;
@@ -166,16 +167,10 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
     return (SparkCollection<T>) wrap(output);
   }
 
-  private Column eq(Column left, Column right, boolean isNullSafe) {
-    if (isNullSafe) {
-      return left.eqNullSafe(right);
-    }
-    return left.equalTo(right);
-  }
 
-  private Dataset<Row> toDataset(JavaRDD<StructuredRecord> rdd, Schema schema) {
+  protected Dataset<Row> toDataset(JavaRDD<StructuredRecord> rdd, Schema schema) {
     StructType sparkSchema = DataFrames.toDataType(schema);
     JavaRDD<Row> rowRDD = rdd.map(record -> DataFrames.toRow(record, sparkSchema));
-    return sqlContext.createDataset(rowRDD.rdd(), RowEncoder.apply(sparkSchema));
+    return sqlContext.createDataFrame(rowRDD.rdd(), sparkSchema);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSource.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.common.Bytes;


### PR DESCRIPTION
Properly handle the case when the inputs into an auto-join stage
have null schemas due to the schema being unknown at deploy time,
usually because of macros.

In order to support this type of use case, added a way for a
plugin to specify the output schema in the JoinDefinition.
This should be used when the output schema cannot be derived
at deployment time due to macros. This is what the existing
Joiner currently requires the user to do for dynamic join
use cases.

For Spark, the implementation becomes significantly more difficult
due to the fact that the schema of each input stage needs to be
known in the Spark driver, in order to convert RDDs into
DataFrames.

Added logic that derives the input schema using the output schema,
selected fields, and join keys. It is possible to derive
a usable schema when all the join keys are present in the final
output schema.