### PR TITLE
[CDAP-17057] Fix preference modal not resetting after error

### DIFF
--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemPrefsAccordion/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/SystemPrefsAccordion/index.js
@@ -181,7 +181,11 @@ export default class SystemPrefsAccordion extends Component {
 
     return (
       <div className="admin-config-container-content system-prefs-container-content">
-        <button className="btn btn-secondary" onClick={this.togglePrefsModal}>
+        <button
+          className="btn btn-secondary"
+          onClick={this.togglePrefsModal}
+          data-cy="edit-system-prefs-btn"
+        >
           {T.translate(`${PREFIX}.create`)}
         </button>
         <ViewAllLabel
@@ -215,6 +219,7 @@ export default class SystemPrefsAccordion extends Component {
         className={classnames('admin-config-container system-prefs-container', {
           expanded: this.props.expanded,
         })}
+        data-cy="system-prefs-accordion"
       >
         {this.renderLabel()}
         {this.renderContent()}

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceAction.scss
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceAction.scss
@@ -246,6 +246,7 @@ $focused-input-color: #66afe9;
 
           .inherited-preferences-container {
             padding-bottom: 40px;
+            padding-top:  15px;
 
             table {
               border-collapse: separate;

--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceModal.js
@@ -32,6 +32,7 @@ import NamespaceStore from 'services/NamespaceStore';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
 import { SCOPES } from 'services/global-constants';
+import If from 'components/If';
 
 export const PREFERENCES_LEVEL = {
   SYSTEM: SCOPES.SYSTEM,
@@ -185,6 +186,7 @@ export default class SetPreferenceModal extends Component {
         },
         (error) => {
           this.setState({
+            saving: false,
             error: isObject(error) ? error.response : error,
           });
         }
@@ -258,6 +260,7 @@ export default class SetPreferenceModal extends Component {
     event.preventDefault();
     this.setState({
       showResetMessage: true,
+      error: null,
     });
     this.getSpecifiedPreferences();
     setTimeout(() => {
@@ -447,7 +450,8 @@ export default class SetPreferenceModal extends Component {
                   <button
                     className="btn btn-primary float-left not-saving"
                     onClick={this.setPreferences}
-                    disabled={this.oneFieldMissing() || this.state.error ? 'disabled' : null}
+                    disabled={this.oneFieldMissing()}
+                    data-cy="save-prefs-btn"
                   >
                     <span>{saveAndCloseLabel}</span>
                   </button>
@@ -455,9 +459,9 @@ export default class SetPreferenceModal extends Component {
                 <span className="float-left reset">
                   <a onClick={this.resetFields}>{resetLink}</a>
                 </span>
-                {this.state.showResetMessage ? (
+                <If condition={this.state.showResetMessage}>
                   <span className="float-left text-success reset-success">Reset Successful</span>
-                ) : null}
+                </If>
                 {this.state.keyValues.pairs ? (
                   <span className="float-right num-rows">
                     {this.state.keyValues.pairs.length === 1 ? (
@@ -469,12 +473,14 @@ export default class SetPreferenceModal extends Component {
                 ) : null}
               </div>
               <div className="preferences-error">
-                {this.state.error ? (
-                  <div className="bg-danger text-white">{this.state.error}</div>
-                ) : null}
+                <If condition={this.state.error}>
+                  <div className="text-danger">{this.state.error}</div>
+                </If>
               </div>
             </div>
-            {!this.props.setAtLevel === PREFERENCES_LEVEL.SYSTEM ? <hr /> : null}
+            <If condition={!this.props.setAtLevel === PREFERENCES_LEVEL.SYSTEM}>
+              <hr />
+            </If>
             <div className="inherited-preferences-container">
               {this.renderInheritedPreferences()}
             </div>

--- a/cdap-ui/cypress/integration/admin.spec.ts
+++ b/cdap-ui/cypress/integration/admin.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { dataCy, loginIfRequired } from '../helpers';
+
+let headers = {};
+
+const TEST_KEY = 'name';
+const TEST_VALUE = 'hello';
+
+describe('Setting and saving preferences', () => {
+  before(() => {
+    loginIfRequired().then(() => {
+      cy.getCookie('CDAP_Auth_Token').then((cookie) => {
+        if (!cookie) {
+          return;
+        }
+        headers = {
+          Authorization: 'Bearer ' + cookie.value,
+        };
+      });
+    });
+  });
+
+  it('Should show error message if user tries to set profile at the instance level', () => {
+    cy.visit('cdap/administration/configuration');
+
+    cy.get(dataCy('system-prefs-accordion')).click();
+    cy.get(dataCy('edit-system-prefs-btn')).click();
+    cy.get(dataCy('key-value-pair-0')).within(() => {
+      cy.get('input[placeholder="key"]')
+        .clear()
+        .type('system.profile.name');
+      cy.get('input[placeholder="value"]')
+        .clear()
+        .type(TEST_VALUE);
+    });
+    cy.get(dataCy('save-prefs-btn')).click();
+    cy.get('.preferences-error').should('exist');
+  });
+  it('Should allow user to save valid preference at instance level after fixing error', () => {
+    cy.get(dataCy('key-value-pair-0')).within(() => {
+      cy.get('input[placeholder="key"]')
+        .clear()
+        .type(TEST_KEY);
+    });
+    cy.get(dataCy('save-prefs-btn')).click();
+    cy.get('.grid-row').within(() => {
+      cy.contains(TEST_KEY).should('be.visible');
+      cy.contains(TEST_VALUE).should('be.visible');
+    });
+  });
+});


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-17057
Build: https://builds.cask.co/browse/CDAP-UDUT718

Addressed bug by resetting "saving" state when user clicks "Save. Also made a few other fixes including:
- Clear error when user clicks "Reset"
- Make "Save" button disabled only when a field is empty but not when there is an error

Last but not least, added basic e2e test that checks that user can see error if they try to set system.profile.name at instance level, and they are also able to clear that error and save a valid preference. 