### PR TITLE
Revert "[CDAP-17014] Bump the timeout for proxy calls to backend to be 30 mins to enable long running sync upgrades"

### DIFF
--- a/cdap-ui/server/express.js
+++ b/cdap-ui/server/express.js
@@ -96,9 +96,6 @@ function makeApp(authAddress, cdapConfig, uiSettings) {
     proxy(urlhelper.constructUrl.bind(null, cdapConfig), {
       parseReqBody: false,
       limit: '500gb',
-      // 30 mins. It is this high to facilitate long running upgrades (running typically ~30mins)
-      // TODO: CDAP-17013 - Tracking to remove timeout when async upgrades are implemented in backend
-      timeout: 1800000,
     })
   );
   app.use(bodyParser.json());


### PR DESCRIPTION
Reverts cdapio/cdap#12397