### PR TITLE
(CDAP-16669) New Dataproc provisioner for existing cluster

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -574,14 +574,7 @@
                       </directory>
                       <includes>
                         <include>*.jar</include>
-                      </includes>
-                    </resource>
-                    <resource>
-                      <directory>
-                        ${project.parent.basedir}/cdap-runtime-ext-emr/src/main/resources
-                      </directory>
-                      <includes>
-                        <include>aws-emr.json</include>
+                        <include>*.json</include>
                       </includes>
                     </resource>
                   </resources>
@@ -602,14 +595,7 @@
                       </directory>
                       <includes>
                         <include>*.jar</include>
-                      </includes>
-                    </resource>
-                    <resource>
-                      <directory>
-                        ${project.parent.basedir}/cdap-runtime-ext-dataproc/src/main/resources
-                      </directory>
-                      <includes>
-                        <include>gcp-dataproc.json</include>
+                        <include>*.json</include>
                       </includes>
                     </resource>
                   </resources>
@@ -630,14 +616,7 @@
                       </directory>
                       <includes>
                         <include>*.jar</include>
-                      </includes>
-                    </resource>
-                    <resource>
-                      <directory>
-                        ${project.parent.basedir}/cdap-runtime-ext-remote-hadoop/src/main/resources
-                      </directory>
-                      <includes>
-                        <include>remote-hadoop.json</include>
+                        <include>*.json</include>
                       </includes>
                     </resource>
                   </resources>

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -20,12 +20,22 @@ import com.google.api.gax.paging.Page;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageBatch;
+import com.google.common.base.Splitter;
+import com.google.common.io.CharStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
@@ -38,6 +48,13 @@ public final class DataprocUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataprocUtils.class);
   private static final String GS_PREFIX = "gs://";
+
+  // keys and values cannot be longer than 63 characters
+  // keys and values can only contain lowercase letters, numbers, underscores, and dashes
+  // keys must start with a lowercase letter
+  // keys cannot be empty
+  private static final Pattern LABEL_KEY_PATTERN = Pattern.compile("^[a-z][a-z0-9_-]{0,62}$");
+  private static final Pattern LABEL_VAL_PATTERN = Pattern.compile("^[a-z0-9_-]{0,63}$");
 
   /**
    * Deletes provided directory path on GCS.
@@ -108,14 +125,132 @@ public final class DataprocUtils {
   }
 
   /**
+   * Parses labels that are expected to be of the form key1=val1,key2=val2 into a map of key values.
+   *
+   * If a label key or value is invalid, a message will be logged but the key-value will not be returned in the map.
+   * Keys and values cannot be longer than 63 characters.
+   * Keys and values can only contain lowercase letters, numeric characters, underscores, and dashes.
+   * Keys must start with a lowercase letter and must not be empty.
+   *
+   * If a label is given without a '=', the label value will be empty.
+   * If a label is given as 'key=', the label value will be empty.
+   * If a label has multiple '=', it will be ignored. For example, 'key=val1=val2' will be ignored.
+   *
+   * @param labelsStr the labels string to parse
+   * @return valid labels from the parsed string
+   */
+  public static Map<String, String> parseLabels(String labelsStr) {
+    Splitter labelSplitter = Splitter.on(',').trimResults().omitEmptyStrings();
+    Splitter kvSplitter = Splitter.on('=').trimResults().omitEmptyStrings();
+
+    Map<String, String> validLabels = new HashMap<>();
+    for (String keyvalue : labelSplitter.split(labelsStr)) {
+      Iterator<String> iter = kvSplitter.split(keyvalue).iterator();
+      if (!iter.hasNext()) {
+        continue;
+      }
+      String key = iter.next();
+      String val = iter.hasNext() ? iter.next() : "";
+      if (iter.hasNext()) {
+        LOG.warn("Ignoring invalid label {}. Labels should be of the form 'key=val' or just 'key'", keyvalue);
+        continue;
+      }
+      if (!LABEL_KEY_PATTERN.matcher(key).matches()) {
+        LOG.warn("Ignoring invalid label key {}. Label keys cannot be longer than 63 characters, must start with "
+                   + "a lowercase letter, and can only contain lowercase letters, numeric characters, underscores,"
+                   + " and dashes.", key);
+        continue;
+      }
+      if (!LABEL_VAL_PATTERN.matcher(val).matches()) {
+        LOG.warn("Ignoring invalid label value {}. Label values cannot be longer than 63 characters, "
+                   + "and can only contain lowercase letters, numeric characters, underscores, and dashes.", val);
+        continue;
+      }
+      validLabels.put(key, val);
+    }
+    return validLabels;
+  }
+
+  /**
    * Parses the given list of IP CIDR blocks into list of {@link IPRange}.
    */
   public static List<IPRange> parseIPRanges(List<String> ranges) {
     return ranges.stream().map(IPRange::new).collect(Collectors.toList());
   }
 
+  /**
+   * Get network from the metadata server.
+   */
+  public static String getSystemNetwork() {
+    try {
+      String network = getMetadata("instance/network-interfaces/0/network");
+      // will be something like projects/<project-number>/networks/default
+      return network.substring(network.lastIndexOf('/') + 1);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Unable to get the network from the environment. "
+                                           + "Please explicitly set the network.", e);
+    }
+  }
+
+  /**
+   * Get zone from the metadata server.
+   */
+  public static String getSystemZone() {
+    try {
+      String zone = getMetadata("instance/zone");
+      // will be something like projects/<project-number>/zones/us-east1-b
+      return zone.substring(zone.lastIndexOf('/') + 1);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Unable to get the zone from the environment. "
+                                           + "Please explicitly set the zone.", e);
+    }
+  }
+
+  /**
+   * Returns the region of the given zone.
+   */
+  public static String getRegionFromZone(String zone) {
+    int idx = zone.lastIndexOf("-");
+    if (idx <= 0) {
+      throw new IllegalArgumentException("Invalid zone. Zone must be in the format of <region>-<zone-name>");
+    }
+    return zone.substring(0, idx);
+  }
+
+  /**
+   * Get project id from the metadata server.
+   */
+  public static String getSystemProjectId() {
+    try {
+      return getMetadata("project/project-id");
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Unable to get project id from the environment. "
+                                           + "Please explicitly set the project id and account key.", e);
+    }
+  }
+
+  /**
+   * Makes a request to the metadata server that lives on the VM, as described at
+   * https://cloud.google.com/compute/docs/storing-retrieving-metadata.
+   */
+  private static String getMetadata(String resource) throws IOException {
+    URL url = new URL("http://metadata.google.internal/computeMetadata/v1/" + resource);
+    HttpURLConnection connection = null;
+    try {
+      connection = (HttpURLConnection) url.openConnection();
+      connection.setRequestProperty("Metadata-Flavor", "Google");
+      connection.connect();
+      try (Reader reader = new InputStreamReader(connection.getInputStream(), StandardCharsets.UTF_8)) {
+        return CharStreams.toString(reader);
+      }
+    } finally {
+      if (connection != null) {
+        connection.disconnect();
+      }
+    }
+  }
+
   private DataprocUtils() {
     // no-op
   }
-
 }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner.dataproc;
