### PR TITLE
[CDAP-16690] Implement virtual scroll into preview data and record view

### DIFF
--- a/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
@@ -42,12 +42,6 @@ export const styles = (theme): StyleRules => ({
     width: 'fit-content',
     minWidth: '100%',
   },
-  recordContainer: {
-    width: '100%',
-  },
-  table: {
-    width: '100%',
-  },
   row: {
     height: 40,
     '&.oddRow': {
@@ -58,30 +52,22 @@ export const styles = (theme): StyleRules => ({
   headerRow: {
     backgroundColor: theme.palette.grey['300'],
     fontWeight: 500,
-  },
-  headerCell: {
     color: theme.palette.common.white,
     fontSize: 14,
   },
   cell: {
-    textAlign: 'center',
+    textAlign: 'left',
     height: '40px',
     lineHeight: '40px',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+    padding: '0px 10px',
   },
-  recordCell: {
-    width: '50%',
-    padding: '0px 5px',
-    '&:first-of-type': {
-      borderRight: `1px solid ${theme.palette.grey['500']}`,
-      fontWeight: 500,
-    },
-  },
+
+  // TO DO: Currently the width is fixed. Future plan is to let users vary the column widths
   tableCell: {
     width: '120px',
     borderLeft: `1px solid ${theme.palette.grey['500']}`,
-    padding: '0px 5px',
     flexGrow: 1,
   },
   indexCell: {
@@ -181,17 +167,14 @@ const DataTableView: React.FC<IDataTableProps> = ({
             justify="space-evenly"
             className={classes.headerRow}
           >
-            <Grid
-              item
-              className={classnames(classes.headerCell, classes.cell, classes.indexCell)}
-            />
+            <Grid item className={classnames(classes.cell, classes.indexCell)} />
             {headers.map((fieldName, i) => {
               const processedFieldName = format(fieldName);
               return (
                 <Grid
                   item
                   key={`header-cell-${i}`}
-                  className={classnames(classes.cell, classes.headerCell, classes.tableCell)}
+                  className={classnames(classes.cell, classes.tableCell)}
                   title={processedFieldName}
                 >
                   {processedFieldName}

--- a/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
@@ -52,6 +52,7 @@ export const styles = (theme): StyleRules => ({
   messageText: messageTextStyle,
   headerRow: {
     backgroundColor: theme.palette.grey['300'],
+    fontWeight: 500,
   },
   headerCell: {
     color: theme.palette.common.white,
@@ -68,6 +69,7 @@ export const styles = (theme): StyleRules => ({
     width: '50%',
     '&:first-of-type': {
       borderRight: `1px solid ${theme.palette.grey['500']}`,
+      fontWeight: 500,
     },
   },
   tableCell: {

--- a/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
@@ -34,11 +34,16 @@ export const messageTextStyle = {
 };
 export const styles = (theme): StyleRules => ({
   root: {
-    width: 'fit-content',
-    minWidth: '100%',
     display: 'inline-block',
     height: 'auto',
     marginTop: theme.spacing(1),
+  },
+  tableContainer: {
+    width: 'fit-content',
+    minWidth: '100%',
+  },
+  recordContainer: {
+    width: '100%',
   },
   table: {
     width: '100%',
@@ -67,6 +72,7 @@ export const styles = (theme): StyleRules => ({
   },
   recordCell: {
     width: '50%',
+    padding: '0px 5px',
     '&:first-of-type': {
       borderRight: `1px solid ${theme.palette.grey['500']}`,
       fontWeight: 500,
@@ -76,6 +82,7 @@ export const styles = (theme): StyleRules => ({
     width: '120px',
     borderLeft: `1px solid ${theme.palette.grey['500']}`,
     padding: '0px 5px',
+    flexGrow: 1,
   },
   indexCell: {
     width: '50px',
@@ -137,13 +144,15 @@ const DataTableView: React.FC<IDataTableProps> = ({
               {i + 1 + startNode}
             </Grid>
             {headers.map((fieldName, k) => {
+              const processedValue = format(record[fieldName]);
               return (
                 <Grid
                   item
                   className={classnames(classes.cell, classes.tableCell)}
                   key={`table-cell-${k}`}
+                  title={processedValue}
                 >
-                  {format(record[fieldName])}
+                  {processedValue}
                 </Grid>
               );
             })}
@@ -162,7 +171,7 @@ const DataTableView: React.FC<IDataTableProps> = ({
   }
 
   return (
-    <Paper className={classes.root}>
+    <Paper className={classnames(classes.root, classes.tableContainer)}>
       <Grid container direction="column" wrap="nowrap">
         <Grid item>
           <Grid
@@ -177,13 +186,15 @@ const DataTableView: React.FC<IDataTableProps> = ({
               className={classnames(classes.headerCell, classes.cell, classes.indexCell)}
             />
             {headers.map((fieldName, i) => {
+              const processedFieldName = format(fieldName);
               return (
                 <Grid
                   item
                   key={`header-cell-${i}`}
                   className={classnames(classes.cell, classes.headerCell, classes.tableCell)}
+                  title={processedFieldName}
                 >
-                  {format(fieldName)}
+                  {processedFieldName}
                 </Grid>
               );
             })}

--- a/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
@@ -30,7 +30,8 @@ const I18N_PREFIX = 'features.PreviewData.DataView.Table';
 
 export const messageTextStyle = {
   fontSize: '1.3rem !important',
-  margin: '10px 0',
+  margin: 'unset',
+  padding: '10px 5px',
 };
 export const styles = (theme): StyleRules => ({
   root: {

--- a/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
@@ -54,19 +54,25 @@ export const styles = (theme): StyleRules => ({
     backgroundColor: theme.palette.grey['300'],
     color: theme.palette.common.white,
     fontSize: 14,
-    '&.indexCell': {
-      width: '40px',
-    },
   },
   cell: {
-    width: '100px',
     textAlign: 'center',
     height: '40px',
+    lineHeight: '40px',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     '&:first-of-type': {
       borderRight: `1px solid ${theme.palette.grey['500']}`,
     },
+  },
+  recordCell: {
+    width: '50%',
+  },
+  tableCell: {
+    width: '100px',
+  },
+  indexCell: {
+    width: '50px',
   },
 });
 
@@ -120,12 +126,16 @@ const DataTableView: React.FC<IDataTableProps> = ({
             className={classnames(classes.row, { oddRow: (i + startNode + 1) % 2 })}
             key={`gridrow-${i}`}
           >
-            <Grid item className={classes.cell}>
+            <Grid item className={classnames(classes.cell, classes.indexCell)}>
               {i + 1 + startNode}
             </Grid>
             {headers.map((fieldName, k) => {
               return (
-                <Grid item className={classes.cell} key={`table-cell-${k}`}>
+                <Grid
+                  item
+                  className={classnames(classes.cell, classes.tableCell)}
+                  key={`table-cell-${k}`}
+                >
                   {format(record[fieldName])}
                 </Grid>
               );
@@ -158,7 +168,7 @@ const DataTableView: React.FC<IDataTableProps> = ({
                 <Grid
                   item
                   key={`header-cell-${i}`}
-                  className={classnames(classes.cell, classes.headerCell)}
+                  className={classnames(classes.cell, classes.headerCell, classes.tableCell)}
                 >
                   {format(fieldName)}
                 </Grid>

--- a/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
@@ -50,8 +50,10 @@ export const styles = (theme): StyleRules => ({
     },
   },
   messageText: messageTextStyle,
-  headerCell: {
+  headerRow: {
     backgroundColor: theme.palette.grey['300'],
+  },
+  headerCell: {
     color: theme.palette.common.white,
     fontSize: 14,
   },
@@ -69,7 +71,7 @@ export const styles = (theme): StyleRules => ({
     width: '50%',
   },
   tableCell: {
-    width: '100px',
+    width: '120px',
   },
   indexCell: {
     width: '50px',
@@ -123,6 +125,7 @@ const DataTableView: React.FC<IDataTableProps> = ({
             container
             direction="row"
             wrap="nowrap"
+            justify="space-between"
             className={classnames(classes.row, { oddRow: (i + startNode + 1) % 2 })}
             key={`gridrow-${i}`}
           >
@@ -158,7 +161,13 @@ const DataTableView: React.FC<IDataTableProps> = ({
     <Paper className={classes.root}>
       <Grid container direction="column" wrap="nowrap">
         <Grid item>
-          <Grid container direction="row" justify="center" alignItems="center">
+          <Grid
+            container
+            direction="row"
+            wrap="nowrap"
+            justify="space-between"
+            className={classes.headerRow}
+          >
             <Grid
               item
               className={classnames(classes.headerCell, classes.cell, classes.indexCell)}

--- a/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
@@ -63,15 +63,17 @@ export const styles = (theme): StyleRules => ({
     lineHeight: '40px',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+  },
+  recordCell: {
+    width: '50%',
     '&:first-of-type': {
       borderRight: `1px solid ${theme.palette.grey['500']}`,
     },
   },
-  recordCell: {
-    width: '50%',
-  },
   tableCell: {
     width: '120px',
+    borderLeft: `1px solid ${theme.palette.grey['500']}`,
+    padding: '0px 5px',
   },
   indexCell: {
     width: '50px',
@@ -125,7 +127,7 @@ const DataTableView: React.FC<IDataTableProps> = ({
             container
             direction="row"
             wrap="nowrap"
-            justify="space-between"
+            justify="space-evenly"
             className={classnames(classes.row, { oddRow: (i + startNode + 1) % 2 })}
             key={`gridrow-${i}`}
           >
@@ -165,7 +167,7 @@ const DataTableView: React.FC<IDataTableProps> = ({
             container
             direction="row"
             wrap="nowrap"
-            justify="space-between"
+            justify="space-evenly"
             className={classes.headerRow}
           >
             <Grid

--- a/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
@@ -118,7 +118,7 @@ const DataTableView: React.FC<IDataTableProps> = ({
             direction="row"
             wrap="nowrap"
             className={classnames(classes.row, { oddRow: (i + startNode + 1) % 2 })}
-            key={`tr-${i}`}
+            key={`gridrow-${i}`}
           >
             <Grid item className={classes.cell}>
               {i + 1 + startNode}

--- a/cdap-ui/app/cdap/components/PreviewData/DataView/TableContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/TableContainer.tsx
@@ -44,8 +44,6 @@ export const styles = (theme): StyleRules => ({
     borderBottom: `1px solid ${theme.palette.grey[400]}`,
     padding: '10px',
     borderRight: `1px solid ${theme.palette.grey[400]}`,
-    '& .record-pane': { width: '100%' },
-    '& .cask-tab-headers': { overflowX: 'scroll' },
   },
   h2Title: {
     fontSize: '1.4rem !important',

--- a/cdap-ui/app/cdap/components/PreviewData/DataView/TableContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/TableContainer.tsx
@@ -44,6 +44,7 @@ export const styles = (theme): StyleRules => ({
     borderBottom: `1px solid ${theme.palette.grey[400]}`,
     padding: '10px',
     borderRight: `1px solid ${theme.palette.grey[400]}`,
+    height: 'inherit',
   },
   h2Title: {
     fontSize: '1.4rem !important',

--- a/cdap-ui/app/cdap/components/PreviewData/DataView/TableContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/TableContainer.tsx
@@ -29,6 +29,9 @@ const I18N_PREFIX = 'features.PreviewData.DataView.TableContainer';
 export const styles = (theme): StyleRules => ({
   outerContainer: {
     display: 'flex',
+    '& :last-of-type': {
+      borderRight: 0,
+    },
   },
   innerContainer: {
     overflow: 'scroll',
@@ -41,9 +44,6 @@ export const styles = (theme): StyleRules => ({
     borderBottom: `1px solid ${theme.palette.grey[400]}`,
     padding: '10px',
     borderRight: `1px solid ${theme.palette.grey[400]}`,
-    '& :last-of-type': {
-      borderRight: 0,
-    },
     '& .record-pane': { width: '100%' },
     '& .cask-tab-headers': { overflowX: 'scroll' },
   },
@@ -85,7 +85,7 @@ const TableContainer: React.FC<IPreviewTableContainerProps> = ({
             const inputRecords = tableValue.records;
             return (
               <div key={`input-table-${i}`}>
-                <Heading type={HeadingTypes.h3} label={inputs.length > 1 ? tableKey : null} />
+                {inputs.length > 1 ? <Heading type={HeadingTypes.h3} label={tableKey} /> : null}
                 <DataTable
                   headers={inputHeaders}
                   records={inputRecords}
@@ -109,7 +109,7 @@ const TableContainer: React.FC<IPreviewTableContainerProps> = ({
             const outputRecords = tableValue.records;
             return (
               <div key={`output-table-${j}`}>
-                <Heading type={HeadingTypes.h3} label={outputs.length > 1 ? tableKey : null} />
+                {outputs.length > 1 ? <Heading type={HeadingTypes.h3} label={tableKey} /> : null}
                 <DataTable
                   headers={outputHeaders}
                   records={outputRecords}

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/Navigator.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/Navigator.tsx
@@ -16,10 +16,10 @@
 
 import React, { useEffect, useState } from 'react';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
-import AbstractWidget from 'components/AbstractWidget';
 import ArrowRightIcon from '@material-ui/icons/ArrowRight';
 import ArrowLeftIcon from '@material-ui/icons/ArrowLeft';
 import IconButton from '@material-ui/core/IconButton';
+import Select from 'components/AbstractWidget/FormInputs/Select';
 
 const styles = (theme): StyleRules => ({
   root: {
@@ -77,12 +77,12 @@ const RecordNavigatorBase: React.FC<IRecordNavigatorProps> = ({
       >
         <ArrowLeftIcon fontSize="large" />
       </IconButton>
-      <span className={classes.select} data-cy="record-dropdown">
-        <AbstractWidget
+      <span className={classes.select}>
+        <Select
           value={`Record ${selectedRecord}`}
-          type="select"
-          widgetProps={{ options: selectOptions }}
           onChange={(e) => updateRecord(e)}
+          widgetProps={{ options: selectOptions }}
+          data-cy="record-dropdown"
         />
       </span>
       <IconButton

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/Navigator.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/Navigator.tsx
@@ -31,6 +31,7 @@ const styles = (theme): StyleRules => ({
   select: {
     display: 'flex',
     alignItems: 'center',
+    width: '120px',
   },
 });
 

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/Navigator.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/Navigator.tsx
@@ -78,12 +78,11 @@ const RecordNavigatorBase: React.FC<IRecordNavigatorProps> = ({
       >
         <ArrowLeftIcon fontSize="large" />
       </IconButton>
-      <span className={classes.select}>
+      <span className={classes.select} data-cy="record-dropdown">
         <Select
           value={`Record ${selectedRecord}`}
           onChange={(e) => updateRecord(e)}
           widgetProps={{ options: selectOptions }}
-          data-cy="record-dropdown"
         />
       </span>
       <IconButton

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
@@ -21,12 +21,19 @@ import RecordNavigator from 'components/PreviewData/RecordView/Navigator';
 import RecordTable from 'components/PreviewData/RecordView/RecordTable';
 import { INode } from 'components/PreviewData/utilities';
 import If from 'components/If';
-import { styles } from 'components/PreviewData/DataView/TableContainer';
+import { styles as tableStyles } from 'components/PreviewData/DataView/TableContainer';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import T from 'i18n-react';
 import classnames from 'classnames';
 
 const I18N_PREFIX = 'features.PreviewData.RecordView.RecordContainer';
+
+const styles = (theme): StyleRules => ({
+  ...tableStyles(theme),
+  recordMargin: {
+    marginBottom: '35px', // from tab height
+  },
+});
 
 interface IRecordViewContainerProps extends WithStyles<typeof styles> {
   tableData: ITableData;
@@ -107,7 +114,13 @@ const RecordViewBase: React.FC<IRecordViewContainerProps> = ({
               [classes.split]: !selectedNode.isSource && !selectedNode.isSink,
             })}
           >
-            <h2 className={classes.h2Title}>{T.translate(`${I18N_PREFIX}.inputHeader`)}</h2>
+            <h2
+              className={classnames(classes.h2Title, {
+                [classes.recordMargin]: !showInputTabs && showOutputTabs,
+              })}
+            >
+              {T.translate(`${I18N_PREFIX}.inputHeader`)}
+            </h2>
             {showInputTabs
               ? getTabs(getTabConfig(inputs, selectedRecord, true))
               : inputs.map(([stageName, stageInfo]) => {
@@ -129,7 +142,13 @@ const RecordViewBase: React.FC<IRecordViewContainerProps> = ({
               [classes.split]: !selectedNode.isSource && !selectedNode.isSink,
             })}
           >
-            <h2 className={classes.h2Title}>{T.translate(`${I18N_PREFIX}.outputHeader`)}</h2>
+            <h2
+              className={classnames(classes.h2Title, {
+                [classes.recordMargin]: !showOutputTabs && showInputTabs,
+              })}
+            >
+              {T.translate(`${I18N_PREFIX}.outputHeader`)}
+            </h2>
             {showOutputTabs
               ? getTabs(getTabConfig(outputs, selectedRecord, false))
               : outputs.map(([stageName, stageInfo]) => {

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
@@ -97,7 +97,7 @@ const RecordViewBase: React.FC<IRecordViewContainerProps> = ({
 
   return (
     <div>
-      <If condition={!selectedNode.isCondition}>
+      <If condition={!selectedNode.isCondition && numRecords > 0}>
         <RecordNavigator
           selectedRecord={selectedRecord}
           numRecords={numRecords}

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
@@ -19,20 +19,14 @@ import ConfigurableTab from 'components/ConfigurableTab';
 import { ITableData } from 'components/PreviewData';
 import RecordNavigator from 'components/PreviewData/RecordView/Navigator';
 import RecordTable from 'components/PreviewData/RecordView/RecordTable';
-import { messageTextStyle } from 'components/PreviewData/DataView/Table';
 import { INode } from 'components/PreviewData/utilities';
 import If from 'components/If';
-import { styles as tableStyles } from 'components/PreviewData/DataView/TableContainer';
+import { styles } from 'components/PreviewData/DataView/TableContainer';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import T from 'i18n-react';
 import classnames from 'classnames';
 
 const I18N_PREFIX = 'features.PreviewData.RecordView.RecordContainer';
-
-const styles = (theme): StyleRules => ({
-  ...tableStyles(theme),
-  messageText: messageTextStyle,
-});
 
 interface IRecordViewContainerProps extends WithStyles<typeof styles> {
   tableData: ITableData;

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
@@ -33,6 +33,22 @@ const styles = (theme): StyleRules => ({
   recordMargin: {
     marginBottom: '35px', // from tab height
   },
+  recordInnerContainer: {
+    overflow: 'scroll',
+    width: '100%',
+    height: '100%',
+  },
+  recordSplit: {
+    maxWidth: '50%',
+    borderBottom: `1px solid ${theme.palette.grey[400]}`,
+    borderRight: `1px solid ${theme.palette.grey[400]}`,
+    '& .record-pane': { width: '100%' },
+    '& .cask-tab-headers': { overflowX: 'scroll' },
+  },
+  recordHeader: {
+    paddingTop: '10px',
+    paddingLeft: '20px',
+  },
 });
 
 interface IRecordViewContainerProps extends WithStyles<typeof styles> {
@@ -110,12 +126,12 @@ const RecordViewBase: React.FC<IRecordViewContainerProps> = ({
       <div className={classes.outerContainer}>
         <If condition={!selectedNode.isSource && !selectedNode.isCondition}>
           <div
-            className={classnames(classes.innerContainer, {
-              [classes.split]: !selectedNode.isSource && !selectedNode.isSink,
+            className={classnames(classes.recordInnerContainer, {
+              [classes.recordSplit]: !selectedNode.isSource && !selectedNode.isSink,
             })}
           >
             <h2
-              className={classnames(classes.h2Title, {
+              className={classnames(classes.h2Title, classes.recordHeader, {
                 [classes.recordMargin]: !showInputTabs && showOutputTabs,
               })}
             >
@@ -138,12 +154,12 @@ const RecordViewBase: React.FC<IRecordViewContainerProps> = ({
         </If>
         <If condition={!selectedNode.isSink && !selectedNode.isCondition}>
           <div
-            className={classnames(classes.innerContainer, {
-              [classes.split]: !selectedNode.isSource && !selectedNode.isSink,
+            className={classnames(classes.recordInnerContainer, {
+              [classes.recordSplit]: !selectedNode.isSource && !selectedNode.isSink,
             })}
           >
             <h2
-              className={classnames(classes.h2Title, {
+              className={classnames(classes.h2Title, classes.recordHeader, {
                 [classes.recordMargin]: !showOutputTabs && showInputTabs,
               })}
             >
@@ -165,7 +181,7 @@ const RecordViewBase: React.FC<IRecordViewContainerProps> = ({
           </div>
         </If>
         <If condition={selectedNode.isCondition}>
-          <div className={classes.innerContainer}>
+          <div className={classes.recordInnerContainer}>
             <h2 className={classes.h2Title}>{T.translate(`${I18N_PREFIX}.conditionHeader`)}</h2>
             <div>
               <RecordTable isCondition={true} />

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
@@ -42,6 +42,7 @@ const styles = (theme): StyleRules => ({
     maxWidth: '50%',
     borderBottom: `1px solid ${theme.palette.grey[400]}`,
     borderRight: `1px solid ${theme.palette.grey[400]}`,
+    height: 'inherit',
     '& .record-pane': { width: '100%' },
     '& .cask-tab-headers': { overflowX: 'scroll' },
   },

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
@@ -70,7 +70,15 @@ const RecordViewBase: React.FC<IRecordViewContainerProps> = ({
   const inputs = tableData.inputs;
   const outputs = tableData.outputs;
 
-  const numRecords = Math.max(tableData.inputFieldCount, tableData.outputFieldCount);
+  const recordCountReducer = (maxRecordCount: number, [stageName, stageInfo]) => {
+    const recordCount = stageInfo.records.length;
+    return Math.max(recordCount, maxRecordCount);
+  };
+
+  const numRecords = Math.max(
+    inputs.reduce(recordCountReducer, 0),
+    outputs.reduce(recordCountReducer, 0)
+  );
 
   const updateRecord = (newVal: string) => {
     const recordNum = parseInt(newVal.split(' ')[1], 10);

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -28,6 +28,14 @@ import Heading, { HeadingTypes } from 'components/Heading';
 
 const I18N_PREFIX = 'features.PreviewData.RecordView.RecordTable';
 
+// Info about rows in record table
+// Max number of visible rows
+const visibleChildCount = 25;
+// Height of row in px
+const childHeight = 40;
+// number of rows in dom but not in viewport
+const childrenUnderFold = 10;
+
 interface IRecordTableProps extends WithStyles<typeof styles> {
   headers?: string[];
   record?: any;
@@ -142,10 +150,10 @@ const RecordTableView: React.FC<IRecordTableProps> = ({
         <Grid item>
           <VirtualScroll
             itemCount={() => headers.length}
-            visibleChildCount={25}
-            childHeight={40}
+            visibleChildCount={visibleChildCount}
+            childHeight={childHeight}
             renderList={renderList}
-            childrenUnderFold={10}
+            childrenUnderFold={childrenUnderFold}
           />
         </Grid>
       </Grid>

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -19,9 +19,9 @@ import VirtualScroll from 'components/VirtualScroll';
 import { PREVIEW_STATUS } from 'services/PreviewStatus';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
-import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import ThemeWrapper from 'components/ThemeWrapper';
-import { styles } from 'components/PreviewData/DataView/Table';
+import { styles as tableStyles } from 'components/PreviewData/DataView/Table';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import Heading, { HeadingTypes } from 'components/Heading';
@@ -35,6 +35,20 @@ const visibleChildCount = 25;
 const childHeight = 40;
 // number of rows in dom but not in viewport
 const childrenUnderFold = 10;
+
+const styles = (theme): StyleRules => ({
+  ...tableStyles(theme),
+  recordCell: {
+    width: '50%',
+    '&:first-of-type': {
+      borderRight: `1px solid ${theme.palette.grey['500']}`,
+      fontWeight: 500,
+    },
+  },
+  recordContainer: {
+    width: '100%',
+  },
+});
 
 interface IRecordTableProps extends WithStyles<typeof styles> {
   headers?: string[];
@@ -139,10 +153,10 @@ const RecordTableView: React.FC<IRecordTableProps> = ({
             alignItems="center"
             className={classes.headerRow}
           >
-            <Grid item className={classnames(classes.headerCell, classes.cell, classes.recordCell)}>
+            <Grid item className={classnames(classes.cell, classes.recordCell)}>
               {T.translate(`${I18N_PREFIX}.fieldName`)}
             </Grid>
-            <Grid item className={classnames(classes.headerCell, classes.cell, classes.recordCell)}>
+            <Grid item className={classnames(classes.cell, classes.recordCell)}>
               {T.translate(`${I18N_PREFIX}.value`)}
             </Grid>
           </Grid>

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -15,36 +15,34 @@
  */
 
 import React from 'react';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableRow from '@material-ui/core/TableRow';
-import TableCell from '@material-ui/core/TableCell';
+import VirtualScroll from 'components/VirtualScroll';
 import Paper from '@material-ui/core/Paper';
-import TableHead from '@material-ui/core/TableHead';
+import Grid from '@material-ui/core/Grid';
 import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 import ThemeWrapper from 'components/ThemeWrapper';
 import { styles } from 'components/PreviewData/DataView/Table';
+import classnames from 'classnames';
 
 const I18N_PREFIX = 'features.PreviewData.RecordView.RecordTable';
 
-const CustomTableCell = withStyles((theme) => ({
-  head: {
-    backgroundColor: theme.palette.grey['300'],
-    color: theme.palette.common.white,
-    padding: 10,
-    fontSize: 14,
-    '&:first-of-type': {
-      borderRight: `1px solid ${theme.palette.grey['500']}`,
-    },
-  },
-  body: {
-    padding: 10,
-    fontSize: 14,
-    '&:first-of-type': {
-      borderRight: `1px solid ${theme.palette.grey['500']}`,
-    },
-  },
-}))(TableCell);
+// const CustomTableCell = withStyles((theme) => ({
+//   head: {
+//     backgroundColor: theme.palette.grey['300'],
+//     color: theme.palette.common.white,
+//     padding: 10,
+//     fontSize: 14,
+//     '&:first-of-type': {
+//       borderRight: `1px solid ${theme.palette.grey['500']}`,
+//     },
+//   },
+//   body: {
+//     padding: 10,
+//     fontSize: 14,
+//     '&:first-of-type': {
+//       borderRight: `1px solid ${theme.palette.grey['500']}`,
+//     },
+//   },
+// }))(TableCell);
 
 interface IRecordTableProps extends WithStyles<typeof styles> {
   headers: string[];
@@ -62,26 +60,60 @@ const RecordTableView: React.FC<IRecordTableProps> = ({ classes, headers, record
     return field;
   };
 
+  const renderList = (visibleNodeCount: number, startNode: number) => {
+    return headers.slice(startNode, startNode + visibleNodeCount).map((fieldName, i) => {
+      return (
+        <React.Fragment>
+          <Grid
+            container
+            direction="row"
+            wrap="nowrap"
+            className={classnames(classes.row, { oddRow: (i + startNode + 1) % 2 })}
+            key={`gridrow-${i}`}
+          >
+            <Grid item className={classes.cell}>
+              {format(fieldName)}
+            </Grid>
+            <Grid item className={classes.cell}>
+              {format(record[fieldName])}
+            </Grid>
+          </Grid>
+        </React.Fragment>
+      );
+    });
+  };
+
   return (
     <Paper className={classes.root}>
-      <Table>
-        <TableHead>
-          <TableRow className={classes.row}>
-            <CustomTableCell>Field</CustomTableCell>
-            <CustomTableCell>Value</CustomTableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {headers.map((fieldName, i) => {
+      <Grid container direction="column" wrap="nowrap">
+        <Grid item>
+          <Grid container direction="row" justify="center" alignItems="center">
+            <Grid item className={classnames(classes.headerCell, classes.cell)}>
+              Field
+            </Grid>
+            <Grid item className={classnames(classes.headerCell, classes.cell)}>
+              Value
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid item>
+          <VirtualScroll
+            itemCount={() => headers.length}
+            visibleChildCount={25}
+            childHeight={40}
+            renderList={renderList}
+            childrenUnderFold={10}
+          />
+          {/* {headers.map((fieldName, i) => {
             return (
               <TableRow className={classes.row} key={`tr-${i}}`}>
                 <CustomTableCell>{format(fieldName)}</CustomTableCell>
                 <CustomTableCell>{format(record[fieldName])}</CustomTableCell>
               </TableRow>
             );
-          })}
-        </TableBody>
-      </Table>
+          })} */}
+        </Grid>
+      </Grid>
     </Paper>
   );
 };

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 import VirtualScroll from 'components/VirtualScroll';
+import { PREVIEW_STATUS } from 'services/PreviewStatus';
 import Paper from '@material-ui/core/Paper';
 import Grid from '@material-ui/core/Grid';
 import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
@@ -23,15 +24,28 @@ import ThemeWrapper from 'components/ThemeWrapper';
 import { styles } from 'components/PreviewData/DataView/Table';
 import classnames from 'classnames';
 import T from 'i18n-react';
+import Heading, { HeadingTypes } from 'components/Heading';
 
 const I18N_PREFIX = 'features.PreviewData.RecordView.RecordTable';
 
 interface IRecordTableProps extends WithStyles<typeof styles> {
-  headers: string[];
-  record: any;
+  headers?: string[];
+  record?: any;
+  selectedRecord?: number;
+  isInput?: boolean;
+  previewStatus?: string;
+  isCondition?: boolean;
 }
 
-const RecordTableView: React.FC<IRecordTableProps> = ({ classes, headers, record }) => {
+const RecordTableView: React.FC<IRecordTableProps> = ({
+  classes,
+  headers,
+  record,
+  selectedRecord,
+  isInput,
+  previewStatus,
+  isCondition,
+}) => {
   // Used to stringify any non-string field values and field names.
   // TO DO: Might not need to do this for field names, need to test with nested schemas.
   // TO DO: Move to utilities, since we also use this in data view
@@ -43,8 +57,35 @@ const RecordTableView: React.FC<IRecordTableProps> = ({ classes, headers, record
     return field;
   };
 
+  const noRecordMsg = () => {
+    let msg;
+    const recordType = isInput ? 'Input' : 'Output';
+    if (isCondition) {
+      msg = T.translate(`${I18N_PREFIX}.previewNotSupported`);
+    } else if (previewStatus === PREVIEW_STATUS.RUNNING || previewStatus === PREVIEW_STATUS.INIT) {
+      // preview is still running but there's no data yet
+      msg = T.translate(`${I18N_PREFIX}.previewRunning`, { recordType });
+    } else if (headers.length > 0) {
+      // not running preview and there is preview data, but not for this record number
+      msg = T.translate(`${I18N_PREFIX}.noSelectedRecord`, { selectedRecord });
+    } else {
+      // not running preview AND there is no preview data for this stage
+      msg = T.translate(`${I18N_PREFIX}.noPreviewRunning`, { recordType });
+    }
+    return (
+      <div>
+        <Heading type={HeadingTypes.h3} label={msg} className={classes.messageText} />
+      </div>
+    );
+  };
+
   const renderList = (visibleNodeCount: number, startNode: number) => {
+    if (!record) {
+      return;
+    }
     return headers.slice(startNode, startNode + visibleNodeCount).map((fieldName, i) => {
+      const processedFieldName = format(fieldName);
+      const processedValue = format(record[fieldName]);
       return (
         <React.Fragment>
           <Grid
@@ -54,11 +95,19 @@ const RecordTableView: React.FC<IRecordTableProps> = ({ classes, headers, record
             className={classnames(classes.row, { oddRow: (i + startNode + 1) % 2 })}
             key={`gridrow-${i}`}
           >
-            <Grid item className={classnames(classes.cell, classes.recordCell)}>
-              {format(fieldName)}
+            <Grid
+              item
+              className={classnames(classes.cell, classes.recordCell)}
+              title={processedFieldName}
+            >
+              {processedFieldName}
             </Grid>
-            <Grid item className={classnames(classes.cell, classes.recordCell)}>
-              {format(record[fieldName])}
+            <Grid
+              item
+              className={classnames(classes.cell, classes.recordCell)}
+              title={processedValue}
+            >
+              {processedValue}
             </Grid>
           </Grid>
         </React.Fragment>
@@ -66,8 +115,13 @@ const RecordTableView: React.FC<IRecordTableProps> = ({ classes, headers, record
     });
   };
 
+  // When the selected record number is out of range
+  if (!record) {
+    return noRecordMsg();
+  }
+
   return (
-    <Paper className={classes.root}>
+    <Paper className={classnames(classes.root, classes.recordContainer)}>
       <Grid container direction="column" wrap="nowrap">
         <Grid item>
           <Grid

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -22,6 +22,7 @@ import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 import ThemeWrapper from 'components/ThemeWrapper';
 import { styles } from 'components/PreviewData/DataView/Table';
 import classnames from 'classnames';
+import T from 'i18n-react';
 
 const I18N_PREFIX = 'features.PreviewData.RecordView.RecordTable';
 
@@ -77,10 +78,10 @@ const RecordTableView: React.FC<IRecordTableProps> = ({ classes, headers, record
             className={classes.headerRow}
           >
             <Grid item className={classnames(classes.headerCell, classes.cell, classes.recordCell)}>
-              Field
+              {T.translate(`${I18N_PREFIX}.fieldName`)}
             </Grid>
             <Grid item className={classnames(classes.headerCell, classes.cell, classes.recordCell)}>
-              Value
+              {T.translate(`${I18N_PREFIX}.value`)}
             </Grid>
           </Grid>
         </Grid>

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -18,13 +18,33 @@ import React from 'react';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
 import Paper from '@material-ui/core/Paper';
 import TableHead from '@material-ui/core/TableHead';
 import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 import ThemeWrapper from 'components/ThemeWrapper';
-import { CustomTableCell, styles } from 'components/PreviewData/DataView/Table';
+import { styles } from 'components/PreviewData/DataView/Table';
 
 const I18N_PREFIX = 'features.PreviewData.RecordView.RecordTable';
+
+const CustomTableCell = withStyles((theme) => ({
+  head: {
+    backgroundColor: theme.palette.grey['300'],
+    color: theme.palette.common.white,
+    padding: 10,
+    fontSize: 14,
+    '&:first-of-type': {
+      borderRight: `1px solid ${theme.palette.grey['500']}`,
+    },
+  },
+  body: {
+    padding: 10,
+    fontSize: 14,
+    '&:first-of-type': {
+      borderRight: `1px solid ${theme.palette.grey['500']}`,
+    },
+  },
+}))(TableCell);
 
 interface IRecordTableProps extends WithStyles<typeof styles> {
   headers: string[];

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -69,7 +69,13 @@ const RecordTableView: React.FC<IRecordTableProps> = ({ classes, headers, record
     <Paper className={classes.root}>
       <Grid container direction="column" wrap="nowrap">
         <Grid item>
-          <Grid container direction="row" justify="center" alignItems="center">
+          <Grid
+            container
+            direction="row"
+            justify="center"
+            alignItems="center"
+            className={classes.headerRow}
+          >
             <Grid item className={classnames(classes.headerCell, classes.cell, classes.recordCell)}>
               Field
             </Grid>

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -25,25 +25,6 @@ import classnames from 'classnames';
 
 const I18N_PREFIX = 'features.PreviewData.RecordView.RecordTable';
 
-// const CustomTableCell = withStyles((theme) => ({
-//   head: {
-//     backgroundColor: theme.palette.grey['300'],
-//     color: theme.palette.common.white,
-//     padding: 10,
-//     fontSize: 14,
-//     '&:first-of-type': {
-//       borderRight: `1px solid ${theme.palette.grey['500']}`,
-//     },
-//   },
-//   body: {
-//     padding: 10,
-//     fontSize: 14,
-//     '&:first-of-type': {
-//       borderRight: `1px solid ${theme.palette.grey['500']}`,
-//     },
-//   },
-// }))(TableCell);
-
 interface IRecordTableProps extends WithStyles<typeof styles> {
   headers: string[];
   record: any;
@@ -53,6 +34,7 @@ const RecordTableView: React.FC<IRecordTableProps> = ({ classes, headers, record
   // Used to stringify any non-string field values and field names.
   // TO DO: Might not need to do this for field names, need to test with nested schemas.
   // TO DO: Move to utilities, since we also use this in data view
+
   const format = (field: any) => {
     if (typeof field === 'object') {
       return JSON.stringify(field);
@@ -71,10 +53,10 @@ const RecordTableView: React.FC<IRecordTableProps> = ({ classes, headers, record
             className={classnames(classes.row, { oddRow: (i + startNode + 1) % 2 })}
             key={`gridrow-${i}`}
           >
-            <Grid item className={classes.cell}>
+            <Grid item className={classnames(classes.cell, classes.recordCell)}>
               {format(fieldName)}
             </Grid>
-            <Grid item className={classes.cell}>
+            <Grid item className={classnames(classes.cell, classes.recordCell)}>
               {format(record[fieldName])}
             </Grid>
           </Grid>
@@ -88,10 +70,10 @@ const RecordTableView: React.FC<IRecordTableProps> = ({ classes, headers, record
       <Grid container direction="column" wrap="nowrap">
         <Grid item>
           <Grid container direction="row" justify="center" alignItems="center">
-            <Grid item className={classnames(classes.headerCell, classes.cell)}>
+            <Grid item className={classnames(classes.headerCell, classes.cell, classes.recordCell)}>
               Field
             </Grid>
-            <Grid item className={classnames(classes.headerCell, classes.cell)}>
+            <Grid item className={classnames(classes.headerCell, classes.cell, classes.recordCell)}>
               Value
             </Grid>
           </Grid>
@@ -104,14 +86,6 @@ const RecordTableView: React.FC<IRecordTableProps> = ({ classes, headers, record
             renderList={renderList}
             childrenUnderFold={10}
           />
-          {/* {headers.map((fieldName, i) => {
-            return (
-              <TableRow className={classes.row} key={`tr-${i}}`}>
-                <CustomTableCell>{format(fieldName)}</CustomTableCell>
-                <CustomTableCell>{format(record[fieldName])}</CustomTableCell>
-              </TableRow>
-            );
-          })} */}
         </Grid>
       </Grid>
     </Paper>

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -47,6 +47,8 @@ const styles = (theme): StyleRules => ({
   },
   recordContainer: {
     width: '100%',
+    padding: '10px',
+    marginTop: 'unset',
   },
 });
 

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -123,6 +123,7 @@ const RecordTableView: React.FC<IRecordTableProps> = ({
               item
               className={classnames(classes.cell, classes.recordCell)}
               title={processedFieldName}
+              data-cy={`fieldname-${processedFieldName}`}
             >
               {processedFieldName}
             </Grid>
@@ -130,6 +131,7 @@ const RecordTableView: React.FC<IRecordTableProps> = ({
               item
               className={classnames(classes.cell, classes.recordCell)}
               title={processedValue}
+              data-cy={`value-${processedValue}`}
             >
               {processedValue}
             </Grid>

--- a/cdap-ui/app/cdap/components/PreviewData/index.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/index.tsx
@@ -163,8 +163,6 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
     </div>
   );
 
-  const showRecordView = tableData.inputFieldCount > 100 || tableData.outputFieldCount > 100;
-
   return (
     <div>
       <If condition={!previewId}>{noPreviewDataMsg(classes)}</If>

--- a/cdap-ui/app/cdap/components/PreviewData/index.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/index.tsx
@@ -30,8 +30,11 @@ import T from 'i18n-react';
 import { extractErrorMessage } from 'services/helpers';
 import ToggleSwitchWidget from 'components/AbstractWidget/ToggleSwitchWidget';
 import classnames from 'classnames';
+import LoadingSVG from 'components/LoadingSVG';
 
 const I18N_PREFIX = 'features.PreviewData';
+// If number of schema fields > maxSchemaSize, show Record view by default
+const maxSchemaSize = 100;
 
 const styles = (): StyleRules => {
   return {
@@ -54,6 +57,11 @@ interface IPreviewDataViewProps extends WithStyles<typeof styles> {
   previewStatus: string;
 }
 
+enum PreviewMode {
+  Record = 'Record',
+  Table = 'Table',
+}
+
 export interface ITableData {
   inputs?: Array<[string, IRecords]>;
   outputs?: Array<[string, IRecords]>;
@@ -74,11 +82,11 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
   const [previewData, setPreviewData] = useState<IPreviewData>({});
   const [tableData, setTableData] = useState<ITableData>({});
   const [error, setError] = useState(null);
-  const [viewMode, setViewMode] = useState('Table');
+  const [viewMode, setViewMode] = useState(PreviewMode.Table);
 
   const widgetProps = {
-    on: { value: 'Record', label: 'Record' },
-    off: { value: 'Table', label: 'Table' },
+    on: { value: PreviewMode.Record, label: PreviewMode.Record },
+    off: { value: PreviewMode.Table, label: PreviewMode.Table },
   };
 
   const updatePreviewCb = (updatedPreview: IPreviewData) => {
@@ -86,7 +94,9 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
     const parsedData = getTableData(updatedPreview);
     setTableData(parsedData);
     setViewMode(
-      parsedData.inputFieldCount > 100 || parsedData.outputFieldCount > 100 ? 'Record' : 'Table'
+      parsedData.inputFieldCount > maxSchemaSize || parsedData.outputFieldCount > maxSchemaSize
+        ? PreviewMode.Record
+        : PreviewMode.Table
     );
   };
 
@@ -138,7 +148,7 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
         label={T.translate(`${I18N_PREFIX}.loading`)}
         className={cls.messageText}
       />
-      <LoadingSVGCentered />
+      <LoadingSVG />
     </div>
   );
 
@@ -169,7 +179,11 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
       <If condition={previewLoading}>{loadingMsg(classes)}</If>
       <If condition={error}>{errorMsg(classes)}</If>
 
-      <If condition={!previewLoading && previewId && !isEmpty(previewData) && viewMode === 'Table'}>
+      <If
+        condition={
+          !previewLoading && previewId && !isEmpty(previewData) && viewMode === PreviewMode.Table
+        }
+      >
         <span className={classes.recordToggle}>
           <ToggleSwitchWidget onChange={setViewMode} value={viewMode} widgetProps={widgetProps} />
         </span>
@@ -180,7 +194,9 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
         />
       </If>
       <If
-        condition={!previewLoading && previewId && !isEmpty(previewData) && viewMode === 'Record'}
+        condition={
+          !previewLoading && previewId && !isEmpty(previewData) && viewMode === PreviewMode.Record
+        }
       >
         <span className={classes.recordToggle}>
           <ToggleSwitchWidget onChange={setViewMode} value={viewMode} widgetProps={widgetProps} />

--- a/cdap-ui/app/cdap/components/PreviewData/index.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/index.tsx
@@ -141,6 +141,22 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
     return { inputs, outputs, inputFieldCount, outputFieldCount };
   };
 
+  const getContent = () => {
+    // preview has not been run yet
+    if (!previewId) {
+      return noPreviewDataMsg(classes);
+    } else if (previewLoading) {
+      // preview data available and getting fetched
+      return loadingMsg(classes);
+    } else if (error) {
+      // i.e. if current preview got overwritten by a more recent preview run
+      return errorMsg(classes);
+    } else if (!isEmpty(previewData)) {
+      // return either table or record container depending on schema size
+      return getContainer();
+    }
+  };
+
   const loadingMsg = (cls) => (
     <div className={cls.headingContainer}>
       <Heading
@@ -173,42 +189,31 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
     </div>
   );
 
-  return (
-    <div>
-      <If condition={!previewId}>{noPreviewDataMsg(classes)}</If>
-      <If condition={previewLoading}>{loadingMsg(classes)}</If>
-      <If condition={error}>{errorMsg(classes)}</If>
+  const getContainer = () => {
+    return (
+      <React.Fragment>
+        <span className={classes.recordToggle}>
+          <ToggleSwitchWidget onChange={setViewMode} value={viewMode} widgetProps={widgetProps} />
+        </span>
+        <If condition={viewMode === PreviewMode.Table}>
+          <PreviewTableContainer
+            tableData={tableData}
+            selectedNode={selectedNode}
+            previewStatus={previewStatus}
+          />
+        </If>
+        <If condition={viewMode === PreviewMode.Record}>
+          <RecordContainer
+            tableData={tableData}
+            selectedNode={selectedNode}
+            previewStatus={previewStatus}
+          />
+        </If>
+      </React.Fragment>
+    );
+  };
 
-      <If
-        condition={
-          !previewLoading && previewId && !isEmpty(previewData) && viewMode === PreviewMode.Table
-        }
-      >
-        <span className={classes.recordToggle}>
-          <ToggleSwitchWidget onChange={setViewMode} value={viewMode} widgetProps={widgetProps} />
-        </span>
-        <PreviewTableContainer
-          tableData={tableData}
-          selectedNode={selectedNode}
-          previewStatus={previewStatus}
-        />
-      </If>
-      <If
-        condition={
-          !previewLoading && previewId && !isEmpty(previewData) && viewMode === PreviewMode.Record
-        }
-      >
-        <span className={classes.recordToggle}>
-          <ToggleSwitchWidget onChange={setViewMode} value={viewMode} widgetProps={widgetProps} />
-        </span>
-        <RecordContainer
-          tableData={tableData}
-          selectedNode={selectedNode}
-          previewStatus={previewStatus}
-        />
-      </If>
-    </div>
-  );
+  return <div>{getContent()}</div>;
 };
 
 const PreviewDataViewStyled = withStyles(styles)(PreviewDataViewBase);

--- a/cdap-ui/app/cdap/components/PreviewData/index.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/index.tsx
@@ -55,10 +55,10 @@ interface IPreviewDataViewProps extends WithStyles<typeof styles> {
 }
 
 export interface ITableData {
-  inputs: Array<[string, IRecords]>;
-  outputs: Array<[string, IRecords]>;
-  inputFieldCount: number;
-  outputFieldCount: number;
+  inputs?: Array<[string, IRecords]>;
+  outputs?: Array<[string, IRecords]>;
+  inputFieldCount?: number;
+  outputFieldCount?: number;
 }
 
 const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
@@ -72,6 +72,7 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
 
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewData, setPreviewData] = useState<IPreviewData>({});
+  const [tableData, setTableData] = useState<ITableData>({});
   const [error, setError] = useState(null);
   const [viewMode, setViewMode] = useState('Table');
 
@@ -82,6 +83,11 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
 
   const updatePreviewCb = (updatedPreview: IPreviewData) => {
     setPreviewData(updatedPreview);
+    const parsedData = getTableData(updatedPreview);
+    setTableData(parsedData);
+    setViewMode(
+      parsedData.inputFieldCount > 100 || parsedData.outputFieldCount > 100 ? 'Record' : 'Table'
+    );
   };
 
   const errorCb = (err: any) => {
@@ -102,16 +108,16 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
     }
   }, [previewId]);
 
-  const getTableData = () => {
+  const getTableData = (prevData: IPreviewData) => {
     let inputs = [];
     let outputs = [];
 
-    if (!isEmpty(previewData)) {
-      if (!isEmpty(previewData.input) && !selectedNode.isSource) {
-        inputs = Object.entries(previewData.input);
+    if (!isEmpty(prevData)) {
+      if (!isEmpty(prevData.input) && !selectedNode.isSource) {
+        inputs = Object.entries(prevData.input);
       }
-      if (!isEmpty(previewData.output) && !selectedNode.isSink) {
-        outputs = Object.entries(previewData.output);
+      if (!isEmpty(prevData.output) && !selectedNode.isSink) {
+        outputs = Object.entries(prevData.output);
       }
     }
 
@@ -124,8 +130,6 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
 
     return { inputs, outputs, inputFieldCount, outputFieldCount };
   };
-
-  const tableData: ITableData = getTableData();
 
   const loadingMsg = (cls) => (
     <div className={cls.headingContainer}>
@@ -159,7 +163,7 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
     </div>
   );
 
-  const showRecordView = tableData.inputFieldCount >= 100 || tableData.outputFieldCount >= 100;
+  const showRecordView = tableData.inputFieldCount > 100 || tableData.outputFieldCount > 100;
 
   return (
     <div>

--- a/cdap-ui/app/cdap/components/PreviewData/index.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/index.tsx
@@ -20,7 +20,6 @@ import { INode, fetchPreview, IRecords, IPreviewData } from 'components/PreviewD
 import If from 'components/If';
 import isEmpty from 'lodash/isEmpty';
 import Heading, { HeadingTypes } from 'components/Heading';
-import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import { messageTextStyle } from 'components/PreviewData/DataView/Table';
 import PreviewTableContainer from 'components/PreviewData/DataView/TableContainer';
 import RecordContainer from 'components/PreviewData/RecordView/RecordContainer';
@@ -40,7 +39,10 @@ const styles = (): StyleRules => {
   return {
     messageText: messageTextStyle,
     headingContainer: {
-      paddingLeft: '10px',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      paddingTop: '50px',
     },
     recordToggle: {
       position: 'absolute',

--- a/cdap-ui/app/cdap/components/PreviewData/index.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/index.tsx
@@ -24,19 +24,25 @@ import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import { messageTextStyle } from 'components/PreviewData/DataView/Table';
 import PreviewTableContainer from 'components/PreviewData/DataView/TableContainer';
 import RecordContainer from 'components/PreviewData/RecordView/RecordContainer';
-import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import ThemeWrapper from 'components/ThemeWrapper';
 import T from 'i18n-react';
 import { extractErrorMessage } from 'services/helpers';
+import ToggleSwitchWidget from 'components/AbstractWidget/ToggleSwitchWidget';
 import classnames from 'classnames';
 
 const I18N_PREFIX = 'features.PreviewData';
 
-const styles = () => {
+const styles = (): StyleRules => {
   return {
     messageText: messageTextStyle,
     headingContainer: {
       paddingLeft: '10px',
+    },
+    recordToggle: {
+      position: 'absolute',
+      top: '8px',
+      right: '35px',
     },
   };
 };
@@ -67,6 +73,12 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewData, setPreviewData] = useState<IPreviewData>({});
   const [error, setError] = useState(null);
+  const [viewMode, setViewMode] = useState('Table');
+
+  const widgetProps = {
+    on: { value: 'Record', label: 'Record' },
+    off: { value: 'Table', label: 'Table' },
+  };
 
   const updatePreviewCb = (updatedPreview: IPreviewData) => {
     setPreviewData(updatedPreview);
@@ -155,14 +167,22 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
       <If condition={previewLoading}>{loadingMsg(classes)}</If>
       <If condition={error}>{errorMsg(classes)}</If>
 
-      <If condition={!previewLoading && previewId && !isEmpty(previewData) && !showRecordView}>
+      <If condition={!previewLoading && previewId && !isEmpty(previewData) && viewMode === 'Table'}>
+        <span className={classes.recordToggle}>
+          <ToggleSwitchWidget onChange={setViewMode} value={viewMode} widgetProps={widgetProps} />
+        </span>
         <PreviewTableContainer
           tableData={tableData}
           selectedNode={selectedNode}
           previewStatus={previewStatus}
         />
       </If>
-      <If condition={!previewLoading && previewId && !isEmpty(previewData) && showRecordView}>
+      <If
+        condition={!previewLoading && previewId && !isEmpty(previewData) && viewMode === 'Record'}
+      >
+        <span className={classes.recordToggle}>
+          <ToggleSwitchWidget onChange={setViewMode} value={viewMode} widgetProps={widgetProps} />
+        </span>
         <RecordContainer
           tableData={tableData}
           selectedNode={selectedNode}

--- a/cdap-ui/app/cdap/components/PreviewData/index.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/index.tsx
@@ -195,7 +195,12 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
     return (
       <React.Fragment>
         <span className={classes.recordToggle}>
-          <ToggleSwitchWidget onChange={setViewMode} value={viewMode} widgetProps={widgetProps} />
+          <ToggleSwitchWidget
+            onChange={setViewMode}
+            value={viewMode}
+            widgetProps={widgetProps}
+            disabled={selectedNode.isCondition}
+          />
         </span>
         <If condition={viewMode === PreviewMode.Table}>
           <PreviewTableContainer

--- a/cdap-ui/app/cdap/components/VirtualScroll/index.tsx
+++ b/cdap-ui/app/cdap/components/VirtualScroll/index.tsx
@@ -87,7 +87,7 @@ const VirtualScroll = ({
         setPromise(p);
       }
     }
-  }, [startNode, visibleNodeCount]);
+  }, [startNode, visibleNodeCount, renderList]);
 
   useEffect(() => {
     if (!promise) {
@@ -98,8 +98,11 @@ const VirtualScroll = ({
       setPromise(null);
     });
   }, [promise]);
+
+  const containerHeight =
+    itmCount > visibleChildCount ? visibleChildCount * childHeight : itmCount * childHeight;
   return (
-    <div style={{ height: visibleChildCount * childHeight }} className={classes.root} ref={ref}>
+    <div style={{ height: containerHeight }} className={classes.root} ref={ref}>
       <div
         style={{
           height: totalHeight,

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -2423,10 +2423,15 @@ features:
     loading: Fetching preview data 
     RecordView:
       RecordContainer:
+        conditionHeader: Input Records and Output Records
         inputHeader: Input Records
         outputHeader: Output Records
       RecordTable:
         fieldName: Field Name
+        noPreviewRunning: "{recordType} records have not been generated. Please verify your logic or try sending more data."
+        noSelectedRecord: "Preview data for this stage contains fewer than {selectedRecord} records."
+        previewNotSupported: Preview data is not supported for condition stages.
+        previewRunning: "{recordType} records have not been generated yet. Please check again in a few minutes."
         value: Value
     runPreview: Run preview to generate preview data.
   PropertiesEditor:

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -2425,6 +2425,9 @@ features:
       RecordContainer:
         inputHeader: Input Records
         outputHeader: Output Records
+      RecordTable:
+        fieldName: Field Name
+        value: Value
     runPreview: Run preview to generate preview data.
   PropertiesEditor:
     AddProperty:

--- a/cdap-ui/app/hydrator/hydrator-modal.less
+++ b/cdap-ui/app/hydrator/hydrator-modal.less
@@ -211,7 +211,7 @@
                   padding: 10px 15px;
                   cursor: pointer;
 
-                  &.active { border-bottom: 2px solid @hydrator-blue; }
+                  &.active { border-bottom: 3px solid @brand-primary-color; }
                   &.disabled {
                     cursor: not-allowed;
                     color: #cccccc;

--- a/cdap-ui/cypress/integration/pipeline.joiner.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.joiner.spec.ts
@@ -323,7 +323,7 @@ describe('Creating pipeline with joiner in pipeline studio', () => {
       cy.get(dataCy(`${sinkNode.nodeName}-preview-data-btn`)).click();
     });
     // Should be able to navigate records and toggle view
-    cy.get(dataCy('toggle-Record'), { timeout: 10000 }).should('exist');
+    cy.get(dataCy('toggle-Record'), { timeout: 15000 }).should('exist');
     cy.get(dataCy('fieldname-field')).should('be.visible');
 
     cy.get(dataCy('record-dropdown')).click();


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16690
Build: https://builds.cask.co/browse/CDAP-UDUT700

- Added toggle so user can choose between table and records view (default is table unless the schema has more than 100 fields)
- Implemented virtual scroll for data and records view

[Two example pipelines, one with 100+ fields in the sources and joiner and another pipeline with 5000 fields](https://drive.google.com/open?id=1kAJjO_Eg7L62-MuzLngA_4zxpy0580g2)
-- Note that you will need to update the service file path for the cdap-gcp-project

Some initial performance comparisons -- Measuring preview tab loading times for Wrangler node with:

**5000 fields (no nesting,  all strings) and 100 rows:**
- Without optimization (6.1.2, no record view or virtual scroll): 1 m 20 s
- With initial optimization (record view, no virtual scroll): 1 s
- With initial optimization (table view, no virtual scroll): 6 s
- With optimization (record view + virtual scroll): 1 s
- With optimization (table view + virtual scroll): 14 s

