### PR TITLE
[CDAP-17133] Modify tab styling for Preview record view

### DIFF
--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
@@ -43,6 +43,7 @@ const styles = (theme): StyleRules => ({
     borderBottom: `1px solid ${theme.palette.grey[400]}`,
     borderRight: `1px solid ${theme.palette.grey[400]}`,
     height: 'inherit',
+    overflowX: 'hidden',
     '& .record-pane': { width: '100%' },
     '& .cask-tab-headers': { overflowX: 'scroll' },
   },

--- a/cdap-ui/app/cdap/components/Tabs/Tabs.scss
+++ b/cdap-ui/app/cdap/components/Tabs/Tabs.scss
@@ -41,7 +41,7 @@
       width: 100%;
       display: flex;
       &:first-child {
-        height: 35px;
+        height: fit-content;
       }
       &:nth-child(2) {
         height: calc(100% - 35px);


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-17133
Build: https://builds.cask.co/browse/CDAP-URUT306

Removed unnecessary horizontal scrollbar and modified the height of tabs for horizontal configurable tabs to not break when using Chrome on Mac with scrollbars always on. 

Before changes, with scrollbar set to always on:

![Screen Shot 2020-07-29 at 6 47 40 PM](https://user-images.githubusercontent.com/16228294/88863961-1a221500-d1d2-11ea-8924-b5e69ba7b30d.png)

After changes, with scrollbar set to always on:
![Screen Shot 2020-07-29 at 7 23 53 PM](https://user-images.githubusercontent.com/16228294/88863969-1db59c00-d1d2-11ea-9911-f98f1f67b9dc.png)

After changes, with scrollbar set to only show based on mouse or trackpad:
![Screen Shot 2020-07-29 at 7 24 03 PM](https://user-images.githubusercontent.com/16228294/88863972-2017f600-d1d2-11ea-94ec-2dd800b049e8.png)


