### PR TITLE
[CDAP-17014] Bump the timeout for proxy calls to backend to be 30 min…

### DIFF
--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -108,6 +108,9 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
     proxy(constructUrl.bind(null, cdapConfig), {
       parseReqBody: false,
       limit: '500gb',
+      // 30 mins. It is this high to facilitate long running upgrades (running typically ~30mins)
+      // TODO: CDAP-17013 - Tracking to remove timeout when async upgrades are implemented in backend
+      timeout: 1800000,
     })
   );
   app.use(bodyParser.json());


### PR DESCRIPTION
…s to enable long running sync upgrades

Cherry-picking https://github.com/cdapio/cdap/pull/12397