### PR TITLE
(CDAP-16953) Correctly suppress runtime monitor warning log

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/proxy/SimpleRelayChannelHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/proxy/SimpleRelayChannelHandler.java
@@ -17,26 +17,17 @@
 package io.cdap.cdap.internal.app.runtime.monitor.proxy;
 
 import io.cdap.cdap.common.http.Channels;
-import io.cdap.cdap.common.logging.LogSamplers;
-import io.cdap.cdap.common.logging.Loggers;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.util.ReferenceCountUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link RelayChannelHandler} that relay traffic from one {@link Channel} to another.
  */
 public final class SimpleRelayChannelHandler extends ChannelInboundHandlerAdapter implements RelayChannelHandler {
-
-  private static final Logger LOG = LoggerFactory.getLogger(SimpleRelayChannelHandler.class);
-  private static final Logger OUTAGE_LOG = Loggers.sampling(
-    LOG, LogSamplers.perMessage(() -> LogSamplers.limitRate(TimeUnit.MINUTES.toMillis(1))));
 
   private final Channel outboundChannel;
 
@@ -68,7 +59,6 @@ public final class SimpleRelayChannelHandler extends ChannelInboundHandlerAdapte
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
     // If there is exception, just close the channel
-    OUTAGE_LOG.warn("Exception raised when relaying messages", cause);
     ctx.close();
   }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/service/AbstractRetryableScheduledService.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/service/AbstractRetryableScheduledService.java
@@ -183,4 +183,18 @@ public abstract class AbstractRetryableScheduledService extends AbstractSchedule
       }
     };
   }
+
+  /**
+   * Returns the number of consecutive failure encountered from {@link #runTask()}.
+   */
+  protected int getFailureCount() {
+    return failureCount;
+  }
+
+  /**
+   * Returns the time in milliseconds of the last start time that {@link #runTask()} was not throwing exception.
+   */
+  protected long getNonFailureStartTime() {
+    return nonFailureStartTime;
+  }
 }


### PR DESCRIPTION
- Failure is expected when a remote runtime just started, hence we delay the warning log for 30 seconds, which should be enough time for the remote runtime to be running