+
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import io.cdap.cdap.runtime.spi.common.DataprocUtils;
+import io.cdap.cdap.runtime.spi.provisioner.Capabilities;
+import io.cdap.cdap.runtime.spi.provisioner.Cluster;
+import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
+import io.cdap.cdap.runtime.spi.provisioner.Provisioner;
+import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
+import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSpecification;
+import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSystemContext;
+import io.cdap.cdap.runtime.spi.runtimejob.DataprocClusterInfo;
+import io.cdap.cdap.runtime.spi.runtimejob.DataprocRuntimeJobManager;
+import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobDetail;
+import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * Abstract implementation for Dataproc based {@link Provisioner}.
+ */
+public abstract class AbstractDataprocProvisioner implements Provisioner {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractDataprocProvisioner.class);
+
+  // The property name for the GCS bucket used by the runtime job manager for launching jobs via the job API
+  // It can be overridden by profile runtime arguments (system.profile.properties.bucket)
+  private static final String BUCKET = "bucket";
+  // Keys for looking up system properties
+  private static final String LABELS_PROPERTY = "labels";
+
+  private final ProvisionerSpecification spec;
+  private ProvisionerSystemContext systemContext;
+
+  protected AbstractDataprocProvisioner(ProvisionerSpecification spec) {
+    this.spec = spec;
+  }
+
+  @Override
+  public final ProvisionerSpecification getSpec() {
+    return spec;
+  }
+
+  @Override
+  public final void initialize(ProvisionerSystemContext systemContext) {
+    this.systemContext = systemContext;
+  }
+
+  @Override
+  public final void deleteCluster(ProvisionerContext context, Cluster cluster) throws Exception {
+    deleteClusterWithStatus(context, cluster);
+  }
+
+  @Override
+  public final ClusterStatus deleteClusterWithStatus(ProvisionerContext context, Cluster cluster) throws Exception {
+    Map<String, String> properties = createContextProperties(context);
+    DataprocConf conf = DataprocConf.create(properties);
+    RuntimeJobManager jobManager = getRuntimeJobManager(context).orElse(null);
+
+    // If there is job manager, check to make sure the job is completed.
+    // Also cleanup files created by the job run.
+    if (jobManager != null) {
+      try {
+        RuntimeJobDetail jobDetail = jobManager.getDetail(context.getProgramRunInfo()).orElse(null);
+        if (jobDetail != null && !jobDetail.getStatus().isTerminated()) {
+          return ClusterStatus.RUNNING;
+        }
+      } finally {
+        jobManager.close();
+      }
+
+      Storage storageClient = StorageOptions.newBuilder().setProjectId(conf.getProjectId())
+        .setCredentials(conf.getDataprocCredentials()).build().getService();
+      DataprocUtils.deleteGCSPath(storageClient, properties.get(BUCKET),
+                                  DataprocUtils.CDAP_GCS_ROOT + "/" + context.getProgramRunInfo().getRun());
+    }
+
+    doDeleteCluster(context, cluster, conf);
+    return ClusterStatus.DELETING;
+  }
+
+  /**
+   * Gets the cluster name for the given context
+   *
+   * @param context the context
+   * @return a string that is a valid cluster name
+   */
+  protected abstract String getClusterName(ProvisionerContext context);
+
+  /**
+   * Performs the delete cluster action.
+   *
+   * @param context the {@link ProvisionerContext} for this delete operation
+   * @param cluster the {@link Cluster} to be deleted
+   * @param conf the {@link DataprocConf} for talking to Dataproc
+   * @throws Exception if failed to delete cluster
+   */
+  protected abstract void doDeleteCluster(ProvisionerContext context,
+                                          Cluster cluster, DataprocConf conf) throws Exception;
+
+  /**
+   * Returns the {@link ProvisionerSystemContext} that was passed to the {@link #initialize(ProvisionerSystemContext)}
+   * method. The system properties will be reloaded via the {@link ProvisionerSystemContext#reloadProperties()}
+   * method upon every time when this method is called.
+   */
+  protected ProvisionerSystemContext getSystemContext() {
+    ProvisionerSystemContext context = Objects.requireNonNull(
+      systemContext, "System context is not available. Please make sure the initialize method has been called.");
+    context.reloadProperties();
+    return context;
+  }
+
+  /**
+   * Provides implementation of {@link RuntimeJobManager}.
+   */
+  @Override
+  public Optional<RuntimeJobManager> getRuntimeJobManager(ProvisionerContext context) {
+    Map<String, String> properties = createContextProperties(context);
+    DataprocConf conf = DataprocConf.create(properties);
+
+    // if this system property is not provided, we will assume that ssh should be used instead of
+    // runtime job manager for job launch.
+    if (!conf.isRuntimeJobManagerEnabled()) {
+      return Optional.empty();
+    }
+    String clusterName = getClusterName(context);
+    String projectId = conf.getProjectId();
+    String region = conf.getRegion();
+    String bucket = properties.get(BUCKET);
+
+    Map<String, String> systemLabels = getSystemLabels();
+    try {
+      return Optional.of(
+        new DataprocRuntimeJobManager(new DataprocClusterInfo(context, clusterName, conf.getDataprocCredentials(),
+                                                              DataprocClient.DATAPROC_GOOGLEAPIS_COM_443,
+                                                              projectId, region, bucket, systemLabels)));
+    } catch (Exception e) {
+      throw new RuntimeException("Error while getting credentials for dataproc. ", e);
+    }
+  }
+
+  @Override
+  public Capabilities getCapabilities() {
+    return new Capabilities(Collections.unmodifiableSet(new HashSet<>(Arrays.asList("fileSet", "externalDataset"))));
+  }
+
+  /**
+   * Returns {@code true} if the given property name from the system context properties
+   * is a default property name for the dataproc config context.
+   */
+  protected boolean isDefaultContextProperty(String property) {
+    if (DataprocConf.CLUSTER_PROPERTIES_PATTERN.matcher(property).find()) {
+      return true;
+    }
+    return ImmutableSet.of(DataprocConf.RUNTIME_JOB_MANAGER, BUCKET).contains(property);
+  }
+
+  /**
+   * Returns a map of default properties to be used for {@link DataprocConf}.
+   */
+  protected Map<String, String> getDefaultContextProperties() {
+    Map<String, String> systemProps = getSystemContext().getProperties();
+
+    // Copy set of default context properties from the system context
+    return systemProps.entrySet().stream()
+      .filter(e -> e.getValue() != null)
+      .filter(e -> isDefaultContextProperty(e.getKey()))
+      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  protected final Map<String, String> createContextProperties(ProvisionerContext context) {
+    Map<String, String> contextProperties = new HashMap<>(context.getProperties());
+
+    // Set the project id based on the context if needed
+    String projectId = getProjectId(context);
+    if (projectId != null) {
+      LOG.trace("Setting Dataproc project ID to {}", projectId);
+      contextProperties.put(DataprocConf.PROJECT_ID_KEY, projectId);
+    }
+
+    // Add default properties
+    getDefaultContextProperties().entrySet().stream()
+      .filter(e -> !contextProperties.containsKey(e.getKey()))
+      .forEach(e -> contextProperties.put(e.getKey(), e.getValue()));
+    return contextProperties;
+  }
+
+  /**
+   * Returns a set of system labels that should be applied to all Dataproc entities.
+   */
+  protected final Map<String, String> getSystemLabels() {
+    Map<String, String> labels = new HashMap<>();
+    ProvisionerSystemContext systemContext = getSystemContext();
+
+    // dataproc only allows label values to be lowercase letters, numbers, or dashes
+    String cdapVersion = systemContext.getCDAPVersion().toLowerCase();
+    cdapVersion = cdapVersion.replaceAll("\\.", "_");
+    labels.put("cdap-version", cdapVersion);
+
+    String extraLabelsStr = systemContext.getProperties().get(LABELS_PROPERTY);
+    // labels are expected to be in format:
+    // name1=val1,name2=val2
+    if (extraLabelsStr != null) {
+      labels.putAll(DataprocUtils.parseLabels(extraLabelsStr));
+    }
+
+    return Collections.unmodifiableMap(labels);
+  }
+
+  /**
+   * Returns the project id based on the given context and the system context. If none is provided, a {@code null}
+   * value will be returned.
+   */
+  @Nullable
+  private String getProjectId(ProvisionerContext context) {
+    // Default the project id from system config if missing or if it is auto-detect
+    String projectId = context.getProperties().get(DataprocConf.PROJECT_ID_KEY);
+    if (Strings.isNullOrEmpty(projectId) || DataprocConf.AUTO_DETECT.equals(projectId)) {
+      projectId = getSystemContext().getProperties().getOrDefault(DataprocConf.PROJECT_ID_KEY, projectId);
+    }
+    return projectId;
+  }
+}

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -50,7 +50,7 @@ import com.google.cloud.dataproc.v1beta2.GetClusterRequest;
 import com.google.cloud.dataproc.v1beta2.InstanceGroupConfig;
 import com.google.cloud.dataproc.v1beta2.NodeInitializationAction;
 import com.google.cloud.dataproc.v1beta2.SoftwareConfig;
-import com.google.common.base.Strings;
+import com.google.common.base.MoreObjects;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsClient;
 import com.google.rpc.Status;
@@ -94,14 +94,10 @@ final class DataprocClient implements AutoCloseable {
                                                                                                    "172.16.0.0/12",
                                                                                                    "192.168.0.0/16"));
   static final String DATAPROC_GOOGLEAPIS_COM_443 = "-dataproc.googleapis.com:443";
-
   private final DataprocConf conf;
   private final ClusterControllerClient client;
   private final Compute compute;
-  private final String projectId;
-  private final String networkHostProjectId;
-  private final String network;
-  private final boolean useInternalIP;
+  private final Network network;
 
   private enum PeeringState {
     ACTIVE,
@@ -109,25 +105,31 @@ final class DataprocClient implements AutoCloseable {
     NONE
   }
 
-  static DataprocClient fromConf(DataprocConf conf,
-                                 boolean privateInstance) throws IOException, GeneralSecurityException {
+  /**
+   * Creates a {@link DataprocClient} from the given {@link DataprocConf}.
+   *
+   * @param conf the configuration for the client
+   * @return a {@link DataprocClient} instance for using Dataproc API
+   * @throws IOException if failed to connect to GCP api during the client creation
+   * @throws GeneralSecurityException if the client is failed to authenticate
+   */
+  static DataprocClient fromConf(DataprocConf conf) throws IOException, GeneralSecurityException {
     ClusterControllerClient client = getClusterControllerClient(conf);
     Compute compute = getCompute(conf);
 
     String network = conf.getNetwork();
     String systemNetwork = null;
     try {
-      systemNetwork = DataprocConf.getSystemNetwork();
+      systemNetwork = DataprocUtils.getSystemNetwork();
     } catch (IllegalArgumentException e) {
       // expected when not running on GCP, ignore
     }
 
     String projectId = conf.getProjectId();
-    String networkHostProjectID = Strings.isNullOrEmpty(conf.getNetworkHostProjectID()) ? projectId :
-      conf.getNetworkHostProjectID();
+    String networkHostProjectId = conf.getNetworkHostProjectID();
     String systemProjectId = null;
     try {
-      systemProjectId = DataprocConf.getSystemProjectId();
+      systemProjectId = DataprocUtils.getSystemProjectId();
     } catch (IllegalArgumentException e) {
       // expected when not running on GCP, ignore
     }
@@ -138,43 +140,20 @@ final class DataprocClient implements AutoCloseable {
     } else if (network == null) {
       // Otherwise, pick a network from the configured project using the Compute API
 
-      network = findNetwork(networkHostProjectID, compute);
+      network = findNetwork(networkHostProjectId, compute);
     }
     if (network == null) {
       throw new IllegalArgumentException("Unable to automatically detect a network, please explicitly set a network.");
     }
 
     String subnet = conf.getSubnet();
-    Network networkInfo = getNetworkInfo(networkHostProjectID, network, compute);
-
-    PeeringState state = getPeeringState(systemNetwork, systemProjectId, networkInfo);
-
-    if (conf.isPreferExternalIP() && state == PeeringState.ACTIVE) {
-      // Peering is setup between the system network and customer network and is in ACTIVE state.
-      // However user has selected to preferred external IP the instance. This is not a private instance and is
-      // capable of communicating with Dataproc cluster with external ip so just add warning message indicating that
-      // internal IP can be used.
-      LOG.info(String.format("VPC Peering from network '%s' in project '%s' to network '%s' " +
-                               "in project '%s' is in the ACTIVE state. Prefer External IP can be set to false " +
-                               "to launch Dataproc clusters with internal IP only.", systemNetwork,
-                             systemProjectId, network, networkHostProjectID));
-    }
-
-    // Use internal IP for the Dataproc cluster if instance is private
-    // or
-    // user has not preferred external IP and (CDAP is running in the same customer project as Dataproc is going to
-    // be launched
-    // or
-    // Network peering is done between customer network and system network and is in ACTIVE mode).
-    boolean useInternalIP = privateInstance ||
-      !conf.isPreferExternalIP() && ((network.equals(systemNetwork) && networkHostProjectID.equals(systemProjectId)) ||
-      state == PeeringState.ACTIVE);
+    Network networkInfo = getNetworkInfo(networkHostProjectId, network, compute);
 
     List<String> subnets = networkInfo.getSubnetworks();
     if (subnet != null && !subnetExists(subnets, subnet)) {
       throw new IllegalArgumentException(String.format("Subnet '%s' does not exist in network '%s' in project '%s'. "
                                                          + "Please use a different subnet.",
-                                                       subnet, network, networkHostProjectID));
+                                                       subnet, network, networkHostProjectId));
     }
 
     // if the network uses custom subnets, a subnet must be provided to the dataproc api
@@ -185,22 +164,16 @@ final class DataprocClient implements AutoCloseable {
       if (subnets == null || subnets.isEmpty()) {
         throw new IllegalArgumentException(String.format("Network '%s' in project '%s' does not contain any subnets. "
                                                            + "Please create a subnet or use a different network.",
-                                                         network, networkHostProjectID));
+                                                         network, networkHostProjectId));
       }
     }
 
     subnet = chooseSubnet(network, subnets, subnet, conf.getRegion());
 
