### PR TITLE
CDAP-17097 add back port schemas to stage spec to fix validate issue

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
@@ -341,7 +341,9 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
       .addInputSchemas(pipelineConfigurer.getStageConfigurer().getInputSchemas())
       .setErrorSchema(stageConfigurer.getErrorSchema());
 
-    if (!type.equals(SplitterTransform.PLUGIN_TYPE)) {
+    if (type.equals(SplitterTransform.PLUGIN_TYPE)) {
+      specBuilder.setPortSchemas(stageConfigurer.getOutputPortSchemas());
+    } else {
       specBuilder.setOutputSchema(stageConfigurer.getOutputSchema());
     }
     return specBuilder;


### PR DESCRIPTION
StageSpec used to contain a map of ports to their schemas. This
map is never used by the backend, but is returned as part of the
stage validation call. This is in turn used by the UI to generate
the set of output ports along with their schemas.

Added back the map to return the API to compatibility and fix the
UI.