### PR TITLE
CDAP-16987 Keep single store for all preview runs owned by PreviewManager.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerModule.java
@@ -22,7 +22,6 @@ import com.google.inject.Inject;
 import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
-import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Names;
 import io.cdap.cdap.app.deploy.Manager;
@@ -87,7 +86,6 @@ public class DefaultPreviewRunnerModule extends PrivateModule implements Preview
   private final PrivilegesManager privilegesManager;
   private final PreferencesService preferencesService;
   private final ProgramRuntimeProviderLoader programRuntimeProviderLoader;
-  private final PreviewRequest previewRequest;
   private final ArtifactRepositoryReaderProvider artifactRepositoryReaderProvider;
   private final PluginFinderProvider pluginFinderProvider;
   private final PreferencesFetcherProvider preferencesFetcherProvider;
@@ -100,8 +98,7 @@ public class DefaultPreviewRunnerModule extends PrivateModule implements Preview
                                     PrivilegesManager privilegesManager, PreferencesService preferencesService,
                                     ProgramRuntimeProviderLoader programRuntimeProviderLoader,
                                     PluginFinderProvider pluginFinderProvider,
-                                    PreferencesFetcherProvider preferencesFetcherProvider,
-                                    @Assisted PreviewRequest previewRequest) {
+                                    PreferencesFetcherProvider preferencesFetcherProvider) {
     this.artifactRepositoryReaderProvider = readerProvider;
     this.artifactStore = artifactStore;
     this.authorizerInstantiator = authorizerInstantiator;
@@ -109,7 +106,6 @@ public class DefaultPreviewRunnerModule extends PrivateModule implements Preview
     this.privilegesManager = privilegesManager;
     this.preferencesService = preferencesService;
     this.programRuntimeProviderLoader = programRuntimeProviderLoader;
-    this.previewRequest = previewRequest;
     this.pluginFinderProvider = pluginFinderProvider;
     this.preferencesFetcherProvider = preferencesFetcherProvider;
   }
@@ -186,8 +182,6 @@ public class DefaultPreviewRunnerModule extends PrivateModule implements Preview
     expose(OwnerStore.class);
     bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);
     expose(OwnerAdmin.class);
