### PR TITLE
[CDAP-16850] Revamp schema editor

### DIFF
--- a/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/Select/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/Select/index.tsx
@@ -21,17 +21,36 @@ import { IWidgetProps } from 'components/AbstractWidget';
 import { objectQuery } from 'services/helpers';
 import { WIDGET_PROPTYPES } from 'components/AbstractWidget/constants';
 import withStyles from '@material-ui/core/styles/withStyles';
-
+import { blue } from 'components/ThemeWrapper/colors';
 const CustomizedInput = withStyles(() => {
   return {
     input: {
       padding: '7px 18px 7px 12px',
       '&:focus': {
         backgroundColor: 'transparent',
+        outline: `1px solid ${blue[100]}`,
       },
     },
   };
 })(InputBase);
+
+const DenseMenuItem = withStyles(() => {
+  return {
+    root: {
+      minHeight: 'unset',
+      paddingTop: '3px',
+      paddingBottom: '3px',
+    },
+  };
+})(MenuItem);
+
+const InlineSelect = withStyles(() => {
+  return {
+    root: {
+      display: 'inline-block',
+    },
+  };
+})(Select);
 
 interface ISelectOptions {
   value: string | number; // We need to expand this when we have complex use cases
@@ -40,9 +59,13 @@ interface ISelectOptions {
 
 interface ISelectWidgetProps {
   options: ISelectOptions[] | string[] | number[];
+  dense?: boolean;
+  inline?: boolean;
 }
 
-interface ISelectProps extends IWidgetProps<ISelectWidgetProps> {}
+interface ISelectProps extends IWidgetProps<ISelectWidgetProps> {
+  inputRef?: (ref: React.ReactNode) => void;
+}
 
 const CustomSelect: React.FC<ISelectProps> = ({
   value,
@@ -50,6 +73,7 @@ const CustomSelect: React.FC<ISelectProps> = ({
   widgetProps,
   disabled,
   dataCy,
+  inputRef,
 }: ISelectProps) => {
   const onChangeHandler = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const v = event.target.value;
@@ -59,12 +83,16 @@ const CustomSelect: React.FC<ISelectProps> = ({
   };
 
   const options = objectQuery(widgetProps, 'options') || objectQuery(widgetProps, 'values') || [];
+  const dense = objectQuery(widgetProps, 'dense') || false;
+  const inline = objectQuery(widgetProps, 'inline') || false;
+  const OptionItem = dense ? DenseMenuItem : MenuItem;
+  const SelectComponent = inline ? InlineSelect : Select;
   const optionValues = options.map((opt) => {
     return ['string', 'number'].indexOf(typeof opt) !== -1 ? { value: opt, label: opt } : opt;
   });
 
   return (
-    <Select
+    <SelectComponent
       fullWidth
       value={value}
       onChange={onChangeHandler}
@@ -73,13 +101,21 @@ const CustomSelect: React.FC<ISelectProps> = ({
       inputProps={{
         'data-cy': dataCy,
       }}
+      MenuProps={{
+        getContentAnchorEl: null,
+        anchorOrigin: {
+          vertical: 'bottom',
+          horizontal: 'left',
+        },
+      }}
+      inputRef={inputRef}
     >
       {optionValues.map((opt) => (
-        <MenuItem value={opt.value} key={opt.value} disabled={opt.disabled}>
+        <OptionItem value={opt.value} key={opt.value}>
           {opt.label}
-        </MenuItem>
+        </OptionItem>
       ))}
-    </Select>
+    </SelectComponent>
   );
 };
 

--- a/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/TextBox/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/TextBox/index.tsx
@@ -27,6 +27,7 @@ interface ITextBoxWidgetProps {
 interface ITextBoxProps extends IWidgetProps<ITextBoxWidgetProps> {
   autoFocus?: boolean;
   inputRef?: (ref: React.ReactNode) => void;
+  className?: string;
 }
 
 const TextBox: React.FC<ITextBoxProps> = ({
@@ -39,6 +40,7 @@ const TextBox: React.FC<ITextBoxProps> = ({
   autoFocus,
   inputRef,
   onKeyPress,
+  className,
 }) => {
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     const v = event.target.value;
@@ -68,6 +70,7 @@ const TextBox: React.FC<ITextBoxProps> = ({
       }}
       autoFocus={autoFocus}
       inputRef={inputRef}
+      className={className}
     />
   );
 };

--- a/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/TextBox/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/TextBox/index.tsx
@@ -24,13 +24,32 @@ interface ITextBoxWidgetProps {
   placeholder?: string;
 }
 
-interface ITextBoxProps extends IWidgetProps<ITextBoxWidgetProps> {}
+interface ITextBoxProps extends IWidgetProps<ITextBoxWidgetProps> {
+  autoFocus?: boolean;
+  inputRef?: (ref: React.ReactNode) => void;
+}
 
-const TextBox: React.FC<ITextBoxProps> = ({ value, onChange, widgetProps, disabled, dataCy }) => {
+const TextBox: React.FC<ITextBoxProps> = ({
+  value,
+  onChange,
+  onBlur,
+  widgetProps,
+  disabled,
+  dataCy,
+  autoFocus,
+  inputRef,
+  onKeyPress,
+}) => {
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     const v = event.target.value;
     if (typeof onChange === 'function') {
       onChange(v);
+    }
+  };
+  const onBlurHandler = (event: React.FocusEvent<HTMLInputElement>) => {
+    const v = event.target.value;
+    if (typeof onBlur === 'function') {
+      onBlur(v);
     }
   };
 
@@ -40,14 +59,18 @@ const TextBox: React.FC<ITextBoxProps> = ({ value, onChange, widgetProps, disabl
       fullWidth
       value={value}
       onChange={onChangeHandler}
+      onBlur={onBlurHandler}
+      onKeyPress={onKeyPress}
       placeholder={placeholder}
       readOnly={disabled}
       inputProps={{
         'data-cy': dataCy,
       }}
+      autoFocus={autoFocus}
+      inputRef={inputRef}
     />
   );
 };
 
-export default TextBox;
+export default React.memo(TextBox);
 (TextBox as any).propTypes = WIDGET_PROPTYPES;

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/ArrayType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/ArrayType/index.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import { schemaTypes } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import { SingleColumnWrapper } from 'components/AbstractWidget/SchemaEditor/SingleColumnWrapper';
+import Select from 'components/AbstractWidget/FormInputs/Select';
+import { IFieldTypeBaseProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { RowButtons } from 'components/AbstractWidget/SchemaEditor/RowButtons';
+
+const ArrayTypeBase = ({
+  type,
+  nullable,
+  onChange,
+  autoFocus,
+  typeProperties,
+}: IFieldTypeBaseProps) => {
+  const [fieldType, setFieldType] = React.useState(type);
+  const [fieldNullable, setFieldNullable] = React.useState(nullable);
+  const [fieldTypeProperties, setFieldTypeProperties] = React.useState(typeProperties || {});
+
+  const onTypePropertiesChangeHandler = (property, value) => {
+    if (property === 'typeProperties') {
+      setFieldTypeProperties(value);
+    }
+    onChange(property, value);
+  };
+  const inputEle = React.useRef(null);
+  React.useEffect(() => {
+    if (autoFocus && inputEle.current) {
+      inputEle.current.focus();
+    }
+  }, [autoFocus]);
+  const onNullable = (checked) => {
+    setFieldNullable(checked);
+    onChange('nullable', checked);
+  };
+  return (
+    <React.Fragment>
+      <SingleColumnWrapper>
+        <Select
+          value={fieldType}
+          onChange={(newValue) => {
+            setFieldType(newValue);
+            onChange('type', newValue);
+          }}
+          widgetProps={{ options: schemaTypes, dense: true }}
+          inputRef={(ref) => (inputEle.current = ref)}
+        />
+      </SingleColumnWrapper>
+      <RowButtons
+        nullable={fieldNullable}
+        onNullable={type === 'union' ? undefined : onNullable}
+        type={fieldType}
+        onChange={onTypePropertiesChangeHandler}
+        typeProperties={fieldTypeProperties}
+      />
+    </React.Fragment>
+  );
+};
+
+const ArrayType = React.memo(ArrayTypeBase);
+export { ArrayType };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/ArrayType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/ArrayType/index.tsx
@@ -15,7 +15,10 @@
  */
 
 import * as React from 'react';
-import { schemaTypes } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import {
+  schemaTypes,
+  AvroSchemaTypesEnum,
+} from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 import { SingleColumnWrapper } from 'components/AbstractWidget/SchemaEditor/SingleColumnWrapper';
 import Select from 'components/AbstractWidget/FormInputs/Select';
 import { IFieldTypeBaseProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
@@ -27,6 +30,7 @@ const ArrayTypeBase = ({
   onChange,
   autoFocus,
   typeProperties,
+  disabled = false,
 }: IFieldTypeBaseProps) => {
   const [fieldType, setFieldType] = React.useState(type);
   const [fieldNullable, setFieldNullable] = React.useState(nullable);
@@ -52,18 +56,20 @@ const ArrayTypeBase = ({
     <React.Fragment>
       <SingleColumnWrapper>
         <Select
+          disabled={disabled}
           value={fieldType}
           onChange={(newValue) => {
             setFieldType(newValue);
             onChange('type', newValue);
           }}
-          widgetProps={{ options: schemaTypes, dense: true }}
+          widgetProps={{ options: schemaTypes, dense: true, native: true }}
           inputRef={(ref) => (inputEle.current = ref)}
         />
       </SingleColumnWrapper>
       <RowButtons
+        disabled={disabled}
         nullable={fieldNullable}
-        onNullable={type === 'union' ? undefined : onNullable}
+        onNullable={type === AvroSchemaTypesEnum.UNION ? undefined : onNullable}
         type={fieldType}
         onChange={onTypePropertiesChangeHandler}
         typeProperties={fieldTypeProperties}

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/FlatSchema.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/FlatSchema.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import isObject from 'lodash/isObject';
+import { INode } from 'components/AbstractWidget/SchemaEditor/Context/SchemaParser';
+import { IFlattenRowType } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { ISchemaManagerOptions } from 'components/AbstractWidget/SchemaEditor/Context/SchemaManager';
+import { InternalTypesEnum } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+
+/**
+ * DFS traversal of the schema tree to flatten.
+ */
+function FlatSchemaBase(
+  schemaTree: INode,
+  options: ISchemaManagerOptions,
+  ancestors = [],
+  isParentCollapsed = false
+) {
+  const result: IFlattenRowType[] = [];
+  if (!schemaTree) {
+    return [];
+  }
+  const { internalType, name, id, children, type, typeProperties, nullable } = schemaTree;
+  const hasChildren = isObject(children) && Object.keys(children).length;
+  const collapsed =
+    hasChildren && internalType !== InternalTypesEnum.SCHEMA ? options.collapseAll : null;
+  result.push({
+    internalType,
+    name,
+    id,
+    type,
+    typeProperties,
+    ancestors,
+    nullable,
+    collapsed,
+    hidden: isParentCollapsed,
+  });
+  if (hasChildren) {
+    let iterable;
+    if (Array.isArray(children.order) && children.order.length) {
+      iterable = children.order;
+      for (const childId of iterable) {
+        result.push(...FlatSchemaBase(children[childId], options, ancestors.concat(id), collapsed));
+      }
+    } else {
+      iterable = children;
+      for (const [_, value] of Object.entries<INode>(iterable)) {
+        result.push(...FlatSchemaBase(value, options, ancestors.concat(id), collapsed));
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Flatten any schema tree node (node + children) to an array.
+ * This is generic to be used on the main avro schema tree as well as any sub tree.
+ * @param schemaTree Avro schema tree to flatten
+ * @param options Options to flatten.
+ * @param ancestors Ancestors of the current tree. The main schema tree will have no ancestors.
+ */
+function FlatSchema(schemaTree: INode, options: ISchemaManagerOptions, ancestors = []) {
+  return FlatSchemaBase(schemaTree, options, ancestors);
+}
+export { FlatSchema };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaGenerator.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaGenerator.ts
@@ -28,12 +28,13 @@ import uuidV4 from 'uuid/v4';
 import {
   getDefaultEmptyAvroSchema,
   InternalTypesEnum,
+  AvroSchemaTypesEnum,
 } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 import { isDisplayTypeComplex } from 'components/AbstractWidget/SchemaEditor/SchemaHelpers';
 
 function generateArrayType(children: IOrderedChildren, nullable: boolean) {
   const finalType = {
-    type: 'array',
+    type: AvroSchemaTypesEnum.ARRAY,
     items: null,
   };
   for (const childId of Object.keys(children)) {
@@ -59,9 +60,9 @@ function generateArrayType(children: IOrderedChildren, nullable: boolean) {
 
 function generateMapType(children: IOrderedChildren, nullable) {
   const finalType = {
-    type: 'map',
-    keys: 'string',
-    values: 'string',
+    type: AvroSchemaTypesEnum.MAP,
+    keys: AvroSchemaTypesEnum.STRING,
+    values: AvroSchemaTypesEnum.STRING,
   };
   for (const childId of Object.keys(children)) {
     const currentChild = children[childId];
@@ -90,7 +91,7 @@ function generateMapType(children: IOrderedChildren, nullable) {
 
 function generateEnumType(children: IOrderedChildren, currentNode: INode, nullable) {
   const finalType: IEnumFieldBase = {
-    type: 'enum',
+    type: AvroSchemaTypesEnum.ENUM,
     symbols: [],
   };
   const { typeProperties: currentTypeProperties = {} } = currentNode;
@@ -120,7 +121,7 @@ function generateEnumType(children: IOrderedChildren, currentNode: INode, nullab
 
 function generateRecordType(children: IOrderedChildren, currentNode: INode, nullable: boolean) {
   const finalType: IRecordField = {
-    type: 'record',
+    type: AvroSchemaTypesEnum.RECORD,
     name: currentNode.name || `name-${uuidV4()}`,
     fields: [],
   };
@@ -184,20 +185,20 @@ function generateLogicalType(child) {
 function generateSchemaFromComplexType(type: string, currentChild, nullable: boolean) {
   const complexTypeChildren: IOrderedChildren = currentChild.children;
   switch (type) {
-    case 'array':
+    case AvroSchemaTypesEnum.ARRAY:
       return generateArrayType(complexTypeChildren, nullable);
-    case 'map':
+    case AvroSchemaTypesEnum.MAP:
       return generateMapType(complexTypeChildren, nullable);
-    case 'enum':
+    case AvroSchemaTypesEnum.ENUM:
       return generateEnumType(complexTypeChildren, currentChild, nullable);
-    case 'union':
+    case AvroSchemaTypesEnum.UNION:
       return generateUnionType(complexTypeChildren);
-    case 'record':
+    case AvroSchemaTypesEnum.RECORD:
       return generateRecordType(complexTypeChildren, currentChild, nullable);
-    case 'time':
-    case 'timestamp':
-    case 'decimal':
-    case 'date':
+    case AvroSchemaTypesEnum.TIME:
+    case AvroSchemaTypesEnum.TIMESTAMP:
+    case AvroSchemaTypesEnum.DECIMAL:
+    case AvroSchemaTypesEnum.DATE:
       return generateLogicalType(currentChild);
     default:
       return type;

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaGenerator.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaGenerator.ts
@@ -1,0 +1,243 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import {
+  INode,
+  IOrderedChildren,
+} from 'components/AbstractWidget/SchemaEditor/Context/SchemaParser';
+import {
+  ISchemaType,
+  IEnumFieldBase,
+  IFieldType,
+  IRecordField,
+} from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+import uuidV4 from 'uuid/v4';
+import {
+  getDefaultEmptyAvroSchema,
+  InternalTypesEnum,
+} from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import { isDisplayTypeComplex } from 'components/AbstractWidget/SchemaEditor/SchemaHelpers';
+
+function generateArrayType(children: IOrderedChildren, nullable: boolean) {
+  const finalType = {
+    type: 'array',
+    items: null,
+  };
+  for (const childId of Object.keys(children)) {
+    const currentChild = children[childId];
+    const { type: childType, nullable: isArrayTypeNullable } = currentChild;
+    const isArrayTypeComplex = isDisplayTypeComplex({ type: childType });
+    if (!isArrayTypeComplex) {
+      finalType.items = isArrayTypeNullable ? [childType, 'null'] : childType;
+      continue;
+    }
+    // nested complex types.
+    const complexType = generateSchemaFromComplexType(
+      childType,
+      currentChild,
+      currentChild.nullable
+    );
+    if (complexType) {
+      finalType.items = complexType;
+    }
+  }
+  return nullable ? [finalType, 'null'] : finalType;
+}
+
+function generateMapType(children: IOrderedChildren, nullable) {
+  const finalType = {
+    type: 'map',
+    keys: 'string',
+    values: 'string',
+  };
+  for (const childId of Object.keys(children)) {
+    const currentChild = children[childId];
+    const { type, nullable: isCurrentChildNullable, internalType } = currentChild;
+    const isMapChildComplexType = isDisplayTypeComplex({ type });
+    if (!isMapChildComplexType) {
+      if (internalType === InternalTypesEnum.MAP_KEYS_SIMPLE_TYPE) {
+        finalType.keys = isCurrentChildNullable ? [type, 'null'] : type;
+      }
+      if (internalType === InternalTypesEnum.MAP_VALUES_SIMPLE_TYPE) {
+        finalType.values = isCurrentChildNullable ? [type, 'null'] : type;
+      }
+      continue;
+    }
+    // nested complex types.
+    const complexType = generateSchemaFromComplexType(type, currentChild, isCurrentChildNullable);
+    if (internalType === InternalTypesEnum.MAP_KEYS_COMPLEX_TYPE_ROOT) {
+      finalType.keys = complexType as any;
+    }
+    if (internalType === InternalTypesEnum.MAP_VALUES_COMPLEX_TYPE_ROOT) {
+      finalType.values = complexType as any;
+    }
+  }
+  return nullable ? [finalType, 'null'] : finalType;
+}
+
+function generateEnumType(children: IOrderedChildren, currentNode: INode, nullable) {
+  const finalType: IEnumFieldBase = {
+    type: 'enum',
+    symbols: [],
+  };
+  const { typeProperties: currentTypeProperties = {} } = currentNode;
+  if (currentTypeProperties.doc) {
+    finalType.doc = currentTypeProperties.doc;
+  }
+  if (currentTypeProperties.aliases) {
+    finalType.aliases = currentTypeProperties.aliases;
+  }
+  if (Array.isArray(children.order)) {
+    for (const childId of children.order) {
+      const currentChild = children[childId];
+      const { typeProperties } = currentChild;
+      if (typeProperties.symbol && typeProperties.symbol !== '') {
+        finalType.symbols.push(typeProperties.symbol);
+      }
+      if (typeProperties.doc) {
+        finalType.doc = typeProperties.doc;
+      }
+      if (typeProperties.aliases) {
+        finalType.aliases = typeProperties.aliases;
+      }
+    }
+  }
+  return nullable ? [finalType, 'null'] : finalType;
+}
+
+function generateRecordType(children: IOrderedChildren, currentNode: INode, nullable: boolean) {
+  const finalType: IRecordField = {
+    type: 'record',
+    name: currentNode.name || `name-${uuidV4()}`,
+    fields: [],
+  };
+  const { typeProperties = {} } = currentNode;
+  if (typeProperties.doc) {
+    finalType.doc = typeProperties.doc;
+  }
+  if (typeProperties.aliases) {
+    finalType.aliases = typeProperties.aliases;
+  }
+  if (Array.isArray(children.order)) {
+    for (const childId of children.order) {
+      const currentChild = children[childId];
+      const { name, type, nullable: isFieldNullable } = currentChild;
+      if (!name || name === '') {
+        continue;
+      }
+      const isFieldTypeComplex = isDisplayTypeComplex({ type });
+      if (!isFieldTypeComplex) {
+        finalType.fields.push({
+          name,
+          type: isFieldNullable ? [type, 'null'] : type,
+        });
+      } else {
+        finalType.fields.push({
+          name,
+          type: generateSchemaFromComplexType(
+            currentChild.type,
+            currentChild,
+            currentChild.nullable
+          ),
+        });
+      }
+    }
+  }
+  return nullable ? [finalType, 'null'] : finalType;
+}
+
+function generateUnionType(children: IOrderedChildren) {
+  const finalType = [];
+  if (Array.isArray(children.order)) {
+    for (const childId of children.order) {
+      const currentChild = children[childId];
+      const { type } = currentChild;
+      const isUnionTypeComplex = isDisplayTypeComplex({ type });
+      if (!isUnionTypeComplex) {
+        finalType.push(type);
+        continue;
+      }
+      finalType.push(generateSchemaFromComplexType(type, currentChild, false));
+    }
+  }
+  return finalType;
+}
+
+function generateLogicalType(child) {
+  const { typeProperties, nullable } = child;
+  return nullable ? [typeProperties, 'null'] : typeProperties;
+}
+
+function generateSchemaFromComplexType(type: string, currentChild, nullable: boolean) {
+  const complexTypeChildren: IOrderedChildren = currentChild.children;
+  switch (type) {
+    case 'array':
+      return generateArrayType(complexTypeChildren, nullable);
+    case 'map':
+      return generateMapType(complexTypeChildren, nullable);
+    case 'enum':
+      return generateEnumType(complexTypeChildren, currentChild, nullable);
+    case 'union':
+      return generateUnionType(complexTypeChildren);
+    case 'record':
+      return generateRecordType(complexTypeChildren, currentChild, nullable);
+    case 'time':
+    case 'timestamp':
+    case 'decimal':
+    case 'date':
+      return generateLogicalType(currentChild);
+    default:
+      return type;
+  }
+}
+
+/**
+ * Utility to convert the entire schema tree to a valid avro schema JSON.
+ * @param schemaTree Schema tree to convert to avro schema JSON.
+ */
+function SchemaGenerator(schemaTree: INode) {
+  const avroSchema: ISchemaType = getDefaultEmptyAvroSchema();
+  if (!schemaTree) {
+    return avroSchema;
+  } else {
+    avroSchema.schema.fields = [];
+  }
+  avroSchema.schema.fields = [];
+  // Top level record fields.
+  const { order } = schemaTree.children;
+  if (Array.isArray(order)) {
+    for (const id of order) {
+      const currentField = schemaTree.children[id];
+      const { name, type, nullable } = currentField;
+      // Skip the newly added rows.
+      if (!name || name === '') {
+        continue;
+      }
+      const isFieldComplexType = isDisplayTypeComplex({ type });
+      const field: IFieldType = {
+        name,
+        type: nullable ? [type, 'null'] : type,
+      };
+      if (isFieldComplexType) {
+        field.type = generateSchemaFromComplexType(type, currentField, nullable);
+      }
+      avroSchema.schema.fields.push(field);
+    }
+  }
+  return avroSchema;
+}
+
+export { SchemaGenerator, generateSchemaFromComplexType };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaManager.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaManager.ts
@@ -37,6 +37,7 @@ import {
   InternalTypesEnum,
   OperationTypesEnum,
   getDefaultEmptyAvroSchema,
+  AvroSchemaTypesEnum,
 } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 
 interface ISchemaManagerOptions {
@@ -141,7 +142,7 @@ class SchemaManagerBase implements ISchemaManager {
       id,
       internalType: InternalTypesEnum.RECORD_SIMPLE_TYPE,
       nullable: false,
-      type: 'string',
+      type: AvroSchemaTypesEnum.STRING,
       name: '',
     };
     tree.children[id] = newlyAddedField;
@@ -166,7 +167,7 @@ class SchemaManagerBase implements ISchemaManager {
       id,
       internalType: InternalTypesEnum.UNION_SIMPLE_TYPE,
       nullable: false,
-      type: 'string',
+      type: AvroSchemaTypesEnum.STRING,
     };
     tree.children[id] = newlyAddedField;
     return {
@@ -179,11 +180,11 @@ class SchemaManagerBase implements ISchemaManager {
 
   private addSpecificTypesToTree = (tree: INode, fieldId: IFieldIdentifier) => {
     switch (tree.type) {
-      case 'enum':
+      case AvroSchemaTypesEnum.ENUM:
         return this.addNewEnumSymbol(tree, fieldId);
-      case 'record':
+      case AvroSchemaTypesEnum.RECORD:
         return this.addNewFieldType(tree, fieldId);
-      case 'union':
+      case AvroSchemaTypesEnum.UNION:
         return this.addNewUnionType(tree, fieldId);
       default:
         return { tree: undefined, newTree: undefined, currentField: undefined };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaManager.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaManager.ts
@@ -1,0 +1,596 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import {
+  IFlattenRowType,
+  IFieldIdentifier,
+  IOnChangePayload,
+} from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import uuidV4 from 'uuid/v4';
+import isEmpty from 'lodash/isEmpty';
+import { INode, parseSchema } from 'components/AbstractWidget/SchemaEditor/Context/SchemaParser';
+import { FlatSchema } from 'components/AbstractWidget/SchemaEditor/Context/FlatSchema';
+import { ISchemaType } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+import { SchemaGenerator } from 'components/AbstractWidget/SchemaEditor/Context/SchemaGenerator';
+import isObject from 'lodash/isObject';
+import {
+  branchCount,
+  initChildren,
+  getInternalType,
+  initTypeProperties,
+} from 'components/AbstractWidget/SchemaEditor/Context/SchemaManagerUtilities';
+import { isNilOrEmpty } from 'services/helpers';
+import {
+  InternalTypesEnum,
+  OperationTypesEnum,
+  getDefaultEmptyAvroSchema,
+} from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+
+interface ISchemaManagerOptions {
+  collapseAll: boolean;
+}
+
+/**
+ * Interface that defines the schema data structure.
+ */
+interface ISchemaManager {
+  getSchemaTree: () => INode;
+  getFlatSchema: () => IFlattenRowType[];
+  getAvroSchema: () => ISchemaType;
+  onChange: (fieldId: IFieldIdentifier, onChangePayload: IOnChangePayload) => IOnChangeReturnType;
+}
+
+interface IOnChangeReturnType {
+  fieldIdToFocus?: string;
+  fieldIndex?: number;
+  nodeDepth?: number;
+}
+
+/**
+ * The Schema Manager is the central place to manage the entire schema
+ *
+ * Internally it has two data-structures,
+ * 1. A tree to convert the JSON avro schema to a representation that we can
+ * process a little bit faster.
+ * 2. A flat array for presentation purpose.
+ *
+ * The tree is used for adding/removing/deleting fields in an avro schema.
+ * It is a basic tree with id, name, type and children.
+ *
+ * The children is usually a map of id to the child node. In specific cases (records and enums)
+ * we need to maintain the order. So in those cases the children map will have a static 'order'
+ * array which maintains the order of the children.
+ *
+ * The flatten array is derived from the tree. It is nothing but a DFS traversal of the tree
+ *
+ * We need two representations because we need one for processing and the other for display purposes.
+ * Flattening the tree as aray helps us with using virtual scroll which improves performance.
+ */
+class SchemaManagerBase implements ISchemaManager {
+  private schemaTree: INode;
+  private flatTree: IFlattenRowType[];
+  private options: ISchemaManagerOptions;
+  constructor(avroSchema, options: ISchemaManagerOptions) {
+    this.schemaTree = parseSchema(avroSchema);
+    this.flatTree = FlatSchema(this.schemaTree, options);
+    this.options = options;
+  }
+
+  public getSchemaTree = () => this.schemaTree;
+  public getFlatSchema = () => this.flatTree;
+  public getAvroSchema = () => SchemaGenerator(this.schemaTree);
+
+  // Generic function to insert the newly created child id into the order array
+  // to maintain order of fields.
+  private insertNewIdToOrder = (order = [], referenceId) => {
+    const id = uuidV4();
+    // +1 to add next to the current element.
+    const currentIndexOfChild = order.findIndex((c) => c === referenceId) + 1;
+    order = [...order.slice(0, currentIndexOfChild), id, ...order.slice(currentIndexOfChild)];
+    return { id, order };
+  };
+
+  private addNewEnumSymbol = (tree: INode, fieldId: IFieldIdentifier) => {
+    if (!tree.children || (tree.children && !Array.isArray(tree.children.order))) {
+      return { tree, newTree: undefined, currentField: undefined };
+    }
+    const { id = uuidV4(), order = [] } = this.insertNewIdToOrder(
+      tree.children.order as string[],
+      fieldId.id
+    );
+    tree.children.order = order;
+    const newlyAddedField = {
+      id,
+      internalType: InternalTypesEnum.ENUM_SYMBOL,
+      typeProperties: {
+        symbol: '',
+      },
+    };
+    tree.children[id] = newlyAddedField;
+    return {
+      tree,
+      newTree: tree.children[id],
+      currentField: tree.children[fieldId.id],
+      newlyAddedField,
+    };
+  };
+
+  private addNewFieldType = (tree: INode, fieldId: IFieldIdentifier) => {
+    if (!tree.children || (tree.children && !Array.isArray(tree.children.order))) {
+      return { tree, newTree: undefined, currentField: undefined };
+    }
+    const { id = uuidV4(), order = [] } = this.insertNewIdToOrder(
+      tree.children.order as string[],
+      fieldId.id
+    );
+    tree.children.order = order;
+    const newlyAddedField = {
+      id,
+      internalType: InternalTypesEnum.RECORD_SIMPLE_TYPE,
+      nullable: false,
+      type: 'string',
+      name: '',
+    };
+    tree.children[id] = newlyAddedField;
+    return {
+      tree,
+      newTree: tree.children[id],
+      currentField: tree.children[fieldId.id],
+      newlyAddedField,
+    };
+  };
+
+  private addNewUnionType = (tree: INode, fieldId: IFieldIdentifier) => {
+    if (!tree.children || (tree.children && !Array.isArray(tree.children.order))) {
+      return { tree, newTree: undefined, currentField: undefined };
+    }
+    const { id = uuidV4(), order = [] } = this.insertNewIdToOrder(
+      tree.children.order as string[],
+      fieldId.id
+    );
+    tree.children.order = order;
+    const newlyAddedField = {
+      id,
+      internalType: InternalTypesEnum.UNION_SIMPLE_TYPE,
+      nullable: false,
+      type: 'string',
+    };
+    tree.children[id] = newlyAddedField;
+    return {
+      tree,
+      newTree: tree.children[id],
+      currentField: tree.children[fieldId.id],
+      newlyAddedField,
+    };
+  };
+
+  private addSpecificTypesToTree = (tree: INode, fieldId: IFieldIdentifier) => {
+    switch (tree.type) {
+      case 'enum':
+        return this.addNewEnumSymbol(tree, fieldId);
+      case 'record':
+        return this.addNewFieldType(tree, fieldId);
+      case 'union':
+        return this.addNewUnionType(tree, fieldId);
+      default:
+        return { tree: undefined, newTree: undefined, currentField: undefined };
+    }
+  };
+
+  private addToTree = (
+    tree: INode,
+    fieldId: IFieldIdentifier
+  ): {
+    tree: INode;
+    newTree: INode;
+    currentField: INode;
+  } => {
+    if (!tree) {
+      return { tree: undefined, newTree: undefined, currentField: undefined };
+    }
+    // Only the top level record fields will have one ancestors. So just add the specific type.
+    if (fieldId.ancestors.length === 1) {
+      return this.addSpecificTypesToTree(tree, fieldId);
+    }
+    // Traverse to the specific child tree in the main schema tree.
+    const { tree: child, newTree, currentField } = this.addToTree(
+      tree.children[fieldId.ancestors[1]],
+      { id: fieldId.id, ancestors: fieldId.ancestors.slice(1) }
+    );
+    // Mutates the main schema tree. This a performance optimization that we need to
+    // to avoid generating huge JSONs on every mutation of the schema.
+    return {
+      tree: {
+        ...tree,
+        children: {
+          ...tree.children,
+          [child.id]: child,
+        },
+      },
+      newTree,
+      currentField,
+    };
+  };
+
+  /**
+   * Add a new field to the current index. This could mean,
+   *  - Add a new field in record schema
+   *  - Add a new Symbol to enum
+   *  - Add a new union type
+   * The results of addition are,
+   *  - Modifying the schema tree to add the new field (tree)
+   *  - Newly added tree
+   *  - Current field to focus on
+   * We don't re-flatten the entire schema tree all the time. We calculate only the newly
+   * added field, it could be a single field or a tree in case of union or map or enum,
+   * and then flatten that sub tree and insert into our flattened array.
+   *
+   * @param fieldId ID of the current row being updated.
+   */
+  private add = (fieldId: IFieldIdentifier): IOnChangeReturnType => {
+    const currentIndex = this.flatTree.findIndex((f) => f.id === fieldId.id);
+    const matchingEntry = this.flatTree[currentIndex];
+    let result: { tree: INode; newTree: INode; currentField: INode };
+    let newFlatSubTree: IFlattenRowType[];
+    const idObj = { id: matchingEntry.id, ancestors: matchingEntry.ancestors };
+    // The result is the newly modified tree, the newly added tree and the current field
+    // The modified tree is the entire schema tree that we maintain
+    // The new tree is for flattening and inserting it into the flattened array
+    // The current field is then passed on to the schema editor for presentation (focus on that specific row)
+    result = this.addToTree(this.schemaTree, idObj);
+    const customOptions = {
+      ...this.options,
+      collapseAll: false,
+    };
+    newFlatSubTree = FlatSchema(result.newTree, customOptions, matchingEntry.ancestors);
+    this.schemaTree = result.tree;
+    const currentFieldBranchCount = branchCount(result.currentField);
+    this.flatTree = [
+      ...this.flatTree.slice(0, currentIndex + currentFieldBranchCount + 1),
+      ...newFlatSubTree,
+      ...this.flatTree.slice(currentIndex + currentFieldBranchCount + 1),
+    ];
+    return {
+      fieldIdToFocus: this.flatTree[currentIndex + currentFieldBranchCount + 1].id,
+      fieldIndex: currentIndex + currentFieldBranchCount + 1,
+    };
+  };
+
+  private removeFromTree = (tree: INode, fieldId) => {
+    if (!tree) {
+      return { tree: undefined };
+    }
+    if (fieldId.ancestors.length === 1) {
+      const field = { ...tree.children[fieldId.id] };
+      let newField;
+      if (Array.isArray(tree.children.order) && Object.keys(tree.children).length === 2) {
+        const {
+          tree: treeWithDefaultChild,
+          newlyAddedField: defaultNewField,
+        } = this.addSpecificTypesToTree(tree, fieldId);
+        newField = defaultNewField;
+        tree = treeWithDefaultChild;
+      }
+      if (Array.isArray(tree.children.order)) {
+        tree.children.order = tree.children.order.filter((id) => id !== fieldId.id);
+      }
+      delete tree.children[fieldId.id];
+      return { tree, removedField: field, newlyAddedField: newField };
+    }
+    const { tree: newTree, removedField, newlyAddedField } = this.removeFromTree(
+      tree.children[fieldId.ancestors[1]],
+      {
+        id: fieldId.id,
+        ancestors: fieldId.ancestors.slice(1),
+      }
+    );
+    return {
+      tree: {
+        ...tree,
+        children: {
+          ...tree.children,
+          ...newTree,
+        },
+      },
+      removedField,
+      newlyAddedField,
+    };
+  };
+
+  /**
+   * Remove a field from the schema. This could be a simple type of row
+   * or a complex type.
+   * There is also a need for us to add a new row as part of removal.
+   *
+   * For instance: This comes up when users delete all the fields in
+   * a record type. We can't have all the fields deleted. Upon the
+   * deleting the final field we still need to add a new field for
+   * the user to be able to keep the record type.
+   * @param fieldId ID of the current row being updated.
+   */
+  private remove = (fieldId: IFieldIdentifier): IOnChangeReturnType => {
+    const currentIndex = this.flatTree.findIndex((f) => f.id === fieldId.id);
+    const matchingEntry = this.flatTree[currentIndex];
+    const idObj = { id: matchingEntry.id, ancestors: matchingEntry.ancestors };
+    const { tree, removedField, newlyAddedField } = this.removeFromTree(this.schemaTree, idObj);
+    this.schemaTree = tree;
+    // branch count to determine the slice in the flattened array.
+    // If the user removed a complex type we need to remove the row
+    // and all of its children.
+    const childrenInBranch = branchCount(removedField);
+    let newFlatSubTree = [];
+    // Newly added row in case we need to maintain the structure of say, a record or an enum.
+    if (newlyAddedField) {
+      const customOptions = {
+        ...this.options,
+        collapseAll: false,
+      };
+      newFlatSubTree = FlatSchema(newlyAddedField, customOptions, matchingEntry.ancestors);
+    }
+    this.flatTree = [
+      ...this.flatTree.slice(0, currentIndex),
+      ...newFlatSubTree,
+      ...this.flatTree.slice(currentIndex + 1 + childrenInBranch), // remove current row along with its children.
+    ];
+    return {
+      fieldIdToFocus: this.flatTree[currentIndex - 1].id,
+      fieldIndex: currentIndex - 1,
+    };
+  };
+
+  private updateTree = (
+    tree: INode,
+    fieldId: IFieldIdentifier,
+    { property, value }: Partial<IOnChangePayload>
+  ): {
+    tree: INode;
+    childrenCount: number;
+    newTree: INode;
+  } => {
+    if (!tree) {
+      return { childrenCount: undefined, tree: undefined, newTree: undefined };
+    }
+    if (fieldId.ancestors.length === 1 && !isEmpty(tree.children[fieldId.id])) {
+      if (property === 'typeProperties' && typeof value === 'object') {
+        tree.children[fieldId.id][property] = {
+          ...tree.children[fieldId.id][property],
+          ...value,
+        };
+      } else {
+        tree.children[fieldId.id][property] = value;
+      }
+      let childrenInBranch = 0;
+      let newChildTree: INode;
+      if (property === 'type') {
+        childrenInBranch = branchCount(tree.children[fieldId.id]);
+        tree.children[fieldId.id].children = initChildren(value);
+        newChildTree = tree.children[fieldId.id];
+        tree.children[fieldId.id].internalType = getInternalType(tree.children[fieldId.id]);
+        tree.children[fieldId.id].typeProperties = initTypeProperties(tree.children[fieldId.id]);
+      }
+      return {
+        tree,
+        childrenCount: childrenInBranch,
+        newTree: newChildTree,
+      };
+    }
+
+    const { tree: child, childrenCount, newTree } = this.updateTree(
+      tree.children[fieldId.ancestors[1]],
+      { id: fieldId.id, ancestors: fieldId.ancestors.slice(1) },
+      { property, value }
+    );
+    return {
+      tree: {
+        ...tree,
+        children: {
+          ...tree.children,
+          [child.id]: child,
+        },
+      },
+      childrenCount,
+      newTree,
+    };
+  };
+
+  /**
+   * Updating a field could be changing the 'name' or the 'type'.
+   *
+   * Updating 'name' is pretty straight forward and involves no complicated steps.
+   * Updating 'type' involves changing from a simple type to a complex type or vice-versa.
+   *
+   * This again involves addition or removal of nodes in the schema.
+   * @param fieldId ID of the current row being updated.
+   * @param onChangePayload - { property, value } - payload for updating.
+   */
+  private update = (
+    fieldId: IFieldIdentifier,
+    { property, value }: Partial<IOnChangePayload>
+  ): IOnChangeReturnType => {
+    const index = this.flatTree.findIndex((f) => f.id === fieldId.id);
+    if (property === 'typeProperties' && typeof value === 'object') {
+      this.flatTree[index][property] = {
+        ...this.flatTree[index][property],
+        ...value,
+      };
+    } else {
+      this.flatTree[index][property] = value;
+    }
+    const matchingEntry = this.flatTree[index];
+    let result: { tree: INode; childrenCount: number; newTree: INode };
+    let newFlatSubTree: IFlattenRowType[];
+    const idObj = { id: matchingEntry.id, ancestors: matchingEntry.ancestors };
+    result = this.updateTree(this.schemaTree, idObj, { property, value });
+    this.schemaTree = result.tree;
+    // If user changed a complex type to a simple type or to another complex type we need
+    // to remove the complex type children first
+    this.flatTree = [
+      ...this.flatTree.slice(0, index),
+      ...this.flatTree.slice(index + result.childrenCount + (!result.newTree ? 0 : 1)),
+    ];
+    const customOptions = {
+      ...this.options,
+      collapseAll: false,
+    };
+    // And then add the newly updated complex type children to the flattened array.
+    if (result.newTree) {
+      newFlatSubTree = FlatSchema(result.newTree, customOptions, matchingEntry.ancestors);
+      this.flatTree = [
+        ...this.flatTree.slice(0, index),
+        ...newFlatSubTree,
+        ...this.flatTree.slice(index),
+      ];
+    }
+    // newFlatSubTree will be of length 1 for simple type changes.
+    if (Array.isArray(newFlatSubTree) && newFlatSubTree.length > 1) {
+      return {
+        fieldIdToFocus: this.flatTree[index + 1].id,
+        fieldIndex: index + 1,
+      };
+    }
+    return {};
+  };
+
+  /**
+   * This is to identify the root tree from the flattened object.
+   * @param fieldObj - id of the flattened row
+   * @param schemaTree - Tree to find the root node.
+   */
+  private getFieldObjFromTree = (fieldObj, schemaTree: INode): INode => {
+    if (fieldObj.id === schemaTree.id) {
+      return schemaTree;
+    }
+    if (fieldObj.ancestors.length === 1) {
+      return schemaTree.children[fieldObj.id];
+    }
+    return this.getFieldObjFromTree(
+      { id: fieldObj.id, ancestors: fieldObj.ancestors.slice(1) },
+      schemaTree.children[fieldObj.ancestors[1]]
+    );
+  };
+
+  /**
+   * Function to collapse/expand a tree.
+   * @param fieldId - id of the field for which the children needs to be
+   * collapsed or expanded.
+   */
+  private collapse = (fieldId: IFieldIdentifier): IOnChangeReturnType => {
+    const matchingIndex = this.flatTree.findIndex((row) => row.id === fieldId.id);
+    const matchingEntry = this.flatTree[matchingIndex];
+    if (!matchingEntry) {
+      return {};
+    }
+    const idObj = { id: matchingEntry.id, ancestors: matchingEntry.ancestors };
+    const fieldObj = this.getFieldObjFromTree(idObj, this.getSchemaTree());
+    this.flatTree[matchingIndex].collapsed = !this.flatTree[matchingIndex].collapsed;
+    const nodeDepth = this.calculateNodeDepthMap(fieldObj);
+    for (let i = 1; i <= nodeDepth; i++) {
+      const currentRow = this.flatTree[matchingIndex + i];
+      const { collapsed } = currentRow;
+      if (typeof collapsed === 'boolean') {
+        if (collapsed === true) {
+          const childTreeDepth = this.calculateNodeDepthMap(
+            this.getFieldObjFromTree(currentRow, this.getSchemaTree())
+          );
+          this.flatTree[matchingIndex + i].hidden = this.flatTree[matchingIndex].collapsed;
+          i += childTreeDepth;
+          continue;
+        } else {
+          this.flatTree[matchingIndex + i].collapsed = this.flatTree[matchingIndex].collapsed;
+        }
+      }
+      this.flatTree[matchingIndex + i].hidden = this.flatTree[matchingIndex].collapsed;
+    }
+    return {};
+  };
+
+  /**
+   * Identify the depth of a parent node. Depth here defines all the immediate children and all
+   * the children of childrens and so on and so forth. We need to calculate this depth because
+   * we do a DFS of our tree to flatten. Now if we need to collapse a subtree we need all the children
+   * (both direct and indirect) because in a flattened array the children comes first before the sibling.
+   * @param tree - Root node to find the depth.
+   */
+  private calculateNodeDepthMap = (tree: INode): number => {
+    let totalDepth = 0;
+    if (isObject(tree.children) && Object.keys(tree.children).length) {
+      totalDepth += Object.keys(tree.children).filter((c) => c !== 'order').length;
+      for (const childId of Object.keys(tree.children)) {
+        if (childId === 'order') {
+          continue;
+        }
+        const childCount = this.calculateNodeDepthMap(tree.children[childId]);
+        totalDepth += childCount;
+      }
+    }
+    return totalDepth;
+  };
+
+  /**
+   * The generic onChange is supposed to handle all types of mutation to the schema.
+   * This onChange is the handler for any changes that happen in the schema (not to be confused with
+   * the onChange in the schemaEditor).
+   * @param fieldId - unique id to identify every field in the schema tree.
+   * @param onChangePayload {type, property, value} - Every onchange call will have the type of
+   * change, the property and the value. The type could be 'add', 'update', 'remove' and property could be
+   * 'name' or 'typeProperties'
+   */
+  public onChange = (
+    fieldId: IFieldIdentifier,
+    { type, property, value }: IOnChangePayload
+  ): IOnChangeReturnType => {
+    if (isNilOrEmpty(fieldId)) {
+      return;
+    }
+    switch (type) {
+      case OperationTypesEnum.UPDATE:
+        return this.update(fieldId, { property, value });
+      case OperationTypesEnum.ADD:
+        return this.add(fieldId);
+      case OperationTypesEnum.REMOVE:
+        return this.remove(fieldId);
+      case OperationTypesEnum.COLLAPSE:
+        return this.collapse(fieldId);
+    }
+  };
+}
+
+/**
+ * Default options for the schema manager. This as of now only has collapseAll.
+ * Will expand to restricting schema types.
+ */
+const defaultOptions: ISchemaManagerOptions = {
+  collapseAll: true,
+};
+
+function SchemaManager(
+  avroSchema = getDefaultEmptyAvroSchema(),
+  options: ISchemaManagerOptions = defaultOptions
+) {
+  if (!options) {
+    options = defaultOptions;
+  } else {
+    options = {
+      ...defaultOptions,
+      ...options,
+    };
+  }
+  const schemaTreeInstance = new SchemaManagerBase(avroSchema, options);
+  return {
+    getInstance: () => schemaTreeInstance,
+  };
+}
+export { SchemaManager, ISchemaManager, IOnChangeReturnType, ISchemaManagerOptions };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaManagerUtilities.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaManagerUtilities.ts
@@ -35,6 +35,7 @@ import {
   defaultRecordType,
   defaultUnionType,
   InternalTypesEnum,
+  AvroSchemaTypesEnum,
 } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 import isEmpty from 'lodash/isEmpty';
 
@@ -88,15 +89,15 @@ const branchCount = (tree: INode): number => {
 
 const initChildren = (type): IOrderedChildren => {
   switch (type) {
-    case 'array':
+    case AvroSchemaTypesEnum.ARRAY:
       return parseArrayType(defaultArrayType);
-    case 'enum':
+    case AvroSchemaTypesEnum.ENUM:
       return parseEnumType(defaultEnumType);
-    case 'map':
+    case AvroSchemaTypesEnum.MAP:
       return parseMapType(defaultMapType);
-    case 'record':
+    case AvroSchemaTypesEnum.RECORD:
       return parseComplexType(defaultRecordType);
-    case 'union':
+    case AvroSchemaTypesEnum.UNION:
       return parseUnionType(defaultUnionType);
     default:
       return;
@@ -108,13 +109,13 @@ const initTypeProperties = (tree: INode) => {
     return {};
   }
   switch (tree.type) {
-    case 'decimal':
+    case AvroSchemaTypesEnum.DECIMAL:
       return defaultDecimalTypeProperties;
-    case 'time':
+    case AvroSchemaTypesEnum.TIME:
       return defaultTimeTypeProperties;
-    case 'timestamp':
+    case AvroSchemaTypesEnum.TIMESTAMP:
       return defaultTimeStampTypeProperties;
-    case 'date':
+    case AvroSchemaTypesEnum.DATE:
       return defaultDateTypeProperties;
     default:
       return {};

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaManagerUtilities.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaManagerUtilities.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import {
+  INode,
+  parseUnionType,
+  parseArrayType,
+  parseEnumType,
+  parseMapType,
+  IOrderedChildren,
+  parseComplexType,
+} from 'components/AbstractWidget/SchemaEditor/Context/SchemaParser';
+import {
+  logicalTypes,
+  defaultTimeStampTypeProperties,
+  defaultDecimalTypeProperties,
+  defaultTimeTypeProperties,
+  defaultDateTypeProperties,
+  defaultArrayType,
+  defaultEnumType,
+  defaultMapType,
+  defaultRecordType,
+  defaultUnionType,
+  InternalTypesEnum,
+} from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import isEmpty from 'lodash/isEmpty';
+
+function getInternalType(tree: INode) {
+  const hasChildren = tree.children ? Object.keys(tree.children).length > 0 : false;
+  if (tree.internalType === InternalTypesEnum.RECORD_SIMPLE_TYPE && hasChildren) {
+    return InternalTypesEnum.RECORD_COMPLEX_TYPE_ROOT;
+  }
+  if (tree.internalType === InternalTypesEnum.RECORD_COMPLEX_TYPE_ROOT && !hasChildren) {
+    return InternalTypesEnum.RECORD_SIMPLE_TYPE;
+  }
+  if (tree.internalType === InternalTypesEnum.UNION_SIMPLE_TYPE && hasChildren) {
+    return InternalTypesEnum.UNION_COMPLEX_TYPE_ROOT;
+  }
+  if (tree.internalType === InternalTypesEnum.UNION_COMPLEX_TYPE_ROOT && !hasChildren) {
+    return InternalTypesEnum.UNION_SIMPLE_TYPE;
+  }
+  if (tree.internalType === InternalTypesEnum.ARRAY_SIMPLE_TYPE && hasChildren) {
+    return InternalTypesEnum.ARRAY_COMPLEX_TYPE_ROOT;
+  }
+  if (tree.internalType === InternalTypesEnum.ARRAY_COMPLEX_TYPE_ROOT && !hasChildren) {
+    return InternalTypesEnum.ARRAY_SIMPLE_TYPE;
+  }
+  if (tree.internalType === InternalTypesEnum.MAP_KEYS_SIMPLE_TYPE && hasChildren) {
+    return InternalTypesEnum.MAP_KEYS_COMPLEX_TYPE_ROOT;
+  }
+  if (tree.internalType === InternalTypesEnum.MAP_KEYS_COMPLEX_TYPE_ROOT && hasChildren) {
+    return InternalTypesEnum.MAP_KEYS_SIMPLE_TYPE;
+  }
+  if (tree.internalType === InternalTypesEnum.MAP_VALUES_SIMPLE_TYPE && hasChildren) {
+    return InternalTypesEnum.MAP_VALUES_COMPLEX_TYPE_ROOT;
+  }
+  if (tree.internalType === InternalTypesEnum.MAP_VALUES_COMPLEX_TYPE_ROOT && hasChildren) {
+    return InternalTypesEnum.MAP_VALUES_SIMPLE_TYPE;
+  }
+  return tree.internalType;
+}
+
+const branchCount = (tree: INode): number => {
+  let count = 0;
+  if (tree && !isEmpty(tree.children) && Object.keys(tree.children).length) {
+    // skip 'order' array which is under children.
+    const children = Object.values(tree.children).filter((child) => !Array.isArray(child));
+    count += children.length;
+    children.forEach((child: INode) => {
+      count += branchCount(child);
+    });
+  }
+  return count;
+};
+
+const initChildren = (type): IOrderedChildren => {
+  switch (type) {
+    case 'array':
+      return parseArrayType(defaultArrayType);
+    case 'enum':
+      return parseEnumType(defaultEnumType);
+    case 'map':
+      return parseMapType(defaultMapType);
+    case 'record':
+      return parseComplexType(defaultRecordType);
+    case 'union':
+      return parseUnionType(defaultUnionType);
+    default:
+      return;
+  }
+};
+
+const initTypeProperties = (tree: INode) => {
+  if (logicalTypes.indexOf(tree.type) === -1) {
+    return {};
+  }
+  switch (tree.type) {
+    case 'decimal':
+      return defaultDecimalTypeProperties;
+    case 'time':
+      return defaultTimeTypeProperties;
+    case 'timestamp':
+      return defaultTimeStampTypeProperties;
+    case 'date':
+      return defaultDateTypeProperties;
+    default:
+      return {};
+  }
+};
+
+export { getInternalType, branchCount, initChildren, initTypeProperties };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaParser.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaParser.ts
@@ -1,0 +1,430 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import { IInternalFieldType } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import {
+  ISchemaType,
+  IDisplayType,
+  IFieldType,
+  IFieldTypeNullable,
+  ILogicalTypeBase,
+} from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+import {
+  getComplexTypeName,
+  isNullable,
+  isComplexType,
+  getNonNullableType,
+  getSimpleType,
+} from 'components/AbstractWidget/SchemaEditor/SchemaHelpers';
+import uuidV4 from 'uuid/v4';
+import { InternalTypesEnum } from '../SchemaConstants';
+
+type ITypeProperties = Record<string, any>;
+
+/**
+ * A generic node of the tree.
+ * name, id, nullable and type - directly translate to the avro schema
+ * children - is a map of child-id and the child node. In cases like records and enums
+ * where the order of children needs to be maintained, the map will have a static
+ * 'order' array.
+ * internalType - purely used for presentation.
+ * typeProperties - Defines the properties of the type. Right now this takes in
+ * symbols in the enum and precision, scale in decimal types.
+ */
+interface INode {
+  name?: string;
+  children?: IOrderedChildren;
+  id: string;
+  internalType: IInternalFieldType;
+  nullable?: boolean;
+  type?: IDisplayType;
+  typeProperties?: ITypeProperties;
+}
+
+type IOrderedChildren = Record<string, INode> | Record<'order', string[]>;
+
+/**
+ * {
+ *  [child-id1]: {
+ *    id: child-id1,
+ *    internalType: 'union-simple-type',
+ *    type: 'string'
+ *  }
+ * }
+ * @param type avro union type
+ * ['string']
+ */
+function parseUnionType(type): IOrderedChildren {
+  const result: IOrderedChildren = {
+    order: [],
+  };
+  for (const subType of type) {
+    const id = uuidV4();
+    result.order.push(id);
+    if (isComplexType(subType)) {
+      const typeName = getComplexTypeName(subType);
+      result[id] = {
+        id,
+        type: typeName,
+        internalType: InternalTypesEnum.UNION_COMPLEX_TYPE_ROOT,
+        children: parseComplexType(subType),
+      };
+    } else {
+      result[id] = {
+        id,
+        type: subType,
+        nullable: false,
+        internalType: InternalTypesEnum.UNION_SIMPLE_TYPE,
+      };
+    }
+  }
+  return result;
+}
+/**
+ * @returns
+ * {
+ *  [child-id1]: {
+ *    internalType: 'array-simple-type',
+ *    type: 'string'
+ *  }
+ * }
+ * @param type avro array type
+ * {
+ *  type: 'array',
+ *  items: 'string'
+ * }
+ */
+function parseArrayType(type): IOrderedChildren {
+  const nullable = isNullable(type);
+  const t = getNonNullableType(type);
+  const id = uuidV4();
+  if (t.items && !isComplexType(t.items)) {
+    return {
+      [id]: {
+        internalType: InternalTypesEnum.ARRAY_SIMPLE_TYPE,
+        id,
+        nullable: isNullable(t.items),
+        type: getNonNullableType(t.items),
+      },
+    };
+  }
+  return {
+    [id]: {
+      internalType: InternalTypesEnum.ARRAY_COMPLEX_TYPE_ROOT,
+      id,
+      nullable,
+      type: getComplexTypeName(t.items),
+      children: parseComplexType(t.items),
+    },
+  };
+}
+
+/**
+ * @returns
+ * {
+ *  order: [child-id1, child-id2,...]
+ *  [child-id1]: {
+ *    id: child-id1,
+ *    internalType: 'enum-symbol',
+ *    typeProperties: {
+ *      symbol: 'symbol1'
+ *    }
+ *  },
+ *  [child-id2]: {
+ *    id: child-id2,
+ *    internalType: 'enum-symbol',
+ *    typeProperties: {
+ *      symbol: 'symbol2'
+ *    }
+ *  }
+ * }
+ * @param type avro enum type
+ * {
+ *  type: 'enum',
+ *  symbols: ['symbol1', 'symbol2', ....]
+ * }
+ */
+function parseEnumType(type): IOrderedChildren {
+  const nullable = isNullable(type);
+  const t = getNonNullableType(type);
+  const result = {
+    order: [],
+  };
+  for (const symbol of t.symbols) {
+    const id = uuidV4();
+    result.order.push(id);
+    result[id] = {
+      id,
+      internalType: InternalTypesEnum.ENUM_SYMBOL,
+      nullable,
+      typeProperties: {
+        symbol,
+      },
+    };
+  }
+  return result;
+}
+
+function getMapSubType(type, internalTypeName): INode {
+  const id = uuidV4();
+  if (!isComplexType(type)) {
+    return {
+      id,
+      internalType: internalTypeName.simpleType,
+      nullable: isNullable(type),
+      type: getNonNullableType(type),
+    };
+  } else {
+    const complexType = getComplexTypeName(type);
+    const nullable = isNullable(type);
+    return {
+      children: parseComplexType(type),
+      id,
+      internalType: internalTypeName.complexType,
+      type: complexType,
+      nullable,
+    };
+  }
+}
+/**
+ * @returns
+ * {
+ *   [child-id1]: {
+ *    "id": child-id1,
+ *    "internalType": "map-keys-simple-type",
+ *    "type": "string"
+ *  },
+ *   [child-id2] {
+ *    "id": child-id2,
+ *    "internalType": "map-values-simple-type",
+ *    "nullable": false,
+ *    "type": "string"
+ *   }
+ * }
+ * @param type avro map type
+ * {
+ *  type: {
+ *    keys: 'string',
+ *    values: 'string',
+ *  }
+ * }
+ */
+function parseMapType(type): IOrderedChildren {
+  const t = getNonNullableType(type);
+  const keysType = t.keys;
+  const valuesType = t.values;
+  const result: Record<string, INode> = {};
+  const mapKeysSubType = getMapSubType(keysType, {
+    simpleType: InternalTypesEnum.MAP_KEYS_SIMPLE_TYPE,
+    complexType: InternalTypesEnum.MAP_KEYS_COMPLEX_TYPE_ROOT,
+  });
+  const mapValuesSubType = getMapSubType(valuesType, {
+    simpleType: InternalTypesEnum.MAP_VALUES_SIMPLE_TYPE,
+    complexType: InternalTypesEnum.MAP_VALUES_COMPLEX_TYPE_ROOT,
+  });
+  result[mapKeysSubType.id] = mapKeysSubType;
+  result[mapValuesSubType.id] = mapValuesSubType;
+  return result;
+}
+/**
+ * @returns -
+ * {
+ *  [child-id1]:{
+ *    id: child-id1,
+ *    internalType: 'record-field-simple-type',
+ *    type: 'string',
+ *  },
+ *  order: [child-id1]
+ * }
+ * @param type - avro record type
+ * {
+ *  name: 'record-name',
+ *  type: 'record',
+ *  fields: [ field1, field2 ...]
+ * }
+ */
+function parseRecordType(type): IOrderedChildren {
+  const t = getNonNullableType(type);
+  const result = {
+    order: [],
+  };
+  for (const field of t.fields) {
+    const child = parseSubTree(field);
+    result.order.push(child.id);
+    result[child.id] = child;
+  }
+  return result;
+}
+
+function parseComplexType(type): IOrderedChildren {
+  const complexTypeName = getComplexTypeName(type);
+  let record: IOrderedChildren = {};
+  switch (complexTypeName) {
+    case 'enum':
+      record = parseEnumType(type);
+      break;
+    case 'array':
+      record = parseArrayType(type);
+      break;
+    case 'record':
+      record = parseRecordType(type);
+      break;
+    case 'union':
+      record = parseUnionType(type);
+      break;
+    case 'map':
+      record = parseMapType(type);
+      break;
+    default:
+      record = {};
+  }
+  return record;
+}
+
+/**
+ * The logical type is similar to a complex type. The only difference is it doesn't have
+ *  children and will have type properties that map the logical property to underlying type.
+ * @param field - field in the schema.
+ */
+function checkForLogicalType(field: IFieldType | IFieldTypeNullable) {
+  let type = field.type;
+  type = getNonNullableType(type) as ILogicalTypeBase;
+  switch (type.logicalType) {
+    case 'decimal':
+      return {
+        typeProperties: {
+          type: 'bytes',
+          logicalType: type.logicalType,
+          precision: type.precision,
+          scale: type.scale,
+        },
+      };
+    case 'date':
+      return {
+        typeProperties: {
+          type: 'int',
+          logicalType: type.logicalType,
+        },
+      };
+    case 'time-micros':
+      return {
+        typeProperties: {
+          type: 'long',
+          logicalType: type.logicalType,
+        },
+      };
+    case 'timestamp-micros':
+      return {
+        typeProperties: {
+          type: 'long',
+          logicalType: type.logicalType,
+        },
+      };
+    default:
+      return {
+        typeProperties: {
+          doc: field.doc,
+          aliases: field.aliases,
+        },
+      };
+  }
+}
+
+/**
+ * Function to parse fields in a record type. Can be a simple field or a complex record type.
+ * @param field - A field in the record type.
+ */
+function parseSubTree(field: IFieldType | IFieldTypeNullable): INode {
+  const { type, name } = field;
+  const nullable = isNullable(type);
+  const complexType = isComplexType(type);
+  const t = getNonNullableType(type);
+  if (!complexType) {
+    return {
+      name,
+      id: uuidV4(),
+      internalType: InternalTypesEnum.RECORD_SIMPLE_TYPE,
+      nullable,
+      type: getSimpleType(t),
+      ...checkForLogicalType(field),
+    };
+  }
+  return {
+    name,
+    children: parseComplexType(type),
+    id: uuidV4(),
+    internalType: InternalTypesEnum.RECORD_COMPLEX_TYPE_ROOT,
+    nullable,
+    type: getComplexTypeName(t),
+    typeProperties: {
+      doc: t.doc,
+      aliases: t.aliases,
+    },
+  };
+}
+
+/**
+ * Parser to convert the avro schema JSON to internal representation of a tree.
+ *
+ * Each node has a type for display and an internal type to determine how rendering
+ * happens. Based on the internal type presentation layer decides to nest/render rows.
+ * @param avroSchema avro schema JSON
+ * @param name default name of the schema.
+ * @return The return is a tree. Will always be a schema type with record type. Can have deep nesting
+ * depending upon the schema complexity.
+ * {
+ *  id: xxx,
+ *  internalType: 'schema',
+ *  type: 'record',
+ *  children: {
+ *    order: [array-of-child-ids],
+ *    [child-id1]: child-id1 node,
+ *    [child-id2]: child-id2 node,
+ *  }
+ * }
+ */
+function parseSchema(avroSchema: ISchemaType, name = 'etlSchemaBody'): INode {
+  const fields = avroSchema.schema.fields;
+  const root: INode = {
+    name,
+    internalType: 'schema', // The 'schema' is only used for top level schema.
+    type: 'record',
+    id: uuidV4(),
+    children: {
+      order: [],
+    } as IOrderedChildren,
+  };
+  for (const field of fields) {
+    const child = parseSubTree(field);
+    if (Array.isArray(root.children.order)) {
+      root.children.order.push(child.id);
+    }
+    root.children[child.id] = child;
+  }
+  return root;
+}
+
+export {
+  parseSchema,
+  INode,
+  ITypeProperties,
+  IOrderedChildren,
+  parseComplexType,
+  parseUnionType,
+  parseArrayType,
+  parseEnumType,
+  parseMapType,
+  checkForLogicalType,
+};

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/EditorTypes.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/EditorTypes.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Contains types used only by the editor for presentation.
+ */
+import { ISimpleType, IComplexTypeNames } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+import { ITypeProperties } from 'components/AbstractWidget/SchemaEditor/Context/SchemaParser';
+import { OperationTypesEnum } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+
+type IInternalFieldType =
+  | 'schema'
+  | 'record-field-simple-type'
+  | 'record-field-complex-type-root'
+  | 'array-simple-type'
+  | 'array-complex-type'
+  | 'array-complex-type-root'
+  | 'enum-symbol'
+  | 'map-keys-complex-type-root'
+  | 'map-keys-simple-type'
+  | 'map-values-complex-type-root'
+  | 'map-values-simple-type'
+  | 'union-simple-type'
+  | 'union-complex-type-root';
+
+/**
+ * Type of flattened row for rendering.
+ * Contains context for that specific row. We have 'ancestors' here to show the
+ * indentation for complex types.
+ *
+ * Every row will have a hidden flag. Potentially every row can be hidden
+ * when the user collapses.
+ *
+ * Rows that has children will have a boolean collapsed.
+ */
+interface IFlattenRowType {
+  id: string;
+  name?: string;
+  type?: ISimpleType | IComplexTypeNames;
+  internalType: IInternalFieldType;
+  nullable?: boolean;
+  ancestors: string[];
+  typeProperties?: ITypeProperties;
+  collapsed?: boolean;
+  hidden?: boolean;
+}
+
+interface IFieldIdentifier {
+  id: string;
+  ancestors: string[];
+}
+type IOnchangeHandler = (property: string, value?: string | boolean | ITypeProperties) => void;
+type IRowOnChangeHandler = (id: IFieldIdentifier, payload: IOnChangePayload) => void;
+interface IFieldTypeBaseProps {
+  name?: string;
+  type?: ISimpleType | IComplexTypeNames;
+  nullable?: boolean;
+  internalType?: IInternalFieldType;
+  typeProperties?: ITypeProperties;
+  onChange: IOnchangeHandler;
+  onAdd: () => void;
+  onRemove: () => void;
+  autoFocus?: boolean;
+}
+
+interface IOnChangePayload {
+  property?: string;
+  value?: string | boolean | ITypeProperties;
+  type:
+    | OperationTypesEnum.UPDATE
+    | OperationTypesEnum.ADD
+    | OperationTypesEnum.REMOVE
+    | OperationTypesEnum.COLLAPSE;
+}
+
+interface IAttributesComponentProps {
+  onChange?: IOnchangeHandler;
+  typeProperties: ITypeProperties;
+  handleClose: () => void;
+}
+
+export {
+  IInternalFieldType,
+  IFlattenRowType,
+  IFieldIdentifier,
+  IFieldTypeBaseProps,
+  IOnChangePayload,
+  IAttributesComponentProps,
+  IOnchangeHandler,
+  IRowOnChangeHandler,
+};

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/EditorTypes.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/EditorTypes.ts
@@ -74,6 +74,7 @@ interface IFieldTypeBaseProps {
   onAdd: () => void;
   onRemove: () => void;
   autoFocus?: boolean;
+  disabled?: boolean;
 }
 
 interface IOnChangePayload {
@@ -90,6 +91,7 @@ interface IAttributesComponentProps {
   onChange?: IOnchangeHandler;
   typeProperties: ITypeProperties;
   handleClose: () => void;
+  disabled?: boolean;
 }
 
 export {

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/EnumType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/EnumType/index.tsx
@@ -32,6 +32,7 @@ const EnumTypeBase = ({
   onAdd,
   onRemove,
   autoFocus,
+  disabled = false,
 }: IFieldTypeBaseProps) => {
   const { symbol } = typeProperties;
   const [enumSymbol, setEnumSymbol] = React.useState(symbol);
@@ -50,6 +51,9 @@ const EnumTypeBase = ({
       onAdd();
       return;
     }
+    if (enumSymbol === newValue) {
+      return;
+    }
     setEnumSymbol(newValue);
     onChange('typeProperties', {
       symbol: newValue,
@@ -66,6 +70,7 @@ const EnumTypeBase = ({
   return (
     <React.Fragment>
       <TextboxOnValium
+        disabled={disabled}
         value={enumSymbol}
         onChange={onChangeHandler}
         placeholder="symbol"
@@ -74,6 +79,7 @@ const EnumTypeBase = ({
         className={classes.textbox}
       />
       <RowButtons
+        disabled={disabled}
         onRemove={onRemove}
         onAdd={onAdd}
         typeProperties={fieldTypeProperties}

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/EnumType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/EnumType/index.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import { IFieldTypeBaseProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { RowButtons } from 'components/AbstractWidget/SchemaEditor/RowButtons';
+import TextboxOnValium from 'components/TextboxOnValium';
+import makeStyles from '@material-ui/core/styles/makeStyles';
+
+const useStyles = makeStyles({
+  textbox: {
+    border: 0,
+  },
+});
+
+const EnumTypeBase = ({
+  typeProperties,
+  onChange,
+  onAdd,
+  onRemove,
+  autoFocus,
+}: IFieldTypeBaseProps) => {
+  const { symbol } = typeProperties;
+  const [enumSymbol, setEnumSymbol] = React.useState(symbol);
+  const inputEle = React.useRef(null);
+  const classes = useStyles();
+  const [fieldTypeProperties, setFieldTypeProperties] = React.useState(typeProperties || {});
+
+  const onTypePropertiesChangeHandler = (property, value) => {
+    if (property === 'typeProperties') {
+      setFieldTypeProperties(value);
+    }
+    onChange(property, value);
+  };
+  const onChangeHandler = (newValue, _, keyPressKeyCode) => {
+    if (keyPressKeyCode === 13) {
+      onAdd();
+      return;
+    }
+    setEnumSymbol(newValue);
+    onChange('typeProperties', {
+      symbol: newValue,
+    });
+  };
+
+  React.useEffect(() => {
+    if (autoFocus) {
+      if (inputEle.current) {
+        inputEle.current.focus();
+      }
+    }
+  }, [autoFocus]);
+  return (
+    <React.Fragment>
+      <TextboxOnValium
+        value={enumSymbol}
+        onChange={onChangeHandler}
+        placeholder="symbol"
+        inputRef={(ref) => (inputEle.current = ref)}
+        onKeyUp={() => ({})}
+        className={classes.textbox}
+      />
+      <RowButtons
+        onRemove={onRemove}
+        onAdd={onAdd}
+        typeProperties={fieldTypeProperties}
+        onChange={onTypePropertiesChangeHandler}
+      />
+    </React.Fragment>
+  );
+};
+const EnumType = React.memo(EnumTypeBase);
+export { EnumType };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldType/index.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import { FieldInputWrapper } from 'components/AbstractWidget/SchemaEditor/FieldWrapper';
+import Select from 'components/AbstractWidget/FormInputs/Select';
+import { schemaTypes } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import { IFieldTypeBaseProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { RowButtons } from 'components/AbstractWidget/SchemaEditor/RowButtons';
+import TextboxOnValium from 'components/TextboxOnValium';
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import { ISimpleType, IComplexTypeNames } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+
+const useStyles = makeStyles({
+  textbox: {
+    border: 0,
+  },
+});
+
+const FieldTypeBase = ({
+  name,
+  type,
+  nullable,
+  onChange,
+  onAdd,
+  onRemove,
+  autoFocus,
+  typeProperties,
+}: IFieldTypeBaseProps) => {
+  /**
+   * We use hooks here because we propagte the state only upwards
+   * via onChange. Any intermediate state is stored here.
+   *
+   * For instance when the user sets the precision and scale of a decimal type we
+   * set that in typeProperties here as part of the hooks for immediate feedback
+   * but at the same time propagate the value via onChange to the parent.
+   *
+   * This state is stored as long as the component is not destroyed. on Unmount and
+   * remount (happens as part of the scroll) we get the values from the parent once
+   * on mount. So the values will be the same as it was last propagated.
+   *
+   * This holds the same for all field type (array, enum, map & union).
+   */
+  const [fieldName, setFieldName] = React.useState(name);
+  const [fieldType, setFieldType] = React.useState<ISimpleType | IComplexTypeNames>(type);
+  const [fieldNullable, setFieldNullable] = React.useState(nullable);
+  const [fieldTypeProperties, setFieldTypeProperties] = React.useState(typeProperties || {});
+  const inputEle = React.useRef(null);
+  const classes = useStyles();
+  React.useEffect(() => {
+    if (autoFocus) {
+      if (inputEle.current) {
+        inputEle.current.focus();
+        inputEle.current.select();
+      }
+    }
+  }, [autoFocus]);
+  const onNullable = (checked) => {
+    setFieldNullable(checked);
+    onChange('nullable', checked);
+  };
+  const onChangeHandler = (newValue, _, keyPressKeyCode) => {
+    if (keyPressKeyCode === 13) {
+      onAdd();
+      return;
+    }
+    setFieldName(newValue);
+    onChange('name', newValue);
+  };
+
+  const onTypeChangeHandler = (newValue) => {
+    setFieldType(newValue);
+    onChange('type', newValue);
+  };
+  const inputRef = (ref) => {
+    inputEle.current = ref;
+  };
+  const onTypePropertiesChangeHandler = (property, value) => {
+    if (property === 'typeProperties') {
+      setFieldTypeProperties(value);
+    }
+    onChange(property, value);
+  };
+
+  return (
+    <React.Fragment>
+      <FieldInputWrapper>
+        <TextboxOnValium
+          className={classes.textbox}
+          value={fieldName}
+          onChange={onChangeHandler}
+          placeholder="Field name"
+          inputRef={inputRef}
+          onKeyUp={() => ({})}
+        />
+        <Select
+          value={fieldType}
+          onChange={onTypeChangeHandler}
+          widgetProps={{ options: schemaTypes, dense: true }}
+        />
+      </FieldInputWrapper>
+      <RowButtons
+        nullable={fieldNullable}
+        onNullable={type === 'union' ? undefined : onNullable}
+        type={fieldType}
+        onAdd={onAdd}
+        onRemove={onRemove}
+        onChange={onTypePropertiesChangeHandler}
+        typeProperties={fieldTypeProperties}
+      />
+    </React.Fragment>
+  );
+};
+
+const FieldType = React.memo(FieldTypeBase);
+export { FieldType };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldType/index.tsx
@@ -17,7 +17,10 @@
 import * as React from 'react';
 import { FieldInputWrapper } from 'components/AbstractWidget/SchemaEditor/FieldWrapper';
 import Select from 'components/AbstractWidget/FormInputs/Select';
-import { schemaTypes } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import {
+  schemaTypes,
+  AvroSchemaTypesEnum,
+} from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 import { IFieldTypeBaseProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
 import { RowButtons } from 'components/AbstractWidget/SchemaEditor/RowButtons';
 import TextboxOnValium from 'components/TextboxOnValium';
@@ -39,6 +42,7 @@ const FieldTypeBase = ({
   onRemove,
   autoFocus,
   typeProperties,
+  disabled = false,
 }: IFieldTypeBaseProps) => {
   /**
    * We use hooks here because we propagte the state only upwards
@@ -73,12 +77,13 @@ const FieldTypeBase = ({
     onChange('nullable', checked);
   };
   const onChangeHandler = (newValue, _, keyPressKeyCode) => {
+    if (newValue !== fieldName) {
+      setFieldName(newValue);
+      onChange('name', newValue);
+    }
     if (keyPressKeyCode === 13) {
       onAdd();
-      return;
     }
-    setFieldName(newValue);
-    onChange('name', newValue);
   };
 
   const onTypeChangeHandler = (newValue) => {
@@ -107,14 +112,22 @@ const FieldTypeBase = ({
           onKeyUp={() => ({})}
         />
         <Select
+          disabled={disabled}
           value={fieldType}
           onChange={onTypeChangeHandler}
-          widgetProps={{ options: schemaTypes, dense: true }}
+          widgetProps={{
+            options: schemaTypes,
+            dense: true,
+            fullWidth: false,
+            inputProps: { title: fieldType },
+            native: true,
+          }}
         />
       </FieldInputWrapper>
       <RowButtons
+        disabled={disabled}
         nullable={fieldNullable}
-        onNullable={type === 'union' ? undefined : onNullable}
+        onNullable={type === AvroSchemaTypesEnum.UNION ? undefined : onNullable}
         type={fieldType}
         onAdd={onAdd}
         onRemove={onRemove}

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/FieldWrapperConstants.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/FieldWrapperConstants.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { INDENTATION_SPACING } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+const rowHeight = 28;
+const rowMarginTop = 2;
+
+export { INDENTATION_SPACING, rowHeight, rowMarginTop };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/FieldWrapperConstants.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/FieldWrapperConstants.ts
@@ -17,5 +17,6 @@
 import { INDENTATION_SPACING } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 const rowHeight = 28;
 const rowMarginTop = 2;
+const schemaRowHeight = rowHeight + 2 * rowMarginTop;
 
-export { INDENTATION_SPACING, rowHeight, rowMarginTop };
+export { INDENTATION_SPACING, rowHeight, rowMarginTop, schemaRowHeight };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/SiblingCommunicationContext.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/SiblingCommunicationContext.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+const SiblingCommunicationContext = React.createContext(null);
+const SiblingCommunicationConsumer = SiblingCommunicationContext.Consumer;
+
+/**
+ * Each row has a sibling line for hierarchical relationship with parent.
+ * There could be multiple lines depending on the number of ancestors a particular
+ * row is nested under.
+ *
+ * The context provides a way to broadcast state changes on the siblingline. Stage changes
+ * happen if user hovers over the line to see the hierarchy with immediate parent.
+ *
+ * In this case the provider broadcasts the current hovered parent-sibling line and that gets highlighted.
+ */
+class SiblingCommunicationProvider extends React.Component {
+  public setActiveParent = (id) => {
+    this.setState({
+      activeParent: id,
+    });
+  };
+  public state = {
+    activeParent: null,
+    setActiveParent: this.setActiveParent.bind(this),
+  };
+
+  public render() {
+    return (
+      <SiblingCommunicationContext.Provider value={this.state}>
+        {this.props.children}
+      </SiblingCommunicationContext.Provider>
+    );
+  }
+}
+
+export { SiblingCommunicationProvider, SiblingCommunicationConsumer };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/SiblingLine.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/SiblingLine.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import classnames from 'classnames';
+const widthOfSiblingLines = 10;
+const borderSizeOfSiblingLines = 2;
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import { blue, red } from 'components/ThemeWrapper/colors';
+import {
+  INDENTATION_SPACING,
+  rowHeight,
+  rowMarginTop,
+} from 'components/AbstractWidget/SchemaEditor/FieldWrapper/FieldWrapperConstants';
+
+const useStyles = makeStyles({
+  root: {
+    position: 'absolute',
+    height: `${rowHeight + rowMarginTop * 2 + 2}px`,
+    width: `${widthOfSiblingLines}px`,
+    borderLeft: `${borderSizeOfSiblingLines}px solid rgba(0, 0, 0, 0.2)`,
+    left: (props) => (props as any).index * -1 * INDENTATION_SPACING,
+  },
+  innerMostSiblingConnector: {
+    '&:after': {
+      position: 'absolute',
+      height: '2px',
+      width: `${INDENTATION_SPACING - borderSizeOfSiblingLines}px`,
+      left: '0px',
+      content: '""',
+      borderTop: '2px solid rgba(0, 0, 0, 0.2)',
+      top: `${rowHeight / 2}px`,
+    },
+  },
+  highlight: {
+    borderLeftColor: `${blue[300]}`,
+    '&:after': {
+      borderTopColor: `${blue[300]}`,
+    },
+  },
+  errorHighlight: {
+    borderLeftColor: `${red[100]}`, // TODO: should be able to use from theme.
+    '&:after': {
+      borderTopColor: `${red[100]}`,
+    },
+  },
+});
+
+const SiblingLine = ({ id, index, activeParent, setActiveParent, ancestors, error = false }) => {
+  const classes = useStyles({ index: ancestors.length - 1 - index });
+  if (index + 1 === ancestors.length - 1) {
+    return (
+      <div
+        onMouseEnter={() => setActiveParent(id)}
+        onMouseLeave={() => setActiveParent(null)}
+        className={classnames(`${classes.root} ${classes.innerMostSiblingConnector}`, {
+          [classes.highlight]: id === activeParent,
+          [classes.errorHighlight]: error,
+        })}
+        key={id}
+        data-ancestor-id={id}
+      />
+    );
+  }
+  return (
+    <div
+      onMouseEnter={() => setActiveParent(id)}
+      onMouseLeave={() => setActiveParent(null)}
+      className={classnames(classes.root, {
+        [classes.highlight]: id === activeParent,
+        [classes.errorHighlight]: error,
+      })}
+      data-ancestor-id={id}
+      key={index}
+    />
+  );
+};
+export { SiblingLine };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/index.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import Box from '@material-ui/core/Box';
+import Paper from '@material-ui/core/Paper';
+import isObject from 'lodash/isObject';
+import withStyles from '@material-ui/core/styles/withStyles';
+import If from 'components/If';
+import { SiblingCommunicationConsumer } from 'components/AbstractWidget/SchemaEditor/FieldWrapper/SiblingCommunicationContext';
+import { SchemaValidatorConsumer } from '../SchemaValidator';
+import isNil from 'lodash/isNil';
+import { SiblingLine } from 'components/AbstractWidget/SchemaEditor/FieldWrapper/SiblingLine';
+import {
+  INDENTATION_SPACING,
+  rowHeight,
+  rowMarginTop,
+} from 'components/AbstractWidget/SchemaEditor/FieldWrapper/FieldWrapperConstants';
+
+interface IFieldWrapperProps {
+  ancestors: string[];
+  children?: React.ReactNode;
+  style?: any;
+  className?: any;
+}
+
+const CustomizedPaper = withStyles(() => {
+  return {
+    root: {
+      padding: '2px 10px 2px 0px',
+      display: 'grid',
+      marginTop: `${rowMarginTop}px`,
+      gridTemplateRows: `${rowHeight}px`,
+      position: 'relative',
+    },
+  };
+})(Paper);
+
+const SiblingsWrapper = withStyles(() => {
+  return {
+    root: {
+      position: 'absolute',
+      left: 0,
+      top: 0,
+    },
+  };
+})(Box);
+
+const FieldWrapperBase = ({
+  ancestors = [],
+  children,
+  style = {},
+  className,
+}: IFieldWrapperProps) => {
+  /**
+   * Based on the number of ancestors we indent the row accordingly. Each ancestor will
+   * have a line indicating hierarchy and a horizontal line with immediate parent
+   *
+   * The design is to have a grid base row
+   * - There is a single column wrapper (for unions and arrays) which is implemented by SingleColumnWrapper
+   * - There is a two column layout for field name/type (or label and type for maps) and the
+   * other for the row buttons. This helps us maintain the vertical alignment for row buttons
+   * no matter what the indentation is.
+   *
+   * The width of the wrapper is reduced based on the indentation.
+   */
+  const spacing = ancestors.length * INDENTATION_SPACING;
+  const firstColumn = '20px';
+  const thirdColumn = `96px`;
+  const errorColumn = '10px';
+  const secondColumn = `calc(100% - (${firstColumn} + ${thirdColumn} + ${errorColumn}))`;
+  let customStyles: Partial<CSSStyleDeclaration> = {
+    marginLeft: `${spacing}px`,
+    gridTemplateColumns: `${firstColumn} ${secondColumn} ${thirdColumn}`,
+    width: `calc(100% - ${spacing + 5 /* box shadow */}px)`,
+    alignItems: 'center',
+  };
+  if (style && isObject(style)) {
+    customStyles = {
+      ...customStyles,
+      ...style,
+    };
+  }
+  return (
+    <CustomizedPaper elevation={2} style={customStyles} className={className}>
+      <If condition={ancestors.length > 1}>
+        <SchemaValidatorConsumer>
+          {({ errorMap }) => {
+            return (
+              <SiblingCommunicationConsumer>
+                {({ activeParent, setActiveParent }) => {
+                  return (
+                    <SiblingsWrapper>
+                      {ancestors.slice(1).map((id, index) => {
+                        return (
+                          <SiblingLine
+                            key={id}
+                            id={id}
+                            activeParent={activeParent}
+                            setActiveParent={setActiveParent}
+                            ancestors={ancestors}
+                            index={index}
+                            error={!isNil(errorMap[id])}
+                          />
+                        );
+                      })}
+                    </SiblingsWrapper>
+                  );
+                }}
+              </SiblingCommunicationConsumer>
+            );
+          }}
+        </SchemaValidatorConsumer>
+      </If>
+      {children}
+    </CustomizedPaper>
+  );
+};
+
+const FieldInputWrapperBase = withStyles(() => {
+  return {
+    root: {
+      display: 'grid',
+      gridTemplateColumns: 'auto 100px',
+    },
+  };
+})(Box);
+
+const FieldWrapper = React.memo(FieldWrapperBase);
+const FieldInputWrapper = React.memo(FieldInputWrapperBase);
+export { FieldWrapper, FieldInputWrapper, rowHeight, rowMarginTop };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/index.tsx
@@ -77,13 +77,13 @@ const FieldWrapperBase = ({
    *
    * The width of the wrapper is reduced based on the indentation.
    */
-  const spacing = ancestors.length * INDENTATION_SPACING;
+  const spacing = (ancestors.length - 1) * INDENTATION_SPACING;
   const firstColumn = '20px';
   const thirdColumn = `96px`;
   const errorColumn = '10px';
   const secondColumn = `calc(100% - (${firstColumn} + ${thirdColumn} + ${errorColumn}))`;
   let customStyles: Partial<CSSStyleDeclaration> = {
-    marginLeft: `${spacing}px`,
+    marginLeft: `${spacing === 0 ? 2 : spacing}px`,
     gridTemplateColumns: `${firstColumn} ${secondColumn} ${thirdColumn}`,
     width: `calc(100% - ${spacing + 5 /* box shadow */}px)`,
     alignItems: 'center',
@@ -134,7 +134,7 @@ const FieldInputWrapperBase = withStyles(() => {
   return {
     root: {
       display: 'grid',
-      gridTemplateColumns: 'auto 100px',
+      gridTemplateColumns: '60% 40%',
     },
   };
 })(Box);

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldsList/FieldRow.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldsList/FieldRow.tsx
@@ -1,0 +1,266 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import {
+  IFlattenRowType,
+  IFieldIdentifier,
+  IOnChangePayload,
+  IRowOnChangeHandler,
+} from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import {
+  schemaTypes,
+  InternalTypesEnum,
+  OperationTypesEnum,
+} from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import { FieldType } from 'components/AbstractWidget/SchemaEditor/FieldType';
+import { UnionType } from 'components/AbstractWidget/SchemaEditor/UnionType';
+import { MapType } from 'components/AbstractWidget/SchemaEditor/MapType';
+import { EnumType } from 'components/AbstractWidget/SchemaEditor/EnumType';
+import { ArrayType } from 'components/AbstractWidget/SchemaEditor/ArrayType';
+import { FieldWrapper } from 'components/AbstractWidget/SchemaEditor/FieldWrapper';
+import { SchemaValidatorConsumer } from 'components/AbstractWidget/SchemaEditor/SchemaValidator';
+import If from 'components/If';
+import ErrorIcon from '@material-ui/icons/ErrorOutline';
+import classnames from 'classnames';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+import Tooltip from '@material-ui/core/Tooltip';
+import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
+import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
+
+const styles = (theme): StyleRules => {
+  return {
+    errorIcon: {
+      position: 'absolute',
+      right: '5px',
+      color: theme.palette.red[200],
+    },
+    erroredRow: {
+      outline: `2px solid ${theme.palette.red[200]}`,
+    },
+    tooltip: {
+      backgroundColor: theme.palette.red[200],
+      color: 'white',
+      fontSize: '12px',
+      wordBreak: 'break-word',
+    },
+  };
+};
+
+interface IFieldRowState {
+  name: string;
+  type: string;
+  nullable: boolean;
+  typeProperties: Record<string, string>;
+}
+
+interface IFieldRowProps extends WithStyles<typeof styles> {
+  field: IFlattenRowType;
+  onChange: IRowOnChangeHandler;
+  autoFocus?: boolean;
+}
+
+class FieldRowBase extends React.Component<IFieldRowProps, IFieldRowState> {
+  public state: IFieldRowState = {
+    name: '',
+    type: schemaTypes[0],
+    nullable: false,
+    typeProperties: {},
+  };
+
+  constructor(props) {
+    super(props);
+    const { field } = this.props;
+    this.state = {
+      name: field.name,
+      type: field.type,
+      nullable: field.nullable,
+      typeProperties: field.typeProperties,
+    };
+  }
+
+  public componentWillReceiveProps() {
+    return;
+  }
+
+  public onChange = (property: string, value) => {
+    if (['name', 'type', 'nullable', 'typeProperties'].indexOf(property) === -1) {
+      return;
+    }
+    const { onChange, field } = this.props;
+    if (onChange) {
+      this.props.onChange(
+        { id: field.id, ancestors: field.ancestors },
+        {
+          property,
+          value,
+          type: OperationTypesEnum.UPDATE,
+        }
+      );
+    }
+    return;
+  };
+
+  public onAdd = () => {
+    const { onChange, field } = this.props;
+    const { id, ancestors } = field;
+    if (onChange) {
+      this.props.onChange(
+        { id, ancestors },
+        {
+          type: OperationTypesEnum.ADD,
+        }
+      );
+    }
+  };
+
+  public onRemove = () => {
+    const { onChange, field } = this.props;
+    const { id, ancestors } = field;
+    if (onChange) {
+      onChange({ id, ancestors }, { type: OperationTypesEnum.REMOVE });
+    }
+  };
+
+  public onToggleCollapse = () => {
+    const { onChange, field } = this.props;
+    const { id, ancestors } = field;
+    if (onChange) {
+      onChange({ id, ancestors }, { type: OperationTypesEnum.COLLAPSE });
+    }
+  };
+
+  public RenderSubType = (field) => {
+    switch (field.internalType) {
+      case InternalTypesEnum.RECORD_SIMPLE_TYPE:
+      case InternalTypesEnum.RECORD_COMPLEX_TYPE_ROOT:
+        return (
+          <FieldType
+            name={this.props.field.name}
+            type={this.props.field.type}
+            nullable={this.props.field.nullable}
+            onChange={this.onChange}
+            onAdd={this.onAdd}
+            onRemove={this.onRemove}
+            autoFocus={this.props.autoFocus}
+            typeProperties={this.props.field.typeProperties}
+          />
+        );
+      case InternalTypesEnum.ARRAY_SIMPLE_TYPE:
+      case InternalTypesEnum.ARRAY_COMPLEX_TYPE:
+      case InternalTypesEnum.ARRAY_COMPLEX_TYPE_ROOT:
+        return (
+          <ArrayType
+            type={this.props.field.type}
+            nullable={this.props.field.nullable}
+            onChange={this.onChange}
+            onAdd={this.onAdd}
+            onRemove={this.onRemove}
+            autoFocus={this.props.autoFocus}
+            typeProperties={this.props.field.typeProperties}
+          />
+        );
+      case InternalTypesEnum.ENUM_SYMBOL:
+        return (
+          <EnumType
+            typeProperties={this.props.field.typeProperties}
+            onChange={this.onChange}
+            onAdd={this.onAdd}
+            onRemove={this.onRemove}
+            autoFocus={this.props.autoFocus}
+          />
+        );
+      case InternalTypesEnum.MAP_KEYS_COMPLEX_TYPE_ROOT:
+      case InternalTypesEnum.MAP_KEYS_SIMPLE_TYPE:
+      case InternalTypesEnum.MAP_VALUES_COMPLEX_TYPE_ROOT:
+      case InternalTypesEnum.MAP_VALUES_SIMPLE_TYPE:
+        return (
+          <MapType
+            internalType={this.props.field.internalType}
+            type={this.props.field.type}
+            nullable={this.props.field.nullable}
+            onChange={this.onChange}
+            onAdd={this.onAdd}
+            onRemove={this.onRemove}
+            autoFocus={this.props.autoFocus}
+            typeProperties={this.props.field.typeProperties}
+          />
+        );
+      case InternalTypesEnum.UNION_SIMPLE_TYPE:
+      case InternalTypesEnum.UNION_COMPLEX_TYPE_ROOT:
+        return (
+          <UnionType
+            type={this.props.field.type}
+            nullable={this.props.field.nullable}
+            onChange={this.onChange}
+            onAdd={this.onAdd}
+            onRemove={this.onRemove}
+            autoFocus={this.props.autoFocus}
+            typeProperties={this.props.field.typeProperties}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  public render() {
+    const { classes } = this.props;
+    const { ancestors, internalType } = this.props.field;
+    if (internalType === InternalTypesEnum.SCHEMA) {
+      return null;
+    }
+    return (
+      <SchemaValidatorConsumer>
+        {({ errorMap = {} }) => {
+          const hasError = errorMap.hasOwnProperty(this.props.field.id);
+          return (
+            <FieldWrapper
+              ancestors={ancestors}
+              className={classnames({
+                [classes.erroredRow]: hasError,
+              })}
+            >
+              <React.Fragment>
+                <If condition={hasError}>
+                  <Tooltip
+                    classes={{ tooltip: classes.tooltip }}
+                    title={errorMap[this.props.field.id]}
+                    placement="right"
+                  >
+                    <ErrorIcon className={classes.errorIcon} />
+                  </Tooltip>
+                </If>
+                <If condition={typeof this.props.field.collapsed === 'boolean'} invisible>
+                  <If condition={this.props.field.collapsed}>
+                    <KeyboardArrowRightIcon onClick={this.onToggleCollapse} />
+                  </If>
+                  <If condition={!this.props.field.collapsed}>
+                    <KeyboardArrowDownIcon onClick={this.onToggleCollapse} />
+                  </If>
+                </If>
+                {this.RenderSubType(this.props.field)}
+              </React.Fragment>
+            </FieldWrapper>
+          );
+        }}
+      </SchemaValidatorConsumer>
+    );
+  }
+}
+
+const FieldRow = React.memo(withStyles(styles)(FieldRowBase));
+export { FieldRow };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldsList/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldsList/index.tsx
@@ -35,11 +35,14 @@ const styles = (): StyleRules => {
 };
 
 interface IFieldsListState {
+  visibleRowCount: number;
   rows: IFlattenRowType[];
   currentRowToFocus: string;
 }
 
 interface IFieldsListProps extends WithStyles<typeof styles> {
+  visibleRowCount?: number;
+  disabled?: boolean;
   value: IFlattenRowType[];
   onChange: (id: IFieldIdentifier, onChangePayload: IOnChangePayload) => IOnChangeReturnType;
 }
@@ -52,13 +55,16 @@ class FieldsListBase extends React.Component<IFieldsListProps, IFieldsListState>
   public state: IFieldsListState = {
     rows: this.props.value || [],
     currentRowToFocus: null,
+    visibleRowCount: this.props.visibleRowCount || FieldsListBase.visibleNodeCount,
   };
   public componentWillReceiveProps(nextProps: IFieldsListProps) {
-    const ids = nextProps.value.map((r) => `${r.id}-${r.hidden}`).join(',');
-    const existingids = this.state.rows.map((r) => `${r.id}-${r.hidden}`).join(',');
-    if (ids !== existingids) {
+    const ids = nextProps.value.map((r) => `${r.id}-${r.hidden}-${r.collapsed}`).join(',');
+    const existingids = this.state.rows.map((r) => `${r.id}-${r.hidden}-${r.collapsed}`).join(',');
+    const { visibleRowCount } = nextProps;
+    if (ids !== existingids || visibleRowCount !== this.state.visibleRowCount) {
       this.setState({
         rows: nextProps.value,
+        visibleRowCount,
       });
     }
   }
@@ -85,6 +91,7 @@ class FieldsListBase extends React.Component<IFieldsListProps, IFieldsListState>
         }
         return (
           <FieldRow
+            disabled={this.props.disabled}
             autoFocus={currentRowToFocus === field.id}
             key={field.id}
             field={field}
@@ -110,7 +117,7 @@ class FieldsListBase extends React.Component<IFieldsListProps, IFieldsListState>
         </SchemaValidatorConsumer>
         <VirtualScroll
           itemCount={() => itemCount}
-          visibleChildCount={FieldsListBase.visibleNodeCount}
+          visibleChildCount={this.state.visibleRowCount}
           childHeight={FieldsListBase.heightOfRow}
           renderList={this.renderList.bind(this)}
           childrenUnderFold={FieldsListBase.childrenUnderFold}
@@ -120,4 +127,4 @@ class FieldsListBase extends React.Component<IFieldsListProps, IFieldsListState>
   }
 }
 const FieldsList = withstyles(styles)(FieldsListBase);
-export { FieldsList };
+export { FieldsList, FieldsListBase };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldsList/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldsList/index.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import {
+  IFlattenRowType,
+  IFieldIdentifier,
+  IOnChangePayload,
+} from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { FieldRow } from 'components/AbstractWidget/SchemaEditor/FieldsList/FieldRow';
+import { SiblingCommunicationProvider } from 'components/AbstractWidget/SchemaEditor/FieldWrapper/SiblingCommunicationContext';
+import { IOnChangeReturnType } from 'components/AbstractWidget/SchemaEditor/Context/SchemaManager';
+import VirtualScroll from 'components/VirtualScroll';
+import { SchemaValidatorConsumer } from 'components/AbstractWidget/SchemaEditor/SchemaValidator';
+import withstyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+const styles = (): StyleRules => {
+  return {
+    errorHighlight: {
+      color: 'red',
+    },
+  };
+};
+
+interface IFieldsListState {
+  rows: IFlattenRowType[];
+  currentRowToFocus: string;
+}
+
+interface IFieldsListProps extends WithStyles<typeof styles> {
+  value: IFlattenRowType[];
+  onChange: (id: IFieldIdentifier, onChangePayload: IOnChangePayload) => IOnChangeReturnType;
+}
+
+class FieldsListBase extends React.Component<IFieldsListProps, IFieldsListState> {
+  public static visibleNodeCount = 20;
+  public static childrenUnderFold = 5;
+  public static heightOfRow = 34;
+
+  public state: IFieldsListState = {
+    rows: this.props.value || [],
+    currentRowToFocus: null,
+  };
+  public componentWillReceiveProps(nextProps: IFieldsListProps) {
+    const ids = nextProps.value.map((r) => `${r.id}-${r.hidden}`).join(',');
+    const existingids = this.state.rows.map((r) => `${r.id}-${r.hidden}`).join(',');
+    if (ids !== existingids) {
+      this.setState({
+        rows: nextProps.value,
+      });
+    }
+  }
+
+  public onChange = (field: IFieldIdentifier, onChangePayload: IOnChangePayload) => {
+    const { fieldIdToFocus } = this.props.onChange(field, onChangePayload);
+    if (typeof fieldIdToFocus === 'string') {
+      this.setState({
+        currentRowToFocus: fieldIdToFocus,
+      });
+    }
+  };
+
+  public renderList = (visibleNodeCount, startNode) => {
+    const { currentRowToFocus } = this.state;
+    // Remove the first row as that is the top level schema row.
+    return this.state.rows
+      .slice(1)
+      .filter((row) => !row.hidden)
+      .slice(startNode, startNode + visibleNodeCount)
+      .map((field, i) => {
+        if (field.hidden) {
+          return null;
+        }
+        return (
+          <FieldRow
+            autoFocus={currentRowToFocus === field.id}
+            key={field.id}
+            field={field}
+            onChange={this.onChange}
+          />
+        );
+      });
+  };
+
+  public render() {
+    const itemCount = this.state.rows.filter((field) => !field.hidden).length;
+    const { classes } = this.props;
+    return (
+      <SiblingCommunicationProvider>
+        <SchemaValidatorConsumer>
+          {({ errorMap = {} }) => {
+            if (errorMap.hasOwnProperty(this.state.rows[0].id)) {
+              return (
+                <div className={classes.errorHighlight}>{errorMap[this.state.rows[0].id]}</div>
+              );
+            }
+          }}
+        </SchemaValidatorConsumer>
+        <VirtualScroll
+          itemCount={() => itemCount}
+          visibleChildCount={FieldsListBase.visibleNodeCount}
+          childHeight={FieldsListBase.heightOfRow}
+          renderList={this.renderList.bind(this)}
+          childrenUnderFold={FieldsListBase.childrenUnderFold}
+        />
+      </SiblingCommunicationProvider>
+    );
+  }
+}
+const FieldsList = withstyles(styles)(FieldsListBase);
+export { FieldsList };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/MapType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/MapType/index.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import Select from 'components/AbstractWidget/FormInputs/Select';
+import {
+  schemaTypes,
+  InternalTypesEnum,
+} from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import Box from '@material-ui/core/Box';
+import withStyles, { StyleRules } from '@material-ui/core/styles/withStyles';
+import { IFieldTypeBaseProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { RowButtons } from 'components/AbstractWidget/SchemaEditor/RowButtons';
+
+const MapWrapper = withStyles(
+  (): StyleRules => {
+    return {
+      root: {
+        display: 'grid',
+        gridTemplateColumns: '35px 100px',
+        alignItems: 'center',
+        gridGap: '10px',
+      },
+    };
+  }
+)(Box);
+
+const MapTypeBase = ({
+  internalType,
+  type,
+  nullable,
+  onChange,
+  autoFocus,
+  typeProperties,
+}: IFieldTypeBaseProps) => {
+  let label = '';
+  const keysType: string[] = [
+    InternalTypesEnum.MAP_KEYS_COMPLEX_TYPE_ROOT,
+    InternalTypesEnum.MAP_KEYS_SIMPLE_TYPE,
+  ];
+  const valuesType: string[] = [
+    InternalTypesEnum.MAP_VALUES_COMPLEX_TYPE_ROOT,
+    InternalTypesEnum.MAP_VALUES_SIMPLE_TYPE,
+  ];
+  if (keysType.indexOf(internalType) !== -1) {
+    label = 'Keys: ';
+  }
+  if (valuesType.indexOf(internalType) !== -1) {
+    label = 'Values: ';
+  }
+  const [fieldType, setFieldType] = React.useState(type);
+  const [fieldNullable, setFieldNullable] = React.useState(nullable);
+  const [fieldTypeProperties, setFieldTypeProperties] = React.useState(typeProperties || {});
+
+  const onTypePropertiesChangeHandler = (property, value) => {
+    if (property === 'typeProperties') {
+      setFieldTypeProperties(value);
+    }
+    onChange(property, value);
+  };
+  const inputEle = React.useRef(null);
+  React.useEffect(() => {
+    if (autoFocus) {
+      if (inputEle.current) {
+        inputEle.current.focus();
+      }
+    }
+  }, [autoFocus]);
+  const onNullable = (checked) => {
+    setFieldNullable(checked);
+    onChange('nullable', checked);
+  };
+  return (
+    <React.Fragment>
+      <MapWrapper>
+        <span>{label}</span>
+        <Select
+          value={fieldType}
+          onChange={(newValue) => {
+            setFieldType(newValue);
+            onChange('type', newValue);
+          }}
+          widgetProps={{ options: schemaTypes, dense: true, inline: true }}
+          inputRef={(ref) => (inputEle.current = ref)}
+        />
+      </MapWrapper>
+      <RowButtons
+        nullable={fieldNullable}
+        onNullable={type === 'union' ? undefined : onNullable}
+        type={fieldType}
+        onChange={onTypePropertiesChangeHandler}
+        typeProperties={fieldTypeProperties}
+      />
+    </React.Fragment>
+  );
+};
+const MapType = React.memo(MapTypeBase);
+export { MapType };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/MapType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/MapType/index.tsx
@@ -19,6 +19,7 @@ import Select from 'components/AbstractWidget/FormInputs/Select';
 import {
   schemaTypes,
   InternalTypesEnum,
+  AvroSchemaTypesEnum,
 } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 import Box from '@material-ui/core/Box';
 import withStyles, { StyleRules } from '@material-ui/core/styles/withStyles';
@@ -45,6 +46,7 @@ const MapTypeBase = ({
   onChange,
   autoFocus,
   typeProperties,
+  disabled = false,
 }: IFieldTypeBaseProps) => {
   let label = '';
   const keysType: string[] = [
@@ -88,18 +90,20 @@ const MapTypeBase = ({
       <MapWrapper>
         <span>{label}</span>
         <Select
+          disabled={disabled}
           value={fieldType}
           onChange={(newValue) => {
             setFieldType(newValue);
             onChange('type', newValue);
           }}
-          widgetProps={{ options: schemaTypes, dense: true, inline: true }}
+          widgetProps={{ options: schemaTypes, dense: true, inline: true, native: true }}
           inputRef={(ref) => (inputEle.current = ref)}
         />
       </MapWrapper>
       <RowButtons
+        disabled={disabled}
         nullable={fieldNullable}
-        onNullable={type === 'union' ? undefined : onNullable}
+        onNullable={type === AvroSchemaTypesEnum.UNION ? undefined : onNullable}
         type={fieldType}
         onChange={onTypePropertiesChangeHandler}
         typeProperties={fieldTypeProperties}

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/AddRowButton.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/AddRowButton.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import AddIcon from '@material-ui/icons/Add';
+import { IconWrapper } from 'components/AbstractWidget/SchemaEditor/RowButtons/IconWrapper';
+
+function AddRowButton({ onAdd }) {
+  return (
+    <IconWrapper onClick={onAdd}>
+      <AddIcon />
+    </IconWrapper>
+  );
+}
+
+export { AddRowButton };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/DecimalAttributes.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/DecimalAttributes.tsx
@@ -24,6 +24,7 @@ import {
 import { IAttributesComponentProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
 import { objectQuery } from 'services/helpers';
 import { useAttributePopoverStyles } from 'components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton';
+import If from 'components/If';
 
 function DecimalTypeAttributes({
   typeProperties,
@@ -73,9 +74,11 @@ function DecimalTypeAttributes({
           onChange={setPrecision}
         />
       </div>
-      <Button variant="contained" color="primary" onClick={onChangeHandler}>
-        Save
-      </Button>
+      <If condition={typeof onChange === 'function'}>
+        <Button variant="contained" color="primary" onClick={onChangeHandler}>
+          Save
+        </Button>
+      </If>
     </React.Fragment>
   );
 }

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/DecimalAttributes.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/DecimalAttributes.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
+import Button from '@material-ui/core/Button';
+import {
+  defaultPrecision,
+  defaultScale,
+} from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import { IAttributesComponentProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { objectQuery } from 'services/helpers';
+import { useAttributePopoverStyles } from 'components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton';
+
+function DecimalTypeAttributes({
+  typeProperties,
+  onChange,
+  handleClose,
+}: IAttributesComponentProps) {
+  const [scale, setScale] = React.useState(objectQuery(typeProperties, 'scale') || defaultScale);
+  const [precision, setPrecision] = React.useState(
+    objectQuery(typeProperties, 'precision') || defaultPrecision
+  );
+  const classes = useAttributePopoverStyles();
+
+  const onChangeHandler = () => {
+    onChange('typeProperties', {
+      scale: parseInt(scale, 10),
+      precision: parseInt(precision, 10),
+    });
+    handleClose();
+  };
+  return (
+    <React.Fragment>
+      <div className={classes.root}>
+        <WidgetWrapper
+          pluginProperty={{
+            name: 'scale',
+            macroSupported: false,
+            description: 'Scale of decimal',
+          }}
+          widgetProperty={{
+            'widget-type': 'number',
+            label: 'Scale',
+          }}
+          value={scale}
+          onChange={setScale}
+        />
+        <WidgetWrapper
+          pluginProperty={{
+            name: 'Precision',
+            macroSupported: false,
+            description: 'Precision of decimal',
+          }}
+          widgetProperty={{
+            'widget-type': 'number',
+            label: 'Precision',
+          }}
+          value={precision}
+          onChange={setPrecision}
+        />
+      </div>
+      <Button variant="contained" color="primary" onClick={onChangeHandler}>
+        Save
+      </Button>
+    </React.Fragment>
+  );
+}
+
+export { DecimalTypeAttributes };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import MoreVertical from '@material-ui/icons/MoreVert';
+import { IconWrapper } from 'components/AbstractWidget/SchemaEditor/RowButtons/IconWrapper';
+import Popover from '@material-ui/core/Popover';
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import { ISimpleType, IComplexTypeNames } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+import { isFlatRowTypeComplex } from 'components/AbstractWidget/SchemaEditor/SchemaHelpers';
+import { RecordEnumTypeAttributes } from 'components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/RecordEnumAttributes';
+import { DecimalTypeAttributes } from 'components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/DecimalAttributes';
+import If from 'components/If';
+import { ITypeProperties } from 'components/AbstractWidget/SchemaEditor/Context/SchemaParser';
+import { IOnchangeHandler } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+
+interface IFieldPropertiesPopoverButtonProps {
+  nullable: boolean;
+  onNullable: (nullable: boolean) => void;
+  type: ISimpleType | IComplexTypeNames;
+  onChange?: IOnchangeHandler;
+  typeProperties: ITypeProperties;
+}
+
+const useAttributePopoverStyles = makeStyles({
+  root: {
+    marginTop: '15px',
+    maxHeight: '250px',
+    overflowY: 'auto',
+    '& >div': {
+      margin: '10px 0',
+    },
+  },
+});
+
+const useStyles = makeStyles((theme) => ({
+  popoverContainer: {
+    padding: theme.spacing(1),
+    width: '300px',
+  },
+}));
+
+function FieldPropertiesPopoverButton({
+  type,
+  onChange,
+  typeProperties,
+}: IFieldPropertiesPopoverButtonProps) {
+  const [anchorEl, setAnchorEl] = React.useState(null);
+
+  function handleClick(event) {
+    setAnchorEl(event.currentTarget);
+  }
+
+  function handleClose() {
+    setAnchorEl(null);
+  }
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'simple-popover' : null;
+  const classes = useStyles();
+  return (
+    <React.Fragment>
+      <IconWrapper onClick={handleClick}>
+        <MoreVertical />
+      </IconWrapper>
+
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+      >
+        <div className={classes.popoverContainer}>
+          <If condition={!isFlatRowTypeComplex(type)}>
+            <strong>No Attributes</strong>
+          </If>
+          <If condition={type === 'record' || type === 'enum'}>
+            <strong>Attributes</strong>
+            <RecordEnumTypeAttributes
+              typeProperties={typeProperties}
+              onChange={onChange}
+              handleClose={handleClose}
+            />
+          </If>
+          <If condition={type === 'decimal'}>
+            <strong>Attributes</strong>
+            <DecimalTypeAttributes
+              typeProperties={typeProperties}
+              onChange={onChange}
+              handleClose={handleClose}
+            />
+          </If>
+        </div>
+      </Popover>
+    </React.Fragment>
+  );
+}
+
+export { FieldPropertiesPopoverButton, useAttributePopoverStyles };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton.tsx
@@ -26,6 +26,7 @@ import { DecimalTypeAttributes } from 'components/AbstractWidget/SchemaEditor/Ro
 import If from 'components/If';
 import { ITypeProperties } from 'components/AbstractWidget/SchemaEditor/Context/SchemaParser';
 import { IOnchangeHandler } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { AvroSchemaTypesEnum } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 
 interface IFieldPropertiesPopoverButtonProps {
   nullable: boolean;
@@ -33,6 +34,7 @@ interface IFieldPropertiesPopoverButtonProps {
   type: ISimpleType | IComplexTypeNames;
   onChange?: IOnchangeHandler;
   typeProperties: ITypeProperties;
+  disabled?: boolean;
 }
 
 const useAttributePopoverStyles = makeStyles({
@@ -50,6 +52,10 @@ const useStyles = makeStyles((theme) => ({
   popoverContainer: {
     padding: theme.spacing(1),
     width: '300px',
+    '&[disabled] *': {
+      color: theme.palette.grey[200],
+      cursor: 'not-allowed',
+    },
   },
 }));
 
@@ -57,6 +63,7 @@ function FieldPropertiesPopoverButton({
   type,
   onChange,
   typeProperties,
+  disabled,
 }: IFieldPropertiesPopoverButtonProps) {
   const [anchorEl, setAnchorEl] = React.useState(null);
 
@@ -91,27 +98,28 @@ function FieldPropertiesPopoverButton({
           horizontal: 'center',
         }}
       >
-        <div className={classes.popoverContainer}>
+        <fieldset className={classes.popoverContainer} disabled={disabled}>
           <If condition={!isFlatRowTypeComplex(type)}>
             <strong>No Attributes</strong>
           </If>
-          <If condition={type === 'record' || type === 'enum'}>
+          <If condition={type === AvroSchemaTypesEnum.RECORD || type === AvroSchemaTypesEnum.ENUM}>
             <strong>Attributes</strong>
             <RecordEnumTypeAttributes
               typeProperties={typeProperties}
-              onChange={onChange}
+              onChange={disabled ? undefined : onChange}
               handleClose={handleClose}
             />
           </If>
-          <If condition={type === 'decimal'}>
+          <If condition={type === AvroSchemaTypesEnum.DECIMAL}>
             <strong>Attributes</strong>
             <DecimalTypeAttributes
               typeProperties={typeProperties}
-              onChange={onChange}
+              onChange={disabled ? undefined : onChange}
               handleClose={handleClose}
+              disabled={disabled}
             />
           </If>
-        </div>
+        </fieldset>
       </Popover>
     </React.Fragment>
   );

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/RecordEnumAttributes.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/RecordEnumAttributes.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
+import Button from '@material-ui/core/Button';
+import { IAttributesComponentProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { useAttributePopoverStyles } from 'components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton';
+
+function RecordEnumTypeAttributes({
+  typeProperties,
+  onChange,
+  handleClose,
+}: IAttributesComponentProps) {
+  const [doc, setDoc] = React.useState(typeProperties.doc || '');
+  const [aliases, setAlias] = React.useState(typeProperties.aliases || []);
+  const classes = useAttributePopoverStyles();
+
+  const onChangeHandler = () => {
+    onChange('typeProperties', {
+      doc,
+      aliases,
+    });
+    handleClose();
+  };
+  return (
+    <React.Fragment>
+      <div className={classes.root}>
+        <WidgetWrapper
+          pluginProperty={{
+            name: 'doc',
+            macroSupported: false,
+            description: 'documentation for the record',
+          }}
+          widgetProperty={{
+            'widget-type': 'textbox',
+            label: 'Doc',
+          }}
+          value={doc}
+          onChange={setDoc}
+        />
+        <WidgetWrapper
+          pluginProperty={{
+            name: 'Aliases',
+            macroSupported: false,
+            description: 'Aliases for the record',
+          }}
+          widgetProperty={{
+            'widget-type': 'csv',
+            label: 'Aliases',
+          }}
+          value={aliases.join(',')}
+          onChange={(value) => {
+            setAlias(value.split(','));
+          }}
+        />
+      </div>
+      <Button variant="contained" color="primary" onClick={onChangeHandler}>
+        Save
+      </Button>
+    </React.Fragment>
+  );
+}
+
+export { RecordEnumTypeAttributes };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/RecordEnumAttributes.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/RecordEnumAttributes.tsx
@@ -19,6 +19,7 @@ import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
 import Button from '@material-ui/core/Button';
 import { IAttributesComponentProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
 import { useAttributePopoverStyles } from 'components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton';
+import If from 'components/If';
 
 function RecordEnumTypeAttributes({
   typeProperties,
@@ -41,13 +42,13 @@ function RecordEnumTypeAttributes({
       <div className={classes.root}>
         <WidgetWrapper
           pluginProperty={{
-            name: 'doc',
+            name: 'documentation',
             macroSupported: false,
             description: 'documentation for the record',
           }}
           widgetProperty={{
             'widget-type': 'textbox',
-            label: 'Doc',
+            label: 'Documentation',
           }}
           value={doc}
           onChange={setDoc}
@@ -68,9 +69,11 @@ function RecordEnumTypeAttributes({
           }}
         />
       </div>
-      <Button variant="contained" color="primary" onClick={onChangeHandler}>
-        Save
-      </Button>
+      <If condition={typeof onChange === 'function'}>
+        <Button variant="contained" color="primary" onClick={onChangeHandler}>
+          Save
+        </Button>
+      </If>
     </React.Fragment>
   );
 }

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/IconWrapper.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/IconWrapper.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import withStyles, { StyleRules } from '@material-ui/core/styles/withStyles';
+import IconButton from '@material-ui/core/IconButton';
+
+export const IconWrapper = withStyles(
+  (): StyleRules => {
+    return {
+      root: {
+        '&:focus': {
+          outline: 'none',
+        },
+      },
+    };
+  }
+)(IconButton);

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/Nullable.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/Nullable.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import CheckBox from '@material-ui/core/Checkbox';
+import CheckBoxIcon from '@material-ui/icons/CheckBox';
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+
+interface INullableBaseProps {
+  nullable: boolean;
+  onNullable: (value: boolean) => void;
+}
+
+const NullableBase = ({ nullable, onNullable: onChange }: INullableBaseProps) => {
+  return (
+    <CheckBox
+      checked={nullable}
+      color="primary"
+      checkedIcon={<CheckBoxIcon fontSize="small" />}
+      icon={<CheckBoxOutlineBlankIcon fontSize="small" />}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+        onChange(e.target.checked);
+      }}
+    />
+  );
+};
+
+const Nullable = React.memo(NullableBase);
+export { Nullable };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/RemoveRowButton.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/RemoveRowButton.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import DeleteIcon from '@material-ui/icons/Delete';
+import withStyles from '@material-ui/core/styles/withStyles';
+import { IconWrapper } from 'components/AbstractWidget/SchemaEditor/RowButtons/IconWrapper';
+const styles = (theme) => {
+  return {
+    root: {
+      color: theme.palette.red[100],
+    },
+  };
+};
+
+function RemoveRowButtonBase({ classes, onRemove }) {
+  return (
+    <IconWrapper onClick={onRemove}>
+      <DeleteIcon className={classes.root} />
+    </IconWrapper>
+  );
+}
+const RemoveRowButton = withStyles(styles)(RemoveRowButtonBase);
+export { RemoveRowButton };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/index.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import withStyles from '@material-ui/core/styles/withStyles';
+import Box from '@material-ui/core/Box';
+import { AddRowButton } from 'components/AbstractWidget/SchemaEditor/RowButtons/AddRowButton';
+import { RemoveRowButton } from 'components/AbstractWidget/SchemaEditor/RowButtons/RemoveRowButton';
+import { FieldPropertiesPopoverButton } from 'components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton';
+import If from 'components/If';
+import { IComplexTypeNames, ISimpleType } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+import { Nullable } from 'components/AbstractWidget/SchemaEditor/RowButtons/Nullable';
+import { IOnchangeHandler } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+/**
+ * Generic row buttons (add, nullable & remove buttons)
+ * Based on the availability of handlers for each action each
+ * button is showed.
+ */
+const RowButtonWrapper = withStyles(() => {
+  return {
+    root: {
+      display: 'grid',
+      gridTemplateColumns: '24px 24px 24px 24px',
+      gridTemplateRows: '24px',
+    },
+  };
+})(Box);
+
+interface IRowButtonsProps {
+  nullable?: boolean;
+  onNullable?: (checked: boolean) => void;
+  onAdd?: () => void;
+  onRemove?: () => void;
+  onChange?: IOnchangeHandler;
+  typeProperties?: Record<string, string>;
+  type?: ISimpleType | IComplexTypeNames;
+}
+
+function RowButtons({
+  type,
+  nullable,
+  onNullable,
+  onAdd,
+  onRemove,
+  onChange,
+  typeProperties,
+}: IRowButtonsProps) {
+  return (
+    <RowButtonWrapper>
+      <If condition={typeof onNullable === 'function'} invisible>
+        <Nullable nullable={nullable} onNullable={onNullable} />
+      </If>
+      <If condition={typeof onAdd === 'function'} invisible>
+        <AddRowButton onAdd={onAdd} />
+      </If>
+      <If condition={typeof onRemove === 'function'} invisible>
+        <RemoveRowButton onRemove={onRemove} />
+      </If>
+      <If condition={type === 'record' || type === 'enum' || type === 'decimal'}>
+        <FieldPropertiesPopoverButton
+          nullable={nullable}
+          onNullable={onNullable}
+          type={type}
+          onChange={onChange}
+          typeProperties={typeProperties}
+        />
+      </If>
+    </RowButtonWrapper>
+  );
+}
+
+export { RowButtons };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/index.tsx
@@ -24,6 +24,7 @@ import If from 'components/If';
 import { IComplexTypeNames, ISimpleType } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
 import { Nullable } from 'components/AbstractWidget/SchemaEditor/RowButtons/Nullable';
 import { IOnchangeHandler } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { AvroSchemaTypesEnum } from '../SchemaConstants';
 /**
  * Generic row buttons (add, nullable & remove buttons)
  * Based on the availability of handlers for each action each
@@ -35,6 +36,9 @@ const RowButtonWrapper = withStyles(() => {
       display: 'grid',
       gridTemplateColumns: '24px 24px 24px 24px',
       gridTemplateRows: '24px',
+      '& [disabled]': {
+        cursor: 'not-allowed',
+      },
     },
   };
 })(Box);
@@ -47,6 +51,7 @@ interface IRowButtonsProps {
   onChange?: IOnchangeHandler;
   typeProperties?: Record<string, string>;
   type?: ISimpleType | IComplexTypeNames;
+  disabled?: boolean;
 }
 
 function RowButtons({
@@ -57,25 +62,33 @@ function RowButtons({
   onRemove,
   onChange,
   typeProperties,
+  disabled = false,
 }: IRowButtonsProps) {
   return (
-    <RowButtonWrapper>
+    <RowButtonWrapper disabled={disabled}>
       <If condition={typeof onNullable === 'function'} invisible>
-        <Nullable nullable={nullable} onNullable={onNullable} />
+        <Nullable nullable={nullable} onNullable={disabled ? undefined : onNullable} />
       </If>
       <If condition={typeof onAdd === 'function'} invisible>
-        <AddRowButton onAdd={onAdd} />
+        <AddRowButton onAdd={disabled ? undefined : onAdd} />
       </If>
       <If condition={typeof onRemove === 'function'} invisible>
-        <RemoveRowButton onRemove={onRemove} />
+        <RemoveRowButton onRemove={disabled ? undefined : onRemove} />
       </If>
-      <If condition={type === 'record' || type === 'enum' || type === 'decimal'}>
+      <If
+        condition={
+          type === AvroSchemaTypesEnum.RECORD ||
+          type === AvroSchemaTypesEnum.ENUM ||
+          type === AvroSchemaTypesEnum.DECIMAL
+        }
+      >
         <FieldPropertiesPopoverButton
           nullable={nullable}
-          onNullable={onNullable}
+          onNullable={disabled ? undefined : onNullable}
           type={type}
-          onChange={onChange}
+          onChange={disabled ? undefined : onChange}
           typeProperties={typeProperties}
+          disabled={disabled}
         />
       </If>
     </RowButtonWrapper>

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SampleTypeFieldChecker.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SampleTypeFieldChecker.ts
@@ -30,13 +30,14 @@ import {
   ISimpleType,
   IComplexTypeFieldNullable,
 } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+import { AvroSchemaTypesEnum } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 
 const mapfield: IMapField = {
   name: 'map1',
   type: {
-    type: 'map',
-    keys: 'string',
-    values: 'string',
+    type: AvroSchemaTypesEnum.MAP,
+    keys: AvroSchemaTypesEnum.STRING,
+    values: AvroSchemaTypesEnum.STRING,
   },
 };
 // tslint:disable-next-line: no-console
@@ -45,8 +46,8 @@ console.log(mapfield.type.keys);
 const arrayField: IArrayField = {
   name: 'arr',
   type: {
-    type: 'array',
-    items: 'string',
+    type: AvroSchemaTypesEnum.ARRAY,
+    items: AvroSchemaTypesEnum.STRING,
   },
 };
 // tslint:disable-next-line: no-console
@@ -54,7 +55,7 @@ console.log(!Array.isArray(arrayField.type) ? arrayField.type.items : arrayField
 
 const unionField: IUnionField = {
   name: 'something',
-  type: ['long', 'string'],
+  type: [AvroSchemaTypesEnum.LONG, AvroSchemaTypesEnum.STRING],
 };
 // tslint:disable-next-line: no-console
 console.log(unionField.type[1]);
@@ -62,7 +63,7 @@ console.log(unionField.type[1]);
 const enumField: IEnumField = {
   name: 'enum1',
   type: {
-    type: 'enum',
+    type: AvroSchemaTypesEnum.ENUM,
     symbols: ['something', 'somethingelse', 'nothing', 'maybesomething'],
   },
 };
@@ -71,16 +72,16 @@ const enumField: IEnumField = {
 console.log(enumField.type.symbols);
 
 const recordField: IRecordField = {
-  type: 'record',
+  type: AvroSchemaTypesEnum.RECORD,
   name: 'record1',
   fields: [
     {
       name: 'name',
-      type: 'string',
+      type: AvroSchemaTypesEnum.STRING,
     },
     {
       name: 'email',
-      type: 'string',
+      type: AvroSchemaTypesEnum.STRING,
     },
   ],
 };
@@ -92,8 +93,8 @@ const complexArrField2: IArrayFieldNullable = {
   name: 'arr1',
   type: [
     {
-      type: 'array',
-      items: 'string',
+      type: AvroSchemaTypesEnum.ARRAY,
+      items: AvroSchemaTypesEnum.STRING,
     },
     'null',
   ],
@@ -110,19 +111,19 @@ const complexArrayField: IArrayFieldNullable = {
   name: 'complexArray',
   type: [
     {
-      type: 'array',
+      type: AvroSchemaTypesEnum.ARRAY,
       items: [
         {
-          type: 'record',
+          type: AvroSchemaTypesEnum.RECORD,
           name: 'ad5bddf76ef2743218d79d3905f0f8e4f',
           fields: [
             {
               name: 'name',
-              type: 'string',
+              type: AvroSchemaTypesEnum.STRING,
             },
             {
               name: 'email',
-              type: 'string',
+              type: AvroSchemaTypesEnum.STRING,
             },
           ],
         },
@@ -134,7 +135,9 @@ const complexArrayField: IArrayFieldNullable = {
 };
 
 if (Array.isArray(complexArrayField.type)) {
-  const a1 = complexArrayField.type.find((t) => t !== 'null' && t.type === 'array');
+  const a1 = complexArrayField.type.find(
+    (t) => t !== 'null' && t.type === AvroSchemaTypesEnum.ARRAY
+  );
   // tslint:disable-next-line: no-console
   console.log(a1 !== 'null' && a1.items);
   if (isNullable(complexArrayField.type)) {
@@ -146,36 +149,36 @@ if (Array.isArray(complexArrayField.type)) {
 const complexUnionField: IUnionField = {
   name: 'something',
   type: [
-    'long',
+    AvroSchemaTypesEnum.LONG,
     {
-      type: 'map',
+      type: AvroSchemaTypesEnum.MAP,
       keys: {
-        type: 'record',
+        type: AvroSchemaTypesEnum.RECORD,
         name: 'a64d56b7343854e81801874b77b536802',
         fields: [
           {
             name: 'sdfsd',
-            type: 'string',
+            type: AvroSchemaTypesEnum.STRING,
           },
           {
             name: 'sdfsdsdfsdf',
-            type: 'string',
+            type: AvroSchemaTypesEnum.STRING,
           },
         ],
       },
-      values: 'string',
+      values: AvroSchemaTypesEnum.STRING,
     },
     {
-      type: 'record',
+      type: AvroSchemaTypesEnum.RECORD,
       name: 'record1',
       fields: [
         {
           name: 'name',
-          type: 'string',
+          type: AvroSchemaTypesEnum.STRING,
         },
         {
           name: 'email',
-          type: 'string',
+          type: AvroSchemaTypesEnum.STRING,
         },
       ],
     },
@@ -184,24 +187,29 @@ const complexUnionField: IUnionField = {
 const isSimpleType = (type: ISimpleType | IComplexTypeFieldNullable) =>
   typeof type === 'string' &&
   [
-    'boolean',
-    'bytes',
-    'date',
-    'decimal',
-    'double',
-    'float',
-    'int',
-    'long',
-    'number',
-    'string',
-    'time',
+    AvroSchemaTypesEnum.BOOLEAN,
+    AvroSchemaTypesEnum.BYTES,
+    AvroSchemaTypesEnum.DATE,
+    AvroSchemaTypesEnum.DECIMAL,
+    AvroSchemaTypesEnum.DOUBLE,
+    AvroSchemaTypesEnum.FLOAT,
+    AvroSchemaTypesEnum.INT,
+    AvroSchemaTypesEnum.LONG,
+    AvroSchemaTypesEnum.STRING,
+    AvroSchemaTypesEnum.TIME,
   ].indexOf(type) !== -1;
 if (Array.isArray(complexUnionField.type)) {
   const map1 = complexUnionField.type
     .filter((t) => typeof t !== 'string')
-    .find((t: IComplexType) => !Array.isArray(t.type) && t.type === 'map') as IMapFieldBase;
+    .find(
+      (t: IComplexType) => !Array.isArray(t.type) && t.type === AvroSchemaTypesEnum.MAP
+    ) as IMapFieldBase;
   let fieldsInRecords;
-  if (!Array.isArray(map1.keys) && typeof map1.keys === 'object' && map1.keys.type === 'record') {
+  if (
+    !Array.isArray(map1.keys) &&
+    typeof map1.keys === 'object' &&
+    map1.keys.type === AvroSchemaTypesEnum.RECORD
+  ) {
     fieldsInRecords = (map1.keys as IRecordField).fields;
   }
   // tslint:disable-next-line: no-console

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SampleTypeFieldChecker.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SampleTypeFieldChecker.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * This is purely a playground to play around and get an understanding on the
+ * schema types. Not used anywhere.
+ */
+import {
+  IArrayField,
+  IArrayFieldNullable,
+  IUnionField,
+  IEnumField,
+  IRecordField,
+  IMapFieldBase,
+  IMapField,
+  IComplexType,
+  ISimpleType,
+  IComplexTypeFieldNullable,
+} from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+
+const mapfield: IMapField = {
+  name: 'map1',
+  type: {
+    type: 'map',
+    keys: 'string',
+    values: 'string',
+  },
+};
+// tslint:disable-next-line: no-console
+console.log(mapfield.type.keys);
+
+const arrayField: IArrayField = {
+  name: 'arr',
+  type: {
+    type: 'array',
+    items: 'string',
+  },
+};
+// tslint:disable-next-line: no-console
+console.log(!Array.isArray(arrayField.type) ? arrayField.type.items : arrayField.type[0]);
+
+const unionField: IUnionField = {
+  name: 'something',
+  type: ['long', 'string'],
+};
+// tslint:disable-next-line: no-console
+console.log(unionField.type[1]);
+
+const enumField: IEnumField = {
+  name: 'enum1',
+  type: {
+    type: 'enum',
+    symbols: ['something', 'somethingelse', 'nothing', 'maybesomething'],
+  },
+};
+// tslint:disable-next-line: no-console
+// tslint:disable-next-line: no-console
+console.log(enumField.type.symbols);
+
+const recordField: IRecordField = {
+  type: 'record',
+  name: 'record1',
+  fields: [
+    {
+      name: 'name',
+      type: 'string',
+    },
+    {
+      name: 'email',
+      type: 'string',
+    },
+  ],
+};
+// tslint:disable-next-line: no-console
+// tslint:disable-next-line: no-console
+console.log(recordField.fields);
+
+const complexArrField2: IArrayFieldNullable = {
+  name: 'arr1',
+  type: [
+    {
+      type: 'array',
+      items: 'string',
+    },
+    'null',
+  ],
+};
+// tslint:disable-next-line: no-console
+console.log(
+  Array.isArray(complexArrField2.type)
+    ? complexArrField2.type.find((t) => t !== 'null' && typeof t.items !== 'undefined')
+    : complexArrField2.type
+);
+
+const isNullable = (type) => Array.isArray(type) && type.find((t) => t === 'null');
+const complexArrayField: IArrayFieldNullable = {
+  name: 'complexArray',
+  type: [
+    {
+      type: 'array',
+      items: [
+        {
+          type: 'record',
+          name: 'ad5bddf76ef2743218d79d3905f0f8e4f',
+          fields: [
+            {
+              name: 'name',
+              type: 'string',
+            },
+            {
+              name: 'email',
+              type: 'string',
+            },
+          ],
+        },
+        'null',
+      ],
+    },
+    'null',
+  ],
+};
+
+if (Array.isArray(complexArrayField.type)) {
+  const a1 = complexArrayField.type.find((t) => t !== 'null' && t.type === 'array');
+  // tslint:disable-next-line: no-console
+  console.log(a1 !== 'null' && a1.items);
+  if (isNullable(complexArrayField.type)) {
+    // tslint:disable-next-line: no-console
+    console.log('nullable is true');
+  }
+}
+
+const complexUnionField: IUnionField = {
+  name: 'something',
+  type: [
+    'long',
+    {
+      type: 'map',
+      keys: {
+        type: 'record',
+        name: 'a64d56b7343854e81801874b77b536802',
+        fields: [
+          {
+            name: 'sdfsd',
+            type: 'string',
+          },
+          {
+            name: 'sdfsdsdfsdf',
+            type: 'string',
+          },
+        ],
+      },
+      values: 'string',
+    },
+    {
+      type: 'record',
+      name: 'record1',
+      fields: [
+        {
+          name: 'name',
+          type: 'string',
+        },
+        {
+          name: 'email',
+          type: 'string',
+        },
+      ],
+    },
+  ],
+};
+const isSimpleType = (type: ISimpleType | IComplexTypeFieldNullable) =>
+  typeof type === 'string' &&
+  [
+    'boolean',
+    'bytes',
+    'date',
+    'decimal',
+    'double',
+    'float',
+    'int',
+    'long',
+    'number',
+    'string',
+    'time',
+  ].indexOf(type) !== -1;
+if (Array.isArray(complexUnionField.type)) {
+  const map1 = complexUnionField.type
+    .filter((t) => typeof t !== 'string')
+    .find((t: IComplexType) => !Array.isArray(t.type) && t.type === 'map') as IMapFieldBase;
+  let fieldsInRecords;
+  if (!Array.isArray(map1.keys) && typeof map1.keys === 'object' && map1.keys.type === 'record') {
+    fieldsInRecords = (map1.keys as IRecordField).fields;
+  }
+  // tslint:disable-next-line: no-console
+  console.log(map1, fieldsInRecords);
+}

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaConstants.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaConstants.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { ISchemaType } from './SchemaTypes';
+
+/**
+ * Defines all the defaults we use for the schema.
+ */
+const logicalTypes = ['time', 'timestamp', 'decimal', 'date'];
+const defaultPrecision = 32;
+const defaultScale = 3;
+const defaultDecimalTypeProperties = {
+  type: 'bytes',
+  logicalType: 'decimal',
+  precision: defaultPrecision,
+  scale: defaultScale,
+};
+const defaultTimeTypeProperties = {
+  type: 'long',
+  logicalType: 'time-micros',
+};
+const defaultTimeStampTypeProperties = {
+  type: 'long',
+  logicalType: 'timestamp-micros',
+};
+const defaultDateTypeProperties = {
+  type: 'int',
+  logicalType: 'date',
+};
+
+const defaultArrayType = {
+  type: 'array',
+  items: 'string',
+};
+const defaultEnumType = {
+  type: 'enum',
+  symbols: [''],
+};
+const defaultMapType = {
+  type: 'map',
+  keys: 'string',
+  values: 'string',
+};
+const defaultRecordType = {
+  name: 'etlSchemaBody',
+  type: 'record',
+  fields: [
+    {
+      name: '',
+      type: 'string',
+    },
+  ],
+};
+const defaultFieldType = {
+  name: '',
+  type: 'string',
+};
+const defaultUnionType = ['string'];
+
+const schemaTypes = [
+  'array',
+  'boolean',
+  'bytes',
+  'double',
+  'enum',
+  'float',
+  'int',
+  'long',
+  'map',
+  'record',
+  'string',
+  'union',
+].concat(logicalTypes);
+
+const logicalTypeToSimpleTypeMap = {
+  'time-micros': 'time',
+  'timestamp-micros': 'timestamp',
+  date: 'date',
+  decimal: 'decimal',
+};
+
+const INDENTATION_SPACING = 15;
+
+const getDefaultEmptyAvroSchema = (): ISchemaType => {
+  return {
+    name: 'etlSchemaBody',
+    schema: {
+      name: 'etlSchemaBody',
+      type: 'record',
+      fields: [
+        {
+          name: '',
+          type: 'string',
+        },
+      ],
+    },
+  };
+};
+
+enum InternalTypesEnum {
+  SCHEMA = 'schema',
+  RECORD_SIMPLE_TYPE = 'record-field-simple-type',
+  RECORD_COMPLEX_TYPE_ROOT = 'record-field-complex-type-root',
+  ARRAY_SIMPLE_TYPE = 'array-simple-type',
+  ARRAY_COMPLEX_TYPE = 'array-complex-type',
+  ARRAY_COMPLEX_TYPE_ROOT = 'array-complex-type-root',
+  ENUM_SYMBOL = 'enum-symbol',
+  MAP_KEYS_COMPLEX_TYPE_ROOT = 'map-keys-complex-type-root',
+  MAP_KEYS_SIMPLE_TYPE = 'map-keys-simple-type',
+  MAP_VALUES_COMPLEX_TYPE_ROOT = 'map-values-complex-type-root',
+  MAP_VALUES_SIMPLE_TYPE = 'map-values-simple-type',
+  UNION_SIMPLE_TYPE = 'union-simple-type',
+  UNION_COMPLEX_TYPE_ROOT = 'union-complex-type-root',
+}
+
+enum OperationTypesEnum {
+  UPDATE = 'update',
+  ADD = 'add',
+  REMOVE = 'remove',
+  COLLAPSE = 'collapse',
+}
+
+export {
+  schemaTypes,
+  INDENTATION_SPACING,
+  logicalTypes,
+  logicalTypeToSimpleTypeMap,
+  defaultPrecision,
+  defaultScale,
+  defaultTimeStampTypeProperties,
+  defaultDecimalTypeProperties,
+  defaultTimeTypeProperties,
+  defaultDateTypeProperties,
+  defaultArrayType,
+  defaultEnumType,
+  defaultMapType,
+  defaultRecordType,
+  defaultUnionType,
+  defaultFieldType,
+  getDefaultEmptyAvroSchema,
+  InternalTypesEnum,
+  OperationTypesEnum,
+};

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaConstants.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaConstants.ts
@@ -16,99 +16,26 @@
 
 import { ISchemaType } from './SchemaTypes';
 
-/**
- * Defines all the defaults we use for the schema.
- */
-const logicalTypes = ['time', 'timestamp', 'decimal', 'date'];
-const defaultPrecision = 32;
-const defaultScale = 3;
-const defaultDecimalTypeProperties = {
-  type: 'bytes',
-  logicalType: 'decimal',
-  precision: defaultPrecision,
-  scale: defaultScale,
-};
-const defaultTimeTypeProperties = {
-  type: 'long',
-  logicalType: 'time-micros',
-};
-const defaultTimeStampTypeProperties = {
-  type: 'long',
-  logicalType: 'timestamp-micros',
-};
-const defaultDateTypeProperties = {
-  type: 'int',
-  logicalType: 'date',
-};
-
-const defaultArrayType = {
-  type: 'array',
-  items: 'string',
-};
-const defaultEnumType = {
-  type: 'enum',
-  symbols: [''],
-};
-const defaultMapType = {
-  type: 'map',
-  keys: 'string',
-  values: 'string',
-};
-const defaultRecordType = {
-  name: 'etlSchemaBody',
-  type: 'record',
-  fields: [
-    {
-      name: '',
-      type: 'string',
-    },
-  ],
-};
-const defaultFieldType = {
-  name: '',
-  type: 'string',
-};
-const defaultUnionType = ['string'];
-
-const schemaTypes = [
-  'array',
-  'boolean',
-  'bytes',
-  'double',
-  'enum',
-  'float',
-  'int',
-  'long',
-  'map',
-  'record',
-  'string',
-  'union',
-].concat(logicalTypes);
-
-const logicalTypeToSimpleTypeMap = {
-  'time-micros': 'time',
-  'timestamp-micros': 'timestamp',
-  date: 'date',
-  decimal: 'decimal',
-};
-
-const INDENTATION_SPACING = 15;
-
-const getDefaultEmptyAvroSchema = (): ISchemaType => {
-  return {
-    name: 'etlSchemaBody',
-    schema: {
-      name: 'etlSchemaBody',
-      type: 'record',
-      fields: [
-        {
-          name: '',
-          type: 'string',
-        },
-      ],
-    },
-  };
-};
+enum AvroSchemaTypesEnum {
+  ARRAY = 'array',
+  BOOLEAN = 'boolean',
+  BYTES = 'bytes',
+  DATE = 'date',
+  DECIMAL = 'decimal',
+  DOUBLE = 'double',
+  ENUM = 'enum',
+  FLOAT = 'float',
+  INT = 'int',
+  LONG = 'long',
+  MAP = 'map',
+  RECORD = 'record',
+  STRING = 'string',
+  TIME = 'time',
+  TIMESTAMP = 'timestamp',
+  UNION = 'union',
+  TIMESTAMPMICROS = 'timestamp-micros',
+  TIMEMICROS = 'time-micros',
+}
 
 enum InternalTypesEnum {
   SCHEMA = 'schema',
@@ -133,6 +60,105 @@ enum OperationTypesEnum {
   COLLAPSE = 'collapse',
 }
 
+/**
+ * Defines all the defaults we use for the schema.
+ */
+const logicalTypes = [
+  AvroSchemaTypesEnum.TIME,
+  AvroSchemaTypesEnum.TIMESTAMP,
+  AvroSchemaTypesEnum.DECIMAL,
+  AvroSchemaTypesEnum.DATE,
+];
+const defaultPrecision = 32;
+const defaultScale = 3;
+const defaultDecimalTypeProperties = {
+  type: AvroSchemaTypesEnum.BYTES,
+  logicalType: AvroSchemaTypesEnum.DECIMAL,
+  precision: defaultPrecision,
+  scale: defaultScale,
+};
+const defaultTimeTypeProperties = {
+  type: AvroSchemaTypesEnum.LONG,
+  logicalType: AvroSchemaTypesEnum.TIMEMICROS,
+};
+const defaultTimeStampTypeProperties = {
+  type: AvroSchemaTypesEnum.LONG,
+  logicalType: AvroSchemaTypesEnum.TIMESTAMPMICROS,
+};
+const defaultDateTypeProperties = {
+  type: AvroSchemaTypesEnum.INT,
+  logicalType: AvroSchemaTypesEnum.DATE,
+};
+
+const defaultArrayType = {
+  type: AvroSchemaTypesEnum.ARRAY,
+  items: AvroSchemaTypesEnum.STRING,
+};
+const defaultEnumType = {
+  type: AvroSchemaTypesEnum.ENUM,
+  symbols: [''],
+};
+const defaultMapType = {
+  type: AvroSchemaTypesEnum.MAP,
+  keys: AvroSchemaTypesEnum.STRING,
+  values: AvroSchemaTypesEnum.STRING,
+};
+const defaultRecordType = {
+  name: 'etlSchemaBody',
+  type: AvroSchemaTypesEnum.RECORD,
+  fields: [
+    {
+      name: '',
+      type: AvroSchemaTypesEnum.STRING,
+    },
+  ],
+};
+const defaultFieldType = {
+  name: '',
+  type: AvroSchemaTypesEnum.STRING,
+};
+const defaultUnionType = [AvroSchemaTypesEnum.STRING];
+
+const schemaTypes = [
+  AvroSchemaTypesEnum.ARRAY,
+  AvroSchemaTypesEnum.BOOLEAN,
+  AvroSchemaTypesEnum.BYTES,
+  AvroSchemaTypesEnum.DOUBLE,
+  AvroSchemaTypesEnum.ENUM,
+  AvroSchemaTypesEnum.FLOAT,
+  AvroSchemaTypesEnum.INT,
+  AvroSchemaTypesEnum.LONG,
+  AvroSchemaTypesEnum.MAP,
+  AvroSchemaTypesEnum.RECORD,
+  AvroSchemaTypesEnum.STRING,
+  AvroSchemaTypesEnum.UNION,
+].concat(logicalTypes);
+
+const logicalTypeToSimpleTypeMap = {
+  'time-micros': AvroSchemaTypesEnum.TIME,
+  'timestamp-micros': AvroSchemaTypesEnum.TIMESTAMP,
+  date: AvroSchemaTypesEnum.DATE,
+  decimal: AvroSchemaTypesEnum.DECIMAL,
+};
+
+const INDENTATION_SPACING = 10;
+
+const getDefaultEmptyAvroSchema = (): ISchemaType => {
+  return {
+    name: 'etlSchemaBody',
+    schema: {
+      name: 'etlSchemaBody',
+      type: AvroSchemaTypesEnum.RECORD,
+      fields: [
+        {
+          name: '',
+          type: AvroSchemaTypesEnum.STRING,
+        },
+      ],
+    },
+  };
+};
+
 export {
   schemaTypes,
   INDENTATION_SPACING,
@@ -151,6 +177,7 @@ export {
   defaultUnionType,
   defaultFieldType,
   getDefaultEmptyAvroSchema,
+  AvroSchemaTypesEnum,
   InternalTypesEnum,
   OperationTypesEnum,
 };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaEditorDemo.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaEditorDemo.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import FormControl from '@material-ui/core/FormControl';
+import { SchemaEditor } from 'components/AbstractWidget/SchemaEditor';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+import LoadingSVGCentered from 'components/LoadingSVGCentered';
+import If from 'components/If';
+import FileDnD from 'components/FileDnD';
+import { Button } from '@material-ui/core';
+import { getDefaultEmptyAvroSchema } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+const emptySchema = getDefaultEmptyAvroSchema();
+
+const styles = (): StyleRules => {
+  return {
+    container: {
+      height: 'auto',
+      display: 'grid',
+      gridTemplateColumns: '50% 50%',
+      padding: '10px',
+    },
+    contentContainer: {
+      height: '100%',
+      display: 'grid',
+    },
+    btnContainer: {
+      margin: '10px 0',
+      textAlign: 'right',
+    },
+    btns: {
+      marginLeft: '5px',
+    },
+  };
+};
+
+interface ISchemaEditorDemoBaseProps extends WithStyles<typeof styles> {}
+
+class SchemaEditorDemoBase extends React.Component<ISchemaEditorDemoBaseProps> {
+  public state = {
+    loading: false,
+    file: {},
+    error: null,
+    schema: emptySchema,
+  };
+  public modifiedSchema = emptySchema;
+  public onDropHandler = (e) => {
+    const reader = new FileReader();
+    reader.onload = (evt) => {
+      try {
+        let schema = JSON.parse(evt.target.result as any);
+        if (Array.isArray(schema)) {
+          schema = schema[0];
+        }
+        this.setState({
+          schema,
+          file: e[0],
+          error: null,
+        });
+      } catch (e) {
+        this.setState({ error: e.message });
+      }
+    };
+    reader.readAsText(e[0], 'UTF-8');
+  };
+
+  public onExport = () => {
+    const blob = new Blob([JSON.stringify(this.modifiedSchema, null, 4)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const exportFileName = 'schema';
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${exportFileName}.json`;
+
+    const clickHandler = (event) => {
+      event.stopPropagation();
+    };
+    a.addEventListener('click', clickHandler, false);
+    a.click();
+  };
+
+  public clearSchema = () => {
+    this.setState({
+      loading: false,
+      file: {},
+      error: null,
+      schema: emptySchema,
+    });
+  };
+
+  public render() {
+    const { classes } = this.props;
+    return (
+      <div className={classes.container}>
+        <FormControl component="fieldset" disabled={this.state.loading}>
+          <div>
+            <FileDnD
+              onDropHandler={this.onDropHandler}
+              file={this.state.file}
+              error={this.state.error}
+            />
+            <div className={classes.btnContainer}>
+              <Button
+                className={classes.btns}
+                onClick={this.onExport}
+                variant="contained"
+                color="primary"
+              >
+                Export
+              </Button>
+              <Button
+                className={classes.btns}
+                onClick={this.clearSchema}
+                variant="contained"
+                color="secondary"
+              >
+                Clear
+              </Button>
+            </div>
+          </div>
+        </FormControl>
+        <div className={classes.contentContainer}>
+          <If condition={this.state.loading}>
+            <LoadingSVGCentered />
+          </If>
+          <If condition={!this.state.loading}>
+            <SchemaEditor
+              schema={this.state.schema}
+              onChange={({ tree: t, flat: f, avroSchema }) => {
+                this.modifiedSchema = avroSchema;
+              }}
+            />
+          </If>
+        </div>
+      </div>
+    );
+  }
+}
+const SchemaEditorDemo = withStyles(styles)(SchemaEditorDemoBase);
+export default React.memo(SchemaEditorDemo);

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaEditorDemo.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaEditorDemo.tsx
@@ -18,11 +18,12 @@ import * as React from 'react';
 import FormControl from '@material-ui/core/FormControl';
 import { SchemaEditor } from 'components/AbstractWidget/SchemaEditor';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
-import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import If from 'components/If';
 import FileDnD from 'components/FileDnD';
 import { Button } from '@material-ui/core';
 import { getDefaultEmptyAvroSchema } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import LoadingSVG from 'components/LoadingSVG';
+
 const emptySchema = getDefaultEmptyAvroSchema();
 
 const styles = (): StyleRules => {
@@ -65,13 +66,25 @@ class SchemaEditorDemoBase extends React.Component<ISchemaEditorDemoBaseProps> {
         if (Array.isArray(schema)) {
           schema = schema[0];
         }
-        this.setState({
-          schema,
-          file: e[0],
-          error: null,
-        });
+        this.setState(
+          {
+            schema,
+            file: e[0],
+            error: null,
+            loading: true,
+          },
+          () => {
+            setTimeout(
+              () =>
+                this.setState({
+                  loading: false,
+                }),
+              1000
+            );
+          }
+        );
       } catch (e) {
-        this.setState({ error: e.message });
+        this.setState({ error: e.message, loading: false });
       }
     };
     reader.readAsText(e[0], 'UTF-8');
@@ -95,12 +108,21 @@ class SchemaEditorDemoBase extends React.Component<ISchemaEditorDemoBaseProps> {
   };
 
   public clearSchema = () => {
-    this.setState({
-      loading: false,
-      file: {},
-      error: null,
-      schema: emptySchema,
-    });
+    this.setState(
+      {
+        loading: true,
+      },
+      () => {
+        setTimeout(() => {
+          this.setState({
+            loading: false,
+            file: {},
+            error: null,
+            schema: emptySchema,
+          });
+        }, 500);
+      }
+    );
   };
 
   public render() {
@@ -136,7 +158,7 @@ class SchemaEditorDemoBase extends React.Component<ISchemaEditorDemoBaseProps> {
         </FormControl>
         <div className={classes.contentContainer}>
           <If condition={this.state.loading}>
-            <LoadingSVGCentered />
+            <LoadingSVG />
           </If>
           <If condition={!this.state.loading}>
             <SchemaEditor

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaHelpers.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaHelpers.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import {
+  IComplexTypeNames,
+  ISimpleType,
+  ILogicalTypeNames,
+} from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+import { logicalTypeToSimpleTypeMap } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import cloneDeep from 'lodash/cloneDeep';
+
+const displayTypes: Array<ISimpleType | IComplexTypeNames | ILogicalTypeNames> = [
+  'array',
+  'enum',
+  'map',
+  'record',
+  'union',
+  'boolean',
+  'bytes',
+  'date',
+  'decimal',
+  'double',
+  'float',
+  'int',
+  'long',
+  'number',
+  'string',
+  'time',
+  'timestamp-micros',
+  'date',
+  'time-micros',
+  'decimal',
+];
+
+/**
+ * Checks if the current avro type is nullable.
+ * @param type any avro type (simple/complex types).
+ */
+const isNullable = (type) => {
+  if (Array.isArray(type)) {
+    return type.find((t) => t === 'null') === 'null';
+  }
+  return false;
+};
+
+const isUnion = (type) => {
+  return Array.isArray(type) && !isNullable(type);
+};
+/**
+ * If the type is nullable get the non-null type for further processing.
+ * @param type any valid avro type
+ */
+const getNonNullableType = (type) => {
+  if (Array.isArray(type) && !isUnion(type)) {
+    const nonNullTypes = type.filter((t) => t !== 'null');
+    if (nonNullTypes.length === 1 && type.length - 1 === nonNullTypes.length) {
+      return nonNullTypes[0];
+    }
+  }
+  return type;
+};
+/**
+ * Helps in getting the simple type or underlying type in a logical type.
+ * @param type valid simple/logical avro type
+ */
+const getSimpleType = (type) => {
+  if (typeof type === 'string') {
+    return type;
+  }
+  if (type && type.logicalType) {
+    return logicalTypeToSimpleTypeMap[type.logicalType];
+  }
+  return type;
+};
+/**
+ * Utility to check if the current type is a complex type to tranverse further
+ * into the schema tree.
+ * @param complexType any valid complex avro type. (map, array, record, union and enum)
+ */
+const isComplexType = (complexType) => {
+  const nullable = isNullable(complexType);
+  let type = complexType;
+  if (nullable) {
+    type = complexType.filter((t) => t !== 'null').pop();
+  }
+  if (typeof type === 'string') {
+    return false;
+  }
+  switch (type.type) {
+    case 'record':
+    case 'enum':
+    case 'array':
+    case 'map':
+      return true;
+    default:
+      return isUnion(complexType) ? true : false;
+  }
+};
+
+const isDisplayTypeLogical = ({ type }) => {
+  switch (type) {
+    case 'decimal':
+    case 'date':
+    case 'time':
+    case 'timestamp':
+      return true;
+    default:
+      return false;
+  }
+};
+
+const isDisplayTypeComplex = ({ type }) => {
+  switch (type) {
+    case 'record':
+    case 'enum':
+    case 'union':
+    case 'map':
+    case 'array':
+      return true;
+    default:
+      return isDisplayTypeLogical({ type }) || false;
+  }
+};
+
+/**
+ * Utility function to get the complex type names.
+ * @param complexType any valid complex avro type.
+ */
+const getComplexTypeName = (complexType): IComplexTypeNames => {
+  const c = complexType;
+  let type;
+  if (isNullable(complexType)) {
+    type = complexType.filter((t) => t !== 'null').pop();
+    type = type.type;
+  } else {
+    type = cloneDeep(c.type);
+  }
+  switch (type) {
+    case 'record':
+    case 'enum':
+    case 'array':
+    case 'map':
+      return type;
+    default:
+      return isUnion(c) ? 'union' : undefined;
+  }
+};
+
+const isFlatRowTypeComplex = (typeName: ISimpleType | IComplexTypeNames) => {
+  switch (typeName) {
+    case 'string':
+    case 'boolean':
+    case 'bytes':
+    case 'double':
+    case 'float':
+    case 'int':
+    case 'long':
+    case 'number':
+    case 'string':
+      return false;
+    default:
+      return true;
+  }
+};
+
+export {
+  isNullable,
+  isUnion,
+  isComplexType,
+  getNonNullableType,
+  getComplexTypeName,
+  displayTypes,
+  getSimpleType,
+  isFlatRowTypeComplex,
+  isDisplayTypeLogical,
+  isDisplayTypeComplex,
+};

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaHelpers.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaHelpers.ts
@@ -19,30 +19,32 @@ import {
   ISimpleType,
   ILogicalTypeNames,
 } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
-import { logicalTypeToSimpleTypeMap } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import {
+  logicalTypeToSimpleTypeMap,
+  AvroSchemaTypesEnum,
+} from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 import cloneDeep from 'lodash/cloneDeep';
 
 const displayTypes: Array<ISimpleType | IComplexTypeNames | ILogicalTypeNames> = [
-  'array',
-  'enum',
-  'map',
-  'record',
-  'union',
-  'boolean',
-  'bytes',
-  'date',
-  'decimal',
-  'double',
-  'float',
-  'int',
-  'long',
-  'number',
-  'string',
-  'time',
-  'timestamp-micros',
-  'date',
-  'time-micros',
-  'decimal',
+  AvroSchemaTypesEnum.ARRAY,
+  AvroSchemaTypesEnum.ENUM,
+  AvroSchemaTypesEnum.MAP,
+  AvroSchemaTypesEnum.RECORD,
+  AvroSchemaTypesEnum.UNION,
+  AvroSchemaTypesEnum.BOOLEAN,
+  AvroSchemaTypesEnum.BYTES,
+  AvroSchemaTypesEnum.DATE,
+  AvroSchemaTypesEnum.DECIMAL,
+  AvroSchemaTypesEnum.DOUBLE,
+  AvroSchemaTypesEnum.FLOAT,
+  AvroSchemaTypesEnum.INT,
+  AvroSchemaTypesEnum.LONG,
+  AvroSchemaTypesEnum.STRING,
+  AvroSchemaTypesEnum.TIME,
+  AvroSchemaTypesEnum.TIMESTAMPMICROS,
+  AvroSchemaTypesEnum.DATE,
+  AvroSchemaTypesEnum.TIMEMICROS,
+  AvroSchemaTypesEnum.DECIMAL,
 ];
 
 /**
@@ -77,7 +79,7 @@ const getNonNullableType = (type) => {
  * @param type valid simple/logical avro type
  */
 const getSimpleType = (type) => {
-  if (typeof type === 'string') {
+  if (typeof type === AvroSchemaTypesEnum.STRING) {
     return type;
   }
   if (type && type.logicalType) {
@@ -96,14 +98,14 @@ const isComplexType = (complexType) => {
   if (nullable) {
     type = complexType.filter((t) => t !== 'null').pop();
   }
-  if (typeof type === 'string') {
+  if (typeof type === AvroSchemaTypesEnum.STRING) {
     return false;
   }
   switch (type.type) {
-    case 'record':
-    case 'enum':
-    case 'array':
-    case 'map':
+    case AvroSchemaTypesEnum.RECORD:
+    case AvroSchemaTypesEnum.ENUM:
+    case AvroSchemaTypesEnum.ARRAY:
+    case AvroSchemaTypesEnum.MAP:
       return true;
     default:
       return isUnion(complexType) ? true : false;
@@ -112,10 +114,10 @@ const isComplexType = (complexType) => {
 
 const isDisplayTypeLogical = ({ type }) => {
   switch (type) {
-    case 'decimal':
-    case 'date':
-    case 'time':
-    case 'timestamp':
+    case AvroSchemaTypesEnum.DECIMAL:
+    case AvroSchemaTypesEnum.DATE:
+    case AvroSchemaTypesEnum.TIME:
+    case AvroSchemaTypesEnum.TIMESTAMP:
       return true;
     default:
       return false;
@@ -124,11 +126,11 @@ const isDisplayTypeLogical = ({ type }) => {
 
 const isDisplayTypeComplex = ({ type }) => {
   switch (type) {
-    case 'record':
-    case 'enum':
-    case 'union':
-    case 'map':
-    case 'array':
+    case AvroSchemaTypesEnum.RECORD:
+    case AvroSchemaTypesEnum.ENUM:
+    case AvroSchemaTypesEnum.UNION:
+    case AvroSchemaTypesEnum.MAP:
+    case AvroSchemaTypesEnum.ARRAY:
       return true;
     default:
       return isDisplayTypeLogical({ type }) || false;
@@ -149,27 +151,26 @@ const getComplexTypeName = (complexType): IComplexTypeNames => {
     type = cloneDeep(c.type);
   }
   switch (type) {
-    case 'record':
-    case 'enum':
-    case 'array':
-    case 'map':
+    case AvroSchemaTypesEnum.RECORD:
+    case AvroSchemaTypesEnum.ENUM:
+    case AvroSchemaTypesEnum.ARRAY:
+    case AvroSchemaTypesEnum.MAP:
       return type;
     default:
-      return isUnion(c) ? 'union' : undefined;
+      return isUnion(c) ? AvroSchemaTypesEnum.UNION : undefined;
   }
 };
 
 const isFlatRowTypeComplex = (typeName: ISimpleType | IComplexTypeNames) => {
   switch (typeName) {
-    case 'string':
-    case 'boolean':
-    case 'bytes':
-    case 'double':
-    case 'float':
-    case 'int':
-    case 'long':
-    case 'number':
-    case 'string':
+    case AvroSchemaTypesEnum.STRING:
+    case AvroSchemaTypesEnum.BOOLEAN:
+    case AvroSchemaTypesEnum.BYTES:
+    case AvroSchemaTypesEnum.DOUBLE:
+    case AvroSchemaTypesEnum.FLOAT:
+    case AvroSchemaTypesEnum.INT:
+    case AvroSchemaTypesEnum.LONG:
+    case AvroSchemaTypesEnum.STRING:
       return false;
     default:
       return true;

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaTypes.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaTypes.ts
@@ -14,26 +14,35 @@
  * the License.
  */
 
+import { AvroSchemaTypesEnum } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 /**
  * Contains types used in parsing an avro schema.
  * TODO: This is a work in progress. We don't use these types yet fully
  * in the schema parser yet.
  */
-type IComplexTypeNames = 'array' | 'enum' | 'map' | 'record' | 'union';
+type IComplexTypeNames =
+  | AvroSchemaTypesEnum.ARRAY
+  | AvroSchemaTypesEnum.ENUM
+  | AvroSchemaTypesEnum.MAP
+  | AvroSchemaTypesEnum.RECORD
+  | AvroSchemaTypesEnum.UNION;
 type ISimpleType =
-  | 'boolean'
-  | 'bytes'
-  | 'date'
-  | 'decimal'
-  | 'double'
-  | 'float'
-  | 'int'
-  | 'long'
-  | 'number'
-  | 'string'
-  | 'time'
-  | 'timestamp';
-type ILogicalTypeNames = 'timestamp-micros' | 'date' | 'time-micros' | 'decimal';
+  | AvroSchemaTypesEnum.BOOLEAN
+  | AvroSchemaTypesEnum.BYTES
+  | AvroSchemaTypesEnum.DATE
+  | AvroSchemaTypesEnum.DECIMAL
+  | AvroSchemaTypesEnum.DOUBLE
+  | AvroSchemaTypesEnum.FLOAT
+  | AvroSchemaTypesEnum.INT
+  | AvroSchemaTypesEnum.LONG
+  | AvroSchemaTypesEnum.STRING
+  | AvroSchemaTypesEnum.TIME
+  | AvroSchemaTypesEnum.TIMESTAMP;
+type ILogicalTypeNames =
+  | AvroSchemaTypesEnum.TIMESTAMPMICROS
+  | AvroSchemaTypesEnum.DATE
+  | AvroSchemaTypesEnum.TIMEMICROS
+  | AvroSchemaTypesEnum.DECIMAL;
 
 type IDisplayType = ISimpleType | IComplexTypeNames;
 
@@ -63,7 +72,7 @@ interface IFieldBaseType {
 }
 
 interface IEnumFieldBase {
-  type: 'enum';
+  type: AvroSchemaTypesEnum.ENUM;
   symbols: string[];
   doc?: string;
   aliases?: string[];
@@ -76,7 +85,7 @@ interface IEnumFieldNullable extends IFieldBaseType {
 }
 
 interface IMapFieldBase {
-  type: 'map';
+  type: AvroSchemaTypesEnum.MAP;
   keys: ISimpleType | ISimpleTypeNullable | IComplexType | IComplexTypeFieldNullable;
   values: ISimpleType | ISimpleTypeNullable | IComplexType | IComplexTypeFieldNullable;
 }
@@ -88,7 +97,7 @@ interface IMapFieldNullable extends IFieldBaseType {
 }
 
 interface IArrayFieldBase {
-  type: 'array';
+  type: AvroSchemaTypesEnum.ARRAY;
   items: ISimpleType | ISimpleTypeNullable | IComplexType | IComplexTypeFieldNullable;
 }
 
@@ -129,7 +138,7 @@ interface IFieldTypeNullable extends IFieldBaseType {
 }
 
 interface IRecordField extends IFieldBaseType {
-  type: 'record';
+  type: AvroSchemaTypesEnum.RECORD;
   fields: Array<IFieldType | IFieldTypeNullable>;
   doc?: string;
   aliases?: string[];

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaTypes.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaTypes.ts
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Contains types used in parsing an avro schema.
+ * TODO: This is a work in progress. We don't use these types yet fully
+ * in the schema parser yet.
+ */
+type IComplexTypeNames = 'array' | 'enum' | 'map' | 'record' | 'union';
+type ISimpleType =
+  | 'boolean'
+  | 'bytes'
+  | 'date'
+  | 'decimal'
+  | 'double'
+  | 'float'
+  | 'int'
+  | 'long'
+  | 'number'
+  | 'string'
+  | 'time'
+  | 'timestamp';
+type ILogicalTypeNames = 'timestamp-micros' | 'date' | 'time-micros' | 'decimal';
+
+type IDisplayType = ISimpleType | IComplexTypeNames;
+
+type ISimpleTypeNullable = Array<ISimpleType | 'null'>;
+
+type IComplexType =
+  | IArrayFieldBase
+  | IEnumFieldBase
+  | IMapFieldBase
+  | IRecordField
+  | IUnionField
+  | ILogicalTypeBase;
+type IComplexTypeNullable =
+  | Array<IArrayFieldBase | 'null'>
+  | Array<IEnumFieldBase | 'null'>
+  | Array<IMapFieldBase | 'null'>
+  | Array<IRecordField | 'null'>;
+
+type IComplexTypeFieldNullable =
+  | IArrayFieldNullable
+  | IEnumFieldNullable
+  | IMapFieldNullable
+  | IRecordFieldNullable;
+
+interface IFieldBaseType {
+  name: string;
+}
+
+interface IEnumFieldBase {
+  type: 'enum';
+  symbols: string[];
+  doc?: string;
+  aliases?: string[];
+}
+interface IEnumField extends IFieldBaseType {
+  type: IEnumFieldBase;
+}
+interface IEnumFieldNullable extends IFieldBaseType {
+  type: Array<IEnumFieldBase | 'null'>;
+}
+
+interface IMapFieldBase {
+  type: 'map';
+  keys: ISimpleType | ISimpleTypeNullable | IComplexType | IComplexTypeFieldNullable;
+  values: ISimpleType | ISimpleTypeNullable | IComplexType | IComplexTypeFieldNullable;
+}
+interface IMapField extends IFieldBaseType {
+  type: IMapFieldBase;
+}
+interface IMapFieldNullable extends IFieldBaseType {
+  type: Array<IMapFieldBase | 'null'>;
+}
+
+interface IArrayFieldBase {
+  type: 'array';
+  items: ISimpleType | ISimpleTypeNullable | IComplexType | IComplexTypeFieldNullable;
+}
+
+interface IArrayField extends IFieldBaseType {
+  type: IArrayFieldBase;
+}
+interface IArrayFieldNullable extends IFieldBaseType {
+  type: Array<IArrayFieldBase | 'null'>;
+}
+
+interface ILogicalTypeBase {
+  type: ISimpleType;
+  logicalType: ILogicalTypeNames;
+  precision?: number;
+  scale?: number;
+}
+
+type ILogicalTypeNullable = Array<ILogicalTypeBase | 'null'>;
+
+interface ILogicalType extends IFieldBaseType {
+  type: ILogicalTypeBase;
+}
+
+interface ILogicalTypeFieldNullable extends IFieldBaseType {
+  type: Array<ILogicalTypeBase | 'null'>;
+}
+
+interface IFieldType extends IFieldBaseType {
+  type: ISimpleType | IComplexType | ILogicalType;
+  doc?: string;
+  aliases?: string[];
+}
+
+interface IFieldTypeNullable extends IFieldBaseType {
+  type: ISimpleTypeNullable | IComplexTypeNullable | ILogicalTypeNullable;
+  doc?: string;
+  aliases?: string[];
+}
+
+interface IRecordField extends IFieldBaseType {
+  type: 'record';
+  fields: Array<IFieldType | IFieldTypeNullable>;
+  doc?: string;
+  aliases?: string[];
+}
+type IRecordFieldNullable = Array<IRecordField | 'null'>;
+
+interface IUnionField extends IFieldBaseType {
+  type: Array<ISimpleType | IComplexType>;
+}
+
+interface ISchemaType {
+  name: string;
+  schema: IRecordField;
+}
+
+export {
+  ISimpleType,
+  IComplexTypeNames,
+  ILogicalTypeNames,
+  ILogicalType,
+  ILogicalTypeFieldNullable,
+  ILogicalTypeNullable,
+  IDisplayType,
+  ISimpleTypeNullable,
+  IComplexTypeNullable,
+  IComplexTypeFieldNullable,
+  IComplexType,
+  IEnumFieldBase,
+  IEnumField,
+  IEnumFieldNullable,
+  IMapFieldBase,
+  IMapField,
+  IMapFieldNullable,
+  IArrayFieldBase,
+  IArrayField,
+  IArrayFieldNullable,
+  IRecordField,
+  IRecordFieldNullable,
+  IUnionField,
+  IFieldType,
+  IFieldTypeNullable,
+  IFieldBaseType,
+  ISchemaType,
+  ILogicalTypeBase,
+};

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaValidator/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaValidator/index.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import cdapavsc from 'services/cdapavscwrapper';
+import {
+  SchemaGenerator,
+  generateSchemaFromComplexType,
+} from 'components/AbstractWidget/SchemaEditor/Context/SchemaGenerator';
+import { ISchemaType } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+import { IFlattenRowType } from '../EditorTypes';
+import { isNilOrEmpty } from 'services/helpers';
+
+/**
+ * Schema validator is independent of the schema editor. It takes in a schema tree
+ * and converts to an avro schema and parses the schema through the avsc library
+ *
+ * The context provides a way to broadcast the error to appropriate row
+ *
+ * We cannot pin point the error to a specific row as avsc library doesn't
+ * provide details on the place of failure. We right now surface the error
+ * to the parent to show the error under a tree.
+ *
+ * This is separate in an effort to push this processing to a web worker in the future.
+ * If we are not able write our own avro schema parser we won't be able to pinpoint
+ * the error to a specific row. In which we have to recurrsively parse each node
+ * in the schema tree to identify specific row of issue. This kind of processing
+ * will bring the UI down which is when we will move this to the web worker.
+ */
+interface ISchemaValidatorProviderBaseState {
+  id: string;
+  time: number;
+  error: string;
+}
+interface ISchemaValidatorContext {
+  validate: (id: string, avroSchema: ISchemaType) => ISchemaValidatorProviderBaseState;
+  errorMap: Record<string, ISchemaValidatorProviderBaseState>;
+}
+const SchemaValidatorContext = React.createContext<ISchemaValidatorContext>({
+  validate: null,
+  errorMap: {},
+});
+const SchemaValidatorConsumer = SchemaValidatorContext.Consumer;
+
+class SchemaValidatorProvider extends React.Component {
+  public defaultState = {
+    errorMap: {},
+  };
+
+  /**
+   * The subtree validation takes in a flat field, its ancestors
+   * and navigates to the appropriate child in the schema tree and parses
+   * the subtree. If it is valid nothing happens. If it is invalid we add the
+   * error to the validator context with the id of the immediate parent of the field
+   *
+   * The error validation consumer is used per row and whichever row is added
+   * to the error map gets highlighted with error.
+   *
+   * The sibliling line connection gets highlighted when parent is higlighted with an
+   * error.
+   * @param field Current flat row updated by user
+   * @param schemaTree schema tree to validate against.
+   */
+  private isSubTreeValidAvroSchema = (field: IFlattenRowType, schemaTree) => {
+    const { ancestors } = field;
+    if (!ancestors || (Array.isArray(ancestors) && !ancestors.length)) {
+      return;
+    }
+    if (ancestors.length === 1) {
+      try {
+        const entireSchema = SchemaGenerator(schemaTree);
+        cdapavsc.parse(entireSchema.schema, { wrapUnions: true });
+      } catch (e) {
+        return { error: e.message, fieldIdToShowError: ancestors[0] };
+      }
+      return;
+    }
+    const validateSchema = (tree) => {
+      const avroSchema = generateSchemaFromComplexType(tree.type, tree, tree.nullable);
+      try {
+        cdapavsc.parse(avroSchema, { wrapUnions: true });
+      } catch (e) {
+        return { error: e.message, fieldIdToShowError: tree.id };
+      }
+    };
+    const goToLowestParent = (parents, tree) => {
+      if (parents.length === 1) {
+        return validateSchema(tree.children[parents[0]]);
+      }
+      return goToLowestParent(parents.slice(1), tree.children[parents[0]]);
+    };
+    return goToLowestParent(ancestors.slice(1), schemaTree);
+  };
+
+  private validate = (field, schemaTree) => {
+    const errorObj = this.isSubTreeValidAvroSchema(field, schemaTree);
+    if (!errorObj) {
+      const { errorMap } = this.state;
+      if (isNilOrEmpty(errorMap)) {
+        return;
+      }
+      field.ancestors.forEach((ancestorId) => {
+        if (errorMap.hasOwnProperty(ancestorId)) {
+          delete errorMap[ancestorId];
+        }
+      });
+      if (errorMap.hasOwnProperty(field.id)) {
+        delete errorMap[field.id];
+      }
+      this.setState({ errorMap });
+      return;
+    }
+    const { fieldIdToShowError, error } = errorObj;
+    this.setState({
+      errorMap: {
+        ...this.state.errorMap,
+        [fieldIdToShowError]: error,
+      },
+    });
+  };
+
+  public state = {
+    ...this.defaultState,
+    validate: this.validate.bind(this),
+  };
+
+  public render() {
+    return (
+      <SchemaValidatorContext.Provider value={this.state}>
+        {this.props.children}
+      </SchemaValidatorContext.Provider>
+    );
+  }
+}
+export { SchemaValidatorProvider, SchemaValidatorConsumer };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SingleColumnWrapper/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SingleColumnWrapper/index.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import withStyles from '@material-ui/core/styles/withStyles';
+import Box from '@material-ui/core/Box';
+/**
+ * Row wrapper used for unions and array type rows.
+ */
+const SingleColumnWrapper = withStyles(() => {
+  return {
+    root: {
+      width: '132px',
+      marginLeft: '-12px',
+    },
+  };
+})(Box);
+
+export { SingleColumnWrapper };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SingleColumnWrapper/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SingleColumnWrapper/index.tsx
@@ -23,7 +23,6 @@ const SingleColumnWrapper = withStyles(() => {
   return {
     root: {
       width: '132px',
-      marginLeft: '-12px',
     },
   };
 })(Box);

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/UnionType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/UnionType/index.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import { schemaTypes } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import { SingleColumnWrapper } from 'components/AbstractWidget/SchemaEditor/SingleColumnWrapper';
+import Select from 'components/AbstractWidget/FormInputs/Select';
+import { IFieldTypeBaseProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { RowButtons } from 'components/AbstractWidget/SchemaEditor/RowButtons';
+
+const UnionTypeBase = ({
+  type,
+  onChange,
+  onAdd,
+  onRemove,
+  autoFocus,
+  typeProperties,
+}: IFieldTypeBaseProps) => {
+  const [fieldType, setFieldType] = React.useState(type);
+  const [fieldTypeProperties, setFieldTypeProperties] = React.useState(typeProperties || {});
+
+  const onTypePropertiesChangeHandler = (property, value) => {
+    if (property === 'typeProperties') {
+      setFieldTypeProperties(value);
+    }
+    onChange(property, value);
+  };
+  const inputEle = React.useRef(null);
+  React.useEffect(() => {
+    if (autoFocus) {
+      if (inputEle.current) {
+        inputEle.current.focus();
+      }
+    }
+  }, [autoFocus]);
+  return (
+    <React.Fragment>
+      <SingleColumnWrapper>
+        <Select
+          value={fieldType}
+          onChange={(newValue) => {
+            setFieldType(newValue);
+            onChange('type', newValue);
+          }}
+          widgetProps={{ options: schemaTypes, dense: true }}
+          inputRef={(ref) => (inputEle.current = ref)}
+        />
+      </SingleColumnWrapper>
+      <RowButtons
+        onAdd={onAdd}
+        onRemove={onRemove}
+        type={fieldType}
+        onChange={onTypePropertiesChangeHandler}
+        typeProperties={fieldTypeProperties}
+      />
+    </React.Fragment>
+  );
+};
+const UnionType = React.memo(UnionTypeBase);
+export { UnionType };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/UnionType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/UnionType/index.tsx
@@ -28,6 +28,7 @@ const UnionTypeBase = ({
   onRemove,
   autoFocus,
   typeProperties,
+  disabled = false,
 }: IFieldTypeBaseProps) => {
   const [fieldType, setFieldType] = React.useState(type);
   const [fieldTypeProperties, setFieldTypeProperties] = React.useState(typeProperties || {});
@@ -50,16 +51,18 @@ const UnionTypeBase = ({
     <React.Fragment>
       <SingleColumnWrapper>
         <Select
+          disabled={disabled}
           value={fieldType}
           onChange={(newValue) => {
             setFieldType(newValue);
             onChange('type', newValue);
           }}
-          widgetProps={{ options: schemaTypes, dense: true }}
+          widgetProps={{ options: schemaTypes, dense: true, native: true }}
           inputRef={(ref) => (inputEle.current = ref)}
         />
       </SingleColumnWrapper>
       <RowButtons
+        disabled={disabled}
         onAdd={onAdd}
         onRemove={onRemove}
         type={fieldType}

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/index.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/styles/withStyles';
+import ThemeWrapper from 'components/ThemeWrapper';
+import {
+  SchemaManager,
+  INode,
+  ISchemaManager,
+  IOnChangeReturnType,
+} from 'components/AbstractWidget/SchemaEditor/Context/SchemaManager';
+import { ISchemaType } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+import {
+  IFlattenRowType,
+  IFieldIdentifier,
+  IOnChangePayload,
+} from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { FieldsList } from 'components/AbstractWidget/SchemaEditor/FieldsList';
+import {
+  SchemaValidatorConsumer,
+  SchemaValidatorProvider,
+} from 'components/AbstractWidget/SchemaEditor/SchemaValidator';
+import { dumbestClone } from 'services/helpers';
+
+const styles = (): StyleRules => {
+  return {
+    schemaContainer: {
+      width: '100%',
+      height: '100%',
+    },
+  };
+};
+
+interface ISchemaEditorProps extends WithStyles<typeof styles> {
+  schema: ISchemaType;
+  onChange: (props: {
+    tree: INode;
+    flat: IFlattenRowType[];
+    avroSchema: ISchemaType;
+  }) => IOnChangeReturnType;
+}
+
+interface ISchemaEditorState {
+  tree: INode;
+  flat: IFlattenRowType[];
+}
+
+class SchemaEditorBase extends React.Component<ISchemaEditorProps, ISchemaEditorState> {
+  private schema: ISchemaManager = null;
+  constructor(props) {
+    super(props);
+    const { options } = props;
+    this.schema = SchemaManager(this.props.schema, options).getInstance();
+    this.state = {
+      flat: dumbestClone(this.schema.getFlatSchema()),
+      tree: dumbestClone(this.schema.getSchemaTree()),
+    };
+  }
+
+  public componentWillReceiveProps(nextProps) {
+    this.schema = SchemaManager(nextProps.schema).getInstance();
+    this.setState({
+      flat: dumbestClone(this.schema.getFlatSchema()),
+      tree: dumbestClone(this.schema.getSchemaTree()),
+    });
+  }
+  public onChange = (validate, fieldId: IFieldIdentifier, onChangePayload: IOnChangePayload) => {
+    const { fieldIdToFocus } = this.schema.onChange(fieldId, onChangePayload);
+    this.setState({
+      flat: [...this.schema.getFlatSchema()],
+      tree: { ...this.schema.getSchemaTree() },
+    });
+    this.props.onChange({
+      tree: this.schema.getSchemaTree(),
+      flat: this.schema.getFlatSchema(),
+      avroSchema: this.schema.getAvroSchema(),
+    });
+    if (typeof validate === 'function' && onChangePayload.value !== '') {
+      validate(fieldId, this.schema.getSchemaTree());
+    }
+    return { fieldIdToFocus };
+  };
+  public render() {
+    const { flat } = this.state;
+    const { classes } = this.props;
+    return (
+      <div>
+        <SchemaValidatorProvider>
+          <div className={classes.schemaContainer}>
+            <SchemaValidatorConsumer>
+              {({ validate }) => (
+                <FieldsList value={flat} onChange={this.onChange.bind(this, validate)} />
+              )}
+            </SchemaValidatorConsumer>
+          </div>
+        </SchemaValidatorProvider>
+      </div>
+    );
+  }
+}
+
+const StyledDemo = withStyles(styles)(SchemaEditorBase);
+function SchemaEditor(props) {
+  return (
+    <ThemeWrapper>
+      <StyledDemo {...props} />
+    </ThemeWrapper>
+  );
+}
+
+export { SchemaEditor };

--- a/cdap-ui/app/cdap/components/AbstractWidget/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/index.tsx
@@ -38,7 +38,9 @@ export interface IStageSchema {
 export interface IWidgetProps<T = any> {
   widgetProps?: T;
   value: string | number;
-  onChange: (value) => void | React.Dispatch<any>;
+  onChange?: (value) => void | React.Dispatch<any>;
+  onBlur?: (value) => void | React.Dispatch<any>;
+  onKeyPress?: (event: React.KeyboardEvent) => void;
   updateAllProperties?: (values: Record<string, string>) => void | React.Dispatch<any>;
   extraConfig?: {
     namespace?: string;

--- a/cdap-ui/app/cdap/components/AppHeader/index.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/index.tsx
@@ -34,6 +34,7 @@ import { objectQuery } from 'services/helpers';
 import { NamespaceLinkContext } from 'components/AppHeader/NamespaceLinkContext';
 import ThemeWrapper from 'components/ThemeWrapper';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
+import { loadDefaultExperiments } from 'components/Lab';
 
 require('styles/bootstrap_4_patch.scss');
 
@@ -66,6 +67,7 @@ class MyAppHeader extends React.PureComponent<IMyAppHeaderProps, IMyAppHeaderSta
   private eventEmitter = ee(ee);
 
   public componentDidMount() {
+    loadDefaultExperiments();
     // Polls for namespace data
     this.namespacesubscription = MyNamespaceApi.pollList().subscribe(
       (res) => {

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -25,7 +25,6 @@ import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import ConfigurationGroupKitchenSync from 'components/ConfigurationGroup/KitchenSync';
 import HomeActions from 'components/Home/HomeActions';
 import ToggleExperiment from 'components/Lab/ToggleExperiment';
-import VirtualScrollDemo from 'components/VirtualScroll/demo';
 import globalEvents from 'services/global-events';
 import ee from 'event-emitter';
 require('./Home.scss');
@@ -199,6 +198,13 @@ export default class Home extends Component {
             exact
             path="/ns/:namespace/vs"
             render={(props) => {
+              const VirtualScrollDemo = Loadable({
+                loader: () =>
+                  import(
+                    /* webpackChunkName: "VirtualScrollDemo" */ 'components/VirtualScroll/demo'
+                  ),
+                loading: LoadingSVGCentered,
+              });
               return (
                 <ToggleExperiment
                   name="virtual-scroll-demo"

--- a/cdap-ui/app/cdap/components/If/index.tsx
+++ b/cdap-ui/app/cdap/components/If/index.tsx
@@ -14,15 +14,34 @@
  * the License.
  */
 import * as React from 'react';
+import Box from '@material-ui/core/Box';
+import withStyles from '@material-ui/core/styles/withStyles';
 
 interface IIfComponentProps {
   condition: boolean;
   children: React.ReactNode;
+  invisible?: boolean;
+  HiddenContainer?: React.ReactNode;
 }
 
-const If: React.FC<IIfComponentProps> = ({ condition, children }) => {
+const If: React.FC<IIfComponentProps> = ({
+  condition,
+  children,
+  invisible = false,
+  HiddenContainer,
+}) => {
   if (!condition) {
-    return null;
+    if (!invisible) {
+      return null;
+    }
+    const InvisibleBox = withStyles(() => {
+      return {
+        root: {
+          visibility: 'hidden',
+        },
+      };
+    })(!HiddenContainer ? Box : (HiddenContainer as React.ComponentType<any>));
+    return <InvisibleBox>{children}</InvisibleBox>;
   }
 
   return <React.Fragment>{children}</React.Fragment>;

--- a/cdap-ui/app/cdap/components/Lab/experiment-list.tsx
+++ b/cdap-ui/app/cdap/components/Lab/experiment-list.tsx
@@ -31,10 +31,9 @@ export default [
   },
   {
     name: 'Schema Editor',
-    description:
-      'Demo for new SchemaEditor. Includes complete rewrite in React + perf improvements',
+    description: 'New SchemaEditor. Includes complete rewrite in React + perf improvements',
     id: 'schema-editor',
     screenshot: null,
-    value: false,
+    value: true,
   },
 ];

--- a/cdap-ui/app/cdap/components/Lab/experiment-list.tsx
+++ b/cdap-ui/app/cdap/components/Lab/experiment-list.tsx
@@ -29,4 +29,12 @@ export default [
     screenshot: null,
     value: false,
   },
+  {
+    name: 'Schema Editor',
+    description:
+      'Demo for new SchemaEditor. Includes complete rewrite in React + perf improvements',
+    id: 'schema-editor',
+    screenshot: null,
+    value: false,
+  },
 ];

--- a/cdap-ui/app/cdap/components/Lab/index.tsx
+++ b/cdap-ui/app/cdap/components/Lab/index.tsx
@@ -148,5 +148,14 @@ class Lab extends React.Component<ILabProps, ILabState> {
   }
 }
 
+function loadDefaultExperiments() {
+  experimentsList.forEach((experiment) => {
+    if (window.localStorage.getItem(experiment.id) === null) {
+      window.localStorage.setItem(experiment.id, experiment.value.toString());
+    }
+  });
+}
+
 const StyledLab = withStyles(styles)(Lab);
 export default StyledLab;
+export { loadDefaultExperiments };

--- a/cdap-ui/app/cdap/components/PluginSchemaEditor/RefreshableSchemaEditor.tsx
+++ b/cdap-ui/app/cdap/components/PluginSchemaEditor/RefreshableSchemaEditor.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import { SchemaEditor } from 'components/AbstractWidget/SchemaEditor';
+import If from 'components/If';
+import LoadingSVG from 'components/LoadingSVG';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+const styles = (): StyleRules => {
+  return {
+    container: {
+      textAlign: 'center',
+    },
+  };
+};
+
+interface IPluginSchema {
+  name: string;
+  schema: string;
+}
+
+interface IRefreshableSchemaEditor extends WithStyles<typeof styles> {
+  schema: IPluginSchema;
+  onChange: (schemas: IPluginSchema) => void;
+  disabled?: boolean;
+  visibleRows?: number;
+}
+
+function RefreshableSchemaEditorBase({
+  schema,
+  onChange,
+  disabled,
+  classes,
+  visibleRows,
+}: IRefreshableSchemaEditor) {
+  const [loading, setLoading] = React.useState(false);
+
+  React.useEffect(() => {
+    setLoading(true);
+    setTimeout(() => {
+      setLoading(false);
+    }, 500);
+  }, [schema]);
+
+  return (
+    <div className={classes.container}>
+      <If condition={loading}>
+        <LoadingSVG />
+      </If>
+      <If condition={!loading}>
+        <SchemaEditor
+          schema={schema}
+          disabled={disabled}
+          onChange={onChange}
+          visibleRows={visibleRows}
+        />
+      </If>
+    </div>
+  );
+}
+const RefreshableSchemaEditor = withStyles(styles)(RefreshableSchemaEditorBase);
+export { RefreshableSchemaEditor };

--- a/cdap-ui/app/cdap/components/PluginSchemaEditor/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginSchemaEditor/index.tsx
@@ -1,0 +1,542 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import Select from 'components/AbstractWidget/FormInputs/Select';
+import { SchemaEditor } from 'components/AbstractWidget/SchemaEditor';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+import ThemeWrapper from 'components/ThemeWrapper';
+import ee from 'event-emitter';
+import { getDefaultEmptyAvroSchema } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import PropTypes from 'prop-types';
+import LoadingSVG from 'components/LoadingSVG';
+import If from 'components/If';
+import TextboxOnValium from 'components/TextboxOnValium';
+import { RefreshableSchemaEditor } from 'components/PluginSchemaEditor/RefreshableSchemaEditor';
+import ConfigurableTab from 'components/ConfigurableTab';
+import classnames from 'classnames';
+import { objectQuery, isNilOrEmptyString } from 'services/helpers';
+import { FieldsListBase } from 'components/AbstractWidget/SchemaEditor/FieldsList';
+import Alert from 'components/Alert';
+import { isObject } from 'vega-lite/build/src/util';
+import { isMacro } from 'services/helpers';
+import DownloadFile from 'services/download-file';
+
+const styles = (theme): StyleRules => {
+  return {
+    container: {
+      display: 'block',
+      height: '100%',
+    },
+    fieldset: {
+      '&[disabled] *': {
+        color: `${theme.palette.grey[200]} !important`,
+        cursor: 'not-allowed !important',
+      },
+    },
+    tabContent: {
+      width: '100%',
+    },
+    header: {
+      display: 'grid',
+      gridTemplateColumns: 'auto 100px',
+      alignItems: 'center',
+      margin: '-15px -10px 5px -10px',
+      padding: '0 10px 5px;',
+      borderBottom: `1px solid ${theme.palette.grey[300]}`,
+    },
+    disabledHeader: {
+      margin: '0 -10px 5px -10px',
+      padding: '0 10px 10px',
+    },
+    title: {
+      fontWeight: 500,
+    },
+    actionsDropdown: {
+      border: `1px solid ${theme.palette.grey[400]}`,
+      borderRadius: '4px',
+    },
+    loadingContainer: {
+      textAlign: 'center',
+    },
+    macroTextBox: {
+      width: '100%',
+      border: `1px solid ${theme.palette.grey[300]}`,
+      borderRadius: '4px',
+      padding: '5px',
+    },
+  };
+};
+
+enum SchemaActionsEnum {
+  IMPORT = 'import',
+  EXPORT = 'export',
+  CLEAR = 'clear',
+  MACRO = 'macro',
+  EDITOR = 'editor',
+  PROPAGATE = 'propagate',
+}
+enum IPluginSchemaEditorModes {
+  Macro = 'macro',
+  Editor = 'editor',
+}
+interface IActionsOptionsObj {
+  disabled?: boolean;
+  tooltip?: string;
+  label: string;
+  value: SchemaActionsEnum;
+  onClick?: () => void;
+}
+interface IPluginSchema {
+  name: string;
+  schema: string;
+}
+type IActionsDropdownTooltip = Record<SchemaActionsEnum, IActionsOptionsObj>;
+interface IPluginSchemaEditorState {
+  error: string;
+  schemas: IPluginSchema[];
+  mode: IPluginSchemaEditorModes;
+  loading: boolean;
+  schemaRowCount: number;
+}
+
+interface IPluginSchemaEditorProps extends WithStyles<typeof styles> {
+  disabled?: boolean;
+  actionsDropdownMap: IActionsDropdownTooltip;
+  schemas: IPluginSchema[];
+  onSchemaChange: (schemas: IPluginSchema[]) => void;
+  schemaTitle?: string;
+  isSchemaMacro?: boolean;
+}
+
+class PluginSchemaEditorBase extends React.PureComponent<
+  IPluginSchemaEditorProps,
+  IPluginSchemaEditorState
+> {
+  private actions: IActionsOptionsObj[] = Object.values(this.props.actionsDropdownMap).map(
+    (value) => value
+  );
+  private containerRef;
+
+  private getMode = () => {
+    if (this.props.disabled) {
+      return isMacro(objectQuery(this.props.schemas, 0, 'schema') || '')
+        ? IPluginSchemaEditorModes.Macro
+        : IPluginSchemaEditorModes.Editor;
+    }
+    return this.props.isSchemaMacro
+      ? IPluginSchemaEditorModes.Macro
+      : IPluginSchemaEditorModes.Editor;
+  };
+
+  public state = {
+    error: null,
+    schemas: this.props.schemas,
+    loading: false,
+    mode: this.getMode(),
+    schemaRowCount: null,
+  };
+
+  private ee = ee(ee);
+
+  constructor(props) {
+    super(props);
+    if (!this.props.disabled) {
+      this.ee.on('schema.import', this.onSchemaImport);
+      this.ee.on('dataset.selected', this.onSchemaImport);
+    }
+    const doesActionDropdownHasExport = Object.keys(this.props.actionsDropdownMap).find(
+      (key) => key.toLowerCase() === 'export'
+    );
+    if (doesActionDropdownHasExport) {
+      // Schema can be exported on detailed view even if it is disabled.
+      this.ee.on('schema.export', this.onSchemaExport);
+    }
+    window.addEventListener('resize', this.calculateSchemaRowCount);
+  }
+
+  public componentWillReceiveProps(nextProps: IPluginSchemaEditorProps) {
+    if (!Object.keys(nextProps.actionsDropdownMap).length) {
+      this.actions = [];
+      return;
+    }
+    this.actions = Object.values(nextProps.actionsDropdownMap).map((value) => value);
+    return;
+  }
+
+  public shouldComponentUpdate(nextProps: IPluginSchemaEditorProps, nextState) {
+    const { disabled, isSchemaMacro, actionsDropdownMap, schemas } = nextProps;
+    const { schemaRowCount, loading, mode, error } = nextState;
+    const newActions = Object.values(actionsDropdownMap)
+      .filter((value) => typeof value === 'string')
+      .join('--');
+    const existingActions = Object.values(this.props.actionsDropdownMap)
+      .filter((value) => typeof value === 'string')
+      .join('--');
+    const existingSchemas = this.props.schemas.map((s) => s.schema).join('__');
+    const newSchemas = schemas.map((s) => s.schema).join('__');
+
+    const didPropsChange =
+      disabled !== this.props.disabled ||
+      isSchemaMacro !== this.props.isSchemaMacro ||
+      newActions !== existingActions ||
+      newSchemas !== existingSchemas;
+
+    const didStateChange =
+      schemaRowCount !== this.state.schemaRowCount ||
+      loading !== this.state.loading ||
+      mode !== this.state.mode ||
+      error !== this.state.error;
+    return didStateChange || didPropsChange;
+  }
+
+  public componentDidMount() {
+    this.calculateSchemaRowCount();
+  }
+
+  public componentWillUnmount() {
+    this.ee.off('schema.import', this.onSchemaImport);
+    this.ee.off('schema.export', this.onSchemaExport);
+    this.ee.on('dataset.selected', this.onSchemaImport);
+    window.removeEventListener('resize', this.calculateSchemaRowCount);
+  }
+
+  public calculateSchemaRowCount = () => {
+    if (this.containerRef) {
+      const { height } = this.containerRef.getBoundingClientRect();
+      let schemaRowCount = Math.floor(height / FieldsListBase.heightOfRow) - 1;
+      // For sinks we can't determine the height. So set it to by default 20 (20 * 34 = 680px in height)
+      if (schemaRowCount < 5) {
+        schemaRowCount = 20;
+      }
+      this.setState({ schemaRowCount });
+    }
+  };
+
+  public onSchemaExport = () => {
+    const schemasToExport = this.props.schemas.map((schema) => {
+      try {
+        return {
+          name: schema.name,
+          schema: JSON.parse(schema.schema),
+        };
+      } catch (e) {
+        return schema;
+      }
+    });
+    // // CDAP-17106 - Need to use generic DownloadFile function here from download-file
+    const blob = new Blob([JSON.stringify(schemasToExport, null, 4)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const exportFileName = 'schema';
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${exportFileName}.json`;
+
+    const clickHandler = (event) => {
+      event.stopPropagation();
+    };
+    a.addEventListener('click', clickHandler, false);
+    a.click();
+  };
+
+  private onSchemaImport = (schemas) => {
+    if (this.state.mode === IPluginSchemaEditorModes.Macro) {
+      return;
+    }
+    let importedSchemas = schemas;
+    if (typeof schemas === 'string') {
+      try {
+        importedSchemas = JSON.parse(schemas);
+      } catch (e) {
+        this.setState({
+          error: e.message,
+        });
+        return;
+      }
+    }
+    let hasError = false;
+    if (!Array.isArray(importedSchemas)) {
+      // This will be the case when we hit 'Apply' button from wrangler.
+      // We don't maintain consistency in importing schemas from multiple
+      // sources. This will take time to fix as we right now throw schemas
+      // in multiple formats across all places.
+      if (isObject(importedSchemas) && !importedSchemas.hasOwnProperty('schema')) {
+        importedSchemas = { name: 'etlSchemaBody', schema: importedSchemas };
+      }
+      importedSchemas = [importedSchemas];
+    }
+    const newSchemas = importedSchemas.map((schema) => {
+      if (typeof schema !== 'object' && schema.hasOwnProperty('schema')) {
+        return { ...getDefaultEmptyAvroSchema() };
+      }
+      const s = { ...schema };
+      try {
+        if (typeof schema.schema === 'string') {
+          s.schema = JSON.parse(schema.schema);
+        }
+      } catch (e) {
+        this.setState({
+          error: e.message,
+        });
+        hasError = true;
+        return;
+      }
+      if (!s.schema || s.schema.type !== 'record' || !Array.isArray(s.schema.fields)) {
+        this.setState({
+          error: 'Imported schema is not a valid Avro schema',
+        });
+        hasError = true;
+        return;
+      }
+      if (s.schema.name) {
+        s.schema.name = s.schema.name.replace('.', '.type');
+      }
+      return s;
+    });
+    if (hasError) {
+      return;
+    }
+    this.setState({ schemas: newSchemas, loading: true }, () => {
+      setTimeout(() => {
+        this.setState({
+          loading: false,
+        });
+        const schemasForPlugin = newSchemas.map((s) => {
+          if (typeof s.schema !== 'string') {
+            s.schema = JSON.stringify(s.schema);
+          }
+          return s;
+        });
+        this.props.onSchemaChange(schemasForPlugin);
+      }, 1000);
+    });
+  };
+
+  private onActionsHandler = (value) => {
+    const specificAction = this.actions.find((action) => action.value === value);
+    if (!specificAction) {
+      return;
+    }
+    specificAction.onClick();
+    if (value === SchemaActionsEnum.CLEAR) {
+      specificAction.onClick();
+      this.setState(
+        {
+          loading: true,
+          schemas: [{ name: 'etlSchemaBody', schema: '' }],
+        },
+        () => {
+          setTimeout(() => {
+            this.setState({
+              loading: false,
+            });
+          }, 1000);
+        }
+      );
+    } else if (value === SchemaActionsEnum.MACRO) {
+      const newState = {
+        mode:
+          this.state.mode === IPluginSchemaEditorModes.Editor
+            ? IPluginSchemaEditorModes.Macro
+            : IPluginSchemaEditorModes.Editor,
+        schemas:
+          this.state.mode === IPluginSchemaEditorModes.Editor
+            ? [{ name: 'etlSchemaBody', schema: '${}' }]
+            : [{ name: 'etlSchemaBody', schema: '' }],
+      };
+      this.setState(newState);
+    }
+  };
+
+  private santizeSchemasForEditor = (schemas = this.state.schemas) => {
+    return (schemas || []).map((s) => {
+      const newSchema = {
+        name: s.name,
+        schema: s.schema,
+      };
+      if (typeof s.schema === 'string') {
+        try {
+          newSchema.schema = JSON.parse(s.schema);
+        } catch (e) {
+          return { ...getDefaultEmptyAvroSchema() };
+        }
+      }
+      return newSchema;
+    });
+  };
+
+  public renderSchemaIntabs = () => {
+    const tabs = this.santizeSchemasForEditor().map((s, i) => {
+      return {
+        id: i,
+        name: s.name,
+        content: (
+          <fieldset disabled={this.props.disabled} className={this.props.classes.fieldset} key={i}>
+            <RefreshableSchemaEditor
+              visibleRows={this.state.schemaRowCount}
+              schema={s}
+              disabled={this.props.disabled}
+              onChange={({ avroSchema }) => {
+                const newSchemas = [...this.props.schemas];
+                newSchemas[i] = avroSchema;
+                newSchemas[i].schema = JSON.stringify(newSchemas[i].schema);
+                this.props.onSchemaChange(newSchemas);
+              }}
+            />
+          </fieldset>
+        ),
+        contentClassName: this.props.classes.tabContent,
+        paneClassName: this.props.classes.tabContent,
+      };
+    });
+    const tabProps = {
+      activeTab: 0,
+      tabConfig: {
+        tabs,
+        layout: 'horizontal',
+        defaultTab: 0,
+      },
+    };
+    return <ConfigurableTab activeTab={tabProps.activeTab} tabConfig={tabProps.tabConfig} />;
+  };
+
+  public renderSchemaEditors = () => {
+    if (
+      this.state.loading ||
+      this.state.mode === IPluginSchemaEditorModes.Macro ||
+      !this.state.schemaRowCount
+    ) {
+      return null;
+    }
+    if (this.state.schemas.length > 1) {
+      return this.renderSchemaIntabs();
+    }
+    if (!this.state.schemas.length && this.props.disabled) {
+      return `No ${this.props.schemaTitle} available`;
+    }
+    return this.santizeSchemasForEditor().map((schema, i) => (
+      <fieldset disabled={this.props.disabled} className={this.props.classes.fieldset}>
+        <SchemaEditor
+          key={i}
+          visibleRows={this.state.schemaRowCount}
+          schema={schema}
+          disabled={this.props.disabled}
+          onChange={({ avroSchema }) => {
+            const newSchemas = [...this.props.schemas];
+            newSchemas[i] = avroSchema;
+            newSchemas[i].schema = JSON.stringify(newSchemas[i].schema);
+            this.props.onSchemaChange(newSchemas);
+          }}
+        />
+      </fieldset>
+    ));
+  };
+
+  public renderMacroEditor = () => {
+    if (
+      this.state.loading ||
+      this.state.mode === IPluginSchemaEditorModes.Editor ||
+      !this.state.schemaRowCount
+    ) {
+      return null;
+    }
+    const macro = this.state.schemas[0].schema;
+    if (this.props.disabled) {
+      return macro;
+    }
+    return (
+      <TextboxOnValium
+        disabled={this.props.disabled}
+        value={macro}
+        className={this.props.classes.macroTextBox}
+        onKeyUp={() => ({})}
+        onChange={(value) => {
+          const newSchemas = [{ name: 'etlSchemaBody', schema: value }];
+          this.setState({
+            schemas: newSchemas,
+          });
+          this.props.onSchemaChange(newSchemas);
+        }}
+      />
+    );
+  };
+
+  public renderHeader = () => {
+    const { classes, schemaTitle, disabled } = this.props;
+    return (
+      <div
+        className={classnames(classes.header, {
+          [classes.disabledHeader]: disabled,
+        })}
+      >
+        <div className={classes.title}>{schemaTitle || 'Schema'}</div>
+        <If condition={this.actions.length > 0}>
+          <Select
+            classes={{ root: classes.actionsDropdown }}
+            value={''}
+            placeholder="Actions"
+            onChange={this.onActionsHandler}
+            widgetProps={{ options: this.actions, dense: true }}
+          />
+        </If>
+      </div>
+    );
+  };
+
+  public render() {
+    const { classes } = this.props;
+    return (
+      <div className={classes.container} ref={(ref) => (this.containerRef = ref)}>
+        {this.renderHeader()}
+        <If condition={this.state.loading}>
+          <div className={classes.loadingContainer}>
+            <LoadingSVG />
+          </div>
+        </If>
+        <Alert
+          showAlert={!isNilOrEmptyString(this.state.error)}
+          message={this.state.error}
+          type="error"
+          onClose={() => {
+            this.setState({ error: null });
+          }}
+        />
+        {this.renderSchemaEditors()}
+        {this.renderMacroEditor()}
+      </div>
+    );
+  }
+}
+const StyledPluginSchemaEditor = withStyles(styles)(PluginSchemaEditorBase);
+
+const PluginSchemaEditor = (props) => {
+  return (
+    <ThemeWrapper>
+      <StyledPluginSchemaEditor {...props} />
+    </ThemeWrapper>
+  );
+};
+(PluginSchemaEditor as any).propTypes = {
+  schemas: PropTypes.array,
+  onSchemaChange: PropTypes.func,
+  disabled: PropTypes.func,
+  actionsDropdownMap: PropTypes.array,
+  schemaTitle: PropTypes.string,
+  isSchemaMacro: PropTypes.func,
+};
+export { PluginSchemaEditor };

--- a/cdap-ui/app/cdap/components/Tabs/TabHeaders/TabHeaders.scss
+++ b/cdap-ui/app/cdap/components/Tabs/TabHeaders/TabHeaders.scss
@@ -16,6 +16,7 @@
 
 .cask-tab-headers {
   background-color: #efefef;
+  overflow-x: auto;
   .cask-tab-head {
     padding: 10px 10px 10px 20px;
   }

--- a/cdap-ui/app/cdap/components/TextboxOnValium/index.js
+++ b/cdap-ui/app/cdap/components/TextboxOnValium/index.js
@@ -95,6 +95,7 @@ export default class TextboxOnValium extends Component {
   render() {
     return (
       <input
+        disabled={this.props.disabled}
         className={this.props.className}
         placeholder={this.props.placeholder}
         ref={
@@ -117,6 +118,7 @@ export default class TextboxOnValium extends Component {
 TextboxOnValium.defaultProps = {
   allowSpace: true,
   validCharacterRegex: null,
+  disabled: false,
 };
 
 TextboxOnValium.propTypes = {
@@ -130,4 +132,5 @@ TextboxOnValium.propTypes = {
   allowSpace: PropTypes.bool,
   shouldSelect: PropTypes.bool,
   validCharacterRegex: PropTypes.object, // regex expression
+  disabled: PropTypes.bool,
 };

--- a/cdap-ui/app/cdap/components/TextboxOnValium/index.js
+++ b/cdap-ui/app/cdap/components/TextboxOnValium/index.js
@@ -96,12 +96,19 @@ export default class TextboxOnValium extends Component {
     return (
       <input
         className={this.props.className}
-        ref={(ref) => (this.textboxRef = ref)}
+        placeholder={this.props.placeholder}
+        ref={
+          this.props.inputRef
+            ? this.props.inputRef
+            : (ref) => {
+                this.textboxRef = ref;
+              }
+        }
         onBlur={this.onBlur}
         onChange={this.updateTextValue}
         value={this.state.textValue}
         onKeyPress={this.handleKeyPress}
-        onKeyUp={this.handleKeyPress}
+        onKeyUp={!this.props.onKeyUp ? this.handleKeyPress : this.props.onKeyUp}
       />
     );
   }
@@ -114,7 +121,10 @@ TextboxOnValium.defaultProps = {
 
 TextboxOnValium.propTypes = {
   onChange: PropTypes.func,
+  placeholder: PropTypes.string,
+  inputRef: PropTypes.func,
   value: PropTypes.string,
+  onKeyUp: PropTypes.func,
   onWarning: PropTypes.func,
   className: PropTypes.string,
   allowSpace: PropTypes.bool,

--- a/cdap-ui/app/cdap/components/VirtualScroll/index.tsx
+++ b/cdap-ui/app/cdap/components/VirtualScroll/index.tsx
@@ -27,6 +27,7 @@ interface IVirtualScrollProps extends WithStyles<typeof styles> {
   visibleChildCount: number;
   childHeight: number;
   childrenUnderFold: number;
+  childrenUnderFoldOnScroll?: number;
   LoadingElement?: React.ReactNode;
 }
 const styles = (): StyleRules => {
@@ -60,6 +61,7 @@ const VirtualScroll = ({
   visibleChildCount,
   childHeight,
   childrenUnderFold,
+  childrenUnderFoldOnScroll = 50,
   classes,
   LoadingElement = () => 'Loading...',
 }: IVirtualScrollProps) => {
@@ -68,15 +70,22 @@ const VirtualScroll = ({
   const totalHeight = itmCount * childHeight;
   const [list, setList] = useState<React.ReactNode>([]);
   const [promise, setPromise] = useState(null);
+  const [scrollingChildrenUnderFold, setScrollingChildrenUnderFold] = useState(childrenUnderFold);
 
-  let startNode = Math.floor(scrollTop / childHeight) - childrenUnderFold;
+  let startNode = Math.floor(scrollTop / childHeight) - scrollingChildrenUnderFold;
   startNode = Math.max(0, startNode);
 
-  const visibleNodeCount = visibleChildCount + 2 * childrenUnderFold;
+  const visibleNodeCount = visibleChildCount + 2 * scrollingChildrenUnderFold;
 
   const offsetY = startNode * childHeight;
 
   useMemo(() => {
+    if (scrollingChildrenUnderFold === childrenUnderFold && startNode > childrenUnderFold) {
+      setScrollingChildrenUnderFold(childrenUnderFold + childrenUnderFoldOnScroll);
+    }
+    if (Array.isArray(list) && startNode + visibleNodeCount < list.length) {
+      return;
+    }
     const newList = renderList(visibleNodeCount, startNode);
     if (Array.isArray(newList)) {
       setList(newList);
@@ -87,7 +96,7 @@ const VirtualScroll = ({
         setPromise(p);
       }
     }
-  }, [startNode, visibleNodeCount, renderList]);
+  }, [startNode, visibleNodeCount, itemCount]);
 
   useEffect(() => {
     if (!promise) {

--- a/cdap-ui/app/cdap/components/VirtualScroll/useScroll.tsx
+++ b/cdap-ui/app/cdap/components/VirtualScroll/useScroll.tsx
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import { useRef, useState, useEffect, MutableRefObject } from 'react';
+import { useRef, useState, useLayoutEffect, MutableRefObject } from 'react';
 
 export function useScroll<T extends HTMLElement = HTMLDivElement>(): [number, MutableRefObject<T>] {
   const [scrollTop, setScrollTop] = useState(0);
@@ -25,7 +25,7 @@ export function useScroll<T extends HTMLElement = HTMLDivElement>(): [number, Mu
       setScrollTop(e.target.scrollTop);
     });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const scrollContainer = ref.current;
 
     if (scrollContainer === undefined) {

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -66,6 +66,7 @@ import If from 'components/If';
 import Page500 from 'components/500';
 import LoadingSVG from 'components/LoadingSVG';
 import { handlePageLevelError } from 'services/helpers';
+import ToggleExperiment from 'components/Lab/ToggleExperiment';
 
 const cookie = new Cookies();
 
@@ -197,7 +198,6 @@ class CDAP extends Component {
     });
     if (!VersionStore.getState().version) {
       MyCDAPVersionApi.get().subscribe((res) => {
-        this.setState({ version: res.version });
         VersionStore.dispatch({
           type: VersionActions.updateVersion,
           payload: {
@@ -288,6 +288,26 @@ class CDAP extends Component {
                   <DAG {...props} />
                 </ErrorBoundary>
               )}
+            />
+            <Route
+              exact
+              path="/schema"
+              render={(props) => {
+                const SchemaEditorDemo = Loadable({
+                  loader: () =>
+                    import(
+                      /* webpackChunkName: "SchemaEditor" */ 'components/AbstractWidget/SchemaEditor/SchemaEditorDemo'
+                    ),
+                  loading: LoadingSVGCentered,
+                });
+                return (
+                  <ToggleExperiment
+                    name="schema-editor"
+                    defaultComponent={<Page404 {...props} />}
+                    experimentalComponent={<SchemaEditorDemo />}
+                  />
+                );
+              }}
             />
             {/*
               Eventually handling 404 should move to the error boundary and all container components will have the error object.

--- a/cdap-ui/app/cdap/services/download-file.js
+++ b/cdap-ui/app/cdap/services/download-file.js
@@ -14,6 +14,7 @@
  * the License.
  */
 
+ // TODO: CDAP-17106 - Need to refactor this function to make it generic for usage across CDAP UI.
  function DownloadFile(fileConfig, postExportCb) {
   const blob = new Blob([JSON.stringify(fileConfig, null, 4)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -490,6 +490,16 @@ function connectWithStore(store, WrappedComponent, ...args) {
   };
 }
 
+function dumbestClone(jsonObj) {
+  let result;
+  try {
+    result = JSON.parse(JSON.stringify(jsonObj));
+  } catch (e) {
+    return jsonObj;
+  }
+  return result;
+}
+
 export {
   objectQuery,
   convertBytesToHumanReadable,
@@ -531,4 +541,5 @@ export {
   handlePageLevelError,
   extractErrorMessage,
   connectWithStore,
+  dumbestClone,
 };

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -124,6 +124,8 @@ var DownloadFile = require('../cdap/services/download-file').default;
 var PreviewUtilities = require('../cdap/components/PreviewData/utilities');
 var PreviewDataView = require('../cdap/components/PreviewData').default;
 var PreviewLogs = require('../cdap/components/PreviewLogs').default;
+var SchemaEditor = require('../cdap/components/AbstractWidget/SchemaEditor').SchemaEditor;
+var PluginSchemaEditor = require('../cdap/components/PluginSchemaEditor').PluginSchemaEditor;
 
 export {
   Store,
@@ -222,4 +224,6 @@ export {
   PreviewUtilities,
   PreviewDataView,
   PreviewLogs,
+  SchemaEditor,
+  PluginSchemaEditor,
 };

--- a/cdap-ui/app/directives/plugin-functions/functions/get-schema/get-schema.js
+++ b/cdap-ui/app/directives/plugin-functions/functions/get-schema/get-schema.js
@@ -28,6 +28,7 @@ angular.module(PKG.name + '.commons')
         var fnConfig = $scope.fnConfig;
         var methodName = fnConfig['plugin-method'] || 'getSchema';
         var methodType = fnConfig.method || 'GET';
+        var ee = window.CaskCommon.ee(window.CaskCommon.ee);
         var getPluginMethodApi = function(methodType) {
           switch(methodType) {
             case 'POST':
@@ -99,6 +100,7 @@ angular.module(PKG.name + '.commons')
 
           modal.result.then(function (obj) {
             EventPipe.emit('schema.import', JSON.stringify(obj.schema));
+            ee.emit('schema.import', JSON.stringify(obj.schema));
             $scope.node.plugin.properties.importQuery = obj.query;
           });
         };

--- a/cdap-ui/app/directives/react-components/index.js
+++ b/cdap-ui/app/directives/react-components/index.js
@@ -168,4 +168,10 @@ angular
   })
   .directive('previewLogs', function (reactDirective) {
     return reactDirective(window.CaskCommon.PreviewLogs);
+  })
+  .directive('schemaEditor', function(reactDirective) {
+    return reactDirective(window.CaskCommon.SchemaEditor);
+  })
+  .directive('pluginSchemaEditor', function(reactDirective) {
+    return reactDirective(window.CaskCommon.PluginSchemaEditor);
   });

--- a/cdap-ui/app/hydrator/bottompanel.less
+++ b/cdap-ui/app/hydrator/bottompanel.less
@@ -300,7 +300,11 @@ body.theme-cdap.state-hydrator {
         margin-top: 20px;
       }
     }
+    .old-output-schema-container {
+      padding-bottom: 10px;
+    }
     .output-schema {
+      height: 100%;
       .schema-propagation-confirm {
         padding-top: 10px;
       }
@@ -313,7 +317,15 @@ body.theme-cdap.state-hydrator {
         }
       }
     }
+    plugin-schema-editor {
+      height: 100%;
+      display: block;
+    }
     .input-schema {
+      height: 100%;
+      .schema-inner {
+        height: 100%;
+      }
       @media (max-width: @screen-md-max) {
         margin-bottom: 15px;
       }

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -43,6 +43,7 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.eventEmitter = window.CaskCommon.ee(window.CaskCommon.ee);
     this.configurationGroupUtilities = window.CaskCommon.ConfigurationGroupUtilities;
     this.dynamicFiltersUtilities = window.CaskCommon.DynamicFiltersUtilities;
+    this.showNewSchemaEditor = window.localStorage['schema-editor'] === 'true';
     this.setDefaults(rPlugin);
     this.myAlertOnValium = myAlertOnValium;
     this.validatePluginProperties = this.validatePluginProperties.bind(this);
@@ -50,6 +51,14 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.previewId = this.getPreviewId();
     this.previewStatus = null;
     this.getStagesAndConnections = this.getStagesAndConnections.bind(this);
+    this.getIsMacroEnabled = this.getIsMacroEnabled.bind(this);
+    this.onImportSchema = this.onImportSchema.bind(this);
+    this.onClearSchema = this.onClearSchema.bind(this);
+    this.onPropagateSchema = this.onPropagateSchema.bind(this);
+    this.onMacroEnabled = this.onMacroEnabled.bind(this);
+    this.onSchemaChange = this.onSchemaChange.bind(this);
+    this.onSchemaImportLinkClick = this.onSchemaImportLinkClick.bind(this);
+    this.isSchemaMacro = this.isSchemaMacro.bind(this);
     this.tabs = [
       {
         label: 'Properties',
@@ -240,7 +249,15 @@ class HydratorPlusPlusNodeConfigCtrl {
             try {
               this.avsc.parse(schemaObj.schema, { wrapUnions: true });
             } catch (e) {
-              this.state.schemaAdvance = true;
+              // If its old schema editor by default set it to advance
+              if (!this.showNewSchemaEditor) {
+                this.state.schemaAdvance = true;
+              } else {
+                // else if its a new schema editor set advance only if the schema is a macro.
+                if (schemaArr.indexOf('${') !== -1) {
+                  this.state.schemaAdvance = true;
+                }
+              }
             }
           }
         });
@@ -248,7 +265,15 @@ class HydratorPlusPlusNodeConfigCtrl {
         try {
           this.avsc.parse(schemaArr, { wrapUnions: true });
         } catch (e) {
-          this.state.schemaAdvance = true;
+          // If its old schema editor by default set it to advance
+          if (!this.showNewSchemaEditor) {
+            this.state.schemaAdvance = true;
+          } else {
+            // else if its a new schema editor set advance only if the schema is a macro.
+            if (schemaArr.indexOf('${') !== -1) {
+              this.state.schemaAdvance = true;
+            }
+          }
         }
       }
     }
@@ -407,14 +432,22 @@ class HydratorPlusPlusNodeConfigCtrl {
 
     reader.onload = (evt) => {
       let data = evt.target.result;
-      this.EventPipe.emit('schema.import', data);
+      if (this.showNewSchemaEditor) {
+        this.eventEmitter.emit('schema.import', data);
+      } else {
+        this.EventPipe.emit('schema.import', data);
+      }
     };
   }
   onSchemaImportLinkClick() {
     this.$timeout(() => document.getElementById('schema-import-link').click());
   }
   exportSchema() {
-    this.EventPipe.emit('schema.export');
+    if (this.showNewSchemaEditor) {
+      this.eventEmitter.emit('schema.export');
+    } else {
+      this.EventPipe.emit('schema.export');
+    }
   }
 
   validateSchema() {
@@ -487,6 +520,19 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.HydratorPlusPlusPluginConfigFactory.validatePluginProperties(nodeInfo, this.state.config, errorCb);
   }
 
+  // MACRO ENABLED SCHEMA
+  toggleAdvance() {
+    if (this.state.node.outputSchema.length > 0) {
+      try {
+        this.avsc.parse(this.state.node.outputSchema[0].schema, { wrapUnions: true });
+      } catch (e) {
+        this.state.node.outputSchema = [this.HydratorPlusPlusNodeService.getOutputSchemaObj('')];
+      }
+    }
+
+    this.state.schemaAdvance = !this.state.schemaAdvance;
+  }
+
   hasUniqueFields(schema, error) {
     if (!schema) { return true; }
 
@@ -544,19 +590,6 @@ class HydratorPlusPlusNodeConfigCtrl {
     return this.ConfigStore.getConfigForExport().config;
   }
 
-  // MACRO ENABLED SCHEMA
-  toggleAdvance() {
-    if (this.state.node.outputSchema.length > 0) {
-      try {
-        this.avsc.parse(this.state.node.outputSchema[0].schema, { wrapUnions: true });
-      } catch (e) {
-        this.state.node.outputSchema = [this.HydratorPlusPlusNodeService.getOutputSchemaObj('')];
-      }
-    }
-
-    this.state.schemaAdvance = !this.state.schemaAdvance;
-  }
-
   // TOOLTIPS FOR DISABLED SCHEMA ACTIONS
   getImportDisabledTooltip() {
     if (this.datasetAlreadyExists) {
@@ -583,6 +616,97 @@ class HydratorPlusPlusNodeConfigCtrl {
       return 'Clearing a schema in Advanced mode is not supported';
     }
     return '';
+  }
+  getIsMacroEnabled() {
+    return (
+      !this.$scope.isDisabled &&
+      this.state.node._backendProperties['schema'] &&
+      this.state.node._backendProperties['schema'].macroSupported
+    );
+  }
+  onClearSchema() {
+    this.$timeout(() => this.state.node['outputSchema'] = [{ name: 'etlSchemaBody', schema: ''}]);
+  }
+  onPropagateSchema() {
+    this.$timeout(() => this.showPropagateConfirm = true);
+  }
+  onMacroEnabled() {
+    this.$timeout(() => this.state.schemaAdvance = !this.state.schemaAdvance);
+  }
+  onSchemaChange(outputSchemas) {
+    this.$timeout(() => this.state.node.outputSchema = outputSchemas);
+  }
+  onImportSchema(stringifiedSchema) {
+    try {
+      this.state.node.outputSchema = JSON.parse(stringifiedSchema);
+      if (!Array.isArray(this.state.node.outputSchema)) {
+        this.$timeout(() => this.state.node.outputSchema = [this.state.node.outputSchema]);
+      }
+    } catch(e) {
+      this.$timeout(() => this.state.node.outputSchema = [{ name: 'etlSchemaBody', schema: ''}]);
+    }
+  }
+  isSchemaMacro() {
+    return this.state.schemaAdvance;
+  }
+  getActionsDropdownMap(isInputSchema) {
+    let actionsMap = {};
+    if (isInputSchema) {
+      return {};
+    }
+    if (this.$scope.isDisabled) {
+      return {
+        export: {
+          value: 'export',
+          label: 'Export',
+          disabled: this.state.schemaAdvance,
+          tooltip: this.state.schemaAdvance ? 'Exporting a schema in Advanced mode is not supported' : '',
+          onClick: this.exportSchema.bind(this),
+        }
+      };
+    }
+    if (this.getIsMacroEnabled()) {
+      actionsMap['macro'] = {
+        value: 'macro',
+        label: this.state.schemaAdvance ? 'Editor' : 'Macro',
+        disabled: this.datasetAlreadyExists,
+        tooltip: this.datasetAlreadyExists ? `The dataset '${this.datasetId}' already exists. Its schema cannot be modified.` : '',
+        onClick: this.onMacroEnabled.bind(this),
+      };
+    }
+    actionsMap = Object.assign({}, actionsMap, {
+      import: {
+        value: 'import',
+        label: 'Import',
+        disabled: this.datasetAlreadyExists || this.state.schemaAdvance,
+        tooltip: this.getImportDisabledTooltip(),
+        onClick: this.onSchemaImportLinkClick.bind(this),
+      },
+      export: {
+        value: 'export',
+        label: 'Export',
+        disabled: this.state.schemaAdvance,
+        tooltip: this.state.schemaAdvance ? 'Exporting a schema in Advanced mode is not supported' : '',
+        onClick: this.exportSchema.bind(this),
+      },
+      propagate: {
+        value: 'propagate',
+        label: 'Propagate',
+        disabled:
+          this.state.schemaAdvance ||
+          this.state.node.type === 'splittertransform',
+        tooltip: this.getPropagateDisabledTooltip(),
+        onClick: this.onPropagateSchema.bind(this),
+      },
+      clear: {
+        value: 'clear',
+        label: 'Clear',
+        disabled: this.datasetAlreadyExists || this.state.schemaAdvance,
+        tooltip: this.getClearDisabledTooltip(),
+        onClick: this.onClearSchema.bind(this),
+      },
+    });
+    return actionsMap;
   }
 }
 

--- a/cdap-ui/app/hydrator/hydrator-modal.less
+++ b/cdap-ui/app/hydrator/hydrator-modal.less
@@ -53,8 +53,6 @@
         // 340px for all the buttons and error validation message
         width: 100%;
         max-width: ~"calc(100% - 340px)";
-        max-width: ~"-moz-calc(100% - 340px)";
-        max-width: ~"-webkit-calc(100% - 340px)";
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
@@ -65,8 +63,6 @@
         // Adjust max-width of modal title when my-jump-link is present
         &.with-jump {
           max-width: ~"calc(100% - 180px)";
-          max-width: ~"-moz-calc(100% - 180px)";
-          max-width: ~"-webkit-calc(100% - 180px)";
         }
 
         p {
@@ -177,8 +173,6 @@
         margin-left: 0;
         width: 100%;
         height: ~"calc(100vh - 100px)";
-        height: ~"-moz-calc(100vh - 100px)";
-        height: ~"-webkit-calc(100vh - 100px)";
         margin-bottom: 0;
       }
 
@@ -220,10 +214,8 @@
               }
               .bottompanel-body {
                 padding: 0 10px 10px 10px;
-                overflow-y: auto;
+                overflow-y: hidden;
                 height: ~"calc(100vh - 180px)";
-                height: ~"-moz-calc(100vh - 180px)";
-                height: ~"-webkit-calc(100vh - 180px)";
                 .reference-tab { padding: 0 10px; }
 
                 .btn-hydrator {
@@ -246,45 +238,42 @@
                   > p,
                   .validator-plugin > div { padding: 20px 10px; }
                   div.config-table {
-                    display: table;
+                    display: grid;
                     width: 100%;
-                    height: ~"calc(100vh - 240px)";
-                    height: ~"-moz-calc(100vh - 240px)";
-                    height: ~"-webkit-calc(100vh - 240px)";
+                    height: ~"calc(100vh - 180px)";
 
                     > div {
-                      display: table-cell;
-                      padding: 20px 10px;
+                      padding: 10px 10px;
                       vertical-align: top;
+                      overflow-y: auto;
+                      .output-schema-container {
+                        height: 100%;
+                      }
                     }
                   }
                   div.source-table {
+                    grid-template-columns: 67% 33%;
                     > div {
                       &:first-child {
                         border-right: 1px solid @table-border-color;
-                        width: 66.66666667%;
                       }
-                      &:last-child { width: 33.33333333%; }
                     }
                   }
                   div.transform-table {
+                    grid-template-columns: minmax(250px, 25%) 50% minmax(250px, 25%);
                     > div {
-                      &:first-child,
-                      &:last-child { width: 25%; }
                       &:nth-child(2) {
-                        width: 50%;
                         border-right: 1px solid @table-border-color;
                         border-left: 1px solid @table-border-color;
                       }
                     }
                   }
                   div.sink-table {
+                    grid-template-columns: 33% 67%;
                     > div {
                       &:first-child {
                         border-right: 1px solid @table-border-color;
-                        width: 33.33333333%;
                       }
-                      &:last-child { width: 66.66666667%; }
                     }
                   }
                 }
@@ -407,8 +396,6 @@ body.theme-cdap {
             .modal-header {
               .modal-title {
                 max-width: ~"calc(100% - 180px)";
-                max-width: ~"-moz-calc(100% - 180px)";
-                max-width: ~"-webkit-calc(100% - 180px)";
               }
             }
             .modal-body {
@@ -416,9 +403,7 @@ body.theme-cdap {
               .console-type {
                 .node-config {
                   div.config-table {
-                    height: ~"calc(100vh - 240px)";
-                    height: ~"-moz-calc(100vh - 240px)";
-                    height: ~"-webkit-calc(100vh - 240px)";
+                    height: ~"calc(100vh - 180px)";
                   }
                 }
               }

--- a/cdap-ui/app/hydrator/services/plugin-config-factory.js
+++ b/cdap-ui/app/hydrator/services/plugin-config-factory.js
@@ -25,6 +25,7 @@ class HydratorPlusPlusPluginConfigFactory {
     this.validatePluginProperties = this.validatePluginProperties.bind(this);
     this.HydratorPlusPlusNodeService = HydratorPlusPlusNodeService;
     this.EventPipe = EventPipe;
+    this.eventEmitter = window.CaskCommon.ee(window.CaskCommon.ee);
   }
   fetchWidgetJson(artifactName, artifactVersion, artifactScope, key) {
     let cache = this.data[`${artifactName}-${artifactVersion}-${artifactScope}-${key}`];
@@ -353,8 +354,10 @@ class HydratorPlusPlusPluginConfigFactory {
           }
           if (schemas.length) {
             this.EventPipe.emit('schema.import', schemas);
+            this.eventEmitter.emit('schema.import', schemas);
           } else if (!this.myHelpers.objectQuery(widgetJson, 'outputs', 0, 'name')) {
             this.EventPipe.emit('schema.clear');
+            this.eventEmitter.emit('schema.clear', schemas);
           }
         }
       }, (err) => {

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-config-form.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-config-form.html
@@ -20,13 +20,13 @@
   </div>
 
   <div>
-    <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
+    <div class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
   </div>
 </div>
 
 <div class="config-table transform-table" ng-if="HydratorPlusPlusNodeConfigCtrl.state.isTransform && HydratorPlusPlusNodeConfigCtrl.state.node.plugin.name !== 'Validator'">
   <div>
-    <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html'"></div>
+    <div class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html'"></div>
   </div>
 
   <div>
@@ -34,7 +34,7 @@
   </div>
 
   <div>
-    <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
+    <div class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
   </div>
 </div>
 
@@ -46,7 +46,7 @@
 
 <div class="config-table sink-table" ng-if="HydratorPlusPlusNodeConfigCtrl.state.isSink">
   <div>
-    <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html'"></div>
+    <div class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html'"></div>
   </div>
 
   <div>
@@ -55,7 +55,7 @@
         <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-properties-template.html'"></div>
       </div>
 
-      <div class="col-xs-12 sink-output-schema" ng-if="HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.isOutputSchemaExists || HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.implicitSchema">
+      <div class="col-xs-12 sink-output-schema output-schema-container" ng-if="HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.isOutputSchemaExists || HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.implicitSchema">
         <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
       </div>
     </div>

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html
@@ -15,12 +15,24 @@
 -->
 <div class="input-schema" data-cy="plugin-input-schema-container">
   <div class="schema-inner" ng-if="::HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema">
-    <h4>Input Schema</h4>
+    <h4 ng-if="!HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor">Input Schema</h4>
+
+    <div class="output-schema" ng-if="HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor">
+      <plugin-schema-editor
+        disabled="true"
+        schemas="HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema"
+        on-schema-change="HydratorPlusPlusNodeConfigCtrl.onSchemaChange"
+        actions-dropdown-map="HydratorPlusPlusNodeConfigCtrl.getActionsDropdownMap(true)"
+        schema-title="'Input Schema'">
+      </plugin-schema-editor>
+    </div>
+
     <my-input-schema
-        data-multiple-inputs="{{::(HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.inputs.multipleInputs === true)}}"
-        input-schema="{{::HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema}}"
-        is-in-studio="!isDisabled"
-        errors="HydratorPlusPlusNodeConfigCtrl.inputSchemaErrors">
+      ng-if="!HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor"
+      data-multiple-inputs="{{::(HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.inputs.multipleInputs === true)}}"
+      input-schema="{{::HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema}}"
+      is-in-studio="!isDisabled"
+      errors="HydratorPlusPlusNodeConfigCtrl.inputSchemaErrors">
     </my-input-schema>
   </div>
 </div>

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
@@ -16,12 +16,13 @@
 
 <div class="output-schema" ng-init="watchproperty=HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.schemaProperties['property-watch']" data-cy="plugin-output-schema-container">
 
-  <div class="schema-error">
+  <div class="schema-error" ng-if="!HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor">
     <ul>
       <li class="text-danger" ng-repeat="error in HydratorPlusPlusNodeConfigCtrl.state.errors">{{ error }}</li>
     </ul>
   </div>
-  <h4>
+
+  <h4 ng-if="!HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor">
     <span ng-if="!HydratorPlusPlusNodeConfigCtrl.state.isSink">Output Schema</span>
     <span ng-if="HydratorPlusPlusNodeConfigCtrl.state.isSink">Schema</span>
 
@@ -94,15 +95,28 @@
         </div>
       </div>
     </div>
-    <my-output-schema
-      schema-advance="HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance"
-      node="HydratorPlusPlusNodeConfigCtrl.state.node"
-      groups-config="HydratorPlusPlusNodeConfigCtrl.state.groupsConfig"
-      update-default-output-schema="HydratorPlusPlusNodeConfigCtrl.updateDefaultOutputSchema(outputSchema)"
-      is-disabled="isDisabled || HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists"
-      errors="HydratorPlusPlusNodeConfigCtrl.outputSchemaErrors">
-    </my-output-schema>
+    <div class="old-output-schema-container" ng-if="!HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor">
+      <my-output-schema
+        schema-advance="HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance"
+        node="HydratorPlusPlusNodeConfigCtrl.state.node"
+        groups-config="HydratorPlusPlusNodeConfigCtrl.state.groupsConfig"
+        update-default-output-schema="HydratorPlusPlusNodeConfigCtrl.updateDefaultOutputSchema(outputSchema)"
+        is-disabled="isDisabled || HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists"
+        errors="HydratorPlusPlusNodeConfigCtrl.outputSchemaErrors">
+      </my-output-schema>
+    </div>
   </fieldset>
+  <div class="output-schema" ng-if="HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor">
+    <plugin-schema-editor
+      schemas="HydratorPlusPlusNodeConfigCtrl.state.node.outputSchema"
+      on-schema-change="HydratorPlusPlusNodeConfigCtrl.onSchemaChange"
+      actions-dropdown-map="HydratorPlusPlusNodeConfigCtrl.getActionsDropdownMap()"
+      schema-title="'Output Schema'"
+      is-schema-macro="HydratorPlusPlusNodeConfigCtrl.isSchemaMacro()"
+      disabled="isDisabled || HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists">
+    </plugin-schema-editor>
+  </div>
+
 </div>
 
 <my-file-select class="sr-only" id="schema-import-link" data-button-icon="fa-upload" on-file-select="HydratorPlusPlusNodeConfigCtrl.importFiles($files)" data-button-label="Import">


### PR DESCRIPTION
**Context**
- This is a complete rewrite of schema editor.
- The goal of the schema to be more scalable and accommodate for editing attributes of certain avro schema types.

**Design**
- The schema editor design can be split into three parts,
  - Presentation - Editor
  - State management - Schema Manager
  - Validator - Schema Validator to validate schema
- Editor represents the visual part of the schema editor. At the core, it renders a list + manages changes to the schema (crud operation)
- Schema Manager is the underlying state management for any operation happening in the Editor. Internally it maintains a tree and a flat list each representing the same avro schema. Tree - for faster manipulation and Flat list - for easier rendering 
- Validator is the module used to validate the schema after each operation. We use customized version of [avsc library](https://github.com/cdapio/ui-schema-parser) to suit our needs

**Implementation**

_Schema Manager_ 
- For any avro schema generates a tree and a flat array
- For each operation (add/remove/update) the Schema Manager mutates the tree. This results in either adding a new subtree, removing a new subtree or modifying the existing subtree.
- This subtree is then flattened and inserted at appropriate position to the existing flat array.
- Tree is a direct tree representation of the avro schema
- List is a DFS traversed list generated from the above tree.

_Editor_
- List contains each node in the avro schema
- Each node in the list is identified by a unique id
- Each node contains a reference to #of ancestors
- Each row is either a two column (unions or maps) or three column like record field with name(or label), type and action buttons

**Other component changes**
- Modified `VirtualScroll` to include a `childrenUnderFoldScroll`. This is to increase the rendered child count on scroll to avoid showing empty white space. This is a common occurrence when using a virtual scroll as browser cannot catch up with scroll and rendering the underlying component quick enough.
- Modified `Select` dropdown to have a dense option to reduce padding.
- Modified `TextboxOnValium` to accept a ref prop to be able to pass on the underlying input element to the parent.
- Modified `If` to accept an additional `invisible` property to set `visibility: hidden` to children. This is to render empty space in place where the component needs to be showed.

**Things coming soon**
- Unit and Integration test for utilities, state management and editor components. - https://github.com/cdapio/cdap/pull/12455
- Replacing schema editor in the plugins modal https://github.com/cdapio/cdap/pull/12478
- Code cleanup https://github.com/cdapio/cdap/pull/12482
  
