### PR TITLE
[CDAP-16835] Change Batch Upgrade REST API to take in list of ApplicationRecords

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultApplicationUpdateContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultApplicationUpdateContext.java
@@ -152,7 +152,7 @@ public class DefaultApplicationUpdateContext implements ApplicationUpdateContext
     throws Exception {
     List<ArtifactId> pluginArtifacts = new ArrayList<>();
     NamespaceId pluginArtifactNamespace =
-        ArtifactScope.SYSTEM.equals(pluginScope) ? NamespaceId.SYSTEM : namespaceId;
+      ArtifactScope.SYSTEM.equals(pluginScope) ? NamespaceId.SYSTEM : namespaceId;
 
     Predicate<io.cdap.cdap.proto.id.ArtifactId> predicate = input -> {
       // Check if it is from the scoped namespace and should check if plugin is in given range if provided.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -465,8 +465,6 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    * Upgrades an existing application by upgrading application artifact versions and plugin artifact versions.
    *
    * @param appId the id of the application to upgrade.
-   * @param programTerminator a program terminator that will stop programs that are removed when updating an app.
-   *                          For example, if an update removes a flow, the terminator defines how to stop that flow.
    * @param allowedArtifactScopes artifact scopes allowed while looking for latest artifacts for upgrade.
    * @param allowSnapshot whether to consider snapshot version of artifacts or not for upgrade.
    * @throws IllegalStateException if something unexpected happened during upgrade.
@@ -478,8 +476,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    * @throws Exception if there was an exception during the upgrade of application. This exception will often wrap
    *                   the actual exception
    */
-  public void upgradeApplication(ApplicationId appId, ProgramTerminator programTerminator,
-                                 Set<ArtifactScope> allowedArtifactScopes, boolean allowSnapshot)
+  public void upgradeApplication(ApplicationId appId, Set<ArtifactScope> allowedArtifactScopes, boolean allowSnapshot)
     throws Exception {
     // Check if the current user has admin privileges on it before updating.
     authorizationEnforcer.enforce(appId, authenticationContext.getPrincipal(), Action.ADMIN);
@@ -509,7 +506,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     Id.Artifact newArtifact = Id.Artifact.fromEntityId(Artifacts.toProtoArtifactId(appId.getParent(), newArtifactId));
     ArtifactDetail newArtifactDetail = artifactRepository.getArtifact(newArtifact);
 
-    updateApplicationInternal(appId, currentSpec.getConfiguration(), programTerminator, newArtifactDetail,
+    updateApplicationInternal(appId, currentSpec.getConfiguration(), programId -> { }, newArtifactDetail,
                               Collections.singletonList(ApplicationConfigUpdateAction.UPGRADE_ARTIFACT),
                               allowedArtifactScopes, allowSnapshot, ownerAdmin.getOwner(appId), false);
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLPlugin.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLPlugin.java
@@ -34,18 +34,30 @@ public class ETLPlugin {
   private final Map<String, String> properties;
   private final ArtifactSelectorConfig artifact;
 
+  // Only for serialization/deserialization purpose for config upgrade to not lose data set by UI during update.
+  private final String label;
+
   public ETLPlugin(String name, String type, Map<String, String> properties) {
-    this(name, type, properties, null);
+    this(name, type, properties, null, null);
   }
 
   public ETLPlugin(String name,
                    String type,
                    Map<String, String> properties,
                    @Nullable ArtifactSelectorConfig artifact) {
+    this(name, type, properties, artifact, null);
+  }
+
+  public ETLPlugin(String name,
+                   String type,
+                   Map<String, String> properties,
+                   @Nullable ArtifactSelectorConfig artifact,
+                   String label) {
     this.name = name;
     this.type = type;
     this.properties = Collections.unmodifiableMap(properties);
     this.artifact = artifact;
+    this.label = label;
   }
 
   public String getName() {
@@ -54,6 +66,10 @@ public class ETLPlugin {
 
   public String getType() {
     return type;
+  }
+
+  public String getLabel() {
+    return label;
   }
 
   public Map<String, String> getProperties() {

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/ApplicationUpdateDetail.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/ApplicationUpdateDetail.java
@@ -29,10 +29,10 @@ public class ApplicationUpdateDetail {
   private final String error;
   private final ApplicationId appId;
 
-  public ApplicationUpdateDetail(ApplicationId appId, String error) {
+  public ApplicationUpdateDetail(ApplicationId appId) {
     this.appId = appId;
     this.statusCode = 200;
-    this.error = error;
+    error = null;
   }
 
   public ApplicationUpdateDetail(ApplicationId appId, HttpErrorStatusProvider statusProvider) {


### PR DESCRIPTION
Changes included in this PR:

- Change Upgrade REST API to take in list of Record similar to ApplicationRecord class. The usecase would be that, users would just be calling /namespace/<namespace-id>/apps API to get all apps in a namespace and than upgrade them using the same response from /apps API.

- Hot fix for bug CDAP-16984 related to UI for not being able to show Joiner properties if label tag is not there. For now, adding back "label" tag. In future, once UI fixes this issue, we can remove it.

- Do not stop pipeline during upgrade.

- Fix status codes and error messages for failures during upgrade.

https://builds.cask.co/browse/CDAP-DUT7247