### PR TITLE
[CDAP-17117] Preview line fix for table view

### DIFF
--- a/cdap-ui/app/cdap/components/PreviewData/DataView/TableContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/TableContainer.tsx
@@ -34,7 +34,7 @@ export const styles = (theme): StyleRules => ({
     },
   },
   innerContainer: {
-    overflow: 'scroll',
+    overflow: 'hidden',
     padding: '10px',
     width: '100%',
   },
@@ -44,6 +44,9 @@ export const styles = (theme): StyleRules => ({
     padding: '10px',
     borderRight: `1px solid ${theme.palette.grey[400]}`,
     height: 'inherit',
+  },
+  tableContainer: {
+    overflow: 'scroll',
   },
   h2Title: {
     fontSize: '1.4rem !important',
@@ -82,7 +85,7 @@ const TableContainer: React.FC<IPreviewTableContainerProps> = ({
             const inputHeaders = tableValue.schemaFields;
             const inputRecords = tableValue.records;
             return (
-              <div key={`input-table-${i}`}>
+              <div key={`input-table-${i}`} className={classes.tableContainer}>
                 {inputs.length > 1 ? <Heading type={HeadingTypes.h3} label={tableKey} /> : null}
                 <DataTable
                   headers={inputHeaders}
@@ -106,7 +109,7 @@ const TableContainer: React.FC<IPreviewTableContainerProps> = ({
             const outputHeaders = tableValue.schemaFields;
             const outputRecords = tableValue.records;
             return (
-              <div key={`output-table-${j}`}>
+              <div key={`output-table-${j}`} className={classes.tableContainer}>
                 {outputs.length > 1 ? <Heading type={HeadingTypes.h3} label={tableKey} /> : null}
                 <DataTable
                   headers={outputHeaders}

--- a/cdap-ui/cypress/integration/pipeline.joiner.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.joiner.spec.ts
@@ -110,7 +110,7 @@ describe('Running preview with joiner plugin in pipeline studio', () => {
     // Start and then immediately stop preview
     cy.get(dataCy('run-preview-btn')).click();
     cy.get(dataCy('stop-preview-btn')).click();
-    cy.get(dataCy('run-preview-btn'), { timeout: 30000 }).should('exist');
+    cy.get(dataCy('run-preview-btn'), { timeout: 35000 }).should('exist');
     cy.get(
       dataCy(`plugin-node-${sourceNode1.nodeName}-${sourceNode1.nodeType}-${sourceNode1.nodeId}`)
     ).within(() => {


### PR DESCRIPTION
To extend the line under the "Input/Output Record" header fully across the table. This change keeps the position of the header fixed while the table scrolls horizontally. 

JIRA: https://issues.cask.co/browse/CDAP-17117
Build: https://builds.cask.co/browse/CDAP-URUT304