### PR TITLE
[CDAP-16835] Adding support for artifact scope and snapshot artifact for upgrade

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationUpdateContext.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationUpdateContext.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactVersionRange;
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -52,33 +53,30 @@ public interface ApplicationUpdateContext {
   String getConfigAsString();
 
   /**
-   * Gets list of plugin artifacts based on given parameters in sorted in ascending order by version.
+   * Returns list of available plugin artifacts based on given parameters.
    *
    * @param pluginType the plugin type.
    * @param pluginName the plugin name.
-   * @param pluginScope the scope to search plugins in.
    * @param pluginRange the range of the version candidate plugins should be in.
    * @return artifact list of plugins which matches with given parameters, sorted in ascending order.
    *         Returns empty list if no artifact for the plugin found.
    */
-  default List<ArtifactId> getPluginArtifacts(String pluginType, String pluginName, ArtifactScope pluginScope,
+  default List<ArtifactId> getPluginArtifacts(String pluginType, String pluginName,
                                               @Nullable ArtifactVersionRange pluginRange) throws Exception {
-    return getPluginArtifacts(pluginType, pluginName, pluginScope, pluginRange, Integer.MAX_VALUE);
+    return getPluginArtifacts(pluginType, pluginName, pluginRange, Integer.MAX_VALUE);
   }
 
   /**
-   * Gets list of plugin artifacts based on given parameters in sorted in ascending order by version.
-   * Returns plugin artifacts using given filters in ascending order.
+   * Returns list of available plugin artifacts based on given parameters.
    *
    * @param pluginType the plugin type.
    * @param pluginName the plugin name.
-   * @param pluginScope the scope to search plugins in.
    * @param pluginRange the range of the version candidate plugins should be in.
    * @param limit number of results to return at max, if null, default will be INT_MAX.
    * @return artifact list of plugins which matches with given parameters, sorted in ascending order.
    *         Returns empty list if no artifact for the plugin found.
    */
-  List<ArtifactId> getPluginArtifacts(String pluginType, String pluginName, ArtifactScope pluginScope,
+  List<ArtifactId> getPluginArtifacts(String pluginType, String pluginName,
                                       @Nullable ArtifactVersionRange pluginRange, int limit) throws Exception;
 
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -28,6 +28,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.dataset.DatasetManagementException;
 import io.cdap.cdap.app.runtime.ProgramController;
@@ -89,6 +90,7 @@ import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -342,6 +344,26 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     responder.sendStatus(HttpResponseStatus.OK);
   }
 
+  private ArtifactScope validateScope(String scope) throws BadRequestException {
+    try {
+      return ArtifactScope.valueOf(scope.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException("Invalid scope " + scope);
+    }
+  }
+
+  private Set<ArtifactScope> getArtifactScopes(Set<String> artifactScopes) throws BadRequestException {
+    // If no scope is provided, consider all artifact scopes.
+    if (artifactScopes.isEmpty()) {
+      return EnumSet.allOf(ArtifactScope.class);
+    }
+    Set<ArtifactScope> scopes = new HashSet<>();
+    for (String scope : artifactScopes) {
+      scopes.add(validateScope(scope));
+    }
+    return scopes;
+  }
+
   /**
    * Updates an existing application.
    */
@@ -389,9 +411,13 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @AuditPolicy(AuditDetail.REQUEST_BODY)
   public void upgradeApplication(HttpRequest request, HttpResponder responder,
                                  @PathParam("namespace-id") String namespaceId,
-                                 @PathParam("app-id") String appName) throws Exception {
-    ApplicationId appId = validateApplicationId(namespaceId, appName);
-    applicationLifecycleService.upgradeApplication(appId, createProgramTerminator());
+                                 @PathParam("app-id") String appName,
+                                 @QueryParam("artifactScope") Set<String> artifactScopes,
+                                 @QueryParam("allowSnapshot") boolean allowSnapshot) throws Exception {
+    ApplicationId appId = validateApplicationId(validateNamespace(namespaceId), appName);
+    Set<ArtifactScope> allowedArtifactScopes = getArtifactScopes(artifactScopes);
+    applicationLifecycleService.upgradeApplication(appId, createProgramTerminator(),
+                                                   allowedArtifactScopes, allowSnapshot);
     ApplicationUpdateDetail updateDetail = new ApplicationUpdateDetail(appId, "upgrade successful.");
     responder.sendJson(HttpResponseStatus.OK, GSON.toJson(updateDetail));
   }
@@ -416,15 +442,20 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/upgrade")
   @AuditPolicy(AuditDetail.REQUEST_BODY)
   public void upgradeApplications(FullHttpRequest request, HttpResponder responder,
-                                  @PathParam("namespace-id") String namespace) throws Exception {
+                                  @PathParam("namespace-id") String namespaceId,
+                                  @QueryParam("artifactScope") Set<String> artifactScopes,
+                                  @QueryParam("allowSnapshot") boolean allowSnapshot) throws Exception {
     // TODO: (CDAP-16910) Improve batch API performance as each application upgrade is an event independent of each
     //  other.
-    List<ApplicationId> appIds = decodeAndValidateBatchApplication(validateNamespace(namespace), request);
+
+    List<ApplicationId> appIds = decodeAndValidateBatchApplication(validateNamespace(namespaceId), request);
+    Set<ArtifactScope> allowedArtifactScopes = getArtifactScopes(artifactScopes);
     List<ApplicationUpdateDetail> details = new ArrayList<>();
     for (ApplicationId appId : appIds) {
       ApplicationUpdateDetail updateDetail;
       try {
-        applicationLifecycleService.upgradeApplication(appId, createProgramTerminator());
+        applicationLifecycleService.upgradeApplication(appId, createProgramTerminator(), allowedArtifactScopes,
+                                                       allowSnapshot);
         updateDetail = new ApplicationUpdateDetail(appId, "upgrade successful.");
       } catch (UnsupportedOperationException e) {
         String errorMessage = String.format("Application %s does not support upgrade.", appId);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -95,6 +95,7 @@ import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AuthorizationEnforcer;
 import io.cdap.cdap.spi.metadata.MetadataMutation;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,11 +107,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
@@ -407,11 +410,65 @@ public class ApplicationLifecycleService extends AbstractIdleService {
   }
 
   /**
+   * Finds latest application artifact for given application and current artifact for upgrading application.
+   * If no artifact found then returns current artifact as the candidate.
+   *
+   * @param appId application Id to find latest app artifact for.
+   * @param currentArtifactId current artifact used by application.
+   * @param allowedArtifactScopes artifact scopes to search in for finding candidate artifacts.
+   * @param allowSnapshot whether to consider snapshot version of artifacts or not for upgrade.
+   * @return {@link ArtifactSummary} for the artifact to be used for upgrade purpose.
+   * @throws NotFoundException if there is no artifact available for given artifact.
+   * @throws Exception if there was an exception during finding candidate artifact.
+   */
+  private ArtifactSummary getLatestAppArtifactForUpgrade(ApplicationId appId, ArtifactId currentArtifactId,
+                                                         Set<ArtifactScope> allowedArtifactScopes,
+                                                         boolean allowSnapshot)
+    throws Exception {
+
+    List<ArtifactSummary> availableArtifacts = new ArrayList<>();
+    // At the least, current artifact should be in the set of available artifacts.
+    availableArtifacts.add(ArtifactSummary.from(currentArtifactId));
+
+    // Find candidate artifacts from all scopes we need to consider.
+    for (ArtifactScope scope: allowedArtifactScopes) {
+      NamespaceId artifactNamespaceToConsider =
+        ArtifactScope.SYSTEM.equals(scope) ? NamespaceId.SYSTEM : appId.getParent();
+      List<ArtifactSummary> artifacts;
+      try {
+        artifacts = artifactRepository.getArtifactSummaries(artifactNamespaceToConsider, currentArtifactId.getName(),
+                                                            Integer.MAX_VALUE, ArtifactSortOrder.ASC);
+      } catch (ArtifactNotFoundException e) {
+        // This can happen if we are looking for candidate artifact in multiple namespace.
+        continue;
+      }
+      for (ArtifactSummary artifactSummary: artifacts) {
+        ArtifactVersion artifactVersion = new ArtifactVersion(artifactSummary.getVersion());
+        // Consider if it is a non-snapshot version artifact or it is a snapshot version than allowSnapshot is true.
+        if ((artifactVersion.isSnapshot() && allowSnapshot) || !artifactVersion.isSnapshot()) {
+          availableArtifacts.add(artifactSummary);
+        }
+      }
+    }
+
+    // Find the artifact with latest version.
+    Optional<ArtifactSummary> newArtifactCandidate = availableArtifacts.stream().max(
+      Comparator.comparing(artifactSummary -> new ArtifactVersion(artifactSummary.getVersion())));
+
+    io.cdap.cdap.proto.id.ArtifactId currentArtifact =
+      new io.cdap.cdap.proto.id.ArtifactId(appId.getNamespace(), currentArtifactId.getName(),
+                                           currentArtifactId.getVersion().getVersion());
+    return newArtifactCandidate.orElseThrow(() -> new ArtifactNotFoundException(currentArtifact));
+  }
+
+  /**
    * Upgrades an existing application by upgrading application artifact versions and plugin artifact versions.
    *
    * @param appId the id of the application to upgrade.
    * @param programTerminator a program terminator that will stop programs that are removed when updating an app.
    *                          For example, if an update removes a flow, the terminator defines how to stop that flow.
+   * @param allowedArtifactScopes artifact scopes allowed while looking for latest artifacts for upgrade.
+   * @param allowSnapshot whether to consider snapshot version of artifacts or not for upgrade.
    * @throws IllegalStateException if something unexpected happened during upgrade.
    * @throws IOException if there was an IO error during initializing application class from artifact.
    * @throws JsonIOException if there was an error in serializing or deserializing app config.
@@ -421,7 +478,8 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    * @throws Exception if there was an exception during the upgrade of application. This exception will often wrap
    *                   the actual exception
    */
-  public void upgradeApplication(ApplicationId appId, ProgramTerminator programTerminator)
+  public void upgradeApplication(ApplicationId appId, ProgramTerminator programTerminator,
+                                 Set<ArtifactScope> allowedArtifactScopes, boolean allowSnapshot)
     throws Exception {
     // Check if the current user has admin privileges on it before updating.
     authorizationEnforcer.enforce(appId, authenticationContext.getPrincipal(), Action.ADMIN);
@@ -432,20 +490,10 @@ public class ApplicationLifecycleService extends AbstractIdleService {
       throw new NotFoundException(appId);
     }
     ArtifactId currentArtifact = currentSpec.getArtifactId();
-    NamespaceId currentArtifactNamespace =
-      ArtifactScope.SYSTEM.equals(currentArtifact.getScope()) ? NamespaceId.SYSTEM : appId.getParent();
 
-    // Get the artifact with latest version for upgrade.
-    List<ArtifactSummary> availableArtifacts =
-      artifactRepository.getArtifactSummaries(currentArtifactNamespace, currentArtifact.getName(), 1,
-                                              ArtifactSortOrder.DESC);
-    if (availableArtifacts.isEmpty()) {
-      String error = String.format("No artifacts found for artifact id %s in namespace %s.", currentArtifact.getName(),
-                                   currentArtifactNamespace);
-      throw new NotFoundException(error);
-    }
-    // The latest version should be first (and only) value in the result.
-    ArtifactSummary candidateArtifact = availableArtifacts.get(0);
+    ArtifactSummary candidateArtifact = getLatestAppArtifactForUpgrade(appId, currentArtifact,
+                                                                       allowedArtifactScopes,
+                                                                       allowSnapshot);
     ArtifactVersion candidateArtifactVersion = new ArtifactVersion(candidateArtifact.getVersion());
 
     // Current artifact should not have higher version than candidate artifact.
@@ -456,14 +504,14 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     }
 
     ArtifactId newArtifactId =
-      new ArtifactId(currentArtifact.getName(), candidateArtifactVersion, currentArtifact.getScope());
+      new ArtifactId(candidateArtifact.getName(), candidateArtifactVersion, candidateArtifact.getScope());
 
     Id.Artifact newArtifact = Id.Artifact.fromEntityId(Artifacts.toProtoArtifactId(appId.getParent(), newArtifactId));
     ArtifactDetail newArtifactDetail = artifactRepository.getArtifact(newArtifact);
 
     updateApplicationInternal(appId, currentSpec.getConfiguration(), programTerminator, newArtifactDetail,
                               Collections.singletonList(ApplicationConfigUpdateAction.UPGRADE_ARTIFACT),
-                              ownerAdmin.getOwner(appId), false);
+                              allowedArtifactScopes, allowSnapshot, ownerAdmin.getOwner(appId), false);
   }
 
   /**
@@ -475,6 +523,8 @@ public class ApplicationLifecycleService extends AbstractIdleService {
                                          ProgramTerminator programTerminator,
                                          ArtifactDetail artifactDetail,
                                          List<ApplicationConfigUpdateAction> updateActions,
+                                         Set<ArtifactScope> allowedArtifactScopes,
+                                         boolean allowSnapshot,
                                          @Nullable KerberosPrincipalId ownerPrincipal,
                                          boolean updateSchedules) throws Exception {
     ApplicationClass appClass = Iterables.getFirst(artifactDetail.getMeta().getClasses().getApps(), null);
@@ -490,7 +540,8 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     String updatedAppConfig;
     DefaultApplicationUpdateContext updateContext =
       new DefaultApplicationUpdateContext(appId.getParent(), appId, artifactDetail.getDescriptor().getArtifactId(),
-                                          artifactRepository, currentConfigStr, updateActions);
+                                          artifactRepository, currentConfigStr, updateActions,
+                                          allowedArtifactScopes, allowSnapshot);
 
     try (CloseableClassLoader artifactClassLoader =
       artifactRepository.createArtifactClassLoader(artifactDetail.getDescriptor().getLocation(),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricClient.java
@@ -81,8 +81,10 @@ import java.io.File;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -653,6 +655,11 @@ public class AppFabricClient {
   }
 
   public void upgradeApplication(ApplicationId appId) throws Exception {
+    upgradeApplication(appId, Collections.emptySet(), false);
+  }
+
+  public void upgradeApplication(ApplicationId appId, Set<String> artifactScopes, boolean allowSnapshot)
+    throws Exception {
     HttpRequest request = new DefaultHttpRequest(
         HttpVersion.HTTP_1_1, HttpMethod.POST,
         String.format("%s/apps/%s/upgrade", getNamespacePath(appId.getNamespace()), appId.getApplication())
@@ -662,7 +669,8 @@ public class AppFabricClient {
 
     MockResponder mockResponder = new MockResponder();
     appLifecycleHttpHandler.upgradeApplication(request, mockResponder, appId.getNamespace(),
-                                               appId.getApplication());
+                                               appId.getApplication(), artifactScopes,
+                                               allowSnapshot);
     verifyResponse(HttpResponseStatus.OK, mockResponder.getStatus(), "Failed to upgrade app");
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import io.cdap.cdap.api.ProgramStatus;
 import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
@@ -171,6 +170,8 @@ public class DataPipelineTest extends HydratorTestBase {
   private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
   private static final ArtifactId UPGRADE_APP_ARTIFACT_ID_1 = NamespaceId.DEFAULT.artifact("app", "1.1.0");
   private static final ArtifactId UPGRADE_APP_ARTIFACT_ID_2 = NamespaceId.DEFAULT.artifact("app", "1.2.0");
+  private static final ArtifactId UPGRADE_APP_ARTIFACT_ID_3_SNAPSHOT =
+    NamespaceId.DEFAULT.artifact("app", "1.3.0-SNAPSHOT");
   private static final ArtifactId OLD_APP_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("app", "0.0.9");
 
   private static final ArtifactSummary APP_ARTIFACT_RANGE = new ArtifactSummary("app", "[0.1.0,1.1.0)");
@@ -209,6 +210,7 @@ public class DataPipelineTest extends HydratorTestBase {
     setupBatchArtifacts(OLD_APP_ARTIFACT_ID, DataPipelineApp.class);
     setupBatchArtifacts(UPGRADE_APP_ARTIFACT_ID_1, DataPipelineApp.class);
     setupBatchArtifacts(UPGRADE_APP_ARTIFACT_ID_2, DataPipelineApp.class);
+    setupBatchArtifacts(UPGRADE_APP_ARTIFACT_ID_3_SNAPSHOT, DataPipelineApp.class);
 
     // Bind different version of filter plugin with different version of data pipeline app in SYSTEM namespace.
     // Will be used to make sure upgrade choose latest version of artifact and only plugin mapped to corresponding
@@ -219,6 +221,10 @@ public class DataPipelineTest extends HydratorTestBase {
                       PluggableFilterTransform.class);
     addPluginArtifact(NamespaceId.SYSTEM.artifact("test-plugins", "1.1.0"), UPGRADE_APP_ARTIFACT_ID_2,
                       PluggableFilterTransform.class);
+    addPluginArtifact(NamespaceId.DEFAULT.artifact("test-plugins", "1.0.8"), UPGRADE_APP_ARTIFACT_ID_2,
+                      PluggableFilterTransform.class);
+    addPluginArtifact(NamespaceId.DEFAULT.artifact("test-plugins", "1.1.1-SNAPSHOT"),
+                      UPGRADE_APP_ARTIFACT_ID_3_SNAPSHOT, PluggableFilterTransform.class);
   }
 
   @After
@@ -3521,9 +3527,10 @@ public class DataPipelineTest extends HydratorTestBase {
     return getMetricsManager().getTotalMetric(tags, "user." + metric);
   }
 
-  /* Unit test tests upgrade for a deployed application.
+  /* Tests upgrade for a deployed application.
      1. Deploy an application with older application artifact (1.0.0) and older filter plugin version (1.0.0).
-     2. Add new version of application artifact (1.0.1) and filter plugin artifact (1.1.0).
+     2. Add new versions of application artifacts (0.0.9, 1.1.0, 1.2.0) and filter plugin artifacts (1.0.5, 1.1.0) in
+        SYSTEM scope (in test class setup).
      3. Upgrade the older deployed application.
      4. Verify that after upgrading, application artifact and filter plugin artifact is upgraded to use latest version
         in its config.
@@ -3576,11 +3583,125 @@ public class DataPipelineTest extends HydratorTestBase {
                         ArtifactScope.SYSTEM);
   }
 
-  /* Unit test tests upgrade for a deployed application with a plugin using plugin range.
+  /* Tests upgrade for a deployed application. Also tests that SNAPSHOT artifacts are being considered for upgrade.
+     1. Deploy an application with older application artifact (1.0.0) and older filter plugin version (1.0.0).
+     2. Add new versions of application artifact (0.0.9, 1.1.0, 1.2.0) and filter plugin artifacts (1.0.5, 1.1.0).
+     3. Also deploy a snapshot version of app artifact 1.3.0-SNAPSHOT and plugin artifact 1.1.1-SNAPSHOT bind to it.
+     3. Upgrade the older deployed application.
+     4. Verify that after upgrading, application artifact and filter plugin artifact is upgraded to use latest version
+        in its config and it uses snapshot versions for both.
+   */
+  @Test
+  public void testSimpleUpgradePipelinesWithSnapshotArtifact() throws Exception {
+    ArtifactSelectorConfig currentArtifactSelector =
+      new ArtifactSelectorConfig(ArtifactScope.USER.name(), "test-plugins", "1.0.0");
+
+    Engine engine = Engine.MAPREDUCE;
+    String sourceName = "testSource" + engine.name();
+    String sinkName = "testSink" + engine.name();
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
+      .setEngine(engine)
+      .addStage(new ETLStage("source", MockSource.getPlugin(sourceName)))
+      .addStage(new ETLStage("filter", PluggableFilterTransform.getPlugin(
+        ValueFilter.NAME, ValueFilter.getProperties("${field}", "${value}"), currentArtifactSelector)))
+      .addStage(new ETLStage("sink", MockSink.getPlugin(sinkName)))
+      .addConnection("source", "filter")
+      .addConnection("filter", "sink")
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("sparkProgramTest");
+    // Deploy app with artifact version 1.0.0.
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+    ApplicationDetail oldAppDetail = getAppDetail(appId);
+    ETLBatchConfig oldBatchConfig = GSON.fromJson(oldAppDetail.getConfiguration(), ETLBatchConfig.class);
+    Map<String, ETLStage> oldStageMap = oldBatchConfig.getStages().stream().collect(
+      Collectors.toMap(ETLStage::getName, e -> e));
+
+    // Upgrade application with allowSnapshot set to true.
+    appManager.upgrade(Collections.emptySet(), true);
+
+    ApplicationDetail upgradedAppDetail = getAppDetail(appId);
+    ETLBatchConfig newBatchConfig = GSON.fromJson(upgradedAppDetail.getConfiguration(), ETLBatchConfig.class);
+    Map<String, ETLStage> newStageMap = newBatchConfig.getStages().stream().collect(
+      Collectors.toMap(ETLStage::getName, e -> e));
+
+    // Compare stages that should be same after upgrade.
+    Assert.assertEquals(oldStageMap.get("source"), newStageMap.get("source"));
+    Assert.assertEquals(oldStageMap.get("sink"), newStageMap.get("sink"));
+
+    // Verify that after upgrade, application upgrades artifact version to latest version available.
+    Assert.assertEquals(UPGRADE_APP_ARTIFACT_ID_3_SNAPSHOT.getVersion(), upgradedAppDetail.getArtifact().getVersion());
+    // Check if the filter stage, for which version should be upgraded to desired version in SYSTEM scope.
+    ETLPlugin upgradedPlugin = newStageMap.get("filter").getPlugin();
+    Assert.assertEquals(upgradedPlugin.getArtifactConfig().getVersion(), "1.1.1-SNAPSHOT");
+    Assert.assertEquals(ArtifactScope.valueOf(upgradedPlugin.getArtifactConfig().getScope().toUpperCase()),
+                        ArtifactScope.USER);
+  }
+
+    /* Tests upgrade for a deployed application. Also tests artifact scope parameter for only considering artifacts in
+       a given scope.
+     1. Deploy an application with older application artifact (1.0.0) and older filter plugin version (1.0.0).
+     2. Add new versions of application artifacts (0.0.9, 1.1.0, 1.2.0) and filter plugin artifacts (1.0.5, 1.1.0) in
+        SYSTEM scope (in test class setup).
+     3. Also deploy a snapshot version of plugin artifact 1.0.8 in USER scope.
+     3. Upgrade the older deployed application with artifact scope set to USER for upgrade.
+     4. Verify that after upgrading, application artifact and filter plugin artifact is upgraded to use latest version
+        in its config and it uses snapshot plugin version with 1.0.8 from USER scope.
+   */
+  @Test
+  public void testSimpleUpgradePipelinesWithArtifactScope() throws Exception {
+    ArtifactSelectorConfig currentArtifactSelector =
+      new ArtifactSelectorConfig(ArtifactScope.USER.name(), "test-plugins", "1.0.0");
+
+    Engine engine = Engine.MAPREDUCE;
+    String sourceName = "testSource" + engine.name();
+    String sinkName = "testSink" + engine.name();
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
+      .setEngine(engine)
+      .addStage(new ETLStage("source", MockSource.getPlugin(sourceName)))
+      .addStage(new ETLStage("filter", PluggableFilterTransform.getPlugin(
+        ValueFilter.NAME, ValueFilter.getProperties("${field}", "${value}"), currentArtifactSelector)))
+      .addStage(new ETLStage("sink", MockSink.getPlugin(sinkName)))
+      .addConnection("source", "filter")
+      .addConnection("filter", "sink")
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("sparkProgramTest");
+    // Deploy app with artifact version 1.0.0.
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+    ApplicationDetail oldAppDetail = getAppDetail(appId);
+    ETLBatchConfig oldBatchConfig = GSON.fromJson(oldAppDetail.getConfiguration(), ETLBatchConfig.class);
+    Map<String, ETLStage> oldStageMap = oldBatchConfig.getStages().stream().collect(
+      Collectors.toMap(ETLStage::getName, e -> e));
+
+    // Upgrade application with artifact scope as USER.
+    appManager.upgrade(Collections.singleton(ArtifactScope.USER.toString()), false);
+
+    ApplicationDetail upgradedAppDetail = getAppDetail(appId);
+    ETLBatchConfig newBatchConfig = GSON.fromJson(upgradedAppDetail.getConfiguration(), ETLBatchConfig.class);
+    Map<String, ETLStage> newStageMap = newBatchConfig.getStages().stream().collect(
+      Collectors.toMap(ETLStage::getName, e -> e));
+
+    // Compare stages that should be same after upgrade.
+    Assert.assertEquals(oldStageMap.get("source"), newStageMap.get("source"));
+    Assert.assertEquals(oldStageMap.get("sink"), newStageMap.get("sink"));
+
+    // Verify that after upgrade, application upgrades artifact version to latest version available.
+    Assert.assertEquals(UPGRADE_APP_ARTIFACT_ID_2.getVersion(), upgradedAppDetail.getArtifact().getVersion());
+    // Check if the filter stage, for which version should be upgraded to desired version in SYSTEM scope.
+    ETLPlugin upgradedPlugin = newStageMap.get("filter").getPlugin();
+    Assert.assertEquals("1.0.8", upgradedPlugin.getArtifactConfig().getVersion());
+    Assert.assertEquals(ArtifactScope.valueOf(upgradedPlugin.getArtifactConfig().getScope().toUpperCase()),
+                        ArtifactScope.USER);
+  }
+
+  /* Tests upgrade for a deployed application with a plugin using plugin range.
    1. Deploy an application with older application artifact (1.0.0) and older filter plugin version with range
       [1.0.0-1.0.5).
-   2. Add multiple versions of same application artifact with latest being (1.2.0).
-   3. Bind newer version of filter plugin 1.1.0 with it.
+   2. Add new versions of application artifacts (0.0.9, 1.1.0, 1.2.0) and filter plugin artifacts (1.0.5, 1.1.0) in
+      SYSTEM scope (in test class setup).
    3. Upgrade the older deployed application.
    4. Verify that after upgrading, application artifact and filter plugin artifact is upgraded to use latest version
       in its config. Also verify that plugin version range for filter stage is changed to use newest version of plugin.
@@ -3634,23 +3755,17 @@ public class DataPipelineTest extends HydratorTestBase {
                         ArtifactScope.SYSTEM);
   }
 
-  /* Unit test tests upgrade for a deployed application with a plugin using plugin range.
+  /* Tests upgrade for a deployed application with a plugin using plugin range.
    1. Deploy an application with older application artifact (1.0.0) and filter plugin version with range
       [1.0.0-2.0.0) to make sure latest version of plugin should be included in it.
-   2. Add multiple versions of same application artifact with latest being (1.2.0).
-   3. Bind newer version of filter plugin 1.1.0 with it.
+   2. Add new versions of application artifacts (0.0.9, 1.1.0, 1.2.0) and filter plugin artifacts (1.0.5, 1.1.0) in
+      SYSTEM scope (in test class setup).
    3. Upgrade the older deployed application.
    4. Verify that after upgrading, application artifact uses latest version in its config.
       But plugin range is not updated as latest version of plugin is still included in the range.
   */
   @Test
   public void testUpgradePipelinesWithNoChangeInPluginRange() throws Exception {
-    // Since filter plugin is not going to upgrade due to its range, the scope of filter plugin still stays USER.
-    // Add a filter plugin in DEFAULT namespace in the proposed range for upgraded artifact version.
-    // Needed to make deployment successful.
-    addPluginArtifact(NamespaceId.DEFAULT.artifact("test-plugins", "1.1.0"), UPGRADE_APP_ARTIFACT_ID_2,
-                      PluggableFilterTransform.class);
-
     ArtifactSelectorConfig currentArtifactSelector =
       new ArtifactSelectorConfig(ArtifactScope.USER.name(), "test-plugins", "[1.0.0,2.0.0)");
 
@@ -3676,8 +3791,9 @@ public class DataPipelineTest extends HydratorTestBase {
     Map<String, ETLStage> oldStageMap = oldBatchConfig.getStages().stream().collect(
       Collectors.toMap(ETLStage::getName, e -> e));
 
-    // Upgrade application.
-    appManager.upgrade();
+    // Upgrade application with consider snapshot enabled to consider highest version of plugin available which is
+    // 1.1.1-SNAPSHOT.
+    appManager.upgrade(Collections.emptySet(), true);
 
     ApplicationDetail upgradedAppDetail = getAppDetail(appId);
     ETLBatchConfig newBatchConfig = GSON.fromJson(upgradedAppDetail.getConfiguration(), ETLBatchConfig.class);
@@ -3691,6 +3807,6 @@ public class DataPipelineTest extends HydratorTestBase {
     Assert.assertEquals(oldStageMap.get("filter"), newStageMap.get("filter"));
 
     // Verify that after upgrade, application upgrades artifact version to latest version available.
-    Assert.assertEquals(upgradedAppDetail.getArtifact().getVersion(), UPGRADE_APP_ARTIFACT_ID_2.getVersion());
+    Assert.assertEquals(upgradedAppDetail.getArtifact().getVersion(), UPGRADE_APP_ARTIFACT_ID_3_SNAPSHOT.getVersion());
   }
 }

--- a/cdap-integration-test/src/main/java/io/cdap/cdap/test/remote/RemoteApplicationManager.java
+++ b/cdap-integration-test/src/main/java/io/cdap/cdap/test/remote/RemoteApplicationManager.java
@@ -45,6 +45,8 @@ import io.cdap.cdap.test.WorkflowManager;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * {@link AbstractApplicationManager} for use in integration tests.
@@ -194,6 +196,11 @@ public class RemoteApplicationManager extends AbstractApplicationManager {
   @Override
   public void upgrade() throws Exception {
     applicationClient.upgradeApplication(application);
+  }
+
+  @Override
+  public void upgrade(Set<String> artifactScopes, boolean allowSnapshot) throws Exception {
+    applicationClient.upgradeApplication(application, artifactScopes, allowSnapshot);
   }
 
   @Override

--- a/cdap-test/src/main/java/io/cdap/cdap/test/ApplicationManager.java
+++ b/cdap-test/src/main/java/io/cdap/cdap/test/ApplicationManager.java
@@ -29,6 +29,8 @@ import io.cdap.cdap.proto.id.ScheduleId;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Instance of this class is for managing deployed application.
@@ -183,9 +185,20 @@ public interface ApplicationManager {
   void delete() throws Exception;
 
   /**
-   * Upgrades the application;
+   * Upgrades the application.
+   *
+   * @throws Exception
    */
   void upgrade() throws Exception;
+
+  /**
+   * Upgrades the application.
+   *
+   * @param artifactScopes Scopes in which to look for artifacts for upgrade. If null, then search in all scopes.
+   * @param allowSnapshot Consider snapshot version of artifacts for upgrade or not.
+   * @throws Exception
+   */
+  void upgrade(Set<String> artifactScopes, boolean allowSnapshot) throws Exception;
 
   /**
    * Returns the application's details.

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/internal/DefaultApplicationManager.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/internal/DefaultApplicationManager.java
@@ -49,6 +49,8 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * A default implementation of {@link ApplicationManager}.
@@ -205,6 +207,11 @@ public class DefaultApplicationManager extends AbstractApplicationManager {
   @Override
   public void upgrade() throws Exception {
     appFabricClient.upgradeApplication(application);
+  }
+
+  @Override
+  public void upgrade(Set<String> artifactScopes, boolean allowSnapshot) throws Exception {
+    appFabricClient.upgradeApplication(application, artifactScopes, allowSnapshot);
   }
 
   @Override


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16835

https://builds.cask.co/browse/CDAP-DUT7238-4/test

This PR introduces new 2 options for upgrade related REST endpoints (`upgradeApplication` and `upgradeApplications`):
1: `artifact-scope`:      
    - . **DEFAULT** If set to null, consider all artifact scopes for finding latest artifact to upgrade to
    - If set to "system", consider only SYSTEM scope to search for artifacts for upgrade.
    - If set to "user", consider only USER scope to search for artifacts for upgrade.

2: `consider-snapshot-artifacts`:
     - **DEFAULT** is false.
     - If set to "true", consider also SNAPSHOT version of artifacts when trying find latest version.