### PR TITLE
[CDAP-17105] Fix properties button being disabled

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -1345,7 +1345,6 @@ angular.module(PKG.name + '.commons')
       });
       if (!_.isEmpty(vm.pluginsMap)) {
         addErrorAlertsEndpointsAndConnections();
-        subAvailablePlugins();
       }
     });
 


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-17105

After a plugin is installed from hub, the properties button was being disabled because the pluginsMap was not being updated. This is to fix the issue.