### PR TITLE
[CDAP-16461] Adding size limit for spark block fetches

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -99,6 +99,7 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
     SparkConf sparkConf = new SparkConf();
     sparkConf.set("spark.streaming.backpressure.enabled", "true");
     sparkConf.set("spark.spark.streaming.blockInterval", String.valueOf(spec.getBatchIntervalMillis() / 5));
+    sparkConf.set("spark.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
     for (Map.Entry<String, String> property : spec.getProperties().entrySet()) {
       sparkConf.set(property.getKey(), property.getValue());
     }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
@@ -98,6 +98,7 @@ public class ETLSpark extends AbstractSpark {
     // turn off auto-broadcast by default until we better understand the implications and can set this to a
     // value that we are confident is safe.
     sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1");
+    sparkConf.set("spark.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
     context.setSparkConf(sparkConf);
 
     Map<String, String> properties = context.getSpecification().getProperties();


### PR DESCRIPTION
Addressing bug outlined in https://issues.cask.co/browse/CDAP-16461