### PR TITLE
[CDAP-16975] Default to latest version while adding plugin from left …

### DIFF
--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -28,6 +28,7 @@ var VersionStore = require('../cdap/services/VersionStore').default;
 var VersionActions = require('../cdap/services/VersionStore/VersionActions').default;
 var Version = require('../cdap/services/VersionRange/Version').default;
 var VersionRange = require('../cdap/services/VersionRange').default;
+var VersionUtilities = require('../cdap/services/VersionRange/VersionUtilities');
 var KeyValuePairs = require('../cdap/components/KeyValuePairs').default;
 var KeyValuePairsMaterial = require('../cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/RuntimeArgsKeyValuePairWrapper/RuntimeArgsPairsMaterial.tsx')
   .default;
@@ -134,6 +135,7 @@ export {
   VersionActions,
   VersionRange,
   Version,
+  VersionUtilities,
   ResourceCenterButton,
   KeyValuePairs,
   KeyValuePairsMaterial,

--- a/cdap-ui/app/directives/complex-schema/complex-schema.js
+++ b/cdap-ui/app/directives/complex-schema/complex-schema.js
@@ -48,6 +48,7 @@ function ComplexSchemaController (avsc, SCHEMA_TYPES, $scope, uuid, $timeout, Sc
     if (!fields.length) {
       return;
     }
+    /* jshint ignore:start */
     vm.io = new IntersectionObserver(
       (entries) => {
         let lastVisibleElement = vm.windowSize;
@@ -82,6 +83,7 @@ function ComplexSchemaController (avsc, SCHEMA_TYPES, $scope, uuid, $timeout, Sc
         threshold: [0, 1],
       }
     );
+    /* jshint ignore:end */
     $scope.observeFields();
   });
 

--- a/cdap-ui/app/hydrator/controllers/create/leftpanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/leftpanel-ctrl.js
@@ -96,7 +96,17 @@ class HydratorPlusPlusLeftPanelCtrl {
         type: this.LEFTPANELSTORE_ACTIONS.PLUGIN_DEFAULT_VERSION_CHECK_AND_UPDATE
       });
       const defaultVersionMap = this.leftpanelStore.getState().plugins.pluginToVersionMap;
-      this.mySettings.set('plugin-default-version', defaultVersionMap);
+      this.mySettings.get('CURRENT_CDAP_VERSION')
+      .then((defaultCDAPVersion) => {
+        if (this.rVersion.version !== defaultCDAPVersion) {
+          return this.mySettings
+            .set('plugin-default-version', {})
+            .then(() => {
+              this.mySettings.set('CURRENT_CDAP_VERSION', this.rVersion.version);
+            });
+        }
+        this.mySettings.set('plugin-default-version', defaultVersionMap);
+      });
     }, 10000);
 
 

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -109,7 +109,7 @@ class HydratorPlusPlusNodeConfigCtrl {
         isSource: this.state.isSource,
         isSink: this.state.isSink,
         isCondition: this.state.isCondition,
-       }
+       };
     }
 
     this.activeTab = 1;

--- a/cdap-ui/app/hydrator/services/hydrator-node-service.js
+++ b/cdap-ui/app/hydrator/services/hydrator-node-service.js
@@ -140,6 +140,33 @@ class HydratorPlusPlusNodeService {
 
     return true;
   }
+
+  getPluginToArtifactMap(plugins = []) {
+    let typeMap = {};
+    plugins.forEach( plugin => {
+      typeMap[plugin.name] = typeMap[plugin.name] || [];
+      typeMap[plugin.name].push(plugin);
+    });
+    return typeMap;
+  }
+
+  getDefaultVersionForPlugin(plugin = {}, defaultVersionMap = {}) {
+    if (!Object.keys(plugin).length) {
+      return {};
+    }
+    let defaultVersionsList = Object.keys(defaultVersionMap);
+    let key = `${plugin.name}-${plugin.type}-${plugin.artifact.name}`;
+    let isDefaultVersionExists = defaultVersionsList.indexOf(key) !== -1;
+
+    let isArtifactExistsInBackend = (plugin.allArtifacts || []).filter(plug => angular.equals(plug.artifact, defaultVersionMap[key]));
+    if (!isDefaultVersionExists || !isArtifactExistsInBackend.length) {
+      const highestVersion = window.CaskCommon.VersionUtilities.findHighestVersion(plugin.allArtifacts.map((plugin) => plugin.artifact.version), true);
+      const latestPluginVersion = plugin.allArtifacts.find((plugin) => plugin.artifact.version === highestVersion);
+      return this.myHelpers.objectQuery(latestPluginVersion, 'artifact');
+    }
+
+    return angular.copy(defaultVersionMap[key]);
+  }
 }
 
 angular.module(PKG.name + '.feature.hydrator')


### PR DESCRIPTION
…panel +  [CDAP-16976] Reset the default plugin store post CDAP upgrade

**Cherry-picking https://github.com/cdapio/cdap/pull/12342 for 6.2**

This is to ensure we have the following behavior,

1. Pre-upgrade - When the user chooses a plugin from side panel in studio we
choose the latest version and set that as default.

2. Pre-upgrade - When the user consciously changes to a older version of the plugin we
default to that specific version after that.

3. Post-upgrade - Once the user upgrades the CDAP platform, we no longer want them to use
the default plugin version they were using in the previous version of CDAP. So we reset
the default plugins and start afresh

4. Post-upgrade, Post-reset - After reset post upgrade we then follow the pre-upgrade behavior
where from then on we choose the latest version of the plugin for the first time and default
to that for subsequent usage.

As part of that we now store the current version of CDAP in the user store. Post upgrade
there will be a mis-match between the cdap version in the user store and the current cdap
version the user is running, indicating that there was an upgrade upon which we then reset.