### PR TITLE
[CDAP-17014] Fixes the timeout issue during CDAP upgrades + Adds decorator for proxy request timeout

### DIFF
--- a/cdap-ui/server.js
+++ b/cdap-ui/server.js
@@ -36,6 +36,7 @@ var cdapConfig,
   hostname,
   hostIP = ip.address();
 
+const DEFAULT_SOCKET_TIMEOUT_MILLS = 1800000 * 2;
 /**
  * Configuring the logger. In order to use the logger anywhere
  * in the BE, include the following:
@@ -140,6 +141,7 @@ cdapConfigurator
       server = http.createServer(app);
       port = cdapConfig['dashboard.bind.port'];
     }
+    server.setTimeout(DEFAULT_SOCKET_TIMEOUT_MILLS);
     server.listen(port, cdapConfig['dashboard.bind.address'], function() {
       log.info('CDAP UI listening on port %s', port);
     });

--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -96,9 +96,10 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
     proxy(urlhelper.constructUrl.bind(null, cdapConfig), {
       parseReqBody: false,
       limit: '500gb',
-      // 30 mins. It is this high to facilitate long running upgrades (running typically ~30mins)
-      // TODO: CDAP-17013 - Tracking to remove timeout when async upgrades are implemented in backend
-      timeout: 1800000,
+      proxyErrorHandler: function(err, res, next) {
+        log.error('Proxy error: ' + JSON.stringify(err));
+        next(err);
+      },
     })
   );
   app.use(bodyParser.json());


### PR DESCRIPTION
- Previous PR (https://github.com/cdapio/cdap/pull/12397) incorrectly bumps the connection timeout of a http request instead of the read timeout
- Added the timeout to the http server we create. 
- **Existing behavior:** If a tcp socket connection opened in nodejs and if it doesn't receive a response back in 2 mins (default timeout) it errors out with `ECONNRESET` ([documentation](https://nodejs.org/dist/latest-v6.x/docs/api/http.html#http_server_settimeout_msecs_callback) for http server timeout)
- **Modified behavior:** waits for `1800000` (30 mins) before timing out