### PR TITLE
[CDAP-16414] Handling graphQL errors in pipeline list view

### DIFF
--- a/cdap-ui/app/cdap/components/500/index.js
+++ b/cdap-ui/app/cdap/components/500/index.js
@@ -59,5 +59,5 @@ export default function Page500({ message, stack }) {
 }
 Page500.propTypes = {
   message: PropTypes.string,
-  stack: PropTypes.object,
+  stack: PropTypes.object || PropTypes.array,
 };

--- a/cdap-ui/app/cdap/components/ErrorBanner/index.tsx
+++ b/cdap-ui/app/cdap/components/ErrorBanner/index.tsx
@@ -20,7 +20,7 @@ import Alert from 'components/Alert';
 
 interface IErrorProps {
   error: object | string | null;
-  onClose: () => void;
+  onClose?: () => void;
 }
 
 const ErrorBanner: React.SFC<IErrorProps> = ({ error, onClose }) => {

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/DeployedPipelineView.scss
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/DeployedPipelineView.scss
@@ -21,12 +21,6 @@
   padding-left: $padding-size;
   padding-right: $padding-size;
 
-  &.error-container {
-    color: $red-02;
-    font-size: 14px;
-    padding-top: 25px;
-  }
-
   .deployed-header {
     height: $header-height;
     line-height: $header-height;

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/index.tsx
@@ -35,9 +35,12 @@ import If from 'components/If';
 
 import './DeployedPipelineView.scss';
 import { objectQuery } from 'services/helpers';
+import T from 'i18n-react';
 
-// For errors of this type coming from graphQl, we show a 500 error instead of a banner.
+// For errors of these types coming from graphQl for pipeline list page, we show a 500 error instead of a banner.
 const HIGH_PRIORITY_ERRORS = new Set(['pipelinesList']);
+const GENERIC_ERROR_ORIGIN = 'generic';
+const I18N_PREFIX = 'features.PipelineList.DeployedPipelineView';
 
 interface IErrorForDisplay {
   message: string;
@@ -107,13 +110,13 @@ const DeployedPipeline: React.FC = () => {
       errorForDisplay = {
         message: error.message.replace(prefix, '').trim(),
         stack: {},
-        errorOrigin: 'generic',
+        errorOrigin: GENERIC_ERROR_ORIGIN,
       };
     } else {
       // Categorizing errors by their origin.
       allErrors.forEach((eachError: IErrorForDisplay) => {
         if (!eachError.errorOrigin) {
-          eachError.errorOrigin = 'generic';
+          eachError.errorOrigin = GENERIC_ERROR_ORIGIN;
         }
         if (errorsByOrigin.hasOwnProperty(eachError.errorOrigin)) {
           errorsByOrigin[eachError.errorOrigin].push(eachError);
@@ -134,8 +137,9 @@ const DeployedPipeline: React.FC = () => {
         // When more than one service is down i.e different error types, consider it high priority.
         hasHighPriorityError = true;
         errorForDisplay = allErrors[0];
-        errorForDisplay.message =
-          'Multiple services ran into issues when trying to retrieve list of pipelines. Please try again later.';
+        errorForDisplay.message = T.translate(
+          `${I18N_PREFIX}.graphQLMultipleServicesDown`
+        ).toString();
       } else {
         // Pick the first error to display to the user.
         errorForDisplay = allErrors[0];
@@ -161,7 +165,7 @@ const DeployedPipeline: React.FC = () => {
               } occured.`
             : ''
         }`
-      : 'Error occured while trying to retrieve information required for list of pipelines.';
+      : T.translate(`${I18N_PREFIX}.graphQLErrorBannerMessage`).toString();
   }
   setFilteredPipelines(data.pipelines);
 

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/index.tsx
@@ -29,9 +29,21 @@ import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import { gql } from 'apollo-boost';
 import { useQuery } from '@apollo/react-hooks';
+import Page500 from 'components/500';
+import ErrorBanner from 'components/ErrorBanner';
+import If from 'components/If';
 
 import './DeployedPipelineView.scss';
 import { objectQuery } from 'services/helpers';
+
+// For errors of this type coming from graphQl, we show a 500 error instead of a banner.
+const HIGH_PRIORITY_ERRORS = new Set(['pipelinesList']);
+
+interface IErrorForDisplay {
+  message: string;
+  stack: object;
+  errorOrigin: string;
+}
 
 const DeployedPipeline: React.FC = () => {
   const QUERY = gql`
@@ -70,25 +82,87 @@ const DeployedPipeline: React.FC = () => {
     return <LoadingSVGCentered />;
   }
 
+  let hasHighPriorityError = false;
+  let errorForDisplay: IErrorForDisplay;
+  const errorsByOrigin = {};
   if (error) {
     // tslint:disable-next-line: no-console
     console.log('error', JSON.stringify(error, null, 2));
     const graphQLErrors = objectQuery(error, 'graphQLErrors') || [];
     const networkErrors = objectQuery(error, 'networkError') || [];
 
-    let errors = graphQLErrors
-      .concat(networkErrors)
-      .map((err) => err.message)
-      .join('\n');
+    const allErrors: IErrorForDisplay[] = graphQLErrors.concat(networkErrors).map((err) => {
+      const stack = objectQuery(err, 'extensions', 'exception', 'stacktrace');
+      const errorOrigin = objectQuery(err, 'extensions', 'exception', 'errorOrigin');
 
-    if (!errors || errors.length === 0) {
+      return {
+        message: err.message,
+        stack,
+        errorOrigin,
+      };
+    });
+
+    if (!allErrors || allErrors.length === 0) {
       const prefix = /^GraphQL error\:/;
-      errors = error.message.replace(prefix, '').trim();
+      errorForDisplay = {
+        message: error.message.replace(prefix, '').trim(),
+        stack: {},
+        errorOrigin: 'generic',
+      };
+    } else {
+      // Categorizing errors by their origin.
+      allErrors.forEach((eachError: IErrorForDisplay) => {
+        if (!eachError.errorOrigin) {
+          eachError.errorOrigin = 'generic';
+        }
+        if (errorsByOrigin.hasOwnProperty(eachError.errorOrigin)) {
+          errorsByOrigin[eachError.errorOrigin].push(eachError);
+        } else {
+          errorsByOrigin[eachError.errorOrigin] = [eachError];
+        }
+      });
+
+      const errorTypes = Object.keys(errorsByOrigin);
+      // Finding the first high priority error for display.
+      const hpError = errorTypes.find((errorType) => HIGH_PRIORITY_ERRORS.has(errorType));
+
+      if (hpError) {
+        // If there is a high priorty error, pick that one.
+        errorForDisplay = errorsByOrigin[hpError][0];
+        hasHighPriorityError = true;
+      } else if (errorTypes.length > 1) {
+        // When more than one service is down i.e different error types, consider it high priority.
+        hasHighPriorityError = true;
+        errorForDisplay = allErrors[0];
+        errorForDisplay.message =
+          'Multiple services ran into issues when trying to retrieve list of pipelines. Please try again later.';
+      } else {
+        // Pick the first error to display to the user.
+        errorForDisplay = allErrors[0];
+      }
     }
 
-    return <div className="pipeline-deployed-view error-container">{errors}</div>;
+    if (hasHighPriorityError) {
+      return (
+        <div className="pipeline-deployed-view">
+          <Page500 message={errorForDisplay.message} stack={errorForDisplay.stack} />
+        </div>
+      );
+    }
   }
 
+  function generateErrorBannerMessage() {
+    const errorTypesCount = Object.keys(errorsByOrigin).length;
+    return errorForDisplay
+      ? `${errorForDisplay.message}${
+          errorTypesCount > 1
+            ? ` and ${errorTypesCount - 1} other error${
+                errorTypesCount - 1 > 1 ? 's' : ''
+              } occured.`
+            : ''
+        }`
+      : 'Error occured while trying to retrieve information required for list of pipelines.';
+  }
   setFilteredPipelines(data.pipelines);
 
   return (
@@ -99,7 +173,9 @@ const DeployedPipeline: React.FC = () => {
           <SearchBox />
           <Pagination />
         </div>
-
+        <If condition={!!error && !hasHighPriorityError}>
+          <ErrorBanner error={generateErrorBannerMessage()} />
+        </If>
         <PipelineTable refetch={refetch} />
       </div>
     </Provider>

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -2116,6 +2116,8 @@ features:
         1: "pipeline "
         _: "pipelines "
     DeployedPipelineView:
+      graphQLErrorBannerMessage: Error occured while trying to retrieve information required for list of pipelines.
+      graphQLMultipleServicesDown: Multiple services ran into issues when trying to retrieve list of pipelines. Please try again later.
       searchPlaceholder: Search by pipeline name
       pipelineCount:
         1: "{context} pipeline"

--- a/cdap-ui/cypress/integration/pipeline.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.spec.ts
@@ -219,14 +219,13 @@ describe('Creating a pipeline', () => {
     cy.get('[data-testid=close-modeless]').click();
   });
 
-  it.only(
-      'opening pipeline with unknown workspace should still render the studio',
-      () => {
-        cy.visit(
-            'pipelines/ns/default/studio?artifactType=cdap-data-pipeline&workspaceId=ebdbb6a7-8a8c-47b5-913f-9b75b1a0');
-        cy.get(dataCy('app-navbar')).should('be.visible');
-        cy.get(dataCy('navbar-toolbar')).should('be.visible');
-        cy.get(dataCy('navbar-hamburger-icon')).click();
-        cy.get(dataCy('navbar-home-link')).should('be.visible');
-      })
+  it('opening pipeline with unknown workspace should still render the studio',
+     () => {
+       cy.visit(
+           'pipelines/ns/default/studio?artifactType=cdap-data-pipeline&workspaceId=ebdbb6a7-8a8c-47b5-913f-9b75b1a0');
+       cy.get(dataCy('app-navbar')).should('be.visible');
+       cy.get(dataCy('navbar-toolbar')).should('be.visible');
+       cy.get(dataCy('navbar-hamburger-icon')).click();
+       cy.get(dataCy('navbar-home-link')).should('be.visible');
+     });
 });

--- a/cdap-ui/graphql/Query/pipelinesResolver.js
+++ b/cdap-ui/graphql/Query/pipelinesResolver.js
@@ -27,11 +27,11 @@ cdapConfigurator.getCDAPConfig().then(function(value) {
 async function queryTypePipelinesResolver(parent, args, context) {
   const namespace = args.namespace;
   const options = resolversCommon.getGETRequestOptions();
+  options.errorOrigin = 'pipelinesList';
 
   const pipelineArtifacts = ['cdap-data-pipeline', 'cdap-data-streams'];
 
   let path = `/v3/namespaces/${namespace}/apps?artifactName=${pipelineArtifacts.join(',')}`;
-
   options.url = urlHelper.constructUrl(cdapConfig, path);
   context.namespace = namespace;
 

--- a/cdap-ui/graphql/Query/statusResolver.js
+++ b/cdap-ui/graphql/Query/statusResolver.js
@@ -26,6 +26,7 @@ cdapConfigurator.getCDAPConfig().then(function(value) {
 async function queryTypeStatusResolver(parent, args, context) {
   const options = resolversCommon.getGETRequestOptions();
   options.url = urlHelper.constructUrl(cdapConfig, '/ping');
+  options.errorOrigin = 'statusPing';
 
   const status = await resolversCommon.requestPromiseWrapper(options, context.auth);
 

--- a/cdap-ui/graphql/helpers/BatchEndpoints/nextRuntime.js
+++ b/cdap-ui/graphql/helpers/BatchEndpoints/nextRuntime.js
@@ -27,6 +27,7 @@ async function batchNextRuntime(req, auth) {
   const namespace = req[0].namespace;
   const options = getPOSTRequestOptions();
   options.url = constructUrl(cdapConfig, `/v3/namespaces/${namespace}/nextruntime`);
+  options.errorOrigin ='nextRuntime';
   const body = req.slice(0, 25).map((reqObj) => reqObj.program);
   options.body = body;
 

--- a/cdap-ui/graphql/helpers/BatchEndpoints/programRuns.js
+++ b/cdap-ui/graphql/helpers/BatchEndpoints/programRuns.js
@@ -28,6 +28,7 @@ async function batchProgramRuns(req, auth) {
   const options = resolversCommon.getPOSTRequestOptions();
   options.url = urlHelper.constructUrl(cdapConfig, `/v3/namespaces/${namespace}/runs`);
   options.body = req.slice(0, 25).map((reqObj) => reqObj.program);
+  options.errorOrigin = 'programRuns';
 
   const runInfo = await resolversCommon.requestPromiseWrapper(options, auth);
 

--- a/cdap-ui/graphql/helpers/BatchEndpoints/totalRuns.js
+++ b/cdap-ui/graphql/helpers/BatchEndpoints/totalRuns.js
@@ -29,6 +29,7 @@ async function batchTotalRuns(req, auth) {
   const namespace = req[0].namespace;
   const options = resolversCommon.getPOSTRequestOptions();
   options.url = urlHelper.constructUrl(cdapConfig, `/v3/namespaces/${namespace}/runcount`);
+  options.errorOrigin = 'totalRuns';
   const body = req.slice(0, 25).map((reqObj) => reqObj.program);
   const chunkedBody = chunk(body, 100);
 

--- a/cdap-ui/graphql/resolvers-common.js
+++ b/cdap-ui/graphql/resolvers-common.js
@@ -16,6 +16,7 @@
 
 const request = require('request');
 const { ApolloError } = require('apollo-server');
+const GENERIC_ERROR_ORIGIN = 'generic';
 
 function getGETRequestOptions() {
   return {
@@ -38,7 +39,7 @@ function requestPromiseWrapper(options, token, bodyModifiersFn) {
     };
   }
   // If there is no affinity specified, we default it to being a generic error.
-  const { errorOrigin = 'generic' } = options;
+  const { errorOrigin = GENERIC_ERROR_ORIGIN } = options;
   return new Promise((resolve, reject) => {
     request(options, (err, response, body) => {
       if (err) {

--- a/cdap-ui/graphql/resolvers-common.js
+++ b/cdap-ui/graphql/resolvers-common.js
@@ -37,18 +37,21 @@ function requestPromiseWrapper(options, token, bodyModifiersFn) {
       Authorization: token,
     };
   }
-
+  // If there is no affinity specified, we default it to being a generic error.
+  const { errorOrigin = 'generic' } = options;
   return new Promise((resolve, reject) => {
     request(options, (err, response, body) => {
       if (err) {
-        const error =  new ApolloError(err, '500');
+        const error = new ApolloError(err, '500', { errorOrigin });
         return reject(error);
       }
 
       const statusCode = response.statusCode;
 
       if (typeof statusCode === 'undefined' || statusCode != 200) {
-        const error = new ApolloError(body, statusCode.toString());
+        const error = new ApolloError(body, statusCode.toString(), {
+          errorOrigin
+        });
         return reject(error);
       }
 


### PR DESCRIPTION
Jira: https://issues.cask.co/browse/CDAP-16414

Currently, graphQL errors in pipeline list view are shown as strings, this PR is to utilize one of the error components we have.

- Will show page level error when call to retrieve pipelines fails (considered high priority failure on this page).
- Will show error banner when we are unable to retrieve other information for the page like total runs, next run etc.
- When multiple of these smaller services fail, we show a page level error.