### PR TITLE
[CDAP-17063] Add additional functionalities to improve user experience (RequestHistoryTab)

### DIFF
--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestActionDialogs/ClearAllDialog/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestActionDialogs/ClearAllDialog/index.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import ConfirmationModal from 'components/ConfirmationModal';
+import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
+import React from 'react';
+import { connect } from 'react-redux';
+
+const mapDispatch = (dispatch) => {
+  return {
+    clearAllRequestLog: () => {
+      dispatch({
+        type: HttpExecutorActions.clearAllRequestLog,
+      });
+    },
+  };
+};
+
+interface IClearAllDialogProps {
+  open: boolean;
+  handleClose: () => void;
+  clearAllRequestLog: () => void;
+}
+
+const ClearAllDialogView: React.FC<IClearAllDialogProps> = ({
+  open,
+  handleClose,
+  clearAllRequestLog,
+}) => {
+  const onClearAllClick = () => {
+    clearAllRequestLog();
+    handleClose();
+  };
+
+  return (
+    <ConfirmationModal
+      isOpen={open}
+      headerTitle={'Clear all your request history'}
+      confirmationElem={<div>Are you sure you want to clear all your request history?</div>}
+      confirmButtonText={'Clear All'}
+      confirmFn={onClearAllClick}
+      cancelFn={handleClose}
+    />
+  );
+};
+
+const ClearAllDialog = connect(null, mapDispatch)(ClearAllDialogView);
+export default ClearAllDialog;

--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestActionDialogs/DeleteDialog/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestActionDialogs/DeleteDialog/index.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import ConfirmationModal from 'components/ConfirmationModal';
+import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
+import React from 'react';
+import { connect } from 'react-redux';
+
+const mapDispatch = (dispatch) => {
+  return {
+    deleteRequestLog: (requestID: string) => {
+      dispatch({
+        type: HttpExecutorActions.deleteRequestLog,
+        payload: {
+          requestID,
+        },
+      });
+    },
+  };
+};
+
+interface IDeleteDialogProps {
+  requestID: string;
+  open: boolean;
+  handleClose: () => void;
+  deleteRequestLog: (requestID: string) => void;
+}
+
+const DeleteDialogView: React.FC<IDeleteDialogProps> = ({
+  requestID,
+  open,
+  handleClose,
+  deleteRequestLog,
+}) => {
+  const onDeleteClick = () => {
+    deleteRequestLog(requestID);
+    handleClose();
+  };
+
+  return (
+    <ConfirmationModal
+      isOpen={open}
+      headerTitle={'Delete your request history'}
+      confirmationElem={<div>Are you sure you want to delete your request history?</div>}
+      confirmButtonText={'Delete'}
+      confirmFn={onDeleteClick}
+      cancelFn={handleClose}
+    />
+  );
+};
+
+const DeleteDialog = connect(null, mapDispatch)(DeleteDialogView);
+export default DeleteDialog;

