### PR TITLE
[CDAP-17107] CDAP WorkflowDriver and CustomActionExecutor Exception Wrapping

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/CustomActionExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/CustomActionExecutor.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.api.annotation.TransactionControl;
 import io.cdap.cdap.api.customaction.AbstractCustomAction;
 import io.cdap.cdap.api.customaction.CustomAction;
 import io.cdap.cdap.api.customaction.CustomActionContext;
+import io.cdap.cdap.common.lang.Exceptions;
 import io.cdap.cdap.common.lang.InstantiatorFactory;
 import io.cdap.cdap.common.lang.PropertyFieldSetter;
 import io.cdap.cdap.data2.transaction.Transactions;
@@ -86,7 +87,7 @@ class CustomActionExecutor {
       customActionContext.setState(new ProgramState(ProgramStatus.COMPLETED, null));
 
     } catch (Throwable t) {
-      customActionContext.setState(new ProgramState(ProgramStatus.FAILED, Throwables.getRootCause(t).getMessage()));
+      customActionContext.setState(new ProgramState(ProgramStatus.FAILED, Exceptions.condenseThrowableMessage(t)));
       Throwables.propagateIfPossible(t, Exception.class);
       throw Throwables.propagate(t);
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -57,6 +57,7 @@ import io.cdap.cdap.app.runtime.ProgramRunnerFactory;
 import io.cdap.cdap.app.runtime.ProgramStateWriter;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.lang.Exceptions;
 import io.cdap.cdap.common.lang.InstantiatorFactory;
 import io.cdap.cdap.common.lang.PropertyFieldSetter;
 import io.cdap.cdap.common.logging.LoggingContextAccessor;
@@ -626,7 +627,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   }
 
   private void executeAll(Iterator<WorkflowNode> iterator, ApplicationSpecification appSpec,
-                          InstantiatorFactory instantiator, ClassLoader classLoader, WorkflowToken token) {
+                          InstantiatorFactory instantiator, ClassLoader classLoader, WorkflowToken token)
+    throws Exception {
     while (iterator.hasNext() && runningThread != null) {
       try {
         blockIfSuspended();
@@ -640,8 +642,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
           workflowContext.setState(new ProgramState(ProgramStatus.KILLED, rootCause.getMessage()));
           break;
         }
-        workflowContext.setState(new ProgramState(ProgramStatus.FAILED, rootCause.getMessage()));
-        throw Throwables.propagate(rootCause);
+        workflowContext.setState(new ProgramState(ProgramStatus.FAILED, Exceptions.condenseThrowableMessage(t)));
+        throw t;
       }
     }
   }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/lang/Exceptions.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/lang/Exceptions.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.lang;
+
+/**
+ * Utility class which provides helper methods concerning exception handling.
+ */
+public class Exceptions {
+  public static final String CONDENSE_COMBINER_STRING = System.lineSeparator() + "Caused by: ";
+
+  /**
+   * Condenses Throwable messages across an exception chain to a single message string. Ignores null and empty messages.
+   * @return The condensed exception string
+   */
+  public static String condenseThrowableMessage(Throwable t) {
+    StringBuilder condensedMessageBuilder = new StringBuilder();
+    condensedMessageBuilder.append(t.getMessage());
+    Throwable current = t.getCause();
+    while (current != null) {
+      String currMessage = current.getMessage();
+      // Ignore null and empty message strings caused by Java runtime
+      if (currMessage != null && currMessage.length() != 0) {
+        condensedMessageBuilder.append(CONDENSE_COMBINER_STRING);
+        condensedMessageBuilder.append(currMessage);
+      }
+      current = current.getCause();
+    }
+    return condensedMessageBuilder.toString();
+  }
+}

--- a/cdap-common/src/test/java/io/cdap/cdap/common/lang/ExceptionsTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/lang/ExceptionsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.lang;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test for Exceptions.
+ */
+public class ExceptionsTest {
+  @Test
+  public void testCondenseMultipleExceptions() {
+    String m1 = "m1";
+    String m2 = "m2";
+    String m3 = "m3";
+    Exception e1 = new Exception(m1);
+    Exception e2 = new Exception(m2, e1);
+    Exception e3 = new Exception(m3, e2);
+    String expected = m3 + Exceptions.CONDENSE_COMBINER_STRING + m2 + Exceptions.CONDENSE_COMBINER_STRING + m1;
+    String condensedMessage = Exceptions.condenseThrowableMessage(e3);
+    Assert.assertEquals(expected, condensedMessage);
+  }
+
+  @Test
+  public void testCondenseExceptionWithNullMessage() {
+    String m1 = "m1";
+    String m2 = null;
+    String m3 = "m3";
+    Exception e1 = new Exception(m1);
+    Exception e2 = new Exception(m2, e1);
+    Exception e3 = new Exception(m3, e2);
+    String expected = m3 + Exceptions.CONDENSE_COMBINER_STRING + m1;
+    String condensedMessage = Exceptions.condenseThrowableMessage(e3);
+    Assert.assertEquals(expected, condensedMessage);
+  }
+
+  @Test
+  public void testCondenseExceptionWithEmptyMessage() {
+    String m1 = "m1";
+    String m2 = "";
+    String m3 = "m3";
+    Exception e1 = new Exception(m1);
+    Exception e2 = new Exception(m2, e1);
+    Exception e3 = new Exception(m3, e2);
+    String expected = m3 + Exceptions.CONDENSE_COMBINER_STRING + m1;
+    String condensedMessage = Exceptions.condenseThrowableMessage(e3);
+    Assert.assertEquals(expected, condensedMessage);
+  }
+}


### PR DESCRIPTION
Prevent CDAP WorkflowDriver and CustomActionExecutor from unwrapping exceptions via Throwables.rootCause(). See [CDAP-17107](https://issues.cask.co/browse/CDAP-17107).