### PR TITLE
CDAP-16955 add metrics for records into an autojoin

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
@@ -202,14 +202,15 @@ public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
       new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, pipelineRuntime, stageSpec);
     compute.initialize(sparkPluginContext);
 
-    JavaRDD<T> countedInput = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in", null));
+    JavaRDD<T> countedInput = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(),
+                                                              Constants.Metrics.RECORDS_IN, null));
     SparkConf sparkConf = jsc.getConf();
     if (sparkConf.getBoolean(Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG, true)) {
       countedInput = countedInput.cache();
     }
 
     return wrap(compute.transform(sparkPluginContext, countedInput)
-                  .map(new CountingFunction<U>(stageName, sec.getMetrics(), "records.out",
+                  .map(new CountingFunction<U>(stageName, sec.getMetrics(), Constants.Metrics.RECORDS_OUT,
                                                sec.getDataTracer(stageName))));
   }
 
@@ -236,7 +237,7 @@ public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
           new BasicSparkExecutionPluginContext(sec, jsc, datasetContext, pipelineRuntime, stageSpec);
 
         JavaRDD<T> countedRDD =
-          rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), "records.in", null));
+          rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), Constants.Metrics.RECORDS_IN, null));
         SparkConf sparkConf = jsc.getConf();
         if (sparkConf.getBoolean(Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG, true)) {
           countedRDD = countedRDD.cache();


### PR DESCRIPTION
Added a no-op map to auto-joiner input to count records in for
the stage, similar to what is done for normal joiners.
Enhanced autojoin unit tests to check values of
records.in and records.out metrics