### PR TITLE
[CDAP-17014] Bump the timeout for proxy calls to backend to be 30 mins to enable long running sync upgrades

### DIFF
--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -96,6 +96,9 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
     proxy(urlhelper.constructUrl.bind(null, cdapConfig), {
       parseReqBody: false,
       limit: '500gb',
+      // 30 mins. It is this high to facilitate long running upgrades (running typically ~30mins)
+      // TODO: CDAP-17013 - Tracking to remove timeout when async upgrades are implemented in backend
+      timeout: 1800000,
     })
   );
   app.use(bodyParser.json());


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-17014

- Today the upgrade calls timesout after 2 mins (default system limit) leading to incomplete upgrades
- A typical upgrade today factors in 6-7 seconds to upgrade a single pipeline and assumes roughly ~300 pipelines which takes roughly 30 mins for the call to complete
- This is not ideal and we are planning on making the upgrades async (as long running tasks)
- Until then when users try the REST api (hitting the proxy endpoint in nodejs server) we wait for 30 mins before timing out the request.
- [CDAP-17013](https://issues.cask.co/browse/CDAP-17013) Corresponding JIRA to remove once we have async upgrades.