--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestRow/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestRow/index.tsx
@@ -1,0 +1,219 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+
+import DeleteDialog from 'components/HttpExecutor/RequestHistoryTab/RequestActionDialogs/DeleteDialog';
+import DeleteIcon from '@material-ui/icons/Delete';
+import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
+import { IRequestHistory } from 'components/HttpExecutor/RequestHistoryTab';
+import { RequestMethod } from 'components/HttpExecutor';
+import ScheduleIcon from '@material-ui/icons/Schedule';
+import Tooltip from '@material-ui/core/Tooltip';
+import classnames from 'classnames';
+import { connect } from 'react-redux';
+
+const styles = (theme): StyleRules => {
+  return {
+    requestRow: {
+      padding: '10px 10px',
+      lineHeight: '24px',
+      display: 'flex',
+      justifyContent: 'space-between',
+      width: '100%',
+      cursor: 'pointer',
+
+      '&:hover:not($selectedRequestRow)': {
+        backgroundColor: theme.palette.grey[700],
+        '& $requestActionButton': {
+          visibility: 'visible',
+        },
+      },
+    },
+    selectedRequestRow: {
+      backgroundColor: `${theme.palette.blue[500]} !important`,
+    },
+    requestMethod: {
+      paddingLeft: '5px',
+      paddingRight: '5px',
+      color: theme.palette.white[50],
+      height: '100%',
+      fontWeight: 800,
+      justifyContent: 'center',
+      alignItems: 'flex-start',
+      fontSize: '10px',
+      width: '10%',
+    },
+    requestMethodText: {
+      width: '100%',
+      textAlign: 'left',
+      alignSelf: 'center',
+    },
+    requestPath: {
+      maxWidth: '70%',
+      minWidth: '70%',
+      wordWrap: 'break-word',
+      textAlign: 'left',
+      alignSelf: 'center',
+      textTransform: 'lowercase',
+      fontSize: '10px',
+      display: 'inline-block',
+      lineHeight: '1.3',
+    },
+    selectedRequestPath: {
+      color: theme.palette.orange[50],
+    },
+    getMethod: {
+      color: theme.palette.green[400],
+    },
+    postMethod: {
+      color: theme.palette.yellow[50],
+    },
+    putMethod: {
+      color: theme.palette.blue[50],
+    },
+    deleteMethod: {
+      color: theme.palette.red[50],
+    },
+    buttonTooltip: {
+      fontSize: '14px',
+      backgroundColor: theme.palette.grey[50],
+    },
+    requestActionButtons: {
+      justifyContent: 'flex-end',
+      whiteSpace: 'nowrap',
+    },
+    requestActionButton: {
+      display: 'inline-block',
+      visibility: 'hidden',
+    },
+    successStatus: {
+      color: theme.palette.green[50],
+    },
+    dangerStatus: {
+      color: theme.palette.red[100],
+    },
+  };
+};
+
+const mapStateToProps = (state) => {
+  return {
+    selectedRequest: state.http.selectedRequest,
+  };
+};
+
+const mapDispatch = (dispatch) => {
+  return {
+    setRequestHistoryView: (request: IRequestHistory) => {
+      dispatch({
+        type: HttpExecutorActions.setRequestHistoryView,
+        payload: request,
+      });
+    },
+  };
+};
+
+interface IRequestRowProps extends WithStyles<typeof styles> {
+  request: IRequestHistory;
+  selectedRequest: IRequestHistory;
+  setRequestHistoryView: (request: IRequestHistory) => void;
+}
+
+const RequestRowView: React.FC<IRequestRowProps> = ({
+  classes,
+  request,
+  selectedRequest,
+  setRequestHistoryView,
+}) => {
+  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
+
+  const onRequestClick = (req: IRequestHistory) => {
+    setRequestHistoryView(req);
+  };
+
+  const isSelectedRequest = selectedRequest && request.timestamp === selectedRequest.timestamp;
+
+  return (
+    <div>
+      <div
+        className={classnames(classes.requestRow, {
+          [classes.selectedRequestRow]: isSelectedRequest,
+        })}
+        onClick={() => onRequestClick(request)}
+      >
+        <div className={classes.requestTimestamp}>
+          <Tooltip
+            classes={{
+              tooltip: classes.buttonTooltip,
+            }}
+            title={request.timestamp}
+            placement="right"
+            className={classes.requestActionButton}
+          >
+            <ScheduleIcon />
+          </Tooltip>
+        </div>
+        <div
+          className={classnames({
+            [classes.successStatus]: request.statusCode < 300,
+            [classes.dangerStatus]: request.statusCode !== null && request.statusCode >= 300,
+          })}
+        >
+          {request.statusCode}
+        </div>
+        <div
+          className={classnames(classes.requestMethod, {
+            [classes.getMethod]: request.method === RequestMethod.GET,
+            [classes.postMethod]: request.method === RequestMethod.POST,
+            [classes.deleteMethod]: request.method === RequestMethod.DELETE,
+            [classes.putMethod]: request.method === RequestMethod.PUT,
+          })}
+        >
+          <div className={classes.requestMethodText}>{request.method}</div>
+        </div>
+        <div
+          className={classnames(classes.requestPath, {
+            [classes.selectedRequestPath]: isSelectedRequest,
+          })}
+        >
+          {request.path}
+        </div>
+        <div className={classes.requestActionButtons}>
+          <Tooltip
+            classes={{
+              tooltip: classes.buttonTooltip,
+            }}
+            title={'Delete request'}
+            placement="bottom"
+            className={classes.requestActionButton}
+          >
+            <DeleteIcon onClick={() => setDeleteDialogOpen(true)} />
+          </Tooltip>
+        </div>
+      </div>
+      <DeleteDialog
+        requestID={request.timestamp}
+        open={deleteDialogOpen}
+        handleClose={() => setDeleteDialogOpen(false)}
+      />
+    </div>
+  );
+};
+
+const RequestRow = withStyles(styles)(connect(mapStateToProps, mapDispatch)(RequestRowView));
+export default RequestRow;

