### PR TITLE
[CDAP-17015] Update Preview UI to handle queued preview runs

### DIFF
--- a/cdap-ui/app/cdap/components/Alert/index.js
+++ b/cdap-ui/app/cdap/components/Alert/index.js
@@ -19,6 +19,7 @@ import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import { Modal } from 'reactstrap';
 import PropTypes from 'prop-types';
+import { ALERT_STATUS } from 'services/AlertStatus';
 
 require('./Alert.scss');
 const CLOSE_TIMEOUT = 3000;
@@ -63,7 +64,7 @@ export default class Alert extends Component {
   }
 
   resetTimeout = () => {
-    if (this.state.type === 'success' || this.state.type === 'info') {
+    if (this.state.type === ALERT_STATUS.Success || this.state.type === ALERT_STATUS.Info) {
       clearTimeout(this.alertTimeout);
       this.alertTimeout = setTimeout(this.onClose, CLOSE_TIMEOUT);
     }

--- a/cdap-ui/app/cdap/components/Alert/index.js
+++ b/cdap-ui/app/cdap/components/Alert/index.js
@@ -21,7 +21,7 @@ import { Modal } from 'reactstrap';
 import PropTypes from 'prop-types';
 
 require('./Alert.scss');
-const SUCCESS_CLOSE_TIMEOUT = 3000;
+const CLOSE_TIMEOUT = 3000;
 
 export default class Alert extends Component {
   state = {
@@ -39,13 +39,10 @@ export default class Alert extends Component {
     type: PropTypes.oneOf(['success', 'error', 'info']),
   };
 
-  successTimeout = null;
+  alertTimeout = null;
 
   componentDidMount() {
-    if (this.state.type === 'success') {
-      clearTimeout(this.successTimeout);
-      this.successTimeout = setTimeout(this.onClose, SUCCESS_CLOSE_TIMEOUT);
-    }
+    this.resetTimeout();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -62,11 +59,15 @@ export default class Alert extends Component {
         element,
       });
     }
-    if (this.state.type === 'success') {
-      clearTimeout(this.successTimeout);
-      this.successTimeout = setTimeout(this.onClose, SUCCESS_CLOSE_TIMEOUT);
-    }
+    this.resetTimeout();
   }
+
+  resetTimeout = () => {
+    if (this.state.type === 'success' || this.state.type === 'info') {
+      clearTimeout(this.alertTimeout);
+      this.alertTimeout = setTimeout(this.onClose, CLOSE_TIMEOUT);
+    }
+  };
 
   onClose = () => {
     this.setState({

--- a/cdap-ui/app/cdap/services/AlertStatus.ts
+++ b/cdap-ui/app/cdap/services/AlertStatus.ts
@@ -14,16 +14,11 @@
  * the License.
  */
 
-enum PREVIEW_STATUS {
-  WAITING = 'WAITING',
-  ACQUIRED = 'ACQUIRED',
-  INIT = 'INIT',
-  RUNNING = 'RUNNING',
-  COMPLETED = 'COMPLETED',
-  DEPLOY_FAILED = 'DEPLOY_FAILED',
-  RUN_FAILED = 'RUN_FAILED',
-  KILLED = 'KILLED',
-  KILLED_BY_TIMER = 'KILLED_BY_TIMER',
+// TO-DO(CDAP-17088): Move this to Alert component once it has been converted to TS
+enum ALERT_STATUS {
+  Success = 'success',
+  Error = 'error',
+  Info = 'info',
 }
 
-export { PREVIEW_STATUS };
+export { ALERT_STATUS };

--- a/cdap-ui/app/cdap/services/global-constants.js
+++ b/cdap-ui/app/cdap/services/global-constants.js
@@ -264,6 +264,13 @@ const GLOBALS = {
             'The artifacts required for this data pipeline are still being loaded. Please try again in a few minutes',
         },
         pluginDoesNotExist: 'This plugin does not exist: ',
+        PREVIEW: {
+          timerLabels: {
+            PENDING: 'Pending',
+            RUNNING: 'Running',
+            DURATION: 'Duration',
+          }
+        }
       },
       wizard: {
         welcomeMessage1: 'Hydrator makes it easy to prepare data so you ',

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -126,6 +126,7 @@ var PreviewDataView = require('../cdap/components/PreviewData').default;
 var PreviewLogs = require('../cdap/components/PreviewLogs').default;
 var SchemaEditor = require('../cdap/components/AbstractWidget/SchemaEditor').SchemaEditor;
 var PluginSchemaEditor = require('../cdap/components/PluginSchemaEditor').PluginSchemaEditor;
+var ALERT_STATUS = require('../cdap/services/AlertStatus').ALERT_STATUS;
 
 export {
   Store,
@@ -226,4 +227,5 @@ export {
   PreviewLogs,
   SchemaEditor,
   PluginSchemaEditor,
+  ALERT_STATUS,
 };

--- a/cdap-ui/app/hydrator/templates/create/toppanel.html
+++ b/cdap-ui/app/hydrator/templates/create/toppanel.html
@@ -232,12 +232,12 @@
         </div>
       </div>
     </div>
-    <div class="btn run-time">
+    <div class="btn run-time" title="{{HydratorPlusPlusTopPanelCtrl.queueStatus}}">
       <div class="btn-container">
         <span>
           {{ HydratorPlusPlusTopPanelCtrl.displayDuration.minutes }}:{{ HydratorPlusPlusTopPanelCtrl.displayDuration.seconds }}
         </span>
-        <div class="button-label">Duration</div>
+        <div class="button-label">{{HydratorPlusPlusTopPanelCtrl.timerLabel}}</div>
       </div>
     </div>
     <div class="btn log-viewer"

--- a/cdap-ui/app/services/alert-on-valium/alert-on-valium.js
+++ b/cdap-ui/app/services/alert-on-valium/alert-on-valium.js
@@ -19,14 +19,14 @@ angular.module(PKG.name + '.services')
     var isAnAlertOpened = false,
         alertObj;
 
-    var SUCCESS_ALERT_DURATION = 4; // duration amount in seconds
+    var SUCCESS_ALERT_DURATION = 3; // duration amount in seconds
 
     function show(obj) {
       if (alertObj) {
         alertObj.hide();
       }
 
-      obj.duration = obj.type === 'success' ? SUCCESS_ALERT_DURATION : false;
+      obj.duration = obj.type === 'success' || obj.type === 'info' ? SUCCESS_ALERT_DURATION : false;
       alertObj = $alert(obj);
       if (obj.templateUrl) {
         alertObj.$scope.templateScope = obj.templateScope;

--- a/cdap-ui/app/services/alert-on-valium/alert-on-valium.js
+++ b/cdap-ui/app/services/alert-on-valium/alert-on-valium.js
@@ -26,7 +26,7 @@ angular.module(PKG.name + '.services')
         alertObj.hide();
       }
 
-      obj.duration = obj.type === 'success' || obj.type === 'info' ? SUCCESS_ALERT_DURATION : false;
+      obj.duration = obj.type === window.CaskCommon.ALERT_STATUS.Success || obj.type === window.CaskCommon.ALERT_STATUS.Info ? SUCCESS_ALERT_DURATION : false;
       alertObj = $alert(obj);
       if (obj.templateUrl) {
         alertObj.$scope.templateScope = obj.templateScope;

--- a/cdap-ui/app/services/helpers.js
+++ b/cdap-ui/app/services/helpers.js
@@ -219,6 +219,14 @@ angular.module(PKG.name+'.services')
     return {errorCode, message};
   }
 
+  function extractErrorMessage(errObj) {
+    let  errorMsg = objectQuery(errObj, 'data') || objectQuery(errObj, 'response') || err;
+    if (typeof errorMsg !== 'string') {
+      errorMsg = JSON.stringify(errorMsg);
+    }
+    return errorMsg;
+  }
+
   /* ----------------------------------------------------------------------- */
   function validNamespaceResolver(stateParams) {
     const { namespace } = stateParams;
@@ -247,6 +255,7 @@ angular.module(PKG.name+'.services')
     getAbsUIUrl: $window.getAbsUIUrl,
     isNumeric: isNumeric,
     handlePageLevelError: handlePageLevelError,
+    extractErrorMessage: extractErrorMessage,
     objHasMissingValues: objHasMissingValues,
     validNamespaceResolver: validNamespaceResolver
   };


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-17015
Build: https://builds.cask.co/browse/CDAP-UDUT810
The preview status API has two new statuses: ACQUIRED and WAITING. WAITING is for when the run has been queued, and ACQUIRED is when the run has been taken off the queue and is about to be run. The updated behavior is:

- When the user clicks "Run", the timer will start (assuming no error from the backend). 
- At this time, the text under the timer will also change from “Duration” to either “N Pending” where (N  is the number of runs ahead in the queue) or “Running” if the run has started. 
- If the user hovers over the “N Pending” text, they will see a slightly longer status update, i.e. “N runs ahead in the queue.” 

Also did some minor refactoring of the existing Preview code and made small fixes to the Alert component to have consistent timeout between React and Angular and work properly for the "info" banner (which is not currently used anywhere). 