### PR TITLE
Cherrypick KubeTwillPrep changes allowing CPU & RAM scaling for SysApps 

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -215,14 +215,6 @@
   </property>
 
   <property>
-    <name>twill.kube.cpu.scaling.factor</name>
-    <value>1.0</value>
-    <description>
-      The cpu scaling factor.
-    </description>
-  </property>
-
-  <property>
     <name>twill.java.heap.memory.ratio</name>
     <value>0.6</value>
     <description>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -215,6 +215,14 @@
   </property>
 
   <property>
+    <name>twill.kube.cpu.scaling.factor</name>
+    <value>1.0</value>
+    <description>
+      The cpu scaling factor.
+    </description>
+  </property>
+
+  <property>
     <name>twill.java.heap.memory.ratio</name>
     <value>0.6</value>
     <description>

--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -76,12 +76,6 @@
       <artifactId>logback-core</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>io.cdap.cdap</groupId>
-          <artifactId>cdap-common</artifactId>
-          <version>6.2.0-SNAPSHOT</version>
-          <scope>compile</scope>
-      </dependency>
   </dependencies>
 
   <profiles>

--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -76,6 +76,16 @@
       <artifactId>logback-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.twill</groupId>
+      <artifactId>twill-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -76,6 +76,12 @@
       <artifactId>logback-core</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>io.cdap.cdap</groupId>
