### PR TITLE
[CDAP-16869] Create a page for outputs configuration [output-name only] (plugin JSON creator)

### DIFF
--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection/index.tsx
@@ -70,6 +70,7 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
   setWidgetToAttributes,
   jsonView,
   setJsonView,
+  outputName,
 }) => {
   const [activeGroupIndex, setActiveGroupIndex] = React.useState(null);
   const [localConfigurationGroups, setLocalConfigurationGroups] = React.useState(
@@ -171,6 +172,7 @@ const ConfigurationGroupsCollectionView: React.FC<ICreateContext & WithStyles<ty
         widgetToAttributes={localWidgetToAttributes}
         jsonView={jsonView}
         setJsonView={setJsonView}
+        outputName={outputName}
       />
       <Heading type={HeadingTypes.h3} label="Configuration Groups" />
       <br />

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/index.tsx
@@ -37,6 +37,7 @@ const JsonMenuView: React.FC<ICreateContext> = ({
   widgetToAttributes,
   jsonView,
   setJsonView,
+  outputName,
 }) => {
   return (
     <div>
@@ -54,6 +55,7 @@ const JsonMenuView: React.FC<ICreateContext> = ({
           widgetToAttributes={widgetToAttributes}
           jsonView={jsonView}
           setJsonView={setJsonView}
+          outputName={outputName}
         />
       </If>
       <If condition={!jsonView}>
@@ -70,6 +72,7 @@ const JsonMenuView: React.FC<ICreateContext> = ({
           widgetToAttributes={widgetToAttributes}
           jsonView={jsonView}
           setJsonView={setJsonView}
+          outputName={outputName}
         />
       </If>
     </div>

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/utilities.ts
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/JsonMenu/utilities.ts
@@ -12,6 +12,7 @@ function getJSONConfig(widgetJSONData) {
     groupToWidgets,
     widgetInfo,
     widgetToAttributes,
+    outputName,
   } = widgetJSONData;
 
   const configurationGroupsData = configurationGroups.map((groupID: string) => {
@@ -45,6 +46,11 @@ function getJSONConfig(widgetJSONData) {
     ...(emitAlerts && { 'emit-alerts': emitAlerts }),
     ...(emitErrors && { 'emit-errors': emitErrors }),
     'configuration-groups': configurationGroupsData,
+    outputs: [
+      {
+        name: outputName,
+      },
+    ],
   };
 
   return config;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/Outputs/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/Content/Outputs/index.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { WithStyles } from '@material-ui/core/styles/withStyles';
+import { styles } from 'components/AbstractWidget/RadioGroupWidget';
+import Heading, { HeadingTypes } from 'components/Heading';
+import JsonMenu from 'components/PluginJSONCreator/Create/Content/JsonMenu';
+import PluginInput from 'components/PluginJSONCreator/Create/Content/PluginInput';
+import StepButtons from 'components/PluginJSONCreator/Create/Content/StepButtons';
+import {
+  CreateContext,
+  createContextConnect,
+  ICreateContext,
+} from 'components/PluginJSONCreator/CreateContextConnect';
+import * as React from 'react';
+
+const OutputsView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
+  classes,
+  pluginName,
+  pluginType,
+  displayName,
+  emitAlerts,
+  emitErrors,
+  configurationGroups,
+  groupToInfo,
+  groupToWidgets,
+  widgetInfo,
+  widgetToAttributes,
+  jsonView,
+  setJsonView,
+  outputName,
+  setOutputName,
+}) => {
+  const [localOutputName, setLocalOutputName] = React.useState(outputName);
+
+  function saveAllResults() {
+    setOutputName(localOutputName);
+  }
+
+  return (
+    <div>
+      <JsonMenu
+        pluginName={pluginName}
+        pluginType={pluginType}
+        displayName={displayName}
+        emitAlerts={emitAlerts}
+        emitErrors={emitErrors}
+        configurationGroups={configurationGroups}
+        groupToInfo={groupToInfo}
+        groupToWidgets={groupToWidgets}
+        widgetInfo={widgetInfo}
+        widgetToAttributes={widgetToAttributes}
+        jsonView={jsonView}
+        setJsonView={setJsonView}
+        outputName={localOutputName}
+      />
+      <Heading type={HeadingTypes.h3} label="Output" />
+      <br />
+      <PluginInput
+        widgetType={'textbox'}
+        value={localOutputName}
+        onChange={setLocalOutputName}
+        label={'Output Name'}
+        placeholder={'output name'}
+        required={false}
+      />
+      <StepButtons nextDisabled={false} onPrevious={saveAllResults} onNext={saveAllResults} />
+    </div>
+  );
+};
+
+const Outputs = createContextConnect(CreateContext, OutputsView);
+export default Outputs;

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/index.tsx
@@ -83,6 +83,10 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     this.setState({ widgetToAttributes });
   };
 
+  public setOutputName = (outputName: string) => {
+    this.setState({ outputName });
+  };
+
   public state = {
     activeStep: 0,
     pluginName: '',
@@ -96,6 +100,7 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     widgetInfo: {},
     widgetToAttributes: {},
     jsonView: true,
+    outputName: '',
 
     setActiveStep: this.setActiveStep,
     setBasicPluginInfo: this.setBasicPluginInfo,
@@ -105,6 +110,7 @@ class CreateView extends React.PureComponent<ICreateContext & WithStyles<typeof 
     setWidgetInfo: this.setWidgetInfo,
     setWidgetToAttributes: this.setWidgetToAttributes,
     setJsonView: this.setJsonView,
+    setOutputName: this.setOutputName,
   };
 
   public render() {

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/Create/steps.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/Create/steps.tsx
@@ -16,6 +16,7 @@
 
 import BasicPluginInfo from 'components/PluginJSONCreator/Create/Content/BasicPluginInfo';
 import ConfigurationGroupsCollection from 'components/PluginJSONCreator/Create/Content/ConfigurationGroupsCollection';
+import Outputs from 'components/PluginJSONCreator/Create/Content/Outputs';
 
 export const STEPS = [
   {
@@ -25,5 +26,9 @@ export const STEPS = [
   {
     label: 'Configuration Groups',
     component: ConfigurationGroupsCollection,
+  },
+  {
+    label: 'Output',
+    component: Outputs,
   },
 ];

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/CreateContextConnect/index.tsx
@@ -31,6 +31,7 @@ interface ICreateState {
   widgetInfo: any;
   widgetToAttributes: any;
   jsonView: boolean;
+  outputName: string;
 
   setActiveStep: (step: number) => void;
   setBasicPluginInfo: (basicPluginInfo: IBasicPluginInfo) => void;
@@ -40,6 +41,7 @@ interface ICreateState {
   setWidgetInfo: (widgetInfo: any) => void;
   setWidgetToAttributes: (widgetToAttributes: any) => void;
   setJsonView: (jsonView: boolean) => void;
+  setOutputName: (outputName: string) => void;
 }
 
 export interface IBasicPluginInfo {

--- a/cdap-ui/app/cdap/components/PluginJSONCreator/constants.tsx
+++ b/cdap-ui/app/cdap/components/PluginJSONCreator/constants.tsx
@@ -24,8 +24,6 @@ export const PluginTypes = Object.keys(GLOBALS.pluginTypeToLabel).filter(
 export const WIDGET_TYPES = Object.keys(WIDGET_FACTORY);
 export const WIDGET_CATEGORY = ['plugin'];
 
-export const SPEC_VERSION = '1.5';
-
 // including additional property that was found from the docs
 // (DOCS: https://docs.cdap.io/cdap/6.1.2/en/developer-manual/pipelines/developing-plugins/presentation-plugins.html)
 export const WIDGET_TYPE_TO_ATTRIBUTES = {
@@ -212,3 +210,5 @@ export const CODE_EDITORS = [
   'scala-editor',
   'sql-editor',
 ];
+
+export const SPEC_VERSION = '1.5';


### PR DESCRIPTION
**(Because I accidentally merged #12218 to another branch, I'm making a new PR for this. Please refer to #12218 for previous reviews and histories.)**

JIRA: https://issues.cask.co/browse/CDAP-16869

In plugin JSON file, there is a key called `outputs`. `outputs` is a list of plugin properties that represent the output schema of a particular plugin.

This PR creates a page for `outputs` field configuration. From the UI side, we'll let the user only set the `name` of the `outputs`.

<img width="1785" alt="Screen Shot 2020-05-28 at 2 15 38 PM" src="https://user-images.githubusercontent.com/14116152/83181353-c07a6d00-a0f2-11ea-9120-10415f5df8e9.png">
