### PR TITLE
Fixed typo in SetPreferenceAction.scss

### DIFF
--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceAction.scss
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceAction.scss
@@ -246,7 +246,7 @@ $focused-input-color: #66afe9;
 
           .inherited-preferences-container {
             padding-bottom: 40px;
-            padding-top:  15px;
+            padding-top: 15px;
 
             table {
               border-collapse: separate;


### PR DESCRIPTION
When building the UI off of the develop branch, I run into the following build issue:
```
[INFO] app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceAction.scss
[INFO]  249:25  ✖  Expected single space after ":" with a single-line declaration   declaration-colon-space-after
[INFO] 
[INFO] 
[ERROR] error Command failed with exit code 1
```

We see the same issue in [this automated build](https://builds.cask.co/browse/CDAP-BPP-1263) as well.