### PR TITLE
CDAP-16902 run pipeline tests in serial since they are expensive

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
@@ -158,6 +158,14 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <version>3.3.0</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- CDAP-16902 avoid running multiple resource intensive tests at the same time -->
+          <forkCount>1</forkCount>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
@@ -256,6 +256,14 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <version>3.3.0</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- CDAP-16902 avoid running multiple resource intensive tests at the same time -->
+          <forkCount>1</forkCount>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
When run together, PreviewDataPipelineTest, AutoJoinerTest, and
ReducibleAggregatorTest seem to timeout with high likelihood.
Overriding the fork from 3 down to 1 to see if running these
tests in serial makes them less flaky.