### PR TITLE
[CDAP-17005] Initialize default config if resolved config is invalid

### DIFF
--- a/cdap-ui/app/directives/my-pipeline-runtime-args/my-pipeline-runtime-args.less
+++ b/cdap-ui/app/directives/my-pipeline-runtime-args/my-pipeline-runtime-args.less
@@ -40,7 +40,7 @@ my-pipeline-runtime-args {
     }
     &.key-value-pair-labels {
       display: grid;
-      grid-template-columns: 1fr 1fr 104px;
+      grid-template-columns: 1fr 1fr 64px;
       grid-gap: 10px;
       margin-right: -25px;
     }
@@ -57,7 +57,8 @@ my-pipeline-runtime-args {
       margin-bottom: 15px;
       justify-content: initial;
       display: grid;
-      grid-template-columns: 1fr 1fr 104px;
+      grid-template-columns: 1fr 1fr 64px;
+      width: 100%;
       grid-gap: 10px;
       input {
         width: 100%;

--- a/cdap-ui/app/hydrator/controllers/create/create-studio-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/create-studio-ctrl.js
@@ -41,7 +41,7 @@ class HydratorPlusPlusStudioCtrl {
     };
     let artifact = getValidArtifact();
 
-    if (rConfig.valid) {
+    if (rConfig.valid && rConfig.config) {
       const modifiedConfig = angular.copy(rConfig.config);
 
       if (!modifiedConfig.artifact) {

--- a/cdap-ui/cypress/integration/pipeline.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import * as Helpers from '../helpers';
+import { dataCy } from '../helpers';
 
 const TEST_PIPELINE_NAME = '__UI_test_pipeline';
 const TEST_PATH = '__UI_test_path';
@@ -217,4 +218,15 @@ describe('Creating a pipeline', () => {
     cy.get('@instrumentationDiv').contains('Off');
     cy.get('[data-testid=close-modeless]').click();
   });
+
+  it.only(
+      'opening pipeline with unknown workspace should still render the studio',
+      () => {
+        cy.visit(
+            'pipelines/ns/default/studio?artifactType=cdap-data-pipeline&workspaceId=ebdbb6a7-8a8c-47b5-913f-9b75b1a0');
+        cy.get(dataCy('app-navbar')).should('be.visible');
+        cy.get(dataCy('navbar-toolbar')).should('be.visible');
+        cy.get(dataCy('navbar-hamburger-icon')).click();
+        cy.get(dataCy('navbar-home-link')).should('be.visible');
+      })
 });


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-17005

When pipeline studio is opened with an absent config, we were throwing a js error that was not rendering pipeline studio.

Fix is to initialize default config if current config is invalid.

Added test for this scenario as well.