### PR TITLE
[CDAP-17051] Add visibility of secure data (Secure Key Manager)

### DIFF
--- a/cdap-ui/app/cdap/components/SecureKeys/SecureKeyCreate/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/SecureKeyCreate/index.tsx
@@ -19,8 +19,12 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import IconButton from '@material-ui/core/IconButton';
+import InputAdornment from '@material-ui/core/InputAdornment';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import TextField from '@material-ui/core/TextField';
+import Visibility from '@material-ui/icons/Visibility';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
 import { MySecureKeyApi } from 'api/securekey';
 import classnames from 'classnames';
 import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
@@ -161,6 +165,17 @@ const SecureKeyCreateView: React.FC<ISecureKeyCreateProps> = ({
             onChange={onLocalDataChange}
             InputProps={{
               className: classes.textField,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle password visibility"
+                    onClick={() => setShowData(!showData)}
+                    edge="end"
+                  >
+                    {showData ? <Visibility /> : <VisibilityOff />}
+                  </IconButton>
+                </InputAdornment>
+              ),
             }}
           />
         </div>

--- a/cdap-ui/app/cdap/components/SecureKeys/SecureKeyEdit/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/SecureKeyEdit/index.tsx
@@ -19,8 +19,12 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import IconButton from '@material-ui/core/IconButton';
+import InputAdornment from '@material-ui/core/InputAdornment';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import TextField from '@material-ui/core/TextField';
+import Visibility from '@material-ui/icons/Visibility';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
 import { MySecureKeyApi } from 'api/securekey';
 import classnames from 'classnames';
 import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
@@ -159,6 +163,17 @@ const SecureKeyEditView: React.FC<ISecureKeyEditProps> = ({
             onChange={onLocalDataChange}
             InputProps={{
               className: classes.textField,
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle password visibility"
+                    onClick={() => setShowData(!showData)}
+                    edge="end"
+                  >
+                    {showData ? <Visibility /> : <VisibilityOff />}
+                  </IconButton>
+                </InputAdornment>
+              ),
             }}
           />
         </div>

--- a/cdap-ui/app/cdap/components/SecureKeys/SecureKeyList/SecureKeyActionButtons/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/SecureKeyList/SecureKeyActionButtons/index.tsx
@@ -19,6 +19,10 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+import If from 'components/If';
+import { Map } from 'immutable';
 import React from 'react';
 import { preventPropagation } from 'services/helpers';
 
@@ -34,7 +38,10 @@ const styles = (theme): StyleRules => {
 
 interface ISecureKeyActionButtonsProps extends WithStyles<typeof styles> {
   keyIndex: number;
+  keyID: string;
+  visibility: Map<string, boolean>;
   setActiveKeyIndex: (index: number) => void;
+  setVisibility: (visibility: Map<string, boolean>) => void;
   setEditMode: (mode: boolean) => void;
   setDeleteMode: (mode: boolean) => void;
 }
@@ -42,12 +49,20 @@ interface ISecureKeyActionButtonsProps extends WithStyles<typeof styles> {
 const SecureKeyActionButtonsView: React.FC<ISecureKeyActionButtonsProps> = ({
   classes,
   keyIndex,
+  keyID,
+  visibility,
   setActiveKeyIndex,
+  setVisibility,
   setEditMode,
   setDeleteMode,
 }) => {
   // Anchor element that appears when menu is clicked
   const [menuEl, setMenuEl] = React.useState(null);
+
+  const toggleVisibility = (event) => {
+    preventPropagation(event);
+    setVisibility(visibility.set(keyID, !visibility.get(keyID)));
+  };
 
   const handleMenuClick = (event) => {
     preventPropagation(event);
@@ -74,6 +89,14 @@ const SecureKeyActionButtonsView: React.FC<ISecureKeyActionButtonsProps> = ({
 
   return (
     <div className={classes.secureKeyActionButtons}>
+      <IconButton onClick={toggleVisibility}>
+        <If condition={!visibility.get(keyID)}>
+          <VisibilityIcon />
+        </If>
+        <If condition={visibility.get(keyID)}>
+          <VisibilityOffIcon />
+        </If>
+      </IconButton>
       <div>
         <IconButton onClick={handleMenuClick}>
           <MoreVertIcon />

--- a/cdap-ui/app/cdap/components/SecureKeys/SecureKeyList/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/SecureKeyList/index.tsx
@@ -27,7 +27,7 @@ import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import { SecureKeyStatus } from 'components/SecureKeys';
 import SecureKeyCreate from 'components/SecureKeys/SecureKeyCreate';
 import SecureKeyActionButtons from 'components/SecureKeys/SecureKeyList/SecureKeyActionButtons';
-import { List } from 'immutable';
+import { List, Map } from 'immutable';
 import * as React from 'react';
 
 const styles = (theme): StyleRules => {
@@ -76,6 +76,8 @@ interface ISecureKeyListProps extends WithStyles<typeof styles> {
   secureKeys: List<any>;
   setSecureKeyStatus: (status: SecureKeyStatus) => void;
   setActiveKeyIndex: (index: number) => void;
+  visibility: Map<string, boolean>;
+  setVisibility: (visibility: Map<string, boolean>) => void;
   setEditMode: (mode: boolean) => void;
   setDeleteMode: (mode: boolean) => void;
   loading: boolean;
@@ -86,6 +88,8 @@ const SecureKeyListView: React.FC<ISecureKeyListProps> = ({
   secureKeys,
   setSecureKeyStatus,
   setActiveKeyIndex,
+  visibility,
+  setVisibility,
   setEditMode,
   setDeleteMode,
   loading,
@@ -146,12 +150,19 @@ const SecureKeyListView: React.FC<ISecureKeyListProps> = ({
                     <TableCell className={classes.descriptionCell}>
                       {keyMetadata.get('description')}
                     </TableCell>
-                    <TableCell className={classes.dataCell}>{keyMetadata.get('data')}</TableCell>
+                    <TableCell className={classes.dataCell}>
+                      <If condition={!visibility.get(keyID)}>
+                        <input id="password" value="password" disabled type="password"></input>
+                      </If>
+                      <If condition={visibility.get(keyID)}>{keyMetadata.get('data')}</If>
+                    </TableCell>
                     <TableCell className={classes.actionButtonsCell}>
                       <SecureKeyActionButtons
                         keyIndex={keyIndex}
                         keyID={keyID}
+                        visibility={visibility}
                         setActiveKeyIndex={setActiveKeyIndex}
+                        setVisibility={setVisibility}
                         setEditMode={setEditMode}
                         setDeleteMode={setDeleteMode}
                       />

--- a/cdap-ui/app/cdap/components/SecureKeys/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/index.tsx
@@ -21,7 +21,7 @@ import If from 'components/If';
 import SecureKeyDelete from 'components/SecureKeys/SecureKeyDelete';
 import SecureKeyEdit from 'components/SecureKeys/SecureKeyEdit';
 import SecureKeyList from 'components/SecureKeys/SecureKeyList';
-import { fromJS, List } from 'immutable';
+import { fromJS, List, Map } from 'immutable';
 import * as React from 'react';
 import { BehaviorSubject } from 'rxjs';
 import { forkJoin } from 'rxjs/observable/forkJoin';
@@ -38,11 +38,6 @@ interface ISecureKeyState {
   name: string;
   properties: Record<string, string>;
   data: string;
-}
-
-export enum SecureKeysPageMode {
-  List = 'LIST',
-  Details = 'DETAILS',
 }
 
 export enum SecureKeyStatus {
@@ -63,6 +58,7 @@ interface ISecureKeysProps extends WithStyles<typeof styles> {}
 
 const SecureKeysView: React.FC<ISecureKeysProps> = ({ classes }) => {
   const [secureKeys, setSecureKeys] = React.useState(List([]));
+  const [visibility, setVisibility] = React.useState(Map<string, boolean>({}));
 
   const [loading, setLoading] = React.useState(true);
   const [secureKeyStatus, setSecureKeyStatus] = React.useState(SecureKeyStatus.Normal);
@@ -116,6 +112,17 @@ const SecureKeysView: React.FC<ISecureKeysProps> = ({ classes }) => {
       setLoading(true);
       // Populate the table with matched secure keys
       setSecureKeys(fromJS(keys));
+      const newVisibility = {};
+      keys.forEach(({ name }) => {
+        // If the secure key alrady exists, do not override visibility.
+        // Otherwise, initialize it to 'false'
+        if (visibility.has(name)) {
+          newVisibility[name] = visibility.get(name);
+        } else {
+          newVisibility[name] = false;
+        }
+      });
+      setVisibility(Map(newVisibility));
       setLoading(false);
     });
 
@@ -157,6 +164,8 @@ const SecureKeysView: React.FC<ISecureKeysProps> = ({ classes }) => {
           setActiveKeyIndex={setActiveKeyIndex}
           setEditMode={setEditMode}
           setDeleteMode={setDeleteMode}
+          visibility={visibility}
+          setVisibility={setVisibility}
           loading={loading}
         />
       </div>


### PR DESCRIPTION
`data` field of secure key has to be protected. Thus, unless user enables the visibility, the UI should not show this `data`.

User can toggle visibility of the secure key by clicking the eye icon.

<img width="1115" alt="Screen Shot 2020-07-01 at 3 44 41 PM" src="https://user-images.githubusercontent.com/14116152/86285215-32424c80-bbb2-11ea-8ea4-a12158e254e5.png">
<img width="1091" alt="Screen Shot 2020-07-01 at 3 44 52 PM" src="https://user-images.githubusercontent.com/14116152/86285218-353d3d00-bbb2-11ea-80db-61e17c80530c.png">
