### PR TITLE
[CDAP-16414] Handling graphQL errors in pipeline list view

### DIFF
--- a/cdap-ui/app/cdap/components/Alert/Alert.scss
+++ b/cdap-ui/app/cdap/components/Alert/Alert.scss
@@ -18,7 +18,7 @@ $close-btn-size: 13px;
 
 .global-alert {
   &.modal-dialog {
-    margin-top: 50px;
+    margin-top: 48px;
     width: 100%;
     max-width: 100%;
 

--- a/cdap-ui/app/cdap/components/ErrorBanner/index.tsx
+++ b/cdap-ui/app/cdap/components/ErrorBanner/index.tsx
@@ -20,7 +20,7 @@ import Alert from 'components/Alert';
 
 interface IErrorProps {
   error: object | string | null;
-  onClose: () => void;
+  onClose?: () => void;
 }
 
 const ErrorBanner: React.SFC<IErrorProps> = ({ error, onClose }) => {

--- a/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/DeployedPipelineView.scss
+++ b/cdap-ui/app/cdap/components/PipelineList/DeployedPipelineView/DeployedPipelineView.scss
@@ -21,12 +21,6 @@
   padding-left: $padding-size;
   padding-right: $padding-size;
 
-  &.error-container {
-    color: $red-02;
-    font-size: 14px;
-    padding-top: 25px;
-  }
-
   .deployed-header {
     height: $header-height;
     line-height: $header-height;

--- a/cdap-ui/app/cdap/components/PipelineList/index.tsx
+++ b/cdap-ui/app/cdap/components/PipelineList/index.tsx
@@ -23,6 +23,7 @@ import { getCurrentNamespace } from 'services/NamespaceStore';
 import Helmet from 'react-helmet';
 import { Theme } from 'services/ThemeHelper';
 import T from 'i18n-react';
+import ErrorBoundary from 'components/ErrorBoundary';
 
 import './PipelineList.scss';
 
@@ -55,7 +56,17 @@ const PipelineList: React.SFC = () => {
       <ResourceCenterButton />
 
       <Switch>
-        <Route exact path="/ns/:namespace/pipelines" component={DeployedPipelineView} />
+        <Route
+          exact
+          path="/ns/:namespace/pipelines"
+          component={() => {
+            return (
+              <ErrorBoundary>
+                <DeployedPipelineView />
+              </ErrorBoundary>
+            );
+          }}
+        />
         <Route exact path="/ns/:namespace/pipelines/drafts" component={DraftPipelineView} />
       </Switch>
     </div>

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -489,6 +489,39 @@ function connectWithStore(store, WrappedComponent, ...args) {
     return <ConnectedWrappedComponent {...props} store={store} />;
   };
 }
+/**
+ * This function formats the graphQl errors by error type
+ * { errorType: ['message1', 'message2'] ....} will be
+ * the format of categorized errors.
+ */
+function categorizeGraphQlErrors(error) {
+  const GENERIC_ERROR_ORIGIN = 'generic';
+  const graphQLErrors = objectQuery(error, 'graphQLErrors') || [];
+  const networkErrors = objectQuery(error, 'networkError') || [];
+  const errorsByOrigin = {};
+  if (graphQLErrors.length === 0 && networkErrors.length === 0 && error) {
+    errorsByOrigin[GENERIC_ERROR_ORIGIN] = error.message;
+  }
+ 
+  graphQLErrors.forEach(error => {
+    const errorOrigin = objectQuery(error, 'extensions', 'exception', 'errorOrigin') || GENERIC_ERROR_ORIGIN;
+    if (errorsByOrigin.hasOwnProperty(errorOrigin)) {
+      errorsByOrigin[errorOrigin].push(error.message);
+    }
+    else {
+      errorsByOrigin[errorOrigin] = [error.message];
+    }
+  });
+  // Categorize all graphQL network errors with type 'network'
+  networkErrors.forEach(error => {
+    if (errorsByOrigin.hasOwnProperty('network')) {
+      errorsByOrigin['network'].push(error.message);
+    } else {
+      errorsByOrigin['network'] = [error.message];
+    }
+  });
+  return errorsByOrigin;
+}
 
 function dumbestClone(jsonObj) {
   let result;
@@ -542,4 +575,5 @@ export {
   extractErrorMessage,
   connectWithStore,
   dumbestClone,
+  categorizeGraphQlErrors
 };

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -2148,6 +2148,7 @@ features:
         1: "pipeline "
         _: "pipelines "
     DeployedPipelineView:
+      graphQLMultipleServicesDown: The system is unable to display the list of pipelines because some of the services are down. Please try again later.
       searchPlaceholder: Search by pipeline name
       pipelineCount:
         1: "{context} pipeline"

--- a/cdap-ui/graphql/Query/pipelinesResolver.js
+++ b/cdap-ui/graphql/Query/pipelinesResolver.js
@@ -18,6 +18,7 @@ import { constructUrl } from 'server/url-helper';
 import { getCDAPConfig } from 'server/cdap-config';
 import { getGETRequestOptions, requestPromiseWrapper } from 'gql/resolvers-common';
 import { orderBy } from 'natural-orderby';
+import { ApolloError } from 'apollo-server';
 
 let cdapConfig;
 getCDAPConfig().then(function(value) {
@@ -35,6 +36,10 @@ export async function queryTypePipelinesResolver(parent, args, context) {
   options.url = constructUrl(cdapConfig, path);
   context.namespace = namespace;
 
-  const apps = await requestPromiseWrapper(options, context.auth);
+  const errorModifiersFn = (error, statusCode) => {
+    return new ApolloError(error, statusCode, { errorOrigin: 'pipelines' });
+  }
+
+  const apps = await requestPromiseWrapper(options, context.auth, null, errorModifiersFn);
   return orderBy(apps, [(app) => app.name], ['asc']);
 }

--- a/cdap-ui/graphql/Query/statusResolver.js
+++ b/cdap-ui/graphql/Query/statusResolver.js
@@ -16,6 +16,7 @@
 
 import { constructUrl } from 'server/url-helper';
 import { getCDAPConfig } from 'server/cdap-config';
+import { ApolloError } from 'apollo-server';
 import { getGETRequestOptions, requestPromiseWrapper } from 'gql/resolvers-common';
 
 let cdapConfig;
@@ -26,8 +27,11 @@ getCDAPConfig().then(function(value) {
 export async function queryTypeStatusResolver(parent, args, context) {
   const options = getGETRequestOptions();
   options.url = constructUrl(cdapConfig, '/ping');
+  const errorModifiersFn = (error, statusCode) => {
+    return new ApolloError(error, statusCode, { errorOrigin: 'statusPing' });
+  }
 
-  const status = await requestPromiseWrapper(options, context.auth);
+  const status = await requestPromiseWrapper(options, context.auth, null, errorModifiersFn);
 
   return status.trim();
 }

--- a/cdap-ui/graphql/helpers/BatchEndpoints/programRuns.js
+++ b/cdap-ui/graphql/helpers/BatchEndpoints/programRuns.js
@@ -16,6 +16,8 @@
 
 import { constructUrl } from 'server/url-helper';
 import { getCDAPConfig } from 'server/cdap-config';
+import { ApolloError } from 'apollo-server';
+
 import { getPOSTRequestOptions, requestPromiseWrapper } from 'gql/resolvers-common';
 
 let cdapConfig;
@@ -28,8 +30,11 @@ export async function batchProgramRuns(req, auth) {
   const options = getPOSTRequestOptions();
   options.url = constructUrl(cdapConfig, `/v3/namespaces/${namespace}/runs`);
   options.body = req.slice(0, 25).map((reqObj) => reqObj.program);
+  const errorModifiersFn = (error, statusCode) => {
+    return new ApolloError(error, statusCode, { errorOrigin: 'programRuns' });
+  }
 
-  const runInfo = await requestPromiseWrapper(options, auth);
+  const runInfo = await requestPromiseWrapper(options, auth, null, errorModifiersFn);
 
   const runsMap = {};
   runInfo.forEach((run) => {

--- a/cdap-ui/graphql/resolvers-common.js
+++ b/cdap-ui/graphql/resolvers-common.js
@@ -31,7 +31,7 @@ export function getPOSTRequestOptions() {
   };
 }
 
-export function requestPromiseWrapper(options, token, bodyModifiersFn) {
+export function requestPromiseWrapper(options, token, bodyModifiersFn, errorModifiersFn) {
   if (token) {
     options.headers = {
       Authorization: token,
@@ -40,15 +40,25 @@ export function requestPromiseWrapper(options, token, bodyModifiersFn) {
 
   return new Promise((resolve, reject) => {
     request(options, (err, response, body) => {
+      const statusCode = response.statusCode;
       if (err) {
-        const error =  new ApolloError(err, '500');
-        return reject(error);
+        let exception;
+        if (typeof errorModifiersFn === 'function') {
+          exception = errorModifiersFn(err, statusCode ? statusCode.toString() : '500');
+        } else {
+          exception = new ApolloError(err, statusCode ? statusCode.toString() : '500');
+        }
+        return reject(exception);
       }
 
-      const statusCode = response.statusCode;
-
+      
       if (typeof statusCode === 'undefined' || statusCode != 200) {
-        const error = new ApolloError(body, statusCode.toString());
+        let error;
+        if (typeof errorModifiersFn === 'function') {
+          error = errorModifiersFn(body, statusCode.toString());
+        } else {
+          error = new ApolloError(body, statusCode.toString());
+        }
         return reject(error);
       }
 


### PR DESCRIPTION
Jira: https://issues.cask.co/browse/CDAP-16414

Currently, graphQL errors in pipeline list view are shown as strings, this PR is to utilize one of the error components we have.
- Will show page level error when call to retrieve pipelines fails (considered high priority failure on this page).
- Will show error banner when we are unable to retrieve other information for the page like total runs, next run etc.
- When multiple of these smaller services fail, we show a page level error.