+          <artifactId>cdap-common</artifactId>
+          <version>6.2.0-SNAPSHOT</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
 
   <profiles>

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -461,7 +461,7 @@ class KubeTwillPreparer implements TwillPreparer {
     Map<String, Quantity> quantityMap = new HashMap<>();
     float cpuMultiplier = Float.parseFloat(cConf.getOrDefault(CPU_MULTIPLIER, DEFAULT_MULTIPLIER));
     float memoryMultiplier = Float.parseFloat(cConf.getOrDefault(MEMORY_MULTIPLIER, DEFAULT_MULTIPLIER));
-    quantityMap.put("cpu", new Quantity(String.valueOf((float) (vCores * cpuMultiplier))));
+    quantityMap.put("cpu", new Quantity(String.format("%dm", (int) (vCores * 1000 * cpuMultiplier))));
     // Use slight larger container size
     quantityMap.put("memory", new Quantity(String.format("%dMi", (int) (memoryMB * memoryMultiplier * 1.2f))));
     resourceRequirements.setRequests(quantityMap);

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -99,7 +99,7 @@ class KubeTwillPreparer implements TwillPreparer {
   private final Map<String, Map<String, String>> environments;
   private final RunId twillRunId;
   private final V1ObjectMeta resourceMeta;
-  private final Map<String, String> kubeMasterConf;
+  private final Map<String, String> cConf;
   private final KubeTwillControllerFactory controllerFactory;
   private final URI appSpec;
   private final URI programOptions;
@@ -107,7 +107,7 @@ class KubeTwillPreparer implements TwillPreparer {
   private final int vcores;
 
   KubeTwillPreparer(ApiClient apiClient, String kubeNamespace, PodInfo podInfo, TwillSpecification spec,
-                    RunId twillRunId, V1ObjectMeta resourceMeta, Map<String, String> kubeMasterConf,
+                    RunId twillRunId, V1ObjectMeta resourceMeta, Map<String, String> cConf,
                     KubeTwillControllerFactory controllerFactory) {
     // only expect one runnable for now
     if (spec.getRunnables().size() != 1) {
@@ -122,7 +122,7 @@ class KubeTwillPreparer implements TwillPreparer {
     this.environments = runnables.stream().collect(Collectors.toMap(r -> r, r -> new HashMap<>()));
     this.twillRunId = twillRunId;
     this.resourceMeta = resourceMeta;
-    this.kubeMasterConf = kubeMasterConf;
+    this.cConf = cConf;
     RuntimeSpecification runtimeSpecification = spec.getRunnables().values().iterator().next();
     ResourceSpecification resourceSpecification = runtimeSpecification.getResourceSpecification();
     this.appSpec = runtimeSpecification.getLocalFiles().stream()
@@ -459,8 +459,8 @@ class KubeTwillPreparer implements TwillPreparer {
 
     V1ResourceRequirements resourceRequirements = new V1ResourceRequirements();
     Map<String, Quantity> quantityMap = new HashMap<>();
-    float cpuMultiplier = Float.parseFloat(kubeMasterConf.getOrDefault(CPU_MULTIPLIER, DEFAULT_MULTIPLIER));
-    float memoryMultiplier = Float.parseFloat(kubeMasterConf.getOrDefault(MEMORY_MULTIPLIER, DEFAULT_MULTIPLIER));
+    float cpuMultiplier = Float.parseFloat(cConf.getOrDefault(CPU_MULTIPLIER, DEFAULT_MULTIPLIER));
+    float memoryMultiplier = Float.parseFloat(cConf.getOrDefault(MEMORY_MULTIPLIER, DEFAULT_MULTIPLIER));
     quantityMap.put("cpu", new Quantity(String.valueOf((float) (vCores * cpuMultiplier))));
     // Use slight larger container size
     quantityMap.put("memory", new Quantity(String.format("%dMi", (int) (memoryMB * memoryMultiplier * 1.2f))));

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -93,7 +93,7 @@ public class KubeTwillRunnerService implements TwillRunnerService {
 
   private final String kubeNamespace;
   private final String resourcePrefix;
-  private final Map<String, String> kubeMasterConf;
+  private final Map<String, String> cConf;
   private final PodInfo podInfo;
   private final DiscoveryServiceClient discoveryServiceClient;
   private final Map<String, String> extraLabels;
@@ -104,12 +104,12 @@ public class KubeTwillRunnerService implements TwillRunnerService {
   private ApiClient apiClient;
 
   public KubeTwillRunnerService(String kubeNamespace, DiscoveryServiceClient discoveryServiceClient,
-                                PodInfo podInfo, String resourcePrefix, Map<String, String> kubeMasterConf,
+                                PodInfo podInfo, String resourcePrefix, Map<String, String> cConf,
                                 Map<String, String> extraLabels) {
     this.kubeNamespace = kubeNamespace;
     this.podInfo = podInfo;
     this.resourcePrefix = resourcePrefix;
-    this.kubeMasterConf = kubeMasterConf;
+    this.cConf = cConf;
     this.discoveryServiceClient = discoveryServiceClient;
     this.extraLabels = Collections.unmodifiableMap(new HashMap<>(extraLabels));
     // Selects all runs start by the k8s twill runner that has the run id label
@@ -146,7 +146,7 @@ public class KubeTwillRunnerService implements TwillRunnerService {
     // so use annotations to store the app name.
     resourceMeta.setAnnotations(Collections.singletonMap(APP_ANNOTATION, spec.getName()));
     return new KubeTwillPreparer(apiClient, kubeNamespace, podInfo,
-                                 spec, runId, resourceMeta, kubeMasterConf, (timeout, timeoutUnit) -> {
+                                 spec, runId, resourceMeta, cConf, (timeout, timeoutUnit) -> {
       // Adds the controller to the LiveInfo.
       liveInfoLock.lock();
       try {

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -93,6 +93,7 @@ public class KubeTwillRunnerService implements TwillRunnerService {
 
   private final String kubeNamespace;
   private final String resourcePrefix;
+  private final Map<String, Float> kubeScalingFactors;
   private final PodInfo podInfo;
   private final DiscoveryServiceClient discoveryServiceClient;
   private final Map<String, String> extraLabels;
@@ -103,10 +104,12 @@ public class KubeTwillRunnerService implements TwillRunnerService {
   private ApiClient apiClient;
 
   public KubeTwillRunnerService(String kubeNamespace, DiscoveryServiceClient discoveryServiceClient,
-                                PodInfo podInfo, String resourcePrefix, Map<String, String> extraLabels) {
+                                PodInfo podInfo, String resourcePrefix, Map<String, Float> kubeScalingFactors,
+                                Map<String, String> extraLabels) {
     this.kubeNamespace = kubeNamespace;
     this.podInfo = podInfo;
     this.resourcePrefix = resourcePrefix;
+    this.kubeScalingFactors = kubeScalingFactors;
     this.discoveryServiceClient = discoveryServiceClient;
     this.extraLabels = Collections.unmodifiableMap(new HashMap<>(extraLabels));
     // Selects all runs start by the k8s twill runner that has the run id label
@@ -143,7 +146,7 @@ public class KubeTwillRunnerService implements TwillRunnerService {
     // so use annotations to store the app name.
     resourceMeta.setAnnotations(Collections.singletonMap(APP_ANNOTATION, spec.getName()));
     return new KubeTwillPreparer(apiClient, kubeNamespace, podInfo,
-                                 spec, runId, resourceMeta, (timeout, timeoutUnit) -> {
+                                 spec, runId, resourceMeta, kubeScalingFactors, (timeout, timeoutUnit) -> {
       // Adds the controller to the LiveInfo.
       liveInfoLock.lock();
       try {

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -93,7 +93,7 @@ public class KubeTwillRunnerService implements TwillRunnerService {
 
   private final String kubeNamespace;
   private final String resourcePrefix;
-  private final Map<String, Float> kubeScalingFactors;
+  private final Map<String, String> kubeMasterConf;
   private final PodInfo podInfo;
   private final DiscoveryServiceClient discoveryServiceClient;
   private final Map<String, String> extraLabels;
@@ -104,12 +104,12 @@ public class KubeTwillRunnerService implements TwillRunnerService {
   private ApiClient apiClient;
 
   public KubeTwillRunnerService(String kubeNamespace, DiscoveryServiceClient discoveryServiceClient,
-                                PodInfo podInfo, String resourcePrefix, Map<String, Float> kubeScalingFactors,
+                                PodInfo podInfo, String resourcePrefix, Map<String, String> kubeMasterConf,
                                 Map<String, String> extraLabels) {
     this.kubeNamespace = kubeNamespace;
     this.podInfo = podInfo;
     this.resourcePrefix = resourcePrefix;
-    this.kubeScalingFactors = kubeScalingFactors;
+    this.kubeMasterConf = kubeMasterConf;
     this.discoveryServiceClient = discoveryServiceClient;
     this.extraLabels = Collections.unmodifiableMap(new HashMap<>(extraLabels));
     // Selects all runs start by the k8s twill runner that has the run id label
@@ -146,7 +146,7 @@ public class KubeTwillRunnerService implements TwillRunnerService {
     // so use annotations to store the app name.
     resourceMeta.setAnnotations(Collections.singletonMap(APP_ANNOTATION, spec.getName()));
     return new KubeTwillPreparer(apiClient, kubeNamespace, podInfo,
-                                 spec, runId, resourceMeta, kubeScalingFactors, (timeout, timeoutUnit) -> {
+                                 spec, runId, resourceMeta, kubeMasterConf, (timeout, timeoutUnit) -> {
       // Adds the controller to the LiveInfo.
       liveInfoLock.lock();
       try {

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -74,8 +74,6 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String INSTANCE_LABEL = "master.environment.k8s.instance.label";
   // Label for the container name
   private static final String CONTAINER_LABEL = "master.environment.k8s.container.label";
-  private static final String CPU_SCALING_FACTOR = "master.environment.k8s.container.cpu.scaling.factor";
-  private static final String MEMORY_SCALING_FACTOR = "master.environment.k8s.container.memory.scaling.factor";
   private static final String POD_INFO_DIR = "master.environment.k8s.pod.info.dir";
   private static final String POD_NAME_FILE = "master.environment.k8s.pod.name.file";
   private static final String POD_LABELS_FILE = "master.environment.k8s.pod.labels.file";
@@ -85,7 +83,6 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String DEFAULT_NAMESPACE = "default";
   private static final String DEFAULT_INSTANCE_LABEL = "cdap.instance";
   private static final String DEFAULT_CONTAINER_LABEL = "cdap.container";
-  private static final String DEFAULT_SCALING_FACTOR = "1.0";
   private static final String DEFAULT_POD_INFO_DIR = "/etc/podinfo";
   private static final String DEFAULT_POD_NAME_FILE = "pod.name";
   private static final String DEFAULT_POD_LABELS_FILE = "pod.labels.properties";
@@ -152,12 +149,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
                namespace, podKillerSelector, delayMillis);
     }
 
-    Map<String, Float> kubeScalingFactors = new HashMap<String, Float>();
-    kubeScalingFactors.put("cpu", Float.parseFloat(conf.getOrDefault(CPU_SCALING_FACTOR, DEFAULT_SCALING_FACTOR)));
-    kubeScalingFactors.put("memory",
-                           Float.parseFloat(conf.getOrDefault(MEMORY_SCALING_FACTOR, DEFAULT_SCALING_FACTOR)));
-
-    twillRunner = new KubeTwillRunnerService(namespace, discoveryService, podInfo, resourcePrefix, kubeScalingFactors,
+    twillRunner = new KubeTwillRunnerService(namespace, discoveryService, podInfo, resourcePrefix, conf,
                                              Collections.singletonMap(instanceLabel, instanceName));
     LOG.info("Kubernetes environment initialized with pod labels {}", podLabels);
   }

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -74,6 +74,8 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String INSTANCE_LABEL = "master.environment.k8s.instance.label";
   // Label for the container name
   private static final String CONTAINER_LABEL = "master.environment.k8s.container.label";
+  private static final String CPU_SCALING_FACTOR = "master.environment.k8s.container.cpu.scaling.factor";
+  private static final String MEMORY_SCALING_FACTOR = "master.environment.k8s.container.memory.scaling.factor";
   private static final String POD_INFO_DIR = "master.environment.k8s.pod.info.dir";
   private static final String POD_NAME_FILE = "master.environment.k8s.pod.name.file";
   private static final String POD_LABELS_FILE = "master.environment.k8s.pod.labels.file";
@@ -83,6 +85,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String DEFAULT_NAMESPACE = "default";
   private static final String DEFAULT_INSTANCE_LABEL = "cdap.instance";
   private static final String DEFAULT_CONTAINER_LABEL = "cdap.container";
+  private static final String DEFAULT_SCALING_FACTOR = "1.0";
   private static final String DEFAULT_POD_INFO_DIR = "/etc/podinfo";
   private static final String DEFAULT_POD_NAME_FILE = "pod.name";
   private static final String DEFAULT_POD_LABELS_FILE = "pod.labels.properties";
@@ -149,7 +152,12 @@ public class KubeMasterEnvironment implements MasterEnvironment {
                namespace, podKillerSelector, delayMillis);
     }
 
-    twillRunner = new KubeTwillRunnerService(namespace, discoveryService, podInfo, resourcePrefix,
+    Map<String, Float> kubeScalingFactors = new HashMap<String, Float>();
+    kubeScalingFactors.put("cpu", Float.parseFloat(conf.getOrDefault(CPU_SCALING_FACTOR, DEFAULT_SCALING_FACTOR)));
+    kubeScalingFactors.put("memory",
+                           Float.parseFloat(conf.getOrDefault(MEMORY_SCALING_FACTOR, DEFAULT_SCALING_FACTOR)));
+
+    twillRunner = new KubeTwillRunnerService(namespace, discoveryService, podInfo, resourcePrefix, kubeScalingFactors,
                                              Collections.singletonMap(instanceLabel, instanceName));
     LOG.info("Kubernetes environment initialized with pod labels {}", podLabels);
   }


### PR DESCRIPTION
These changes allow us to scale up down CPU and RAM for pods to run System Apps. 

One of the PR was not properly squashed, thus multiple cherrypicks. 

At the high level 3 logical changes: 
1. Code refactoring: have to cherry pick due to actual functional change depending on it
2. Actual change to add scaling functionality 
3. A bug fix that was missing in 2. 

No conflict during cherrypicking. 