### PR TITLE
[CDAP-16930] Handling missing plugins in studio and detail view

### DIFF
--- a/cdap-ui/app/cdap/components/MarketPlaceEntity/index.js
+++ b/cdap-ui/app/cdap/components/MarketPlaceEntity/index.js
@@ -171,6 +171,7 @@ export default class MarketPlaceEntity extends Component {
               <button
                 className="btn btn-primary"
                 onClick={() => this.setState({ performSingleAction: true })}
+                data-cy={`${this.state.entityDetail.actions[0].type}-btn`}
               >
                 {T.translate(
                   'features.Market.action-types.' +

--- a/cdap-ui/app/cdap/components/PlusButtonModal/index.js
+++ b/cdap-ui/app/cdap/components/PlusButtonModal/index.js
@@ -91,7 +91,7 @@ export default class PlusButtonModal extends Component {
             </span>
           </span>
           <div className="float-right">
-            <div className="modal-close-btn" onClick={this.closeHandler}>
+            <div className="modal-close-btn" onClick={this.closeHandler} data-cy="hub-close-btn">
               <IconSVG name="icon-close" />
             </div>
           </div>

--- a/cdap-ui/app/cdap/components/Wizard/index.js
+++ b/cdap-ui/app/cdap/components/Wizard/index.js
@@ -267,6 +267,7 @@ export default class Wizard extends Component {
             ? 'disabled'
             : null
         }
+        data-cy="wizard-finish-btn"
       >
         <span>{T.translate('features.Wizard.NavigationButtons.finish')}</span>
       </button>
@@ -360,7 +361,11 @@ export default class Wizard extends Component {
     let callToActionInfo = this.state.callToActionInfo;
     return (
       <div>
-        <div className="close-section float-right" onClick={this.props.onClose.bind(null, true)}>
+        <div
+          className="close-section float-right"
+          onClick={this.props.onClose.bind(null, true)}
+          data-cy="wizard-result-icon-close-btn"
+        >
           <IconSVG name="icon-close" />
         </div>
         <div className="result-container">

--- a/cdap-ui/app/cdap/services/PipelineErrorFactory.js
+++ b/cdap-ui/app/cdap/services/PipelineErrorFactory.js
@@ -76,6 +76,13 @@ let isUniqueNodeNames = (nodes, cb) => {
   return isRuleValid;
 };
 
+let hasNoBackendProperties = (nodes, cb) => {
+  const badNodes = nodes ? nodes.filter(node => !node._backendProperties) : [];
+  if(badNodes.length){
+    cb(badNodes);
+  }
+};
+
 let hasAtleastOneSource = (nodes, cb) => {
   let error;
   let countSource = 0;
@@ -365,6 +372,7 @@ export {
   hasValidClientResources,
   hasAtleastOneSource,
   hasAtLeastOneSink,
+  hasNoBackendProperties,
   isNodeNameUnique,
   allNodesConnected,
   allConnectionsValid,

--- a/cdap-ui/app/cdap/services/global-constants.js
+++ b/cdap-ui/app/cdap/services/global-constants.js
@@ -220,6 +220,7 @@ const GLOBALS = {
             'INVALID-STAGES': "Found 'stages' property outside of config specification.",
             'INVALID-CONNECTIONS': "Found 'connections' property outside of config specification.",
             'INVALID-SYNTAX': 'Syntax Error. Ill-formed pipeline configuration',
+            'NO-BACKEND-PROPS': 'Plugin artifact is missing.'
           },
           PREVIEW: {
             'NO-SOURCE-SINK': 'Please add a source and sink to the pipeline',

--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -318,7 +318,7 @@ angular.module(PKG.name + '.commons')
           vm.instance.makeTarget(node.name, targetOptions);
         }
         let key = generatePluginMapKey(node);
-        node.isPluginAvailable = Boolean(myHelpers.objectQuery(vm.pluginsMap,key,'widgets')) ;
+        node.isPluginAvailable = Boolean(myHelpers.objectQuery(vm.pluginsMap, key, 'widgets')) ;
       });
     }
 
@@ -1341,7 +1341,7 @@ angular.module(PKG.name + '.commons')
       vm.pluginsMap = AvailablePluginsStore.getState().plugins.pluginsMap;
       $scope.nodes.forEach(node => {
         let key = generatePluginMapKey(node);
-        node.isPluginAvailable = Boolean(myHelpers.objectQuery(vm.pluginsMap,key,'widgets')) ;
+        node.isPluginAvailable = Boolean(myHelpers.objectQuery(vm.pluginsMap, key, 'widgets')) ;
       });
       if (!_.isEmpty(vm.pluginsMap)) {
         addErrorAlertsEndpointsAndConnections();

--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -317,6 +317,8 @@ angular.module(PKG.name + '.commons')
           }
           vm.instance.makeTarget(node.name, targetOptions);
         }
+        let key = generatePluginMapKey(node);
+        node.isPluginAvailable = Boolean(myHelpers.objectQuery(vm.pluginsMap,key,'widgets')) ;
       });
     }
 
@@ -1337,6 +1339,10 @@ angular.module(PKG.name + '.commons')
 
     let subAvailablePlugins = AvailablePluginsStore.subscribe(() => {
       vm.pluginsMap = AvailablePluginsStore.getState().plugins.pluginsMap;
+      $scope.nodes.forEach(node => {
+        let key = generatePluginMapKey(node);
+        node.isPluginAvailable = Boolean(myHelpers.objectQuery(vm.pluginsMap,key,'widgets')) ;
+      });
       if (!_.isEmpty(vm.pluginsMap)) {
         addErrorAlertsEndpointsAndConnections();
         subAvailablePlugins();

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -151,8 +151,8 @@
                   data-nodetype="condition-false">
               <div class="endpoint-caret" ng-if="!DAGPlusPlusCtrl.isDisabled"></div>
             </div>
-            <div ng-click="!disableNodeClick && DAGPlusPlusCtrl.onNodeClick($event, node)">
-              <div class="error-node-notification" ng-if="node.errorCount > 0">
+            <div ng-click="node.isPluginAvailable && !disableNodeClick && DAGPlusPlusCtrl.onNodeClick($event, node)">
+              <div class="error-node-notification" ng-if="node.errorCount > 0" data-cy="node-badge">
                 <span class="badge" ng-class="{'badge-warning': !node.error, 'badge-danger': node.error}">
                   <span>{{node.errorCount}}</span>
                 </span>
@@ -180,10 +180,12 @@
                       ng-class="{ 'hidden': DAGPlusPlusCtrl.nodeMenuOpen === node.name}"
                       ng-bind="node.plugin.artifact.version">
                 </div>
-                <button class="node-configure-btn"
-                        ng-class="{'btn-shown': DAGPlusPlusCtrl.nodeMenuOpen === node.name}"
-                        ng-click="!disableNodeClick && DAGPlusPlusCtrl.onNodeClick($event, node)">
-                  <span class="node-configure-btn-label">
+                <button data-cy="node-properties-btn" ng-class="{'node-configure-btn': true,
+                                 'btn-shown': DAGPlusPlusCtrl.nodeMenuOpen === node.name,
+                                 'btn-disabled': !node.isPluginAvailable}"
+                  ng-click="!disableNodeClick && DAGPlusPlusCtrl.onNodeClick($event, node)" ng-disabled="!node.isPluginAvailable">
+                  <span class="node-configure-btn-label" uib-tooltip="{{ !node.isPluginAvailable ? 'Plugin artifact is not available.' : ''}}"
+                    tooltip-popup-delay="300" tooltip-placement="right">
                     Properties
                   </span>
                 </button>

--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -446,6 +446,9 @@ my-dag-plus {
           &.btn-shown {
             display: initial;
           }
+          &.btn-disabled {
+            cursor: not-allowed;
+          }
         }
 
         &:hover,

--- a/cdap-ui/app/hydrator/controllers/create/partials/console-tab-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/console-tab-ctrl.js
@@ -48,9 +48,14 @@ class HydratorPlusPlusConsoleTabService {
         case 'INVALID-CONNECTIONS':
           errorMessage.push(message.payload.connections.join(', ') + ' - invalid connection');
           break;
-        case 'NO-BACKEND-PROPS':
-          errorMessage.push(`Artifact${message.payload.nodes.length > 1 ? 's': ''} ${message.payload.nodes.join(', ')} ${message.payload.nodes.length > 1 ? 'are': 'is'} not available.`);
+        case 'NO-BACKEND-PROPS': {
+          const multiplePlugins = message.payload.nodes.length > 1;
+          const suffix = multiplePlugins ? 's' : '';
+          const pluginNames = message.payload.nodes.join(', ');
+          const messageStr = `Artifact${suffix} ${pluginNames} ${multiplePlugins ? 'are' : 'is'} not available.`;
+          errorMessage.push(messageStr);
           break;
+        }
         case 'success':
           successMessage.push(message.content);
           break;

--- a/cdap-ui/app/hydrator/controllers/create/partials/console-tab-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/console-tab-ctrl.js
@@ -48,6 +48,9 @@ class HydratorPlusPlusConsoleTabService {
         case 'INVALID-CONNECTIONS':
           errorMessage.push(message.payload.connections.join(', ') + ' - invalid connection');
           break;
+        case 'NO-BACKEND-PROPS':
+          errorMessage.push(`Artifact${message.payload.nodes.length > 1 ? 's': ''} ${message.payload.nodes.join(', ')} ${message.payload.nodes.length > 1 ? 'are': 'is'} not available.`);
+          break;
         case 'success':
           successMessage.push(message.content);
           break;

--- a/cdap-ui/app/hydrator/services/create/actions/available-plugins-action-creator.js
+++ b/cdap-ui/app/hydrator/services/create/actions/available-plugins-action-creator.js
@@ -126,6 +126,19 @@ class PipelineAvailablePluginsActions {
   _fetchInfo(availablePluginsMap, namespace, plugins) {
     const reqBody = plugins.map((plugin) => plugin.info);
 
+    const getKeyFromPluginProps = pluginProperties => {
+      return pluginProperties[0].split('.')[1];
+    };
+
+    const pluginsByKey = new Map();
+    plugins.forEach(plugin => {
+      const pluginProperties = this.myHelpers.objectQuery(plugin, 'info', 'properties');
+      if (pluginProperties.length > 0) {
+        const key = getKeyFromPluginProps(pluginProperties);
+        pluginsByKey.set(key, plugin);
+      }
+    });
+
     this.api.fetchAllPluginsProperties({ namespace }, reqBody)
       .$promise
       .then((res) => {
@@ -133,10 +146,8 @@ class PipelineAvailablePluginsActions {
           let pluginProperties = Object.keys(plugin.properties);
           if (pluginProperties.length === 0) { return; }
 
-          let pluginKey = pluginProperties[0].split('.')[1];
-          const { key } = plugins.find(pl =>
-            pl.key.includes(pluginKey)
-          );
+          let pluginKey = getKeyFromPluginProps(pluginProperties);
+          const { key } = pluginsByKey.get(pluginKey);
 
           availablePluginsMap[key].doc = plugin.properties[`doc.${pluginKey}`];
 

--- a/cdap-ui/app/hydrator/services/create/actions/available-plugins-action-creator.js
+++ b/cdap-ui/app/hydrator/services/create/actions/available-plugins-action-creator.js
@@ -129,12 +129,14 @@ class PipelineAvailablePluginsActions {
     this.api.fetchAllPluginsProperties({ namespace }, reqBody)
       .$promise
       .then((res) => {
-        res.forEach((plugin, index) => {
+        res.forEach((plugin) => {
           let pluginProperties = Object.keys(plugin.properties);
           if (pluginProperties.length === 0) { return; }
 
           let pluginKey = pluginProperties[0].split('.')[1];
-          let key = plugins[index].key;
+          const { key } = plugins.find(pl =>
+            pl.key.includes(pluginKey)
+          );
 
           availablePluginsMap[key].doc = plugin.properties[`doc.${pluginKey}`];
 

--- a/cdap-ui/app/hydrator/services/create/actions/available-plugins-action-creator.js
+++ b/cdap-ui/app/hydrator/services/create/actions/available-plugins-action-creator.js
@@ -127,7 +127,8 @@ class PipelineAvailablePluginsActions {
     const reqBody = plugins.map((plugin) => plugin.info);
 
     const getKeyFromPluginProps = pluginProperties => {
-      return pluginProperties[0].split('.')[1];
+      const key = this.myHelpers.objectQuery(pluginProperties, '0');
+      return key ? key.split('.')[1] : '';
     };
 
     const pluginsByKey = new Map();

--- a/cdap-ui/app/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/hydrator/services/create/stores/config-store.js
@@ -659,7 +659,10 @@ class HydratorPlusPlusConfigStore {
                 });
               });
           },
-          (err) => console.log('ERROR fetching backend properties for nodes', err)
+          ((err) => {
+            console.log('ERROR fetching backend properties for nodes', err);
+            this.validateState();
+          }).bind(this)
         );
     }
   }
@@ -781,7 +784,12 @@ class HydratorPlusPlusConfigStore {
     ];
     let nodes = this.state.__ui__.nodes;
     let connections = angular.copy(this.state.config.connections);
-    nodes.forEach( node => { node.errorCount = 0;});
+    //resetting any existing errors or warnings
+    nodes.forEach(node => {
+      node.errorCount = 0;
+      delete node.warning;
+      delete node.error;
+    });
     let errors = [];
     this.HydratorPlusPlusConsoleActions.resetMessages();
     let setErrorWarningFlagOnNode = (node) => {
@@ -830,9 +838,26 @@ class HydratorPlusPlusConfigStore {
         });
       }
     });
+    errorFactory.hasNoBackendProperties(nodes, errorNodes => {
+      if (errorNodes) {
+        isStateValid = false;
+        errorNodes.forEach(node => {
+          node.error = true;
+          node.errorCount += 1;
+          setErrorWarningFlagOnNode(node);
+        });
+        errors.push({
+          type: "NO-BACKEND-PROPS",
+          payload: {
+            nodes: errorNodes.map(node => node.name || node.plugin.name)
+          }
+        });
+      }
+    });
     errorFactory.isRequiredFieldsFilled(nodes, (err, node, unFilledRequiredFields) => {
       if (err) {
         isStateValid = false;
+        node.warning = true;
         node.errorCount += unFilledRequiredFields;
         setErrorWarningFlagOnNode(node);
       }

--- a/cdap-ui/app/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/hydrator/services/create/stores/config-store.js
@@ -847,7 +847,7 @@ class HydratorPlusPlusConfigStore {
           setErrorWarningFlagOnNode(node);
         });
         errors.push({
-          type: "NO-BACKEND-PROPS",
+          type: 'NO-BACKEND-PROPS',
           payload: {
             nodes: errorNodes.map(node => node.name || node.plugin.name)
           }

--- a/cdap-ui/app/hydrator/templates/create/toppanel.html
+++ b/cdap-ui/app/hydrator/templates/create/toppanel.html
@@ -115,7 +115,8 @@
          tooltip-enable="!HydratorPlusPlusTopPanelCtrl.hasNodes"
          tooltip-class="toppanel-tooltip"
          tooltip-append-to-body="true"
-         ng-disabled="!HydratorPlusPlusTopPanelCtrl.hasNodes">
+         ng-disabled="!HydratorPlusPlusTopPanelCtrl.hasNodes"
+         data-cy="pipeline-draft-save-btn">
       <div class="btn-container">
         <span class="fa icon-savedraft"></span>
         <div class="button-label">Save</div>

--- a/cdap-ui/app/hydrator/templates/partial/error-template.html
+++ b/cdap-ui/app/hydrator/templates/partial/error-template.html
@@ -14,7 +14,7 @@
   the License.
 -->
 <div class="alert" ng-class="[type ? 'alert-' + type : null]">
-  <button type="button" class="close" ng-if="dismissable" ng-click="$hide()">&times;</button>
+  <button type="button" class="close" ng-if="dismissable" ng-click="$hide()" data-cy="banner-dismiss-btn">&times;</button>
   <span ng-if="title">
     <strong ng-bind="title"></strong>&nbsp;
     <span ng-bind-html="content"></span>

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/configuration-tab.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/configuration-tab.html
@@ -19,16 +19,27 @@
   <div ng-class="{'modal-sink': HydratorPlusPlusNodeConfigCtrl.state.node.type === 'sink'}">
     <div ng-show="!showinfo">
       <div ng-if="HydratorPlusPlusNodeConfigCtrl.state.configfetched">
-
+      
         <div ng-if="HydratorPlusPlusNodeConfigCtrl.state.noproperty !== 0">
           <div ng-if="(HydratorPlusPlusNodeConfigCtrl.state.configfetched && !HydratorPlusPlusNodeConfigCtrl.state.noconfig)">
-            <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-config-form.html'"></div>
+            <div
+              ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-config-form.html'">
+            </div>
           </div>
         </div>
-
-        <div ng-if="HydratorPlusPlusNodeConfigCtrl.state.noproperty === 0" class="no-plugin-properties-message">
+      
+        <div
+          ng-if="HydratorPlusPlusNodeConfigCtrl.state.isValidPlugin && HydratorPlusPlusNodeConfigCtrl.state.noproperty === 0"
+          class="no-plugin-properties-message">
           <div class="well well-lg text-center">
             <h4>No Properties found for Plugin '{{::HydratorPlusPlusNodeConfigCtrl.state.node.plugin.name}}'</h4>
+          </div>
+        </div>
+        <div
+          ng-if="!HydratorPlusPlusNodeConfigCtrl.state.isValidPlugin && HydratorPlusPlusNodeConfigCtrl.state.noproperty === 0"
+          class="no-plugin-properties-message">
+          <div class="well well-lg text-center">
+            <h4>Plugin artifact is not available.</h4>
           </div>
         </div>
       </div>

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/popover.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/popover.html
@@ -37,6 +37,7 @@
   </span>
   <div class="btn-group pull-right">
     <button class="btn btn-primary validate-btn" type="button"
+            data-cy="plugin-properties-validate-btn"
             ng-if="!isDisabled"
             ng-class="{'disabled': HydratorPlusPlusNodeConfigCtrl.validating}"
             ng-click="!HydratorPlusPlusNodeConfigCtrl.validating && HydratorPlusPlusNodeConfigCtrl.validatePluginProperties()">
@@ -95,6 +96,11 @@
         <div class="bottompanel-body"
              ng-if="HydratorPlusPlusNodeConfigCtrl.activeTab === 1 && HydratorPlusPlusNodeConfigCtrl.state.isValidPlugin"
              ng-include="HydratorPlusPlusNodeConfigCtrl.tabs[0].templateUrl">
+        </div>
+        <div class="bottompanel-body"
+        ng-if="HydratorPlusPlusNodeConfigCtrl.activeTab === 1 && !HydratorPlusPlusNodeConfigCtrl.state.isValidPlugin"
+        ng-include="HydratorPlusPlusNodeConfigCtrl.tabs[0].templateUrl">
+        <span>Plugin artifact is not available.</span>
         </div>
         <div class="bottompanel-body"
              ng-if="HydratorPlusPlusNodeConfigCtrl.activeTab === 2"

--- a/cdap-ui/cypress/fixtures/missing-artifact-pipeline.json
+++ b/cdap-ui/cypress/fixtures/missing-artifact-pipeline.json
@@ -1,0 +1,149 @@
+{
+    "artifact": {
+        "name": "cdap-data-pipeline",
+        "version": "6.1.3-SNAPSHOT",
+        "scope": "SYSTEM"
+    },
+    "description": "Data Pipeline Application",
+    "name": "missing-artifact",
+    "config": {
+        "resources": {
+            "memoryMB": 2048,
+            "virtualCores": 1
+        },
+        "driverResources": {
+            "memoryMB": 2048,
+            "virtualCores": 1
+        },
+        "connections": [
+            {
+                "from": "File",
+                "to": "Wrangler"
+            },
+            {
+                "from": "Wrangler",
+                "to": "PDFExtractor"
+            },
+            {
+                "from": "PDFExtractor",
+                "to": "Trash"
+            }
+        ],
+        "comments": [],
+        "postActions": [],
+        "properties": {},
+        "processTimingEnabled": true,
+        "stageLoggingEnabled": false,
+        "stages": [
+            {
+                "name": "File",
+                "plugin": {
+                    "name": "File",
+                    "type": "batchsource",
+                    "label": "File",
+                    "artifact": {
+                        "name": "core-plugins",
+                        "version": "2.3.6-SNAPSHOT",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "format": "text",
+                        "skipHeader": "false",
+                        "filenameOnly": "false",
+                        "recursive": "false",
+                        "ignoreNonExistingFolders": "false",
+                        "referenceName": "invalid",
+                        "path": "testpath",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"offset\",\"type\":\"long\"},{\"name\":\"body\",\"type\":\"string\"}]}"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"offset\",\"type\":\"long\"},{\"name\":\"body\",\"type\":\"string\"}]}"
+            },
+            {
+                "name": "Wrangler",
+                "plugin": {
+                    "name": "Wrangler",
+                    "type": "transform",
+                    "label": "Wrangler",
+                    "artifact": {
+                        "name": "wrangler-transform",
+                        "version": "4.1.7-SNAPSHOT",
+                        "scope": "SYSTEM"
+                    },
+                    "properties": {
+                        "field": "*",
+                        "precondition": "false",
+                        "threshold": "1",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"body\",\"type\":[\"bytes\",\"null\"]}]}",
+                        "workspaceId": "b6d9b1a7-bf7d-4ed2-8b12-2a1130742a0c",
+                        "directives": "set-type :body bytes"
+                    }
+                },
+                "outputSchema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"body\",\"type\":[\"bytes\",\"null\"]}]}",
+                "inputSchema": [
+                    {
+                        "name": "File",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"offset\",\"type\":\"long\"},{\"name\":\"body\",\"type\":\"string\"}]}"
+                    }
+                ]
+            },
+            {
+                "name": "PDFExtractor",
+                "plugin": {
+                    "name": "PDFExtractor",
+                    "type": "transform",
+                    "label": "PDFExtractor",
+                    "artifact": {
+                        "name": "pdf-extractor-transform",
+                        "version": "2.0.0",
+                        "scope": "USER"
+                    },
+                    "properties": {
+                        "continueOnError": "false",
+                        "sourceFieldName": "body"
+                    }
+                },
+                "outputSchema": "{\"name\":\"etlSchemaBody\",\"type\":\"record\",\"fields\":[{\"name\":\"raw_pdf_data\",\"type\":[\"bytes\",\"null\"]},{\"name\":\"text\",\"type\":[\"string\",\"null\"]},{\"name\":\"page_count\",\"type\":[\"int\",\"null\"]},{\"name\":\"title\",\"type\":[\"string\",\"null\"]},{\"name\":\"author\",\"type\":[\"string\",\"null\"]},{\"name\":\"subject\",\"type\":[\"string\",\"null\"]},{\"name\":\"keywords\",\"type\":[\"string\",\"null\"]},{\"name\":\"creator\",\"type\":[\"string\",\"null\"]},{\"name\":\"producer\",\"type\":[\"string\",\"null\"]},{\"name\":\"creation_date\",\"type\":[\"long\",\"null\"]},{\"name\":\"modification_date\",\"type\":[\"long\",\"null\"]},{\"name\":\"trapped\",\"type\":[\"string\",\"null\"]}]}",
+                "inputSchema": [
+                    {
+                        "name": "Wrangler",
+                        "schema": "{\"type\":\"record\",\"name\":\"etlSchemaBody\",\"fields\":[{\"name\":\"body\",\"type\":[\"bytes\",\"null\"]}]}"
+                    }
+                ]
+            },
+            {
+                "name": "Trash",
+                "plugin": {
+                    "name": "Trash",
+                    "type": "batchsink",
+                    "label": "Trash",
+                    "artifact": {
+                        "name": "trash-plugin",
+                        "version": "1.2.0",
+                        "scope": "USER"
+                    },
+                    "properties": {
+                        "referenceName": "Trash"
+                    }
+                },
+                "outputSchema": [
+                    {
+                        "name": "etlSchemaBody",
+                        "schema": "{\"name\":\"fileRecord\",\"type\":\"record\",\"fields\":[{\"name\":\"offset\",\"type\":\"long\"},{\"name\":\"body\",\"type\":\"string\"}]}"
+                    }
+                ],
+                "inputSchema": [
+                    {
+                        "name": "File",
+                        "schema": "{\"name\":\"fileRecord\",\"type\":\"record\",\"fields\":[{\"name\":\"offset\",\"type\":\"long\"},{\"name\":\"body\",\"type\":\"string\"}]}"
+                    }
+                ]
+            }
+        ],
+        "schedule": "0 * * * *",
+        "engine": "spark",
+        "numOfRecordsPreview": 100,
+        "description": "Data Pipeline Application",
+        "maxConcurrentRuns": 1
+    }
+}

--- a/cdap-ui/cypress/support/commands.ts
+++ b/cdap-ui/cypress/support/commands.ts
@@ -279,3 +279,16 @@ Cypress.Commands.add('start_wrangler', (headers) => {
     }
   });
 });
+
+Cypress.Commands.add('delete_artifact_via_api', (headers, artifactName, version) => {
+  return cy.request({
+    method: 'DELETE',
+    url: `http://${Cypress.env('host')}:11015/v3/namespaces/default/artifacts/${artifactName}/versions/${version}`,
+    headers,
+    failOnStatusCode: false
+  }).then(resp => {
+    // 404 if the artifact is already deleted.
+    expect(resp.status).to.be.oneOf([200, 404]);
+  });
+});
+

--- a/cdap-ui/cypress/typings/index.d.ts
+++ b/cdap-ui/cypress/typings/index.d.ts
@@ -85,6 +85,15 @@ declare global {
        */
 
       create_SPANNER_connection: (connectionId: string, projectId?: string, serviceAccountPath?: string) => void;
+
+      /**
+       * Deletes specified artifact via REST API
+       *  @headers - Any request headers to be passed.
+       *  @artifactName - Name of artifact to be deleted.
+       *  @version - Version of the artifact to be deleted.
+       */
+
+      delete_artifact_via_api: (headers: any, artifactName: string, version: string) => Chainable<Request>;
     }
     // tslint:disable-next-line: interface-name
     interface Window {


### PR DESCRIPTION
Jira: https://issues.cask.co/browse/CDAP-16930

Plugin artifacts could be missing from the pipeline either in the studio or in the detail view and currently we do not communicate this to the user in any form. 

This PR
- Adds an error badge to the node indicating there's something wrong with the node in studio.
- Disables the properties button with a tooltip in studio and detail view.
- If users try to deploy the pipeline with missing artifact, they would see an error banner.
- Fixes an issue where we incorrectly populate pluginsMap (Jira: https://issues.cask.co/browse/CDAP-17042)