### PR TITLE
CDAP-16935 partition dataframes before join

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/AutoJoinerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/AutoJoinerTest.java
@@ -309,7 +309,8 @@ public class AutoJoinerTest extends HydratorTestBase {
     MockSource.writeInput(inputManager, purchaseData);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    Map<String, String> args = Collections.singletonMap(MockAutoJoiner.PARTITIONS_ARGUMENT, "1");
+    workflowManager.startAndWaitForRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(output);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -318,6 +319,7 @@ public class AutoJoinerTest extends HydratorTestBase {
 
     validateMetric(5, appId, "join.records.in");
     validateMetric(expected.size(), appId, "join.records.out");
+    validateMetric(1, appId, "sink." + MockSink.INITIALIZED_COUNT_METRIC);
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/join/JoinRequest.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/join/JoinRequest.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.join.JoinField;
 
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Request to join some collection to another collection.
@@ -34,9 +35,11 @@ public class JoinRequest {
   private final List<JoinField> fields;
   private final Schema outputSchema;
   private final List<JoinCollection> toJoin;
+  private final Integer numPartitions;
 
   public JoinRequest(String stageName, String leftStage, List<String> leftKey, Schema leftSchema, boolean leftRequired,
-                     boolean nullSafe, List<JoinField> fields, Schema outputSchema, List<JoinCollection> toJoin) {
+                     boolean nullSafe, List<JoinField> fields, Schema outputSchema, List<JoinCollection> toJoin,
+                     @Nullable Integer numPartitions) {
     this.stageName = stageName;
     this.leftStage = leftStage;
     this.leftKey = leftKey;
@@ -46,6 +49,7 @@ public class JoinRequest {
     this.leftSchema = leftSchema;
     this.outputSchema = outputSchema;
     this.toJoin = toJoin;
+    this.numPartitions = numPartitions;
   }
 
   public String getStageName() {
@@ -82,5 +86,10 @@ public class JoinRequest {
 
   public Schema getOutputSchema() {
     return outputSchema;
+  }
+
+  @Nullable
+  public Integer getNumPartitions() {
+    return numPartitions;
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/scala/io/cdap/cdap/etl/spark/plugin/literalsBridge.scala
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/scala/io/cdap/cdap/etl/spark/plugin/literalsBridge.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.plugin
+
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.types.DataType
+
+// Only exists to allow Java to get the default Literal for a data type, because 'default' is a reserved Java keyword.
+object LiteralsBridge {
+
+  def defaultLiteral(dataType: DataType): Literal = Literal.default(dataType)
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.etl.spark.SparkCollection;
 import io.cdap.cdap.etl.spark.function.CountingFunction;
 import io.cdap.cdap.etl.spark.join.JoinCollection;
 import io.cdap.cdap.etl.spark.join.JoinRequest;
+import io.cdap.cdap.etl.spark.plugin.LiteralsBridge;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
@@ -35,6 +36,7 @@ import org.apache.spark.sql.DataFrame;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructType;
 import scala.collection.JavaConversions;
 import scala.collection.Seq;
@@ -45,7 +47,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
 /**
  * Spark1 RDD collection.
@@ -66,7 +67,8 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
     String stageName = joinRequest.getStageName();
     Function<StructuredRecord, StructuredRecord> recordsInCounter =
       new CountingFunction<>(stageName, sec.getMetrics(), Constants.Metrics.RECORDS_IN, sec.getDataTracer(stageName));
-    DataFrame left = toDataFrame(((JavaRDD<StructuredRecord>) rdd).map(recordsInCounter), joinRequest.getLeftSchema());
+    StructType leftSparkSchema = DataFrames.toDataType(joinRequest.getLeftSchema());
+    DataFrame left = toDataFrame(((JavaRDD<StructuredRecord>) rdd).map(recordsInCounter), leftSparkSchema);
     collections.put(joinRequest.getLeftStage(), left);
 
     List<Column> leftJoinColumns = joinRequest.getLeftKey().stream()
@@ -89,11 +91,13 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
         Join #2 is a left outer because TMP1 becomes 'required', since it uses required input B.
         Join #3 is an inner join even though it contains 2 optional datasets, because 'B' is still required.
      */
+    Integer joinPartitions = joinRequest.getNumPartitions();
     boolean seenRequired = joinRequest.isLeftRequired();
     DataFrame joined = left;
     for (JoinCollection toJoin : joinRequest.getToJoin()) {
       RDDCollection<StructuredRecord> data = (RDDCollection<StructuredRecord>) toJoin.getData();
-      DataFrame right = toDataFrame(data.rdd.map(recordsInCounter), toJoin.getSchema());
+      StructType sparkSchema = DataFrames.toDataType(toJoin.getSchema());
+      DataFrame right = toDataFrame(data.rdd.map(recordsInCounter), sparkSchema);
       collections.put(toJoin.getStage(), right);
 
       List<Column> rightJoinColumns = toJoin.getKey().stream()
@@ -121,6 +125,19 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
 
       if (toJoin.isBroadcast()) {
         right = functions.broadcast(right);
+      }
+      // repartition on the join keys with the number of partitions specified in the join request.
+      // since they are partitioned on the same thing, spark will not repartition during the join,
+      // which allows us to use a different number of partitions per joiner instead of using the global
+      // spark.sql.shuffle.partitions setting in the spark conf
+      if (joinPartitions != null && !toJoin.isBroadcast()) {
+        right = partitionOnKey(right, toJoin.getKey(), joinRequest.isNullSafe(), sparkSchema, joinPartitions);
+        // only need to repartition the left side if this is the first join,
+        // as intermediate joins will already be partitioned on the key
+        if (joined == left) {
+          joined = partitionOnKey(joined, joinRequest.getLeftKey(), joinRequest.isNullSafe(),
+                                  leftSparkSchema, joinPartitions);
+        }
       }
       joined = joined.join(right, joinOn, joinType);
 
@@ -173,10 +190,31 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
     return (SparkCollection<T>) wrap(output);
   }
 
-  private DataFrame toDataFrame(JavaRDD<StructuredRecord> rdd, @Nullable Schema schema) {
-    StructType sparkSchema = DataFrames.toDataType(schema);
+  private DataFrame toDataFrame(JavaRDD<StructuredRecord> rdd, StructType sparkSchema) {
     JavaRDD<Row> rowRDD = rdd.map(record -> DataFrames.toRow(record, sparkSchema));
     return sqlContext.createDataFrame(rowRDD.rdd(), sparkSchema);
+  }
+
+  private DataFrame partitionOnKey(DataFrame df, List<String> key, boolean isNullSafe, StructType sparkSchema,
+                                   int numPartitions) {
+    List<Column> columns = getPartitionColumns(df, key, isNullSafe, sparkSchema);
+    return df.repartition(numPartitions, JavaConversions.asScalaBuffer(columns).toSeq());
+  }
+
+  private List<Column> getPartitionColumns(DataFrame df, List<String> key, boolean isNullSafe, StructType sparkSchema) {
+    if (!isNullSafe) {
+      return key.stream().map(df::col).collect(Collectors.toList());
+    }
+
+    // if a null safe join is happening, spark will partition on coalesce(col, [default val]),
+    // where the default val is dependent on the column type and defined in
+    // org.apache.spark.sql.catalyst.expressions.Literal
+    return key.stream().map(keyCol -> {
+      int fieldIndex = sparkSchema.fieldIndex(keyCol);
+      DataType dataType = sparkSchema.fields()[fieldIndex].dataType();
+      Column defaultCol = new Column(LiteralsBridge.defaultLiteral(dataType));
+      return functions.coalesce(df.col(keyCol), defaultCol);
+    }).collect(Collectors.toList());
   }
 
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.etl.spark.SparkCollection;
 import io.cdap.cdap.etl.spark.function.CountingFunction;
 import io.cdap.cdap.etl.spark.join.JoinCollection;
 import io.cdap.cdap.etl.spark.join.JoinRequest;
+import io.cdap.cdap.etl.spark.plugin.LiteralsBridge;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
@@ -34,8 +35,8 @@ import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
-import org.apache.spark.sql.catalyst.encoders.RowEncoder;
 import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.StructType;
 import scala.collection.JavaConversions;
 import scala.collection.Seq;
@@ -46,7 +47,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
 /**
  * Spark2 RDD collection.
@@ -68,8 +68,8 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
     String stageName = joinRequest.getStageName();
     Function<StructuredRecord, StructuredRecord> recordsInCounter =
       new CountingFunction<>(stageName, sec.getMetrics(), Constants.Metrics.RECORDS_IN, sec.getDataTracer(stageName));
-    Dataset<Row> left = toDataset(stageName, ((JavaRDD<StructuredRecord>) rdd).map(recordsInCounter),
-                                  joinRequest.getLeftSchema());
+    StructType leftSparkSchema = DataFrames.toDataType(joinRequest.getLeftSchema());
+    Dataset<Row> left = toDataset(stageName, ((JavaRDD<StructuredRecord>) rdd).map(recordsInCounter), leftSparkSchema);
     collections.put(joinRequest.getLeftStage(), left);
 
     List<Column> leftJoinColumns = joinRequest.getLeftKey().stream()
@@ -92,11 +92,13 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
         Join #2 is a left outer because TMP1 becomes 'required', since it uses required input B.
         Join #3 is an inner join even though it contains 2 optional datasets, because 'B' is still required.
      */
+    Integer joinPartitions = joinRequest.getNumPartitions();
     boolean seenRequired = joinRequest.isLeftRequired();
     Dataset<Row> joined = left;
     for (JoinCollection toJoin : joinRequest.getToJoin()) {
       RDDCollection<StructuredRecord> data = (RDDCollection<StructuredRecord>) toJoin.getData();
-      Dataset<Row> right = toDataset(stageName, data.rdd.map(recordsInCounter), toJoin.getSchema());
+      StructType sparkSchema = DataFrames.toDataType(toJoin.getSchema());
+      Dataset<Row> right = toDataset(stageName, data.rdd.map(recordsInCounter), sparkSchema);
       collections.put(toJoin.getStage(), right);
 
       List<Column> rightJoinColumns = toJoin.getKey().stream()
@@ -124,6 +126,19 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
 
       if (toJoin.isBroadcast()) {
         right = functions.broadcast(right);
+      }
+      // repartition on the join keys with the number of partitions specified in the join request.
+      // since they are partitioned on the same thing, spark will not repartition during the join,
+      // which allows us to use a different number of partitions per joiner instead of using the global
+      // spark.sql.shuffle.partitions setting in the spark conf
+      if (joinPartitions != null && !toJoin.isBroadcast()) {
+        right = partitionOnKey(right, toJoin.getKey(), joinRequest.isNullSafe(), sparkSchema, joinPartitions);
+        // only need to repartition the left side if this is the first join,
+        // as intermediate joins will already be partitioned on the key
+        if (joined == left) {
+          joined = partitionOnKey(joined, joinRequest.getLeftKey(), joinRequest.isNullSafe(),
+                                  leftSparkSchema, joinPartitions);
+        }
       }
       joined = joined.join(right, joinOn, joinType);
 
@@ -178,9 +193,31 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
   }
 
 
-  protected Dataset<Row> toDataset(String stageName, JavaRDD<StructuredRecord> rdd, Schema schema) {
-    StructType sparkSchema = DataFrames.toDataType(schema);
+  protected Dataset<Row> toDataset(String stageName, JavaRDD<StructuredRecord> rdd, StructType sparkSchema) {
     JavaRDD<Row> rowRDD = rdd.map(record -> DataFrames.toRow(record, sparkSchema));
     return sqlContext.createDataFrame(rowRDD.rdd(), sparkSchema);
+  }
+
+  private Dataset<Row> partitionOnKey(Dataset<Row> df, List<String> key, boolean isNullSafe, StructType sparkSchema,
+                                      int numPartitions) {
+    List<Column> columns = getPartitionColumns(df, key, isNullSafe, sparkSchema);
+    return df.repartition(numPartitions, JavaConversions.asScalaBuffer(columns).toSeq());
+  }
+
+  private List<Column> getPartitionColumns(Dataset<Row> df, List<String> key, boolean isNullSafe,
+                                           StructType sparkSchema) {
+    if (!isNullSafe) {
+      return key.stream().map(df::col).collect(Collectors.toList());
+    }
+
+    // if a null safe join is happening, spark will partition on coalesce(col, [default val]),
+    // where the default val is dependent on the column type and defined in
+    // org.apache.spark.sql.catalyst.expressions.Literal
+    return key.stream().map(keyCol -> {
+      int fieldIndex = sparkSchema.fieldIndex(keyCol);
+      DataType dataType = sparkSchema.fields()[fieldIndex].dataType();
+      Column defaultCol = new Column(LiteralsBridge.defaultLiteral(dataType));
+      return functions.coalesce(df.col(keyCol), defaultCol);
+    }).collect(Collectors.toList());
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSink.java
@@ -59,6 +59,7 @@ import java.util.stream.Collectors;
 @Name(MockSink.NAME)
 public class MockSink extends BatchSink<StructuredRecord, byte[], Put> {
   public static final String NAME = "Mock";
+  public static final String INITIALIZED_COUNT_METRIC = "initialized.count";
   public static final PluginClass PLUGIN_CLASS = getPluginClass();
   private static final byte[] SCHEMA_COL = Bytes.toBytes("s");
   private static final byte[] RECORD_COL = Bytes.toBytes("r");
@@ -103,6 +104,7 @@ public class MockSink extends BatchSink<StructuredRecord, byte[], Put> {
   @Override
   public void initialize(BatchRuntimeContext context) throws Exception {
     super.initialize(context);
+    context.getMetrics().count(INITIALIZED_COUNT_METRIC, 1);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/joiner/MockAutoJoiner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/joiner/MockAutoJoiner.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.api.plugin.PluginPropertyField;
 import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
+import io.cdap.cdap.etl.api.batch.BatchJoinerContext;
 import io.cdap.cdap.etl.api.join.AutoJoinerContext;
 import io.cdap.cdap.etl.api.join.JoinCondition;
 import io.cdap.cdap.etl.api.join.JoinDefinition;
@@ -54,6 +55,7 @@ import javax.annotation.Nullable;
 @Name(MockAutoJoiner.NAME)
 public class MockAutoJoiner extends BatchAutoJoiner {
   public static final String NAME = "MockAutoJoiner";
+  public static final String PARTITIONS_ARGUMENT = "partitions";
   public static final PluginClass PLUGIN_CLASS = getPluginClass();
   private static final Gson GSON = new Gson();
   private static final Type LIST = new TypeToken<List<String>>() { }.getType();
@@ -116,6 +118,15 @@ public class MockAutoJoiner extends BatchAutoJoiner {
       builder.setOutputSchema(outputSchema);
     }
     return builder.build();
+  }
+
+  @Override
+  public void prepareRun(BatchJoinerContext context) throws Exception {
+    super.prepareRun(context);
+    String partitionsStr = context.getArguments().get(PARTITIONS_ARGUMENT);
+    if (partitionsStr != null) {
+      context.setNumPartitions(Integer.parseInt(partitionsStr));
+    }
   }
 
   /**


### PR DESCRIPTION
partition dataframes right before the join using the same
partitioning as the join would, except using the number of
partitions specified by the plugin instead of a global number
defined by the spark conf.