### PR TITLE
[CDAP-16850] New schema editor integration with pipelines

### DIFF
--- a/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/TextBox/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/TextBox/index.tsx
@@ -27,6 +27,7 @@ interface ITextBoxWidgetProps {
 interface ITextBoxProps extends IWidgetProps<ITextBoxWidgetProps> {
   autoFocus?: boolean;
   inputRef?: (ref: React.ReactNode) => void;
+  className?: string;
 }
 
 const TextBox: React.FC<ITextBoxProps> = ({
@@ -39,6 +40,7 @@ const TextBox: React.FC<ITextBoxProps> = ({
   autoFocus,
   inputRef,
   onKeyPress,
+  className,
 }) => {
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
     const v = event.target.value;
@@ -68,6 +70,7 @@ const TextBox: React.FC<ITextBoxProps> = ({
       }}
       autoFocus={autoFocus}
       inputRef={inputRef}
+      className={className}
     />
   );
 };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/ArrayType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/ArrayType/index.tsx
@@ -15,7 +15,10 @@
  */
 
 import * as React from 'react';
-import { schemaTypes } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import {
+  schemaTypes,
+  AvroSchemaTypesEnum,
+} from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 import { SingleColumnWrapper } from 'components/AbstractWidget/SchemaEditor/SingleColumnWrapper';
 import Select from 'components/AbstractWidget/FormInputs/Select';
 import { IFieldTypeBaseProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
@@ -27,6 +30,7 @@ const ArrayTypeBase = ({
   onChange,
   autoFocus,
   typeProperties,
+  disabled = false,
 }: IFieldTypeBaseProps) => {
   const [fieldType, setFieldType] = React.useState(type);
   const [fieldNullable, setFieldNullable] = React.useState(nullable);
@@ -52,18 +56,20 @@ const ArrayTypeBase = ({
     <React.Fragment>
       <SingleColumnWrapper>
         <Select
+          disabled={disabled}
           value={fieldType}
           onChange={(newValue) => {
             setFieldType(newValue);
             onChange('type', newValue);
           }}
-          widgetProps={{ options: schemaTypes, dense: true }}
+          widgetProps={{ options: schemaTypes, dense: true, native: true }}
           inputRef={(ref) => (inputEle.current = ref)}
         />
       </SingleColumnWrapper>
       <RowButtons
+        disabled={disabled}
         nullable={fieldNullable}
-        onNullable={type === 'union' ? undefined : onNullable}
+        onNullable={type === AvroSchemaTypesEnum.UNION ? undefined : onNullable}
         type={fieldType}
         onChange={onTypePropertiesChangeHandler}
         typeProperties={fieldTypeProperties}

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaGenerator.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaGenerator.ts
@@ -28,12 +28,13 @@ import uuidV4 from 'uuid/v4';
 import {
   getDefaultEmptyAvroSchema,
   InternalTypesEnum,
+  AvroSchemaTypesEnum,
 } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 import { isDisplayTypeComplex } from 'components/AbstractWidget/SchemaEditor/SchemaHelpers';
 
 function generateArrayType(children: IOrderedChildren, nullable: boolean) {
   const finalType = {
-    type: 'array',
+    type: AvroSchemaTypesEnum.ARRAY,
     items: null,
   };
   for (const childId of Object.keys(children)) {
@@ -59,9 +60,9 @@ function generateArrayType(children: IOrderedChildren, nullable: boolean) {
 
 function generateMapType(children: IOrderedChildren, nullable) {
   const finalType = {
-    type: 'map',
-    keys: 'string',
-    values: 'string',
+    type: AvroSchemaTypesEnum.MAP,
+    keys: AvroSchemaTypesEnum.STRING,
+    values: AvroSchemaTypesEnum.STRING,
   };
   for (const childId of Object.keys(children)) {
     const currentChild = children[childId];
@@ -90,7 +91,7 @@ function generateMapType(children: IOrderedChildren, nullable) {
 
 function generateEnumType(children: IOrderedChildren, currentNode: INode, nullable) {
   const finalType: IEnumFieldBase = {
-    type: 'enum',
+    type: AvroSchemaTypesEnum.ENUM,
     symbols: [],
   };
   const { typeProperties: currentTypeProperties = {} } = currentNode;
@@ -120,7 +121,7 @@ function generateEnumType(children: IOrderedChildren, currentNode: INode, nullab
 
 function generateRecordType(children: IOrderedChildren, currentNode: INode, nullable: boolean) {
   const finalType: IRecordField = {
-    type: 'record',
+    type: AvroSchemaTypesEnum.RECORD,
     name: currentNode.name || `name-${uuidV4()}`,
     fields: [],
   };
@@ -184,20 +185,20 @@ function generateLogicalType(child) {
 function generateSchemaFromComplexType(type: string, currentChild, nullable: boolean) {
   const complexTypeChildren: IOrderedChildren = currentChild.children;
   switch (type) {
-    case 'array':
+    case AvroSchemaTypesEnum.ARRAY:
       return generateArrayType(complexTypeChildren, nullable);
-    case 'map':
+    case AvroSchemaTypesEnum.MAP:
       return generateMapType(complexTypeChildren, nullable);
-    case 'enum':
+    case AvroSchemaTypesEnum.ENUM:
       return generateEnumType(complexTypeChildren, currentChild, nullable);
-    case 'union':
+    case AvroSchemaTypesEnum.UNION:
       return generateUnionType(complexTypeChildren);
-    case 'record':
+    case AvroSchemaTypesEnum.RECORD:
       return generateRecordType(complexTypeChildren, currentChild, nullable);
-    case 'time':
-    case 'timestamp':
-    case 'decimal':
-    case 'date':
+    case AvroSchemaTypesEnum.TIME:
+    case AvroSchemaTypesEnum.TIMESTAMP:
+    case AvroSchemaTypesEnum.DECIMAL:
+    case AvroSchemaTypesEnum.DATE:
       return generateLogicalType(currentChild);
     default:
       return type;

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaManager.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaManager.ts
@@ -37,6 +37,7 @@ import {
   InternalTypesEnum,
   OperationTypesEnum,
   getDefaultEmptyAvroSchema,
+  AvroSchemaTypesEnum,
 } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 
 interface ISchemaManagerOptions {
@@ -141,7 +142,7 @@ class SchemaManagerBase implements ISchemaManager {
       id,
       internalType: InternalTypesEnum.RECORD_SIMPLE_TYPE,
       nullable: false,
-      type: 'string',
+      type: AvroSchemaTypesEnum.STRING,
       name: '',
     };
     tree.children[id] = newlyAddedField;
@@ -166,7 +167,7 @@ class SchemaManagerBase implements ISchemaManager {
       id,
       internalType: InternalTypesEnum.UNION_SIMPLE_TYPE,
       nullable: false,
-      type: 'string',
+      type: AvroSchemaTypesEnum.STRING,
     };
     tree.children[id] = newlyAddedField;
     return {
@@ -179,11 +180,11 @@ class SchemaManagerBase implements ISchemaManager {
 
   private addSpecificTypesToTree = (tree: INode, fieldId: IFieldIdentifier) => {
     switch (tree.type) {
-      case 'enum':
+      case AvroSchemaTypesEnum.ENUM:
         return this.addNewEnumSymbol(tree, fieldId);
-      case 'record':
+      case AvroSchemaTypesEnum.RECORD:
         return this.addNewFieldType(tree, fieldId);
-      case 'union':
+      case AvroSchemaTypesEnum.UNION:
         return this.addNewUnionType(tree, fieldId);
       default:
         return { tree: undefined, newTree: undefined, currentField: undefined };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaManagerUtilities.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaManagerUtilities.ts
@@ -35,6 +35,7 @@ import {
   defaultRecordType,
   defaultUnionType,
   InternalTypesEnum,
+  AvroSchemaTypesEnum,
 } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 import isEmpty from 'lodash/isEmpty';
 
@@ -88,15 +89,15 @@ const branchCount = (tree: INode): number => {
 
 const initChildren = (type): IOrderedChildren => {
   switch (type) {
-    case 'array':
+    case AvroSchemaTypesEnum.ARRAY:
       return parseArrayType(defaultArrayType);
-    case 'enum':
+    case AvroSchemaTypesEnum.ENUM:
       return parseEnumType(defaultEnumType);
-    case 'map':
+    case AvroSchemaTypesEnum.MAP:
       return parseMapType(defaultMapType);
-    case 'record':
+    case AvroSchemaTypesEnum.RECORD:
       return parseComplexType(defaultRecordType);
-    case 'union':
+    case AvroSchemaTypesEnum.UNION:
       return parseUnionType(defaultUnionType);
     default:
       return;
@@ -108,13 +109,13 @@ const initTypeProperties = (tree: INode) => {
     return {};
   }
   switch (tree.type) {
-    case 'decimal':
+    case AvroSchemaTypesEnum.DECIMAL:
       return defaultDecimalTypeProperties;
-    case 'time':
+    case AvroSchemaTypesEnum.TIME:
       return defaultTimeTypeProperties;
-    case 'timestamp':
+    case AvroSchemaTypesEnum.TIMESTAMP:
       return defaultTimeStampTypeProperties;
-    case 'date':
+    case AvroSchemaTypesEnum.DATE:
       return defaultDateTypeProperties;
     default:
       return {};

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/EditorTypes.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/EditorTypes.ts
@@ -74,6 +74,7 @@ interface IFieldTypeBaseProps {
   onAdd: () => void;
   onRemove: () => void;
   autoFocus?: boolean;
+  disabled?: boolean;
 }
 
 interface IOnChangePayload {
@@ -90,6 +91,7 @@ interface IAttributesComponentProps {
   onChange?: IOnchangeHandler;
   typeProperties: ITypeProperties;
   handleClose: () => void;
+  disabled?: boolean;
 }
 
 export {

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/EnumType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/EnumType/index.tsx
@@ -32,6 +32,7 @@ const EnumTypeBase = ({
   onAdd,
   onRemove,
   autoFocus,
+  disabled = false,
 }: IFieldTypeBaseProps) => {
   const { symbol } = typeProperties;
   const [enumSymbol, setEnumSymbol] = React.useState(symbol);
@@ -50,6 +51,9 @@ const EnumTypeBase = ({
       onAdd();
       return;
     }
+    if (enumSymbol === newValue) {
+      return;
+    }
     setEnumSymbol(newValue);
     onChange('typeProperties', {
       symbol: newValue,
@@ -66,6 +70,7 @@ const EnumTypeBase = ({
   return (
     <React.Fragment>
       <TextboxOnValium
+        disabled={disabled}
         value={enumSymbol}
         onChange={onChangeHandler}
         placeholder="symbol"
@@ -74,6 +79,7 @@ const EnumTypeBase = ({
         className={classes.textbox}
       />
       <RowButtons
+        disabled={disabled}
         onRemove={onRemove}
         onAdd={onAdd}
         typeProperties={fieldTypeProperties}

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldType/index.tsx
@@ -17,7 +17,10 @@
 import * as React from 'react';
 import { FieldInputWrapper } from 'components/AbstractWidget/SchemaEditor/FieldWrapper';
 import Select from 'components/AbstractWidget/FormInputs/Select';
-import { schemaTypes } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import {
+  schemaTypes,
+  AvroSchemaTypesEnum,
+} from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 import { IFieldTypeBaseProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
 import { RowButtons } from 'components/AbstractWidget/SchemaEditor/RowButtons';
 import TextboxOnValium from 'components/TextboxOnValium';
@@ -39,6 +42,7 @@ const FieldTypeBase = ({
   onRemove,
   autoFocus,
   typeProperties,
+  disabled = false,
 }: IFieldTypeBaseProps) => {
   /**
    * We use hooks here because we propagte the state only upwards
@@ -73,12 +77,13 @@ const FieldTypeBase = ({
     onChange('nullable', checked);
   };
   const onChangeHandler = (newValue, _, keyPressKeyCode) => {
+    if (newValue !== fieldName) {
+      setFieldName(newValue);
+      onChange('name', newValue);
+    }
     if (keyPressKeyCode === 13) {
       onAdd();
-      return;
     }
-    setFieldName(newValue);
-    onChange('name', newValue);
   };
 
   const onTypeChangeHandler = (newValue) => {
@@ -107,14 +112,22 @@ const FieldTypeBase = ({
           onKeyUp={() => ({})}
         />
         <Select
+          disabled={disabled}
           value={fieldType}
           onChange={onTypeChangeHandler}
-          widgetProps={{ options: schemaTypes, dense: true }}
+          widgetProps={{
+            options: schemaTypes,
+            dense: true,
+            fullWidth: false,
+            inputProps: { title: fieldType },
+            native: true,
+          }}
         />
       </FieldInputWrapper>
       <RowButtons
+        disabled={disabled}
         nullable={fieldNullable}
-        onNullable={type === 'union' ? undefined : onNullable}
+        onNullable={type === AvroSchemaTypesEnum.UNION ? undefined : onNullable}
         type={fieldType}
         onAdd={onAdd}
         onRemove={onRemove}

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/FieldWrapperConstants.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/FieldWrapperConstants.ts
@@ -17,5 +17,6 @@
 import { INDENTATION_SPACING } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 const rowHeight = 28;
 const rowMarginTop = 2;
+const schemaRowHeight = rowHeight + 2 * rowMarginTop;
 
-export { INDENTATION_SPACING, rowHeight, rowMarginTop };
+export { INDENTATION_SPACING, rowHeight, rowMarginTop, schemaRowHeight };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldWrapper/index.tsx
@@ -77,13 +77,13 @@ const FieldWrapperBase = ({
    *
    * The width of the wrapper is reduced based on the indentation.
    */
-  const spacing = ancestors.length * INDENTATION_SPACING;
+  const spacing = (ancestors.length - 1) * INDENTATION_SPACING;
   const firstColumn = '20px';
   const thirdColumn = `96px`;
   const errorColumn = '10px';
   const secondColumn = `calc(100% - (${firstColumn} + ${thirdColumn} + ${errorColumn}))`;
   let customStyles: Partial<CSSStyleDeclaration> = {
-    marginLeft: `${spacing}px`,
+    marginLeft: `${spacing === 0 ? 2 : spacing}px`,
     gridTemplateColumns: `${firstColumn} ${secondColumn} ${thirdColumn}`,
     width: `calc(100% - ${spacing + 5 /* box shadow */}px)`,
     alignItems: 'center',
@@ -134,7 +134,7 @@ const FieldInputWrapperBase = withStyles(() => {
   return {
     root: {
       display: 'grid',
-      gridTemplateColumns: 'auto 100px',
+      gridTemplateColumns: '60% 40%',
     },
   };
 })(Box);

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldsList/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/FieldsList/index.tsx
@@ -35,11 +35,14 @@ const styles = (): StyleRules => {
 };
 
 interface IFieldsListState {
+  visibleRowCount: number;
   rows: IFlattenRowType[];
   currentRowToFocus: string;
 }
 
 interface IFieldsListProps extends WithStyles<typeof styles> {
+  visibleRowCount?: number;
+  disabled?: boolean;
   value: IFlattenRowType[];
   onChange: (id: IFieldIdentifier, onChangePayload: IOnChangePayload) => IOnChangeReturnType;
 }
@@ -52,13 +55,16 @@ class FieldsListBase extends React.Component<IFieldsListProps, IFieldsListState>
   public state: IFieldsListState = {
     rows: this.props.value || [],
     currentRowToFocus: null,
+    visibleRowCount: this.props.visibleRowCount || FieldsListBase.visibleNodeCount,
   };
   public componentWillReceiveProps(nextProps: IFieldsListProps) {
-    const ids = nextProps.value.map((r) => `${r.id}-${r.hidden}`).join(',');
-    const existingids = this.state.rows.map((r) => `${r.id}-${r.hidden}`).join(',');
-    if (ids !== existingids) {
+    const ids = nextProps.value.map((r) => `${r.id}-${r.hidden}-${r.collapsed}`).join(',');
+    const existingids = this.state.rows.map((r) => `${r.id}-${r.hidden}-${r.collapsed}`).join(',');
+    const { visibleRowCount } = nextProps;
+    if (ids !== existingids || visibleRowCount !== this.state.visibleRowCount) {
       this.setState({
         rows: nextProps.value,
+        visibleRowCount,
       });
     }
   }
@@ -85,6 +91,7 @@ class FieldsListBase extends React.Component<IFieldsListProps, IFieldsListState>
         }
         return (
           <FieldRow
+            disabled={this.props.disabled}
             autoFocus={currentRowToFocus === field.id}
             key={field.id}
             field={field}
@@ -110,7 +117,7 @@ class FieldsListBase extends React.Component<IFieldsListProps, IFieldsListState>
         </SchemaValidatorConsumer>
         <VirtualScroll
           itemCount={() => itemCount}
-          visibleChildCount={FieldsListBase.visibleNodeCount}
+          visibleChildCount={this.state.visibleRowCount}
           childHeight={FieldsListBase.heightOfRow}
           renderList={this.renderList.bind(this)}
           childrenUnderFold={FieldsListBase.childrenUnderFold}
@@ -120,4 +127,4 @@ class FieldsListBase extends React.Component<IFieldsListProps, IFieldsListState>
   }
 }
 const FieldsList = withstyles(styles)(FieldsListBase);
-export { FieldsList };
+export { FieldsList, FieldsListBase };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/MapType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/MapType/index.tsx
@@ -19,6 +19,7 @@ import Select from 'components/AbstractWidget/FormInputs/Select';
 import {
   schemaTypes,
   InternalTypesEnum,
+  AvroSchemaTypesEnum,
 } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 import Box from '@material-ui/core/Box';
 import withStyles, { StyleRules } from '@material-ui/core/styles/withStyles';
@@ -45,6 +46,7 @@ const MapTypeBase = ({
   onChange,
   autoFocus,
   typeProperties,
+  disabled = false,
 }: IFieldTypeBaseProps) => {
   let label = '';
   const keysType: string[] = [
@@ -88,18 +90,20 @@ const MapTypeBase = ({
       <MapWrapper>
         <span>{label}</span>
         <Select
+          disabled={disabled}
           value={fieldType}
           onChange={(newValue) => {
             setFieldType(newValue);
             onChange('type', newValue);
           }}
-          widgetProps={{ options: schemaTypes, dense: true, inline: true }}
+          widgetProps={{ options: schemaTypes, dense: true, inline: true, native: true }}
           inputRef={(ref) => (inputEle.current = ref)}
         />
       </MapWrapper>
       <RowButtons
+        disabled={disabled}
         nullable={fieldNullable}
-        onNullable={type === 'union' ? undefined : onNullable}
+        onNullable={type === AvroSchemaTypesEnum.UNION ? undefined : onNullable}
         type={fieldType}
         onChange={onTypePropertiesChangeHandler}
         typeProperties={fieldTypeProperties}

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/DecimalAttributes.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/DecimalAttributes.tsx
@@ -24,6 +24,7 @@ import {
 import { IAttributesComponentProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
 import { objectQuery } from 'services/helpers';
 import { useAttributePopoverStyles } from 'components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton';
+import If from 'components/If';
 
 function DecimalTypeAttributes({
   typeProperties,
@@ -73,9 +74,11 @@ function DecimalTypeAttributes({
           onChange={setPrecision}
         />
       </div>
-      <Button variant="contained" color="primary" onClick={onChangeHandler}>
-        Save
-      </Button>
+      <If condition={typeof onChange === 'function'}>
+        <Button variant="contained" color="primary" onClick={onChangeHandler}>
+          Save
+        </Button>
+      </If>
     </React.Fragment>
   );
 }

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton.tsx
@@ -26,6 +26,7 @@ import { DecimalTypeAttributes } from 'components/AbstractWidget/SchemaEditor/Ro
 import If from 'components/If';
 import { ITypeProperties } from 'components/AbstractWidget/SchemaEditor/Context/SchemaParser';
 import { IOnchangeHandler } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { AvroSchemaTypesEnum } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 
 interface IFieldPropertiesPopoverButtonProps {
   nullable: boolean;
@@ -33,6 +34,7 @@ interface IFieldPropertiesPopoverButtonProps {
   type: ISimpleType | IComplexTypeNames;
   onChange?: IOnchangeHandler;
   typeProperties: ITypeProperties;
+  disabled?: boolean;
 }
 
 const useAttributePopoverStyles = makeStyles({
@@ -50,6 +52,10 @@ const useStyles = makeStyles((theme) => ({
   popoverContainer: {
     padding: theme.spacing(1),
     width: '300px',
+    '&[disabled] *': {
+      color: theme.palette.grey[200],
+      cursor: 'not-allowed',
+    },
   },
 }));
 
@@ -57,6 +63,7 @@ function FieldPropertiesPopoverButton({
   type,
   onChange,
   typeProperties,
+  disabled,
 }: IFieldPropertiesPopoverButtonProps) {
   const [anchorEl, setAnchorEl] = React.useState(null);
 
@@ -91,27 +98,28 @@ function FieldPropertiesPopoverButton({
           horizontal: 'center',
         }}
       >
-        <div className={classes.popoverContainer}>
+        <fieldset className={classes.popoverContainer} disabled={disabled}>
           <If condition={!isFlatRowTypeComplex(type)}>
             <strong>No Attributes</strong>
           </If>
-          <If condition={type === 'record' || type === 'enum'}>
+          <If condition={type === AvroSchemaTypesEnum.RECORD || type === AvroSchemaTypesEnum.ENUM}>
             <strong>Attributes</strong>
             <RecordEnumTypeAttributes
               typeProperties={typeProperties}
-              onChange={onChange}
+              onChange={disabled ? undefined : onChange}
               handleClose={handleClose}
             />
           </If>
-          <If condition={type === 'decimal'}>
+          <If condition={type === AvroSchemaTypesEnum.DECIMAL}>
             <strong>Attributes</strong>
             <DecimalTypeAttributes
               typeProperties={typeProperties}
-              onChange={onChange}
+              onChange={disabled ? undefined : onChange}
               handleClose={handleClose}
+              disabled={disabled}
             />
           </If>
-        </div>
+        </fieldset>
       </Popover>
     </React.Fragment>
   );

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/RecordEnumAttributes.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/RecordEnumAttributes.tsx
@@ -19,6 +19,7 @@ import WidgetWrapper from 'components/ConfigurationGroup/WidgetWrapper';
 import Button from '@material-ui/core/Button';
 import { IAttributesComponentProps } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
 import { useAttributePopoverStyles } from 'components/AbstractWidget/SchemaEditor/RowButtons/FieldAttributes/FieldAttributesPopoverButton';
+import If from 'components/If';
 
 function RecordEnumTypeAttributes({
   typeProperties,
@@ -41,13 +42,13 @@ function RecordEnumTypeAttributes({
       <div className={classes.root}>
         <WidgetWrapper
           pluginProperty={{
-            name: 'doc',
+            name: 'documentation',
             macroSupported: false,
             description: 'documentation for the record',
           }}
           widgetProperty={{
             'widget-type': 'textbox',
-            label: 'Doc',
+            label: 'Documentation',
           }}
           value={doc}
           onChange={setDoc}
@@ -68,9 +69,11 @@ function RecordEnumTypeAttributes({
           }}
         />
       </div>
-      <Button variant="contained" color="primary" onClick={onChangeHandler}>
-        Save
-      </Button>
+      <If condition={typeof onChange === 'function'}>
+        <Button variant="contained" color="primary" onClick={onChangeHandler}>
+          Save
+        </Button>
+      </If>
     </React.Fragment>
   );
 }

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/RowButtons/index.tsx
@@ -24,6 +24,7 @@ import If from 'components/If';
 import { IComplexTypeNames, ISimpleType } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
 import { Nullable } from 'components/AbstractWidget/SchemaEditor/RowButtons/Nullable';
 import { IOnchangeHandler } from 'components/AbstractWidget/SchemaEditor/EditorTypes';
+import { AvroSchemaTypesEnum } from '../SchemaConstants';
 /**
  * Generic row buttons (add, nullable & remove buttons)
  * Based on the availability of handlers for each action each
@@ -35,6 +36,9 @@ const RowButtonWrapper = withStyles(() => {
       display: 'grid',
       gridTemplateColumns: '24px 24px 24px 24px',
       gridTemplateRows: '24px',
+      '& [disabled]': {
+        cursor: 'not-allowed',
+      },
     },
   };
 })(Box);
@@ -47,6 +51,7 @@ interface IRowButtonsProps {
   onChange?: IOnchangeHandler;
   typeProperties?: Record<string, string>;
   type?: ISimpleType | IComplexTypeNames;
+  disabled?: boolean;
 }
 
 function RowButtons({
@@ -57,25 +62,33 @@ function RowButtons({
   onRemove,
   onChange,
   typeProperties,
+  disabled = false,
 }: IRowButtonsProps) {
   return (
-    <RowButtonWrapper>
+    <RowButtonWrapper disabled={disabled}>
       <If condition={typeof onNullable === 'function'} invisible>
-        <Nullable nullable={nullable} onNullable={onNullable} />
+        <Nullable nullable={nullable} onNullable={disabled ? undefined : onNullable} />
       </If>
       <If condition={typeof onAdd === 'function'} invisible>
-        <AddRowButton onAdd={onAdd} />
+        <AddRowButton onAdd={disabled ? undefined : onAdd} />
       </If>
       <If condition={typeof onRemove === 'function'} invisible>
-        <RemoveRowButton onRemove={onRemove} />
+        <RemoveRowButton onRemove={disabled ? undefined : onRemove} />
       </If>
-      <If condition={type === 'record' || type === 'enum' || type === 'decimal'}>
+      <If
+        condition={
+          type === AvroSchemaTypesEnum.RECORD ||
+          type === AvroSchemaTypesEnum.ENUM ||
+          type === AvroSchemaTypesEnum.DECIMAL
+        }
+      >
         <FieldPropertiesPopoverButton
           nullable={nullable}
-          onNullable={onNullable}
+          onNullable={disabled ? undefined : onNullable}
           type={type}
-          onChange={onChange}
+          onChange={disabled ? undefined : onChange}
           typeProperties={typeProperties}
+          disabled={disabled}
         />
       </If>
     </RowButtonWrapper>

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SampleTypeFieldChecker.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SampleTypeFieldChecker.ts
@@ -30,13 +30,14 @@ import {
   ISimpleType,
   IComplexTypeFieldNullable,
 } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
+import { AvroSchemaTypesEnum } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 
 const mapfield: IMapField = {
   name: 'map1',
   type: {
-    type: 'map',
-    keys: 'string',
-    values: 'string',
+    type: AvroSchemaTypesEnum.MAP,
+    keys: AvroSchemaTypesEnum.STRING,
+    values: AvroSchemaTypesEnum.STRING,
   },
 };
 // tslint:disable-next-line: no-console
@@ -45,8 +46,8 @@ console.log(mapfield.type.keys);
 const arrayField: IArrayField = {
   name: 'arr',
   type: {
-    type: 'array',
-    items: 'string',
+    type: AvroSchemaTypesEnum.ARRAY,
+    items: AvroSchemaTypesEnum.STRING,
   },
 };
 // tslint:disable-next-line: no-console
@@ -54,7 +55,7 @@ console.log(!Array.isArray(arrayField.type) ? arrayField.type.items : arrayField
 
 const unionField: IUnionField = {
   name: 'something',
-  type: ['long', 'string'],
+  type: [AvroSchemaTypesEnum.LONG, AvroSchemaTypesEnum.STRING],
 };
 // tslint:disable-next-line: no-console
 console.log(unionField.type[1]);
@@ -62,7 +63,7 @@ console.log(unionField.type[1]);
 const enumField: IEnumField = {
   name: 'enum1',
   type: {
-    type: 'enum',
+    type: AvroSchemaTypesEnum.ENUM,
     symbols: ['something', 'somethingelse', 'nothing', 'maybesomething'],
   },
 };
@@ -71,16 +72,16 @@ const enumField: IEnumField = {
 console.log(enumField.type.symbols);
 
 const recordField: IRecordField = {
-  type: 'record',
+  type: AvroSchemaTypesEnum.RECORD,
   name: 'record1',
   fields: [
     {
       name: 'name',
-      type: 'string',
+      type: AvroSchemaTypesEnum.STRING,
     },
     {
       name: 'email',
-      type: 'string',
+      type: AvroSchemaTypesEnum.STRING,
     },
   ],
 };
@@ -92,8 +93,8 @@ const complexArrField2: IArrayFieldNullable = {
   name: 'arr1',
   type: [
     {
-      type: 'array',
-      items: 'string',
+      type: AvroSchemaTypesEnum.ARRAY,
+      items: AvroSchemaTypesEnum.STRING,
     },
     'null',
   ],
@@ -110,19 +111,19 @@ const complexArrayField: IArrayFieldNullable = {
   name: 'complexArray',
   type: [
     {
-      type: 'array',
+      type: AvroSchemaTypesEnum.ARRAY,
       items: [
         {
-          type: 'record',
+          type: AvroSchemaTypesEnum.RECORD,
           name: 'ad5bddf76ef2743218d79d3905f0f8e4f',
           fields: [
             {
               name: 'name',
-              type: 'string',
+              type: AvroSchemaTypesEnum.STRING,
             },
             {
               name: 'email',
-              type: 'string',
+              type: AvroSchemaTypesEnum.STRING,
             },
           ],
         },
@@ -134,7 +135,9 @@ const complexArrayField: IArrayFieldNullable = {
 };
 
 if (Array.isArray(complexArrayField.type)) {
-  const a1 = complexArrayField.type.find((t) => t !== 'null' && t.type === 'array');
+  const a1 = complexArrayField.type.find(
+    (t) => t !== 'null' && t.type === AvroSchemaTypesEnum.ARRAY
+  );
   // tslint:disable-next-line: no-console
   console.log(a1 !== 'null' && a1.items);
   if (isNullable(complexArrayField.type)) {
@@ -146,36 +149,36 @@ if (Array.isArray(complexArrayField.type)) {
 const complexUnionField: IUnionField = {
   name: 'something',
   type: [
-    'long',
+    AvroSchemaTypesEnum.LONG,
     {
-      type: 'map',
+      type: AvroSchemaTypesEnum.MAP,
       keys: {
-        type: 'record',
+        type: AvroSchemaTypesEnum.RECORD,
         name: 'a64d56b7343854e81801874b77b536802',
         fields: [
           {
             name: 'sdfsd',
-            type: 'string',
+            type: AvroSchemaTypesEnum.STRING,
           },
           {
             name: 'sdfsdsdfsdf',
-            type: 'string',
+            type: AvroSchemaTypesEnum.STRING,
           },
         ],
       },
-      values: 'string',
+      values: AvroSchemaTypesEnum.STRING,
     },
     {
-      type: 'record',
+      type: AvroSchemaTypesEnum.RECORD,
       name: 'record1',
       fields: [
         {
           name: 'name',
-          type: 'string',
+          type: AvroSchemaTypesEnum.STRING,
         },
         {
           name: 'email',
-          type: 'string',
+          type: AvroSchemaTypesEnum.STRING,
         },
       ],
     },
@@ -184,24 +187,29 @@ const complexUnionField: IUnionField = {
 const isSimpleType = (type: ISimpleType | IComplexTypeFieldNullable) =>
   typeof type === 'string' &&
   [
-    'boolean',
-    'bytes',
-    'date',
-    'decimal',
-    'double',
-    'float',
-    'int',
-    'long',
-    'number',
-    'string',
-    'time',
+    AvroSchemaTypesEnum.BOOLEAN,
+    AvroSchemaTypesEnum.BYTES,
+    AvroSchemaTypesEnum.DATE,
+    AvroSchemaTypesEnum.DECIMAL,
+    AvroSchemaTypesEnum.DOUBLE,
+    AvroSchemaTypesEnum.FLOAT,
+    AvroSchemaTypesEnum.INT,
+    AvroSchemaTypesEnum.LONG,
+    AvroSchemaTypesEnum.STRING,
+    AvroSchemaTypesEnum.TIME,
   ].indexOf(type) !== -1;
 if (Array.isArray(complexUnionField.type)) {
   const map1 = complexUnionField.type
     .filter((t) => typeof t !== 'string')
-    .find((t: IComplexType) => !Array.isArray(t.type) && t.type === 'map') as IMapFieldBase;
+    .find(
+      (t: IComplexType) => !Array.isArray(t.type) && t.type === AvroSchemaTypesEnum.MAP
+    ) as IMapFieldBase;
   let fieldsInRecords;
-  if (!Array.isArray(map1.keys) && typeof map1.keys === 'object' && map1.keys.type === 'record') {
+  if (
+    !Array.isArray(map1.keys) &&
+    typeof map1.keys === 'object' &&
+    map1.keys.type === AvroSchemaTypesEnum.RECORD
+  ) {
     fieldsInRecords = (map1.keys as IRecordField).fields;
   }
   // tslint:disable-next-line: no-console

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaConstants.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaConstants.ts
@@ -16,99 +16,26 @@
 
 import { ISchemaType } from './SchemaTypes';
 
-/**
- * Defines all the defaults we use for the schema.
- */
-const logicalTypes = ['time', 'timestamp', 'decimal', 'date'];
-const defaultPrecision = 32;
-const defaultScale = 3;
-const defaultDecimalTypeProperties = {
-  type: 'bytes',
-  logicalType: 'decimal',
-  precision: defaultPrecision,
-  scale: defaultScale,
-};
-const defaultTimeTypeProperties = {
-  type: 'long',
-  logicalType: 'time-micros',
-};
-const defaultTimeStampTypeProperties = {
-  type: 'long',
-  logicalType: 'timestamp-micros',
-};
-const defaultDateTypeProperties = {
-  type: 'int',
-  logicalType: 'date',
-};
-
-const defaultArrayType = {
-  type: 'array',
-  items: 'string',
-};
-const defaultEnumType = {
-  type: 'enum',
-  symbols: [''],
-};
-const defaultMapType = {
-  type: 'map',
-  keys: 'string',
-  values: 'string',
-};
-const defaultRecordType = {
-  name: 'etlSchemaBody',
-  type: 'record',
-  fields: [
-    {
-      name: '',
-      type: 'string',
-    },
-  ],
-};
-const defaultFieldType = {
-  name: '',
-  type: 'string',
-};
-const defaultUnionType = ['string'];
-
-const schemaTypes = [
-  'array',
-  'boolean',
-  'bytes',
-  'double',
-  'enum',
-  'float',
-  'int',
-  'long',
-  'map',
-  'record',
-  'string',
-  'union',
-].concat(logicalTypes);
-
-const logicalTypeToSimpleTypeMap = {
-  'time-micros': 'time',
-  'timestamp-micros': 'timestamp',
-  date: 'date',
-  decimal: 'decimal',
-};
-
-const INDENTATION_SPACING = 15;
-
-const getDefaultEmptyAvroSchema = (): ISchemaType => {
-  return {
-    name: 'etlSchemaBody',
-    schema: {
-      name: 'etlSchemaBody',
-      type: 'record',
-      fields: [
-        {
-          name: '',
-          type: 'string',
-        },
-      ],
-    },
-  };
-};
+enum AvroSchemaTypesEnum {
+  ARRAY = 'array',
+  BOOLEAN = 'boolean',
+  BYTES = 'bytes',
+  DATE = 'date',
+  DECIMAL = 'decimal',
+  DOUBLE = 'double',
+  ENUM = 'enum',
+  FLOAT = 'float',
+  INT = 'int',
+  LONG = 'long',
+  MAP = 'map',
+  RECORD = 'record',
+  STRING = 'string',
+  TIME = 'time',
+  TIMESTAMP = 'timestamp',
+  UNION = 'union',
+  TIMESTAMPMICROS = 'timestamp-micros',
+  TIMEMICROS = 'time-micros',
+}
 
 enum InternalTypesEnum {
   SCHEMA = 'schema',
@@ -133,6 +60,105 @@ enum OperationTypesEnum {
   COLLAPSE = 'collapse',
 }
 
+/**
+ * Defines all the defaults we use for the schema.
+ */
+const logicalTypes = [
+  AvroSchemaTypesEnum.TIME,
+  AvroSchemaTypesEnum.TIMESTAMP,
+  AvroSchemaTypesEnum.DECIMAL,
+  AvroSchemaTypesEnum.DATE,
+];
+const defaultPrecision = 32;
+const defaultScale = 3;
+const defaultDecimalTypeProperties = {
+  type: AvroSchemaTypesEnum.BYTES,
+  logicalType: AvroSchemaTypesEnum.DECIMAL,
+  precision: defaultPrecision,
+  scale: defaultScale,
+};
+const defaultTimeTypeProperties = {
+  type: AvroSchemaTypesEnum.LONG,
+  logicalType: AvroSchemaTypesEnum.TIMEMICROS,
+};
+const defaultTimeStampTypeProperties = {
+  type: AvroSchemaTypesEnum.LONG,
+  logicalType: AvroSchemaTypesEnum.TIMESTAMPMICROS,
+};
+const defaultDateTypeProperties = {
+  type: AvroSchemaTypesEnum.INT,
+  logicalType: AvroSchemaTypesEnum.DATE,
+};
+
+const defaultArrayType = {
+  type: AvroSchemaTypesEnum.ARRAY,
+  items: AvroSchemaTypesEnum.STRING,
+};
+const defaultEnumType = {
+  type: AvroSchemaTypesEnum.ENUM,
+  symbols: [''],
+};
+const defaultMapType = {
+  type: AvroSchemaTypesEnum.MAP,
+  keys: AvroSchemaTypesEnum.STRING,
+  values: AvroSchemaTypesEnum.STRING,
+};
+const defaultRecordType = {
+  name: 'etlSchemaBody',
+  type: AvroSchemaTypesEnum.RECORD,
+  fields: [
+    {
+      name: '',
+      type: AvroSchemaTypesEnum.STRING,
+    },
+  ],
+};
+const defaultFieldType = {
+  name: '',
+  type: AvroSchemaTypesEnum.STRING,
+};
+const defaultUnionType = [AvroSchemaTypesEnum.STRING];
+
+const schemaTypes = [
+  AvroSchemaTypesEnum.ARRAY,
+  AvroSchemaTypesEnum.BOOLEAN,
+  AvroSchemaTypesEnum.BYTES,
+  AvroSchemaTypesEnum.DOUBLE,
+  AvroSchemaTypesEnum.ENUM,
+  AvroSchemaTypesEnum.FLOAT,
+  AvroSchemaTypesEnum.INT,
+  AvroSchemaTypesEnum.LONG,
+  AvroSchemaTypesEnum.MAP,
+  AvroSchemaTypesEnum.RECORD,
+  AvroSchemaTypesEnum.STRING,
+  AvroSchemaTypesEnum.UNION,
+].concat(logicalTypes);
+
+const logicalTypeToSimpleTypeMap = {
+  'time-micros': AvroSchemaTypesEnum.TIME,
+  'timestamp-micros': AvroSchemaTypesEnum.TIMESTAMP,
+  date: AvroSchemaTypesEnum.DATE,
+  decimal: AvroSchemaTypesEnum.DECIMAL,
+};
+
+const INDENTATION_SPACING = 10;
+
+const getDefaultEmptyAvroSchema = (): ISchemaType => {
+  return {
+    name: 'etlSchemaBody',
+    schema: {
+      name: 'etlSchemaBody',
+      type: AvroSchemaTypesEnum.RECORD,
+      fields: [
+        {
+          name: '',
+          type: AvroSchemaTypesEnum.STRING,
+        },
+      ],
+    },
+  };
+};
+
 export {
   schemaTypes,
   INDENTATION_SPACING,
@@ -151,6 +177,7 @@ export {
   defaultUnionType,
   defaultFieldType,
   getDefaultEmptyAvroSchema,
+  AvroSchemaTypesEnum,
   InternalTypesEnum,
   OperationTypesEnum,
 };

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaEditorDemo.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaEditorDemo.tsx
@@ -18,11 +18,12 @@ import * as React from 'react';
 import FormControl from '@material-ui/core/FormControl';
 import { SchemaEditor } from 'components/AbstractWidget/SchemaEditor';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
-import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import If from 'components/If';
 import FileDnD from 'components/FileDnD';
 import { Button } from '@material-ui/core';
 import { getDefaultEmptyAvroSchema } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import LoadingSVG from 'components/LoadingSVG';
+
 const emptySchema = getDefaultEmptyAvroSchema();
 
 const styles = (): StyleRules => {
@@ -65,13 +66,25 @@ class SchemaEditorDemoBase extends React.Component<ISchemaEditorDemoBaseProps> {
         if (Array.isArray(schema)) {
           schema = schema[0];
         }
-        this.setState({
-          schema,
-          file: e[0],
-          error: null,
-        });
+        this.setState(
+          {
+            schema,
+            file: e[0],
+            error: null,
+            loading: true,
+          },
+          () => {
+            setTimeout(
+              () =>
+                this.setState({
+                  loading: false,
+                }),
+              1000
+            );
+          }
+        );
       } catch (e) {
-        this.setState({ error: e.message });
+        this.setState({ error: e.message, loading: false });
       }
     };
     reader.readAsText(e[0], 'UTF-8');
@@ -95,12 +108,21 @@ class SchemaEditorDemoBase extends React.Component<ISchemaEditorDemoBaseProps> {
   };
 
   public clearSchema = () => {
-    this.setState({
-      loading: false,
-      file: {},
-      error: null,
-      schema: emptySchema,
-    });
+    this.setState(
+      {
+        loading: true,
+      },
+      () => {
+        setTimeout(() => {
+          this.setState({
+            loading: false,
+            file: {},
+            error: null,
+            schema: emptySchema,
+          });
+        }, 500);
+      }
+    );
   };
 
   public render() {
@@ -136,7 +158,7 @@ class SchemaEditorDemoBase extends React.Component<ISchemaEditorDemoBaseProps> {
         </FormControl>
         <div className={classes.contentContainer}>
           <If condition={this.state.loading}>
-            <LoadingSVGCentered />
+            <LoadingSVG />
           </If>
           <If condition={!this.state.loading}>
             <SchemaEditor

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaHelpers.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaHelpers.ts
@@ -19,30 +19,32 @@ import {
   ISimpleType,
   ILogicalTypeNames,
 } from 'components/AbstractWidget/SchemaEditor/SchemaTypes';
-import { logicalTypeToSimpleTypeMap } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import {
+  logicalTypeToSimpleTypeMap,
+  AvroSchemaTypesEnum,
+} from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 import cloneDeep from 'lodash/cloneDeep';
 
 const displayTypes: Array<ISimpleType | IComplexTypeNames | ILogicalTypeNames> = [
-  'array',
-  'enum',
-  'map',
-  'record',
-  'union',
-  'boolean',
-  'bytes',
-  'date',
-  'decimal',
-  'double',
-  'float',
-  'int',
-  'long',
-  'number',
-  'string',
-  'time',
-  'timestamp-micros',
-  'date',
-  'time-micros',
-  'decimal',
+  AvroSchemaTypesEnum.ARRAY,
+  AvroSchemaTypesEnum.ENUM,
+  AvroSchemaTypesEnum.MAP,
+  AvroSchemaTypesEnum.RECORD,
+  AvroSchemaTypesEnum.UNION,
+  AvroSchemaTypesEnum.BOOLEAN,
+  AvroSchemaTypesEnum.BYTES,
+  AvroSchemaTypesEnum.DATE,
+  AvroSchemaTypesEnum.DECIMAL,
+  AvroSchemaTypesEnum.DOUBLE,
+  AvroSchemaTypesEnum.FLOAT,
+  AvroSchemaTypesEnum.INT,
+  AvroSchemaTypesEnum.LONG,
+  AvroSchemaTypesEnum.STRING,
+  AvroSchemaTypesEnum.TIME,
+  AvroSchemaTypesEnum.TIMESTAMPMICROS,
+  AvroSchemaTypesEnum.DATE,
+  AvroSchemaTypesEnum.TIMEMICROS,
+  AvroSchemaTypesEnum.DECIMAL,
 ];
 
 /**
@@ -77,7 +79,7 @@ const getNonNullableType = (type) => {
  * @param type valid simple/logical avro type
  */
 const getSimpleType = (type) => {
-  if (typeof type === 'string') {
+  if (typeof type === AvroSchemaTypesEnum.STRING) {
     return type;
   }
   if (type && type.logicalType) {
@@ -96,14 +98,14 @@ const isComplexType = (complexType) => {
   if (nullable) {
     type = complexType.filter((t) => t !== 'null').pop();
   }
-  if (typeof type === 'string') {
+  if (typeof type === AvroSchemaTypesEnum.STRING) {
     return false;
   }
   switch (type.type) {
-    case 'record':
-    case 'enum':
-    case 'array':
-    case 'map':
+    case AvroSchemaTypesEnum.RECORD:
+    case AvroSchemaTypesEnum.ENUM:
+    case AvroSchemaTypesEnum.ARRAY:
+    case AvroSchemaTypesEnum.MAP:
       return true;
     default:
       return isUnion(complexType) ? true : false;
@@ -112,10 +114,10 @@ const isComplexType = (complexType) => {
 
 const isDisplayTypeLogical = ({ type }) => {
   switch (type) {
-    case 'decimal':
-    case 'date':
-    case 'time':
-    case 'timestamp':
+    case AvroSchemaTypesEnum.DECIMAL:
+    case AvroSchemaTypesEnum.DATE:
+    case AvroSchemaTypesEnum.TIME:
+    case AvroSchemaTypesEnum.TIMESTAMP:
       return true;
     default:
       return false;
@@ -124,11 +126,11 @@ const isDisplayTypeLogical = ({ type }) => {
 
 const isDisplayTypeComplex = ({ type }) => {
   switch (type) {
-    case 'record':
-    case 'enum':
-    case 'union':
-    case 'map':
-    case 'array':
+    case AvroSchemaTypesEnum.RECORD:
+    case AvroSchemaTypesEnum.ENUM:
+    case AvroSchemaTypesEnum.UNION:
+    case AvroSchemaTypesEnum.MAP:
+    case AvroSchemaTypesEnum.ARRAY:
       return true;
     default:
       return isDisplayTypeLogical({ type }) || false;
@@ -149,27 +151,26 @@ const getComplexTypeName = (complexType): IComplexTypeNames => {
     type = cloneDeep(c.type);
   }
   switch (type) {
-    case 'record':
-    case 'enum':
-    case 'array':
-    case 'map':
+    case AvroSchemaTypesEnum.RECORD:
+    case AvroSchemaTypesEnum.ENUM:
+    case AvroSchemaTypesEnum.ARRAY:
+    case AvroSchemaTypesEnum.MAP:
       return type;
     default:
-      return isUnion(c) ? 'union' : undefined;
+      return isUnion(c) ? AvroSchemaTypesEnum.UNION : undefined;
   }
 };
 
 const isFlatRowTypeComplex = (typeName: ISimpleType | IComplexTypeNames) => {
   switch (typeName) {
-    case 'string':
-    case 'boolean':
-    case 'bytes':
-    case 'double':
-    case 'float':
-    case 'int':
-    case 'long':
-    case 'number':
-    case 'string':
+    case AvroSchemaTypesEnum.STRING:
+    case AvroSchemaTypesEnum.BOOLEAN:
+    case AvroSchemaTypesEnum.BYTES:
+    case AvroSchemaTypesEnum.DOUBLE:
+    case AvroSchemaTypesEnum.FLOAT:
+    case AvroSchemaTypesEnum.INT:
+    case AvroSchemaTypesEnum.LONG:
+    case AvroSchemaTypesEnum.STRING:
       return false;
     default:
       return true;

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaTypes.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SchemaTypes.ts
@@ -14,26 +14,35 @@
  * the License.
  */
 
+import { AvroSchemaTypesEnum } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
 /**
  * Contains types used in parsing an avro schema.
  * TODO: This is a work in progress. We don't use these types yet fully
  * in the schema parser yet.
  */
-type IComplexTypeNames = 'array' | 'enum' | 'map' | 'record' | 'union';
+type IComplexTypeNames =
+  | AvroSchemaTypesEnum.ARRAY
+  | AvroSchemaTypesEnum.ENUM
+  | AvroSchemaTypesEnum.MAP
+  | AvroSchemaTypesEnum.RECORD
+  | AvroSchemaTypesEnum.UNION;
 type ISimpleType =
-  | 'boolean'
-  | 'bytes'
-  | 'date'
-  | 'decimal'
-  | 'double'
-  | 'float'
-  | 'int'
-  | 'long'
-  | 'number'
-  | 'string'
-  | 'time'
-  | 'timestamp';
-type ILogicalTypeNames = 'timestamp-micros' | 'date' | 'time-micros' | 'decimal';
+  | AvroSchemaTypesEnum.BOOLEAN
+  | AvroSchemaTypesEnum.BYTES
+  | AvroSchemaTypesEnum.DATE
+  | AvroSchemaTypesEnum.DECIMAL
+  | AvroSchemaTypesEnum.DOUBLE
+  | AvroSchemaTypesEnum.FLOAT
+  | AvroSchemaTypesEnum.INT
+  | AvroSchemaTypesEnum.LONG
+  | AvroSchemaTypesEnum.STRING
+  | AvroSchemaTypesEnum.TIME
+  | AvroSchemaTypesEnum.TIMESTAMP;
+type ILogicalTypeNames =
+  | AvroSchemaTypesEnum.TIMESTAMPMICROS
+  | AvroSchemaTypesEnum.DATE
+  | AvroSchemaTypesEnum.TIMEMICROS
+  | AvroSchemaTypesEnum.DECIMAL;
 
 type IDisplayType = ISimpleType | IComplexTypeNames;
 
@@ -63,7 +72,7 @@ interface IFieldBaseType {
 }
 
 interface IEnumFieldBase {
-  type: 'enum';
+  type: AvroSchemaTypesEnum.ENUM;
   symbols: string[];
   doc?: string;
   aliases?: string[];
@@ -76,7 +85,7 @@ interface IEnumFieldNullable extends IFieldBaseType {
 }
 
 interface IMapFieldBase {
-  type: 'map';
+  type: AvroSchemaTypesEnum.MAP;
   keys: ISimpleType | ISimpleTypeNullable | IComplexType | IComplexTypeFieldNullable;
   values: ISimpleType | ISimpleTypeNullable | IComplexType | IComplexTypeFieldNullable;
 }
@@ -88,7 +97,7 @@ interface IMapFieldNullable extends IFieldBaseType {
 }
 
 interface IArrayFieldBase {
-  type: 'array';
+  type: AvroSchemaTypesEnum.ARRAY;
   items: ISimpleType | ISimpleTypeNullable | IComplexType | IComplexTypeFieldNullable;
 }
 
@@ -129,7 +138,7 @@ interface IFieldTypeNullable extends IFieldBaseType {
 }
 
 interface IRecordField extends IFieldBaseType {
-  type: 'record';
+  type: AvroSchemaTypesEnum.RECORD;
   fields: Array<IFieldType | IFieldTypeNullable>;
   doc?: string;
   aliases?: string[];

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SingleColumnWrapper/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/SingleColumnWrapper/index.tsx
@@ -23,7 +23,6 @@ const SingleColumnWrapper = withStyles(() => {
   return {
     root: {
       width: '132px',
-      marginLeft: '-12px',
     },
   };
 })(Box);

--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/UnionType/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/UnionType/index.tsx
@@ -28,6 +28,7 @@ const UnionTypeBase = ({
   onRemove,
   autoFocus,
   typeProperties,
+  disabled = false,
 }: IFieldTypeBaseProps) => {
   const [fieldType, setFieldType] = React.useState(type);
   const [fieldTypeProperties, setFieldTypeProperties] = React.useState(typeProperties || {});
@@ -50,16 +51,18 @@ const UnionTypeBase = ({
     <React.Fragment>
       <SingleColumnWrapper>
         <Select
+          disabled={disabled}
           value={fieldType}
           onChange={(newValue) => {
             setFieldType(newValue);
             onChange('type', newValue);
           }}
-          widgetProps={{ options: schemaTypes, dense: true }}
+          widgetProps={{ options: schemaTypes, dense: true, native: true }}
           inputRef={(ref) => (inputEle.current = ref)}
         />
       </SingleColumnWrapper>
       <RowButtons
+        disabled={disabled}
         onAdd={onAdd}
         onRemove={onRemove}
         type={fieldType}

--- a/cdap-ui/app/cdap/components/PluginSchemaEditor/RefreshableSchemaEditor.tsx
+++ b/cdap-ui/app/cdap/components/PluginSchemaEditor/RefreshableSchemaEditor.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import { SchemaEditor } from 'components/AbstractWidget/SchemaEditor';
+import If from 'components/If';
+import LoadingSVG from 'components/LoadingSVG';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+const styles = (): StyleRules => {
+  return {
+    container: {
+      textAlign: 'center',
+    },
+  };
+};
+
+interface IPluginSchema {
+  name: string;
+  schema: string;
+}
+
+interface IRefreshableSchemaEditor extends WithStyles<typeof styles> {
+  schema: IPluginSchema;
+  onChange: (schemas: IPluginSchema) => void;
+  disabled?: boolean;
+  visibleRows?: number;
+}
+
+function RefreshableSchemaEditorBase({
+  schema,
+  onChange,
+  disabled,
+  classes,
+  visibleRows,
+}: IRefreshableSchemaEditor) {
+  const [loading, setLoading] = React.useState(false);
+
+  React.useEffect(() => {
+    setLoading(true);
+    setTimeout(() => {
+      setLoading(false);
+    }, 500);
+  }, [schema]);
+
+  return (
+    <div className={classes.container}>
+      <If condition={loading}>
+        <LoadingSVG />
+      </If>
+      <If condition={!loading}>
+        <SchemaEditor
+          schema={schema}
+          disabled={disabled}
+          onChange={onChange}
+          visibleRows={visibleRows}
+        />
+      </If>
+    </div>
+  );
+}
+const RefreshableSchemaEditor = withStyles(styles)(RefreshableSchemaEditorBase);
+export { RefreshableSchemaEditor };

--- a/cdap-ui/app/cdap/components/PluginSchemaEditor/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginSchemaEditor/index.tsx
@@ -1,0 +1,542 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import * as React from 'react';
+import Select from 'components/AbstractWidget/FormInputs/Select';
+import { SchemaEditor } from 'components/AbstractWidget/SchemaEditor';
+import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
+import ThemeWrapper from 'components/ThemeWrapper';
+import ee from 'event-emitter';
+import { getDefaultEmptyAvroSchema } from 'components/AbstractWidget/SchemaEditor/SchemaConstants';
+import PropTypes from 'prop-types';
+import LoadingSVG from 'components/LoadingSVG';
+import If from 'components/If';
+import TextboxOnValium from 'components/TextboxOnValium';
+import { RefreshableSchemaEditor } from 'components/PluginSchemaEditor/RefreshableSchemaEditor';
+import ConfigurableTab from 'components/ConfigurableTab';
+import classnames from 'classnames';
+import { objectQuery, isNilOrEmptyString } from 'services/helpers';
+import { FieldsListBase } from 'components/AbstractWidget/SchemaEditor/FieldsList';
+import Alert from 'components/Alert';
+import { isObject } from 'vega-lite/build/src/util';
+import { isMacro } from 'services/helpers';
+import DownloadFile from 'services/download-file';
+
+const styles = (theme): StyleRules => {
+  return {
+    container: {
+      display: 'block',
+      height: '100%',
+    },
+    fieldset: {
+      '&[disabled] *': {
+        color: `${theme.palette.grey[200]} !important`,
+        cursor: 'not-allowed !important',
+      },
+    },
+    tabContent: {
+      width: '100%',
+    },
+    header: {
+      display: 'grid',
+      gridTemplateColumns: 'auto 100px',
+      alignItems: 'center',
+      margin: '-15px -10px 5px -10px',
+      padding: '0 10px 5px;',
+      borderBottom: `1px solid ${theme.palette.grey[300]}`,
+    },
+    disabledHeader: {
+      margin: '0 -10px 5px -10px',
+      padding: '0 10px 10px',
+    },
+    title: {
+      fontWeight: 500,
+    },
+    actionsDropdown: {
+      border: `1px solid ${theme.palette.grey[400]}`,
+      borderRadius: '4px',
+    },
+    loadingContainer: {
+      textAlign: 'center',
+    },
+    macroTextBox: {
+      width: '100%',
+      border: `1px solid ${theme.palette.grey[300]}`,
+      borderRadius: '4px',
+      padding: '5px',
+    },
+  };
+};
+
+enum SchemaActionsEnum {
+  IMPORT = 'import',
+  EXPORT = 'export',
+  CLEAR = 'clear',
+  MACRO = 'macro',
+  EDITOR = 'editor',
+  PROPAGATE = 'propagate',
+}
+enum IPluginSchemaEditorModes {
+  Macro = 'macro',
+  Editor = 'editor',
+}
+interface IActionsOptionsObj {
+  disabled?: boolean;
+  tooltip?: string;
+  label: string;
+  value: SchemaActionsEnum;
+  onClick?: () => void;
+}
+interface IPluginSchema {
+  name: string;
+  schema: string;
+}
+type IActionsDropdownTooltip = Record<SchemaActionsEnum, IActionsOptionsObj>;
+interface IPluginSchemaEditorState {
+  error: string;
+  schemas: IPluginSchema[];
+  mode: IPluginSchemaEditorModes;
+  loading: boolean;
+  schemaRowCount: number;
+}
+
+interface IPluginSchemaEditorProps extends WithStyles<typeof styles> {
+  disabled?: boolean;
+  actionsDropdownMap: IActionsDropdownTooltip;
+  schemas: IPluginSchema[];
+  onSchemaChange: (schemas: IPluginSchema[]) => void;
+  schemaTitle?: string;
+  isSchemaMacro?: boolean;
+}
+
+class PluginSchemaEditorBase extends React.PureComponent<
+  IPluginSchemaEditorProps,
+  IPluginSchemaEditorState
+> {
+  private actions: IActionsOptionsObj[] = Object.values(this.props.actionsDropdownMap).map(
+    (value) => value
+  );
+  private containerRef;
+
+  private getMode = () => {
+    if (this.props.disabled) {
+      return isMacro(objectQuery(this.props.schemas, 0, 'schema') || '')
+        ? IPluginSchemaEditorModes.Macro
+        : IPluginSchemaEditorModes.Editor;
+    }
+    return this.props.isSchemaMacro
+      ? IPluginSchemaEditorModes.Macro
+      : IPluginSchemaEditorModes.Editor;
+  };
+
+  public state = {
+    error: null,
+    schemas: this.props.schemas,
+    loading: false,
+    mode: this.getMode(),
+    schemaRowCount: null,
+  };
+
+  private ee = ee(ee);
+
+  constructor(props) {
+    super(props);
+    if (!this.props.disabled) {
+      this.ee.on('schema.import', this.onSchemaImport);
+      this.ee.on('dataset.selected', this.onSchemaImport);
+    }
+    const doesActionDropdownHasExport = Object.keys(this.props.actionsDropdownMap).find(
+      (key) => key.toLowerCase() === 'export'
+    );
+    if (doesActionDropdownHasExport) {
+      // Schema can be exported on detailed view even if it is disabled.
+      this.ee.on('schema.export', this.onSchemaExport);
+    }
+    window.addEventListener('resize', this.calculateSchemaRowCount);
+  }
+
+  public componentWillReceiveProps(nextProps: IPluginSchemaEditorProps) {
+    if (!Object.keys(nextProps.actionsDropdownMap).length) {
+      this.actions = [];
+      return;
+    }
+    this.actions = Object.values(nextProps.actionsDropdownMap).map((value) => value);
+    return;
+  }
+
+  public shouldComponentUpdate(nextProps: IPluginSchemaEditorProps, nextState) {
+    const { disabled, isSchemaMacro, actionsDropdownMap, schemas } = nextProps;
+    const { schemaRowCount, loading, mode, error } = nextState;
+    const newActions = Object.values(actionsDropdownMap)
+      .filter((value) => typeof value === 'string')
+      .join('--');
+    const existingActions = Object.values(this.props.actionsDropdownMap)
+      .filter((value) => typeof value === 'string')
+      .join('--');
+    const existingSchemas = this.props.schemas.map((s) => s.schema).join('__');
+    const newSchemas = schemas.map((s) => s.schema).join('__');
+
+    const didPropsChange =
+      disabled !== this.props.disabled ||
+      isSchemaMacro !== this.props.isSchemaMacro ||
+      newActions !== existingActions ||
+      newSchemas !== existingSchemas;
+
+    const didStateChange =
+      schemaRowCount !== this.state.schemaRowCount ||
+      loading !== this.state.loading ||
+      mode !== this.state.mode ||
+      error !== this.state.error;
+    return didStateChange || didPropsChange;
+  }
+
+  public componentDidMount() {
+    this.calculateSchemaRowCount();
+  }
+
+  public componentWillUnmount() {
+    this.ee.off('schema.import', this.onSchemaImport);
+    this.ee.off('schema.export', this.onSchemaExport);
+    this.ee.on('dataset.selected', this.onSchemaImport);
+    window.removeEventListener('resize', this.calculateSchemaRowCount);
+  }
+
+  public calculateSchemaRowCount = () => {
+    if (this.containerRef) {
+      const { height } = this.containerRef.getBoundingClientRect();
+      let schemaRowCount = Math.floor(height / FieldsListBase.heightOfRow) - 1;
+      // For sinks we can't determine the height. So set it to by default 20 (20 * 34 = 680px in height)
+      if (schemaRowCount < 5) {
+        schemaRowCount = 20;
+      }
+      this.setState({ schemaRowCount });
+    }
+  };
+
+  public onSchemaExport = () => {
+    const schemasToExport = this.props.schemas.map((schema) => {
+      try {
+        return {
+          name: schema.name,
+          schema: JSON.parse(schema.schema),
+        };
+      } catch (e) {
+        return schema;
+      }
+    });
+    // // CDAP-17106 - Need to use generic DownloadFile function here from download-file
+    const blob = new Blob([JSON.stringify(schemasToExport, null, 4)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const exportFileName = 'schema';
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${exportFileName}.json`;
+
+    const clickHandler = (event) => {
+      event.stopPropagation();
+    };
+    a.addEventListener('click', clickHandler, false);
+    a.click();
+  };
+
+  private onSchemaImport = (schemas) => {
+    if (this.state.mode === IPluginSchemaEditorModes.Macro) {
+      return;
+    }
+    let importedSchemas = schemas;
+    if (typeof schemas === 'string') {
+      try {
+        importedSchemas = JSON.parse(schemas);
+      } catch (e) {
+        this.setState({
+          error: e.message,
+        });
+        return;
+      }
+    }
+    let hasError = false;
+    if (!Array.isArray(importedSchemas)) {
+      // This will be the case when we hit 'Apply' button from wrangler.
+      // We don't maintain consistency in importing schemas from multiple
+      // sources. This will take time to fix as we right now throw schemas
+      // in multiple formats across all places.
+      if (isObject(importedSchemas) && !importedSchemas.hasOwnProperty('schema')) {
+        importedSchemas = { name: 'etlSchemaBody', schema: importedSchemas };
+      }
+      importedSchemas = [importedSchemas];
+    }
+    const newSchemas = importedSchemas.map((schema) => {
+      if (typeof schema !== 'object' && schema.hasOwnProperty('schema')) {
+        return { ...getDefaultEmptyAvroSchema() };
+      }
+      const s = { ...schema };
+      try {
+        if (typeof schema.schema === 'string') {
+          s.schema = JSON.parse(schema.schema);
+        }
+      } catch (e) {
+        this.setState({
+          error: e.message,
+        });
+        hasError = true;
+        return;
+      }
+      if (!s.schema || s.schema.type !== 'record' || !Array.isArray(s.schema.fields)) {
+        this.setState({
+          error: 'Imported schema is not a valid Avro schema',
+        });
+        hasError = true;
+        return;
+      }
+      if (s.schema.name) {
+        s.schema.name = s.schema.name.replace('.', '.type');
+      }
+      return s;
+    });
+    if (hasError) {
+      return;
+    }
+    this.setState({ schemas: newSchemas, loading: true }, () => {
+      setTimeout(() => {
+        this.setState({
+          loading: false,
+        });
+        const schemasForPlugin = newSchemas.map((s) => {
+          if (typeof s.schema !== 'string') {
+            s.schema = JSON.stringify(s.schema);
+          }
+          return s;
+        });
+        this.props.onSchemaChange(schemasForPlugin);
+      }, 1000);
+    });
+  };
+
+  private onActionsHandler = (value) => {
+    const specificAction = this.actions.find((action) => action.value === value);
+    if (!specificAction) {
+      return;
+    }
+    specificAction.onClick();
+    if (value === SchemaActionsEnum.CLEAR) {
+      specificAction.onClick();
+      this.setState(
+        {
+          loading: true,
+          schemas: [{ name: 'etlSchemaBody', schema: '' }],
+        },
+        () => {
+          setTimeout(() => {
+            this.setState({
+              loading: false,
+            });
+          }, 1000);
+        }
+      );
+    } else if (value === SchemaActionsEnum.MACRO) {
+      const newState = {
+        mode:
+          this.state.mode === IPluginSchemaEditorModes.Editor
+            ? IPluginSchemaEditorModes.Macro
+            : IPluginSchemaEditorModes.Editor,
+        schemas:
+          this.state.mode === IPluginSchemaEditorModes.Editor
+            ? [{ name: 'etlSchemaBody', schema: '${}' }]
+            : [{ name: 'etlSchemaBody', schema: '' }],
+      };
+      this.setState(newState);
+    }
+  };
+
+  private santizeSchemasForEditor = (schemas = this.state.schemas) => {
+    return (schemas || []).map((s) => {
+      const newSchema = {
+        name: s.name,
+        schema: s.schema,
+      };
+      if (typeof s.schema === 'string') {
+        try {
+          newSchema.schema = JSON.parse(s.schema);
+        } catch (e) {
+          return { ...getDefaultEmptyAvroSchema() };
+        }
+      }
+      return newSchema;
+    });
+  };
+
+  public renderSchemaIntabs = () => {
+    const tabs = this.santizeSchemasForEditor().map((s, i) => {
+      return {
+        id: i,
+        name: s.name,
+        content: (
+          <fieldset disabled={this.props.disabled} className={this.props.classes.fieldset} key={i}>
+            <RefreshableSchemaEditor
+              visibleRows={this.state.schemaRowCount}
+              schema={s}
+              disabled={this.props.disabled}
+              onChange={({ avroSchema }) => {
+                const newSchemas = [...this.props.schemas];
+                newSchemas[i] = avroSchema;
+                newSchemas[i].schema = JSON.stringify(newSchemas[i].schema);
+                this.props.onSchemaChange(newSchemas);
+              }}
+            />
+          </fieldset>
+        ),
+        contentClassName: this.props.classes.tabContent,
+        paneClassName: this.props.classes.tabContent,
+      };
+    });
+    const tabProps = {
+      activeTab: 0,
+      tabConfig: {
+        tabs,
+        layout: 'horizontal',
+        defaultTab: 0,
+      },
+    };
+    return <ConfigurableTab activeTab={tabProps.activeTab} tabConfig={tabProps.tabConfig} />;
+  };
+
+  public renderSchemaEditors = () => {
+    if (
+      this.state.loading ||
+      this.state.mode === IPluginSchemaEditorModes.Macro ||
+      !this.state.schemaRowCount
+    ) {
+      return null;
+    }
+    if (this.state.schemas.length > 1) {
+      return this.renderSchemaIntabs();
+    }
+    if (!this.state.schemas.length && this.props.disabled) {
+      return `No ${this.props.schemaTitle} available`;
+    }
+    return this.santizeSchemasForEditor().map((schema, i) => (
+      <fieldset disabled={this.props.disabled} className={this.props.classes.fieldset}>
+        <SchemaEditor
+          key={i}
+          visibleRows={this.state.schemaRowCount}
+          schema={schema}
+          disabled={this.props.disabled}
+          onChange={({ avroSchema }) => {
+            const newSchemas = [...this.props.schemas];
+            newSchemas[i] = avroSchema;
+            newSchemas[i].schema = JSON.stringify(newSchemas[i].schema);
+            this.props.onSchemaChange(newSchemas);
+          }}
+        />
+      </fieldset>
+    ));
+  };
+
+  public renderMacroEditor = () => {
+    if (
+      this.state.loading ||
+      this.state.mode === IPluginSchemaEditorModes.Editor ||
+      !this.state.schemaRowCount
+    ) {
+      return null;
+    }
+    const macro = this.state.schemas[0].schema;
+    if (this.props.disabled) {
+      return macro;
+    }
+    return (
+      <TextboxOnValium
+        disabled={this.props.disabled}
+        value={macro}
+        className={this.props.classes.macroTextBox}
+        onKeyUp={() => ({})}
+        onChange={(value) => {
+          const newSchemas = [{ name: 'etlSchemaBody', schema: value }];
+          this.setState({
+            schemas: newSchemas,
+          });
+          this.props.onSchemaChange(newSchemas);
+        }}
+      />
+    );
+  };
+
+  public renderHeader = () => {
+    const { classes, schemaTitle, disabled } = this.props;
+    return (
+      <div
+        className={classnames(classes.header, {
+          [classes.disabledHeader]: disabled,
+        })}
+      >
+        <div className={classes.title}>{schemaTitle || 'Schema'}</div>
+        <If condition={this.actions.length > 0}>
+          <Select
+            classes={{ root: classes.actionsDropdown }}
+            value={''}
+            placeholder="Actions"
+            onChange={this.onActionsHandler}
+            widgetProps={{ options: this.actions, dense: true }}
+          />
+        </If>
+      </div>
+    );
+  };
+
+  public render() {
+    const { classes } = this.props;
+    return (
+      <div className={classes.container} ref={(ref) => (this.containerRef = ref)}>
+        {this.renderHeader()}
+        <If condition={this.state.loading}>
+          <div className={classes.loadingContainer}>
+            <LoadingSVG />
+          </div>
+        </If>
+        <Alert
+          showAlert={!isNilOrEmptyString(this.state.error)}
+          message={this.state.error}
+          type="error"
+          onClose={() => {
+            this.setState({ error: null });
+          }}
+        />
+        {this.renderSchemaEditors()}
+        {this.renderMacroEditor()}
+      </div>
+    );
+  }
+}
+const StyledPluginSchemaEditor = withStyles(styles)(PluginSchemaEditorBase);
+
+const PluginSchemaEditor = (props) => {
+  return (
+    <ThemeWrapper>
+      <StyledPluginSchemaEditor {...props} />
+    </ThemeWrapper>
+  );
+};
+(PluginSchemaEditor as any).propTypes = {
+  schemas: PropTypes.array,
+  onSchemaChange: PropTypes.func,
+  disabled: PropTypes.func,
+  actionsDropdownMap: PropTypes.array,
+  schemaTitle: PropTypes.string,
+  isSchemaMacro: PropTypes.func,
+};
+export { PluginSchemaEditor };

--- a/cdap-ui/app/cdap/components/Tabs/TabHeaders/TabHeaders.scss
+++ b/cdap-ui/app/cdap/components/Tabs/TabHeaders/TabHeaders.scss
@@ -16,6 +16,7 @@
 
 .cask-tab-headers {
   background-color: #efefef;
+  overflow-x: auto;
   .cask-tab-head {
     padding: 10px 10px 10px 20px;
   }

--- a/cdap-ui/app/cdap/components/TextboxOnValium/index.js
+++ b/cdap-ui/app/cdap/components/TextboxOnValium/index.js
@@ -95,6 +95,7 @@ export default class TextboxOnValium extends Component {
   render() {
     return (
       <input
+        disabled={this.props.disabled}
         className={this.props.className}
         placeholder={this.props.placeholder}
         ref={
@@ -117,6 +118,7 @@ export default class TextboxOnValium extends Component {
 TextboxOnValium.defaultProps = {
   allowSpace: true,
   validCharacterRegex: null,
+  disabled: false,
 };
 
 TextboxOnValium.propTypes = {
@@ -130,4 +132,5 @@ TextboxOnValium.propTypes = {
   allowSpace: PropTypes.bool,
   shouldSelect: PropTypes.bool,
   validCharacterRegex: PropTypes.object, // regex expression
+  disabled: PropTypes.bool,
 };

--- a/cdap-ui/app/cdap/services/download-file.js
+++ b/cdap-ui/app/cdap/services/download-file.js
@@ -14,6 +14,7 @@
  * the License.
  */
 
+ // TODO: CDAP-17106 - Need to refactor this function to make it generic for usage across CDAP UI.
  function DownloadFile(fileConfig, postExportCb) {
   const blob = new Blob([JSON.stringify(fileConfig, null, 4)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -124,6 +124,8 @@ var DownloadFile = require('../cdap/services/download-file').default;
 var PreviewUtilities = require('../cdap/components/PreviewData/utilities');
 var PreviewDataView = require('../cdap/components/PreviewData').default;
 var PreviewLogs = require('../cdap/components/PreviewLogs').default;
+var SchemaEditor = require('../cdap/components/AbstractWidget/SchemaEditor').SchemaEditor;
+var PluginSchemaEditor = require('../cdap/components/PluginSchemaEditor').PluginSchemaEditor;
 
 export {
   Store,
@@ -222,4 +224,6 @@ export {
   PreviewUtilities,
   PreviewDataView,
   PreviewLogs,
+  SchemaEditor,
+  PluginSchemaEditor,
 };

--- a/cdap-ui/app/directives/plugin-functions/functions/get-schema/get-schema.js
+++ b/cdap-ui/app/directives/plugin-functions/functions/get-schema/get-schema.js
@@ -28,6 +28,7 @@ angular.module(PKG.name + '.commons')
         var fnConfig = $scope.fnConfig;
         var methodName = fnConfig['plugin-method'] || 'getSchema';
         var methodType = fnConfig.method || 'GET';
+        var ee = window.CaskCommon.ee(window.CaskCommon.ee);
         var getPluginMethodApi = function(methodType) {
           switch(methodType) {
             case 'POST':
@@ -99,6 +100,7 @@ angular.module(PKG.name + '.commons')
 
           modal.result.then(function (obj) {
             EventPipe.emit('schema.import', JSON.stringify(obj.schema));
+            ee.emit('schema.import', JSON.stringify(obj.schema));
             $scope.node.plugin.properties.importQuery = obj.query;
           });
         };

--- a/cdap-ui/app/directives/react-components/index.js
+++ b/cdap-ui/app/directives/react-components/index.js
@@ -168,4 +168,10 @@ angular
   })
   .directive('previewLogs', function (reactDirective) {
     return reactDirective(window.CaskCommon.PreviewLogs);
+  })
+  .directive('schemaEditor', function(reactDirective) {
+    return reactDirective(window.CaskCommon.SchemaEditor);
+  })
+  .directive('pluginSchemaEditor', function(reactDirective) {
+    return reactDirective(window.CaskCommon.PluginSchemaEditor);
   });

--- a/cdap-ui/app/hydrator/bottompanel.less
+++ b/cdap-ui/app/hydrator/bottompanel.less
@@ -300,7 +300,11 @@ body.theme-cdap.state-hydrator {
         margin-top: 20px;
       }
     }
+    .old-output-schema-container {
+      padding-bottom: 10px;
+    }
     .output-schema {
+      height: 100%;
       .schema-propagation-confirm {
         padding-top: 10px;
       }
@@ -313,7 +317,15 @@ body.theme-cdap.state-hydrator {
         }
       }
     }
+    plugin-schema-editor {
+      height: 100%;
+      display: block;
+    }
     .input-schema {
+      height: 100%;
+      .schema-inner {
+        height: 100%;
+      }
       @media (max-width: @screen-md-max) {
         margin-bottom: 15px;
       }

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -43,6 +43,7 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.eventEmitter = window.CaskCommon.ee(window.CaskCommon.ee);
     this.configurationGroupUtilities = window.CaskCommon.ConfigurationGroupUtilities;
     this.dynamicFiltersUtilities = window.CaskCommon.DynamicFiltersUtilities;
+    this.showNewSchemaEditor = window.localStorage['schema-editor'] === 'true';
     this.setDefaults(rPlugin);
     this.myAlertOnValium = myAlertOnValium;
     this.validatePluginProperties = this.validatePluginProperties.bind(this);
@@ -50,6 +51,14 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.previewId = this.getPreviewId();
     this.previewStatus = null;
     this.getStagesAndConnections = this.getStagesAndConnections.bind(this);
+    this.getIsMacroEnabled = this.getIsMacroEnabled.bind(this);
+    this.onImportSchema = this.onImportSchema.bind(this);
+    this.onClearSchema = this.onClearSchema.bind(this);
+    this.onPropagateSchema = this.onPropagateSchema.bind(this);
+    this.onMacroEnabled = this.onMacroEnabled.bind(this);
+    this.onSchemaChange = this.onSchemaChange.bind(this);
+    this.onSchemaImportLinkClick = this.onSchemaImportLinkClick.bind(this);
+    this.isSchemaMacro = this.isSchemaMacro.bind(this);
     this.tabs = [
       {
         label: 'Properties',
@@ -240,7 +249,15 @@ class HydratorPlusPlusNodeConfigCtrl {
             try {
               this.avsc.parse(schemaObj.schema, { wrapUnions: true });
             } catch (e) {
-              this.state.schemaAdvance = true;
+              // If its old schema editor by default set it to advance
+              if (!this.showNewSchemaEditor) {
+                this.state.schemaAdvance = true;
+              } else {
+                // else if its a new schema editor set advance only if the schema is a macro.
+                if (schemaArr.indexOf('${') !== -1) {
+                  this.state.schemaAdvance = true;
+                }
+              }
             }
           }
         });
@@ -248,7 +265,15 @@ class HydratorPlusPlusNodeConfigCtrl {
         try {
           this.avsc.parse(schemaArr, { wrapUnions: true });
         } catch (e) {
-          this.state.schemaAdvance = true;
+          // If its old schema editor by default set it to advance
+          if (!this.showNewSchemaEditor) {
+            this.state.schemaAdvance = true;
+          } else {
+            // else if its a new schema editor set advance only if the schema is a macro.
+            if (schemaArr.indexOf('${') !== -1) {
+              this.state.schemaAdvance = true;
+            }
+          }
         }
       }
     }
@@ -407,14 +432,22 @@ class HydratorPlusPlusNodeConfigCtrl {
 
     reader.onload = (evt) => {
       let data = evt.target.result;
-      this.EventPipe.emit('schema.import', data);
+      if (this.showNewSchemaEditor) {
+        this.eventEmitter.emit('schema.import', data);
+      } else {
+        this.EventPipe.emit('schema.import', data);
+      }
     };
   }
   onSchemaImportLinkClick() {
     this.$timeout(() => document.getElementById('schema-import-link').click());
   }
   exportSchema() {
-    this.EventPipe.emit('schema.export');
+    if (this.showNewSchemaEditor) {
+      this.eventEmitter.emit('schema.export');
+    } else {
+      this.EventPipe.emit('schema.export');
+    }
   }
 
   validateSchema() {
@@ -487,6 +520,19 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.HydratorPlusPlusPluginConfigFactory.validatePluginProperties(nodeInfo, this.state.config, errorCb);
   }
 
+  // MACRO ENABLED SCHEMA
+  toggleAdvance() {
+    if (this.state.node.outputSchema.length > 0) {
+      try {
+        this.avsc.parse(this.state.node.outputSchema[0].schema, { wrapUnions: true });
+      } catch (e) {
+        this.state.node.outputSchema = [this.HydratorPlusPlusNodeService.getOutputSchemaObj('')];
+      }
+    }
+
+    this.state.schemaAdvance = !this.state.schemaAdvance;
+  }
+
   hasUniqueFields(schema, error) {
     if (!schema) { return true; }
 
@@ -544,19 +590,6 @@ class HydratorPlusPlusNodeConfigCtrl {
     return this.ConfigStore.getConfigForExport().config;
   }
 
-  // MACRO ENABLED SCHEMA
-  toggleAdvance() {
-    if (this.state.node.outputSchema.length > 0) {
-      try {
-        this.avsc.parse(this.state.node.outputSchema[0].schema, { wrapUnions: true });
-      } catch (e) {
-        this.state.node.outputSchema = [this.HydratorPlusPlusNodeService.getOutputSchemaObj('')];
-      }
-    }
-
-    this.state.schemaAdvance = !this.state.schemaAdvance;
-  }
-
   // TOOLTIPS FOR DISABLED SCHEMA ACTIONS
   getImportDisabledTooltip() {
     if (this.datasetAlreadyExists) {
@@ -583,6 +616,97 @@ class HydratorPlusPlusNodeConfigCtrl {
       return 'Clearing a schema in Advanced mode is not supported';
     }
     return '';
+  }
+  getIsMacroEnabled() {
+    return (
+      !this.$scope.isDisabled &&
+      this.state.node._backendProperties['schema'] &&
+      this.state.node._backendProperties['schema'].macroSupported
+    );
+  }
+  onClearSchema() {
+    this.$timeout(() => this.state.node['outputSchema'] = [{ name: 'etlSchemaBody', schema: ''}]);
+  }
+  onPropagateSchema() {
+    this.$timeout(() => this.showPropagateConfirm = true);
+  }
+  onMacroEnabled() {
+    this.$timeout(() => this.state.schemaAdvance = !this.state.schemaAdvance);
+  }
+  onSchemaChange(outputSchemas) {
+    this.$timeout(() => this.state.node.outputSchema = outputSchemas);
+  }
+  onImportSchema(stringifiedSchema) {
+    try {
+      this.state.node.outputSchema = JSON.parse(stringifiedSchema);
+      if (!Array.isArray(this.state.node.outputSchema)) {
+        this.$timeout(() => this.state.node.outputSchema = [this.state.node.outputSchema]);
+      }
+    } catch(e) {
+      this.$timeout(() => this.state.node.outputSchema = [{ name: 'etlSchemaBody', schema: ''}]);
+    }
+  }
+  isSchemaMacro() {
+    return this.state.schemaAdvance;
+  }
+  getActionsDropdownMap(isInputSchema) {
+    let actionsMap = {};
+    if (isInputSchema) {
+      return {};
+    }
+    if (this.$scope.isDisabled) {
+      return {
+        export: {
+          value: 'export',
+          label: 'Export',
+          disabled: this.state.schemaAdvance,
+          tooltip: this.state.schemaAdvance ? 'Exporting a schema in Advanced mode is not supported' : '',
+          onClick: this.exportSchema.bind(this),
+        }
+      };
+    }
+    if (this.getIsMacroEnabled()) {
+      actionsMap['macro'] = {
+        value: 'macro',
+        label: this.state.schemaAdvance ? 'Editor' : 'Macro',
+        disabled: this.datasetAlreadyExists,
+        tooltip: this.datasetAlreadyExists ? `The dataset '${this.datasetId}' already exists. Its schema cannot be modified.` : '',
+        onClick: this.onMacroEnabled.bind(this),
+      };
+    }
+    actionsMap = Object.assign({}, actionsMap, {
+      import: {
+        value: 'import',
+        label: 'Import',
+        disabled: this.datasetAlreadyExists || this.state.schemaAdvance,
+        tooltip: this.getImportDisabledTooltip(),
+        onClick: this.onSchemaImportLinkClick.bind(this),
+      },
+      export: {
+        value: 'export',
+        label: 'Export',
+        disabled: this.state.schemaAdvance,
+        tooltip: this.state.schemaAdvance ? 'Exporting a schema in Advanced mode is not supported' : '',
+        onClick: this.exportSchema.bind(this),
+      },
+      propagate: {
+        value: 'propagate',
+        label: 'Propagate',
+        disabled:
+          this.state.schemaAdvance ||
+          this.state.node.type === 'splittertransform',
+        tooltip: this.getPropagateDisabledTooltip(),
+        onClick: this.onPropagateSchema.bind(this),
+      },
+      clear: {
+        value: 'clear',
+        label: 'Clear',
+        disabled: this.datasetAlreadyExists || this.state.schemaAdvance,
+        tooltip: this.getClearDisabledTooltip(),
+        onClick: this.onClearSchema.bind(this),
+      },
+    });
+    return actionsMap;
   }
 }
 

--- a/cdap-ui/app/hydrator/hydrator-modal.less
+++ b/cdap-ui/app/hydrator/hydrator-modal.less
@@ -53,8 +53,6 @@
         // 340px for all the buttons and error validation message
         width: 100%;
         max-width: ~"calc(100% - 340px)";
-        max-width: ~"-moz-calc(100% - 340px)";
-        max-width: ~"-webkit-calc(100% - 340px)";
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
@@ -65,8 +63,6 @@
         // Adjust max-width of modal title when my-jump-link is present
         &.with-jump {
           max-width: ~"calc(100% - 180px)";
-          max-width: ~"-moz-calc(100% - 180px)";
-          max-width: ~"-webkit-calc(100% - 180px)";
         }
 
         p {
@@ -177,8 +173,6 @@
         margin-left: 0;
         width: 100%;
         height: ~"calc(100vh - 100px)";
-        height: ~"-moz-calc(100vh - 100px)";
-        height: ~"-webkit-calc(100vh - 100px)";
         margin-bottom: 0;
       }
 
@@ -220,10 +214,8 @@
               }
               .bottompanel-body {
                 padding: 0 10px 10px 10px;
-                overflow-y: auto;
+                overflow-y: hidden;
                 height: ~"calc(100vh - 180px)";
-                height: ~"-moz-calc(100vh - 180px)";
-                height: ~"-webkit-calc(100vh - 180px)";
                 .reference-tab { padding: 0 10px; }
 
                 .btn-hydrator {
@@ -246,45 +238,42 @@
                   > p,
                   .validator-plugin > div { padding: 20px 10px; }
                   div.config-table {
-                    display: table;
+                    display: grid;
                     width: 100%;
-                    height: ~"calc(100vh - 240px)";
-                    height: ~"-moz-calc(100vh - 240px)";
-                    height: ~"-webkit-calc(100vh - 240px)";
+                    height: ~"calc(100vh - 180px)";
 
                     > div {
-                      display: table-cell;
-                      padding: 20px 10px;
+                      padding: 10px 10px;
                       vertical-align: top;
+                      overflow-y: auto;
+                      .output-schema-container {
+                        height: 100%;
+                      }
                     }
                   }
                   div.source-table {
+                    grid-template-columns: 67% 33%;
                     > div {
                       &:first-child {
                         border-right: 1px solid @table-border-color;
-                        width: 66.66666667%;
                       }
-                      &:last-child { width: 33.33333333%; }
                     }
                   }
                   div.transform-table {
+                    grid-template-columns: minmax(250px, 25%) 50% minmax(250px, 25%);
                     > div {
-                      &:first-child,
-                      &:last-child { width: 25%; }
                       &:nth-child(2) {
-                        width: 50%;
                         border-right: 1px solid @table-border-color;
                         border-left: 1px solid @table-border-color;
                       }
                     }
                   }
                   div.sink-table {
+                    grid-template-columns: 33% 67%;
                     > div {
                       &:first-child {
                         border-right: 1px solid @table-border-color;
-                        width: 33.33333333%;
                       }
-                      &:last-child { width: 66.66666667%; }
                     }
                   }
                 }
@@ -407,8 +396,6 @@ body.theme-cdap {
             .modal-header {
               .modal-title {
                 max-width: ~"calc(100% - 180px)";
-                max-width: ~"-moz-calc(100% - 180px)";
-                max-width: ~"-webkit-calc(100% - 180px)";
               }
             }
             .modal-body {
@@ -416,9 +403,7 @@ body.theme-cdap {
               .console-type {
                 .node-config {
                   div.config-table {
-                    height: ~"calc(100vh - 240px)";
-                    height: ~"-moz-calc(100vh - 240px)";
-                    height: ~"-webkit-calc(100vh - 240px)";
+                    height: ~"calc(100vh - 180px)";
                   }
                 }
               }

--- a/cdap-ui/app/hydrator/services/plugin-config-factory.js
+++ b/cdap-ui/app/hydrator/services/plugin-config-factory.js
@@ -25,6 +25,7 @@ class HydratorPlusPlusPluginConfigFactory {
     this.validatePluginProperties = this.validatePluginProperties.bind(this);
     this.HydratorPlusPlusNodeService = HydratorPlusPlusNodeService;
     this.EventPipe = EventPipe;
+    this.eventEmitter = window.CaskCommon.ee(window.CaskCommon.ee);
   }
   fetchWidgetJson(artifactName, artifactVersion, artifactScope, key) {
     let cache = this.data[`${artifactName}-${artifactVersion}-${artifactScope}-${key}`];
@@ -353,8 +354,10 @@ class HydratorPlusPlusPluginConfigFactory {
           }
           if (schemas.length) {
             this.EventPipe.emit('schema.import', schemas);
+            this.eventEmitter.emit('schema.import', schemas);
           } else if (!this.myHelpers.objectQuery(widgetJson, 'outputs', 0, 'name')) {
             this.EventPipe.emit('schema.clear');
+            this.eventEmitter.emit('schema.clear', schemas);
           }
         }
       }, (err) => {

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-config-form.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-config-form.html
@@ -20,13 +20,13 @@
   </div>
 
   <div>
-    <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
+    <div class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
   </div>
 </div>
 
 <div class="config-table transform-table" ng-if="HydratorPlusPlusNodeConfigCtrl.state.isTransform && HydratorPlusPlusNodeConfigCtrl.state.node.plugin.name !== 'Validator'">
   <div>
-    <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html'"></div>
+    <div class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html'"></div>
   </div>
 
   <div>
@@ -34,7 +34,7 @@
   </div>
 
   <div>
-    <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
+    <div class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
   </div>
 </div>
 
@@ -46,7 +46,7 @@
 
 <div class="config-table sink-table" ng-if="HydratorPlusPlusNodeConfigCtrl.state.isSink">
   <div>
-    <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html'"></div>
+    <div class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html'"></div>
   </div>
 
   <div>
@@ -55,7 +55,7 @@
         <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-properties-template.html'"></div>
       </div>
 
-      <div class="col-xs-12 sink-output-schema" ng-if="HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.isOutputSchemaExists || HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.implicitSchema">
+      <div class="col-xs-12 sink-output-schema output-schema-container" ng-if="HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.isOutputSchemaExists || HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.implicitSchema">
         <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
       </div>
     </div>

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html
@@ -15,12 +15,24 @@
 -->
 <div class="input-schema" data-cy="plugin-input-schema-container">
   <div class="schema-inner" ng-if="::HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema">
-    <h4>Input Schema</h4>
+    <h4 ng-if="!HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor">Input Schema</h4>
+
+    <div class="output-schema" ng-if="HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor">
+      <plugin-schema-editor
+        disabled="true"
+        schemas="HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema"
+        on-schema-change="HydratorPlusPlusNodeConfigCtrl.onSchemaChange"
+        actions-dropdown-map="HydratorPlusPlusNodeConfigCtrl.getActionsDropdownMap(true)"
+        schema-title="'Input Schema'">
+      </plugin-schema-editor>
+    </div>
+
     <my-input-schema
-        data-multiple-inputs="{{::(HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.inputs.multipleInputs === true)}}"
-        input-schema="{{::HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema}}"
-        is-in-studio="!isDisabled"
-        errors="HydratorPlusPlusNodeConfigCtrl.inputSchemaErrors">
+      ng-if="!HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor"
+      data-multiple-inputs="{{::(HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.inputs.multipleInputs === true)}}"
+      input-schema="{{::HydratorPlusPlusNodeConfigCtrl.state.node.inputSchema}}"
+      is-in-studio="!isDisabled"
+      errors="HydratorPlusPlusNodeConfigCtrl.inputSchemaErrors">
     </my-input-schema>
   </div>
 </div>

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html
@@ -16,12 +16,13 @@
 
 <div class="output-schema" ng-init="watchproperty=HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.outputSchema.schemaProperties['property-watch']" data-cy="plugin-output-schema-container">
 
-  <div class="schema-error">
+  <div class="schema-error" ng-if="!HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor">
     <ul>
       <li class="text-danger" ng-repeat="error in HydratorPlusPlusNodeConfigCtrl.state.errors">{{ error }}</li>
     </ul>
   </div>
-  <h4>
+
+  <h4 ng-if="!HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor">
     <span ng-if="!HydratorPlusPlusNodeConfigCtrl.state.isSink">Output Schema</span>
     <span ng-if="HydratorPlusPlusNodeConfigCtrl.state.isSink">Schema</span>
 
@@ -94,15 +95,28 @@
         </div>
       </div>
     </div>
-    <my-output-schema
-      schema-advance="HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance"
-      node="HydratorPlusPlusNodeConfigCtrl.state.node"
-      groups-config="HydratorPlusPlusNodeConfigCtrl.state.groupsConfig"
-      update-default-output-schema="HydratorPlusPlusNodeConfigCtrl.updateDefaultOutputSchema(outputSchema)"
-      is-disabled="isDisabled || HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists"
-      errors="HydratorPlusPlusNodeConfigCtrl.outputSchemaErrors">
-    </my-output-schema>
+    <div class="old-output-schema-container" ng-if="!HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor">
+      <my-output-schema
+        schema-advance="HydratorPlusPlusNodeConfigCtrl.state.schemaAdvance"
+        node="HydratorPlusPlusNodeConfigCtrl.state.node"
+        groups-config="HydratorPlusPlusNodeConfigCtrl.state.groupsConfig"
+        update-default-output-schema="HydratorPlusPlusNodeConfigCtrl.updateDefaultOutputSchema(outputSchema)"
+        is-disabled="isDisabled || HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists"
+        errors="HydratorPlusPlusNodeConfigCtrl.outputSchemaErrors">
+      </my-output-schema>
+    </div>
   </fieldset>
+  <div class="output-schema" ng-if="HydratorPlusPlusNodeConfigCtrl.showNewSchemaEditor">
+    <plugin-schema-editor
+      schemas="HydratorPlusPlusNodeConfigCtrl.state.node.outputSchema"
+      on-schema-change="HydratorPlusPlusNodeConfigCtrl.onSchemaChange"
+      actions-dropdown-map="HydratorPlusPlusNodeConfigCtrl.getActionsDropdownMap()"
+      schema-title="'Output Schema'"
+      is-schema-macro="HydratorPlusPlusNodeConfigCtrl.isSchemaMacro()"
+      disabled="isDisabled || HydratorPlusPlusNodeConfigCtrl.datasetAlreadyExists">
+    </plugin-schema-editor>
+  </div>
+
 </div>
 
 <my-file-select class="sr-only" id="schema-import-link" data-button-icon="fa-upload" on-file-select="HydratorPlusPlusNodeConfigCtrl.importFiles($files)" data-button-label="Import">


### PR DESCRIPTION
### Integrating schema editor (https://github.com/cdapio/cdap/pull/12450) with pipelines

**Approach**
- Compose `SchemaEditor` into a new component named `PluginSchemaEditor` along with other `Actions` available on the schema.
- Have retained the logic to enable/disable the schema actions in angular for the most part.
- Some of the logic, like export, are still in react. We use the same event based system for import/export/clear
- PluginSchemaEditor will also determine the height of the container to determine the number of rows that needs to be rendered (required by the virtual scroll)

**Fixes from previous PR**
- Fixes `SchemaManager` to handle logical types for all complex types
- Adds validation on import of schema
- Adds the ability to set `disabled` for the schema editor to become non-editable.

 
**Note**
- This PR creates feature parity with existing schema editor.
- However at any point if the user thinks they are experiencing any regressions they can switch off the experiment which will enable them to use the older schema editor
- The experiment will be on by default.
- All the changes to angular side are additive and does not remove any existing functionality.

**Things to do**
- Unit tests (https://github.com/cdapio/cdap/pull/12455)
- Integration tests