### PR TITLE
(CDAP-17001) Reduce unit-test JVM memory to 5GB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1553,7 +1553,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.19.1</version>
           <configuration>
-            <argLine>-Xmx8192m -Djava.awt.headless=true -XX:+UseG1GC -XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError</argLine>
+            <argLine>-Xmx5000m -Djava.awt.headless=true -XX:+UseG1GC -XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError</argLine>
             <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
             <reuseForks>false</reuseForks>
             <forkCount>3</forkCount>


### PR DESCRIPTION
Unit tests run with 3 concurrent JVMs, reducing it to 5GB so that it can fit into system that has 16GB memory