### PR TITLE
[CDAP-17062] Group and sort request logs by timestamp (RequestHistoryTab)

### DIFF
--- a/cdap-ui/app/cdap/components/HttpExecutor/utilities.ts
+++ b/cdap-ui/app/cdap/components/HttpExecutor/utilities.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { List, Map } from 'immutable';
+
+import { IRequestHistory } from 'components/HttpExecutor/RequestHistoryTab';
+import moment from 'moment';
+
+export function getDateID(date: Date) {
+  return moment(date).format('dddd, MMMM D, YYYY');
+}
+
+export function getRequestsByDate(log: Map<string, List<IRequestHistory>>, dateID: string) {
+  return log.get(dateID) || List([]);
+}

--- a/cdap-ui/app/cdap/components/LogViewer/LogLevel.tsx
+++ b/cdap-ui/app/cdap/components/LogViewer/LogLevel.tsx
@@ -15,13 +15,15 @@
  */
 
 import * as React from 'react';
-import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
-import { LogLevel as LogLevelEnum } from 'components/LogViewer/types';
-import DataFetcher from 'components/LogViewer/DataFetcher';
-import Popover from 'components/Popover';
-import If from 'components/If';
+
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+
 import ArrowDropDown from '@material-ui/icons/ArrowDropDown';
+import DataFetcher from 'components/LogViewer/DataFetcher';
 import IconSVG from 'components/IconSVG';
+import If from 'components/If';
+import { LogLevel as LogLevelEnum } from 'components/LogViewer/types';
+import Popover from 'components/Popover';
 
 const styles = (theme): StyleRules => {
   return {

--- a/cdap-ui/app/cdap/components/LogViewer/index.tsx
+++ b/cdap-ui/app/cdap/components/LogViewer/index.tsx
@@ -15,15 +15,17 @@
  */
 
 import * as React from 'react';
-import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+
 import { ILogResponse, LogLevel as LogLevelEnum } from 'components/LogViewer/types';
+import TopPanel, { TOP_PANEL_HEIGHT } from 'components/LogViewer/TopPanel';
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+
+import Alert from 'components/Alert';
 import DataFetcher from 'components/LogViewer/DataFetcher';
+import LogLevel from 'components/LogViewer/LogLevel';
 import LogRow from 'components/LogViewer/LogRow';
 import debounce from 'lodash/debounce';
-import TopPanel, { TOP_PANEL_HEIGHT } from 'components/LogViewer/TopPanel';
-import LogLevel from 'components/LogViewer/LogLevel';
 import { extractErrorMessage } from 'services/helpers';
-import Alert from 'components/Alert';
 
 export function logsTableGridStyle(theme): StyleRules {
   return {


### PR DESCRIPTION
<img width="1792" alt="Screen Shot 2020-07-08 at 11 54 00 AM" src="https://user-images.githubusercontent.com/14116152/86941487-feb37500-c111-11ea-8223-b19909aa1468.png">

Request history logs are now grouped and sorted by timestamp.

Before this PR, `requestLog` was kept in unsorted `List<IRequestHistory>`. Now, `requestLog` is in `Map<string, List<IRequestHistory>`, which maps timestamp date (e.g. April 5th) to a sorted list of corresponding request histories.