### PR TITLE
(CDAP-17019) Upgrade netty-http to 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <mockftp.version>2.6</mockftp.version>
     <mockito.version>1.9.5</mockito.version>
     <mysql.version>5.1.21</mysql.version>
-    <netty.http.version>1.4.0</netty.http.version>
+    <netty.http.version>1.5.0</netty.http.version>
     <netty.version>4.1.16.Final</netty.version>
     <quartz.version>2.2.0</quartz.version>
     <resteasy.version>3.0.8.Final</resteasy.version>


### PR DESCRIPTION
This is to avoid OOM when the ChunkResponder is used for sending responses, which is used by the log handler.

Also it allows explicit call the flush out buffered chunks to stream responses back to client.