### PR TITLE
[CDAP-16690] Add record view when number of fields is large

### DIFF
--- a/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
@@ -28,18 +28,24 @@ import Heading, { HeadingTypes } from 'components/Heading';
 import ThemeWrapper from 'components/ThemeWrapper';
 import T from 'i18n-react';
 
-const I18N_PREFIX = 'features.PreviewData.Table';
+const I18N_PREFIX = 'features.PreviewData.DataView.Table';
 
-const CustomTableCell = withStyles((theme) => ({
+export const CustomTableCell = withStyles((theme) => ({
   head: {
     backgroundColor: theme.palette.grey['300'],
     color: theme.palette.common.white,
     padding: 10,
     fontSize: 14,
+    '&:first-of-type': {
+      borderRight: `1px solid ${theme.palette.grey['500']}`,
+    },
   },
   body: {
     padding: 10,
     fontSize: 14,
+    '&:first-of-type': {
+      borderRight: `1px solid ${theme.palette.grey['500']}`,
+    },
   },
 }))(TableCell);
 
@@ -47,7 +53,7 @@ export const messageTextStyle = {
   fontSize: '1.3rem !important',
   margin: '10px 0',
 };
-const styles = (theme) => ({
+export const styles = (theme) => ({
   root: {
     width: '100%',
     display: 'inline-block',
@@ -119,6 +125,7 @@ const DataTableView: React.FC<IDataTableProps> = ({
       <Table>
         <TableHead>
           <TableRow className={classes.row}>
+            <CustomTableCell />
             {headers.map((fieldName, i) => {
               return (
                 <CustomTableCell key={`header-cell-${i}`}>{format(fieldName)}</CustomTableCell>
@@ -130,6 +137,7 @@ const DataTableView: React.FC<IDataTableProps> = ({
           {records.map((record, j) => {
             return (
               <TableRow className={classes.row} key={`tr-${j}`}>
+                <CustomTableCell>{j + 1}</CustomTableCell>
                 {headers.map((fieldName, k) => {
                   return (
                     <CustomTableCell key={`table-cell-${k}`}>

--- a/cdap-ui/app/cdap/components/PreviewData/DataView/TableContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/TableContainer.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import If from 'components/If';
-import DataTable from 'components/PreviewData/Table';
+import DataTable from 'components/PreviewData/DataView/Table';
 import { ITableData } from 'components/PreviewData';
 import { INode } from 'components/PreviewData/utilities';
 import Heading, { HeadingTypes } from 'components/Heading';
@@ -24,9 +24,9 @@ import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/wit
 import classnames from 'classnames';
 import T from 'i18n-react';
 
-const I18N_PREFIX = 'features.PreviewData.TableContainer';
+const I18N_PREFIX = 'features.PreviewData.DataView.TableContainer';
 
-const styles = (theme): StyleRules => ({
+export const styles = (theme): StyleRules => ({
   outerContainer: {
     display: 'flex',
   },
@@ -34,6 +34,7 @@ const styles = (theme): StyleRules => ({
     overflow: 'scroll',
     padding: '10px',
     width: '100%',
+    height: '100%',
   },
   split: {
     maxWidth: '50%',
@@ -43,6 +44,8 @@ const styles = (theme): StyleRules => ({
     '& :last-of-type': {
       borderRight: 0,
     },
+    '& .record-pane': { width: '100%' },
+    '& .cask-tab-headers': { overflowX: 'scroll' },
   },
   h2Title: {
     fontSize: '1.4rem !important',
@@ -66,8 +69,8 @@ const TableContainer: React.FC<IPreviewTableContainerProps> = ({
   selectedNode,
   previewStatus,
 }) => {
-  const inputs = Object.entries(tableData.inputs);
-  const outputs = Object.entries(tableData.outputs);
+  const inputs = tableData.inputs;
+  const outputs = tableData.outputs;
   return (
     <div className={classes.outerContainer}>
       <If condition={!selectedNode.isSource && !selectedNode.isCondition}>

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/Navigator.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/Navigator.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import classnames from 'classnames';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+import AbstractWidget from 'components/AbstractWidget';
+import ArrowRightIcon from '@material-ui/icons/ArrowRight';
+import ArrowLeftIcon from '@material-ui/icons/ArrowLeft';
+import IconButton from '@material-ui/core/IconButton';
+
+const styles = (theme): StyleRules => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: '0px 10px',
+    borderBottom: `1px solid ${theme.palette.grey[400]}`,
+  },
+  select: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+});
+
+interface IRecordNavigatorProps extends WithStyles<typeof styles> {
+  selectedRecord: number;
+  numRecords: number;
+  updateRecord: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  prevOperation: () => void;
+  nextOperation: () => void;
+}
+
+const RecordNavigatorBase: React.FC<IRecordNavigatorProps> = ({
+  classes,
+  selectedRecord,
+  numRecords,
+  updateRecord,
+  prevOperation,
+  nextOperation,
+}) => {
+  const prevDisabled = selectedRecord - 1 < 1;
+  const nextDisabled = selectedRecord + 1 > numRecords;
+
+  const createSelectOptions = () => {
+    const options = [];
+    for (let i = 1; i <= numRecords; i++) {
+      const value = `Record ${i}`;
+      options.push({ value, label: value });
+    }
+    return options;
+  };
+
+  const [selectOptions, setOptions] = useState([]);
+
+  useEffect(() => {
+    setOptions(createSelectOptions());
+  }, []);
+
+  return (
+    <div className={classes.root}>
+      <IconButton onClick={!prevDisabled ? prevOperation : undefined} disabled={prevDisabled}>
+        <ArrowLeftIcon fontSize="large" />
+      </IconButton>
+      <span className={classes.select}>
+        <AbstractWidget
+          value={`Record ${selectedRecord}`}
+          type="select"
+          widgetProps={{ options: selectOptions }}
+          onChange={(e) => updateRecord(e)}
+        />
+      </span>
+      <IconButton onClick={!nextDisabled ? nextOperation : undefined} disabled={nextDisabled}>
+        <ArrowRightIcon fontSize="large" />
+      </IconButton>
+    </div>
+  );
+};
+
+const RecordNavigator = withStyles(styles)(RecordNavigatorBase);
+
+export default RecordNavigator;

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React, { useState } from 'react';
+import ConfigurableTab from 'components/ConfigurableTab';
+import { ITableData } from 'components/PreviewData';
+import RecordNavigator from 'components/PreviewData/RecordView/Navigator';
+import RecordTable from 'components/PreviewData/RecordView/RecordTable';
+import { INode } from 'components/PreviewData/utilities';
+import If from 'components/If';
+import { styles as tableStyles } from 'components/PreviewData/DataView/TableContainer';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+import T from 'i18n-react';
+import classnames from 'classnames';
+
+const I18N_PREFIX = 'features.PreviewData.RecordView.RecordContainer';
+
+const styles = (theme): StyleRules => ({
+  ...tableStyles(theme),
+});
+
+interface IRecordViewContainerProps extends WithStyles<typeof styles> {
+  tableData: ITableData;
+  selectedNode: INode;
+  previewStatus?: string;
+}
+
+const RecordViewBase: React.FC<IRecordViewContainerProps> = ({
+  classes,
+  tableData,
+  selectedNode,
+}) => {
+  const [selectedRecord, setRecord] = useState(1);
+  const [activeTab, setActiveTab] = useState(null);
+
+  const inputs = tableData.inputs;
+  const outputs = tableData.outputs;
+
+  const numRecords = Math.max(tableData.inputFieldCount, tableData.outputFieldCount);
+
+  const updateRecord = (newVal: string) => {
+    const recordNum = parseInt(newVal.split(' ')[1], 10);
+    setRecord(recordNum);
+  };
+
+  const showInputTabs = inputs.length > 1;
+  const showOutputTabs = outputs.length > 1;
+
+  const handleTabClick = (id) => {
+    setActiveTab(id);
+  };
+
+  const getTabConfig = (stagesInfo, recordNum: number) => {
+    const recordIndex = recordNum - 1;
+    const tabs = stagesInfo.map(([stageName, recordInfo], index) => {
+      return {
+        id: index + 1,
+        name: stageName,
+        content: (
+          <RecordTable headers={recordInfo.schemaFields} record={recordInfo.records[recordIndex]} />
+        ),
+        paneClassName: 'record-pane',
+      };
+    });
+    return {
+      defaultTab: 1,
+      layout: 'horizontal',
+      tabs,
+    };
+  };
+
+  const getTabs = (config) => {
+    return <ConfigurableTab tabConfig={config} onTabClick={handleTabClick} activeTab={activeTab} />;
+  };
+
+  return (
+    <div>
+      <RecordNavigator
+        selectedRecord={selectedRecord}
+        numRecords={numRecords}
+        updateRecord={updateRecord}
+        prevOperation={() => setRecord(selectedRecord - 1)}
+        nextOperation={() => setRecord(selectedRecord + 1)}
+      />
+      <div className={classes.outerContainer}>
+        <If condition={!selectedNode.isSource && !selectedNode.isCondition}>
+          <div
+            className={classnames(classes.innerContainer, {
+              [classes.split]: !selectedNode.isSource && !selectedNode.isSink,
+            })}
+          >
+            <h2 className={classes.h2Title}>{T.translate(`${I18N_PREFIX}.inputHeader`)}</h2>
+            {showInputTabs
+              ? getTabs(getTabConfig(inputs, selectedRecord))
+              : inputs.map(([stageName, stageInfo]) => {
+                  return (
+                    <RecordTable
+                      headers={stageInfo.schemaFields}
+                      record={stageInfo.records[selectedRecord - 1]}
+                    />
+                  );
+                })}
+          </div>
+        </If>
+        <If condition={!selectedNode.isSink && !selectedNode.isCondition}>
+          <div
+            className={classnames(classes.innerContainer, {
+              [classes.split]: !selectedNode.isSource && !selectedNode.isSink,
+            })}
+          >
+            <h2 className={classes.h2Title}>{T.translate(`${I18N_PREFIX}.outputHeader`)}</h2>
+            {showOutputTabs
+              ? getTabs(getTabConfig(outputs, selectedRecord))
+              : outputs.map(([stageName, stageInfo]) => {
+                  return (
+                    <RecordTable
+                      headers={stageInfo.schemaFields}
+                      record={stageInfo.records[selectedRecord - 1]}
+                    />
+                  );
+                })}
+          </div>
+        </If>
+      </div>
+    </div>
+  );
+};
+
+const RecordContainer = withStyles(styles)(RecordViewBase);
+
+export default RecordContainer;

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import React from 'react';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableRow from '@material-ui/core/TableRow';
+import Paper from '@material-ui/core/Paper';
+import TableHead from '@material-ui/core/TableHead';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import ThemeWrapper from 'components/ThemeWrapper';
+import { CustomTableCell, styles } from 'components/PreviewData/DataView/Table';
+
+const I18N_PREFIX = 'features.PreviewData.RecordView.RecordTable';
+
+interface IRecordTableProps extends WithStyles<typeof styles> {
+  headers: string[];
+  record: any;
+}
+
+const RecordTableView: React.FC<IRecordTableProps> = ({ classes, headers, record }) => {
+  // Used to stringify any non-string field values and field names.
+  // TO DO: Might not need to do this for field names, need to test with nested schemas.
+  // TO DO: Move to utilities, since we also use this in data view
+  const format = (field: any) => {
+    if (typeof field === 'object') {
+      return JSON.stringify(field);
+    }
+    return field;
+  };
+
+  return (
+    <Paper className={classes.root}>
+      <Table>
+        <TableHead>
+          <TableRow className={classes.row}>
+            <CustomTableCell>Field</CustomTableCell>
+            <CustomTableCell>Value</CustomTableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {headers.map((fieldName, i) => {
+            return (
+              <TableRow className={classes.row} key={`tr-${i}}`}>
+                <CustomTableCell>{format(fieldName)}</CustomTableCell>
+                <CustomTableCell>{format(record[fieldName])}</CustomTableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Paper>
+  );
+};
+
+const StyledRecordTable = withStyles(styles)(RecordTableView);
+
+function RecordTable(props) {
+  return (
+    <ThemeWrapper>
+      <StyledRecordTable {...props} />
+    </ThemeWrapper>
+  );
+}
+
+export default RecordTable;

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -2410,17 +2410,22 @@ features:
       viewNamespace: View pipelines in namespace
     viewPipeline: View Pipeline
   PreviewData:
+    DataView:
+      Table:
+        noPreviewRunning: "{recordType} records have not been generated. Please verify your logic or try sending more data."
+        previewNotSupported: Preview data is not supported for condition stages.
+        previewRunning: "{recordType} records have not been generated yet. Please check again in a few minutes."
+      TableContainer:
+        conditionHeader: Input Records and Output Records
+        inputHeader: Input Records
+        outputHeader: Output Records
     errorHeader: Error fetching preview data. Please try re-running preview.
     loading: Fetching preview data 
+    RecordView:
+      RecordContainer:
+        inputHeader: Input Records
+        outputHeader: Output Records
     runPreview: Run preview to generate preview data.
-    Table: 
-      noPreviewRunning: "{recordType} records have not been generated. Please verify your logic or try sending more data."
-      previewNotSupported: Preview data is not supported for condition stages.
-      previewRunning: "{recordType} records have not been generated yet. Please check again in a few minutes."
-    TableContainer:
-      conditionHeader: Input Records and Output Records
-      inputHeader: Input Records
-      outputHeader: Output Records
   PropertiesEditor:
     AddProperty:
       button: Add Property


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16690
Build: https://builds.cask.co/browse/CDAP-UDUT679

- Added row numbers for data table view
- Added record view for when number of fields in schema is large (currently 100 or greater, but this can be changed easily). 
- Can navigate records using record dropdown or by clicking forward/backward. 
- If there are multiple inputs or outputs, will show each stage's records in its own tab

[An example pipeline with 100+ fields in the sources and joiner (but not the sink, so you should see the table view for the sink)](https://drive.google.com/open?id=1kAJjO_Eg7L62-MuzLngA_4zxpy0580g2) -- need to update the service file path for the cdap-gcp-project!

![Screen Shot 2020-06-17 at 7 29 55 PM](https://user-images.githubusercontent.com/16228294/84961141-8557d200-b0d1-11ea-8d9a-a8ad26a0b56f.png)

![record_view](https://user-images.githubusercontent.com/16228294/84961160-91dc2a80-b0d1-11ea-8fdd-a371e8b33946.gif)