-
-    bind(PreviewRequest.class).toInstance(previewRequest);
 
     bind(PluginFinder.class).toProvider(pluginFinderProvider);
     expose(PluginFinder.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewManager.java
@@ -15,7 +15,6 @@
  */
 package io.cdap.cdap.app.preview;
 
-import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.logging.read.LogReader;
 import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.ApplicationId;
@@ -36,19 +35,14 @@ public interface PreviewManager {
   ApplicationId start(NamespaceId namespace, AppRequest<?> request) throws Exception;
 
   /**
-   * Get the {@link PreviewRunner} responsible for managing the given preview.
-   * @param preview the application id of the preview for which {@link PreviewRunner} is to be returned
-   * @return the {@link PreviewRunner} associted with the preview
-   * @throws NotFoundException if the preview application is not found
+   * Get the {@link PreviewRunner} responsible for managing the preview.
+   * @return the {@link PreviewRunner} associated with the preview
    */
-  PreviewRunner getRunner(ApplicationId preview) throws NotFoundException;
+  PreviewRunner getRunner();
 
   /**
    * Returns a {@link LogReader} for reading logs for the given preview.
-   *
-   * @param preview the application id of the preview for which {@link LogReader} is to be returned
    * @return the {@link LogReader} for reading logs for the given preview
-   * @throws NotFoundException if the preview application is not found
    */
-  LogReader getLogReader(ApplicationId preview) throws NotFoundException;
+  LogReader getLogReader();
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunner.java
@@ -17,14 +17,15 @@
 package io.cdap.cdap.app.preview;
 
 import com.google.gson.JsonElement;
+import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.metrics.query.MetricsQueryHelper;
+import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 /**
  * Interface responsible for managing the lifecycle of a single preview application
@@ -33,27 +34,26 @@ import javax.annotation.Nullable;
 public interface PreviewRunner {
 
   /**
-   * Returns the {@link PreviewRequest} for this runner.
-   */
-  PreviewRequest getPreviewRequest();
-
-  /**
    * Start the preview of an application.
-   * @throws Exception if there were any error during starting preview
+   * @param previewRequest request representing preview
+   * @throws Exception when there is error while starting preview
    */
-  void startPreview() throws Exception;
+  void startPreview(PreviewRequest previewRequest) throws Exception;
 
   /**
-   * Get the status of the preview represented by this {@link PreviewRunner}.
-   * @return the status associated with the preview
+   * Get the status of the preview.
+   * @param applicationId id of the preview application for which preview status is to be returned
+   * @return the status of the preview
+   * @throws NotFoundException if preview application is not found
    */
-  PreviewStatus getStatus();
+  PreviewStatus getStatus(ApplicationId applicationId) throws NotFoundException;
 
   /**
-   * Stop the preview run represented by this {@link PreviewRunner}.
-   * @throws Exception if there were any error during stopping preview
+   * Stop the preview run represented by this {@link ApplicationId}.
+   * @param applicationId id of the preview
+   * @throws Exception thrown when any error in stopping the preview run
    */
-  void stopPreview() throws Exception;
+  void stopPreview(ApplicationId applicationId) throws Exception;
 
   /**
    * Get list of tracers used in the preview run represented by this {@link PreviewRunner}.
@@ -63,23 +63,18 @@ public interface PreviewRunner {
 
   /**
    * Get the data associated with the preview run represented by this {@link PreviewRunner}.
+   * @param applicationId the id of the preview application
    * @param tracerName the name of the tracer used for preview
    * @return the {@link Map} of properties associated with the tracer for a given preview
    */
-  Map<String, List<JsonElement>> getData(String tracerName);
-
-  /**
-   * Get the run id of the program executed as a part of preview.
-   * @return the {@link ProgramRunId} associated with the preview
-   */
-  ProgramRunId getProgramRunId();
+  Map<String, List<JsonElement>> getData(ApplicationId applicationId, String tracerName);
 
   /**
    * Get the run record of the program executed as a part of preview.
-   * @return the {@link RunRecordDetail} associated with the preview or {@code null} if there is no run record
+   * @param applicationId the id of the preview application
+   * @return the {@link ProgramRunId} associated with the preview or {@code null} if there is no run record
    */
-  @Nullable
-  RunRecordDetail getRunRecord();
+  RunRecordDetail getRunRecord(ApplicationId applicationId) throws Exception;
 
   /**
    * Get the helper object to query for metrics for the preview run.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModuleFactory.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModuleFactory.java
@@ -19,9 +19,9 @@ package io.cdap.cdap.app.preview;
 import com.google.inject.Module;
 
 /**
- * A factory for creating guice {@link Module} for a given {@link PreviewRequest}.
+ * A factory for creating guice {@link Module} for preview runner.
  */
 public interface PreviewRunnerModuleFactory {
 
-  PreviewRunnerModule create(PreviewRequest previewRequest);
+  PreviewRunnerModule create();
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -33,9 +33,7 @@ import io.cdap.cdap.app.preview.PreviewManager;
 import io.cdap.cdap.app.preview.PreviewRequest;
 import io.cdap.cdap.app.preview.PreviewRunner;
 import io.cdap.cdap.app.preview.PreviewRunnerModuleFactory;
-import io.cdap.cdap.app.preview.PreviewStatus;
 import io.cdap.cdap.common.BadRequestException;
-import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
@@ -44,7 +42,6 @@ import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
 import io.cdap.cdap.common.guice.preview.PreviewDiscoveryRuntimeModule;
-import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.common.utils.Networks;
 import io.cdap.cdap.config.guice.ConfigStoreModule;
 import io.cdap.cdap.data.runtime.DataSetServiceModules;
@@ -76,19 +73,13 @@ import org.apache.twill.discovery.DiscoveryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
@@ -106,9 +97,9 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
   private final DatasetFramework datasetFramework;
   private final SecureStore secureStore;
   private final TransactionSystemClient transactionSystemClient;
-  private final ConcurrentMap<ApplicationId, Injector> appInjectors;
   private final Path previewDataDir;
   private final PreviewRunnerModuleFactory previewRunnerModuleFactory;
+  private Injector previewInjector;
 
   @Inject
   DefaultPreviewManager(CConfiguration cConf, Configuration hConf,
@@ -124,67 +115,25 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
     this.secureStore = secureStore;
     this.transactionSystemClient = transactionSystemClient;
     this.previewDataDir = Paths.get(cConf.get(Constants.CFG_LOCAL_DATA_DIR), "preview").toAbsolutePath();
-    this.appInjectors = new ConcurrentHashMap<>();
     this.maxPreviews = cConf.getInt(Constants.Preview.PREVIEW_CACHE_SIZE, 10);
     this.previewRunnerModuleFactory = previewRunnerModuleFactory;
   }
 
   @Override
   protected void startUp() throws Exception {
-    File previewDir = previewDataDir.toFile();
-
-    // Only load the latest maxPreviews and delete the rest
-    List<File> previewRunDirs = DirUtils.listFiles(previewDir, File::isDirectory).stream()
-      .sorted((f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()))
-      .collect(Collectors.toList());
-
-    if (previewRunDirs.size() > maxPreviews) {
-      for (File dir : previewRunDirs.subList(maxPreviews, previewRunDirs.size())) {
-        try {
-          DirUtils.deleteDirectoryContents(dir);
-          LOG.debug("Removed preview run directory {}", dir);
-        } catch (IOException e) {
-          LOG.warn("Failed to delete unused preview run directory {}", dir, e);
-        }
-      }
-    }
-
-    for (File file : (Iterable<File>) previewRunDirs.stream().limit(maxPreviews)::iterator) {
-      ProgramId programId;
-      String name = file.getName();
-      try {
-        String[] parts = name.split("\\.");
-        programId = new ProgramId(parts[0], parts[1], parts[2], parts[3]);
-      } catch (Exception e) {
-        // if there is an exception converting to a preview id, just continue
-        LOG.debug("Failed to parse the file directory {} to a valid preview id", name, e);
-        continue;
-      }
-      Injector injector = createPreviewInjector(new PreviewRequest(programId));
-      PreviewRunner runner = injector.getInstance(PreviewRunner.class);
-      if (runner instanceof Service) {
-        try {
-          ((Service) runner).startAndWait();
-        } catch (Exception e) {
-          // If there is any failure, just log and delete the directory as the data directory for this preview run
-          // can be corrupted
-          LOG.warn("Failed to start the preview runner for old preview run at directory {}", file, e);
-          injector = null;
-        }
-      }
-      if (injector != null) {
-        appInjectors.put(programId.getParent(), injector);
-      }
+    previewInjector = createPreviewInjector();
+    PreviewRunner runner = previewInjector.getInstance(PreviewRunner.class);
+    if (runner instanceof Service) {
+      ((Service) runner).startAndWait();
     }
   }
 
   @Override
   protected synchronized void shutDown() throws Exception {
-    appInjectors.values().stream()
-      .map(injector -> injector.getInstance(PreviewRunner.class))
-      .filter(Service.class::isInstance)
-      .map(Service.class::cast)
-      .forEach(this::stopQuietly);
+    PreviewRunner runner = previewInjector.getInstance(PreviewRunner.class);
+    if (runner instanceof Service) {
+      stopQuietly((Service) runner);
+    }
   }
 
   @Override
@@ -192,105 +141,32 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
     // make sure preview id is unique for each run
     ApplicationId previewApp = namespace.app(RunIds.generate().getId());
     ProgramId programId = getProgramIdFromRequest(previewApp, appRequest);
+    PreviewRequest previewRequest = new PreviewRequest(programId, appRequest);
 
     if (state() != State.RUNNING) {
       throw new IllegalStateException("Preview service is not running. Cannot start preview for " + programId);
     }
 
-    Injector injector;
-    synchronized (this) {
-      if (!ensureCapacity()) {
-        throw new IllegalStateException("There are currently " + maxPreviews +
-                                          " concurrent active previews running. Please retry in a minute.");
-      }
-
-      PreviewRequest previewRequest = new PreviewRequest(programId, appRequest);
-      injector = createPreviewInjector(previewRequest);
-      appInjectors.put(previewApp, injector);
-    }
-
-    PreviewRunner runner = injector.getInstance(PreviewRunner.class);
-    if (runner instanceof Service) {
-      ((Service) runner).startAndWait();
-    }
-    try {
-      runner.startPreview();
-      return previewApp;
-    } catch (Exception e) {
-      if (runner instanceof Service) {
-        stopQuietly((Service) runner);
-      }
-      appInjectors.remove(previewApp);
-      removePreviewDir(programId);
-      throw e;
-    }
+    PreviewRunner runner = previewInjector.getInstance(PreviewRunner.class);
+    runner.startPreview(previewRequest);
+    return previewApp;
   }
 
   @Override
-  public PreviewRunner getRunner(ApplicationId preview) throws NotFoundException {
-    Injector injector = appInjectors.get(preview);
-    if (injector == null) {
-      throw new NotFoundException(preview);
-    }
-
-    return injector.getInstance(PreviewRunner.class);
+  public PreviewRunner getRunner() {
+    return previewInjector.getInstance(PreviewRunner.class);
   }
 
   @Override
-  public LogReader getLogReader(ApplicationId preview) throws NotFoundException {
-    Injector injector = appInjectors.get(preview);
-    if (injector == null) {
-      throw new NotFoundException(preview);
-    }
-
-    return injector.getInstance(LogReader.class);
-  }
-
-  /**
-   * Ensures there is available slots for running preview.
-   *
-   * @return {@code true} if more preview can be executed, {@code false} otherwise.
-   */
-  private boolean ensureCapacity() {
-    if (appInjectors.size() < maxPreviews) {
-      return true;
-    }
-    // Find a completed preview and evict it
-    ApplicationId applicationId = null;
-    for (Map.Entry<ApplicationId, Injector> entry : appInjectors.entrySet()) {
-      PreviewRunner runner = entry.getValue().getInstance(PreviewRunner.class);
-
-      try {
-        PreviewStatus status = runner.getStatus();
-        if (status != null && status.getStatus().isEndState()) {
-          applicationId = entry.getKey();
-          break;
-        }
-      } catch (Exception e) {
-        LOG.warn("Unable to get the preview status for {}", entry.getKey(), e);
-      }
-    }
-
-    if (applicationId == null) {
-      return false;
-    }
-
-    Injector injector = appInjectors.remove(applicationId);
-    PreviewRunner runner = injector.getInstance(PreviewRunner.class);
-    if (runner instanceof Service) {
-      stopQuietly((Service) runner);
-    }
-    ProgramId programId = runner.getPreviewRequest().getProgram();
-    removePreviewDir(programId);
-    LOG.debug("Evicted old preview run {}", programId);
-    return true;
+  public LogReader getLogReader() {
+    return previewInjector.getInstance(LogReader.class);
   }
 
   /**
    * Create injector for the given application id.
    */
   @VisibleForTesting
-  Injector createPreviewInjector(PreviewRequest previewRequest) throws IOException {
+  Injector createPreviewInjector() throws IOException {
     CConfiguration previewCConf = CConfiguration.copy(cConf);
 
     // Change all services bind address to local host
@@ -300,7 +176,7 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
       .filter(s -> s.endsWith(".bind.address"))
       .forEach(key -> previewCConf.set(key, localhost));
 
-    Path previewDir = Files.createDirectories(getPreviewDirPath(previewRequest.getProgram()));
+    Path previewDir = Files.createDirectories(previewDataDir);
 
     previewCConf.set(Constants.CFG_LOCAL_DATA_DIR, previewDir.toString());
     previewCConf.setIfUnset(Constants.CFG_DATA_LEVELDB_DIR, previewDir.toString());
@@ -324,7 +200,7 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
       new PreviewDiscoveryRuntimeModule(discoveryService),
       new LocalLocationModule(),
       new ConfigStoreModule(),
-      previewRunnerModuleFactory.create(previewRequest),
+      previewRunnerModuleFactory.create(),
       new ProgramRunnerRuntimeModule().getStandaloneModules(),
       new PreviewDataModules().getDataFabricModule(transactionSystemClient),
       new PreviewDataModules().getDataSetsModule(datasetFramework),
@@ -357,11 +233,6 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
       });
   }
 
-  @VisibleForTesting
-  Map<ApplicationId, Injector> getCache() {
-    return new HashMap<>(appInjectors);
-  }
-
   private ProgramId getProgramIdFromRequest(ApplicationId preview, AppRequest request) throws BadRequestException {
     PreviewConfig previewConfig = request.getPreview();
     if (previewConfig == null) {
@@ -384,21 +255,5 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
     } catch (Exception e) {
       LOG.debug("Error stopping the preview runner.", e);
     }
-  }
-
-  private void removePreviewDir(ProgramId programId) {
-    Path previewDirPath = getPreviewDirPath(programId);
-    try {
-      DataTracerFactoryProvider.removeDataTracerFactory(programId.getParent());
-      DirUtils.deleteDirectoryContents(previewDirPath.toFile());
-    } catch (IOException e) {
-      LOG.debug("Error deleting the preview directory {}", previewDirPath, e);
-    }
-  }
-
-  private Path getPreviewDirPath(ProgramId programId) {
-    // the preview directory will be <namespace-name>.<app-id>.<program-type>.<program-name>
-    return previewDataDir.resolve(String.format("%s.%s.%s.%s", programId.getNamespace(), programId.getApplication(),
-                                                programId.getType().name(), programId.getProgram()));
   }
 }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16987

Removed appInjector cache from the PreviewManager. 
Passing applicationId to the preview runner methods to fetch data corresponding to the given application.