-    return new DataprocClient(new DataprocConf(conf, network, subnet), client, compute, useInternalIP);
+    return new DataprocClient(new DataprocConf(conf, network, subnet), client, compute, networkInfo);
   }
 
-  private static PeeringState getPeeringState(@Nullable String systemNetwork,
-                                              String systemProjectId, Network networkInfo) {
-    // systemNetwork can be null when CDAP is not running on GCP for example CDAP running in sandbox environment
-    if (systemNetwork == null) {
-      return PeeringState.NONE;
-    }
-
+  private static PeeringState getPeeringState(String systemProjectId, String systemNetwork, Network networkInfo) {
     // note: vpc network is a global resource.
     // https://cloud.google.com/compute/docs/regions-zones/global-regional-zonal-resources#globalresources
     String systemNetworkPath = String.format("https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s",
@@ -261,7 +234,7 @@ final class DataprocClient implements AutoCloseable {
                                                          + "Please create a network in the project.", project));
     }
 
-    for (Network network: networks) {
+    for (Network network : networks) {
       if ("default".equals(network.getName())) {
         return network.getName();
       }
@@ -290,6 +263,9 @@ final class DataprocClient implements AutoCloseable {
     return zoneUri.substring(idx + 1);
   }
 
+  /*
+   * Using the input Google Credentials retrieve the Dataproc Cluster controller client
+   */
   private static ClusterControllerClient getClusterControllerClient(DataprocConf conf) throws IOException {
     CredentialsProvider credentialsProvider = FixedCredentialsProvider.create(conf.getDataprocCredentials());
 
@@ -302,6 +278,9 @@ final class DataprocClient implements AutoCloseable {
     return ClusterControllerClient.create(controllerSettings);
   }
 
+  /*
+   * Retrieve Google Compute Instance using Credentials
+   */
   private static Compute getCompute(DataprocConf conf) throws GeneralSecurityException, IOException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     return new Compute.Builder(httpTransport, JacksonFactory.getDefaultInstance(), conf.getComputeCredential())
@@ -309,30 +288,29 @@ final class DataprocClient implements AutoCloseable {
       .build();
   }
 
-  private DataprocClient(DataprocConf conf, ClusterControllerClient client, Compute compute, boolean useInternalIP) {
-    this.projectId = conf.getProjectId();
-    this.network = conf.getNetwork();
-    this.networkHostProjectId = Strings.isNullOrEmpty(conf.getNetworkHostProjectID()) ? projectId :
-      conf.getNetworkHostProjectID();
-    this.useInternalIP = useInternalIP;
+  private DataprocClient(DataprocConf conf, ClusterControllerClient client, Compute compute, Network network) {
     this.conf = conf;
     this.client = client;
     this.compute = compute;
+    this.network = network;
   }
 
   /**
    * Create a cluster. This will return after the initial request to create the cluster is completed.
    * At this point, the cluster is likely not yet running, but in a provisioning state.
-   * @param name the name of the cluster to create
+   *
+   * @param name         the name of the cluster to create
    * @param imageVersion the image version for the cluster
-   * @param labels labels to set on the cluster
+   * @param labels       labels to set on the cluster
+   * @param privateInstance {@code true} to indicate using private instance
    * @return create operation metadata
-   * @throws InterruptedException if the thread was interrupted while waiting for the initial request to complete
-   * @throws AlreadyExistsException if the cluster already exists
-   * @throws IOException if there was an I/O error talking to Google Compute APIs
+   * @throws InterruptedException        if the thread was interrupted while waiting for the initial request to complete
+   * @throws AlreadyExistsException      if the cluster already exists
+   * @throws IOException                 if there was an I/O error talking to Google Compute APIs
    * @throws RetryableProvisionException if there was a non 4xx error code returned
    */
-  public ClusterOperationMetadata createCluster(String name, String imageVersion, Map<String, String> labels)
+  ClusterOperationMetadata createCluster(String name, String imageVersion, Map<String, String> labels,
+                                         boolean privateInstance)
     throws RetryableProvisionException, InterruptedException, IOException {
 
     try {
@@ -360,51 +338,37 @@ final class DataprocClient implements AutoCloseable {
       if (conf.getZone() != null) {
         clusterConfig.setZoneUri(conf.getZone());
       }
-      String networkHostProjectId = Strings.isNullOrEmpty(conf.getNetworkHostProjectID()) ? projectId :
-        conf.getNetworkHostProjectID();
 
       // subnets are unique within a location, not within a network, which is why these configs are mutually exclusive.
       if (conf.getSubnet() != null) {
         clusterConfig.setSubnetworkUri(conf.getSubnet());
       } else {
-        clusterConfig.setNetworkUri(String.format("projects/%s/global/networks/%s", networkHostProjectId,
-                                                  conf.getNetwork()));
+        clusterConfig.setNetworkUri(network.getSelfLink());
       }
 
       //Add any defined Network Tags
       clusterConfig.addAllTags(conf.getNetworkTags());
+      boolean internalIPOnly = isInternalIPOnly(privateInstance, publicKey != null);
 
       // if public key is not null that means ssh is used to launch / monitor job on dataproc
       if (publicKey != null) {
         int maxTags = Math.max(0, DataprocConf.MAX_NETWORK_TAGS - clusterConfig.getTagsCount());
-        List<String> tags = getFirewallTargetTags(useInternalIP);
+        List<String> tags = getFirewallTargetTags(internalIPOnly);
         if (tags.size() > maxTags) {
           LOG.warn("No more than 64 tags can be added. Firewall tags ignored: {}", tags.subList(maxTags, tags.size()));
         }
         tags.stream().limit(maxTags).forEach(clusterConfig::addTags);
       }
 
-      // if internal ip is prefered then create dataproc cluster without external ip for better security
-      if (useInternalIP) {
-        clusterConfig.setInternalIpOnly(true);
-      }
+      // if internal ip is preferred then create dataproc cluster without external ip for better security
+      clusterConfig.setInternalIpOnly(internalIPOnly);
 
       Map<String, String> clusterProperties = new HashMap<>(conf.getClusterProperties());
-      // The additional property is needed to be able to provision a singlenode cluster on
-      // dataproc. Dataproc has an issue that it will treat 0 number of worker
-      // nodes as the default number, which means it will always provision a
-      // cluster with 2 worker nodes if this property is not set. Refer to
-      // https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/single-node-clusters
-      // for more information.
-      clusterProperties.put("dataproc:dataproc.allow.zero.workers", "true");
       // Enable/Disable stackdriver
       clusterProperties.put("dataproc:dataproc.logging.stackdriver.enable",
-                        Boolean.toString(conf.isStackdriverLoggingEnabled()));
+                            Boolean.toString(conf.isStackdriverLoggingEnabled()));
       clusterProperties.put("dataproc:dataproc.monitoring.stackdriver.enable",
-                        Boolean.toString(conf.isStackdriverMonitoringEnabled()));
-      // enable container logs by default for ephemeral clusters.
-      clusterProperties.put("yarn:yarn.nodemanager.delete.debug-delay-sec", "86400");
-
+                            Boolean.toString(conf.isStackdriverMonitoringEnabled()));
 
       ClusterConfig.Builder builder = ClusterConfig.newBuilder()
         .setEndpointConfig(EndpointConfig.newBuilder()
@@ -455,7 +419,7 @@ final class DataprocClient implements AutoCloseable {
         .build();
 
       OperationFuture<Cluster, ClusterOperationMetadata> operationFuture =
-        client.createClusterAsync(projectId, conf.getRegion(), cluster);
+        client.createClusterAsync(conf.getProjectId(), conf.getRegion(), cluster);
       return operationFuture.getMetadata().get();
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
@@ -479,7 +443,7 @@ final class DataprocClient implements AutoCloseable {
     try {
       DeleteClusterRequest request = DeleteClusterRequest.newBuilder()
         .setClusterName(name)
-        .setProjectId(projectId)
+        .setProjectId(conf.getProjectId())
         .setRegion(conf.getRegion())
         .build();
 
@@ -529,7 +493,7 @@ final class DataprocClient implements AutoCloseable {
     // if it failed, try to get the create operation and log the error message
     try {
       if (status == io.cdap.cdap.runtime.spi.provisioner.ClusterStatus.FAILED) {
-        String resourceName = String.format("projects/%s/regions/%s/operations", projectId, conf.getRegion());
+        String resourceName = String.format("projects/%s/regions/%s/operations", conf.getProjectId(), conf.getRegion());
         String filter = String.format("clusterName=%s AND operationType=CREATE", name);
         OperationsClient.ListOperationsPagedResponse operationsResponse =
           client.getOperationsClient().listOperations(resourceName, filter);
@@ -592,7 +556,7 @@ final class DataprocClient implements AutoCloseable {
     try {
       return Optional.of(client.getCluster(GetClusterRequest.newBuilder()
                                              .setClusterName(name)
-                                             .setProjectId(projectId)
+                                             .setProjectId(conf.getProjectId())
                                              .setRegion(conf.getRegion())
                                              .build()));
     } catch (NotFoundException e) {
@@ -608,6 +572,59 @@ final class DataprocClient implements AutoCloseable {
   }
 
   /**
+   * Determines if the Dataproc cluster is private IP only.
+   *
+   * @param privateInstance a system config to force using private instance
+   * @param sshRuntimeMonitor {@code true} if SSH is used for runtime monitoring
+   * @return {@code true} for pribvate IP only Dataproc cluster
+   */
+  private boolean isInternalIPOnly(boolean privateInstance, boolean sshRuntimeMonitor) {
+    String systemProjectId = null;
+    String systemNetwork = null;
+    try {
+      systemProjectId = DataprocUtils.getSystemProjectId();
+      systemNetwork = DataprocUtils.getSystemNetwork();
+    } catch (IllegalArgumentException e) {
+      // expected when not running on GCP, ignore
+    }
+
+    // Use private IP only cluster if privateInstance is true or if the compute profile required
+    if (!privateInstance && conf.isPreferExternalIP()) {
+      return false;
+    }
+
+    // If it is forced to be private instance or
+    // if CDAP runs in GCP project and runtime job manager is used and monitoring is not done through SSH,
+    // then we don't need to validate network connectivity
+    if (privateInstance || (systemProjectId != null && conf.isRuntimeJobManagerEnabled() && !sshRuntimeMonitor)) {
+      return true;
+    }
+
+    // If the CDAP is not running on GCP VM, then we just honor the prefer external IP config
+    if (systemProjectId == null || systemNetwork == null) {
+      return true;
+    }
+
+    // SSH will be used for job launching and/or monitoring, we need to validate network connectivity
+    // CDAP and Dataproc are in the same network, should be able to use private IP only cluster
+    if (systemProjectId.equals(conf.getNetworkHostProjectID()) && systemNetwork.equals(network.getName())) {
+      return true;
+    }
+
+    // Check network is peering, we can use private ip only cluster
+    PeeringState state = getPeeringState(systemProjectId, systemNetwork, network);
+    if (state == PeeringState.ACTIVE) {
+      return true;
+    }
+
+    // If there is no network connectivity and yet private ip only cluster is requested, raise an exception
+    throw new DataprocRuntimeException(
+      String.format("Direct network connectivity is needed for private Dataproc cluster between VPC %s/%s and %s/%s",
+                    systemProjectId, systemNetwork, conf.getNetworkHostProjectID(), network.getName())
+    );
+  }
+
+  /**
    * Finds ingress firewall rules for the configured network that matches the required firewall port as
    * defined in {@link FirewallPort}.
    *
@@ -615,7 +632,7 @@ final class DataprocClient implements AutoCloseable {
    * @throws IOException If failed to discover those firewall rules
    */
   private List<String> getFirewallTargetTags(boolean useInternalIP) throws IOException {
-    FirewallList firewalls = compute.firewalls().list(networkHostProjectId).execute();
+    FirewallList firewalls = compute.firewalls().list(conf.getNetworkHostProjectID()).execute();
     List<String> tags = new ArrayList<>();
     Set<FirewallPort> requiredPorts = EnumSet.allOf(FirewallPort.class);
 
@@ -625,7 +642,7 @@ final class DataprocClient implements AutoCloseable {
       // we want to get the last section of the path and compare to the configured network name
       int idx = firewall.getNetwork().lastIndexOf('/');
       String networkName = idx >= 0 ? firewall.getNetwork().substring(idx + 1) : firewall.getNetwork();
-      if (!networkName.equals(network)) {
+      if (!networkName.equals(network.getName())) {
         continue;
       }
 
@@ -677,7 +694,7 @@ final class DataprocClient implements AutoCloseable {
       throw new IllegalArgumentException(String.format(
         "Could not find an ingress firewall rule for network '%s' in project '%s' for ports '%s'. " +
           "Please create a rule to allow incoming traffic on those ports for your IP range.",
-        network, networkHostProjectId, portList));
+        network.getName(), conf.getNetworkHostProjectID(), portList));
     }
     return tags;
   }
@@ -713,7 +730,7 @@ final class DataprocClient implements AutoCloseable {
   private Node getNode(Compute compute, Node.Type type, String zone, String nodeName) throws IOException {
     Instance instance;
     try {
-      instance = compute.instances().get(projectId, zone, nodeName).execute();
+      instance = compute.instances().get(conf.getProjectId(), zone, nodeName).execute();
     } catch (GoogleJsonResponseException e) {
       // this can happen right after a cluster is created
       if (e.getStatusCode() == 404) {
@@ -725,7 +742,7 @@ final class DataprocClient implements AutoCloseable {
     for (NetworkInterface networkInterface : instance.getNetworkInterfaces()) {
       Path path = Paths.get(networkInterface.getNetwork());
       String networkName = path.getFileName().toString();
-      if (network.equals(networkName)) {
+      if (network.getName().equals(networkName)) {
         // if the cluster does not have an external ip then then access config is null
         if (networkInterface.getAccessConfigs() != null) {
           for (AccessConfig accessConfig : networkInterface.getAccessConfigs()) {
@@ -744,13 +761,15 @@ final class DataprocClient implements AutoCloseable {
     } catch (ParseException e) {
       ts = -1L;
     }
-    String ip = properties.get("ip.external");
-    if (useInternalIP) {
-      ip = properties.get("ip.internal");
-    }
+
+    // For internal IP only cluster, nodes only have ip.internal.
+    String ip = MoreObjects.firstNonNull(properties.get("ip.external"), properties.get("ip.internal"));
     return new Node(nodeName, type, ip, ts, properties);
   }
 
+  /**
+   * Converts Google Dataproc cluster status to CDAP Cluster Status
+   */
   private io.cdap.cdap.runtime.spi.provisioner.ClusterStatus convertStatus(ClusterStatus status) {
     switch (status.getState()) {
       case ERROR:

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -32,7 +32,6 @@ import com.google.api.services.compute.model.Firewall;
 import com.google.api.services.compute.model.FirewallList;
 import com.google.api.services.compute.model.Instance;
 import com.google.api.services.compute.model.Network;
-import com.google.api.services.compute.model.NetworkInterface;
 import com.google.api.services.compute.model.NetworkList;
 import com.google.api.services.compute.model.NetworkPeering;
 import com.google.cloud.dataproc.v1beta2.Cluster;
@@ -50,7 +49,6 @@ import com.google.cloud.dataproc.v1beta2.GetClusterRequest;
 import com.google.cloud.dataproc.v1beta2.InstanceGroupConfig;
 import com.google.cloud.dataproc.v1beta2.NodeInitializationAction;
 import com.google.cloud.dataproc.v1beta2.SoftwareConfig;
-import com.google.common.base.MoreObjects;
 import com.google.longrunning.Operation;
 import com.google.longrunning.OperationsClient;
 import com.google.rpc.Status;
@@ -63,8 +61,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -739,22 +735,21 @@ final class DataprocClient implements AutoCloseable {
       throw e;
     }
     Map<String, String> properties = new HashMap<>();
-    for (NetworkInterface networkInterface : instance.getNetworkInterfaces()) {
-      Path path = Paths.get(networkInterface.getNetwork());
-      String networkName = path.getFileName().toString();
-      if (network.getName().equals(networkName)) {
-        // if the cluster does not have an external ip then then access config is null
-        if (networkInterface.getAccessConfigs() != null) {
-          for (AccessConfig accessConfig : networkInterface.getAccessConfigs()) {
-            if (accessConfig.getNatIP() != null) {
-              properties.put("ip.external", accessConfig.getNatIP());
-              break;
-            }
+
+    // Dataproc cluster node should only have exactly one network
+    instance.getNetworkInterfaces().stream().findFirst().ifPresent(networkInterface -> {
+      // if the cluster does not have an external ip then then access config is null
+      if (networkInterface.getAccessConfigs() != null) {
+        for (AccessConfig accessConfig : networkInterface.getAccessConfigs()) {
+          if (accessConfig.getNatIP() != null) {
+            properties.put("ip.external", accessConfig.getNatIP());
+            break;
           }
         }
-        properties.put("ip.internal", networkInterface.getNetworkIP());
       }
-    }
+      properties.put("ip.internal", networkInterface.getNetworkIP());
+    });
+
     long ts;
     try {
       ts = DATE_FORMAT.parse(instance.getCreationTimestamp()).getTime();
@@ -763,7 +758,10 @@ final class DataprocClient implements AutoCloseable {
     }
 
     // For internal IP only cluster, nodes only have ip.internal.
-    String ip = MoreObjects.firstNonNull(properties.get("ip.external"), properties.get("ip.internal"));
+    String ip = properties.get("ip.external");
+    if (ip == null) {
+      ip = properties.get("ip.internal");
+    }
     return new Node(nodeName, type, ip, ts, properties);
   }
 

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -17,48 +17,32 @@
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
 import com.google.cloud.dataproc.v1beta2.ClusterOperationMetadata;
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.RuntimeMonitorType;
-import io.cdap.cdap.runtime.spi.common.DataprocUtils;
-import io.cdap.cdap.runtime.spi.provisioner.Capabilities;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
 import io.cdap.cdap.runtime.spi.provisioner.PollingStrategies;
 import io.cdap.cdap.runtime.spi.provisioner.PollingStrategy;
-import io.cdap.cdap.runtime.spi.provisioner.Provisioner;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSpecification;
-import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSystemContext;
-import io.cdap.cdap.runtime.spi.runtimejob.DataprocClusterInfo;
-import io.cdap.cdap.runtime.spi.runtimejob.DataprocRuntimeJobManager;
-import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobDetail;
-import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobManager;
 import io.cdap.cdap.runtime.spi.ssh.SSHContext;
 import io.cdap.cdap.runtime.spi.ssh.SSHKeyPair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Provisions a cluster using GCP Dataproc.
  */
-public class DataprocProvisioner implements Provisioner {
+public class DataprocProvisioner extends AbstractDataprocProvisioner {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataprocProvisioner.class);
   private static final ProvisionerSpecification SPEC = new ProvisionerSpecification(
@@ -67,89 +51,21 @@ public class DataprocProvisioner implements Provisioner {
       "Hadoop clusters in a simpler, more cost-efficient way on Google Cloud Platform.");
   private static final String CLUSTER_PREFIX = "cdap-";
 
-  // Keys for looking up system properties
-  private static final String LABELS_PROPERTY = "labels";
-
   // Key which is set to true if the instance only have private ip assigned to it else false
   private static final String PRIVATE_INSTANCE = "privateInstance";
-  // The GCS bucket used by the runtime job manager for launching jobs via the job API
-  // It can be overridden by profile runtime arguments (system.profile.properties.bucket)
-  private static final String BUCKET = "bucket";
 
-  // keys and values cannot be longer than 63 characters
-  // keys and values can only contain lowercase letters, numbers, underscores, and dashes
-  // keys must start with a lowercase letter
-  // keys cannot be empty
-  private static final Pattern LABEL_KEY_PATTERN = Pattern.compile("^[a-z][a-z0-9_-]{0,62}$");
-  private static final Pattern LABEL_VAL_PATTERN = Pattern.compile("^[a-z0-9_-]{0,63}$");
   private static final Pattern NETWORK_TAGS_PATTERN = Pattern.compile(("^[a-z][a-z0-9-]{0,62}$"));
 
-  private ProvisionerSystemContext systemContext;
-
-  @Override
-  public ProvisionerSpecification getSpec() {
-    return SPEC;
-  }
-
-  @Override
-  public void initialize(ProvisionerSystemContext systemContext) {
-    this.systemContext = systemContext;
-  }
-
-  /**
-   * Parses labels that are expected to be of the form key1=val1,key2=val2 into a map of key values.
-   *
-   * If a label key or value is invalid, a message will be logged but the key-value will not be returned in the map.
-   * Keys and values cannot be longer than 63 characters.
-   * Keys and values can only contain lowercase letters, numeric characters, underscores, and dashes.
-   * Keys must start with a lowercase letter and must not be empty.
-   *
-   * If a label is given without a '=', the label value will be empty.
-   * If a label is given as 'key=', the label value will be empty.
-   * If a label has multiple '=', it will be ignored. For example, 'key=val1=val2' will be ignored.
-   *
-   * @param labelsStr the labels string to parse
-   * @return valid labels from the parsed string
-   */
-  @VisibleForTesting
-  static Map<String, String> parseLabels(String labelsStr) {
-    Splitter labelSplitter = Splitter.on(',').trimResults().omitEmptyStrings();
-    Splitter kvSplitter = Splitter.on('=').trimResults().omitEmptyStrings();
-
-    Map<String, String> validLabels = new HashMap<>();
-    for (String keyvalue : labelSplitter.split(labelsStr)) {
-      Iterator<String> iter = kvSplitter.split(keyvalue).iterator();
-      if (!iter.hasNext()) {
-        continue;
-      }
-      String key = iter.next();
-      String val = iter.hasNext() ? iter.next() : "";
-      if (iter.hasNext()) {
-        LOG.info("Ignoring invalid label {}. Labels should be of the form 'key=val' or just 'key'", keyvalue);
-        continue;
-      }
-      if (!LABEL_KEY_PATTERN.matcher(key).matches()) {
-        LOG.info("Ignoring invalid label key {}. Label keys cannot be longer than 63 characters, must start with "
-                   + "a lowercase letter, and can only contain lowercase letters, numeric characters, underscores,"
-                   + " and dashes.", key);
-        continue;
-      }
-      if (!LABEL_VAL_PATTERN.matcher(val).matches()) {
-        LOG.info("Ignoring invalid label value {}. Label values cannot be longer than 63 characters, "
-                   + "and can only contain lowercase letters, numeric characters, underscores, and dashes.", val);
-        continue;
-      }
-      validLabels.put(key, val);
-    }
-    return validLabels;
+  @SuppressWarnings("WeakerAccess")
+  public DataprocProvisioner() {
+    super(SPEC);
   }
 
   @Override
   public void validateProperties(Map<String, String> properties) {
-    systemContext.reloadProperties();
-    DataprocConf conf = DataprocConf.fromProperties(properties);
-    boolean privateInstance = Boolean.parseBoolean(systemContext.getProperties().getOrDefault(PRIVATE_INSTANCE,
-                                                                                              "false"));
+    DataprocConf conf = DataprocConf.create(properties);
+    boolean privateInstance = Boolean.parseBoolean(getSystemContext().getProperties().get(PRIVATE_INSTANCE));
+
     if (privateInstance && conf.isPreferExternalIP()) {
       // When prefer external IP is set to true it means only Dataproc external ip can be used to for communication
       // the instance being private instance is incapable of using external ip for communication
@@ -174,7 +90,7 @@ public class DataprocProvisioner implements Provisioner {
 
   @Override
   public Cluster createCluster(ProvisionerContext context) throws Exception {
-    DataprocConf conf = DataprocConf.create(createContextProperties(context), null);
+    DataprocConf conf = DataprocConf.create(createContextProperties(context));
 
     if (context.getRuntimeMonitorType() == RuntimeMonitorType.SSH || !conf.isRuntimeJobManagerEnabled()) {
       // Generates and set the ssh key if it does not have one.
@@ -190,14 +106,9 @@ public class DataprocProvisioner implements Provisioner {
       }
     }
 
-    // Reload system context properties and get system labels
-    systemContext.reloadProperties();
-    Map<String, String> systemLabels = getSystemLabels(systemContext);
+    String clusterName = getClusterName(context);
 
-    String clusterName = getClusterName(context.getProgramRunInfo());
-
-    try (DataprocClient client =
-           DataprocClient.fromConf(conf, Boolean.parseBoolean(systemContext.getProperties().get(PRIVATE_INSTANCE)))) {
+    try (DataprocClient client = DataprocClient.fromConf(conf)) {
       // if it already exists, it means this is a retry. We can skip actually making the request
       Optional<Cluster> existing = client.getCluster(clusterName);
       if (existing.isPresent()) {
@@ -217,9 +128,15 @@ public class DataprocProvisioner implements Provisioner {
         }
       }
 
+      // Reload system context properties and get system labels
+      Map<String, String> systemLabels = getSystemLabels();
       LOG.info("Creating Dataproc cluster {} in project {}, in region {}, with image {}, with system labels {}",
-               clusterName, conf.getProjectId(), conf.getRegion(), imageVersion, systemLabels);
-      ClusterOperationMetadata createOperationMeta = client.createCluster(clusterName, imageVersion, systemLabels);
+               clusterName, conf.getProjectId(),
+               conf.getRegion(), imageVersion, systemLabels);
+
+      boolean privateInstance = Boolean.parseBoolean(getSystemContext().getProperties().get(PRIVATE_INSTANCE));
+      ClusterOperationMetadata createOperationMeta = client.createCluster(clusterName, imageVersion,
+                                                                          systemLabels, privateInstance);
       int numWarnings = createOperationMeta.getWarningsCount();
       if (numWarnings > 0) {
         LOG.warn("Encountered {} warning{} while creating Dataproc cluster:\n{}",
@@ -232,71 +149,34 @@ public class DataprocProvisioner implements Provisioner {
 
   @Override
   public ClusterStatus getClusterStatus(ProvisionerContext context, Cluster cluster) throws Exception {
-    DataprocConf conf = DataprocConf.fromProperties(createContextProperties(context));
-    String clusterName = getClusterName(context.getProgramRunInfo());
-    // Reload system context properties
-    systemContext.reloadProperties();
-    try (DataprocClient client =
-           DataprocClient.fromConf(conf, Boolean.parseBoolean(systemContext.getProperties().get(PRIVATE_INSTANCE)))) {
+    DataprocConf conf = DataprocConf.create(createContextProperties(context));
+    String clusterName = getClusterName(context);
+    try (DataprocClient client = DataprocClient.fromConf(conf)) {
       return client.getClusterStatus(clusterName);
     }
   }
 
   @Override
   public Cluster getClusterDetail(ProvisionerContext context, Cluster cluster) throws Exception {
-    DataprocConf conf = DataprocConf.fromProperties(createContextProperties(context));
-    String clusterName = getClusterName(context.getProgramRunInfo());
-    // Reload system context properties
-    systemContext.reloadProperties();
-    try (DataprocClient client =
-           DataprocClient.fromConf(conf, Boolean.parseBoolean(systemContext.getProperties().get(PRIVATE_INSTANCE)))) {
+    DataprocConf conf = DataprocConf.create(createContextProperties(context));
+    String clusterName = getClusterName(context);
+    try (DataprocClient client = DataprocClient.fromConf(conf)) {
       Optional<Cluster> existing = client.getCluster(clusterName);
       return existing.orElseGet(() -> new Cluster(cluster, ClusterStatus.NOT_EXISTS));
     }
   }
 
   @Override
-  public void deleteCluster(ProvisionerContext context, Cluster cluster) throws Exception {
-    deleteClusterWithStatus(context, cluster);
-  }
-
-  @Override
-  public ClusterStatus deleteClusterWithStatus(ProvisionerContext context, Cluster cluster) throws Exception {
-    // Reload system context properties
-    systemContext.reloadProperties();
-
-    Map<String, String> properties = createContextProperties(context);
-    DataprocConf conf = DataprocConf.fromProperties(properties);
-    RuntimeJobManager jobManager = getRuntimeJobManager(context).orElse(null);
-
-    if (jobManager != null) {
-      try {
-        // If there is job manager, check to make sure the job is completed.
-        // Also cleanup files created by the job run.
-        RuntimeJobDetail jobDetail = jobManager.getDetail(context.getProgramRunInfo()).orElse(null);
-        if (jobDetail != null && !jobDetail.getStatus().isTerminated()) {
-          return ClusterStatus.RUNNING;
-        }
-      } finally {
-        jobManager.close();
-      }
-
-      Storage storageClient = StorageOptions.newBuilder().setProjectId(conf.getProjectId())
-        .setCredentials(conf.getDataprocCredentials()).build().getService();
-      DataprocUtils.deleteGCSPath(storageClient, properties.get(BUCKET),
-                                  DataprocUtils.CDAP_GCS_ROOT + "/" + context.getProgramRunInfo().getRun());
-    }
-    String clusterName = getClusterName(context.getProgramRunInfo());
-    try (DataprocClient client =
-           DataprocClient.fromConf(conf, Boolean.parseBoolean(systemContext.getProperties().get(PRIVATE_INSTANCE)))) {
+  protected void doDeleteCluster(ProvisionerContext context, Cluster cluster, DataprocConf conf) throws Exception {
+    String clusterName = getClusterName(context);
+    try (DataprocClient client = DataprocClient.fromConf(conf)) {
       client.deleteCluster(clusterName);
     }
-    return ClusterStatus.DELETING;
   }
 
   @Override
   public PollingStrategy getPollingStrategy(ProvisionerContext context, Cluster cluster) {
-    DataprocConf conf = DataprocConf.fromProperties(createContextProperties(context));
+    DataprocConf conf = DataprocConf.create(createContextProperties(context));
     PollingStrategy strategy = PollingStrategies.fixedInterval(conf.getPollInterval(), TimeUnit.SECONDS);
     switch (cluster.getStatus()) {
       case CREATING:
@@ -310,87 +190,57 @@ public class DataprocProvisioner implements Provisioner {
   }
 
   @Override
-  public Capabilities getCapabilities() {
-    return new Capabilities(Collections.unmodifiableSet(new HashSet<>(Arrays.asList("fileSet", "externalDataset"))));
+  protected boolean isDefaultContextProperty(String property) {
+    if (super.isDefaultContextProperty(property)) {
+      return true;
+    }
+    return ImmutableSet.of(
+      DataprocConf.PREFER_EXTERNAL_IP,
+      DataprocConf.NETWORK,
+      DataprocConf.NETWORK_HOST_PROJECT_ID,
+      DataprocConf.STACKDRIVER_LOGGING_ENABLED,
+      DataprocConf.STACKDRIVER_MONITORING_ENABLED,
+      DataprocConf.COMPONENT_GATEWAY_ENABLED,
+      DataprocConf.IMAGE_VERSION
+    ).contains(property);
   }
 
-  private Map<String, String> getSystemLabels(ProvisionerSystemContext systemContext) {
-    Map<String, String> labels = new HashMap<>();
-    // dataproc only allows label values to be lowercase letters, numbers, or dashes
-    String cdapVersion = systemContext.getCDAPVersion().toLowerCase();
-    cdapVersion = cdapVersion.replaceAll("\\.", "_");
-    labels.put("cdap-version", cdapVersion);
+  @Override
+  protected Map<String, String> getDefaultContextProperties() {
+    Map<String, String> properties = new HashMap<>(super.getDefaultContextProperties());
 
-    String extraLabelsStr = systemContext.getProperties().get(LABELS_PROPERTY);
-    // labels are expected to be in format:
-    // name1=val1,name2=val2
-    if (extraLabelsStr != null) {
-      labels.putAll(parseLabels(extraLabelsStr));
-    }
+    // set some dataproc properties that we know will make program execution more stable
+    properties.put("dataproc:dataproc.conscrypt.provider.enable", "false");
+    properties.put("yarn:yarn.nodemanager.pmem-check-enabled", "false");
+    properties.put("yarn:yarn.nodemanager.vmem-check-enabled", "false");
 
-    return Collections.unmodifiableMap(labels);
+    // The additional property is needed to be able to provision a singlenode cluster on
+    // dataproc. Dataproc has an issue that it will treat 0 number of worker
+    // nodes as the default number, which means it will always provision a
+    // cluster with 2 worker nodes if this property is not set. Refer to
+    // https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/single-node-clusters
+    // for more information.
+    properties.put("dataproc:dataproc.allow.zero.workers", "true");
+
+    // Retain logs
+    properties.put("yarn:yarn.nodemanager.delete.debug-delay-sec", "86400");
+
+    return properties;
   }
 
   /**
-   * Creates properties for the current context. It will default missing values from the system context properties.
+   * Gets the cluster name for the given context.
+   * Name must start with a lowercase letter followed by up to 51 lowercase letters,
+   * numbers, or hyphens, and cannot end with a hyphen
+   * We'll use app-runid, where app is truncated to fit, lowercased, and stripped of invalid characters.
+   *
+   * @param context the provisioner context
+   * @return a string that is a valid cluster name
    */
-  @VisibleForTesting
-  Map<String, String> createContextProperties(ProvisionerContext context) {
-    Map<String, String> contextProperties = new HashMap<>(context.getProperties());
+  @Override
+  protected String getClusterName(ProvisionerContext context) {
+    ProgramRunInfo programRunInfo = context.getProgramRunInfo();
 
-    // Default the project id from system config if missing or if it is auto-detect
-    String contextProjectId = contextProperties.get(DataprocConf.PROJECT_ID_KEY);
-    if (contextProjectId == null || DataprocConf.AUTO_DETECT.equals(contextProjectId)) {
-      contextProjectId = systemContext.getProperties().getOrDefault(DataprocConf.PROJECT_ID_KEY, contextProjectId);
-      if (contextProjectId != null) {
-        LOG.trace("Setting default Dataproc project ID to {}", contextProjectId);
-        contextProperties.put(DataprocConf.PROJECT_ID_KEY, contextProjectId);
-      }
-    }
-
-    // Default settings from the system context
-    List<String> keys = new ArrayList<>(
-      Arrays.asList(DataprocConf.PREFER_EXTERNAL_IP,
-                    DataprocConf.NETWORK,
-                    DataprocConf.NETWORK_HOST_PROJECT_ID,
-                    DataprocConf.STACKDRIVER_LOGGING_ENABLED,
-                    DataprocConf.STACKDRIVER_MONITORING_ENABLED,
-                    DataprocConf.COMPONENT_GATEWAY_ENABLED,
-                    DataprocConf.IMAGE_VERSION,
-                    DataprocConf.RUNTIME_JOB_MANAGER,
-                    BUCKET)
-    );
-
-    // Default dataproc cluster property settings from the system context
-    // (i.e. those settings specifying configuration files of the dataproc cluster and the property
-    // key value paris within those files that should be overridden)
-    systemContext.getProperties().keySet().stream()
-      .filter(key -> DataprocConf.CLUSTER_PROPERTIES_PATTERN.matcher(key).find())
-      .collect(Collectors.toCollection(() -> keys));
-
-    for (String key : keys) {
-      if (!contextProperties.containsKey(key)) {
-        String value = systemContext.getProperties().get(key);
-        if (value != null) {
-          LOG.trace("Setting default Dataproc property {} to {}", key, value);
-          contextProperties.put(key, value.trim());
-        }
-      }
-    }
-
-    // set some dataproc properties that we know will make program execution more stable
-    contextProperties.put("dataproc:dataproc.conscrypt.provider.enable", "false");
-    contextProperties.put("yarn:yarn.nodemanager.pmem-check-enabled", "false");
-    contextProperties.put("yarn:yarn.nodemanager.vmem-check-enabled", "false");
-
-    return contextProperties;
-  }
-
-  // Name must start with a lowercase letter followed by up to 51 lowercase letters,
-  // numbers, or hyphens, and cannot end with a hyphen
-  // We'll use app-runid, where app is truncated to fit, lowercased, and stripped of invalid characters
-  @VisibleForTesting
-  static String getClusterName(ProgramRunInfo programRunInfo) {
     String cleanedAppName = programRunInfo.getApplication().replaceAll("[^A-Za-z0-9\\-]", "").toLowerCase();
     // 51 is max length, need to subtract the prefix and 1 extra for the '-' separating app name and run id
     int maxAppLength = 51 - CLUSTER_PREFIX.length() - 1 - programRunInfo.getRun().length();
@@ -398,35 +248,5 @@ public class DataprocProvisioner implements Provisioner {
       cleanedAppName = cleanedAppName.substring(0, maxAppLength);
     }
     return CLUSTER_PREFIX + cleanedAppName + "-" + programRunInfo.getRun();
-  }
-
-  /**
-   * Provides implementation of {@link RuntimeJobManager}.
-   */
-  @Override
-  public Optional<RuntimeJobManager> getRuntimeJobManager(ProvisionerContext context) {
-    Map<String, String> properties = createContextProperties(context);
-    DataprocConf conf = DataprocConf.create(properties, null);
-
-    // if this system property is not provided, we will assume that ssh should be used instead of
-    // runtime job manager for job launch.
-    if (!conf.isRuntimeJobManagerEnabled()) {
-      return Optional.empty();
-    }
-    String clusterName = getClusterName(context.getProgramRunInfo());
-    String projectId = conf.getProjectId();
-    String region = conf.getRegion();
-    String bucket = properties.get(BUCKET);
-
-    Map<String, String> systemLabels = getSystemLabels(systemContext);
-    try {
-      return Optional.of(
-        new DataprocRuntimeJobManager(new DataprocClusterInfo(context, clusterName, conf.getDataprocCredentials(),
-                                                              DataprocClient.DATAPROC_GOOGLEAPIS_COM_443,
-                                                              projectId, region, bucket, systemLabels)));
-    } catch (Exception e) {
-      throw new RuntimeException("Error while getting credentials for dataproc. ", e);
-    }
-
   }
 }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocRuntimeException.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocRuntimeException.java
@@ -24,6 +24,10 @@ import com.google.common.base.Throwables;
  */
 public class DataprocRuntimeException extends RuntimeException {
 
+  public DataprocRuntimeException(String message) {
+    super(message);
+  }
+
   public DataprocRuntimeException(Throwable cause) {
     super(createMessage(cause), cause);
   }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocTool.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocTool.java
@@ -86,7 +86,7 @@ public class DataprocTool {
       }
       try (Reader reader = new FileReader(configFile)) {
         Map<String, String> map = GSON.fromJson(reader, new TypeToken<Map<String, String>>() { }.getType());
-        conf = DataprocConf.create(map, null);
+        conf = DataprocConf.create(map);
       }
     } else {
       if (!commandLine.hasOption('k')) {
@@ -102,15 +102,15 @@ public class DataprocTool {
       Map<String, String> properties = new HashMap<>();
       properties.put("accountKey", commandLine.getOptionValue('k'));
       properties.put("projectId", commandLine.getOptionValue('p'));
-      conf = DataprocConf.fromProperties(properties);
+      conf = DataprocConf.create(properties);
     }
 
     String imageVersion = commandLine.hasOption('i') ? commandLine.getOptionValue('i') : "1.2";
 
     String name = commandLine.getOptionValue('n');
-    try (DataprocClient client = DataprocClient.fromConf(conf, false)) {
+    try (DataprocClient client = DataprocClient.fromConf(conf)) {
       if (PROVISION.equalsIgnoreCase(command)) {
-        ClusterOperationMetadata createOp = client.createCluster(name, imageVersion, Collections.emptyMap());
+        ClusterOperationMetadata createOp = client.createCluster(name, imageVersion, Collections.emptyMap(), false);
         System.out.println(GSON.toJson(createOp));
       } else if (DETAILS.equalsIgnoreCase(command)) {
         Optional<Cluster> cluster = client.getCluster(name);

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/ExistingDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/ExistingDataprocProvisioner.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner.dataproc;
+
+import com.google.common.base.Strings;
+import io.cdap.cdap.runtime.spi.RuntimeMonitorType;
+import io.cdap.cdap.runtime.spi.provisioner.Cluster;
+import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
+import io.cdap.cdap.runtime.spi.provisioner.PollingStrategies;
+import io.cdap.cdap.runtime.spi.provisioner.PollingStrategy;
+import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
+import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSpecification;
+import io.cdap.cdap.runtime.spi.ssh.SSHKeyPair;
+import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Provisioner for connecting an existing Dataproc cluster.
+ */
+public class ExistingDataprocProvisioner extends AbstractDataprocProvisioner {
+
+  private static final ProvisionerSpecification SPEC = new ProvisionerSpecification(
+    "gcp-existing-dataproc", "Existing Dataproc",
+    "Connect and Execute jobs on existing Dataproc cluster.");
+  // Keys for looking up system properties
+
+  private static final String CLUSTER_NAME = "clusterName";
+  private static final String SSH_USER = "sshUser";
+  private static final String SSH_KEY = "sshKey";
+
+  public ExistingDataprocProvisioner() {
+    super(SPEC);
+  }
+
+  @Override
+  public void validateProperties(Map<String, String> properties) {
+    // Creates the DataprocConf for validation
+    DataprocConf.create(properties);
+
+    String clusterName = properties.get(CLUSTER_NAME);
+    if (Strings.isNullOrEmpty(clusterName)) {
+      throw new IllegalArgumentException("Dataproc cluster name is missing");
+    }
+  }
+
+  @Override
+  protected String getClusterName(ProvisionerContext context) {
+    return context.getProperties().get(CLUSTER_NAME);
+  }
+
+  @Override
+  public Cluster createCluster(ProvisionerContext context) throws Exception {
+    Map<String, String> contextProperties = createContextProperties(context);
+    DataprocConf conf = DataprocConf.create(contextProperties);
+
+    if (context.getRuntimeMonitorType() == RuntimeMonitorType.SSH) {
+      String sshUser = contextProperties.get(SSH_USER);
+      String sshKey = contextProperties.get(SSH_KEY);
+      if (Strings.isNullOrEmpty(sshUser) || Strings.isNullOrEmpty(sshKey)) {
+        throw new DataprocRuntimeException("SSH User and key are required for monitoring through SSH.");
+      }
+
+      SSHKeyPair sshKeyPair = new SSHKeyPair(new SSHPublicKey(sshUser, ""),
+                                             () -> sshKey.getBytes(StandardCharsets.UTF_8));
+      // The ssh context shouldn't be null, but protect it in case there is platform bug
+      Optional.ofNullable(context.getSSHContext()).ifPresent(c -> c.setSSHKeyPair(sshKeyPair));
+    }
+
+    String clusterName = contextProperties.get(CLUSTER_NAME);
+    try (DataprocClient client = DataprocClient.fromConf(conf)) {
+      client.updateClusterLabels(clusterName, getSystemLabels());
+      return client.getCluster(clusterName)
+        .filter(c -> c.getStatus() == ClusterStatus.RUNNING)
+        .orElseThrow(() -> new DataprocRuntimeException("Dataproc cluster " + clusterName +
+                                                          " does not exist or not in running state."));
+    }
+  }
+
+  @Override
+  protected void doDeleteCluster(ProvisionerContext context, Cluster cluster, DataprocConf conf) {
+    // no-op
+  }
+
+  @Override
+  public ClusterStatus getClusterStatus(ProvisionerContext context, Cluster cluster) {
+    ClusterStatus status = cluster.getStatus();
+    return status == ClusterStatus.DELETING ? ClusterStatus.NOT_EXISTS : status;
+  }
+
+  @Override
+  public Cluster getClusterDetail(ProvisionerContext context, Cluster cluster) {
+    return new Cluster(cluster, getClusterStatus(context, cluster));
+  }
+
+  @Override
+  public PollingStrategy getPollingStrategy(ProvisionerContext context, Cluster cluster) {
+    return PollingStrategies.fixedInterval(0, TimeUnit.SECONDS);
+  }
+}

--- a/cdap-runtime-ext-dataproc/src/main/resources/META-INF/services/io.cdap.cdap.runtime.spi.provisioner.Provisioner
+++ b/cdap-runtime-ext-dataproc/src/main/resources/META-INF/services/io.cdap.cdap.runtime.spi.provisioner.Provisioner
@@ -15,3 +15,4 @@
 #
 
 io.cdap.cdap.runtime.spi.provisioner.dataproc.DataprocProvisioner
+io.cdap.cdap.runtime.spi.provisioner.dataproc.ExistingDataprocProvisioner

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-existing-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-existing-dataproc.json
@@ -1,0 +1,101 @@
+{
+  "icon": {
+    "type": "inline",
+    "arguments": {
+      "data": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFUAAABVCAYAAAA49ahaAAAOU0lEQVR4Xu2deXRU1R3Hv3febEkmewiEnUAQRaniUtuq1SyEsBSxDepxgR4Rat2ONSBJEAeSSdh6WihuqK3K0SqporIJWVuxQkux0oJKQAsBIfskmSSzvttzJyaTyczkvTfvTUg43L9g3u/+7u9+3u/d+7trCC4nxQkQxTVeVojLUEPgBJehDimolJJUk3Usp9EP43nHoHl5KpWGuhzW+oqVYadDwNOtUvHKGo1UdUDPr6aUPAXQiFAZLl8vaSeE/u4Wq+o5o5Hw8vV5NCgK9XYjNXB6vhoUI5Q0MqS6CC64rKqUKiOxKFWOYlCzjVTbpHN9ByBeKeMGUE9jnI0bWWIkdiXKVAxqerFzOwWylTDqYuggQElZrnqBEmUrAnXGBjrB5XCdAlG+jVaikqJ0UFBOw03cv4x8K0q+HyFFoKYVO04AJEWuMRc/PzlRnstdIdcO2VBT1zqzCKV75BoyWPJTQmZVrFDvlWOPLKjZ2ZRrmu5sBBAtx4hBlrcl7og6vqSEuIK1SxbUtGLHGgDPBlv4IM5XUJ6rWRWsfUFDzTI2Rtk1kU0ghAu28EGbj1KX1tEWt9cY3xqMjUFDTSuyVwC4I5hCh0ieyvI8bWowtgYFNa3IdhVAjgVT4NDKQ6eW5+mOS7U5SKiOGgI6WmphQ02egpwtz9OMkWq3ZKgZxbZsSsl2qQUNVXlC6ILSXF2JFPslQWXj+2atvQnAIJ59klJ9UbLtsXZtnJR5AUlQM4rsmyjoE6JMuYSECMjm0jztk2KrJBrq3I00odNurwWgEqv8EpLjw7Ta4TtzSIOYOomGmm6yfQaCm8UoVUpGrwGmjVUh3gDYncB5M8Xxc1Qp9dL0UBwsy9f9SEwmUVAz19unu5z8v8QoVEJmVBzBmp9rMCbBd9rL6QIqj7vw2z1OuBSdrxe2nFOrrt+3XHtESFIU1PSizlqAJAopU+L5/Bs5PJKmBhGwzOoAHtpqR13rQHourSvLCxsuVE9BqBmmzsWUkFeEFCnxPHMah5zZatGqHE4ge7MV7TbBaojWKSRIKH24ND/s1f7k+rUmazPVOSy2FgA6ocLkPg/TAjue0oHz0w2euuBEuI4gKdZ3muFMgxMPbXUAZMD6T5vGoIve+wSxBapzv1DTiju3EYr75QITkz9ntgbMU3un9w6248V9rWDtKEtR4Sq8vDTBB+5DLzTgtDkcZODAbivLC3tQMtRMU3uSC6pzA7VEsitHD53GY+bfjlux6p1mH7s1HMGuvOHQaTz+8PHnnVi7wwy1PnpgwLKlF/Cj9uVHnPcHNqCnphd1fglgihgvU0Jm/wq9V+c0t7gWbZ3+u/eFtxvwy9TInmKbLTzmr2chNAYOLPBVWV7YlaKhpq913ALe+YkSsMTo0HDAnuX6HlFKgYw153s++746bpqkw/oH43p+7rBRzDJd6Pn/gHmsSn1r2QrNgb72+XoqpSS9uKMJIDFigCglU5ob5qUqq/A8Ou3+w6V7fmLArzKjeuRbOnjMW+uBOnAeS81lueFxIMTLUB+o6UUdOQA2KAVLrJ6+UHcd7sDGj8w+2VUE2JmbhAi9x/TK/3Zi9Xbf9neAPHZZWV74xt6GekG93VhnUGsMzDrxwaJYagJypXnensrEX9rXincOeHbjqDmC5x9OwBWjevVoAB7d2oBjNf43lwwAWKfTYYmtMib2GOoFNd3UvgsgsxXiJEmNP6hMgdVOcfSMHQYdweRRWqj7hKP1rS5kb/D+9L0LJlDro0K8lEZ3l+VHzOkutwdqerE5GbzmZCh2AoqhW5oXLkbMS4anwIINF9DQJryaHGKPpVA5JpXlxnzDDPRANXWcBOhEyTVTKINUqDwPLHmxDicvOERbEFqw5FRZfvikHqhpBZaZREVk7coQXbMAgr2hspDKYuURGRZ46PnSvha8e8ACqdMpoQRLeZpV/qzhY5K9nXLN1R2smzXIBSMnf2+ozAvTjOcweaQW6x6IR0yEf7gslFr2egNOnBfvrSEOtyyxKeExJL2o9WFQ1VY5QJTIW5rnWfZiUFOfO+tWy6YAZ14XgZx5sX4nW5gM6/lXbGsIOALzZ1/IPJbwS0i6yXIGgORlWCVA9tYRCGq3jJoDnpwTiznXR/ida2Wd1o6DFjy/1wz2bzEpRGBrSHqhxQmCi751RwhqN6Q4A4e1DyRg8kjvWLX7ud1JsW5HMyqOdohqbxUHS+Ei6aY2ke9VzLsPXqY0z9Okd33+NQGVsZDlmnE6mO5LCNiZ1be48PTr9TjT0H97yxZsGFjBpQYJVSMZhW2DwlP394Ga1g/UniCbAL/4USSWZsYEbG8PnbBi9bsNAecRepoXpaYNmadmuNtUOiBtql5DcNMkDuOHqdwBck0Tj4PVLrBZpmCgetpbgmez43HbVN+hLpNhIdqOQ214fk//7a0yTQGpcff+hJKQ9v4x4QTF94Zh4nD/odHpBh7jEjzP3CGVCE/thjpllBZbliSCY7Mt/aTWDh6L/nABzZbAIzC5YCmhS9xxqrm6LWRx6k0T1VizIAwC9fVC0QWVBSX9p3CtCvnZ8fjxFP8e6i8368juWncO7dZA69tdbSwRWs71b5olJiUyxv1q0wpaZqpCMKKaMpLDpkXhko+sCEFVqYD7b4vGolRWef+1Y/DYI43aV+BMvQMLN/tdCelRFozH8u4RVfTHPSXOMLWepIBiY3+m+MNlBrB2tHdyuihOnneApxQpI7Vga059U39Qb5ioR+F9w7zWqHrnZ8CefK0W5nbeDXVUvBqbFw9HrME7anzslVocOxNwQdStUgpYApzanx/lGfszBWyWivAqxWap0q7W4JmfeZZIWBmffd2JlW/Xg0HrTs/Mj8PM6d4jZH9Qh0VzWP9gIsYn+o9Pmb4G9zTgOZ+XxLx1Z95orxfx+bdW/OaPdUItjFiwlKp431kqpj3D1LoLoIrMp77xiAFJsZ7Oh8WLCzexU5a+6cWlSZgyWtvzoAtq1yFnrZogZ148Mq4V3r257I06HD7Z6beMu26OxOOzPetabMJmrilwLOxRIqaNJbtL86N851OZEjbzr9HoFJn5/zAnEmFaz6e9/M06/LPaf4XZxMnLjyT11IOFQJmrz2DujQY8NostAQk6lFvgjmcDnzZnI7H3nvFs/mbrX7MKhDvD7pL7aQqcDoct8Mw/UzCj0JxDQWSvUe1ZEQU2Xu9OdxbXoKXdf4/LmFUUjvMix3rnCL3/EKzW7ET+W/V45ddJXsDv3nAWdS3+w6Vp4/XYtNizDcoNdY14qIHaWAK6bP/KmMBrVO5aUUoyTK1st7Ss1dQPl3l7at62Oneb6i9dOUaHF5YKn2ZnPfqGHY0o+6Ld3QntXz0WbN2qO+0+bMHGD9hZOd+0ZekITB3j2b3EXsw9G33bX6Fvoo/Hmkvzo4RXU5nS9MLWWwh4Wev+ry2NxJheAX1dS1clKPu2+6RXHx2JiUmeNrXvczbr9MHBVmzZ0+QeHXWnp+fFY86Nnk0V7PeC7fWoONrupeLeW6OxJDPW67cX9jah5NNgjkl52lgK1a1lK6NErPt/X3RGoVnWDpWfXqVB/nzvdadDJzrx3J/rYHN0kWHh1MoFCbhtauBO6MuzNqx4sxZsNNQ3seZhZ/5Ynzb3dJ0Dlf9pd3tx5nURGBbtvTjscLFP/3TAzRpC3uq2XRf1VemqePE7VFgmtpeK5x2y9lK9/3QUDL3W57uN/V+dAy6eInmENuDAwNzucsP8+lz/9xosSo3BwlRpLdWad+vd0GUk6nBwoz9dP9ZvONNvv5pR0LwNhAS9629CIoeXFhtE996sksyLtuxuwkf/aBNd5+V3JSCrT6wbKPOblWb8qdx3k4bowtyC5K0q0/iAXAT3pzpbW2TtT71uvBqmeyN81uv9VaLsCwvWvd8Q1GeZ/oMI5NyZEHCkxaKJVW/X4cg3Vmn8fKVt0CCmyjghoCLBCDDDZF4MSmXtpDbogYLsMLBevu/ECut4vjprQ/F79agRmFAWosHi2R+mhOOOayIwJqFr5HXqgh3lRy3497eyYbr1UYIlfy1M7peHIFSmKKOwme1TlLfnn1IQZyuunaDD+EStu0lgEA+f6oT9+45LCNrFfk4I6ioLk+Xv+e/qtMzTeUrln06hFA4ra00GxQqO5HdEVNwNlQXjBDmI8tQub236DFDgHNVQBUvIoarCZFHnyERDnbuxNcFmddZSJU78DTGwFITnedeIT4pT6sW4t2io37etm6DU2dQhBZZsqTIlPy4GqDvgEivI5LKNx7RmdZJyp6iHBFjSPkzTGVdinCr6djVJULu8tTEbUPC8/yAHS1Tk7sqCZEn3G0iGysDOKGisoQTK3UwxWMESnK0qnCR5+T4oqFlFjVe5eCh7h8pgBKuiV1cWpEiuZ1BQ3d5a2FABEGVv+xlUYGlVpSklqPoFDZXdS+XiaJPim9sGA1hKXHotjdtrTAlmwlVa7983UsgsqF9DQZS/Qe0igyWgpoqiySulREa9ZYP2VHeIlb2da5mWGpq7/i4aWNKSUH0kvqRkgfDpjADUZUF1t62mpizwfGhupbwoYOmcyqLJu4P1UsnBf6CCZhTUnwAQmvtTBxAsAamuKEqZLAeoglDNE0Adobvpd2DAUo7HpLK1k91noeQk2Z9/d+GZBQ3bKWjo7qQOMVgC8peKohRF7FcMKrtdrYWr/w4gobs9PURgeaApUetIkjK+78+TFYPKCmHbhnQcqaagwjsjgv2+FAdLaqk2ZlLvA7vBmtadT1GoTCn7ixR/VzWuhop/CjREdwIqAJYH7VAR8vuEE1+skhM++XsBikPtXUhq4XfjOGiGcbxT8XLYmRNnh/QBD+HUVAVSX2FKHjp/O0Xup3Mp5Ffcgy4FKHLrcBmqXIJ+8l+GGgKo/wfsUyhPEm1t6gAAAABJRU5ErkJggg=="
+    }
+  },
+  "configuration-groups": [
+    {
+      "label": "Cluster Information",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "Project ID",
+          "name": "projectId",
+          "description": "Google Cloud Project ID, which uniquely identifies your project. You can find it on the Dashboard in the Cloud Platform Console. If the system is running on Google Cloud Platform, this can be left blank or set to 'auto-detect' and the system's project id will be used.",
+          "widget-attributes": {
+            "placeholder": "Specify your GCP Project ID"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Cluster Name",
+          "name": "clusterName",
+          "required": true,
+          "description": "The Dataproc cluster name used to execute pipelines.",
+          "widget-attributes": {
+            "placeholder": "Specify Dataproc cluster name to submit jobs. Ensure the cluster exists and is accessible from service account."
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Region",
+          "name": "region",
+          "description": "The region where the Dataproc cluster is located.",
+          "widget-attributes": {
+            "values": [
+              "auto-detect",
+              "asia-east1",
+              "asia-east2",
+              "asia-northeast1",
+              "asia-northeast2",
+              "asia-south1",
+              "asia-southeast1",
+              "australia-southeast1",
+              "europe-north1",
+              "europe-west1",
+              "europe-west2",
+              "europe-west3",
+              "europe-west4",
+              "europe-west6",
+              "northamerica-northeast1",
+              "southamerica-east1",
+              "us-central1",
+              "us-east1",
+              "us-east4",
+              "us-west1",
+              "us-west2"
+            ],
+            "default": "us-east1",
+            "size": "medium"
+          }
+        },
+        {
+          "widget-type": "securekey-textarea",
+          "label": "Service Account Key",
+          "name": "accountKey",
+          "description": "A service account is a special type of Google account that belongs to your application or a virtual machine (VM), instead of to an individual end user. Paste the contents of the service account key JSON file that you can download from the service accounts section under IAM and admin on the Cloud Console. If the system is running on Google Cloud Platform, this can be left blank or set to 'auto-detect' and the system's credentials will be used.",
+          "widget-attributes": {
+            "placeholder": "Specify the GCP service account"
+          }
+        }
+      ]
+    },
+    {
+      "label": "Monitoring",
+      "properties": [
+        {
+          "widget-type": "textbox",
+          "label": "SSH User",
+          "name": "sshUser",
+          "required": false,
+          "description": "The user to SSH to the cluster for monitoring.",
+          "widget-attributes": {
+            "placeholder": "Specify the SSH user"
+          }
+        },
+        {
+          "widget-type": "securekey-textarea",
+          "label": "SSH Private Key",
+          "name": "sshKey",
+          "required": false,
+          "description": "The SSH private key for the user that will connect to the cluster for monitoring.",
+          "widget-attributes": {
+            "placeholder": "Specify the private key for SSH"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/common/DataprocUtilsTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/common/DataprocUtilsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link DataprocUtils}.
+ */
+public class DataprocUtilsTest {
+
+  @Test
+  public void testParseSingleLabel() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("key", "val");
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("key=val"));
+  }
+
+  @Test
+  public void testParseMultipleLabels() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("k1", "v1");
+    expected.put("k2", "v2");
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("k1=v1,k2=v2"));
+  }
+
+  @Test
+  public void testParseLabelsIgnoresWhitespace() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("k1", "v1");
+    expected.put("k2", "v2");
+    Assert.assertEquals(expected, DataprocUtils.parseLabels(" k1  =\tv1  ,\nk2 = v2  "));
+  }
+
+  @Test
+  public void testParseLabelsWithoutVal() {
+    Map<String, String> expected = new HashMap<>();
+    expected.put("k1", "");
+    expected.put("k2", "");
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("k1,k2="));
+  }
+
+  @Test
+  public void testParseLabelsIgnoresInvalidKey() {
+    Map<String, String> expected = new HashMap<>();
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("A"));
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("0"));
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("a.b"));
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("a^b"));
+    StringBuilder longStr = new StringBuilder();
+    for (int i = 0; i < 64; i++) {
+      longStr.append('a');
+    }
+    Assert.assertEquals(expected, DataprocUtils.parseLabels(longStr.toString()));
+  }
+
+  @Test
+  public void testParseLabelsIgnoresInvalidVal() {
+    Map<String, String> expected = new HashMap<>();
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("a=A"));
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("a=ab.c"));
+    StringBuilder longStr = new StringBuilder();
+    for (int i = 0; i < 64; i++) {
+      longStr.append('a');
+    }
+    Assert.assertEquals(expected, DataprocUtils.parseLabels(String.format("a=%s", longStr.toString())));
+  }
+}

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerContext.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerContext.java
@@ -30,10 +30,17 @@ import javax.annotation.Nullable;
 
 
 public class MockProvisionerContext implements ProvisionerContext {
-  private Map<String, String> properties;
+
+  private final Map<String, String> properties;
+  private final ProgramRunInfo programRunInfo;
 
   public MockProvisionerContext() {
-    properties = new HashMap<>();
+    this(null);
+  }
+
+  public MockProvisionerContext(ProgramRunInfo programRunInfo) {
+    this.properties = new HashMap<>();
+    this.programRunInfo = programRunInfo;
   }
 
   @Override
@@ -43,7 +50,7 @@ public class MockProvisionerContext implements ProvisionerContext {
 
   @Override
   public ProgramRunInfo getProgramRunInfo() {
-    return null;
+    return programRunInfo;
   }
 
   @Override


### PR DESCRIPTION
This PR has two commits.

1. Refactor the existing Dataproc provisioner code to extract common implementation for the ephemeral and existing clusters.
   * In the process, also clean some clumsy code around private cluster logic
2. Added a new provisioner for existing Dataproc cluster