### PR TITLE
[CDAP-17050] Add UI support for managing secure keys and viewing secure data (Secure Key Manager)

### DIFF
--- a/cdap-ui/app/cdap/api/securekey.js
+++ b/cdap-ui/app/cdap/api/securekey.js
@@ -14,15 +14,18 @@
  * the License.
  */
 
-import { apiCreator } from 'services/resource-helper';
 import DataSourceConfigurer from 'services/datasource/DataSourceConfigurer';
+import { apiCreator } from 'services/resource-helper';
 const dataSrc = DataSourceConfigurer.getInstance();
 
 const basepath = '/namespaces/:namespace/securekeys';
 const keyPath = `${basepath}/:key`;
+const keyMetadataPath = `${keyPath}/:key`;
 
 export const MySecureKeyApi = {
   list: apiCreator(dataSrc, 'GET', 'REQUEST', basepath),
-  add: apiCreator(dataSrc, 'PUT', 'REQUEST', keyPath),
+  getSecureData: apiCreator(dataSrc, 'GET', 'REQUEST', keyPath),
+  getKeyMetadata: apiCreator(dataSrc, 'GET', 'REQUEST', keyMetadataPath),
+  put: apiCreator(dataSrc, 'PUT', 'REQUEST', keyPath),
   delete: apiCreator(dataSrc, 'DELETE', 'REQUEST', keyPath),
 };

