### PR TITLE
[CDAP-16871] Configure widget-attributes for each property (plugin JSON creator)

### DIFF
--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/BasicPluginInfo/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/BasicPluginInfo/index.tsx
@@ -49,6 +49,7 @@ const BasicPluginInfoView: React.FC<ICreateContext & WithStyles<typeof styles>> 
   groupToInfo,
   groupToWidgets,
   widgetInfo,
+  widgetToAttributes,
   jsonView,
   setJsonView,
 }) => {
@@ -83,6 +84,7 @@ const BasicPluginInfoView: React.FC<ICreateContext & WithStyles<typeof styles>> 
         groupToInfo={groupToInfo}
         groupToWidgets={groupToWidgets}
         widgetInfo={widgetInfo}
+        widgetToAttributes={widgetToAttributes}
         jsonView={jsonView}
         setJsonView={setJsonView}
       />

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/index.tsx
@@ -66,6 +66,8 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
   setGroupToWidgets,
   widgetInfo,
   setWidgetInfo,
+  widgetToAttributes,
+  setWidgetToAttributes,
   jsonView,
   setJsonView,
 }) => {
@@ -76,6 +78,7 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
   const [localGroupToInfo, setLocalGroupToInfo] = React.useState(groupToInfo);
   const [localGroupToWidgets, setLocalGroupToWidgets] = React.useState(groupToWidgets);
   const [localWidgetInfo, setLocalWidgetInfo] = React.useState(widgetInfo);
+  const [localWidgetToAttributes, setLocalWidgetToAttributes] = React.useState(widgetToAttributes);
 
   function addConfigurationGroup(index: number) {
     return () => {
@@ -127,10 +130,13 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
 
       // Delete all the widget information that belong to the group
       const newWidgetInfo = localWidgetInfo;
+      const newWidgetToAttributes = localWidgetToAttributes;
       widgets.forEach((widget) => {
         delete newWidgetInfo[widget];
+        delete newWidgetToAttributes[widget];
       });
       setLocalWidgetInfo(newWidgetInfo);
+      setLocalWidgetToAttributes(newWidgetToAttributes);
     };
   }
 
@@ -147,6 +153,7 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
     setGroupToInfo(localGroupToInfo);
     setGroupToWidgets(localGroupToWidgets);
     setWidgetInfo(localWidgetInfo);
+    setWidgetToAttributes(localWidgetToAttributes);
   }
 
   return (
@@ -161,6 +168,7 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
         groupToInfo={localGroupToInfo}
         groupToWidgets={localGroupToWidgets}
         widgetInfo={localWidgetInfo}
+        widgetToAttributes={localWidgetToAttributes}
         jsonView={jsonView}
         setJsonView={setJsonView}
       />
@@ -202,6 +210,8 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
                   setGroupToWidgets={setLocalGroupToWidgets}
                   widgetInfo={localWidgetInfo}
                   setWidgetInfo={setLocalWidgetInfo}
+                  widgetToAttributes={localWidgetToAttributes}
+                  setWidgetToAttributes={setLocalWidgetToAttributes}
                 />
               </ExpansionPanelActions>
             </ExpansionPanel>

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/index.tsx
@@ -34,6 +34,7 @@ const JsonMenuView: React.FC<ICreateContext> = ({
   groupToInfo,
   groupToWidgets,
   widgetInfo,
+  widgetToAttributes,
   jsonView,
   setJsonView,
 }) => {
@@ -50,6 +51,7 @@ const JsonMenuView: React.FC<ICreateContext> = ({
           groupToInfo={groupToInfo}
           groupToWidgets={groupToWidgets}
           widgetInfo={widgetInfo}
+          widgetToAttributes={widgetToAttributes}
           jsonView={jsonView}
           setJsonView={setJsonView}
         />
@@ -65,6 +67,7 @@ const JsonMenuView: React.FC<ICreateContext> = ({
           groupToInfo={groupToInfo}
           groupToWidgets={groupToWidgets}
           widgetInfo={widgetInfo}
+          widgetToAttributes={widgetToAttributes}
           jsonView={jsonView}
           setJsonView={setJsonView}
         />

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/utilities.ts
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/utilities.ts
@@ -11,18 +11,24 @@ function getJSONConfig(widgetJSONData) {
     groupToInfo,
     groupToWidgets,
     widgetInfo,
+    widgetToAttributes,
   } = widgetJSONData;
 
   const configurationGroupsData = configurationGroups.map((groupID: string) => {
     const groupLabel = groupToInfo[groupID].label;
     const widgetData = groupToWidgets[groupID].map((widgetID: string) => {
       const info: IWidgetInfo = widgetInfo[widgetID];
+      const widgetAttributes = widgetToAttributes[widgetID];
 
       return {
         'widget-type': info.widgetType,
         label: info.label,
         name: info.name,
         ...(info.widgetCategory && { 'widget-category': info.widgetCategory }),
+        ...(widgetAttributes &&
+          Object.keys(widgetAttributes).length > 0 && {
+            'widget-attributes': widgetAttributes,
+          }),
       };
     });
     return {

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/WidgetAttributeInput/AttributeKeyValueInput/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/WidgetAttributeInput/AttributeKeyValueInput/index.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
+
+const AttributeKeyValueInput = ({
+  keyField,
+  valueField,
+  keyRequired,
+  valueRequired,
+  widgetToAttributes,
+  setWidgetToAttributes,
+  widgetID,
+  field,
+}) => {
+  const onKeyChange = (newVal) => {
+    setWidgetToAttributes((prevObjs) => ({
+      ...prevObjs,
+      [widgetID]: {
+        ...prevObjs[widgetID],
+        [field]: {
+          ...prevObjs[widgetID][field],
+          [keyField]: newVal,
+        },
+      },
+    }));
+  };
+
+  const onValueChange = (newVal) => {
+    setWidgetToAttributes((prevObjs) => ({
+      ...prevObjs,
+      [widgetID]: {
+        ...prevObjs[widgetID],
+        [field]: {
+          ...prevObjs[widgetID][field],
+          [valueField]: newVal,
+        },
+      },
+    }));
+  };
+
+  const keyWidget = {
+    label: field + ' ' + keyField,
+    name: keyField,
+    'widget-type': 'textbox',
+    'widget-attributes': {},
+  };
+
+  const valueWidget = {
+    label: field + ' ' + valueField,
+    name: keyField,
+    'widget-type': 'textbox',
+    'widget-attributes': {},
+  };
+
+  const keyProperty = {
+    required: keyRequired,
+    name: keyField,
+  };
+
+  const valueProperty = {
+    required: valueRequired,
+    name: valueField,
+  };
+
+  const currentKey = widgetToAttributes[widgetID][field][keyField]
+    ? widgetToAttributes[widgetID][field][keyField]
+    : '';
+  const currentValue = widgetToAttributes[widgetID][field][valueField]
+    ? widgetToAttributes[widgetID][field][valueField]
+    : '';
+
+  return (
+    <div>
+      <WidgetWrapper
+        widgetProperty={keyWidget}
+        pluginProperty={keyProperty}
+        value={currentKey}
+        onChange={onKeyChange}
+      />
+
+      <WidgetWrapper
+        widgetProperty={valueWidget}
+        pluginProperty={valueProperty}
+        value={currentValue}
+        onChange={onValueChange}
+      />
+    </div>
+  );
+};
+
+export default AttributeKeyValueInput;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/WidgetAttributeInput/AttributeMultipleValuesInput/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/WidgetAttributeInput/AttributeMultipleValuesInput/index.tsx
@@ -1,0 +1,321 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import withStyles, { StyleRules } from '@material-ui/core/styles/withStyles';
+import If from 'components/If';
+import KeyValuePairs from 'components/KeyValuePairs';
+import { COMMON_DELIMITER } from 'components/PluginJSONCreator/constants';
+import PluginInput from 'components/PluginJSONCreator/Create/Content/PluginInput';
+import * as React from 'react';
+
+/*
+ * AttributeMultipleValuesInput is a component used for setting widget-attributes of "array" type.
+ * For instance, users will be able to set following widget attributes.
+ *
+ * Example 1)
+ *     "options": [
+ *       {
+ *         "id": "true",
+ *        "label": "true"
+ *       },
+ *       {
+ *         "id": "false",
+ *         "label": "false"
+ *       }
+ *     ]
+ * Example 2)
+ *     "values": [
+ *       "json",
+ *       "xml",
+ *       "tsv",
+ *       "csv",
+ *       "text",
+ *       "blob"
+ *     ],
+ *
+ * As we can see from the examples above, this can be an array of string or an array of object (ID-Label pair).
+ * In this component, a prop named 'supportedTypes' stores all the available types for a certain field.
+ *
+ * For instance, 'select' widget has an attribute field called 'options'.
+ * 'options' can be of different types, therefore its 'supportedTypes' is as following:
+ *     ['ISelectOptions[]', 'string[]', 'number[]']
+ * If the user selects ISelectOptions[], then it that means the 'options' field will be
+ * an array of ISelectOptions.
+ * Since ISelectOptions interface is defined to be a 'value' and 'label' pair,
+ * our component should render multiple input rows of key-value pairs.
+ *
+ * Some types such as 'IDropdownOption', can be string, number, or value-label pair.
+ *     export type IDropdownOption = string | number | IComplexDropdown;
+ *     interface IComplexDropdown {
+ *       value: string | number;
+ *       label: string;
+ *     }
+ * Therefore, we should futher process IDropdownOption[], by adding all the available types in the function
+ * 'processSupportedTypes'.
+ *     supportedTypes.add(SupportedType.String);
+ *     supportedTypes.add(SupportedType.Number);
+ *     supportedTypes.add(SupportedType.ValueLabelPair);
+ */
+
+export enum SupportedType {
+  String = 'string',
+  Number = 'number',
+  ValueLabelPair = 'Value-Label pair',
+  IDLabelPair = 'ID-Label pair',
+}
+
+const styles = (): StyleRules => {
+  return {
+    typeSelectInput: {
+      marginTop: '5px',
+      marginBottom: '5px',
+      width: '20%',
+    },
+  };
+};
+
+export const processSupportedTypes = (types: string[]) => {
+  const allTypes = new Set();
+  types.forEach((type) => {
+    switch (type) {
+      case 'string[]':
+        allTypes.add(SupportedType.String);
+        break;
+      case 'number[]':
+        allTypes.add(SupportedType.Number);
+        break;
+      case 'IOption[]':
+        allTypes.add(SupportedType.IDLabelPair);
+        break;
+      case 'IDropdownOption[]':
+        allTypes.add(SupportedType.String);
+        allTypes.add(SupportedType.Number);
+        allTypes.add(SupportedType.ValueLabelPair);
+        break;
+      case 'ISelectOptions[]':
+        allTypes.add(SupportedType.ValueLabelPair);
+        break;
+      case 'FilterOption[]':
+        allTypes.add(SupportedType.String);
+        allTypes.add(SupportedType.IDLabelPair);
+        break;
+      default:
+        // Add the default type in case the type is not supported
+        allTypes.add(SupportedType.String);
+        break;
+    }
+  });
+  return allTypes;
+};
+
+const AttributeMultipleValuesInputView = ({
+  classes,
+  supportedTypes,
+  widgetToAttributes,
+  setWidgetToAttributes,
+  widgetID,
+  field,
+}) => {
+  const cleanSupportedTypes = Array.from(processSupportedTypes(supportedTypes).values());
+  const [selectedType, setSelectedType] = React.useState(null);
+  const [currentInput, setCurrentInput] = React.useState(null);
+
+  React.useEffect(() => {
+    const initialType = getInitialType();
+    setSelectedType(initialType);
+    setCurrentInput(getCurrentWidgetAttributeValues(initialType));
+  }, []);
+
+  /*
+   * The input fields can have some pre-populated values.
+   * For instance, when the user imports a plugin JSON file into the UI,
+   * It should parse those pre-populated values of widget attributes
+   * and decide what should be 'selectedType' for the component.
+   */
+  function getInitialType() {
+    const widgetAttributeValues = widgetToAttributes[widgetID][field];
+    let newType;
+    if (!widgetAttributeValues || widgetAttributeValues.length === 0) {
+      newType = cleanSupportedTypes[0];
+    } else if (widgetAttributeValues[0].value) {
+      newType = SupportedType.ValueLabelPair;
+    } else if (widgetAttributeValues[0].id) {
+      newType = SupportedType.IDLabelPair;
+    } else {
+      newType = SupportedType.String;
+    }
+    return newType;
+  }
+
+  /*
+   * The input fields can have some pre-populated values.
+   * For instance, when the user imports a plugin JSON file into the UI,
+   * it should parse those pre-populated values of widget attributes
+   * and populate the input fields.
+   */
+  function getCurrentWidgetAttributeValues(newType) {
+    if (!newType) {
+      return '';
+    } else if (newType === SupportedType.Number || newType === SupportedType.String) {
+      return processAttributeValues();
+    } else {
+      return processKeyValueAttributeValues();
+    }
+  }
+
+  /*
+   * Process simple attribute values in order to pass them to the input component.
+   * The component 'CSVWidget' receives the data of following structure.
+   *
+   * Example)
+   *     "GET,POST,PUT,DELETE"
+   */
+  function processAttributeValues() {
+    const widgetAttributeValues = widgetToAttributes[widgetID][field];
+    return widgetAttributeValues ? widgetAttributeValues.join(COMMON_DELIMITER) : '';
+  }
+
+  /*
+   * Process key-value attribute values in order to pass the values to the input component.
+   * The component 'KeyValuePairs' receives the data of following structure.
+   *    { pairs: [{ key: '', value: '' }] }
+   */
+  function processKeyValueAttributeValues() {
+    const widgetAttributeValues = widgetToAttributes[widgetID][field];
+    if (widgetAttributeValues && widgetAttributeValues.length > 0) {
+      return {
+        pairs: widgetAttributeValues.map((keyvalue) => {
+          if (keyvalue.id) {
+            return {
+              key: keyvalue.id,
+              value: keyvalue.label,
+            };
+          } else {
+            return {
+              key: keyvalue.value,
+              value: keyvalue.label,
+            };
+          }
+        }),
+      };
+    } else {
+      return { pairs: [{ key: '', value: '' }] };
+    }
+  }
+
+  const switchInputType = (newType) => {
+    setSelectedType(newType);
+    setCurrentInput(getCurrentWidgetAttributeValues(newType));
+
+    // When user switches the 'selectedType', the value will reset back to an empty array.
+    setWidgetToAttributes((prevObjs) => ({
+      ...prevObjs,
+      [widgetID]: { ...prevObjs[widgetID], [field]: [] },
+    }));
+  };
+
+  const onAttributeChange = (newVal) => {
+    setCurrentInput(newVal);
+    setWidgetToAttributes((prevObjs) => ({
+      ...prevObjs,
+      [widgetID]: { ...prevObjs[widgetID], [field]: newVal.split(COMMON_DELIMITER) },
+    }));
+  };
+
+  const onKeyValueAttributeChange = (keyvalue, type: SupportedType) => {
+    if (type === SupportedType.ValueLabelPair) {
+      const keyvaluePairs = keyvalue.pairs.map((pair) => {
+        return { value: pair.key, label: pair.value };
+      });
+      setWidgetToAttributes((prevObjs) => ({
+        ...prevObjs,
+        [widgetID]: { ...prevObjs[widgetID], [field]: keyvaluePairs },
+      }));
+    } else {
+      const keyvaluePairs = keyvalue.pairs.map((pair) => {
+        return { id: pair.key, label: pair.value };
+      });
+      setWidgetToAttributes((prevObjs) => ({
+        ...prevObjs,
+        [widgetID]: { ...prevObjs[widgetID], [field]: keyvaluePairs },
+      }));
+    }
+  };
+
+  const renderAttributeMultipleValuesInput = () => {
+    switch (selectedType) {
+      case SupportedType.ValueLabelPair:
+        return (
+          <KeyValuePairs
+            keyValues={currentInput}
+            onKeyValueChange={(keyvalue) => onKeyValueAttributeChange(keyvalue, selectedType)}
+            keyPlaceholder={'value'}
+            valuePlaceholder={'label'}
+          />
+        );
+      case SupportedType.IDLabelPair:
+        return (
+          <KeyValuePairs
+            keyValues={currentInput}
+            onKeyValueChange={(keyvalue) => onKeyValueAttributeChange(keyvalue, selectedType)}
+            keyPlaceholder={'id'}
+            valuePlaceholder={'label'}
+          />
+        );
+      case SupportedType.Number:
+        return (
+          <PluginInput
+            widgetType={'dsv'}
+            value={currentInput}
+            onChange={onAttributeChange}
+            label={field}
+            required={true}
+          />
+        );
+      default:
+        return (
+          <PluginInput
+            widgetType={'dsv'}
+            value={currentInput}
+            onChange={onAttributeChange}
+            label={field}
+            required={true}
+          />
+        );
+    }
+  };
+
+  return (
+    <div>
+      <If condition={cleanSupportedTypes.length > 1}>
+        <div className={classes.typeSelectInput}>
+          <PluginInput
+            widgetType={'select'}
+            value={selectedType}
+            onChange={switchInputType}
+            label={'select value type'}
+            options={cleanSupportedTypes}
+          />
+        </div>
+      </If>
+
+      {renderAttributeMultipleValuesInput()}
+    </div>
+  );
+};
+
+const AttributeMultipleValuesInput = withStyles(styles)(AttributeMultipleValuesInputView);
+export default AttributeMultipleValuesInput;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/WidgetAttributeInput/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/WidgetAttributeInput/index.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import withStyles, { StyleRules } from '@material-ui/core/styles/withStyles';
+import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
+import { CODE_EDITORS } from 'components/PluginJSONCreator/constants';
+import PluginInput from 'components/PluginJSONCreator/Create/Content/PluginInput';
+import AttributeKeyValueInput from 'components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/WidgetAttributeInput/AttributeKeyValueInput';
+import AttributeMultipleValuesInput from 'components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/WidgetAttributeInput/AttributeMultipleValuesInput';
+import * as React from 'react';
+
+const styles = (): StyleRules => {
+  return {
+    widgetAttributeInput: {
+      width: '100%',
+      marginTop: '10px',
+      marginBottom: '10px',
+    },
+  };
+};
+
+const WidgetAttributeInputView = ({
+  classes,
+  field,
+  fieldInfo,
+  widgetToAttributes,
+  setWidgetToAttributes,
+  widgetID,
+  widgetType,
+}) => {
+  const onAttributeChange = (newVal) => {
+    setWidgetToAttributes((prevObjs) => ({
+      ...prevObjs,
+      [widgetID]: { ...prevObjs[widgetID], [field]: newVal },
+    }));
+  };
+
+  const generateAttributeInput = (fieldType) => {
+    if (fieldType === 'IToggle' || fieldType === 'IOption') {
+      const props = {
+        keyRequired: true,
+        valueRequired: true,
+        widgetToAttributes,
+        setWidgetToAttributes,
+        widgetID,
+        field,
+      };
+
+      const finalProps = {
+        ...props,
+        ...(fieldType === 'IToggle' && { keyField: 'label', valueField: 'value' }),
+        ...(fieldType === 'IOption' && { keyField: 'id', valueField: 'label' }),
+      };
+
+      return <AttributeKeyValueInput {...finalProps} />;
+    } else {
+      const props = {
+        label: field,
+        value: widgetToAttributes[widgetID][field],
+        onChange: onAttributeChange,
+        required: fieldInfo.required,
+        // Set default widgetType in case fieldType is invalid
+        widgetType: 'textbox',
+      };
+
+      const finalProps = {
+        ...props,
+        ...(fieldType === 'string' && { widgetType: 'textbox' }),
+        ...(fieldType === 'number' && { widgetType: 'number' }),
+        ...(fieldType === 'boolean' && { widgetType: 'select', options: ['true', 'false'] }),
+      };
+
+      return <PluginInput {...finalProps} />;
+    }
+  };
+
+  const renderAttributeInput = () => {
+    if (!fieldInfo) {
+      return;
+    }
+
+    if (field === 'default' && CODE_EDITORS.includes(widgetType)) {
+      return (
+        <WidgetWrapper
+          widgetProperty={{
+            field,
+            name: field,
+            'widget-type': widgetType,
+            'widget-attributes': {},
+          }}
+          pluginProperty={{
+            required: fieldInfo.required,
+            name: 'code-editor',
+          }}
+          value={widgetToAttributes[widgetID][field]}
+          onChange={onAttributeChange}
+        />
+      );
+    }
+
+    const isMultipleInput = fieldInfo.type.includes('[]');
+    const supportedTypes = fieldInfo.type.split('|');
+    if (isMultipleInput) {
+      return (
+        <AttributeMultipleValuesInput
+          supportedTypes={supportedTypes}
+          widgetToAttributes={widgetToAttributes}
+          setWidgetToAttributes={setWidgetToAttributes}
+          widgetID={widgetID}
+          field={field}
+        />
+      );
+    } else {
+      return generateAttributeInput(fieldInfo.type);
+    }
+  };
+
+  return <div className={classes.widgetAttributeINput}>{renderAttributeInput()}</div>;
+};
+
+const WidgetAttributeInput = withStyles(styles)(WidgetAttributeInputView);
+export default WidgetAttributeInput;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/index.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import IconButton from '@material-ui/core/IconButton';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import CloseIcon from '@material-ui/icons/Close';
+import If from 'components/If';
+import { h2Styles } from 'components/Markdown/MarkdownHeading';
+import { WIDGET_TYPE_TO_ATTRIBUTES } from 'components/PluginJSONCreator/constants';
+import WidgetAttributeInput from 'components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection/WidgetAttributeInput';
+import WidgetInput from 'components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetInput';
+import { ICreateContext } from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+
+const styles = (theme): StyleRules => {
+  return {
+    widgetAttributesTitle: {
+      marginTop: '15px',
+      marginBottom: '15px',
+    },
+    h2Title: {
+      ...h2Styles(theme).root,
+      marginBottom: '5px',
+    },
+  };
+};
+
+interface IWidgetAttributesCollectionProps extends WithStyles<typeof styles>, ICreateContext {
+  widgetAttributesOpen: boolean;
+  onWidgetAttributesClose: () => void;
+  widgetID: number;
+}
+
+const WidgetAttributesCollectionView: React.FC<IWidgetAttributesCollectionProps> = ({
+  classes,
+  widgetAttributesOpen,
+  onWidgetAttributesClose,
+  widgetID,
+  widgetInfo,
+  setWidgetInfo,
+  widgetToAttributes,
+  setWidgetToAttributes,
+}) => {
+  const widget = widgetInfo[widgetID];
+  const widgetType = widget ? widget.widgetType : null;
+  const attributeFields =
+    widgetToAttributes && widgetToAttributes[widgetID]
+      ? Object.keys(widgetToAttributes[widgetID])
+      : [];
+  return (
+    <div>
+      <Dialog
+        open={widgetAttributesOpen}
+        onClose={onWidgetAttributesClose}
+        disableBackdropClick={true}
+        fullWidth={true}
+        maxWidth={'md'}
+        classes={{ paper: classes.attributeDialog }}
+      >
+        <DialogTitle disableTypography className={classes.dialogTitle}>
+          <IconButton onClick={onWidgetAttributesClose}>
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent>
+          <div className={classes.widgetAttributesTitle}>
+            <h1 className={classes.h2Title}>Widget Property</h1>
+          </div>
+          <WidgetInput
+            widgetInfo={widgetInfo}
+            widgetID={widgetID}
+            setWidgetInfo={setWidgetInfo}
+            widgetToAttributes={widgetToAttributes}
+            setWidgetToAttributes={setWidgetToAttributes}
+          />
+          <If condition={attributeFields && attributeFields.length > 0}>
+            <div className={classes.widgetAttributesTitle}>
+              <h2 className={classes.h2Title}>Configure Widget</h2>
+            </div>
+          </If>
+          {attributeFields.map((field, fieldIndex) => {
+            const fieldInfo = WIDGET_TYPE_TO_ATTRIBUTES[widgetType]
+              ? WIDGET_TYPE_TO_ATTRIBUTES[widgetType][field]
+              : {};
+            return (
+              <WidgetAttributeInput
+                key={fieldIndex}
+                widgetType={widgetType}
+                field={field}
+                fieldInfo={fieldInfo}
+                widgetToAttributes={widgetToAttributes}
+                setWidgetToAttributes={setWidgetToAttributes}
+                widgetID={widgetID}
+              />
+            );
+          })}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+const WidgetAttributesCollection = withStyles(styles)(WidgetAttributesCollectionView);
+export default WidgetAttributesCollection;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetInput/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetInput/index.tsx
@@ -16,7 +16,11 @@
 
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import If from 'components/If';
-import { WIDGET_CATEGORY, WIDGET_TYPES } from 'components/PluginJSONCreator/constants';
+import {
+  WIDGET_CATEGORY,
+  WIDGET_TYPES,
+  WIDGET_TYPE_TO_ATTRIBUTES,
+} from 'components/PluginJSONCreator/constants';
 import PluginInput from 'components/PluginJSONCreator/Create/Content/PluginInput';
 import { ICreateContext } from 'components/PluginJSONCreator/CreateContextConnect';
 import * as React from 'react';
@@ -45,6 +49,8 @@ const WidgetInputView: React.FC<IWidgetInputProps> = ({
   widgetID,
   widgetInfo,
   setWidgetInfo,
+  widgetToAttributes,
+  setWidgetToAttributes,
 }) => {
   function onNameChange() {
     return (name) => {
@@ -70,6 +76,14 @@ const WidgetInputView: React.FC<IWidgetInputProps> = ({
         ...prevObjs,
         [widgetID]: { ...prevObjs[widgetID], widgetType },
       }));
+
+      setWidgetToAttributes({
+        ...widgetToAttributes,
+        [widgetID]: Object.keys(WIDGET_TYPE_TO_ATTRIBUTES[widgetType]).reduce((acc, curr) => {
+          acc[curr] = '';
+          return acc;
+        }, {}),
+      });
     };
   }
 

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/WidgetCollection/index.tsx
@@ -19,6 +19,7 @@ import Divider from '@material-ui/core/Divider';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import If from 'components/If';
 import WidgetActionButtons from 'components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetActionButtons';
+import WidgetAttributesCollection from 'components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetAttributesCollection';
 import WidgetInput from 'components/PluginJSONCreator/Create/Content/WidgetCollection/WidgetInput';
 import { ICreateContext, IWidgetInfo } from 'components/PluginJSONCreator/CreateContextConnect';
 import * as React from 'react';
@@ -77,6 +78,8 @@ const WidgetCollectionView: React.FC<IWidgetCollectionProps> = ({
   groupToWidgets,
   setWidgetInfo,
   setGroupToWidgets,
+  widgetToAttributes,
+  setWidgetToAttributes,
 }) => {
   const [activeWidgets, setActiveWidgets] = React.useState(groupID ? groupToWidgets[groupID] : []);
   const [openWidgetIndex, setOpenWidgetIndex] = React.useState(null);
@@ -114,6 +117,11 @@ const WidgetCollectionView: React.FC<IWidgetCollectionProps> = ({
           name: '',
         } as IWidgetInfo,
       });
+
+      setWidgetToAttributes({
+        ...widgetToAttributes,
+        [newWidgetID]: {},
+      });
     };
   }
 
@@ -131,7 +139,20 @@ const WidgetCollectionView: React.FC<IWidgetCollectionProps> = ({
 
       const { [widgetToDelete]: info, ...restWidgetInfo } = widgetInfo;
       setWidgetInfo(restWidgetInfo);
+
+      const { [widgetToDelete]: attributes, ...restWidgetToAttributes } = widgetToAttributes;
+      setWidgetToAttributes(restWidgetToAttributes);
     };
+  }
+
+  function openWidgetAttributes(widgetIndex) {
+    return () => {
+      setOpenWidgetIndex(widgetIndex);
+    };
+  }
+
+  function closeWidgetAttributes() {
+    setOpenWidgetIndex(null);
   }
 
   return (
@@ -149,12 +170,32 @@ const WidgetCollectionView: React.FC<IWidgetCollectionProps> = ({
                   widgetInfo={widgetInfo}
                   widgetID={widgetID}
                   setWidgetInfo={setWidgetInfo}
+                  widgetToAttributes={widgetToAttributes}
+                  setWidgetToAttributes={setWidgetToAttributes}
                 />
                 <WidgetActionButtons
                   onAddWidgetToGroup={addWidgetToGroup(widgetIndex)}
                   onDeleteWidgetFromGroup={deleteWidgetFromGroup(widgetIndex)}
                 />
+
+                <WidgetAttributesCollection
+                  widgetAttributesOpen={openWidgetIndex === widgetIndex}
+                  onWidgetAttributesClose={closeWidgetAttributes}
+                  widgetID={widgetID}
+                  widgetInfo={widgetInfo}
+                  setWidgetInfo={setWidgetInfo}
+                  widgetToAttributes={widgetToAttributes}
+                  setWidgetToAttributes={setWidgetToAttributes}
+                />
               </div>
+              <Button
+                variant="contained"
+                color="primary"
+                component="span"
+                onClick={openWidgetAttributes(widgetIndex)}
+              >
+                Attributes
+              </Button>
               <If condition={activeWidgets && widgetIndex < activeWidgets.length - 1}>
                 <Divider className={classes.widgetDivider} />
               </If>

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
@@ -79,6 +79,10 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     this.setState({ jsonView });
   };
 
+  public setWidgetToAttributes = (widgetToAttributes: any) => {
+    this.setState({ widgetToAttributes });
+  };
+
   public state = {
     activeStep: 0,
     pluginName: '',
@@ -90,6 +94,7 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     groupToInfo: {},
     groupToWidgets: {},
     widgetInfo: {},
+    widgetToAttributes: {},
     jsonView: true,
 
     setActiveStep: this.setActiveStep,
@@ -98,6 +103,7 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     setGroupToInfo: this.setGroupToInfo,
     setGroupToWidgets: this.setGroupToWidgets,
     setWidgetInfo: this.setWidgetInfo,
+    setWidgetToAttributes: this.setWidgetToAttributes,
     setJsonView: this.setJsonView,
   };
 

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
@@ -29,6 +29,7 @@ interface ICreateState {
   groupToInfo: any;
   groupToWidgets: any;
   widgetInfo: any;
+  widgetToAttributes: any;
   jsonView: boolean;
 
   setActiveStep: (step: number) => void;
@@ -37,6 +38,7 @@ interface ICreateState {
   setGroupToInfo: (groupToInfo: any) => void;
   setGroupToWidgets: (groupToWidgets: any) => void;
   setWidgetInfo: (widgetInfo: any) => void;
+  setWidgetToAttributes: (widgetToAttributes: any) => void;
   setJsonView: (jsonView: boolean) => void;
 }
 

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/constants.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/constants.tsx
@@ -25,3 +25,190 @@ export const WIDGET_TYPES = Object.keys(WIDGET_FACTORY);
 export const WIDGET_CATEGORY = ['plugin'];
 
 export const SPEC_VERSION = '1.5';
+
+// including additional property that was found from the docs
+// (DOCS: https://docs.cdap.io/cdap/6.1.2/en/developer-manual/pipelines/developing-plugins/presentation-plugins.html)
+export const WIDGET_TYPE_TO_ATTRIBUTES = {
+  'connection-browser': {
+    connectionType: { type: 'string', required: true },
+    label: { type: 'string', required: true },
+  },
+  csv: {
+    'value-placeholder': { type: 'string', required: false },
+    delimeter: { type: 'string', required: false },
+  },
+  'dataset-selector': {
+    placeholder: { type: 'string', required: false },
+  },
+  daterange: {},
+  datetime: {},
+  'ds-multiplevalues': {
+    placeholders: { type: 'string[]', required: false },
+    'values-delimiter': { type: 'string', required: false },
+    numValues: { type: 'string|number', required: true },
+    delimiter: { type: 'string', required: false },
+  },
+  dsv: {
+    'value-placeholder': { type: 'string', required: false },
+    delimeter: { type: 'string', required: false },
+  },
+  'function-dropdown-with-alias': {
+    /*
+    TODO: After confirming
+    placeholders?: Record<string, string>;
+    dropdownOptions: IDropdownOption[];
+    delimiter?: string;
+    */
+  },
+  dlp: {
+    transforms: { type: 'ITransformProp[]', required: true },
+    filters: { type: 'FilterOption[]', required: true },
+    delimiter: { type: 'string', required: false },
+  },
+  'get-schema': {
+    position: { type: 'Position', required: false },
+  },
+  'input-field-selector': {
+    // no attributes according to the docs
+    multiselect: { type: 'boolean', required: false },
+    allowedTypes: { type: 'string[]', required: false },
+  },
+  'keyvalue-dropdown': {
+    'key-placeholder': { type: 'string', required: false },
+    'kv-delimiter': { type: 'string', required: false },
+    dropdownOptions: { type: 'IDropdownOption[]', required: true },
+    delimiter: { type: 'string', required: false },
+  },
+  'keyvalue-encoded': {
+    // TODO: After confirming
+  },
+  keyvalue: {
+    'key-placeholder': { type: 'string', required: false },
+    'value-placeholder': { type: 'string', required: false },
+    'kv-delimiter': { type: 'string', required: false },
+    delimiter: { type: 'string', required: false },
+    // including additional property that was found from one of the json files
+    showDelimiter: { type: 'boolean', required: false },
+  },
+  'memory-dropdown': {
+    // TODO: After confirming
+  },
+  'memory-textbox': {
+    // TODO: After confirming
+  },
+  'multi-select': {
+    delimiter: { type: 'string', required: true },
+    options: { type: 'IOption[]', required: true },
+    showSelectionCount: { type: 'boolean', required: false },
+    // including additional property that was found from the docs
+    defaultValue: { type: 'string[]', required: false },
+  },
+  number: {
+    min: { type: 'number', required: false },
+    max: { type: 'number', required: false },
+    // including additional property that was found from the docs
+    default: { type: 'number', required: false },
+  },
+  password: {
+    placeholder: { type: 'string', required: false },
+  },
+  'plugin-list': {
+    'plugin-type': { type: 'string', required: true },
+  },
+  'radio-group': {
+    layout: { type: 'string', required: true },
+    options: { type: 'IOption[]', required: true },
+    default: { type: 'string', required: false },
+  },
+  'securekey-password': {
+    // TODO: After confirming
+  },
+  'securekey-text': {
+    // TODO: After confirming
+  },
+  'securekey-textarea': {
+    // TODO: After confirming
+  },
+  select: {
+    options: { type: 'ISelectOptions[]|string[]|number[]', required: true },
+    default: { type: 'string', required: false },
+  },
+  text: {
+    placeholder: { type: 'string', required: false },
+  },
+  textbox: {
+    placeholder: { type: 'string', required: false },
+    default: { type: 'string', required: false },
+  },
+  toggle: {
+    on: { type: 'IToggle', required: true },
+    off: { type: 'IToggle', required: true },
+    default: { type: 'string', required: false },
+  },
+
+  // CODE EDITORS
+  'javascript-editor': {
+    default: { type: 'string', required: false },
+  },
+  'json-editor': {
+    default: { type: 'string', required: false },
+  },
+  'python-editor': {
+    default: { type: 'string', required: false },
+  },
+  'scala-editor': {
+    default: { type: 'string', required: false },
+  },
+  'sql-editor': {
+    default: { type: 'string', required: false },
+  },
+  textarea: {
+    // including additional property that was found from the docs
+    placeholder: { type: 'string', required: false },
+    rows: { type: 'number', required: false },
+  },
+
+  // JOINS
+  // TODO: After confirming
+  'join-types': {},
+  'sql-conditions': {},
+  'sql-select-fields': {},
+
+  // Rules Engine
+  // TODO: After confirming
+  'rules-engine-editor': {},
+
+  // Wrangler
+  // TODO: After confirming
+  'wrangler-directives': {},
+
+  // extra ones found from the docs
+  // TODO: After confirming
+  hidden: {
+    default: { type: 'string', required: false },
+  },
+  'non-editable-schema-editor': {
+    // schema: schema that will be used as the output schema for the plugin
+  },
+  schema: {
+    'schema-default-type': { type: 'string', required: true },
+    'schema-types': { type: 'string[]', required: true },
+  },
+  'stream-selector': {},
+  'textarea-validate': {
+    placeholder: { type: 'string', required: false },
+    // 'validate-endpoint': plugin function endpoint to hit to validate the contents of the textarea
+    'validate-button-text': { type: 'string', required: true },
+    'validate-success-message': { type: 'string', required: true },
+  },
+};
+
+export const COMMON_DELIMITER = ',';
+
+export const CODE_EDITORS = [
+  'javascript-editor',
+  'json-editor',
+  'python-editor',
+  'scala-editor',
+  'sql-editor',
+];


### PR DESCRIPTION
**(Because I accidentally merged #12217 to another branch, I'm making a new PR for this. Please refer to #12217 for previous reviews and histories.)**



JIRA: https://issues.cask.co/browse/CDAP-16871

Let users configure `widget-attributes` for their widgets. Depending on the `widget-type`, it may carry different `widget-attributes`.

Current Progress
* `widget-attributes` changes based on the `widget-type`.
* Users are able to configure `widget-attributes` of each widget.
* Show the JSON output including the `widget-attributes`.

**Dialog that configure widget properties**

<img width="1785" alt="Screen Shot 2020-05-28 at 12 00 44 PM" src="https://user-images.githubusercontent.com/14116152/83165264-41c60580-a0db-11ea-844e-98ab4339af48.png">

**Changes are reflected in other components**

<img width="1778" alt="Screen Shot 2020-05-28 at 12 00 14 PM" src="https://user-images.githubusercontent.com/14116152/83165280-45f22300-a0db-11ea-9182-6e5a79273df4.png">

TODO (to be addressed)
* There are some widgets (e.g. DLPCustomWidget) that haven't been implemented due to their complexities. I will be sure to discuss with @elfenheart and @ajainarayanan regarding this.
* I have stored key-value pairs (`widget-type` -> corresponding `widget-attributes`) in `constants.ts` to implement this feature. Also, there are some `widget-attributes` with multiple possible types, which I have dealt with by hardcoding. I will try to further address this.