--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestSearch/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestSearch/index.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
+
+import IconButton from '@material-ui/core/IconButton';
+import InputBase from '@material-ui/core/InputBase';
+import Paper from '@material-ui/core/Paper';
+import React from 'react';
+import SearchIcon from '@material-ui/icons/Search';
+
+const styles = (theme): StyleRules => {
+  return {
+    root: {
+      padding: '2px 4px',
+      display: 'flex',
+      alignItems: 'center',
+      width: '100%',
+      borderTop: `1px solid ${theme.palette.grey[300]}`,
+      borderBottom: `1px solid ${theme.palette.grey[300]}`,
+    },
+    searchInput: {
+      marginLeft: theme.spacing(1),
+      flex: 1,
+    },
+    searchIcon: {
+      padding: 10,
+    },
+  };
+};
+
+interface IRequestSearchProps extends WithStyles<typeof styles> {
+  searchText: string;
+  setSearchText: (searchText: string) => void;
+}
+
+const RequestSearchView: React.FC<IRequestSearchProps> = ({
+  classes,
+  searchText,
+  setSearchText,
+}) => {
+  return (
+    <Paper className={classes.root} elevation={0}>
+      <IconButton type="submit" className={classes.searchIcon}>
+        <SearchIcon />
+      </IconButton>
+      <InputBase
+        className={classes.searchInput}
+        placeholder="Search"
+        value={searchText}
+        onChange={(e) => setSearchText(e.target.value)}
+      />
+    </Paper>
+  );
+};
+
+const RequestSearch = withStyles(styles)(RequestSearchView);
+export default RequestSearch;

--- a/cdap-ui/app/cdap/components/HttpExecutor/SaveCalls/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/SaveCalls/index.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+
+import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
+import Switch from '@material-ui/core/Switch';
+import { connect } from 'react-redux';
+
+const mapStateToProps = (state) => {
+  return {
+    saveCalls: state.http.saveCalls,
+  };
+};
+
+const mapDispatch = (dispatch) => {
+  return {
+    toggleSaveCalls: () => {
+      dispatch({
+        type: HttpExecutorActions.toggleSaveCalls,
+      });
+    },
+  };
+};
+
+interface ISaveCallsProps {
+  saveCalls: boolean;
+  toggleSaveCalls: () => void;
+}
+
+const SaveCallsView: React.FC<ISaveCallsProps> = ({ saveCalls, toggleSaveCalls }) => {
+  return (
+    <div>
+      <Switch
+        checked={saveCalls}
+        onChange={() => toggleSaveCalls()}
+        color="primary"
+        name="checkedB"
+        inputProps={{ 'aria-label': 'primary checkbox' }}
+      />
+      Save calls
+    </div>
+  );
+};
+
+const SaveCalls = connect(mapStateToProps, mapDispatch)(SaveCallsView);
+export default SaveCalls;