--- a/cdap-ui/app/cdap/components/SecureKeys/SecureKeyCreate/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/SecureKeyCreate/index.tsx
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { COMMON_DELIMITER, COMMON_KV_DELIMITER } from 'components/SecureKeys/constants';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import { Map } from 'immutable';
+import { MySecureKeyApi } from 'api/securekey';
+import React from 'react';
+import TextField from '@material-ui/core/TextField';
+import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+
+const styles = (theme): StyleRules => {
+  return {
+    secureKeyInput: {
+      margin: `${theme.Spacing(3)}px ${theme.spacing(1)}px`,
+    },
+  };
+};
+
+interface ISecureKeyCreateProps extends WithStyles<typeof styles> {
+  state: any;
+  open: boolean;
+  handleClose: () => void;
+  alertSuccess: () => void;
+  alertFailure: () => void;
+}
+
+const SecureKeyCreateView: React.FC<ISecureKeyCreateProps> = ({
+  classes,
+  state,
+  open,
+  handleClose,
+  alertSuccess,
+  alertFailure,
+}) => {
+  const { secureKeys } = state;
+
+  const [localName, setLocalName] = React.useState('');
+  const [localDescription, setLocalDescription] = React.useState('');
+  const [localData, setLocalData] = React.useState('');
+  // 'properties' are in key-value form, keep a state in string form
+  const [localPropertiesInString, setLocalPropertiesInString] = React.useState('');
+
+  const onLocalNameChange = (e) => {
+    setLocalName(e.target.value);
+  };
+
+  const onLocalDescriptionChange = (e) => {
+    setLocalDescription(e.target.value);
+  };
+
+  const onLocalDataChange = (e) => {
+    setLocalData(e.target.value);
+  };
+
+  const onLocalPropertiesChange = (keyvalue) => {
+    setLocalPropertiesInString(keyvalue);
+  };
+
+  const convertLocalPropertiesInString = (keyvalue: string) => {
+    let keyvaluePairs = Map({});
+    keyvalue.split(COMMON_DELIMITER).forEach((pair) => {
+      const [key, value] = pair.split(COMMON_KV_DELIMITER);
+      keyvaluePairs = keyvaluePairs.set(key, value);
+    });
+    return keyvaluePairs;
+  };
+
+  const saveSecureKey = () => {
+    // Duplicate key name should raise an error
+    const keyIDs = secureKeys.map((key) => key.get('name'));
+    if (keyIDs.includes(localName)) {
+      alertFailure();
+      return;
+    }
+
+    addSecureKey();
+  };
+
+  const addSecureKey = () => {
+    const namespace = getCurrentNamespace();
+
+    const params = {
+      namespace,
+      key: localName,
+    };
+
+    const requestBody = {
+      description: localDescription,
+      data: localData,
+      properties: convertLocalPropertiesInString(localPropertiesInString),
+    };
+
+    MySecureKeyApi.put(params, requestBody).subscribe(() => {
+      setLocalName('');
+      setLocalDescription('');
+      setLocalData('');
+      setLocalPropertiesInString('');
+      alertSuccess();
+      handleClose();
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>Create secure key</DialogTitle>
+      <DialogContent>
+        <div className={classes.secureKeyInput}>
+          <TextField
+            required
+            variant="outlined"
+            label="Name"
+            defaultValue={localName}
+            onChange={onLocalNameChange}
+            fullWidth
+            InputProps={{
+              className: classes.textField,
+            }}
+          />
+        </div>
+        <div className={classes.secureKeyInput}>
+          <TextField
+            required
+            variant="outlined"
+            label="Description"
+            defaultValue={localDescription}
+            onChange={onLocalDescriptionChange}
+            fullWidth
+            InputProps={{
+              className: classes.textField,
+            }}
+          />
+        </div>
+        <div className={classes.secureKeyInput}>
+          <TextField
+            required
+            variant="outlined"
+            label="Data"
+            type="password"
+            value={localData}
+            onChange={onLocalDataChange}
+            fullWidth
+            InputProps={{
+              className: classes.textField,
+            }}
+          />
+        </div>
+        <div className={classes.secureKeyInput}>
+          <WidgetWrapper
+            widgetProperty={{
+              label: 'Properties',
+              name: 'Properties',
+              'widget-type': 'keyvalue',
+              'widget-attributes': {
+                delimiter: COMMON_DELIMITER,
+                'kv-delimiter': COMMON_KV_DELIMITER,
+                'key-placeholder': 'key',
+                'value-placeholder': 'value',
+              },
+            }}
+            pluginProperty={{
+              required: false,
+              name: 'Properties',
+            }}
+            value={localPropertiesInString}
+            onChange={(keyvalue) => onLocalPropertiesChange(keyvalue)}
+          />
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} color="primary">
+          Cancel
+        </Button>
+        <Button
+          onClick={saveSecureKey}
+          color="primary"
+          disabled={!localName || !localDescription || !localData}
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+const SecureKeyCreate = withStyles(styles)(SecureKeyCreateView);
+export default SecureKeyCreate;

--- a/cdap-ui/app/cdap/components/SecureKeys/SecureKeyDelete/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/SecureKeyDelete/index.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import ConfirmationModal from 'components/ConfirmationModal';
+import { MySecureKeyApi } from 'api/securekey';
+import React from 'react';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+
+interface ISecureKeyDeleteProps {
+  state: any;
+  open: boolean;
+  handleClose: () => void;
+  alertSuccess: () => void;
+}
+
+const SecureKeyDelete: React.FC<ISecureKeyDeleteProps> = ({
+  state,
+  open,
+  handleClose,
+  alertSuccess,
+}) => {
+  const { secureKeys, activeKeyIndex } = state;
+
+  const deleteSecureKey = () => {
+    const key = secureKeys.get(activeKeyIndex).get('name');
+
+    const namespace = getCurrentNamespace();
+    const params = {
+      namespace,
+      key,
+    };
+
+    MySecureKeyApi.delete(params).subscribe(() => {
+      handleClose();
+      alertSuccess();
+    });
+  };
+
+  return (
+    <ConfirmationModal
+      headerTitle={'Delete secure key'}
+      confirmationElem={'Are you sure you want to delete your secure key from your CDAP Account?'}
+      confirmButtonText={'Delete'}
+      confirmFn={deleteSecureKey}
+      cancelFn={handleClose}
+      isOpen={open}
+    />
+  );
+};
+
+export default SecureKeyDelete;

--- a/cdap-ui/app/cdap/components/SecureKeys/SecureKeyEdit/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/SecureKeyEdit/index.tsx
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { COMMON_DELIMITER, COMMON_KV_DELIMITER } from 'components/SecureKeys/constants';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import { Map } from 'immutable';
+import { MySecureKeyApi } from 'api/securekey';
+import React from 'react';
+import TextField from '@material-ui/core/TextField';
+import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+import isNil from 'lodash/isNil';
+
+const styles = (theme): StyleRules => {
+  return {
+    secureKeyInput: {
+      margin: `${theme.Spacing(3)}px ${theme.spacing(1)}px`,
+    },
+  };
+};
+
+interface ISecureKeyEditProps extends WithStyles<typeof styles> {
+  state: any;
+  open: boolean;
+  handleClose: () => void;
+  alertSuccess: () => void;
+}
+
+const SecureKeyEditView: React.FC<ISecureKeyEditProps> = ({
+  classes,
+  state,
+  open,
+  alertSuccess,
+  handleClose,
+}) => {
+  const { secureKeys, activeKeyIndex } = state;
+
+  const keyMetadata = secureKeys.get(activeKeyIndex);
+  const keyID = keyMetadata ? keyMetadata.get('name') : '';
+  const [localDescription, setLocalDescription] = React.useState(
+    keyMetadata ? keyMetadata.get('description') : ''
+  );
+  const [localData, setLocalData] = React.useState('');
+  // since 'properties' are in key-value form, keep a separate state in string form
+  const properties = keyMetadata ? keyMetadata.get('properties') : '';
+  const [localPropertiesInString, setLocalPropertiesInString] = React.useState('');
+
+  const [valueIsChanged, setValueIsChanged] = React.useState(false);
+
+  React.useEffect(() => {
+    if (isNil(properties)) {
+      return;
+    }
+    setLocalPropertiesInString(
+      properties
+        .entrySeq()
+        .map((e) => e.join(COMMON_KV_DELIMITER))
+        .join(COMMON_DELIMITER)
+    );
+  }, [properties]);
+
+  const onLocalDescriptionChange = (e) => {
+    setLocalDescription(e.target.value);
+    setValueIsChanged(true);
+  };
+
+  const onLocalDataChange = (e) => {
+    setLocalData(e.target.value);
+    setValueIsChanged(true);
+  };
+
+  const onLocalPropertiesChange = (keyvalue) => {
+    setLocalPropertiesInString(keyvalue);
+    setValueIsChanged(true);
+  };
+
+  const convertLocalPropertiesInString = (keyvalue: string) => {
+    let keyvaluePairs = Map({});
+    keyvalue.split(COMMON_DELIMITER).forEach((pair) => {
+      const [key, value] = pair.split(COMMON_KV_DELIMITER);
+      keyvaluePairs = keyvaluePairs.set(key, value);
+    });
+    return keyvaluePairs;
+  };
+
+  const editSecureKey = () => {
+    const namespace = getCurrentNamespace();
+
+    const params = {
+      namespace,
+      key: keyID,
+    };
+
+    const requestBody = {
+      description: localDescription,
+      properties: convertLocalPropertiesInString(localPropertiesInString),
+      data: localData,
+    };
+
+    MySecureKeyApi.put(params, requestBody).subscribe(() => {
+      setLocalDescription('');
+      setLocalData('');
+      setLocalPropertiesInString('');
+      alertSuccess();
+      handleClose();
+    });
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose}>
+      <DialogTitle>Edit {keyID}</DialogTitle>
+      <DialogContent>
+        <div className={classes.secureKeyInput}>
+          <TextField
+            required
+            variant="outlined"
+            label="Description"
+            defaultValue={localDescription}
+            onChange={onLocalDescriptionChange}
+            fullWidth
+            InputProps={{
+              className: classes.textField,
+            }}
+          />
+        </div>
+        <div className={classes.secureKeyInput}>
+          <TextField
+            required
+            variant="outlined"
+            label="Data"
+            type={'password'}
+            value={localData}
+            onChange={onLocalDataChange}
+            fullWidth
+            InputProps={{
+              className: classes.textField,
+            }}
+          />
+        </div>
+        <div className={classes.secureKeyInput}>
+          <WidgetWrapper
+            widgetProperty={{
+              label: 'Properties',
+              name: 'Properties',
+              'widget-type': 'keyvalue',
+              'widget-attributes': {
+                delimiter: COMMON_DELIMITER,
+                'kv-delimiter': COMMON_KV_DELIMITER,
+                'key-placeholder': 'key',
+                'value-placeholder': 'value',
+              },
+            }}
+            pluginProperty={{
+              required: false,
+              name: 'Properties',
+            }}
+            value={localPropertiesInString}
+            onChange={(keyvalue) => onLocalPropertiesChange(keyvalue)}
+          />
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} color="primary">
+          Cancel
+        </Button>
+        <Button
+          onClick={editSecureKey}
+          color="primary"
+          disabled={!valueIsChanged || !localDescription || !localData}
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+const SecureKeyEdit = withStyles(styles)(SecureKeyEditView);
+export default SecureKeyEdit;

--- a/cdap-ui/app/cdap/components/SecureKeys/SecureKeyList/SecureKeyActionButtons/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/SecureKeyList/SecureKeyActionButtons/index.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import IconButton from '@material-ui/core/IconButton';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import React from 'react';
+import { preventPropagation } from 'services/helpers';
+
+const styles = (theme): StyleRules => {
+  return {
+    secureKeyActionButtons: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+  };
+};
+
+interface ISecureKeyActionButtonsProps extends WithStyles<typeof styles> {
+  openDeleteDialog: (index: number) => void;
+  keyIndex: number;
+}
+
+const SecureKeyActionButtonsView: React.FC<ISecureKeyActionButtonsProps> = ({
+  classes,
+  openDeleteDialog,
+  keyIndex,
+}) => {
+  // Anchor element that appears when menu is clicked
+  const [menuEl, setMenuEl] = React.useState(null);
+
+  const handleMenuClick = (event) => {
+    preventPropagation(event);
+    setMenuEl(event.currentTarget);
+  };
+
+  const handleMenuClose = (event) => {
+    preventPropagation(event);
+    setMenuEl(null);
+  };
+
+  const onDeleteClick = (event, index) => {
+    openDeleteDialog(index);
+    handleMenuClose(event);
+  };
+
+  return (
+    <div className={classes.secureKeyActionButtons}>
+      <div>
+        <IconButton onClick={handleMenuClick}>
+          <MoreVertIcon />
+        </IconButton>
+        <ClickAwayListener onClickAway={handleMenuClose}>
+          <Menu anchorEl={menuEl} open={Boolean(menuEl)} onClose={handleMenuClose}>
+            <MenuItem onClick={(e) => onDeleteClick(e, keyIndex)}>Delete</MenuItem>
+          </Menu>
+        </ClickAwayListener>
+      </div>
+    </div>
+  );
+};
+
+const SecureKeyActionButtons = withStyles(styles)(SecureKeyActionButtonsView);
+export default SecureKeyActionButtons;

--- a/cdap-ui/app/cdap/components/SecureKeys/SecureKeyList/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/SecureKeyList/index.tsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+
+import Button from '@material-ui/core/Button';
+import Paper from '@material-ui/core/Paper';
+import SecureKeyActionButtons from 'components/SecureKeys/SecureKeyList/SecureKeyActionButtons';
+import SecureKeyCreate from 'components/SecureKeys/SecureKeyCreate';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+
+export const CustomTableCell = withStyles((theme) => ({
+  head: {
+    backgroundColor: theme.palette.grey['300'],
+    color: theme.palette.common.white,
+    padding: 10,
+    fontSize: 14,
+    '&:first-of-type': {
+      borderRight: `1px solid ${theme.palette.grey['500']}`,
+    },
+  },
+  body: {
+    padding: 10,
+    fontSize: 14,
+    '&:first-of-type': {
+      borderRight: `1px solid ${theme.palette.grey['500']}`,
+    },
+  },
+}))(TableCell);
+
+const styles = (theme): StyleRules => {
+  return {
+    secureKeysTitle: {
+      paddingTop: theme.spacing(1),
+    },
+    secureKeyManager: {
+      display: 'grid',
+      alignItems: 'center',
+      gridTemplateColumns: 'repeat(7, 1fr)',
+    },
+    addSecureKeyButton: {
+      gridRow: '1',
+      gridColumnStart: '1',
+    },
+    root: {
+      width: '100%',
+      display: 'inline-block',
+      height: 'auto',
+      marginTop: theme.spacing(1),
+    },
+    row: {
+      height: 40,
+      '&:nth-of-type(odd)': {
+        backgroundColor: theme.palette.grey['600'],
+      },
+      cursor: 'pointer',
+      hover: {
+        cursor: 'pointer',
+      },
+    },
+    nameCell: {
+      width: '30%',
+    },
+    descriptionCell: {
+      width: '60%',
+    },
+    actionButtonsCell: {
+      width: '10%',
+    },
+  };
+};
+
+interface ISecureKeyListProps extends WithStyles<typeof styles> {
+  state: any;
+  alertSuccess: () => void;
+  alertFailure: () => void;
+  openDeleteDialog: (index: number) => void;
+  openEditDialog: (index: number) => void;
+}
+
+const SecureKeyListView: React.FC<ISecureKeyListProps> = ({
+  classes,
+  state,
+  alertSuccess,
+  alertFailure,
+  openDeleteDialog,
+  openEditDialog,
+}) => {
+  const { secureKeys } = state;
+
+  const [createDialogOpen, setCreateDialogOpen] = React.useState(false);
+
+  return (
+    <div>
+      <h1 className={classes.secureKeysTitle}>Secure keys</h1>
+      <div className={classes.secureKeyManager}>
+        <div className={classes.addSecureKeyButton}>
+          <Button
+            variant="outlined"
+            color="primary"
+            size="small"
+            onClick={() => setCreateDialogOpen(true)}
+          >
+            Add Secure Key
+          </Button>
+        </div>
+      </div>
+
+      <Paper className={classes.root}>
+        <Table>
+          <TableHead>
+            <TableRow className={classes.row}>
+              <CustomTableCell>Key</CustomTableCell>
+              <CustomTableCell>Description</CustomTableCell>
+              <CustomTableCell></CustomTableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {secureKeys.map((keyMetadata, keyIndex) => {
+              const keyID = keyMetadata.get('name');
+              return (
+                <TableRow
+                  key={keyMetadata.get('name')}
+                  hover
+                  selected
+                  className={classes.row}
+                  onClick={() => openEditDialog(keyIndex)}
+                >
+                  <CustomTableCell className={classes.nameCell}>{keyID}</CustomTableCell>
+                  <CustomTableCell className={classes.descriptionCell}>
+                    {keyMetadata.get('description')}
+                  </CustomTableCell>
+                  <CustomTableCell className={classes.actionButtonsCell}>
+                    <SecureKeyActionButtons
+                      state={state}
+                      openDeleteDialog={openDeleteDialog}
+                      keyIndex={keyIndex}
+                      keyID={keyID}
+                    />
+                  </CustomTableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </Paper>
+
+      <SecureKeyCreate
+        state={state}
+        open={createDialogOpen}
+        handleClose={() => setCreateDialogOpen(false)}
+        alertSuccess={alertSuccess}
+        alertFailure={alertFailure}
+      />
+    </div>
+  );
+};
+
+const SecureKeyList = withStyles(styles)(SecureKeyListView);
+export default SecureKeyList;

--- a/cdap-ui/app/cdap/components/SecureKeys/constants.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/constants.tsx
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+export const COMMON_DELIMITER = ',';
+export const COMMON_KV_DELIMITER = ';';

--- a/cdap-ui/app/cdap/components/SecureKeys/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2019-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -15,165 +15,193 @@
  */
 
 import * as React from 'react';
-import { getCurrentNamespace } from 'services/NamespaceStore';
-import { MySecureKeyApi } from 'api/securekey';
-import TextField from '@material-ui/core/TextField';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
-import DeleteIcon from '@material-ui/icons/Delete';
-import Button from '@material-ui/core/Button';
-import IconButton from '@material-ui/core/IconButton';
-import Paper from '@material-ui/core/Paper';
 
-interface IState {
-  secureKeys: any[];
-  name: string;
+import { List, fromJS } from 'immutable';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+
+import Alert from 'components/Alert';
+import If from 'components/If';
+import LoadingSVGCentered from 'components/LoadingSVGCentered';
+import { MySecureKeyApi } from 'api/securekey';
+import SecureKeyDelete from 'components/SecureKeys/SecureKeyDelete';
+import SecureKeyEdit from 'components/SecureKeys/SecureKeyEdit';
+import SecureKeyList from 'components/SecureKeys/SecureKeyList';
+import { getCurrentNamespace } from 'services/NamespaceStore';
+
+interface ISecureKeyState {
+  createdEpochMs?: number;
   description: string;
+  name: string;
+  properties: Record<string, string>;
   data: string;
 }
 
-// Currently a hidden link to internally manage secure keys
-export default class SecureKeys extends React.PureComponent<{}, IState> {
-  public state = {
-    secureKeys: [],
-    name: '',
-    description: '',
-    data: '',
-  };
+export enum SecureKeyStatus {
+  Normal = 'Normal',
+  Success = 'SUCCESS',
+  Failure = 'FAILURE',
+}
 
-  public componentDidMount() {
-    this.fetchSecureKeys();
-  }
+export const initialState = {
+  secureKeys: List([]),
+  secureKeyStatus: SecureKeyStatus.Normal,
+  editMode: false,
+  deleteMode: false,
+  activeKeyIndex: null,
+  loading: true,
+};
 
-  private fetchSecureKeys = () => {
-    const namespace = getCurrentNamespace();
-
-    MySecureKeyApi.list({ namespace }).subscribe((res) => {
-      this.setState({
-        secureKeys: res,
-      });
-    });
-  };
-
-  private handleChange = (property) => {
-    return (e) => {
-      // @ts-ignore
-      this.setState({
-        [property]: e.target.value,
-      });
-    };
-  };
-
-  private addKey = () => {
-    const { name, description, data } = this.state;
-
-    if (!name || !data) {
-      return;
-    }
-
-    const namespace = getCurrentNamespace();
-
-    const params = {
-      namespace,
-      key: name,
-    };
-
-    const requestBody = {
-      description,
-      data,
-    };
-
-    MySecureKeyApi.add(params, requestBody).subscribe(() => {
-      this.setState({
-        name: '',
-        description: '',
-        data: '',
-      });
-      this.fetchSecureKeys();
-    });
-  };
-
-  private deleteKey = (key) => {
-    const namespace = getCurrentNamespace();
-    const params = {
-      namespace,
-      key,
-    };
-
-    MySecureKeyApi.delete(params).subscribe(this.fetchSecureKeys);
-  };
-
-  public render() {
-    return (
-      <div className="secure-keys-container container">
-        <h1>Secure Keys</h1>
-
-        <div className="key-input">
-          <TextField
-            label="Name"
-            value={this.state.name}
-            onChange={this.handleChange('name')}
-            margin="normal"
-            fullWidth={true}
-            variant="outlined"
-          />
-
-          <TextField
-            label="Description"
-            value={this.state.description}
-            onChange={this.handleChange('description')}
-            margin="normal"
-            fullWidth={true}
-            variant="outlined"
-          />
-
-          <TextField
-            label="data"
-            value={this.state.data}
-            onChange={this.handleChange('data')}
-            margin="normal"
-            fullWidth={true}
-            multiline={true}
-            variant="outlined"
-          />
-
-          <Button variant="contained" color="primary" onClick={this.addKey}>
-            Add Secure Key
-          </Button>
-        </div>
-
-        <hr />
-
-        <div className="key-lists">
-          <Paper>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Key</TableCell>
-                  <TableCell>Description</TableCell>
-                  <TableCell />
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {this.state.secureKeys.map((key) => (
-                  <TableRow key={key.name}>
-                    <TableCell>{key.name}</TableCell>
-                    <TableCell>{key.description}</TableCell>
-                    <TableCell>
-                      <IconButton color="secondary" onClick={this.deleteKey.bind(this, key.name)}>
-                        <DeleteIcon />
-                      </IconButton>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </Paper>
-        </div>
-      </div>
-    );
+export function reducer(state, action) {
+  switch (action.type) {
+    case 'SET_SECURE_KEYS':
+      return { ...state, secureKeys: action.secureKeys };
+    case 'SET_SECURE_KEY_STATUS':
+      return { ...state, secureKeyStatus: action.secureKeyStatus };
+    case 'SET_EDIT_MODE':
+      return { ...state, editMode: action.editMode };
+    case 'SET_DELETE_MODE':
+      return { ...state, deleteMode: action.deleteMode };
+    case 'SET_ACTIVE_KEY_INDEX':
+      return { ...state, activeKeyIndex: action.activeKeyIndex };
+    case 'SET_LOADING':
+      return { ...state, loading: action.loading };
+    default:
+      return state;
   }
 }
+
+const styles = (): StyleRules => {
+  return {
+    content: {
+      padding: '50px',
+    },
+    loadingBox: {
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+  };
+};
+
+interface ISecureKeysProps extends WithStyles<typeof styles> {}
+
+const SecureKeysView: React.FC<ISecureKeysProps> = ({ classes }) => {
+  const [state, dispatch] = React.useReducer(reducer, initialState);
+
+  const { secureKeyStatus, editMode, deleteMode, loading } = state;
+
+  const namespace = getCurrentNamespace();
+
+  React.useEffect(() => {
+    fetchSecureKeys();
+  }, []);
+
+  const fetchSecureKeys = () => {
+    // Update the states with incoming secure keys.
+    // Whenever user adds/edits/deletes a secure key, securekeyStatus emits a new value.
+    // In such case, re-call MySecureKeyApi.list to reflect the changes
+    MySecureKeyApi.list({ namespace }).subscribe((keys: ISecureKeyState[]) => {
+      dispatch({ type: 'SET_LOADING', loading: true });
+      if (!keys) {
+        return;
+      }
+
+      // Populate the table with matched secure keys
+      dispatch({ type: 'SET_SECURE_KEYS', secureKeys: fromJS(keys) });
+      dispatch({ type: 'SET_LOADING', loading: false });
+    });
+  };
+
+  // Success Alert component always closes after 3000ms.
+  // Failure Alert component status closes only when user manually closes it.
+  // Reset status when an Alert component is closed.
+  const onAlertClose = () => {
+    dispatch({ type: 'SET_SECURE_KEY_STATUS', secureKeyStatus: SecureKeyStatus.Normal });
+  };
+
+  const onEditDialogClose = () => {
+    dispatch({ type: 'SET_EDIT_MODE', editMode: false });
+    dispatch({ type: 'SET_ACTIVE_KEY_INDEX', activeKeyIndex: null });
+  };
+
+  const onDeleteDialogClose = () => {
+    dispatch({ type: 'SET_DELETE_MODE', deleteMode: false });
+    dispatch({ type: 'SET_ACTIVE_KEY_INDEX', activeKeyIndex: null });
+  };
+
+  const alertSuccess = () => {
+    dispatch({ type: 'SET_SECURE_KEY_STATUS', secureKeyStatus: SecureKeyStatus.Success });
+
+    fetchSecureKeys();
+  };
+
+  const alertFailure = () => {
+    dispatch({ type: 'SET_SECURE_KEY_STATUS', secureKeyStatus: SecureKeyStatus.Failure });
+  };
+
+  const openDeleteDialog = (keyIndex) => {
+    dispatch({ type: 'SET_DELETE_MODE', deleteMode: true });
+    dispatch({ type: 'SET_ACTIVE_KEY_INDEX', activeKeyIndex: keyIndex });
+  };
+
+  const openEditDialog = (keyIndex) => {
+    dispatch({ type: 'SET_EDIT_MODE', editMode: true });
+    dispatch({ type: 'SET_ACTIVE_KEY_INDEX', activeKeyIndex: keyIndex });
+  };
+
+  return (
+    <div className="container">
+      <Alert
+        message={'saved successfully'}
+        showAlert={secureKeyStatus === SecureKeyStatus.Success}
+        type="success"
+        onClose={onAlertClose}
+      />
+      <Alert
+        message={'Error: Duplicate key name'}
+        showAlert={secureKeyStatus === SecureKeyStatus.Failure}
+        type="error"
+        onClose={onAlertClose}
+      />
+
+      <div className={classes.content}>
+        <If condition={loading}>
+          <div className={classes.loadingBox}>
+            <LoadingSVGCentered />
+          </div>
+        </If>
+        <If condition={!loading}>
+          <SecureKeyList
+            state={state}
+            alertSuccess={alertSuccess}
+            alertFailure={alertFailure}
+            openEditDialog={openEditDialog}
+            openDeleteDialog={openDeleteDialog}
+          />
+        </If>
+      </div>
+
+      <If condition={editMode}>
+        <SecureKeyEdit
+          state={state}
+          open={editMode}
+          handleClose={onEditDialogClose}
+          alertSuccess={alertSuccess}
+        />
+      </If>
+      <If condition={deleteMode}>
+        <SecureKeyDelete
+          state={state}
+          open={deleteMode}
+          handleClose={onDeleteDialogClose}
+          alertSuccess={alertSuccess}
+        />
+      </If>
+    </div>
+  );
+};
+
+const SecureKeys = withStyles(styles)(SecureKeysView);
+export default SecureKeys;


### PR DESCRIPTION
Manage secure keys http://localhost:11011/cdap/ns/default/securekeys

- Currently we fetch `name` and `description` only. Use Observable to fetch secure `data` as well.
  * Since `data` is fetched with separate backend request call.
- Refine frontend design
  * Added separate dialogs for editing / creating / deleting secure keys.
- Error validation
   * Disallow adding duplicate `name` for secure keys

<img width="1792" alt="Screen Shot 2020-07-01 at 3 22 09 PM" src="https://user-images.githubusercontent.com/14116152/86283707-7849e100-bbaf-11ea-8346-e75898b5e102.png">
<img width="1792" alt="Screen Shot 2020-07-01 at 3 22 15 PM" src="https://user-images.githubusercontent.com/14116152/86283719-7f70ef00-bbaf-11ea-98a0-8f0fc2c39e52.png">
<img width="1792" alt="Screen Shot 2020-07-01 at 3 22 24 PM" src="https://user-images.githubusercontent.com/14116152/86283723-813ab280-bbaf-11ea-826f-b232945d39e7.png">
<img width="1792" alt="Screen Shot 2020-07-01 at 3 22 31 PM" src="https://user-images.githubusercontent.com/14116152/86283731-839d0c80-bbaf-11ea-9dec-bcffa124a0fb.png">
