### PR TITLE
[CDAP-17105] Fix plugin properties button being disabled

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -565,6 +565,11 @@ angular.module(PKG.name + '.commons')
 
     function initNodes() {
       angular.forEach($scope.nodes, function (node) {
+        const key = generatePluginMapKey(node);
+        const ispluginsMapAvailable = Object.keys(vm.pluginsMap).length;
+        // If pluginsMap is not available yet, consider the plugin to be valid until we know otherwise
+        node.isPluginAvailable = ispluginsMapAvailable ?
+            Boolean(myHelpers.objectQuery(vm.pluginsMap, key, 'widgets')) : true;
         if (node.type === 'condition') {
           initConditionNode(node.name);
         } else if (node.type === 'splittertransform') {
@@ -587,8 +592,6 @@ angular.module(PKG.name + '.commons')
           }
           vm.instance.makeTarget(node.name, targetOptions);
         }
-        let key = generatePluginMapKey(node);
-        node.isPluginAvailable = Boolean(myHelpers.objectQuery(vm.pluginsMap, key, 'widgets')) ;
       });
     }
 
@@ -1688,7 +1691,6 @@ angular.module(PKG.name + '.commons')
       });
       if (!_.isEmpty(vm.pluginsMap)) {
         addErrorAlertsEndpointsAndConnections();
-        subAvailablePlugins();
       }
     });
 

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -207,7 +207,7 @@
                                  'btn-disabled': !node.isPluginAvailable}"
                   ng-click="!disableNodeClick && DAGPlusPlusCtrl.onNodeClick($event, node)" ng-disabled="!node.isPluginAvailable">
                   <span class="node-configure-btn-label" uib-tooltip="{{ !node.isPluginAvailable ? 'Plugin artifact is not available.' : ''}}"
-                    tooltip-popup-delay="300" tooltip-placement="right">
+                    tooltip-popup-delay="300" tooltip-placement="right" tooltip-append-to-body="true">
                     Properties
                   </span>
                 </button>


### PR DESCRIPTION
JIRA : https://issues.cask.co/browse/CDAP-17105

After a plugin is installed from hub, the properties button was being disabled because the pluginsMap was not being updated. This is to fix the issue.