### PR TITLE
[CDAP-16712] Separate out preview manager and preview runners so that they can be run independently in their own containers.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
@@ -24,9 +24,9 @@ import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
+import com.google.inject.Scopes;
 import com.google.inject.name.Named;
 import com.google.inject.util.Modules;
-import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.security.store.SecureStore;
 import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
 import io.cdap.cdap.common.NotFoundException;
@@ -46,26 +46,28 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
 import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
 import io.cdap.cdap.data2.metadata.writer.NoOpMetadataServiceClient;
-import io.cdap.cdap.internal.app.preview.PreviewRequestFetcherFactory;
 import io.cdap.cdap.internal.app.preview.PreviewRunnerService;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
-import io.cdap.cdap.logging.guice.LocalLogAppenderModule;
+import io.cdap.cdap.logging.appender.LogAppender;
+import io.cdap.cdap.logging.appender.tms.PreviewTMSLogAppender;
 import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
 import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
+import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.guice.preview.PreviewSecureStoreModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
+import org.apache.twill.common.Threads;
 import org.apache.twill.discovery.DiscoveryService;
+import org.apache.twill.internal.ServiceListenerAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.Map;
-import java.util.UUID;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -83,9 +85,9 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
   private final SecureStore secureStore;
   private final TransactionSystemClient transactionSystemClient;
   private final PreviewRunnerModule previewRunnerModule;
-  private final Map<String, PreviewRunnerService> previewPollers;
+  private final Set<PreviewRunnerService> previewRunnerServices;
   private final LevelDBTableService previewLevelDBTableService;
-  private final PreviewRequestFetcherFactory previewRequestFetcherFactory;
+  private final PreviewRunnerServiceFactory previewRunnerServiceFactory;
   private PreviewRunner runner;
 
   @Inject
@@ -97,7 +99,7 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
     @Named(DataSetsModules.BASE_DATASET_FRAMEWORK) DatasetFramework datasetFramework,
     TransactionSystemClient transactionSystemClient,
     @Named(PreviewConfigModule.PREVIEW_LEVEL_DB) LevelDBTableService previewLevelDBTableService,
