### PR TITLE
[CDAP-16890] Create a page for filters configuration (widget JSON creator)

### DIFF
--- a/cdap-ui/app/cdap/components/ConfigurationGroup/types.ts
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/types.ts
@@ -46,7 +46,7 @@ export enum PropertyShowConfigTypeEnums {
 export type IPropertyShowConfigTypes =
   | PropertyShowConfigTypeEnums.GROUP
   | PropertyShowConfigTypeEnums.PROPERTY;
-interface IPropertyShowConfig {
+export interface IPropertyShowConfig {
   name: string;
   type?: IPropertyShowConfigTypes;
 }

--- a/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/DynamicPluginFilters.ts
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/DynamicPluginFilters.ts
@@ -15,27 +15,27 @@
  */
 
 // jexl library to parse js expression specified in widget json
-import jexl from 'jexl';
 import {
-  IConfigurationGroup,
-  IWidgetJson,
-  PluginProperties,
-  IWidgetProperty,
-  IPropertyFilter,
   CustomOperator,
+  IConfigurationGroup,
+  IPropertyFilter,
+  IPropertyTypedValues,
   IPropertyValues,
   IPropertyValueType,
-  IPropertyTypedValues,
+  IWidgetJson,
+  IWidgetProperty,
+  PluginProperties,
   PropertyShowConfigTypeEnums,
 } from 'components/ConfigurationGroup/types';
-import flatten from 'lodash/flatten';
-import difference from 'lodash/difference';
-import { objectQuery, isMacro, removeEmptyJsonValues } from 'services/helpers';
 import {
   IProcessedConfigurationGroups,
   processConfigurationGroups,
 } from 'components/ConfigurationGroup/utilities';
+import jexl from 'jexl';
+import difference from 'lodash/difference';
+import flatten from 'lodash/flatten';
 import isPlainObject from 'lodash/isPlainObject';
+import { isMacro, objectQuery, removeEmptyJsonValues } from 'services/helpers';
 
 export interface IFilteredWidgetProperty extends IWidgetProperty {
   show?: boolean;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/BasicPluginInfo/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/BasicPluginInfo/index.tsx
@@ -56,6 +56,11 @@ const BasicPluginInfoView: React.FC<ICreateContext & WithStyles<typeof styles>> 
   setPluginState,
   JSONStatus,
   setJSONStatus,
+  filters,
+  filterToName,
+  filterToCondition,
+  filterToShowList,
+  showToInfo,
 }) => {
   const [localPluginName, setLocalPluginName] = React.useState(pluginName);
   const [localPluginType, setLocalPluginType] = React.useState(pluginType);
@@ -95,6 +100,11 @@ const BasicPluginInfoView: React.FC<ICreateContext & WithStyles<typeof styles>> 
         setPluginState={setPluginState}
         JSONStatus={JSONStatus}
         setJSONStatus={setJSONStatus}
+        filters={filters}
+        filterToName={filterToName}
+        filterToCondition={filterToCondition}
+        filterToShowList={filterToShowList}
+        showToInfo={showToInfo}
       />
       <Heading type={HeadingTypes.h3} label="Basic Plugin Information" />
       <div className={classes.basicPluginInput}>

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/index.tsx
@@ -74,6 +74,11 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
   setPluginState,
   JSONStatus,
   setJSONStatus,
+  filters,
+  filterToName,
+  filterToCondition,
+  filterToShowList,
+  showToInfo,
 }) => {
   const [activeGroupIndex, setActiveGroupIndex] = React.useState(null);
   const [localConfigurationGroups, setLocalConfigurationGroups] = React.useState(
@@ -176,6 +181,11 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
         liveView={liveView}
         setLiveView={setLiveView}
         outputName={outputName}
+        filters={filters}
+        filterToName={filterToName}
+        filterToCondition={filterToCondition}
+        filterToShowList={filterToShowList}
+        showToInfo={showToInfo}
         setPluginState={setPluginState}
         JSONStatus={JSONStatus}
         setJSONStatus={setJSONStatus}

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/Filters/FilterCollection/FilterConditionInput/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/Filters/FilterCollection/FilterConditionInput/index.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { StyleRules, withStyles, WithStyles } from '@material-ui/core/styles';
+import { CustomOperator } from 'components/ConfigurationGroup/types';
+import Heading, { HeadingTypes } from 'components/Heading';
+import If from 'components/If';
+import { OPERATOR_VALUES } from 'components/PluginJSONCreator/constants';
+import PluginInput from 'components/PluginJSONCreator/Create/Content/PluginInput';
+import { ICreateContext, IWidgetInfo } from 'components/PluginJSONCreator/CreateContextConnect';
+import isNil from 'lodash/isNil';
+import * as React from 'react';
+
+const styles = (): StyleRules => {
+  return {
+    filterConditionInput: {
+      marginTop: '10px',
+      marginBottom: '10px',
+    },
+  };
+};
+
+export enum FilterConditionMode {
+  Operator = 'operator',
+  Expression = 'expression',
+}
+
+enum FilterConditionProperty {
+  Expression = 'expression',
+  Property = 'property',
+  Operator = 'operator',
+  Value = 'value',
+}
+
+interface IFilterConditionInputProps extends WithStyles<typeof styles>, ICreateContext {
+  filterID: string;
+}
+
+const FilterConditionInputview: React.FC<IFilterConditionInputProps> = ({
+  classes,
+  filterID,
+  filterToCondition,
+  setFilterToCondition,
+  widgetInfo,
+}) => {
+  const existingCondition = filterToCondition[filterID];
+
+  const [conditionMode, setConditionMode] = React.useState(
+    existingCondition.expression ? FilterConditionMode.Expression : FilterConditionMode.Operator
+  );
+
+  const allWidgetNames = widgetInfo
+    ? Object.values(widgetInfo)
+        .map((info: IWidgetInfo) => info.name)
+        .filter((widgetName) => !isNil(widgetName))
+    : [];
+
+  React.useEffect(() => {
+    // reset condition data
+    if (conditionMode === FilterConditionMode.Expression) {
+      setFilterToCondition((prevObjs) => ({
+        ...prevObjs,
+        [filterID]: { expression: existingCondition.expression },
+      }));
+    } else {
+      setFilterToCondition((prevObjs) => ({
+        ...prevObjs,
+        [filterID]: {
+          property: existingCondition.property,
+          operator: existingCondition.operator,
+          value: existingCondition.value,
+        },
+      }));
+    }
+  }, [conditionMode]);
+
+  function setFilterCondition(conditionProperty: string) {
+    return (val) => {
+      setFilterToCondition((prevObjs) => ({
+        ...prevObjs,
+        [filterID]: { ...prevObjs[filterID], [conditionProperty]: val },
+      }));
+    };
+  }
+
+  return (
+    <If condition={existingCondition}>
+      <Heading type={HeadingTypes.h6} label="Show these widgets by the following condition..." />
+      <div className={classes.filterConditionInput}>
+        <PluginInput
+          widgetType={'radio-group'}
+          value={conditionMode}
+          onChange={setConditionMode}
+          label={'Condition Type'}
+          options={Object.values(FilterConditionMode).map((mode) => ({ id: mode, label: mode }))}
+          layout={'inline'}
+        />
+      </div>
+      <If condition={conditionMode === FilterConditionMode.Expression}>
+        <div className={classes.filterConditionInput}>
+          <PluginInput
+            widgetType={'textbox'}
+            value={existingCondition.expression ? existingCondition.expression : ''}
+            onChange={setFilterCondition(FilterConditionProperty.Expression)}
+            label={FilterConditionProperty.Expression}
+            required={false}
+          />
+        </div>
+      </If>
+      <If condition={conditionMode === FilterConditionMode.Operator}>
+        <div className={classes.filterConditionInput}>
+          <PluginInput
+            widgetType={'select'}
+            value={existingCondition.property}
+            onChange={setFilterCondition(FilterConditionProperty.Property)}
+            label={FilterConditionProperty.Property}
+            options={allWidgetNames}
+          />
+        </div>
+        <div className={classes.filterConditionInput}>
+          <PluginInput
+            widgetType={'select'}
+            value={existingCondition.operator}
+            onChange={setFilterCondition(FilterConditionProperty.Operator)}
+            label={FilterConditionProperty.Operator}
+            options={OPERATOR_VALUES}
+          />
+        </div>
+        <If
+          condition={
+            existingCondition.operator === CustomOperator.EQUALTO ||
+            existingCondition.operator === CustomOperator.NOTEQUALTO
+          }
+        >
+          <div className={classes.filterConditionInput}>
+            <PluginInput
+              widgetType={'textbox'}
+              value={existingCondition.value}
+              onChange={setFilterCondition(FilterConditionProperty.Value)}
+              label={FilterConditionProperty.Value}
+              required={false}
+            />
+          </div>
+        </If>
+      </If>
+    </If>
+  );
+};
+
+const FilterConditionInput = withStyles(styles)(FilterConditionInputview);
+export default FilterConditionInput;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/Filters/FilterCollection/FilterShowlistInput/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/Filters/FilterCollection/FilterShowlistInput/index.tsx
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import IconButton from '@material-ui/core/IconButton';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import AddIcon from '@material-ui/icons/Add';
+import DeleteIcon from '@material-ui/icons/Delete';
+import classnames from 'classnames';
+import { IPropertyShowConfig } from 'components/ConfigurationGroup/types';
+import Heading, { HeadingTypes } from 'components/Heading';
+import If from 'components/If';
+import { SHOW_TYPE_VALUES } from 'components/PluginJSONCreator/constants';
+import PluginInput from 'components/PluginJSONCreator/Create/Content/PluginInput';
+import { ICreateContext, IWidgetInfo } from 'components/PluginJSONCreator/CreateContextConnect';
+import isNil from 'lodash/isNil';
+import * as React from 'react';
+import uuidV4 from 'uuid/v4';
+
+const styles = (): StyleRules => {
+  return {
+    showConfigCollection: {
+      display: 'grid',
+      gridAutoFlow: 'column',
+      width: '100%',
+    },
+    showConfigInput: {
+      gridRow: '1',
+      width: '100%',
+    },
+    showConfigNameInput: {
+      gridColumnStart: '1',
+      gridColumnEnd: '8',
+    },
+    showConfigTypeInput: {
+      gridColumnStart: '9',
+      gridColumnEnd: '15',
+    },
+    showAddDeleteButtonInput: {
+      gridColumnStart: '19',
+      gridColumnEnd: '20',
+    },
+    showAddDeleteButton: {
+      float: 'right',
+    },
+  };
+};
+
+interface IFilterShowlistInputProps extends WithStyles<typeof styles>, ICreateContext {
+  filterID: string;
+}
+
+const FilterShowlistInputView: React.FC<IFilterShowlistInputProps> = ({
+  classes,
+  filterID,
+  filterToShowList,
+  setFilterToShowList,
+  showToInfo,
+  setShowToInfo,
+  widgetInfo,
+}) => {
+  const allWidgetNames = widgetInfo
+    ? Object.values(widgetInfo)
+        .map((info: IWidgetInfo) => info.name)
+        .filter((widgetName) => !isNil(widgetName))
+    : [];
+
+  function setShowProperty(showID: string, property: string) {
+    return (val) => {
+      setShowToInfo((prevObjs) => ({
+        ...prevObjs,
+        [showID]: { ...prevObjs[showID], [property]: val },
+      }));
+    };
+  }
+
+  function addShowToFilter(filterObjID: string, index?: number) {
+    const newShowID = 'Show_' + uuidV4();
+
+    setShowToInfo({
+      ...showToInfo,
+      [newShowID]: {
+        name: '',
+      } as IPropertyShowConfig,
+    });
+
+    if (index === undefined) {
+      setFilterToShowList({
+        ...filterToShowList,
+        [filterObjID]: [...filterToShowList[filterObjID], newShowID],
+      });
+    } else {
+      const showList = filterToShowList[filterObjID];
+
+      if (showList.length === 0) {
+        showList.splice(0, 0, newShowID);
+      } else {
+        showList.splice(index + 1, 0, newShowID);
+      }
+
+      setFilterToShowList({
+        ...filterToShowList,
+        [filterObjID]: showList,
+      });
+    }
+  }
+
+  function deleteShowFromFilter(filterObjID: string, index: number) {
+    const showList = filterToShowList[filterObjID];
+
+    const showToDelete = showList[index];
+
+    showList.splice(index, 1);
+
+    setFilterToShowList({
+      ...filterToShowList,
+      [filterObjID]: showList,
+    });
+
+    const { [showToDelete]: tmp, ...restShowToInfo } = showToInfo;
+    setShowToInfo(restShowToInfo);
+  }
+
+  return (
+    <If condition={!isNil(filterToShowList[filterID])}>
+      <Heading type={HeadingTypes.h6} label="Add widgets to configure" />
+      {filterToShowList[filterID].map((showID: string, showIndex: number) => {
+        return (
+          <If key={showID} condition={showToInfo[showID]}>
+            <div className={classes.showConfigCollection}>
+              <div className={classnames(classes.showConfigInput, classes.showConfigNameInput)}>
+                <PluginInput
+                  widgetType={'select'}
+                  value={showToInfo[showID].name}
+                  onChange={setShowProperty(showID, 'name')}
+                  label={'name'}
+                  options={allWidgetNames}
+                  required={true}
+                />
+              </div>
+              <div className={classnames(classes.showConfigInput, classes.showConfigTypeInput)}>
+                <PluginInput
+                  widgetType={'select'}
+                  value={showToInfo[showID].type}
+                  onChange={setShowProperty(showID, 'type')}
+                  options={SHOW_TYPE_VALUES}
+                  label={'type'}
+                  required={false}
+                />
+              </div>
+              <div
+                className={classnames(classes.showConfigInput, classes.showAddDeleteButtonInput)}
+              >
+                <div className={classes.showAddDeleteButton}>
+                  <IconButton
+                    onClick={() => addShowToFilter(filterID, showIndex)}
+                    data-cy="add-row"
+                  >
+                    <AddIcon fontSize="small" />
+                  </IconButton>
+                  <IconButton
+                    onClick={() => deleteShowFromFilter(filterID, showIndex)}
+                    color="secondary"
+                    data-cy="remove-row"
+                  >
+                    <DeleteIcon fontSize="small" />
+                  </IconButton>
+                </div>
+              </div>
+            </div>
+          </If>
+        );
+      })}
+    </If>
+  );
+};
+
+const FilterShowlistInput = withStyles(styles)(FilterShowlistInputView);
+export default FilterShowlistInput;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/Filters/FilterCollection/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/Filters/FilterCollection/index.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Button from '@material-ui/core/Button';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import { IPropertyShowConfig } from 'components/ConfigurationGroup/types';
+import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
+import If from 'components/If';
+import FilterConditionInput from 'components/PluginJSONCreator/Create/Content/Filters/FilterCollection/FilterConditionInput';
+import FilterShowlistInput from 'components/PluginJSONCreator/Create/Content/Filters/FilterCollection/FilterShowlistInput';
+import { ICreateContext } from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+import uuidV4 from 'uuid/v4';
+
+const styles = (theme): StyleRules => {
+  return {
+    filterInput: {
+      display: 'block',
+      marginTop: '30px',
+      marginBottom: '30px',
+    },
+    nestedFilters: {
+      border: `1px solid ${theme.palette.grey[300]}`,
+      borderRadius: '6px',
+      position: 'relative',
+      padding: '7px',
+      margin: '25px',
+    },
+    filterContainer: {
+      width: '90%',
+    },
+  };
+};
+
+const FilterNameInput = ({ filterID, filterToName, setFilterToName }) => {
+  function setFilterName(filterObjID: string) {
+    return (name) => {
+      setFilterToName((prevObjs) => ({ ...prevObjs, [filterObjID]: name }));
+    };
+  }
+
+  const label = 'Filter Name';
+
+  const widget = {
+    label,
+    'widget-type': 'textbox',
+  };
+
+  const property = {
+    required: false,
+    name: label,
+  };
+
+  return (
+    <WidgetWrapper
+      widgetProperty={widget}
+      pluginProperty={property}
+      value={filterToName[filterID]}
+      onChange={setFilterName(filterID)}
+    />
+  );
+};
+
+const FilterCollectionView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
+  classes,
+  filters,
+  setFilters,
+  filterToName,
+  setFilterToName,
+  filterToCondition,
+  setFilterToCondition,
+  filterToShowList,
+  setFilterToShowList,
+  showToInfo,
+  setShowToInfo,
+  widgetInfo,
+}) => {
+  function addFilter(index: number) {
+    const newFilterID = 'Filter_' + uuidV4();
+
+    const newFilters = [...filters];
+
+    if (newFilters.length === 0) {
+      newFilters.splice(0, 0, newFilterID);
+    } else {
+      newFilters.splice(index + 1, 0, newFilterID);
+    }
+
+    setFilters(newFilters);
+
+    setFilterToName({ ...filterToName, [newFilterID]: '' });
+    setFilterToCondition({ ...filterToCondition, [newFilterID]: {} });
+
+    // put one empty show as a placeholder
+    const newShowID = 'Show_' + uuidV4();
+    setFilterToShowList({
+      ...filterToShowList,
+      [newFilterID]: [newShowID],
+    });
+    setShowToInfo({
+      ...showToInfo,
+      [newShowID]: {
+        name: '',
+      } as IPropertyShowConfig,
+    });
+  }
+
+  function deleteFilter(index: number) {
+    const newFilters = [...filters];
+    const filterToDelete = newFilters[index];
+    newFilters.splice(index, 1);
+    setFilters(newFilters);
+
+    const { [filterToDelete]: name, ...restFilterToName } = filterToName;
+    setFilterToName(restFilterToName);
+
+    const { [filterToDelete]: condition, ...restFilterToCondition } = filterToCondition;
+    setFilterToCondition(restFilterToCondition);
+
+    const { [filterToDelete]: showList, ...restFilterToShowList } = filterToShowList;
+    setFilterToShowList(restFilterToShowList);
+
+    showList.map((show) => {
+      const { [show]: info, ...rest } = showToInfo;
+      setShowToInfo(rest);
+    });
+  }
+
+  return (
+    <div>
+      {filters.map((filterID: string, filterIndex: number) => {
+        return (
+          <div key={filterID} className={classes.nestedFilters}>
+            <div className={classes.filterContainer}>
+              <div>
+                <Button variant="contained" color="primary" onClick={() => addFilter(filterIndex)}>
+                  Add Filter
+                </Button>
+                <Button
+                  variant="contained"
+                  color="inherit"
+                  onClick={() => deleteFilter(filterIndex)}
+                >
+                  Delete Filter
+                </Button>
+                <div className={classes.filterInput}>
+                  <FilterNameInput
+                    filterID={filterID}
+                    filterToName={filterToName}
+                    setFilterToName={setFilterToName}
+                  />
+                </div>
+                <div className={classes.filterInput}>
+                  <FilterShowlistInput
+                    filterID={filterID}
+                    filterToShowList={filterToShowList}
+                    setFilterToShowList={setFilterToShowList}
+                    showToInfo={showToInfo}
+                    setShowToInfo={setShowToInfo}
+                    widgetInfo={widgetInfo}
+                  />
+                </div>
+                <div className={classes.filterInput}>
+                  <FilterConditionInput
+                    filterID={filterID}
+                    filterToCondition={filterToCondition}
+                    setFilterToCondition={setFilterToCondition}
+                    widgetInfo={widgetInfo}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+      <If condition={filters.length === 0}>
+        <Button variant="contained" color="primary" onClick={() => addFilter(0)}>
+          Add Filter
+        </Button>
+      </If>
+    </div>
+  );
+};
+
+const FilterCollection = withStyles(styles)(FilterCollectionView);
+export default FilterCollection;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/Filters/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/Filters/index.tsx
@@ -15,8 +15,8 @@
  */
 
 import Heading, { HeadingTypes } from 'components/Heading';
+import FilterCollection from 'components/PluginJSONCreator/Create/Content/Filters/FilterCollection';
 import JsonMenu from 'components/PluginJSONCreator/Create/Content/JsonMenu';
-import PluginInput from 'components/PluginJSONCreator/Create/Content/PluginInput';
 import StepButtons from 'components/PluginJSONCreator/Create/Content/StepButtons';
 import {
   CreateContext,
@@ -25,7 +25,7 @@ import {
 } from 'components/PluginJSONCreator/CreateContextConnect';
 import * as React from 'react';
 
-const OutputsView: React.FC<ICreateContext> = ({
+const FiltersView: React.FC<ICreateContext> = ({
   pluginName,
   pluginType,
   displayName,
@@ -36,23 +36,35 @@ const OutputsView: React.FC<ICreateContext> = ({
   groupToWidgets,
   widgetInfo,
   widgetToAttributes,
+  filters,
+  setFilters,
+  filterToName,
+  setFilterToName,
+  filterToCondition,
+  setFilterToCondition,
+  filterToShowList,
+  setFilterToShowList,
+  showToInfo,
+  setShowToInfo,
   liveView,
   setLiveView,
   outputName,
-  setOutputName,
+  setPluginState,
   JSONStatus,
   setJSONStatus,
-  setPluginState,
-  filters,
-  filterToName,
-  filterToCondition,
-  filterToShowList,
-  showToInfo,
 }) => {
-  const [localOutputName, setLocalOutputName] = React.useState(outputName);
+  const [localFilters, setLocalFilters] = React.useState(filters);
+  const [localFilterToName, setLocalFilterToName] = React.useState(filterToName);
+  const [localFilterToCondition, setLocalFilterToCondition] = React.useState(filterToCondition);
+  const [localFilterToShowList, setLocalFilterToShowList] = React.useState(filterToShowList);
+  const [localShowToInfo, setLocalShowToInfo] = React.useState(showToInfo);
 
   function saveAllResults() {
-    setOutputName(localOutputName);
+    setFilters(localFilters);
+    setFilterToName(localFilterToName);
+    setFilterToCondition(localFilterToCondition);
+    setFilterToShowList(localFilterToShowList);
+    setShowToInfo(localShowToInfo);
   }
 
   return (
@@ -68,32 +80,36 @@ const OutputsView: React.FC<ICreateContext> = ({
         groupToWidgets={groupToWidgets}
         widgetInfo={widgetInfo}
         widgetToAttributes={widgetToAttributes}
+        filters={localFilters}
+        filterToName={localFilterToName}
+        filterToCondition={localFilterToCondition}
+        filterToShowList={localFilterToShowList}
+        showToInfo={localShowToInfo}
         liveView={liveView}
         setLiveView={setLiveView}
-        outputName={localOutputName}
+        outputName={outputName}
+        setPluginState={setPluginState}
         JSONStatus={JSONStatus}
         setJSONStatus={setJSONStatus}
-        setPluginState={setPluginState}
-        filters={filters}
-        filterToName={filterToName}
-        filterToCondition={filterToCondition}
-        filterToShowList={filterToShowList}
-        showToInfo={showToInfo}
       />
-      <Heading type={HeadingTypes.h3} label="Output" />
-      <br />
-      <PluginInput
-        widgetType={'textbox'}
-        value={localOutputName}
-        onChange={setLocalOutputName}
-        label={'Output Name'}
-        placeholder={'output name'}
-        required={false}
+      <Heading type={HeadingTypes.h3} label="Filters" />
+      <FilterCollection
+        filters={localFilters}
+        setFilters={setLocalFilters}
+        filterToName={localFilterToName}
+        setFilterToName={setLocalFilterToName}
+        filterToCondition={localFilterToCondition}
+        setFilterToCondition={setLocalFilterToCondition}
+        filterToShowList={localFilterToShowList}
+        setFilterToShowList={setLocalFilterToShowList}
+        showToInfo={localShowToInfo}
+        setShowToInfo={setLocalShowToInfo}
+        widgetInfo={widgetInfo}
       />
       <StepButtons nextDisabled={false} onPrevious={saveAllResults} onNext={saveAllResults} />
     </div>
   );
 };
 
-const Outputs = createContextConnect(CreateContext, OutputsView);
-export default Outputs;
+const Filters = createContextConnect(CreateContext, FiltersView);
+export default Filters;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/JsonActionButtons/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/JsonActionButtons/index.tsx
@@ -14,8 +14,9 @@
  * the License.
  */
 
-import { Button, Tooltip } from '@material-ui/core';
+import Button from '@material-ui/core/Button';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import Tooltip from '@material-ui/core/Tooltip';
 import FullscreenExitIcon from '@material-ui/icons/FullscreenExit';
 import GetAppIcon from '@material-ui/icons/GetApp';
 import { JSONStatusMessage } from 'components/PluginJSONCreator/Create/Content/JsonMenu';

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/LiveViewer/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/LiveViewer/index.tsx
@@ -99,11 +99,11 @@ const LiveViewerView: React.FC<ILiveViewerProps> = ({
   downloadDisabled,
   JSONErrorMessage,
 }) => {
-  const [liveViewMode, setLiveViewMode] = React.useState(LiveViewMode.ConfigurationGroupsView);
+  const [liveViewMode, setLiveViewMode] = React.useState(LiveViewMode.JSONView);
 
   // Values needed for Configuration Groups live view
   const [pluginProperties, setPluginProperties] = React.useState(null);
-  const [values, setValues] = React.useState<Record<string, string>>({});
+  const [values, onChange] = React.useState<Record<string, string>>({});
 
   const [loading, setLoading] = React.useState(false);
 

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/index.tsx
@@ -102,6 +102,11 @@ const JsonMenuView: React.FC<ICreateContext & WithStyles<typeof styles>> = (widg
         newWidgetInfo,
         newWidgetToAttributes,
         newOutputName,
+        newFilters,
+        newFilterToName,
+        newFilterToCondition,
+        newFilterToShowList,
+        newShowToInfo,
       } = parsePluginJSON(filename, pluginJSON);
 
       setPluginState({
@@ -112,6 +117,11 @@ const JsonMenuView: React.FC<ICreateContext & WithStyles<typeof styles>> = (widg
         widgetInfo: newWidgetInfo,
         widgetToAttributes: newWidgetToAttributes,
         outputName: newOutputName,
+        filters: newFilters,
+        filterToName: newFilterToName,
+        filterToCondition: newFilterToCondition,
+        filterToShowList: newFilterToShowList,
+        showToInfo: newShowToInfo,
       });
 
       setJSONStatus(JSONStatusMessage.Success);

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/PluginInput/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/PluginInput/index.tsx
@@ -29,10 +29,12 @@ const PluginInput = ({
   keyPlaceholder = null,
   valuePlaceholder = null,
   kvDelimiter = null,
+  layout = null,
 }) => {
   let widgetAttributes;
   if (widgetType !== 'toggle') {
     widgetAttributes = {
+      ...(layout && { layout }),
       ...(delimeter && { delimeter }),
       ...(options && { options }),
       ...(placeholder && { placeholder }),

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/index.tsx
@@ -164,7 +164,7 @@ const WidgetCollectionView: React.FC<IWidgetCollectionProps> = ({
       <div className={classes.widgetContainer}>
         {activeWidgets.map((widgetID, widgetIndex) => {
           return (
-            <If condition={widgetInfo[widgetID]} key={widgetIndex}>
+            <If key={widgetID} condition={widgetInfo[widgetID]}>
               <div className={classes.eachWidget}>
                 <WidgetInput
                   widgetInfo={widgetInfo}

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
@@ -92,6 +92,26 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     this.setState({ JSONStatus });
   };
 
+  public setFilters = (filters: string[]) => {
+    this.setState({ filters });
+  };
+
+  public setFilterToName = (filterToName: any) => {
+    this.setState({ filterToName });
+  };
+
+  public setFilterToCondition = (filterToCondition: any) => {
+    this.setState({ filterToCondition });
+  };
+
+  public setFilterToShowList = (filterToShowList: any) => {
+    this.setState({ filterToShowList });
+  };
+
+  public setShowToInfo = (showToInfo: any) => {
+    this.setState({ showToInfo });
+  };
+
   public setPluginState = ({
     basicPluginInfo,
     configurationGroups,
@@ -100,6 +120,11 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     widgetInfo,
     widgetToAttributes,
     outputName,
+    filters,
+    filterToName,
+    filterToCondition,
+    filterToShowList,
+    showToInfo,
   }) => {
     const { pluginName, pluginType, displayName, emitAlerts, emitErrors } = basicPluginInfo;
     this.setState({
@@ -114,6 +139,11 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
       widgetInfo,
       widgetToAttributes,
       outputName,
+      filters,
+      filterToName,
+      filterToCondition,
+      filterToShowList,
+      showToInfo,
     });
   };
 
@@ -132,6 +162,11 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     liveView: true,
     outputName: '',
     JSONStatus: JSONStatusMessage.Normal,
+    filters: [],
+    filterToName: {},
+    filterToCondition: {},
+    filterToShowList: {},
+    showToInfo: {},
 
     setActiveStep: this.setActiveStep,
     setBasicPluginInfo: this.setBasicPluginInfo,
@@ -144,6 +179,11 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     setOutputName: this.setOutputName,
     setPluginState: this.setPluginState,
     setJSONStatus: this.setJSONStatus,
+    setFilters: this.setFilters,
+    setFilterToName: this.setFilterToName,
+    setFilterToCondition: this.setFilterToCondition,
+    setFilterToShowList: this.setFilterToShowList,
+    setShowToInfo: this.setShowToInfo,
   };
 
   public render() {

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/steps.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/steps.tsx
@@ -16,6 +16,7 @@
 
 import BasicPluginInfo from 'components/PluginJSONCreator/Create/Content/BasicPluginInfo';
 import ConfigurationGroupsCollection from 'components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection';
+import Filters from 'components/PluginJSONCreator/Create/Content/Filters';
 import Outputs from 'components/PluginJSONCreator/Create/Content/Outputs';
 
 export const STEPS = [
@@ -30,5 +31,9 @@ export const STEPS = [
   {
     label: 'Output',
     component: Outputs,
+  },
+  {
+    label: 'Filters',
+    component: Filters,
   },
 ];

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
@@ -34,6 +34,11 @@ interface ICreateState {
   liveView: boolean;
   outputName: string;
   JSONStatus: JSONStatusMessage;
+  filters: string[];
+  filterToName: any;
+  filterToCondition: any;
+  filterToShowList: any;
+  showToInfo: any;
 
   setActiveStep: (step: number) => void;
   setBasicPluginInfo: (basicPluginInfo: IBasicPluginInfo) => void;
@@ -46,6 +51,11 @@ interface ICreateState {
   setOutputName: (outputName: string) => void;
   setPluginState: (pluginState: any) => void;
   setJSONStatus: (JSONStatus: JSONStatusMessage) => void;
+  setFilters: (filters: string[]) => void;
+  setFilterToName: (filterToName: any) => void;
+  setFilterToCondition: (filterToCondition: any) => void;
+  setFilterToShowList: (filterToShowList: any) => void;
+  setShowToInfo: (showToInfo: any) => void;
 }
 
 export interface IBasicPluginInfo {

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/constants.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/constants.tsx
@@ -15,6 +15,7 @@
  */
 
 import { WIDGET_FACTORY } from 'components/AbstractWidget/AbstractWidgetFactory';
+import { CustomOperator, PropertyShowConfigTypeEnums } from 'components/ConfigurationGroup/types';
 import { GLOBALS } from 'services/global-constants';
 
 export const PluginTypes = Object.keys(GLOBALS.pluginTypeToLabel).filter(
@@ -212,3 +213,7 @@ export const CODE_EDITORS = [
 ];
 
 export const SPEC_VERSION = '1.5';
+
+// FILTER PAGE
+export const OPERATOR_VALUES = Object.values(CustomOperator);
+export const SHOW_TYPE_VALUES = Object.values(PropertyShowConfigTypeEnums);


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16890

In plugin JSON file, there is a key called `filters`. `filters` is a list of plugin properties that configures show / hide of the widgets.

This PR creates a page for `filters` field configuration. 

Current Progress:
* Users are able to configure `filters` in the UI by editing input fields.
* Import `filters` by parsing the file content
* In the `ConfigurationGroups` view, certain widgets are hidden if it is specified so in the `filters` field.

<img width="1768" alt="Screen Shot 2020-06-02 at 12 48 33 PM" src="https://user-images.githubusercontent.com/14116152/83546922-749f3d80-a4cf-11ea-9426-836bacef371c.png">

<img width="1776" alt="Screen Shot 2020-06-02 at 12 55 20 PM" src="https://user-images.githubusercontent.com/14116152/83547503-55ed7680-a4d0-11ea-953d-933f11ca4f10.png">