--- a/cdap-ui/app/cdap/components/HttpExecutor/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/index.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -24,10 +24,17 @@ import { Provider } from 'react-redux';
 import React from 'react';
 import RequestHistoryTab from 'components/HttpExecutor/RequestHistoryTab';
 import RequestMetadata from 'components/HttpExecutor/RequestMetadata';
+import SaveCalls from 'components/HttpExecutor/SaveCalls';
 import SendButton from 'components/HttpExecutor/SendButton';
 import StatusCode from 'components/HttpExecutor/StatusCode';
 import { StyleRules } from '@material-ui/core/styles';
 import T from 'i18n-react';
+
+const PREFIX = 'features.HttpExecutor';
+
+require('./HttpExecutor.scss');
+
+export const LEFT_PANEL_WIDTH = 500;
 
 export enum RequestMethod {
   GET = 'GET',
@@ -35,12 +42,6 @@ export enum RequestMethod {
   PUT = 'PUT',
   DELETE = 'DELETE',
 }
-
-const PREFIX = 'features.HttpExecutor';
-
-require('./HttpExecutor.scss');
-
-export const LEFT_PANEL_WIDTH = 300;
 
 const styles = (theme): StyleRules => {
   return {
@@ -57,6 +58,27 @@ const styles = (theme): StyleRules => {
         overflowY: 'auto',
       },
     },
+    introPageRow: {
+      display: 'grid',
+      width: '100%',
+      gridTemplateColumns: 'repeat(7, 1fr)',
+      paddingTop: `${theme.Spacing(2)}px`,
+    },
+    pageTitle: {
+      fontSize: '20px',
+      paddingLeft: `${theme.Spacing(3)}px`,
+      gridColumnStart: '1',
+      gridColumnEnd: '2',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    saveCalls: {
+      gridColumnStart: '7',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
   };
 };
 
@@ -66,6 +88,13 @@ const HttpExecutorView: React.FC<WithStyles<typeof styles>> = ({ classes }) => {
       <div className={classes.content}>
         <RequestHistoryTab />
         <div className="http-executor">
+          <div className={classes.introPageRow}>
+            <div className={classes.pageTitle}>Http calls executor</div>
+            <div className={classes.saveCalls}>
+              <SaveCalls />
+            </div>
+          </div>
+
           <div className="request-section">
             <MethodSelector />
             <InputPath />
@@ -80,7 +109,6 @@ const HttpExecutorView: React.FC<WithStyles<typeof styles>> = ({ classes }) => {
                 <StatusCode />
               </span>
             </div>
-
             <HttpResponse />
           </div>
         </div>

--- a/cdap-ui/app/cdap/components/HttpExecutor/store/HttpExecutorActions.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/store/HttpExecutorActions.js
@@ -25,6 +25,9 @@ const HttpExecutorActions = {
   reset: 'HTTP_RESET',
   setRequestLog: 'HTTP_SET_REQUEST_LOG',
   setRequestHistoryView: 'HTTP_SET_REQUEST_HISTORY_VIEW',
+  toggleSaveCalls: 'HTTP_TOGGLE_SAVE_CALLS',
+  deleteRequestLog: 'HTTP_DELETE_REQUEST_LOG',
+  clearAllRequestLog: 'HTTP_CLEAR_ALL_REQUEST_LOG',
 };
 
 export default HttpExecutorActions;


### PR DESCRIPTION
<img width="1792" alt="Screen Shot 2020-07-09 at 8 23 36 AM" src="https://user-images.githubusercontent.com/14116152/87039652-7ee2e480-c1bd-11ea-9ecf-0ad2d79f924f.png">

- Hovering over a request log, we can see additional icons, which allow us to
    1. view timestamp of the log
    2. delete request log
- Search over request logs
-  Enable / disable save mode. When `saveRequests` mode is on, we save requests.
- Clear all request logs