-    PreviewRunnerModule previewRunnerModule, PreviewRequestFetcherFactory previewRequestFetcherFactory) {
+    PreviewRunnerModule previewRunnerModule, PreviewRunnerServiceFactory previewRunnerServiceFactory) {
     this.previewCConf = previewCConf;
     this.previewHConf = previewHConf;
     this.previewSConf = previewSConf;
@@ -106,16 +108,15 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
     this.discoveryService = discoveryService;
     this.transactionSystemClient = transactionSystemClient;
     this.maxConcurrentPreviews = previewCConf.getInt(Constants.Preview.CACHE_SIZE, 10);
-    this.previewPollers = new ConcurrentHashMap<>();
+    this.previewRunnerServices = ConcurrentHashMap.newKeySet();
     this.previewRunnerModule = previewRunnerModule;
     this.previewLevelDBTableService = previewLevelDBTableService;
-    this.previewRequestFetcherFactory = previewRequestFetcherFactory;
+    this.previewRunnerServiceFactory = previewRunnerServiceFactory;
   }
 
   @Override
   protected void startUp() throws Exception {
     Injector previewInjector = createPreviewInjector();
-
     // Starts common services
     runner = previewInjector.getInstance(PreviewRunner.class);
     if (runner instanceof Service) {
@@ -124,21 +125,32 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
 
     // Create and start the preview poller services.
     for (int i = 0; i < maxConcurrentPreviews; i++) {
-      String pollerInfo = UUID.randomUUID().toString();
+      PreviewRunnerService pollerService = previewRunnerServiceFactory.create(runner);
 
-      PreviewRunnerService pollerService = new PreviewRunnerService(
-        previewCConf, previewInjector.getInstance(PreviewRunner.class),
-        previewRequestFetcherFactory.create(Bytes.toBytes(pollerInfo)));
+      pollerService.addListener(new ServiceListenerAdapter() {
+        @Override
+        public void terminated(State from) {
+          previewRunnerServices.remove(pollerService);
+          if (previewRunnerServices.isEmpty()) {
+            try {
+              stop();
+            } catch (Exception e) {
+              // should not happen
+              LOG.error("Failed to shutdown the preview runner manager service.", e);
+            }
+          }
+        }
+      }, Threads.SAME_THREAD_EXECUTOR);
 
       pollerService.startAndWait();
-      previewPollers.put(pollerInfo, pollerService);
+      previewRunnerServices.add(pollerService);
     }
   }
 
   @Override
   protected void shutDown() throws Exception {
     // Should stop the polling service, hence individual preview runs, before stopping the top level preview runner.
-    for (Service pollerService : previewPollers.values()) {
+    for (Service pollerService : previewRunnerServices) {
       stopQuietly(pollerService);
     }
 
@@ -156,17 +168,18 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
   }
 
   @Override
-  public void stop(byte[] runnerId) throws Exception {
-    PreviewRunnerService service = previewPollers.get(Bytes.toString(runnerId));
-    if (service == null) {
-      throw new NotFoundException("Preview run cannot be stopped. Please try stopping again or start new preview run.");
+  public void stop(ApplicationId preview) throws Exception {
+    for (PreviewRunnerService previewRunnerService : previewRunnerServices) {
+      if (!preview.equals(previewRunnerService.getPreviewApplication().orElse(null))) {
+        continue;
+      }
+      previewRunnerService.stopAndWait();
+      PreviewRunnerService newService = previewRunnerServiceFactory.create(runner);
+      newService.startAndWait();
+      previewRunnerServices.add(newService);
+      return;
     }
-    service.stopAndWait();
-    String newRunnerId = UUID.randomUUID().toString();
-    PreviewRunnerService newService = new PreviewRunnerService(
-      previewCConf, runner, previewRequestFetcherFactory.create(Bytes.toBytes(newRunnerId)));
-    newService.startAndWait();
-    previewPollers.put(newRunnerId, newService);
+    throw new NotFoundException("Preview run cannot be stopped. Please try stopping again or start new preview run.");
   }
 
   /**
@@ -190,8 +203,13 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
       // Use the in-memory module for metrics collection, which metrics still get persisted to dataset, but
       // save threads for reading metrics from TMS, as there won't be metrics in TMS.
       new MetricsClientRuntimeModule().getInMemoryModules(),
-      new LocalLogAppenderModule(),
-      new MessagingServerRuntimeModule().getInMemoryModules(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(LogAppender.class).to(PreviewTMSLogAppender.class).in(Scopes.SINGLETON);
+        }
+      },
+    new MessagingServerRuntimeModule().getInMemoryModules(),
       Modules.override(new MetadataReaderWriterModules().getInMemoryModules()).with(new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewConfigModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewConfigModule.java
@@ -76,6 +76,9 @@ public class PreviewConfigModule extends AbstractModule {
     // Don't load custom log pipelines in preview
     previewCConf.unset(Constants.Logging.PIPELINE_CONFIG_DIR);
 
+    previewCConf.set(Constants.Logging.TMS_TOPIC_PREFIX, "previewlog");
+    previewCConf.setInt(Constants.Logging.NUM_PARTITIONS, 1);
+
     // Setup Hadoop configuration
     previewHConf = new Configuration(hConf);
     previewHConf.set(MRConfig.FRAMEWORK_NAME, MRConfig.LOCAL_FRAMEWORK_NAME);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewHttpServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewHttpServer.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.metrics.MetricsReporterHook;
 import io.cdap.cdap.common.security.HttpsEnabler;
 import io.cdap.cdap.gateway.handlers.preview.PreviewHttpHandler;
+import io.cdap.cdap.gateway.handlers.preview.PreviewHttpHandlerInternal;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.http.NettyHttpService;
@@ -39,6 +40,7 @@ import org.apache.twill.discovery.DiscoveryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 /**
@@ -56,13 +58,14 @@ public class PreviewHttpServer extends AbstractIdleService {
   @Inject
   PreviewHttpServer(CConfiguration cConf, SConfiguration sConf,
                     DiscoveryService discoveryService, PreviewHttpHandler previewHttpHandler,
+                    PreviewHttpHandlerInternal previewHttpHandlerInternal,
                     MetricsCollectionService metricsCollectionService,
                     PreviewManager previewManager) {
     this.discoveryService = discoveryService;
     NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf, Constants.Service.PREVIEW_HTTP)
       .setHost(cConf.get(Constants.Preview.ADDRESS))
       .setPort(cConf.getInt(Constants.Preview.PORT))
-      .setHttpHandlers(previewHttpHandler)
+      .setHttpHandlers(Arrays.asList(previewHttpHandler, previewHttpHandlerInternal))
       .setConnectionBacklog(cConf.getInt(Constants.Preview.BACKLOG_CONNECTIONS))
       .setExecThreadPoolSize(cConf.getInt(Constants.Preview.EXEC_THREADS))
       .setBossThreadPoolSize(cConf.getInt(Constants.Preview.BOSS_THREADS))

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewManager.java
@@ -17,7 +17,6 @@ package io.cdap.cdap.app.preview;
 
 import com.google.gson.JsonElement;
 import io.cdap.cdap.common.NotFoundException;
-import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.logging.read.LogReader;
 import io.cdap.cdap.metrics.query.MetricsQueryHelper;
 import io.cdap.cdap.proto.artifact.AppRequest;
@@ -27,6 +26,8 @@ import io.cdap.cdap.proto.id.ProgramRunId;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Interface used for managing the preview runs.
@@ -83,4 +84,11 @@ public interface PreviewManager {
    * @return the {@link LogReader} for reading logs for the given preview
    */
   LogReader getLogReader();
+
+  /**
+   * Poll the next available request in the queue.
+   * @param pollerInfo information about the poller
+   * @return {@code PreviewRequest} if such request is available in the queue
+   */
+  Optional<PreviewRequest> poll(@Nullable byte[] pollerInfo);
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRequestQueue.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRequestQueue.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import net.jcip.annotations.ThreadSafe;
 
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Interface designed for holding {@link PreviewRequest}s that are in WAITING state.
@@ -30,10 +31,10 @@ import java.util.Optional;
 public interface PreviewRequestQueue {
   /**
    * Poll the next available request in the queue.
-   * @param pollerInfo information about the poller
+   * @param pollerInfo information about the poller.
    * @return {@code PreviewRequest} if such request is available in the queue
    */
-  Optional<PreviewRequest> poll(byte[] pollerInfo);
+  Optional<PreviewRequest> poll(@Nullable byte[] pollerInfo);
 
   /**
    * Add a preview request in the queue.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerManagerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerManagerModule.java
@@ -16,44 +16,99 @@
 
 package io.cdap.cdap.app.preview;
 
+import com.google.inject.Exposed;
+import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Names;
+import io.cdap.cdap.common.runtime.RuntimeModule;
 import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
 import io.cdap.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.dataset2.DefaultDatasetDefinitionRegistryFactory;
-import io.cdap.cdap.internal.app.preview.DirectPreviewRequestFetcherFactory;
-import io.cdap.cdap.internal.app.preview.PreviewRequestFetcherFactory;
-import io.cdap.cdap.internal.app.preview.PreviewRunnerServiceStopper;
+import io.cdap.cdap.internal.app.preview.DirectPreviewRequestFetcher;
+import io.cdap.cdap.internal.app.preview.PreviewRequestFetcher;
+import io.cdap.cdap.internal.app.preview.PreviewRunStopper;
+import io.cdap.cdap.internal.app.preview.PreviewRunnerService;
+import io.cdap.cdap.internal.app.preview.RemotePreviewRequestFetcher;
+import org.apache.twill.discovery.DiscoveryServiceClient;
 
 /**
  * Guice module to provide bindings for {@link PreviewRunnerManager} service.
  */
-public class PreviewRunnerManagerModule extends PrivateModule {
+public class PreviewRunnerManagerModule extends RuntimeModule {
+
   @Override
-  protected void configure() {
-    bind(DatasetDefinitionRegistryFactory.class)
-      .to(DefaultDatasetDefinitionRegistryFactory.class).in(Scopes.SINGLETON);
-
-    bind(DatasetFramework.class)
-      .annotatedWith(Names.named(DataSetsModules.BASE_DATASET_FRAMEWORK))
-      .to(RemoteDatasetFramework.class);
-    bind(PreviewRunnerModule.class).to(DefaultPreviewRunnerModule.class);
-
-    bind(DefaultPreviewRunnerManager.class).in(Scopes.SINGLETON);
-    bind(PreviewRunnerServiceStopper.class).to(DefaultPreviewRunnerManager.class);
-    expose(PreviewRunnerServiceStopper.class);
-    bind(PreviewRunnerManager.class).to(DefaultPreviewRunnerManager.class);
-    expose(PreviewRunnerManager.class);
+  public Module getInMemoryModules() {
+    return getStandaloneModules();
   }
 
-  @Provides
-  @Singleton
-  PreviewRequestFetcherFactory getPreviewRequestQueueFetcher(PreviewRequestQueue previewRequestQueue) {
-    return new DirectPreviewRequestFetcherFactory(previewRequestQueue);
+  @Override
+  public Module getStandaloneModules() {
+
+    return new PrivateModule() {
+      @Override
+      protected void configure() {
+        bind(DatasetDefinitionRegistryFactory.class)
+          .to(DefaultDatasetDefinitionRegistryFactory.class).in(Scopes.SINGLETON);
+
+        bind(DatasetFramework.class)
+          .annotatedWith(Names.named(DataSetsModules.BASE_DATASET_FRAMEWORK))
+          .to(RemoteDatasetFramework.class);
+        bind(PreviewRunnerModule.class).to(DefaultPreviewRunnerModule.class);
+
+        bind(DefaultPreviewRunnerManager.class).in(Scopes.SINGLETON);
+        bind(PreviewRunStopper.class).to(DefaultPreviewRunnerManager.class);
+        expose(PreviewRunStopper.class);
+        bind(PreviewRunnerManager.class).to(DefaultPreviewRunnerManager.class);
+        expose(PreviewRunnerManager.class);
+
+        install(new FactoryModuleBuilder()
+                  .implement(PreviewRunnerService.class, PreviewRunnerService.class)
+                  .build(PreviewRunnerServiceFactory.class));
+      }
+
+      @Provides
+      @Singleton
+      @Exposed
+      PreviewRequestFetcher getPreviewRequestQueueFetcher(PreviewRequestQueue previewRequestQueue) {
+        return new DirectPreviewRequestFetcher(previewRequestQueue);
+      }
+    };
+  }
+
+  @Override
+  public Module getDistributedModules() {
+    return new PrivateModule() {
+      @Override
+      protected void configure() {
+        bind(DatasetDefinitionRegistryFactory.class)
+          .to(DefaultDatasetDefinitionRegistryFactory.class).in(Scopes.SINGLETON);
+
+        bind(DatasetFramework.class)
+          .annotatedWith(Names.named(DataSetsModules.BASE_DATASET_FRAMEWORK))
+          .to(RemoteDatasetFramework.class);
+        bind(PreviewRunnerModule.class).to(DefaultPreviewRunnerModule.class);
+
+        bind(DefaultPreviewRunnerManager.class).in(Scopes.SINGLETON);
+        bind(PreviewRunnerManager.class).to(DefaultPreviewRunnerManager.class);
+        expose(PreviewRunnerManager.class);
+
+        install(new FactoryModuleBuilder()
+                  .implement(PreviewRunnerService.class, PreviewRunnerService.class)
+                  .build(PreviewRunnerServiceFactory.class));
+      }
+
+      @Provides
+      @Singleton
+      @Exposed
+      PreviewRequestFetcher getPreviewRequestQueueFetcher(DiscoveryServiceClient discoveryServiceClient) {
+        return new RemotePreviewRequestFetcher(discoveryServiceClient, new byte[0]);
+      }
+    };
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerServiceFactory.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerServiceFactory.java
@@ -16,10 +16,16 @@
 
 package io.cdap.cdap.app.preview;
 
-import io.cdap.cdap.internal.app.preview.PreviewRunStopper;
+import io.cdap.cdap.internal.app.preview.PreviewRunnerService;
 
 /**
- * It is just a tagging interface for guice binding of {@link DefaultPreviewRunnerManager}.
+ * Factory for creating {@link PreviewRunnerService} instances.
  */
-public interface PreviewRunnerManager extends PreviewRunStopper {
+public interface PreviewRunnerServiceFactory {
+  /**
+   * Creates an instance of {@link PreviewRunnerService}.
+   * @param runner runner used by service to run preview
+   * @return an instance of {@link PreviewRunnerService}
+   */
+  PreviewRunnerService create(PreviewRunner runner);
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/preview/PreviewHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/preview/PreviewHttpHandlerInternal.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers.preview;
+
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.app.preview.PreviewManager;
+import io.cdap.cdap.app.preview.PreviewRequest;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * Internal {@link HttpHandler} for Preview system.
+ */
+@Singleton
+@Path(Constants.Gateway.INTERNAL_API_VERSION_3 + "/previews")
+public class PreviewHttpHandlerInternal extends AbstractHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(PreviewHttpHandlerInternal.class);
+  private static final Gson GSON = new Gson();
+  private final PreviewManager previewManager;
+
+  @Inject
+  PreviewHttpHandlerInternal(PreviewManager previewManager) {
+    this.previewManager = previewManager;
+  }
+
+  @POST
+  @Path("/requests/pull")
+  public void poll(FullHttpRequest request, HttpResponder responder) throws Exception {
+    byte[] pollerInfo = Bytes.toBytes(request.content().nioBuffer());
+    Optional<PreviewRequest> previewRequestOptional = previewManager.poll(pollerInfo);
+    if (previewRequestOptional.isPresent()) {
+      LOG.info("Received poller info is {}", Bytes.toString(pollerInfo));
+      responder.sendString(HttpResponseStatus.OK, GSON.toJson(previewRequestOptional.get()));
+    } else {
+      responder.sendStatus(HttpResponseStatus.OK);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRequestQueue.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRequestQueue.java
@@ -38,6 +38,7 @@ import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Thread-safe implementation of {@link PreviewRequestQueue} backed by {@link PreviewStore}.
@@ -63,7 +64,7 @@ public class DefaultPreviewRequestQueue implements PreviewRequestQueue {
   }
 
   @Override
-  public Optional<PreviewRequest> poll(byte[] pollerInfo) {
+  public Optional<PreviewRequest> poll(@Nullable byte[] pollerInfo) {
     while (true) {
       PreviewRequest previewRequest = requestQueue.poll();
       if (previewRequest == null) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DirectPreviewRequestFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DirectPreviewRequestFetcher.java
@@ -17,22 +17,24 @@
 package io.cdap.cdap.internal.app.preview;
 
 import com.google.inject.Inject;
+import io.cdap.cdap.app.preview.PreviewRequest;
 import io.cdap.cdap.app.preview.PreviewRequestQueue;
 
-/**
- * Factory for creating {@link PreviewRequestFetcher} that fetches the requests directly from the
- * {@link PreviewRequestQueue}.
- */
-public class DirectPreviewRequestFetcherFactory implements PreviewRequestFetcherFactory {
-  private final PreviewRequestQueue requestQueue;
+import java.io.IOException;
+import java.util.Optional;
 
-  @Inject
-  public DirectPreviewRequestFetcherFactory(PreviewRequestQueue requestQueue) {
-    this.requestQueue = requestQueue;
+/**
+ * Implementation of {@link PreviewRequestFetcher} which fetches directly from {@link PreviewRequestQueue}.
+ */
+public class DirectPreviewRequestFetcher implements PreviewRequestFetcher {
+  private final PreviewRequestQueue previewRequestQueue;
+
+  public DirectPreviewRequestFetcher(PreviewRequestQueue previewRequestQueue) {
+    this.previewRequestQueue = previewRequestQueue;
   }
 
   @Override
-  public PreviewRequestFetcher create(byte[] pollerInfo) {
-    return () -> requestQueue.poll(pollerInfo);
+  public Optional<PreviewRequest> fetch() throws IOException {
+    return previewRequestQueue.poll(null);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRequestPollerInfoProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRequestPollerInfoProvider.java
@@ -14,16 +14,15 @@
  * the License.
  */
 
+
 package io.cdap.cdap.internal.app.preview;
 
 /**
- * Interface to kill the preview runner service.
+ * Interface that provides poller info used for polling the preview requests.
  */
-public interface PreviewRunnerServiceStopper {
+public interface PreviewRequestPollerInfoProvider {
   /**
-   * Stops the {@link PreviewRunnerService} identified by the runner id.
-   * @param runnerId id of the preview runner service to be stopped
-   * @throws Exception if any error while stopping
+   * @return the poller info in generic byte array
    */
-  void stop(byte[] runnerId) throws Exception;
+  byte[] get();
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunStopper.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunStopper.java
@@ -14,12 +14,18 @@
  * the License.
  */
 
-package io.cdap.cdap.app.preview;
+package io.cdap.cdap.internal.app.preview;
 
-import io.cdap.cdap.internal.app.preview.PreviewRunStopper;
+import io.cdap.cdap.proto.id.ApplicationId;
 
 /**
- * It is just a tagging interface for guice binding of {@link DefaultPreviewRunnerManager}.
+ * Interface to kill the preview runner service.
  */
-public interface PreviewRunnerManager extends PreviewRunStopper {
+public interface PreviewRunStopper {
+  /**
+   * Stops the preview as identified by the application id.
+   * @param preview id of the preview application to be stopped
+   * @throws Exception if any error while stopping
+   */
+  void stop(ApplicationId preview) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewTMSLogSubscriber.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewTMSLogSubscriber.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.preview;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.cdap.cdap.api.messaging.Message;
+import io.cdap.cdap.api.messaging.MessagingContext;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.app.preview.PreviewConfigModule;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.common.utils.ImmutablePair;
+import io.cdap.cdap.internal.app.runtime.monitor.RemoteExecutionLogProcessor;
+import io.cdap.cdap.internal.app.store.AppMetadataStore;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
+import io.cdap.cdap.messaging.subscriber.AbstractMessagingSubscriberService;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.spi.data.StructuredTableContext;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import org.apache.tephra.TxConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Iterator;
+import javax.annotation.Nullable;
+
+/**
+ * TMS Log subscriber for preview logs.
+ */
+public class PreviewTMSLogSubscriber extends AbstractMessagingSubscriberService<Iterator<byte[]>> {
+  private static final Logger LOG = LoggerFactory.getLogger(PreviewTMSLogSubscriber.class);
+  private static final String CONSUMER_NAME = "preview.log.writer";
+  private static final String TOPIC_NAME = "previewlog0";
+
+  private final MultiThreadMessagingContext messagingContext;
+  private final TransactionRunner transactionRunner;
+  private final RemoteExecutionLogProcessor logProcessor;
+  private final int maxRetriesOnError;
+  private int errorCount = 0;
+  private String erroredMessageId = null;
+
+  @Inject
+  PreviewTMSLogSubscriber(CConfiguration cConf,
+                          @Named(PreviewConfigModule.GLOBAL_TMS) MessagingService messagingService,
+                          MetricsCollectionService metricsCollectionService,
+                          TransactionRunner transactionRunner, RemoteExecutionLogProcessor logProcessor) {
+    super(
+      NamespaceId.SYSTEM.topic(TOPIC_NAME),
+      cConf.getInt(Constants.Metadata.MESSAGING_FETCH_SIZE),
+      cConf.getInt(TxConstants.Manager.CFG_TX_TIMEOUT),
+      cConf.getLong(Constants.Metadata.MESSAGING_POLL_DELAY_MILLIS),
+      RetryStrategies.fromConfiguration(cConf, "system.preview."),
+      metricsCollectionService.getContext(
+        ImmutableMap.of(Constants.Metrics.Tag.COMPONENT, Constants.Service.PREVIEW_HTTP,
+                        Constants.Metrics.Tag.INSTANCE_ID, "0",
+                        Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace(),
+                        Constants.Metrics.Tag.TOPIC, TOPIC_NAME,
+                        Constants.Metrics.Tag.CONSUMER, CONSUMER_NAME
+      )));
+
+    this.messagingContext = new MultiThreadMessagingContext(messagingService);
+    this.transactionRunner = transactionRunner;
+    this.maxRetriesOnError = cConf.getInt(Constants.Metadata.MESSAGING_RETRIES_ON_CONFLICT);
+    this.logProcessor = logProcessor;
+  }
+
+  @Override
+  protected TransactionRunner getTransactionRunner() {
+    return transactionRunner;
+  }
+
+  @Nullable
+  @Override
+  protected String loadMessageId(StructuredTableContext context) throws Exception {
+    AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
+    return appMetadataStore.retrieveSubscriberState(getTopicId().getTopic(), CONSUMER_NAME);
+  }
+
+  @Override
+  protected void storeMessageId(StructuredTableContext context, String messageId) throws Exception {
+    AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
+    appMetadataStore.persistSubscriberState(getTopicId().getTopic(), CONSUMER_NAME, messageId);
+  }
+
+  @Override
+  protected void processMessages(StructuredTableContext structuredTableContext,
+                                 Iterator<ImmutablePair<String, Iterator<byte[]>>> messages) throws Exception {
+    while (messages.hasNext()) {
+      ImmutablePair<String, Iterator<byte[]>> next = messages.next();
+      String messageId = next.getFirst();
+      Iterator<byte[]> message = next.getSecond();
+      try {
+        logProcessor.process(message);
+      } catch (Exception e) {
+        if (messageId.equals(erroredMessageId)) {
+          errorCount++;
+          if (errorCount >= maxRetriesOnError) {
+            LOG.warn("Skipping preview message {} after processing it has caused {} consecutive errors: {}",
+                     message, errorCount, e.getMessage());
+            continue;
+          }
+        } else {
+          erroredMessageId = messageId;
+          errorCount = 1;
+        }
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  protected MessagingContext getMessagingContext() {
+    return messagingContext;
+  }
+
+  @Override
+  protected Iterator<byte[]> decodeMessage(Message message) throws Exception {
+    return Collections.singletonList(message.getPayload()).iterator();
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/RemotePreviewRequestFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/RemotePreviewRequestFetcher.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.preview;
+
+import com.google.common.base.Charsets;
+import com.google.gson.Gson;
+import io.cdap.cdap.app.preview.PreviewRequest;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpResponse;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+/**
+ * Fetch preview requests from remote server.
+ */
+public class RemotePreviewRequestFetcher implements PreviewRequestFetcher {
+  private final RemoteClient remoteClientInternal;
+  private final byte[] pollerInfo;
+  private static final Gson GSON = new Gson();
+
+  public RemotePreviewRequestFetcher(DiscoveryServiceClient discoveryServiceClient, byte[] pollerInfo) {
+    this.remoteClientInternal = new RemoteClient(discoveryServiceClient, Constants.Service.PREVIEW_HTTP,
+                                                 new DefaultHttpRequestConfig(false),
+                                                 Constants.Gateway.INTERNAL_API_VERSION_3 + "/previews");
+    this.pollerInfo = pollerInfo;
+  }
+
+  @Override
+  public Optional<PreviewRequest> fetch() throws IOException {
+    HttpRequest.Builder builder = remoteClientInternal.requestBuilder(HttpMethod.POST, "requests/pull");
+    builder.withBody(ByteBuffer.wrap(pollerInfo));
+    HttpResponse httpResponse = remoteClientInternal.execute(builder.build());
+    if (httpResponse.getResponseCode() == 200) {
+      PreviewRequest previewRequest = GSON.fromJson(httpResponse.getResponseBodyAsString(), PreviewRequest.class);
+      return Optional.ofNullable(previewRequest);
+    }
+    throw new IOException(String.format("Received status code:%s and body: %s", httpResponse.getResponseCode(),
+                                        httpResponse.getResponseBodyAsString(Charsets.UTF_8)));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/k8s/PreviewRequestPollerInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/k8s/PreviewRequestPollerInfo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.k8s;
+
+/**
+ * Poller information holder.
+ */
+public class PreviewRequestPollerInfo {
+  private final int instanceId;
+  private final String instanceUid;
+
+  public PreviewRequestPollerInfo(String instanceName, String instanceUid) {
+    // Since preview runners are launched as statefulsets in K8s, container name for the
+    // preview runner is of the form preview-runner-<ordinal> where ordinal is numeric value such
+    // as 0, 1, 2..
+    // We need to just pass the ordinal as instance id so that correct pod can be killed.
+    String[] parts = instanceName.split("-");
+    this.instanceId = Integer.parseInt(parts[parts.length - 1]);
+    this.instanceUid = instanceUid;
+  }
+
+  public int getInstanceId() {
+    return instanceId;
+  }
+
+  public String getInstanceUid() {
+    return instanceUid;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/k8s/PreviewRunnerOptions.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/k8s/PreviewRunnerOptions.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.k8s;
+
+import io.cdap.cdap.common.options.Option;
+import io.cdap.cdap.master.environment.k8s.EnvironmentOptions;
+
+/**
+ * Environment options for preview runners.
+ */
+public class PreviewRunnerOptions extends EnvironmentOptions {
+  public static final String INSTANCE_NAME_FILE_PATH = "instanceNameFilePath";
+  public static final String INSTANCE_UID_FILE_PATH = "instanceUidFilePath";
+
+  @Option(name = INSTANCE_NAME_FILE_PATH, usage = "Path to file containing container name.")
+  private String instanceNameFilePath;
+
+  @Option(name = INSTANCE_UID_FILE_PATH, usage = "Path to file containing uid of container.")
+  private String instanceUidFilePath;
+
+  public String getInstanceNameFilePath() {
+    return instanceNameFilePath;
+  }
+
+  public String getInstanceUidFilePath() {
+    return instanceUidFilePath;
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManagerTest.java
@@ -40,7 +40,6 @@ import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data.runtime.TransactionExecutorModule;
 import io.cdap.cdap.explore.guice.ExploreClientModule;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
-import io.cdap.cdap.logging.guice.LocalLogAppenderModule;
 import io.cdap.cdap.logging.guice.LogReaderRuntimeModules;
 import io.cdap.cdap.logging.read.LogReader;
 import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
@@ -92,7 +91,6 @@ public class DefaultPreviewManagerTest {
       new AppFabricServiceRuntimeModule().getInMemoryModules(),
       new ProgramRunnerRuntimeModule().getInMemoryModules(),
       new NonCustomLocationUnitTestModule(),
-      new LocalLogAppenderModule(),
       new LogReaderRuntimeModules().getInMemoryModules(),
       new MetricsClientRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
@@ -112,7 +110,7 @@ public class DefaultPreviewManagerTest {
           bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
           bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);
           // bind PreviewRunnerStopper to Mock implementation
-          bind(PreviewRunnerServiceStopper.class).toInstance(runnerId -> {
+          bind(PreviewRunStopper.class).toInstance(runnerId -> {
 
           });
         }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewRunnerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewRunnerServiceTest.java
@@ -56,7 +56,7 @@ public class PreviewRunnerServiceTest {
   public void testStartAndStop() throws InterruptedException, ExecutionException, TimeoutException {
     MockPreviewRunner mockRunner = new MockPreviewRunner();
     MockPreviewRequestFetcher fetcher = new MockPreviewRequestFetcher();
-    PreviewRunnerService runnerService = new PreviewRunnerService(createCConf(), mockRunner, fetcher);
+    PreviewRunnerService runnerService = new PreviewRunnerService(createCConf(), fetcher, mockRunner);
     runnerService.startAndWait();
 
     Tasks.waitFor(true, () -> fetcher.fetchCount.get() > 0, 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
@@ -68,7 +68,7 @@ public class PreviewRunnerServiceTest {
   public void testStopPreview() throws InterruptedException, ExecutionException, TimeoutException {
     MockPreviewRunner mockRunner = new MockPreviewRunner();
     MockPreviewRequestFetcher fetcher = new MockPreviewRequestFetcher();
-    PreviewRunnerService runnerService = new PreviewRunnerService(createCConf(), mockRunner, fetcher);
+    PreviewRunnerService runnerService = new PreviewRunnerService(createCConf(), fetcher, mockRunner);
     runnerService.startAndWait();
 
     ProgramId programId = NamespaceId.DEFAULT.app("app").program(ProgramType.WORKFLOW, "workflow");
@@ -89,7 +89,7 @@ public class PreviewRunnerServiceTest {
 
     MockPreviewRunner mockRunner = new MockPreviewRunner();
     MockPreviewRequestFetcher fetcher = new MockPreviewRequestFetcher();
-    PreviewRunnerService runnerService = new PreviewRunnerService(cConf, mockRunner, fetcher);
+    PreviewRunnerService runnerService = new PreviewRunnerService(cConf, fetcher, mockRunner);
     runnerService.startAndWait();
 
     ProgramId programId = NamespaceId.DEFAULT.app("app").program(ProgramType.WORKFLOW, "workflow");

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2179,7 +2179,7 @@
 
   <property>
     <name>messaging.system.topics</name>
-    <value>${audit.topic},${metadata.messaging.topic},${data.event.topic},${metrics.topic.prefix}:${metrics.messaging.topic.num},${metrics.admin.topic},${time.event.topic},${program.status.event.topic},${program.status.record.event.topic},${log.tms.topic.prefix}:${log.publish.num.partitions},${preview.messaging.topic}</value>
+    <value>${audit.topic},${metadata.messaging.topic},${data.event.topic},${metrics.topic.prefix}:${metrics.messaging.topic.num},${metrics.admin.topic},${time.event.topic},${program.status.event.topic},${program.status.record.event.topic},${log.tms.topic.prefix}:${log.publish.num.partitions},${preview.messaging.topic},previewlog0</value>
     <description>
       A comma-separated list of topics that are always available in the
       system namespace. Multiple topics sharing the same prefix and

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMain.java
@@ -37,6 +37,8 @@ import io.cdap.cdap.data.runtime.DataSetServiceModules;
 import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data2.audit.AuditModule;
 import io.cdap.cdap.explore.client.ExploreClient;
+import io.cdap.cdap.internal.app.preview.PreviewRequestPollerInfoProvider;
+import io.cdap.cdap.internal.app.preview.PreviewRunStopper;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
@@ -67,7 +69,14 @@ public class PreviewServiceMain extends AbstractServiceMain<EnvironmentOptions> 
   protected List<Module> getServiceModules(MasterEnvironment masterEnv, EnvironmentOptions options) {
     return Arrays.asList(
       new PreviewHttpModule(),
-      new PreviewRunnerManagerModule(),
+      new PreviewRunnerManagerModule().getDistributedModules(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(PreviewRunStopper.class).toInstance(runnerId -> {
+          });
+        }
+      },
       new DataSetServiceModules().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
       new AppFabricServiceRuntimeModule().getStandaloneModules(),
@@ -86,6 +95,7 @@ public class PreviewServiceMain extends AbstractServiceMain<EnvironmentOptions> 
         @Override
         protected void configure() {
           bind(ExploreClient.class).to(UnsupportedExploreClient.class);
+          bind(PreviewRequestPollerInfoProvider.class).toInstance(() -> new byte[0]);
         }
       }
     );

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
@@ -102,6 +102,8 @@ public class MasterServiceMainTestBase {
     cConf.setInt(Constants.Router.ROUTER_PORT, 0);
     cConf.setInt(Constants.Router.ROUTER_SSL_PORT, 0);
 
+    cConf.setInt(Constants.Preview.CACHE_SIZE, 1);
+
     // Use remote fetcher for runtime server
     cConf.setClass(Constants.RuntimeMonitor.RUN_RECORD_FETCHER_CLASS,
                    RemoteProgramRunRecordFetcher.class, ProgramRunRecordFetcher.class);

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
@@ -43,7 +43,9 @@ import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -71,6 +73,18 @@ public class PreviewServiceMainTest extends MasterServiceMainTestBase {
     deleteAllArtifact();
   }
 
+  @BeforeClass
+  public static void initPreviewService() throws Exception {
+    // Start the preview service main, which will use its own local datadir, thus should fetch artifact location
+    // from appFabric when running a preview
+    startService(PreviewServiceMain.class);
+  }
+
+  @AfterClass
+  public static void afterPreviewService() throws Exception {
+    stopService(PreviewServiceMain.class);
+  }
+
   @Test
   public void testPreviewSimpleApp() throws Exception {
     // Build the app
@@ -81,10 +95,6 @@ public class PreviewServiceMainTest extends MasterServiceMainTestBase {
     String artifactName = PreviewTestApp.class.getSimpleName();
     String artifactVersion = "1.0.0-SNAPSHOT";
     deployArtifact(appJar, artifactName, artifactVersion);
-
-    // Start the preview service main, which will use its own local datadir, thus should fetch artifact location
-    // from appFabric when running a preview
-    startService(PreviewServiceMain.class);
 
     // Run a preview
     ArtifactSummary artifactSummary = new ArtifactSummary(artifactName, artifactVersion);
@@ -108,9 +118,6 @@ public class PreviewServiceMainTest extends MasterServiceMainTestBase {
     Assert.assertEquals(Collections.singletonMap(PreviewTestApp.TRACER_KEY,
                                                  Collections.singletonList(PreviewTestApp.TRACER_VAL)),
                         tracerData);
-
-    // Stop the preview service main to
-    stopService(PreviewServiceMain.class);
 
     // Clean up
     deleteArtfiact(artifactName, artifactVersion);
@@ -146,9 +153,6 @@ public class PreviewServiceMainTest extends MasterServiceMainTestBase {
         .build(), getHttpRequestConfig());
     Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
 
-    // Start preview service
-    startService(PreviewServiceMain.class);
-
     // Run a preview
     String expectedOutput = "output_value";
     ArtifactId appArtifactId = new ArtifactId(appArtifactName, new ArtifactVersion(artifactVersion),
@@ -176,8 +180,6 @@ public class PreviewServiceMainTest extends MasterServiceMainTestBase {
     Assert.assertEquals(Collections.singletonMap(PreviewTestAppWithPlugin.TRACER_KEY,
                                                  Collections.singletonList(expectedOutput)),
                         tracerData);
-
-    stopService(PreviewServiceMain.class);
   }
 
   /**
@@ -260,5 +262,4 @@ public class PreviewServiceMainTest extends MasterServiceMainTestBase {
   private HttpRequestConfig getHttpRequestConfig() {
     return new HttpRequestConfig(0, 0, false);
   }
-
 }

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -539,7 +539,7 @@ public class StandaloneMain {
       new AuthorizationEnforcementModule().getStandaloneModules(),
       new PreviewConfigModule(cConf, new Configuration(), SConfiguration.create()),
       new PreviewHttpModule(),
-      new PreviewRunnerManagerModule(),
+      new PreviewRunnerManagerModule().getStandaloneModules(),
       new MessagingServerRuntimeModule().getStandaloneModules(),
       new AppFabricServiceRuntimeModule().getStandaloneModules(),
       new MonitorHandlerModule(false),

--- a/cdap-standalone/src/test/java/io/cdap/cdap/StandaloneMainTest.java
+++ b/cdap-standalone/src/test/java/io/cdap/cdap/StandaloneMainTest.java
@@ -21,7 +21,7 @@ import io.cdap.cdap.app.preview.PreviewManager;
 import io.cdap.cdap.app.preview.PreviewRunnerManager;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.gateway.handlers.preview.PreviewHttpHandler;
-import io.cdap.cdap.internal.app.preview.PreviewRunnerServiceStopper;
+import io.cdap.cdap.internal.app.preview.PreviewRunStopper;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionManager;
 import org.junit.Assert;
@@ -38,10 +38,10 @@ public class StandaloneMainTest {
     Assert.assertNotNull(sdk.getInjector().getInstance(PreviewHttpHandler.class));
     PreviewManager previewManager = sdk.getInjector().getInstance(PreviewManager.class);
     PreviewRunnerManager previewRunnerManager = sdk.getInjector().getInstance(PreviewRunnerManager.class);
-    PreviewRunnerServiceStopper previewRunnerServiceStopper
-      = sdk.getInjector().getInstance(PreviewRunnerServiceStopper.class);
+    PreviewRunStopper previewRunStopper
+      = sdk.getInjector().getInstance(PreviewRunStopper.class);
 
-    Assert.assertSame(previewRunnerManager, previewRunnerServiceStopper);
+    Assert.assertSame(previewRunnerManager, previewRunStopper);
     TransactionManager txManager = sdk.getInjector().getInstance(TransactionManager.class);
     txManager.startAndWait();
     ((Service) previewManager).startAndWait();

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -288,7 +288,7 @@ public class TestBase {
       new MessagingServerRuntimeModule().getInMemoryModules(),
       new PreviewConfigModule(cConf, new Configuration(), SConfiguration.create()),
       new PreviewHttpModule(),
-      new PreviewRunnerManagerModule(),
+      new PreviewRunnerManagerModule().getInMemoryModules(),
       new MockProvisionerModule(),
       new AbstractModule() {
         @Override

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/tms/PreviewTMSLogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/tms/PreviewTMSLogAppender.java
@@ -14,12 +14,21 @@
  * the License.
  */
 
-package io.cdap.cdap.app.preview;
+package io.cdap.cdap.logging.appender.tms;
 
-import io.cdap.cdap.internal.app.preview.PreviewRunStopper;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.messaging.MessagingService;
 
 /**
- * It is just a tagging interface for guice binding of {@link DefaultPreviewRunnerManager}.
+ * TMS Log Appender used for Preview. Only difference with {@link TMSLogAppender} is
+ * an instance of MessagingService it receives.
  */
-public interface PreviewRunnerManager extends PreviewRunStopper {
+public class PreviewTMSLogAppender extends TMSLogAppender  {
+  @Inject
+  PreviewTMSLogAppender(CConfiguration cConf,
+                        @Named("globalTMS") MessagingService messagingService) {
+    super(cConf, messagingService);
+  }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/tms/TMSLogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/tms/TMSLogAppender.java
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Log appender that publishes log messages to TMS.
  */
-public final class TMSLogAppender extends LogAppender {
+public class TMSLogAppender extends LogAppender {
 
   private static final String APPENDER_NAME = "TMSLogAppender";
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16712

This PR has following changes:
1. Implementation of remote preview request feature.
2. Preview logs via TMS.
3. Guice module adjustments required for the separation of preview manager and preview runners.

