### PR TITLE
CDAP-16994 fix schema equality check during pipeline deployment

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Schemas.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Schemas.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.data.schema.SchemaHash;
+
+/**
+ * Schema utility methods
+ */
+public class Schemas {
+
+  private Schemas() {
+    // no-op constructor for utility class
+  }
+
+  public static boolean equalsIgnoringRecordName(Schema s1, Schema s2) {
+    SchemaHash hash1 = new SchemaHash(s1, false);
+    SchemaHash hash2 = new SchemaHash(s2, false);
+    return hash1.equals(hash2);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/record/StructuredRecordComparator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/record/StructuredRecordComparator.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.etl.common.record;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.common.Schemas;
 
 import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
@@ -153,7 +154,7 @@ public class StructuredRecordComparator implements Comparator<StructuredRecord> 
       case RECORD:
         if (val instanceof StructuredRecord) {
           StructuredRecord s = (StructuredRecord) val;
-          return s.getSchema().equals(schema);
+          return Schemas.equalsIgnoringRecordName(s.getSchema(), schema);
         } else {
           return false;
         }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
@@ -55,6 +55,7 @@ import io.cdap.cdap.etl.common.Constants;
 import io.cdap.cdap.etl.common.DefaultAutoJoinerContext;
 import io.cdap.cdap.etl.common.DefaultPipelineConfigurer;
 import io.cdap.cdap.etl.common.DefaultStageConfigurer;
+import io.cdap.cdap.etl.common.Schemas;
 import io.cdap.cdap.etl.planner.Dag;
 import io.cdap.cdap.etl.proto.ArtifactSelectorConfig;
 import io.cdap.cdap.etl.proto.Connection;
@@ -241,7 +242,7 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
             // this check isn't perfect, as we should still error if 2 transforms are inputs,
             // one has null schema and another has non-null schema.
             // todo: fix this cleanly and fully
-            if (outputSchema != null && !outputSchema.equals(schema)) {
+            if (outputSchema != null && !Schemas.equalsIgnoringRecordName(outputSchema, schema)) {
               throw new IllegalArgumentException("Cannot have different input schemas going into stage " + stageName);
             }
             outputSchema = schema;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/SchemaPropagator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/SchemaPropagator.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.condition.Condition;
 import io.cdap.cdap.etl.common.DefaultPipelineConfigurer;
 import io.cdap.cdap.etl.common.DefaultStageConfigurer;
+import io.cdap.cdap.etl.common.Schemas;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 
 import java.util.Map;
@@ -111,9 +112,18 @@ public class SchemaPropagator {
     }
   }
 
-  private boolean hasSameSchema(Map<String, Schema> inputSchemas, Schema inputSchema) {
+  private boolean hasSameSchema(Map<String, Schema> inputSchemas, @Nullable Schema inputSchema) {
     if (!inputSchemas.isEmpty()) {
-      return Objects.equals(inputSchemas.values().iterator().next(), inputSchema);
+      Schema s = inputSchemas.values().iterator().next();
+      if (s == null && inputSchema == null) {
+        return true;
+      } else if (s == null) {
+        return false;
+      } else if (inputSchema == null) {
+        return false;
+      }
+
+      return Schemas.equalsIgnoringRecordName(s, inputSchema);
     }
     return true;
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/SchemasTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/SchemasTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests for {@link Schema}
+ */
+public class SchemasTest {
+
+  @Test
+  public void testEqualsIgnoringRecordNameFlat() {
+    List<Schema.Field> fields = new ArrayList<>();
+    fields.add(Schema.Field.of("a", Schema.of(Schema.Type.STRING)));
+    fields.add(Schema.Field.of("b", Schema.of(Schema.Type.BOOLEAN)));
+    Schema s1 = Schema.recordOf("s1", fields);
+    Schema s2 = Schema.recordOf("s2", fields);
+    Assert.assertNotEquals(s1, s2);
+    Assert.assertTrue(Schemas.equalsIgnoringRecordName(s1, s2));
+  }
+
+  @Test
+  public void testEqualsIgnoringRecordNameInsideRecord() {
+    Schema inner1 = Schema.recordOf("inner1", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
+    Schema inner2 = Schema.recordOf("inner2", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
+
+    Schema outer1 = Schema.recordOf("outer1", Schema.Field.of("inner", inner1));
+    Schema outer2 = Schema.recordOf("outer2", Schema.Field.of("inner", inner2));
+    Assert.assertNotEquals(outer1, outer2);
+    Assert.assertTrue(Schemas.equalsIgnoringRecordName(outer1, outer2));
+  }
+
+  @Test
+  public void testEqualsIgnoringRecordNameInsideUnion() {
+    Schema inner1 = Schema.recordOf("inner1", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
+    Schema inner2 = Schema.recordOf("inner2", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
+
+    Schema s1 = Schema.recordOf("s1", Schema.Field.of("u", Schema.unionOf(inner1, Schema.of(Schema.Type.NULL))));
+    Schema s2 = Schema.recordOf("s2", Schema.Field.of("u", Schema.unionOf(inner2, Schema.of(Schema.Type.NULL))));
+    Assert.assertNotEquals(s1, s2);
+    Assert.assertTrue(Schemas.equalsIgnoringRecordName(s1, s2));
+
+    Schema inner3 = Schema.recordOf("inner3", Schema.Field.of("x", Schema.of(Schema.Type.LONG)));
+    Schema s3 = Schema.recordOf("s3", Schema.Field.of("u", Schema.unionOf(inner3, Schema.of(Schema.Type.NULL))));
+    Assert.assertFalse(Schemas.equalsIgnoringRecordName(s1, s3));
+  }
+
+  @Test
+  public void testEqualsIgnoringRecordNameInsideMap() {
+    Schema inner1 = Schema.recordOf("inner1", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
+    Schema inner2 = Schema.recordOf("inner2", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
+
+    Schema s1 = Schema.recordOf("s1", Schema.Field.of("u", Schema.mapOf(Schema.of(Schema.Type.STRING), inner1)));
+    Schema s2 = Schema.recordOf("s2", Schema.Field.of("u", Schema.mapOf(Schema.of(Schema.Type.STRING), inner2)));
+    Assert.assertNotEquals(s1, s2);
+    Assert.assertTrue(Schemas.equalsIgnoringRecordName(s1, s2));
+
+    Schema inner3 = Schema.recordOf("inner3", Schema.Field.of("x", Schema.of(Schema.Type.LONG)));
+    Schema s3 = Schema.recordOf("s3", Schema.Field.of("u", Schema.mapOf(Schema.of(Schema.Type.STRING), inner3)));
+    Assert.assertFalse(Schemas.equalsIgnoringRecordName(s1, s3));
+  }
+
+  @Test
+  public void testEqualsIgnoringRecordNameInsideArray() {
+    Schema inner1 = Schema.recordOf("inner1", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
+    Schema inner2 = Schema.recordOf("inner2", Schema.Field.of("x", Schema.of(Schema.Type.INT)));
+
+    Schema s1 = Schema.recordOf("s1", Schema.Field.of("u", Schema.arrayOf(inner1)));
+    Schema s2 = Schema.recordOf("s2", Schema.Field.of("u", Schema.arrayOf(inner2)));
+    Assert.assertNotEquals(s1, s2);
+    Assert.assertTrue(Schemas.equalsIgnoringRecordName(s1, s2));
+
+    Schema inner3 = Schema.recordOf("inner3", Schema.Field.of("x", Schema.of(Schema.Type.LONG)));
+    Schema s3 = Schema.recordOf("s3", Schema.Field.of("u", Schema.arrayOf(inner3)));
+    Assert.assertFalse(Schemas.equalsIgnoringRecordName(s1, s3));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
@@ -69,6 +69,7 @@ import javax.annotation.Nullable;
  */
 public class PipelineSpecGeneratorTest {
   private static final Schema SCHEMA_A = Schema.recordOf("a", Schema.Field.of("a", Schema.of(Schema.Type.STRING)));
+  private static final Schema SCHEMA_A2 = Schema.recordOf("a2", Schema.Field.of("a", Schema.of(Schema.Type.STRING)));
   private static final Schema SCHEMA_B = Schema.recordOf("b", Schema.Field.of("b", Schema.of(Schema.Type.STRING)));
   private static final Schema SCHEMA_ABC = Schema.recordOf("abc",
                                                            Schema.Field.of("a", Schema.of(Schema.Type.STRING)),
@@ -76,6 +77,7 @@ public class PipelineSpecGeneratorTest {
                                                            Schema.Field.of("c", Schema.of(Schema.Type.INT)));
   private static final Map<String, String> EMPTY_MAP = ImmutableMap.of();
   private static final ETLPlugin MOCK_SOURCE = new ETLPlugin("mocksource", BatchSource.PLUGIN_TYPE, EMPTY_MAP);
+  private static final ETLPlugin MOCK_SOURCE2 = new ETLPlugin("mocksource2", BatchSource.PLUGIN_TYPE, EMPTY_MAP);
   private static final ETLPlugin MOCK_TRANSFORM_A = new ETLPlugin("mockA", Transform.PLUGIN_TYPE, EMPTY_MAP);
   private static final ETLPlugin MOCK_TRANSFORM_B = new ETLPlugin("mockB", Transform.PLUGIN_TYPE, EMPTY_MAP);
   private static final ETLPlugin MOCK_TRANSFORM_ABC = new ETLPlugin("mockABC", Transform.PLUGIN_TYPE, EMPTY_MAP);
@@ -98,6 +100,8 @@ public class PipelineSpecGeneratorTest {
     Set<ArtifactId> artifactIds = ImmutableSet.of(ARTIFACT_ID);
     pluginConfigurer.addMockPlugin(BatchSource.PLUGIN_TYPE, "mocksource",
                                    MockPlugin.builder().setOutputSchema(SCHEMA_A).build(), artifactIds);
+    pluginConfigurer.addMockPlugin(BatchSource.PLUGIN_TYPE, "mocksource2",
+                                   MockPlugin.builder().setOutputSchema(SCHEMA_A2).build(), artifactIds);
     pluginConfigurer.addMockPlugin(Transform.PLUGIN_TYPE, "mockA",
                                    MockPlugin.builder().setOutputSchema(SCHEMA_A).setErrorSchema(SCHEMA_B).build(),
                                    artifactIds);
@@ -120,7 +124,6 @@ public class PipelineSpecGeneratorTest {
                                                    ImmutableSet.of(BatchSink.PLUGIN_TYPE),
                                                    Engine.MAPREDUCE);
   }
-
 
   @Test(expected = IllegalArgumentException.class)
   public void testUniqueStageNames() throws ValidationException {
@@ -289,6 +292,44 @@ public class PipelineSpecGeneratorTest {
       .setStageLoggingEnabled(etlConfig.isStageLoggingEnabled())
       .setNumOfRecordsPreview(etlConfig.getNumOfRecordsPreview())
       .build();
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testInputSchemasWithDifferentName() {
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
+      .addStage(new ETLStage("s1", MOCK_SOURCE))
+      .addStage(new ETLStage("s2", MOCK_SOURCE2))
+      .addStage(new ETLStage("sink", MOCK_SINK))
+      .addConnection("s1", "sink")
+      .addConnection("s2", "sink")
+      .setNumOfRecordsPreview(100)
+      .build();
+
+    Map<String, String> emptyMap = Collections.emptyMap();
+    PipelineSpec expected = BatchPipelineSpec.builder()
+      .addStage(
+        StageSpec.builder("s1", new PluginSpec(BatchSource.PLUGIN_TYPE, "mocksource", emptyMap, ARTIFACT_ID))
+          .addOutput(SCHEMA_A, "sink")
+          .build())
+      .addStage(
+        StageSpec.builder("s2", new PluginSpec(BatchSource.PLUGIN_TYPE, "mocksource2", emptyMap, ARTIFACT_ID))
+          .addOutput(SCHEMA_A2, "sink")
+          .build())
+      .addStage(
+        StageSpec.builder("sink", new PluginSpec(BatchSink.PLUGIN_TYPE, "mocksink", emptyMap, ARTIFACT_ID))
+          .addInputSchemas(ImmutableMap.of("s1", SCHEMA_A, "s2", SCHEMA_A2))
+          .setErrorSchema(SCHEMA_A)
+          .build())
+      .addConnections(etlConfig.getConnections())
+      .setResources(etlConfig.getResources())
+      .setDriverResources(new Resources(1024, 1))
+      .setClientResources(new Resources(1024, 1))
+      .setStageLoggingEnabled(etlConfig.isStageLoggingEnabled())
+      .setNumOfRecordsPreview(etlConfig.getNumOfRecordsPreview())
+      .build();
+
+    PipelineSpec actual = specGenerator.generateSpec(etlConfig);
     Assert.assertEquals(expected, actual);
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -55,6 +55,7 @@ import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
 import io.cdap.cdap.etl.common.NoopStageStatisticsCollector;
 import io.cdap.cdap.etl.common.PipelinePhase;
 import io.cdap.cdap.etl.common.RecordInfo;
+import io.cdap.cdap.etl.common.Schemas;
 import io.cdap.cdap.etl.common.StageStatisticsCollector;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 import io.cdap.cdap.etl.spark.function.AlertPassFilter;
@@ -556,7 +557,7 @@ public abstract class SparkPipelineRunner {
 
         Schema existingSchema = keySchema.get(keyFieldNum);
         if (existingSchema != null && existingSchema.isSimpleOrNullableSimple() &&
-          !existingSchema.equals(keyFieldSchema)) {
+          !Schemas.equalsIgnoringRecordName(existingSchema, keyFieldSchema)) {
           // this is an invalid join definition
           // this condition is normally checked at deployment time,
           // but it will be skipped if the input schema is not known.


### PR DESCRIPTION
Fixed a bug that would cause pipeline deployment to fails if
two stages have the same output stage and their output schemas
are exactly the same except for the schema name.

Implemented a schema equality check that ignores record name
when checking equality, and used it for the validation checks.