### PR TITLE
[CDAP-16784] Add Kryo serializers for unmodifiable class types

### DIFF
--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/serializer/UnmodifiableCollectionSerializer.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/serializer/UnmodifiableCollectionSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.runtime.spark.serializer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.CollectionSerializer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+
+/**
+ * Kryo serializer for Collections.UnmodifiableCollection
+ */
+public class UnmodifiableCollectionSerializer extends Serializer<Collection> {
+  @Override
+  public void write(Kryo kryo, Output output, Collection collection) {
+    CollectionSerializer collectionSerializer = new CollectionSerializer();
+    collectionSerializer.write(kryo, output, collection);
+  }
+
+  @Override
+  public Collection read(Kryo kryo, Input input, Class<Collection> aClass) {
+    CollectionSerializer collectionSerializer = new CollectionSerializer();
+    Class<?> collectionClass = LinkedList.class;
+    Object object = collectionSerializer.read(kryo, input, (Class<Collection>) collectionClass);
+
+    return Collections.unmodifiableCollection((Collection) object);
+  }
+}

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/serializer/UnmodifiableListSerializer.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/serializer/UnmodifiableListSerializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.runtime.spark.serializer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.CollectionSerializer;
+import org.apache.commons.collections.list.UnmodifiableList;
+import org.apache.commons.collections.map.UnmodifiableMap;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Kryo serializer for Collections.UnmodifiableList
+ */
+public class UnmodifiableListSerializer extends Serializer<List> {
+
+  @Override
+  public void write(Kryo kryo, Output output, List objects) {
+    CollectionSerializer collectionSerializer = new CollectionSerializer();
+    collectionSerializer.write(kryo, output, objects);
+  }
+
+  @Override
+  public List<Object> read(Kryo kryo, Input input, Class<List> aClass) {
+    CollectionSerializer collectionSerializer = new CollectionSerializer();
+    Class<?> listClass = LinkedList.class;
+    Object object = collectionSerializer.read(kryo, input, (Class<Collection>) listClass);
+
+    return Collections.unmodifiableList((List) object);
+  }
+}

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/serializer/UnmodifiableMapSerializer.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/serializer/UnmodifiableMapSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.runtime.spark.serializer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.MapSerializer;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Kryo serializer for Collections.UnmodifiableMap
+ */
+public class UnmodifiableMapSerializer extends Serializer<Map> {
+  @Override
+  public void write(Kryo kryo, Output output, Map map) {
+    MapSerializer mapSerializer = new MapSerializer();
+    mapSerializer.write(kryo, output, map);
+  }
+
+  @Override
+  public Map read(Kryo kryo, Input input, Class<Map> aClass) {
+    MapSerializer mapSerializer = new MapSerializer();
+    Class<?> mapClass = LinkedHashMap.class;
+    Object object = mapSerializer.read(kryo, input, (Class<Map>) mapClass);
+
+    return Collections.unmodifiableMap((Map) object);
+  }
+}

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/serializer/UnmodifiableSetSerializer.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/serializer/UnmodifiableSetSerializer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.runtime.spark.serializer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.CollectionSerializer;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Kryo serializer for Collections.UnmodifiableSet
+ */
+public class UnmodifiableSetSerializer extends Serializer<Set> {
+  @Override
+  public void write(Kryo kryo, Output output, Set set) {
+    CollectionSerializer collectionSerializer = new CollectionSerializer();
+    collectionSerializer.write(kryo, output, set);
+  }
+
+  @Override
+  public Set read(Kryo kryo, Input input, Class<Set> aClass) {
+    CollectionSerializer collectionSerializer = new CollectionSerializer();
+    Class<?> setClass = LinkedHashSet.class;
+    Object object = collectionSerializer.read(kryo, input, (Class<Collection>) setClass);
+
+    return Collections.unmodifiableSet((Set) object);
+  }
+}

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/serializer/UnmodifiableSortedMapSerializer.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/serializer/UnmodifiableSortedMapSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.runtime.spark.serializer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.DefaultSerializers;
+import com.esotericsoftware.kryo.serializers.MapSerializer;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+
+/**
+ * Kryo serializer for Collections.UnmodifiableSortedMap
+ */
+public class UnmodifiableSortedMapSerializer extends Serializer<SortedMap> {
+  @Override
+  public void write(Kryo kryo, Output output, SortedMap map) {
+    MapSerializer mapSerializer = new MapSerializer();
+    mapSerializer.write(kryo, output, map);
+  }
+
+  @Override
+  public SortedMap read(Kryo kryo, Input input, Class<SortedMap> aClass) {
+    MapSerializer mapSerializer = new MapSerializer();
+    Class<?> mapClass = TreeMap.class;
+    Object object = mapSerializer.read(kryo, input, (Class<Map>) mapClass);
+
+    return Collections.unmodifiableSortedMap((SortedMap) object);
+  }
+}

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/serializer/UnmodifiableSortedSetSerializer.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/serializer/UnmodifiableSortedSetSerializer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.runtime.spark.serializer;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.serializers.CollectionSerializer;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * Kryo serializer for Collections.UnmodifiableSortedSet
+ */
+public class UnmodifiableSortedSetSerializer extends Serializer<SortedSet> {
+  @Override
+  public void write(Kryo kryo, Output output, SortedSet sortedSet) {
+    CollectionSerializer collectionSerializer = new CollectionSerializer();
+    collectionSerializer.write(kryo, output, sortedSet);
+  }
+
+  @Override
+  public SortedSet read(Kryo kryo, Input input, Class<SortedSet> aClass) {
+    CollectionSerializer collectionSerializer = new CollectionSerializer();
+    Class<?> sortedSetClass = TreeSet.class;
+    Object object = collectionSerializer.read(kryo, input, (Class<Collection>) sortedSetClass);
+
+    return Collections.unmodifiableSortedSet((SortedSet) object);
+  }
+}

