### PR TITLE
[CDAP-17084] Limit request log entries to be <= 200 (RequestHistoryTab)

### DIFF
--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/index.tsx
@@ -17,7 +17,11 @@
 import * as React from 'react';
 
 import { List, Map } from 'immutable';
-import { getDateID, getRequestsByDate } from 'components/HttpExecutor/utilities';
+import {
+  compareByTimestamp,
+  getDateID,
+  getRequestsByDate,
+} from 'components/HttpExecutor/utilities';
 import withStyles, { StyleRules, WithStyles } from '@material-ui/core/styles/withStyles';
 
 import Button from '@material-ui/core/Button';
@@ -179,18 +183,6 @@ const RequestHistoryTabView: React.FC<IRequestHistoryTabProps> = ({
       // If REQUEST_HISTORY key doesn't exist in localStorage, initialize it
       localStorage.setItem(REQUEST_HISTORY, JSON.stringify([]));
       setRequestLog(Map({}));
-    }
-  };
-
-  const compareByTimestamp = (a: string, b: string) => {
-    const timestampA = new Date(a);
-    const timestampB = new Date(b);
-    if (timestampA < timestampB) {
-      return 1;
-    } else if (timestampA > timestampB) {
-      return -1;
-    } else {
-      return 0;
     }
   };
 

--- a/cdap-ui/app/cdap/components/HttpExecutor/utilities.ts
+++ b/cdap-ui/app/cdap/components/HttpExecutor/utilities.ts
@@ -26,3 +26,15 @@ export function getDateID(date: Date) {
 export function getRequestsByDate(log: Map<string, List<IRequestHistory>>, dateID: string) {
   return log.get(dateID) || List([]);
 }
+
+export function compareByTimestamp(a: string, b: string) {
+  const timestampA = new Date(a);
+  const timestampB = new Date(b);
+  if (timestampA < timestampB) {
+    return 1;
+  } else if (timestampA > timestampB) {
+    return -1;
+  } else {
+    return 0;
+  }
+}


### PR DESCRIPTION
Limit request log entries to be <= 200 counts. If there are more than 200 logs added, delete the oldest log from both localstorage and local UI states.