### PR TITLE
fix md5 for docs

### DIFF
--- a/cdap-docs/admin-manual/build.sh
+++ b/cdap-docs/admin-manual/build.sh
@@ -20,7 +20,7 @@ source ../vars
 source ../_common/common-build.sh
 
 DEFAULT_XML="../../cdap-common/src/main/resources/cdap-default.xml"
-DEFAULT_XML_MD5_HASH="d803ed1e5d44b04598cb262cd46e0e30"
+DEFAULT_XML_MD5_HASH="e5952812f2e9cfa59cbbb526e6378c9c"
 
 DEFAULT_TOOL="../tools/cdap-default/doc-cdap-default.py"
 DEFAULT_DEPRECATED_XML="../tools/cdap-default/cdap-default-deprecated.xml"


### PR DESCRIPTION
This is to fix the failing Docs Build and Test: https://builds.cask.co/browse/CDAP-DBT42-BCD-163/log