### PR TITLE
[CDAP-16959] Avoiding creation of uuid if already present for macros

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineConfigurations/Store/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/Store/index.js
@@ -192,34 +192,23 @@ const resetRuntimeArgToResolvedValue = (index, runtimeArgs, resolvedMacros) => {
 };
 
 const getRuntimeArgsForDisplay = (currentRuntimeArgs, macrosMap) => {
-  const macrosWithIds = {};
-  let runtimeArgsMap = {};
-
-  // holds provided macros in an object here even though we don't need the value,
-  // because object hash is faster than Array.indexOf
   if (currentRuntimeArgs.pairs) {
-    currentRuntimeArgs.pairs.forEach((currentPair) => {
-      let key = currentPair.key;
-      runtimeArgsMap[key] = currentPair.value || '';
-      if (currentPair.uniqueId && Object.prototype.hasOwnProperty.call(macrosMap, key)) {
-        macrosWithIds[key] = currentPair.uniqueId;
-      }
-    });
-    currentRuntimeArgs.pairs = currentRuntimeArgs.pairs.filter((keyValuePair) => {
-      return Object.keys(macrosMap).indexOf(keyValuePair.key) === -1;
-    });
+    currentRuntimeArgs.pairs = currentRuntimeArgs.pairs
+      .map((currentPair) => {
+        const key = currentPair.key;
+        if (Object.prototype.hasOwnProperty.call(macrosMap, key)) {
+          return {
+            key,
+            value: currentPair.value || '',
+            showReset: macrosMap[key].showReset,
+            uniqueId: currentPair.uniqueId || 'id-' + uuidV4(),
+            notDeletable: true,
+          };
+        }
+        return currentPair;
+      })
+      .sort((a, b) => Boolean(b.notDeletable) - Boolean(a.notDeletable));
   }
-  let macros = Object.keys(macrosMap).map((macroKey) => {
-    return {
-      key: macroKey,
-      value: runtimeArgsMap[macroKey] || '',
-      showReset: macrosMap[macroKey].showReset,
-      uniqueId: macrosWithIds[macroKey] || 'id-' + uuidV4(),
-      notDeletable: true,
-    };
-  });
-  // Placing macros in the front so they're displayed at top.
-  currentRuntimeArgs.pairs = macros.concat(currentRuntimeArgs.pairs);
   return currentRuntimeArgs;
 };
 

--- a/cdap-ui/app/cdap/components/PipelineConfigurations/Store/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/Store/index.js
@@ -192,7 +192,7 @@ const resetRuntimeArgToResolvedValue = (index, runtimeArgs, resolvedMacros) => {
 };
 
 const getRuntimeArgsForDisplay = (currentRuntimeArgs, macrosMap) => {
-  let providedMacros = {};
+  const macrosWithIds = {};
   let runtimeArgsMap = {};
 
   // holds provided macros in an object here even though we don't need the value,
@@ -201,8 +201,8 @@ const getRuntimeArgsForDisplay = (currentRuntimeArgs, macrosMap) => {
     currentRuntimeArgs.pairs.forEach((currentPair) => {
       let key = currentPair.key;
       runtimeArgsMap[key] = currentPair.value || '';
-      if (currentPair.notDeletable && currentPair.provided) {
-        providedMacros[key] = currentPair.value;
+      if (currentPair.uniqueId && Object.prototype.hasOwnProperty.call(macrosMap, key)) {
+        macrosWithIds[key] = currentPair.uniqueId;
       }
     });
     currentRuntimeArgs.pairs = currentRuntimeArgs.pairs.filter((keyValuePair) => {
@@ -214,11 +214,11 @@ const getRuntimeArgsForDisplay = (currentRuntimeArgs, macrosMap) => {
       key: macroKey,
       value: runtimeArgsMap[macroKey] || '',
       showReset: macrosMap[macroKey].showReset,
-      uniqueId: 'id-' + uuidV4(),
+      uniqueId: macrosWithIds[macroKey] || 'id-' + uuidV4(),
       notDeletable: true,
-      provided: Object.prototype.hasOwnProperty.call(providedMacros, macroKey),
     };
   });
+  // Placing macros in the front so they're displayed at top.
   currentRuntimeArgs.pairs = macros.concat(currentRuntimeArgs.pairs);
   return currentRuntimeArgs;
 };

--- a/cdap-ui/app/cdap/components/PreviewData/index.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/index.tsx
@@ -63,21 +63,18 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
     setPreviewData(updatedPreview);
   };
 
-  useEffect(
-    () => {
-      if (previewId) {
-        fetchPreview(
-          selectedNode,
-          previewId,
-          stages,
-          connections,
-          setPreviewLoading,
-          updatePreviewCb
-        );
-      }
-    },
-    [previewId]
-  );
+  useEffect(() => {
+    if (previewId) {
+      fetchPreview(
+        selectedNode,
+        previewId,
+        stages,
+        connections,
+        setPreviewLoading,
+        updatePreviewCb
+      );
+    }
+  }, [previewId]);
 
   const getTableData = () => {
     let inputs = {};

--- a/cdap-ui/app/directives/my-pipeline-runtime-args/my-pipeline-runtime-args.html
+++ b/cdap-ui/app/directives/my-pipeline-runtime-args/my-pipeline-runtime-args.html
@@ -17,7 +17,7 @@
 <div class="step-content-heading">
   Specify runtime arguments or update the ones derived from preferences
   <div class="step-content-subtitle">
-    By default, values for all runtime arguments must be provided before running the pipeline. If a stage in your pipeline provides the value of an argument, you can skip that argument by marking it as provided.
+    By default, values for all runtime arguments must be provided before running the pipeline. If a stage in your pipeline provides the value of an argument, it needs to be left empty.
   </div>
 </div>
 <div class="runtime-arguments-values key-value-pair-values">

--- a/cdap-ui/cypress/integration/pipeline.runtimeargs.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.runtimeargs.spec.ts
@@ -263,7 +263,7 @@ describe('Deploying pipeline with temporary runtime arguments', () => {
     ).click();
     cy.get(
       `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(2)} ${dataCy(RUNTIME_ARGS_KEY_SELECTOR)}`
-    ).should('not.exist');
+    ).should('not.contain','test key 3');
     cy.get(dataCy('run-deployed-pipeline-modal-btn')).click();
     cy.get(dataCy('Failed'), { timeout: PIPELINE_RUN_TIMEOUT }).should('exist');
     cy.get('.arrow-btn-container').click();
@@ -288,7 +288,7 @@ describe('Deploying pipeline with temporary runtime arguments', () => {
       `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(2)} ${dataCy(
         RUNTIME_ARGS_VALUE_SELECTOR
       )}`
-    ).should('not.exist');
+    ).should('not.contain','runtime_args_key3');
   });
 });
 
@@ -386,7 +386,7 @@ describe('Deploying pipeline with saved runtime arguments', () => {
       `${dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)} ${dataCy(2)} ${dataCy(
         RUNTIME_ARGS_VALUE_SELECTOR
       )}`
-    ).should('not.exist');
+    ).should('not.contain', 'runtime_args_value4');
     cy.assert_runtime_args_row(0, 'source_path', SOURCE_PATH_VAL, true);
     cy.assert_runtime_args_row(1, 'sink_path', SINK_PATH_VAL, true);
   });


### PR DESCRIPTION
- Re-using existing UUID when retrieving macros for display. 
- Update text for runtime arguments description in preview.

JIRA: https://issues.cask.co/browse/CDAP-16959