### PR TITLE
[CDAP-16972] Fix to stop pipeline preview running properly

### DIFF
--- a/cdap-ui/app/cdap/components/KeyValuePairs/KeyValueStoreActions.js
+++ b/cdap-ui/app/cdap/components/KeyValuePairs/KeyValueStoreActions.js
@@ -44,12 +44,12 @@ const convertKeyValuePairsObjToMap = (keyValues) => {
 const keyValuePairsHaveMissingValues = (keyValues) => {
   if (keyValues.pairs) {
     return keyValues.pairs.some((keyValuePair) => {
-      if (keyValuePair.notDeletable && keyValuePair.provided) {
-        return false;
+      if (keyValuePair.notDeletable && keyValuePair.value === '') {
+        return true;
       }
       let emptyKeyField = keyValuePair.key.length === 0;
       let emptyValueField = keyValuePair.value.length === 0;
-      // buttons are disabled when either the key or the value of a pair is empty, but not both
+      // buttons are disabled only when the key of a pair is empty, empty values are considered provided.
       return (emptyKeyField && !emptyValueField) || (!emptyKeyField && emptyValueField);
     });
   }

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineRunButton.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineRunButton.js
@@ -24,6 +24,7 @@ import PipelineRuntimeArgsDropdownBtn from 'components/PipelineDetails/PipelineR
 import PipelineConfigurationsStore from 'components/PipelineConfigurations/Store';
 import { convertKeyValuePairsToMap } from 'services/helpers';
 import T from 'i18n-react';
+import { fetchAndUpdateRuntimeArgs } from 'components/PipelineConfigurations/Store/ActionCreator';
 
 const PREFIX = 'features.PipelineDetails.TopPanel';
 
@@ -38,6 +39,7 @@ export default class PipelineRunButton extends Component {
 
   state = {
     showRunOptions: false,
+    showLoading: false,
   };
 
   toggleRunConfigOption = (showRunOptions) => {
@@ -49,11 +51,13 @@ export default class PipelineRunButton extends Component {
     });
   };
 
-  runPipelineOrToggleConfig = () => {
+  runPipelineOrToggleConfig = async () => {
     if (this.props.runButtonLoading) {
       return;
     }
-
+    this.setState({ showLoading: true });
+    await fetchAndUpdateRuntimeArgs().toPromise();
+    this.setState({ showLoading: false });
     if (!this.state.showRunOptions) {
       let { isMissingKeyValues } = PipelineConfigurationsStore.getState();
       if (isMissingKeyValues) {
@@ -102,10 +106,13 @@ export default class PipelineRunButton extends Component {
         disabled={this.props.runButtonLoading}
       >
         <div className="btn-container">
-          {this.props.runButtonLoading ? (
+          {this.props.runButtonLoading || this.state.showLoading ? (
             <span className="text-success">
               <IconSVG name="icon-spinner" className="fa-spin" />
-              <div className="button-label">{T.translate(`${PREFIX}.starting`)}</div>
+              <div className="button-label">
+                {this.props.runButtonLoading ? T.translate(`${PREFIX}.starting`) : null}
+                {this.state.showLoading ? T.translate(`${PREFIX}.loading`) : null}
+              </div>
             </span>
           ) : (
             <span className="text-success">

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -2083,6 +2083,7 @@ features:
       duplicate: Duplicate
       export: Export
       exportModalTitle: Export pipeline configuration
+      loading: Loading
       run: Run
       schedule: Schedule
       starting: Starting

--- a/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config-ctrl.js
+++ b/cdap-ui/app/directives/my-pipeline-configurations/my-batch-pipeline-config/my-batch-pipeline-config-ctrl.js
@@ -140,9 +140,17 @@ class MyBatchPipelineConfigCtrl {
   }
 
   buttonsAreDisabled() {
+    let runtimeArgsMissingValues = false;
     let customConfigMissingValues = false;
-    customConfigMissingValues = this.HydratorPlusPlusHydratorService.keyValuePairsHaveMissingValues(this.customEngineConfig);
-    return customConfigMissingValues;
+    if (this.isDeployed || this.showPreviewConfig) {
+      runtimeArgsMissingValues =
+          this.HydratorPlusPlusHydratorService.keyValuePairsHaveMissingValues(
+              this.runtimeArguments);
+    }
+    customConfigMissingValues =
+        this.HydratorPlusPlusHydratorService.keyValuePairsHaveMissingValues(
+            this.customEngineConfig);
+    return runtimeArgsMissingValues || customConfigMissingValues;
   }
 
   onDriverMemoryChange(value) {

--- a/cdap-ui/app/hydrator/services/hydrator-service.js
+++ b/cdap-ui/app/hydrator/services/hydrator-service.js
@@ -351,11 +351,14 @@ class HydratorPlusPlusHydratorService {
   keyValuePairsHaveMissingValues(keyValues) {
     if (keyValues.pairs) {
       return keyValues.pairs.some((keyValuePair) => {
-        if (keyValuePair.notDeletable && keyValuePair.provided) { return false; }
+        if (keyValuePair.notDeletable && keyValuePair.value === '') {
+          return false;
+        }
         let emptyKeyField = (keyValuePair.key.length === 0);
         let emptyValueField = (keyValuePair.value.length === 0);
-        // buttons are disabled when either the key or the value of a pair is empty, but not both
-        return (emptyKeyField && !emptyValueField) || (!emptyKeyField && emptyValueField);
+        // buttons are disabled only when the key of a pair is empty, empty
+        // values are considered provided.
+        return (emptyKeyField && !emptyValueField);
       });
     }
     return false;

--- a/cdap-ui/app/hydrator/templates/create/toppanel.html
+++ b/cdap-ui/app/hydrator/templates/create/toppanel.html
@@ -181,7 +181,7 @@
           ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && !HydratorPlusPlusTopPanelCtrl.previewRunning"
           ng-click="!HydratorPlusPlusTopPanelCtrl.previewLoading &&
           HydratorPlusPlusTopPanelCtrl.hasNodes &&
-          HydratorPlusPlusTopPanelCtrl.startOrStopPreview()"
+          HydratorPlusPlusTopPanelCtrl.notifyOrToggleRun()"
           uib-tooltip="Start building a pipeline before starting preview"
           tooltip-placement="bottom"
           tooltip-class="toppanel-tooltip"
@@ -195,7 +195,7 @@
     </div>
     <div class="btn"
           ng-if="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.previewRunning"
-          ng-click="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.startOrStopPreview()"
+          ng-click="!HydratorPlusPlusTopPanelCtrl.previewLoading && HydratorPlusPlusTopPanelCtrl.notifyOrToggleRun()"
           ng-disabled="HydratorPlusPlusTopPanelCtrl.previewLoading"
           data-cy="stop-preview-btn">
       <div class="btn-container">
@@ -246,7 +246,7 @@
     runtime-arguments="HydratorPlusPlusTopPanelCtrl.runtimeArguments"
     apply-runtime-arguments="HydratorPlusPlusTopPanelCtrl.applyRuntimeArguments()"
     resolved-macros="HydratorPlusPlusTopPanelCtrl.resolvedMacros"
-    run-pipeline="HydratorPlusPlusTopPanelCtrl.doStartOrStopPreview()"
+    run-pipeline="HydratorPlusPlusTopPanelCtrl.startOrStopPreview()"
     pipeline-name="{{HydratorPlusPlusTopPanelCtrl.state.metadata['name']}}"
     pipeline-action="Run"
     on-close="HydratorPlusPlusTopPanelCtrl.viewConfig = false"


### PR DESCRIPTION
After provided checkbox was removed, we made a decision to show the runtime arguments modal when user clicks on start preview and when the arguments are empt. The intention was to bring it to users' attention that they are about to run a preview with empty arguments.

We missed a corner case where the preview was already running with empty macros(they're provided) and if users click stop, we were showing the modal again because the runtime arguments were empty.

JIRA: https://issues.cask.co/browse/CDAP-16972