### PR TITLE
(CDAP-16455) Output Dataproc job logs to console

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocJobMain.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocJobMain.java
@@ -74,8 +74,12 @@ public class DataprocJobMain {
                                                                  Constants.Files.TWILL_JAR));
     Arrays.stream(urls).forEach(url -> LOG.debug("Classpath URL: {}", url));
 
-    // create new URL classloader with provided classpath
-    try (URLClassLoader newCL = new URLClassLoader(urls, cl.getParent())) {
+    // Create new URL classloader with provided classpath.
+    // Don't close the classloader since this is the main classloader,
+    // which can be used for shutdown hook execution.
+    // Closing it too early can result in NoClassDefFoundError in shutdown hook execution.
+    URLClassLoader newCL = new URLClassLoader(urls, cl.getParent());
+    try {
       Thread.currentThread().setContextClassLoader(newCL);
 
       // load environment class and create instance of it

--- a/cdap-runtime-ext-dataproc/src/main/resources/logback-console.xml
+++ b/cdap-runtime-ext-dataproc/src/main/resources/logback-console.xml
@@ -1,0 +1,28 @@
+<!--
+  Copyright © 2020 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+<configuration>
+
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{ISO8601} - %-5p [%t:%logger{1}@%L] - %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <root>
+    <appender-ref ref="stdout"/>
+  </root>
+
+</configuration>


### PR DESCRIPTION
- This allows the Dataproc job agent to pickup the logs and include them as the job output