### PR TITLE
[CDAP-16975][CDAP-16976] Select latest version as default when choosing a plugin in UI + reset default plugins post upgrade

### DIFF
--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -26,6 +26,7 @@ var VersionStore = require('../cdap/services/VersionStore').default;
 var VersionActions = require('../cdap/services/VersionStore/VersionActions').default;
 var Version = require('../cdap/services/VersionRange/Version').default;
 var VersionRange = require('../cdap/services/VersionRange').default;
+var VersionUtilities = require('../cdap/services/VersionRange/VersionUtilities');
 var KeyValuePairs = require('../cdap/components/KeyValuePairs').default;
 var KeyValueStore = require('../cdap/components/KeyValuePairs/KeyValueStore').default;
 var KeyValueStoreActions = require('../cdap/components/KeyValuePairs/KeyValueStoreActions').default;
@@ -120,6 +121,7 @@ export {
   VersionActions,
   VersionRange,
   Version,
+  VersionUtilities,
   ResourceCenterButton,
   KeyValuePairs,
   KeyValueStore,

--- a/cdap-ui/app/directives/complex-schema/complex-schema.js
+++ b/cdap-ui/app/directives/complex-schema/complex-schema.js
@@ -48,6 +48,7 @@ function ComplexSchemaController (avsc, SCHEMA_TYPES, $scope, uuid, $timeout, Sc
     if (!fields.length) {
       return;
     }
+    /* jshint ignore:start */
     vm.io = new IntersectionObserver(
       (entries) => {
         let lastVisibleElement = vm.windowSize;
@@ -82,6 +83,7 @@ function ComplexSchemaController (avsc, SCHEMA_TYPES, $scope, uuid, $timeout, Sc
         threshold: [0, 1],
       }
     );
+    /* jshint ignore:end */
     $scope.observeFields();
   });
 

--- a/cdap-ui/app/hydrator/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/leftpanel-ctrl.js
@@ -96,7 +96,17 @@ class HydratorPlusPlusLeftPanelCtrl {
         type: this.LEFTPANELSTORE_ACTIONS.PLUGIN_DEFAULT_VERSION_CHECK_AND_UPDATE
       });
       const defaultVersionMap = this.leftpanelStore.getState().plugins.pluginToVersionMap;
-      this.mySettings.set('plugin-default-version', defaultVersionMap);
+      this.mySettings.get('CURRENT_CDAP_VERSION')
+      .then((defaultCDAPVersion) => {
+        if (this.rVersion.version !== defaultCDAPVersion) {
+          return this.mySettings
+            .set('plugin-default-version', {})
+            .then(() => {
+              this.mySettings.set('CURRENT_CDAP_VERSION', this.rVersion.version);
+            });
+        }
+        this.mySettings.set('plugin-default-version', defaultVersionMap);
+      });
     }, 10000);
 
 

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -109,7 +109,7 @@ class HydratorPlusPlusNodeConfigCtrl {
         isSource: this.state.isSource,
         isSink: this.state.isSink,
         isCondition: this.state.isCondition,
-       }
+       };
     }
 
     this.activeTab = 1;

--- a/cdap-ui/app/hydrator/services/hydrator-node-service.js
+++ b/cdap-ui/app/hydrator/services/hydrator-node-service.js
@@ -140,6 +140,33 @@ class HydratorPlusPlusNodeService {
 
     return true;
   }
+
+  getPluginToArtifactMap(plugins = []) {
+    let typeMap = {};
+    plugins.forEach( plugin => {
+      typeMap[plugin.name] = typeMap[plugin.name] || [];
+      typeMap[plugin.name].push(plugin);
+    });
+    return typeMap;
+  }
+
+  getDefaultVersionForPlugin(plugin = {}, defaultVersionMap = {}) {
+    if (!Object.keys(plugin).length) {
+      return {};
+    }
+    let defaultVersionsList = Object.keys(defaultVersionMap);
+    let key = `${plugin.name}-${plugin.type}-${plugin.artifact.name}`;
+    let isDefaultVersionExists = defaultVersionsList.indexOf(key) !== -1;
+
+    let isArtifactExistsInBackend = (plugin.allArtifacts || []).filter(plug => angular.equals(plug.artifact, defaultVersionMap[key]));
+    if (!isDefaultVersionExists || !isArtifactExistsInBackend.length) {
+      const highestVersion = window.CaskCommon.VersionUtilities.findHighestVersion(plugin.allArtifacts.map((plugin) => plugin.artifact.version), true);
+      const latestPluginVersion = plugin.allArtifacts.find((plugin) => plugin.artifact.version === highestVersion);
+      return this.myHelpers.objectQuery(latestPluginVersion, 'artifact');
+    }
+
+    return angular.copy(defaultVersionMap[key]);
+  }
 }
 
 angular.module(PKG.name + '.feature.hydrator')


### PR DESCRIPTION
JIRAs:
https://issues.cask.co/browse/CDAP-16975
https://issues.cask.co/browse/CDAP-16976

Context:
- The Current behavior of UI is to default to a specific version of the plugin once chosen by the user forever.
- This will be a problem when the user upgrades their CDAP instance
- We want them to use the latest version of the plugin upon upgrade.
As part of this we do two things,

1. Make sure if there is no default version for a plugin in the user store, choose the latest version among the list of available versions of the plugin
2. If the user, for some reason chooses an older version of the plugin, then default to that particular plugin.
3. Once the user upgrades the CDAP instance we then reset the default plugin versions in the user store.
4. This will help the user choose the latest version of the plugin when they upgrade. And after this if the user chooses to use an older version they can do so and that will be defaulted to from then on.