### PR TITLE
[CDAP-17052] Add detail page for secure key (Secure Key Manager)

### DIFF
--- a/cdap-ui/app/cdap/components/SecureKeys/SecureKeyDelete/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/SecureKeyDelete/index.tsx
@@ -21,7 +21,7 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import { MySecureKeyApi } from 'api/securekey';
 import If from 'components/If';
-import { SecureKeyStatus } from 'components/SecureKeys';
+import { SecureKeysPageMode, SecureKeyStatus } from 'components/SecureKeys';
 import { List } from 'immutable';
 import React from 'react';
 import { getCurrentNamespace } from 'services/NamespaceStore';
@@ -32,6 +32,7 @@ interface ISecureKeyDeleteProps {
   secureKeys: List<any>;
   activeKeyIndex: number;
   setActiveKeyIndex: (index: number) => void;
+  setPageMode: (mode: SecureKeysPageMode) => void;
   setSecureKeyStatus: (status: SecureKeyStatus) => void;
 }
 
@@ -41,6 +42,7 @@ const SecureKeyDelete: React.FC<ISecureKeyDeleteProps> = ({
   handleClose,
   activeKeyIndex,
   setActiveKeyIndex,
+  setPageMode,
   setSecureKeyStatus,
 }) => {
   const deleteSecureKey = () => {
@@ -54,6 +56,7 @@ const SecureKeyDelete: React.FC<ISecureKeyDeleteProps> = ({
 
     MySecureKeyApi.delete(params).subscribe(() => {
       handleClose();
+      setPageMode(SecureKeysPageMode.List);
       setActiveKeyIndex(null);
       setSecureKeyStatus(SecureKeyStatus.Success);
     });

--- a/cdap-ui/app/cdap/components/SecureKeys/SecureKeyDetails/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/SecureKeyDetails/index.tsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import Button from '@material-ui/core/Button';
+import Divider from '@material-ui/core/Divider';
+import FormControl from '@material-ui/core/FormControl';
+import IconButton from '@material-ui/core/IconButton';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import Paper from '@material-ui/core/Paper';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+import TextField from '@material-ui/core/TextField';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
+import FileCopyOutlinedIcon from '@material-ui/icons/FileCopyOutlined';
+import Visibility from '@material-ui/icons/Visibility';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
+import classnames from 'classnames';
+import { SecureKeysPageMode } from 'components/SecureKeys';
+import { List } from 'immutable';
+import * as React from 'react';
+import { copyToClipBoard } from 'services/Clipboard';
+
+const styles = (theme): StyleRules => {
+  return {
+    secureKeysTitle: {
+      paddingTop: theme.spacing(1),
+    },
+    divider: {
+      width: '100vw',
+    },
+    secureKeyDetails: {
+      margin: `${theme.Spacing(3)}px 0px`,
+      border: `1px solid ${theme.palette.grey[300]}`,
+      borderRadius: '6px',
+      padding: theme.spacing(3),
+      display: 'grid',
+      gridTemplateColumns: 'repeat(4, 1fr)',
+    },
+    keyID: {
+      gridColumnStart: '1',
+      gridColumnEnd: '2',
+    },
+    details: {
+      gridColumnStart: '2',
+      gridColumnEnd: '5',
+    },
+    secureKeyActionButton: {
+      margin: theme.spacing(1),
+      float: 'right',
+    },
+    secureKeyInput: {
+      margin: `${theme.Spacing(1)}px 0px`,
+      whiteSpace: 'nowrap',
+      wordWrap: 'normal',
+      paddingRight: '12px',
+      letterSpacing: '.00625em',
+      fontSize: '1rem',
+      lineHeight: '1.5rem',
+    },
+  };
+};
+
+interface ISecureKeysDetailsProps extends WithStyles<typeof styles> {
+  secureKeys: List<any>;
+  activeKeyIndex: number;
+  setActiveKeyIndex: (index: number) => void;
+  setPageMode: (pageMode: SecureKeysPageMode) => void;
+  deleteKey: (index: number) => void;
+  setEditMode: (mode: boolean) => void;
+  setDeleteMode: (mode: boolean) => void;
+}
+
+const SecureKeysDetailsView: React.FC<ISecureKeysDetailsProps> = ({
+  classes,
+  activeKeyIndex,
+  secureKeys,
+  setActiveKeyIndex,
+  setPageMode,
+  setEditMode,
+  setDeleteMode,
+}) => {
+  const [showData, setShowData] = React.useState(false);
+
+  const keyMetadata = secureKeys.get(activeKeyIndex);
+
+  const handleBackButtonClick = () => {
+    setPageMode(SecureKeysPageMode.List);
+    setActiveKeyIndex(null);
+  };
+
+  return (
+    <div>
+      <h1 className={classes.secureKeysTitle}>
+        <IconButton onClick={handleBackButtonClick}>
+          <ArrowBackIcon />
+        </IconButton>
+        {keyMetadata.get('name')}
+      </h1>
+      <Divider className={classes.divider} />
+      <Paper className={classes.secureKeyDetails} elevation={0}>
+        <div className={classes.keyID}>{keyMetadata.get('name')}</div>
+        <div className={classes.details}>
+          <FormControl
+            fullWidth
+            className={classnames(classes.margin, classes.textField)}
+            variant="outlined"
+          >
+            <TextField
+              type={'text'}
+              value={keyMetadata.get('description')}
+              variant="filled"
+              className={classes.secureKeyInput}
+              InputProps={{
+                readOnly: true,
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton onClick={() => copyToClipBoard(keyMetadata.get('description'))}>
+                      <FileCopyOutlinedIcon />
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+          </FormControl>
+
+          <FormControl
+            fullWidth
+            className={classnames(classes.margin, classes.textField)}
+            variant="outlined"
+          >
+            <TextField
+              type={showData ? 'text' : 'password'}
+              value={'password'}
+              variant="filled"
+              color="primary"
+              className={classes.secureKeyInput}
+              InputProps={{
+                readOnly: true,
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      aria-label="toggle password visibility"
+                      onClick={() => setShowData(!showData)}
+                      edge="end"
+                    >
+                      {showData ? <Visibility /> : <VisibilityOff />}
+                    </IconButton>
+                    <IconButton onClick={() => copyToClipBoard(keyMetadata.get('data'))}>
+                      <FileCopyOutlinedIcon />
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+          </FormControl>
+
+          <Button
+            className={classes.secureKeyActionButton}
+            variant="outlined"
+            color="primary"
+            size="medium"
+            onClick={() => setDeleteMode(true)}
+          >
+            Delete
+          </Button>
+          <Button
+            className={classes.secureKeyActionButton}
+            variant="outlined"
+            color="primary"
+            size="medium"
+            onClick={() => setEditMode(true)}
+          >
+            Edit
+          </Button>
+        </div>
+      </Paper>
+    </div>
+  );
+};
+
+const SecureKeysDetails = withStyles(styles)(SecureKeysDetailsView);
+export default SecureKeysDetails;

--- a/cdap-ui/app/cdap/components/SecureKeys/SecureKeyList/index.tsx
+++ b/cdap-ui/app/cdap/components/SecureKeys/SecureKeyList/index.tsx
@@ -15,6 +15,7 @@
  */
 
 import Button from '@material-ui/core/Button';
+import Divider from '@material-ui/core/Divider';
 import Paper from '@material-ui/core/Paper';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 import Table from '@material-ui/core/Table';
@@ -24,7 +25,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import If from 'components/If';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
-import { SecureKeyStatus } from 'components/SecureKeys';
+import { SecureKeysPageMode, SecureKeyStatus } from 'components/SecureKeys';
 import SecureKeyCreate from 'components/SecureKeys/SecureKeyCreate';
 import SecureKeyActionButtons from 'components/SecureKeys/SecureKeyList/SecureKeyActionButtons';
 import { List, Map } from 'immutable';
@@ -32,6 +33,9 @@ import * as React from 'react';
 
 const styles = (theme): StyleRules => {
   return {
+    divider: {
+      width: '100vw',
+    },
     secureKeysTitle: {
       paddingTop: theme.spacing(1),
     },
@@ -78,6 +82,7 @@ interface ISecureKeyListProps extends WithStyles<typeof styles> {
   setActiveKeyIndex: (index: number) => void;
   visibility: Map<string, boolean>;
   setVisibility: (visibility: Map<string, boolean>) => void;
+  setPageMode: (pageMode: SecureKeysPageMode) => void;
   setEditMode: (mode: boolean) => void;
   setDeleteMode: (mode: boolean) => void;
   loading: boolean;
@@ -90,6 +95,7 @@ const SecureKeyListView: React.FC<ISecureKeyListProps> = ({
   setActiveKeyIndex,
   visibility,
   setVisibility,
+  setPageMode,
   setEditMode,
   setDeleteMode,
   loading,
@@ -98,6 +104,7 @@ const SecureKeyListView: React.FC<ISecureKeyListProps> = ({
 
   const onSecureKeyClick = (keyIndex) => {
     return () => {
+      setPageMode(SecureKeysPageMode.Details);
       setActiveKeyIndex(keyIndex);
     };
   };
@@ -105,6 +112,7 @@ const SecureKeyListView: React.FC<ISecureKeyListProps> = ({
   return (
     <div>
       <h1 className={classes.secureKeysTitle}>Secure keys</h1>
+      <Divider className={classes.divider} />
       <div className={classes.secureKeyManager}>
         <div className={classes.addSecureKeyButton}>
           <Button


### PR DESCRIPTION
Add detail page for each secure key. This page will be opened if user clicks a table row that represents a secure key.

<img width="1792" alt="Screen Shot 2020-07-01 at 3 57 04 PM" src="https://user-images.githubusercontent.com/14116152/86286231-1b9cf500-bbb4-11ea-8dfc-74ca1c7e07cd.png">
<img width="1792" alt="Screen Shot 2020-07-01 at 3 57 10 PM" src="https://user-images.githubusercontent.com/14116152/86286236-1d66b880-bbb4-11ea-93b1-0e23114c333a.png">
