### PR TITLE
[CDAP-16937][CDAP-16940] Fixes preview style + bump idle timeout to be 5 mins

### DIFF
--- a/cdap-ui/app/cdap/components/PreviewData/TableContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/TableContainer.tsx
@@ -42,6 +42,8 @@ const styles = (theme): StyleRules => ({
     borderRight: `1px solid ${theme.palette.grey[400]}`,
     '& :last-of-type': {
       borderRight: 0,
+      overflowX: 'auto',
+      borderRadius: 0,
     },
   },
   h2Title: {
@@ -82,7 +84,9 @@ const TableContainer: React.FC<IPreviewTableContainerProps> = ({
             const inputRecords = tableValue.records;
             return (
               <div key={`input-table-${i}`}>
-                <Heading type={HeadingTypes.h3} label={inputs.length > 1 ? tableKey : null} />
+                <If condition={inputs.length > 1}>
+                  <Heading type={HeadingTypes.h3} label={tableKey} />
+                </If>
                 <DataTable
                   headers={inputHeaders}
                   records={inputRecords}
@@ -106,7 +110,9 @@ const TableContainer: React.FC<IPreviewTableContainerProps> = ({
             const outputRecords = tableValue.records;
             return (
               <div key={`output-table-${j}`}>
-                <Heading type={HeadingTypes.h3} label={outputs.length > 1 ? tableKey : null} />
+                <If condition={inputs.length > 1}>
+                  <Heading type={HeadingTypes.h3} label={tableKey} />
+                </If>
                 <DataTable
                   headers={outputHeaders}
                   records={outputRecords}

--- a/cdap-ui/app/cdap/services/WindowManager/index.ts
+++ b/cdap-ui/app/cdap/services/WindowManager/index.ts
@@ -41,7 +41,7 @@ class WindowManager {
     ifvisible.on('wakeup', () => {
       this.onFocusHandler();
     });
-    ifvisible.setIdleDuration(30);
+    ifvisible.setIdleDuration(300);
     this.initWorker();
   }
   /**


### PR DESCRIPTION
JIRAs
https://issues.cask.co/browse/CDAP-16937
https://issues.cask.co/browse/CDAP-16940

**CDAP-16937**
- Minor styling fixes for new preview data view

**CDAP-16940**
_**Problem**_
- User waits for X seconds after starting the pipeline in the UI
- Nothing happens
- Refresh and UI shows the latest state of the pipeline
- This happens because we pause all polling after 30 seconds of inactivity in the page.

_**Solution**_
- Bump the idle timeout to be 5 mins instead of 30 seconds. If there is no interaction from the user on CDAP UI for 5 mins we stop all polling.