### PR TITLE
Update commons-collections version to 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
     <cdap.client.version>1.4.0</cdap.client.version>
     <commons.cli.version>1.2</commons.cli.version>
     <commons.compress.version>1.18</commons.compress.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <fastutil.version>6.5.6</fastutil.version>
     <findbugs.jsr305.version>2.0.1</findbugs.jsr305.version>
     <geronimo.version>2.0.0</geronimo.version>
@@ -476,6 +477,11 @@
         <version>${commons.cli.version}</version>
       </dependency>
       <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>${commons-collections.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.twill</groupId>
         <artifactId>twill-common</artifactId>
         <version>${twill.version}</version>
@@ -593,6 +599,10 @@
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
@@ -851,6 +861,10 @@
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
The commons-collections v3.2.1 has a vulnerability which was fixed in v3.2.2. Refer: https://commons.apache.org/proper/commons-collections/release_3_2_2.html
CDAP is using hadoop-common version (2.3.0) and hbase-common (1.0.1.1) in pom which is pulling the commons-collections version 3.2.1. I've excluded the transitive dependency and added the commons-collections v3.2.2 as a direct dependency in the pom.

The CDAP Jira ticket: https://issues.cask.co/browse/CDAP-17083