### PR TITLE
[CDAP-16959] Avoiding creation of uuid if already present for macros

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineConfigurations/Store/index.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/Store/index.js
@@ -188,34 +188,23 @@ const resetRuntimeArgToResolvedValue = (index, runtimeArgs, resolvedMacros) => {
 };
 
 const getRuntimeArgsForDisplay = (currentRuntimeArgs, macrosMap) => {
-  let providedMacros = {};
-  let runtimeArgsMap = {};
-
-  // holds provided macros in an object here even though we don't need the value,
-  // because object hash is faster than Array.indexOf
   if (currentRuntimeArgs.pairs) {
-    currentRuntimeArgs.pairs.forEach((currentPair) => {
-      let key = currentPair.key;
-      runtimeArgsMap[key] = currentPair.value || '';
-      if (currentPair.notDeletable && currentPair.provided) {
-        providedMacros[key] = currentPair.value;
-      }
-    });
-    currentRuntimeArgs.pairs = currentRuntimeArgs.pairs.filter((keyValuePair) => {
-      return Object.keys(macrosMap).indexOf(keyValuePair.key) === -1;
-    });
+    currentRuntimeArgs.pairs = currentRuntimeArgs.pairs
+      .map((currentPair) => {
+        const key = currentPair.key;
+        if (Object.prototype.hasOwnProperty.call(macrosMap, key)) {
+          return {
+            key,
+            value: currentPair.value || '',
+            showReset: macrosMap[key].showReset,
+            uniqueId: currentPair.uniqueId || 'id-' + uuidV4(),
+            notDeletable: true,
+          };
+        }
+        return currentPair;
+      })
+      .sort((a, b) => Boolean(b.notDeletable) - Boolean(a.notDeletable));
   }
-  let macros = Object.keys(macrosMap).map((macroKey) => {
-    return {
-      key: macroKey,
-      value: runtimeArgsMap[macroKey] || '',
-      showReset: macrosMap[macroKey].showReset,
-      uniqueId: 'id-' + uuidV4(),
-      notDeletable: true,
-      provided: providedMacros.hasOwnProperty(macroKey),
-    };
-  });
-  currentRuntimeArgs.pairs = macros.concat(currentRuntimeArgs.pairs);
   return currentRuntimeArgs;
 };
 

--- a/cdap-ui/app/directives/my-pipeline-runtime-args/my-pipeline-runtime-args.less
+++ b/cdap-ui/app/directives/my-pipeline-runtime-args/my-pipeline-runtime-args.less
@@ -40,7 +40,7 @@ my-pipeline-runtime-args {
     }
     &.key-value-pair-labels {
       display: grid;
-      grid-template-columns: 1fr 1fr 62px;
+      grid-template-columns: 1fr 1fr 104px;
       grid-gap: 10px;
       margin-right: -25px;
     }
@@ -57,7 +57,7 @@ my-pipeline-runtime-args {
       margin-bottom: 15px;
       justify-content: initial;
       display: grid;
-      grid-template-columns: 1fr 1fr auto;
+      grid-template-columns: 1fr 1fr 104px;
       grid-gap: 10px;
       input {
         width: 100%;

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -109,7 +109,7 @@ class HydratorPlusPlusNodeConfigCtrl {
         isSource: this.state.isSource,
         isSink: this.state.isSink,
         isCondition: this.state.isCondition,
-       }
+       };
     }
 
     this.activeTab = 1;

--- a/cdap-ui/app/hydrator/services/hydrator-service.js
+++ b/cdap-ui/app/hydrator/services/hydrator-service.js
@@ -361,36 +361,37 @@ class HydratorPlusPlusHydratorService {
     return false;
   }
 
-  getRuntimeArgsForDisplay(currentRuntimeArgs, macrosMap, userRuntimeArgumentsMap) {
-    let runtimeArguments = {};
-    let providedMacros = {};
-
+getRuntimeArgsForDisplay(currentRuntimeArgs, macrosMap, userRuntimeArgumentsMap) {
+    const macrosWithIds = {};
+    let runtimeArgsMap = {};
+  
     // holds provided macros in an object here even though we don't need the value,
     // because object hash is faster than Array.indexOf
     if (currentRuntimeArgs.pairs) {
       currentRuntimeArgs.pairs.forEach((currentPair) => {
         let key = currentPair.key;
-        if (currentPair.notDeletable && currentPair.provided) {
-          providedMacros[key] = currentPair.value;
+        runtimeArgsMap[key] = currentPair.value || '';
+        if (currentPair.uniqueId && Object.prototype.hasOwnProperty.call(macrosMap, key)) {
+          macrosWithIds[key] = currentPair.uniqueId;
         }
       });
+      currentRuntimeArgs.pairs = currentRuntimeArgs.pairs.filter((keyValuePair) => {
+        return Object.keys(macrosMap).indexOf(keyValuePair.key) === -1;
+      });
     }
-    let macros = Object.keys(macrosMap).map(macroKey => {
-      let provided = false;
-      if (providedMacros.hasOwnProperty(macroKey)) {
-        provided = true;
-      }
+    let macros = Object.keys(macrosMap).map((macroKey) => {
       return {
         key: macroKey,
-        value: macrosMap[macroKey],
-        uniqueId: 'id-' + this.uuid.v4(),
+        value: runtimeArgsMap[macroKey] || '',
+        showReset: macrosMap[macroKey].showReset,
+        uniqueId: macrosWithIds[macroKey] || 'id-' + this.uuid.v4(),
         notDeletable: true,
-        provided
       };
     });
     let userRuntimeArguments = this.convertMapToKeyValuePairs(userRuntimeArgumentsMap);
-    runtimeArguments.pairs = macros.concat(userRuntimeArguments);
-    return runtimeArguments;
+    // Placing macros in the front so they're displayed at top.
+    currentRuntimeArgs.pairs = macros.concat(userRuntimeArguments);
+    return currentRuntimeArgs;
   }
 
   convertRuntimeArgsToMacros(runtimeArguments) {


### PR DESCRIPTION
Re-using existing UUID when retrieving macros for display.

JIRA: https://issues.cask.co/browse/CDAP-16959