### PR TITLE
[CDAP-17066] Integration test for RequestHistoryTab in HttpExecutor

### DIFF
--- a/cdap-ui/app/cdap/components/ConfirmationModal/index.js
+++ b/cdap-ui/app/cdap/components/ConfirmationModal/index.js
@@ -14,15 +14,14 @@
  * the License.
  */
 
-import PropTypes from 'prop-types';
-
-import React, { Component } from 'react';
-import { Modal, ModalHeader, ModalBody, ModalFooter } from 'reactstrap';
 import CardActionFeedback from 'components/CardActionFeedback';
 import IconSVG from 'components/IconSVG';
-import Mousetrap from 'mousetrap';
-import T from 'i18n-react';
 import If from 'components/If';
+import T from 'i18n-react';
+import Mousetrap from 'mousetrap';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { Modal, ModalBody, ModalFooter, ModalHeader } from 'reactstrap';
 
 require('./ConfirmationModal.scss');
 
@@ -143,6 +142,7 @@ export default class ConfirmationModal extends Component {
         backdrop="static"
         zIndex={1061}
         keyboard={this.props.keyboard}
+        data-cy="confirm-dialog"
       >
         <ModalHeader>
           {this.props.headerTitle}

--- a/cdap-ui/app/cdap/components/HttpExecutor/HttpResponse/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/HttpResponse/index.js
@@ -15,7 +15,6 @@
  */
 
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import { connect } from 'react-redux';
 
@@ -36,7 +35,7 @@ function HttpResponseView({ response }) {
 
   return (
     <div className="response-container">
-      <pre>{viewResponse}</pre>
+      <pre data-cy="response">{viewResponse}</pre>
     </div>
   );
 }

--- a/cdap-ui/app/cdap/components/HttpExecutor/InputPath/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/InputPath/index.js
@@ -56,6 +56,7 @@ function InputPathView({ value, onChange }) {
           placeholder={T.translate(`${PREFIX}.path`)}
           value={value}
           onChange={onChange}
+          data-cy="request-path-input"
         />
       </div>
     </div>

--- a/cdap-ui/app/cdap/components/HttpExecutor/MethodSelector/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/MethodSelector/index.js
@@ -14,11 +14,10 @@
  * the License.
  */
 
+import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import { connect } from 'react-redux';
-import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
 
 const mapStateToProps = (state) => {
   return {
@@ -44,7 +43,12 @@ function MethodSelectorView({ onChange, value }) {
 
   return (
     <div className="method-selector-container">
-      <select className="form-control" value={value} onChange={onChange}>
+      <select
+        className="form-control"
+        data-cy="request-method-selector"
+        value={value}
+        onChange={onChange}
+      >
         {METHODS.map((method) => {
           return (
             <option value={method} key={method}>

--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestRow/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestRow/index.tsx
@@ -151,6 +151,7 @@ const RequestRowView: React.FC<IRequestRowProps> = ({
   return (
     <div>
       <div
+        data-cy={`request-row-${request.timestamp}`}
         className={classnames(classes.requestRow, {
           [classes.selectedRequestRow]: isSelectedRequest,
         })}
@@ -164,8 +165,9 @@ const RequestRowView: React.FC<IRequestRowProps> = ({
             title={request.timestamp}
             placement="right"
             className={classes.requestActionButton}
+            data-cy="timestamp-tooltip"
           >
-            <ScheduleIcon />
+            <ScheduleIcon data-cy="timestamp-icon" />
           </Tooltip>
         </div>
         <div
@@ -184,9 +186,12 @@ const RequestRowView: React.FC<IRequestRowProps> = ({
             [classes.putMethod]: request.method === RequestMethod.PUT,
           })}
         >
-          <div className={classes.requestMethodText}>{request.method}</div>
+          <div className={classes.requestMethodText} data-cy="request-method">
+            {request.method}
+          </div>
         </div>
         <div
+          data-cy="request-path"
           className={classnames(classes.requestPath, {
             [classes.selectedRequestPath]: isSelectedRequest,
           })}
@@ -202,7 +207,7 @@ const RequestRowView: React.FC<IRequestRowProps> = ({
             placement="bottom"
             className={classes.requestActionButton}
           >
-            <DeleteIcon onClick={() => setDeleteDialogOpen(true)} />
+            <DeleteIcon data-cy="delete-icon" onClick={() => setDeleteDialogOpen(true)} />
           </Tooltip>
         </div>
       </div>

--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestSearch/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestSearch/index.tsx
@@ -62,6 +62,7 @@ const RequestSearchView: React.FC<IRequestSearchProps> = ({
         placeholder="Search"
         value={searchText}
         onChange={(e) => setSearchText(e.target.value)}
+        data-cy="request-search-input"
       />
     </Paper>
   );

--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/index.tsx
@@ -191,13 +191,14 @@ const RequestHistoryTabView: React.FC<IRequestHistoryTabProps> = ({
   };
 
   return (
-    <div className={classes.root}>
+    <div className={classes.root} data-cy="request-history-tab">
       <div className={classes.introRow}>
         <div className={classes.title}>Calls history</div>
         <Button
           color="primary"
           onClick={() => setClearAllDialogOpen(true)}
           className={classes.clearAllBtn}
+          data-cy="clear-btn"
         >
           Clear
         </Button>

--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestMetadata/Body/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestMetadata/Body/index.js
@@ -14,11 +14,10 @@
  * the License.
  */
 
+import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import { connect } from 'react-redux';
-import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
 
 const mapStateToProps = (state) => {
   return {
@@ -42,7 +41,7 @@ const mapDispatch = (dispatch) => {
 function BodyView({ value, onChange }) {
   return (
     <div className="request-body">
-      <textarea className="form-control" value={value} onChange={onChange} />
+      <textarea data-cy="request-body" className="form-control" value={value} onChange={onChange} />
     </div>
   );
 }

--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestMetadata/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestMetadata/index.js
@@ -14,15 +14,14 @@
  * the License.
  */
 
-import PropTypes from 'prop-types';
-
-import React from 'react';
+import classnames from 'classnames';
 import Body from 'components/HttpExecutor/RequestMetadata/Body';
 import Header from 'components/HttpExecutor/RequestMetadata/Header';
-import { connect } from 'react-redux';
 import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
-import classnames from 'classnames';
 import T from 'i18n-react';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 
 const PREFIX = 'features.HttpExecutor';
 
@@ -61,6 +60,7 @@ function RequestMetadataView({ activeTab, onTabClick, method }) {
             active: activeTab === 0,
           })}
           onClick={onTabClick.bind(null, 0, false)}
+          data-cy="header-btn"
         >
           <span>{T.translate(`${PREFIX}.header`)}</span>
         </div>
@@ -70,6 +70,7 @@ function RequestMetadataView({ activeTab, onTabClick, method }) {
             disabled: bodyDisabled,
           })}
           onClick={onTabClick.bind(null, 1, bodyDisabled)}
+          data-cy="body-btn"
         >
           <span>{T.translate(`${PREFIX}.body`)}</span>
         </div>

--- a/cdap-ui/app/cdap/components/HttpExecutor/SaveCalls/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/SaveCalls/index.tsx
@@ -47,6 +47,7 @@ const SaveCallsView: React.FC<ISaveCallsProps> = ({ saveCalls, toggleSaveCalls }
       <Switch
         checked={saveCalls}
         onChange={() => toggleSaveCalls()}
+        data-cy="save-mode-btn"
         color="primary"
         name="checkedB"
         inputProps={{ 'aria-label': 'primary checkbox' }}

--- a/cdap-ui/app/cdap/components/HttpExecutor/SendButton/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/SendButton/index.js
@@ -14,16 +14,16 @@
  * the License.
  */
 
-import React from 'react';
 import { execute } from 'components/HttpExecutor/store/HttpExecutorActionCreator';
 import T from 'i18n-react';
+import React from 'react';
 
 const PREFIX = 'features.HttpExecutor';
 
 export default function SendButton() {
   return (
     <div className="send-button-container text-right">
-      <button className="btn btn-primary" onClick={execute}>
+      <button className="btn btn-primary" onClick={execute} data-cy="send-btn">
         {T.translate(`${PREFIX}.send`)}
       </button>
     </div>

--- a/cdap-ui/app/cdap/components/HttpExecutor/StatusCode/index.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/StatusCode/index.js
@@ -14,12 +14,11 @@
  * the License.
  */
 
-import PropTypes from 'prop-types';
-
-import React from 'react';
-import { connect } from 'react-redux';
 import classnames from 'classnames';
 import T from 'i18n-react';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
 
 const PREFIX = 'features.HttpExecutor';
 
@@ -39,6 +38,7 @@ function StatusCodeView({ code }) {
           'text-success': code < 300,
           'text-danger': code !== null && code >= 300,
         })}
+        data-cy="response-status-code"
       >
         {code}
       </div>

--- a/cdap-ui/cypress/integration/httpexecutor.requesthistorytab.spec.ts
+++ b/cdap-ui/cypress/integration/httpexecutor.requesthistorytab.spec.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as Helpers from '../helpers';
+let headers = {};
+
+const { dataCy } = Helpers;
+
+const MOCK_LOCAL_STORAGE = JSON.stringify([
+    {
+      method: 'GET',
+      path: 'hello.com',
+      body: 'hello',
+      headers: { pairs: [{ key: '', value: '', uniqueId: '6fd93a6e-5b2f-47aa-8143-157629bdf457' }] },
+      response: 'Problem accessing: /v3/hello.com. Reason: Not Found',
+      statusCode: 404,
+      timestamp: '7/5/2020, 6:54:19 PM',
+    },
+    {
+      method: 'DELETE',
+      path: 'hello2.com',
+      body: 'hello2',
+      headers: { pairs: [{ key: '', value: '', uniqueId: '6fd93a6e-5b2f-47aa-8143-157629bdf457' }] },
+      response: 'Problem accessing: /v3/hello2.com. Reason: Not Found',
+      statusCode: 404,
+      timestamp: '7/6/2020, 6:54:19 PM',
+    },
+    {
+      method: 'POST',
+      path: 'hello3.com',
+      body: 'hello3',
+      headers: { pairs: [{ key: '', value: '', uniqueId: '6fd93a6e-5b2f-47aa-8143-157629bdf457' }] },
+      response: 'Problem accessing: /v3/hello3.com. Reason: Not Found',
+      statusCode: 409,
+      timestamp: '7/7/2020, 6:54:19 PM',
+    }
+  ]);
+
+describe('RequestHistoryTab in httpExecutor', () => {
+  // Uses API call to login instead of logging in manually through UI
+  before(() => {
+    Helpers.loginIfRequired().then(() => {
+      cy.getCookie('CDAP_Auth_Token').then((cookie) => {
+        if (!cookie) {
+          return;
+        }
+        headers = {
+          Authorization: 'Bearer ' + cookie.value,
+        };
+      });
+    });
+  });
+
+  describe('Accessing and managing secure keys', () => {
+    before(() => {
+      // Set local storage before visiting the page
+      localStorage.setItem('RequestHistory', MOCK_LOCAL_STORAGE);
+      cy.visit('/httpexecutor');
+    });
+
+    it('should show populate requestHistoryTab with existing items in localStorage', () => {
+      JSON.parse(MOCK_LOCAL_STORAGE).forEach((req) => {
+        const timestamp = req.timestamp;
+
+        cy.get(dataCy(`request-row-${timestamp}`)).should('exist');
+
+        cy.get(`${dataCy(`request-row-${timestamp}`)} ${dataCy('request-path')}`)
+          .invoke('text')
+          .should((text) => {
+            expect(text).to.eq(req.path);
+          });
+        cy.get(`${dataCy(`request-row-${timestamp}`)} ${dataCy('request-method')}`)
+          .invoke('text')
+          .should((text) => {
+            expect(text).to.eq(req.method);
+          });
+
+        // Check if main page has been populated correctly
+        cy.get(dataCy(`request-row-${timestamp}`)).click();
+        cy.get(dataCy('request-method-selector'))
+          .invoke('val')
+          .should((val) => {
+            expect(val).to.eq(req.method);
+          });
+        cy.get(dataCy('request-path-input'))
+          .invoke('val')
+          .should((val) => {
+            expect(val).to.eq(req.path);
+          });
+        cy.get(dataCy('response-status-code'))
+          .invoke('text')
+          .should((text) => {
+            expect(text).to.eq(req.statusCode.toString());
+          });
+        cy.get(dataCy('response'))
+          .invoke('text')
+          .should((text) => {
+            expect(text).to.eq(req.response);
+          });
+        if (req.method === 'POST') {
+          cy.get(dataCy('body-btn')).click();
+          cy.get(dataCy('request-body'))
+            .invoke('val')
+            .should((val) => {
+              expect(val).to.eq(req.body);
+            });
+        }
+      });
+    });
+
+    it('should search for requests from RequestHistoryTab', () => {
+      // All the requests include searchText1 in their path,
+      // validate every request appears in requestHistoryTab
+      const searchText1 = 'hello';
+      cy.get(dataCy('request-search-input'))
+        .click()
+        .focused()
+        .clear()
+        .type(searchText1);
+      cy.get('[data-cy*="request-row"]').should(
+        'have.length',
+        JSON.parse(MOCK_LOCAL_STORAGE).length
+      );
+
+      // Only one request include searchText2 in their path
+      const searchText2 = 'hello.com';
+      cy.get(dataCy('request-search-input'))
+        .click()
+        .focused()
+        .clear()
+        .type(searchText2);
+      cy.get('[data-cy*="request-row"]').should('have.length', 1);
+
+      // None of the requests include searchText3 in their path
+      const searchText3 = 'hellooo';
+      cy.get(dataCy('request-search-input'))
+        .click()
+        .focused()
+        .clear()
+        .type(searchText3);
+      cy.get('[data-cy*="request-row"]').should('have.length', 0);
+
+      // Clear out all the search text
+      cy.get(dataCy('request-search-input'))
+        .click()
+        .focused()
+        .clear();
+    });
+
+    it('should add a request to requestHistoryTab', () => {
+      // Should add a new request when the save mode is off
+      cy.get(dataCy('save-mode-btn')).click(); // turn off the save mode
+      const newRequest1 = {
+        method: 'DELETE',
+        path: 'https://new-request-1.com',
+      };
+      // Attempt to add a new request
+      cy.get(dataCy('request-method-selector')).select(newRequest1.method);
+      cy.get(dataCy('request-path-input'))
+        .clear()
+        .click()
+        .type(newRequest1.path);
+      cy.get(dataCy('send-btn')).click();
+      // Validate a new request has NOT been added to requestHistoryTab
+      cy.get('[data-cy*="request-row"]').should(
+        'have.length',
+        JSON.parse(MOCK_LOCAL_STORAGE).length
+      );
+
+      // Should add a new request when the save mode is on
+      cy.get(dataCy('save-mode-btn')).click(); // turn on the save mode
+      const newRequest2 = {
+        method: 'POST',
+        path: 'https://new-request-2.com',
+        body: 'hello4',
+      };
+      // Attempt to add a new request
+      cy.get(dataCy('request-method-selector')).select(newRequest2.method);
+      cy.get(dataCy('request-path-input'))
+        .clear()
+        .click()
+        .type(newRequest2.path);
+      cy.get(dataCy('request-body'))
+        .clear()
+        .click()
+        .type(newRequest2.body);
+      cy.get(dataCy('send-btn')).click();
+      // Validate a new request has been added to requestHistoryTab
+      cy.get('[data-cy*="request-row"]').should(
+        'have.length',
+        JSON.parse(MOCK_LOCAL_STORAGE).length + 1
+      );
+    });
+
+    it('should delete a request from RequestHistoryTab', () => {
+      // Delete the latest request from RequestHistoryTab
+      cy.get('[data-cy*="request-row"]').within(() => {
+        // Since delete-icon is a hidden element, we need click({force: true})
+        cy.get(dataCy('delete-icon'))
+          .first() // the first element has the latest request
+          .invoke('show')
+          .click({ force: true });
+      });
+
+      // Check whether a delete dialog has been opened
+      cy.get(dataCy('confirm-dialog')).should('exist');
+
+      // Confirm delete
+      cy.get(dataCy('Delete')).click();
+
+      // Validate the request has been deleted from requestHistoryTab
+      cy.get('[data-cy*="request-row"]').should(
+        'have.length',
+        JSON.parse(MOCK_LOCAL_STORAGE).length // back to the original length since the previous test added another request
+      );
+    });
+
+    it('should clear all requests in RequestHistoryTab', () => {
+      cy.get(dataCy('clear-btn')).click({ force: true }); // clear all the requests
+
+      // Check whether a clear dialog has been opened
+      cy.get(dataCy('confirm-dialog')).should('exist');
+
+      // Confirm clear
+      cy.get(dataCy('Clear All')).click();
+
+      // Validate all the requests has been cleared from requestHistoryTab
+      cy.get('[data-cy*="request-row"]').should('have.length', 0);
+    });
+  });
+});


### PR DESCRIPTION
Add integration test for the plugin JSON creator to test the following functionalities:

- Render the request logs, sorted by timestamp
- Add a request
- Delete a request
- Search for requests
- Enable / disable save mode
- Clear all requests