--- a/cdap-spark-core-base/src/test/java/io/cdap/cdap/app/runtime/spark/serializer/KryoSerializerTest.java
+++ b/cdap-spark-core-base/src/test/java/io/cdap/cdap/app/runtime/spark/serializer/KryoSerializerTest.java
@@ -29,11 +29,153 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  * Unit tests for various Kryo serializers in CDAP.
  */
 public class KryoSerializerTest {
+
+  @Test
+  public void testUnmodifiableSortedSetSerializer() {
+    SortedSet<String> tempSortedSet = new TreeSet<>();
+    tempSortedSet.addAll(Arrays.asList("This is a test string in a list".split(" ")));
+    SortedSet unmodifableSortedSet = Collections.unmodifiableSortedSet(tempSortedSet);
+
+    Kryo kryo = new Kryo();
+    Class<?> sortedSetClass = Collections.unmodifiableSortedSet(new TreeSet<>()).getClass();
+    kryo.addDefaultSerializer(sortedSetClass, UnmodifiableSortedSetSerializer.class);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (Output output = new Output(bos)) {
+      kryo.writeObject(output, unmodifableSortedSet);
+    }
+
+    Input input = new Input(bos.toByteArray());
+    SortedSet newSortedSet = (SortedSet) kryo.readObject(input, sortedSetClass);
+
+    Assert.assertEquals(unmodifableSortedSet, newSortedSet);
+  }
+
+  @Test
+  public void testUnmodifiableCollectionSerializer() {
+    Collection unmodifableCollection = Collections
+      .unmodifiableCollection(Arrays.asList("This is a test string in a list".split(" ")));
+
+    Kryo kryo = new Kryo();
+    Class<?> collectionClass = Collections.unmodifiableCollection(new LinkedList<>()).getClass();
+    kryo.addDefaultSerializer(collectionClass, UnmodifiableCollectionSerializer.class);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (Output output = new Output(bos)) {
+      kryo.writeObject(output, unmodifableCollection);
+    }
+
+    Input input = new Input(bos.toByteArray());
+    Collection newCollection = (Collection) kryo.readObject(input, collectionClass);
+
+    Assert.assertEquals(unmodifableCollection.toArray(), newCollection.toArray());
+  }
+
+  @Test
+  public void testUnmodifiableSetSerializer() {
+    Set<String> tempSet = new HashSet<String>();
+    tempSet.addAll(Arrays.asList("This is a test string in a list".split(" ")));
+    Set unmodifableSet = Collections.unmodifiableSet(tempSet);
+
+    Kryo kryo = new Kryo();
+    Class<?> setClass = Collections.unmodifiableSet(new HashSet<>()).getClass();
+    kryo.addDefaultSerializer(setClass, UnmodifiableSetSerializer.class);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (Output output = new Output(bos)) {
+      kryo.writeObject(output, unmodifableSet);
+    }
+
+    Input input = new Input(bos.toByteArray());
+    Set newSet = (Set) kryo.readObject(input, setClass);
+
+    Assert.assertEquals(unmodifableSet, newSet);
+  }
+
+  @Test
+  public void testUnmodifiableListSerializer() {
+    List unmodifableList = Collections.unmodifiableList(Arrays.asList("This is a test string in a list".split(" ")));
+
+    Kryo kryo = new Kryo();
+    Class<?> listClass = Collections.unmodifiableList(new LinkedList<>()).getClass();
+    kryo.addDefaultSerializer(listClass, UnmodifiableListSerializer.class);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (Output output = new Output(bos)) {
+      kryo.writeObject(output, unmodifableList);
+    }
+
+    Input input = new Input(bos.toByteArray());
+    List newList = (List) kryo.readObject(input, listClass);
+
+    Assert.assertEquals(unmodifableList, newList);
+  }
+
+  @Test
+  public void testUnmodifiableMapSerializer() {
+    HashMap<Integer, Integer> squaresMap = new HashMap<>();
+    for (int i = 0; i < 10; i++) {
+      squaresMap.put(i, i * i);
+    }
+
+    Map<Integer, Integer> unmodifiableMap = Collections.unmodifiableMap(squaresMap);
+    Kryo kryo = new Kryo();
+    Class<?> mapClass = Collections.unmodifiableMap(new HashMap<>()).getClass();
+    kryo.addDefaultSerializer(mapClass, UnmodifiableMapSerializer.class);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (Output output = new Output(bos)) {
+      kryo.writeObject(output, unmodifiableMap);
+    }
+
+    Input input = new Input(bos.toByteArray());
+    Map newMap = (Map) kryo.readObject(input, mapClass);
+
+    Assert.assertEquals(unmodifiableMap, newMap);
+  }
+
+  @Test
+  public void testUnmodifiableSortedMapSerializer() {
+    SortedMap<Integer, Integer> squaresMap = new TreeMap<>();
+    for (int i = 0; i < 10; i++) {
+      squaresMap.put(i, i * i);
+    }
+
+    SortedMap<Integer, Integer> unmodifiableSortedMap = Collections.unmodifiableSortedMap(squaresMap);
+    Kryo kryo = new Kryo();
+    Class<?> sortedMapClass = Collections.unmodifiableSortedMap(new TreeMap<>()).getClass();
+    kryo.addDefaultSerializer(sortedMapClass, UnmodifiableSortedMapSerializer.class);
+
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    try (Output output = new Output(bos)) {
+      kryo.writeObject(output, unmodifiableSortedMap);
+    }
+
+    Input input = new Input(bos.toByteArray());
+    SortedMap newSortedMap = (SortedMap) kryo.readObject(input, sortedMapClass);
+
+    Assert.assertEquals(unmodifiableSortedMap, newSortedMap);
+  }
 
   @Test
   public void testSchemaSerializer() {
@@ -96,19 +238,21 @@ public class KryoSerializerTest {
       "node", Schema.Field.of("children", Schema.nullableOf(Schema.arrayOf(Schema.recordOf("node")))));
 
     return Schema.recordOf("record",
-      Schema.Field.of("boolean", Schema.of(Schema.Type.BOOLEAN)),
-      Schema.Field.of("int", Schema.of(Schema.Type.INT)),
-      Schema.Field.of("long", Schema.of(Schema.Type.LONG)),
-      Schema.Field.of("float", Schema.of(Schema.Type.FLOAT)),
-      Schema.Field.of("double", Schema.of(Schema.Type.DOUBLE)),
-      Schema.Field.of("string", Schema.of(Schema.Type.STRING)),
-      Schema.Field.of("bytes", Schema.of(Schema.Type.BYTES)),
-      Schema.Field.of("ts", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)),
-      Schema.Field.of("enum", Schema.enumWith("a", "b", "c")),
-      Schema.Field.of("array", Schema.arrayOf(Schema.of(Schema.Type.INT))),
-      Schema.Field.of("map", Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.INT))),
-      Schema.Field.of("union", Schema.unionOf(Schema.of(Schema.Type.NULL), Schema.of(Schema.Type.STRING))),
-      Schema.Field.of("node", nodeSchema)
+                           Schema.Field.of("boolean", Schema.of(Schema.Type.BOOLEAN)),
+                           Schema.Field.of("int", Schema.of(Schema.Type.INT)),
+                           Schema.Field.of("long", Schema.of(Schema.Type.LONG)),
+                           Schema.Field.of("float", Schema.of(Schema.Type.FLOAT)),
+                           Schema.Field.of("double", Schema.of(Schema.Type.DOUBLE)),
+                           Schema.Field.of("string", Schema.of(Schema.Type.STRING)),
+                           Schema.Field.of("bytes", Schema.of(Schema.Type.BYTES)),
+                           Schema.Field.of("ts", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)),
+                           Schema.Field.of("enum", Schema.enumWith("a", "b", "c")),
+                           Schema.Field.of("array", Schema.arrayOf(Schema.of(Schema.Type.INT))),
+                           Schema.Field
+                             .of("map", Schema.mapOf(Schema.of(Schema.Type.STRING), Schema.of(Schema.Type.INT))),
+                           Schema.Field
+                             .of("union", Schema.unionOf(Schema.of(Schema.Type.NULL), Schema.of(Schema.Type.STRING))),
+                           Schema.Field.of("node", nodeSchema)
     );
   }
 }


### PR DESCRIPTION
Kryo serializer was causing [unit test failures](https://builds.cask.co/browse/CDAP-DUT7219-9/test) when enabled as the default serializer for spark. The failures were caused by Kryo's incorrect handling of the `Unmodifiable` classes within `java.util.Collections`. Custom serializers were added to correctly handle these types