### PR TITLE
[CDAP-16617] Revert add entity modal to be smaller size + fix error m…

### DIFF
--- a/cdap-ui/app/cdap/components/PlusButtonModal/PlusButtonModal.scss
+++ b/cdap-ui/app/cdap/components/PlusButtonModal/PlusButtonModal.scss
@@ -69,6 +69,14 @@ $horizontal-tab-height: 45px;
     overflow: hidden;
     max-width: unset;
 
+    &.add-entity-modal {
+      width: 75vw;
+      max-width: 1200px;
+      margin: 0 auto;
+      max-height: 75vh;
+      margin-top: 120px;
+    }
+
     .modal-content {
       border-radius: 0;
       height: 100%;
@@ -186,6 +194,10 @@ $horizontal-tab-height: 45px;
       .modal-footer {
         padding: 0;
         text-align: initial;
+        .card-action-feedback {
+          width: 100%;
+          margin: 0;
+        }
       }
     }
   }


### PR DESCRIPTION
…essage container

- Specifically targets add entity modal to be of smaller size
- Fixes the way we show error message when any task fails in the add entity modal.

![add-entity](https://user-images.githubusercontent.com/1452845/84331755-ef0b3580-ab3f-11ea-8d8b-d66561fe897d.gif)
