### PR TITLE
CDAP-16943 use byte[] instead of ByteBuffer for record conversion

### DIFF
--- a/cdap-api-spark-base/src/main/java/io/cdap/cdap/api/spark/sql/DataFrames.java
+++ b/cdap-api-spark-base/src/main/java/io/cdap/cdap/api/spark/sql/DataFrames.java
@@ -386,9 +386,8 @@ public final class DataFrames {
       case FLOAT:
       case DOUBLE:
       case STRING:
-        return value;
       case BYTES:
-        return ByteBuffer.wrap((byte[]) value);
+        return value;
       case ARRAY: {
         // Value must be a collection
         @SuppressWarnings("unchecked")

--- a/cdap-spark-core-base/src/test/java/io/cdap/cdap/api/spark/sql/DataFramesTest.java
+++ b/cdap-spark-core-base/src/test/java/io/cdap/cdap/api/spark/sql/DataFramesTest.java
@@ -240,7 +240,7 @@ public class DataFramesTest {
     Assert.assertEquals(30f, record.<Float>get("floatField").floatValue(), 0.0001f);
     Assert.assertEquals(40d, record.<Double>get("doubleField").doubleValue(), 0.0001d);
     Assert.assertEquals("String", record.<String>get("stringField"));
-    Assert.assertEquals(ByteBuffer.wrap(new byte[] {1, 2, 3}), record.<ByteBuffer>get("bytesField"));
+    Assert.assertArrayEquals(new byte[] {1, 2, 3}, record.<byte[]>get("bytesField"));
     Assert.assertNull(record.get("nullableField"));
     Assert.assertEquals(Arrays.asList("1", "2", "3"), record.<Collection<String>>get("arrayField"));
     Assert.assertEquals(Collections.singletonMap("k", "v"), record.<Map<String, String>>get("mapField"));


### PR DESCRIPTION
When converting from a spark Row to a cdap StructuredRecord,
use a byte[] for byte fields instead of a ByteBuffer.
This is because downstream plugins are less likely to have
issues dealing with byte[] and because ByteBuffer is not
serializable, which can cause issues in certain Spark pipelines.