### PR TITLE
[CDAP-17137] Fix preview stop bug and empty error message bug

### DIFF
--- a/cdap-ui/app/cdap/services/datasource/index.js
+++ b/cdap-ui/app/cdap/services/datasource/index.js
@@ -328,7 +328,7 @@ export default class Datasource {
     // stopping existing polls
     for (let key in this.bindings) {
       if (this.bindings[key].type === 'POLL') {
-        this.stopPoll(this.bindings[key].resource);
+        this.stopPoll(this.bindings[key].resource.id);
       }
     }
     this.bindings = {};

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -678,15 +678,31 @@ class HydratorPlusPlusTopPanelCtrl {
     };
     this.previewLoading = true;
     this.loadingLabel = 'Stopping';
-    this.stopTimer();
-    this.updateTimerLabelAndTitle();
     this.myPipelineApi
         .stopPreview(params, {})
         .$promise
         .then(
-          (err) => {
+          () => {
+            this.stopTimer();
+            this.updateTimerLabelAndTitle();
             this.previewLoading = false;
             this.previewRunning = false;
+            this.dataSrc.stopPoll(this.pollId);
+            this.pollId = null;
+
+            let pipelinePreviewPlaceholder = 'The preview of the pipeline';
+            let pipelineName = this.HydratorPlusPlusConfigStore.getName();
+            if (pipelineName.length > 0) {
+              pipelinePreviewPlaceholder += ` "${pipelineName}"`;
+            }
+            this.myAlertOnValium.show({
+              type: 'success',
+              content: `${pipelinePreviewPlaceholder} was stopped.`
+            });
+          },
+          (err) => {
+            this.previewLoading = false;
+            this.previewRunning = true;
             this.myAlertOnValium.show({type: 'danger', content: err.data});
         });
   }
@@ -698,6 +714,7 @@ class HydratorPlusPlusTopPanelCtrl {
       _cdapNsPath: '/previews/' + previewId + '/status',
       interval: 1000
     }, (res) => {
+      this.pollId = res.__pollId__;
       if (this.previewStore) {
         this.previewStore.dispatch({
           type: this.PREVIEWSTORE_ACTIONS.SET_PREVIEW_STATUS,
@@ -722,6 +739,7 @@ class HydratorPlusPlusTopPanelCtrl {
         this.stopTimer();
         this.previewRunning = false;
         this.dataSrc.stopPoll(res.__pollId__);
+        this.pollId = null;
         let pipelinePreviewPlaceholder = 'The preview of the pipeline';
         let pipelineName = this.HydratorPlusPlusConfigStore.getName();
         if (pipelineName.length > 0) {
@@ -732,11 +750,6 @@ class HydratorPlusPlusTopPanelCtrl {
             type: 'success',
             content: `${pipelinePreviewPlaceholder} has completed successfully.`
           });
-        } else if (res.status === KILLED) {
-          this.myAlertOnValium.show({
-            type: 'success',
-            content: `${pipelinePreviewPlaceholder} was stopped.`
-          });
         } else if (res.status === DEPLOY_FAILED || res.status === RUN_FAILED) {
           this.myAlertOnValium.show({
             type: 'danger',
@@ -746,6 +759,7 @@ class HydratorPlusPlusTopPanelCtrl {
       }
     }, (err) => {
       this.stopTimer();
+      this.updateTimerLabelAndTitle();
       let errorMsg = this.myHelpers.extractErrorMessage(err);
       this.myAlertOnValium.show({
         type: 'danger',
@@ -753,6 +767,7 @@ class HydratorPlusPlusTopPanelCtrl {
       });
       this.previewRunning = false;
       this.dataSrc.stopPoll(poll.__pollId__);
+      this.pollId = null;
     });
   }
 

--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -691,7 +691,7 @@ class HydratorPlusPlusTopPanelCtrl {
             this.pollId = null;
 
             let pipelinePreviewPlaceholder = 'The preview of the pipeline';
-            let pipelineName = this.HydratorPlusPlusConfigStore.getName();
+            const pipelineName = this.HydratorPlusPlusConfigStore.getName();
             if (pipelineName.length > 0) {
               pipelinePreviewPlaceholder += ` "${pipelineName}"`;
             }

--- a/cdap-ui/app/services/cask-angular-socket-datasource/datasource.js
+++ b/cdap-ui/app/services/cask-angular-socket-datasource/datasource.js
@@ -153,7 +153,7 @@ var socketDataSource = angular.module(PKG.name+'.services');
           Object.keys(self.bindings).forEach(function(key) {
             var b = self.bindings[key];
             if (b.poll) {
-              stopPoll(self.bindings, b.resource);
+              stopPoll(self.bindings, b.resource.id);
             }
           });
 
@@ -172,7 +172,7 @@ var socketDataSource = angular.module(PKG.name+'.services');
 
       function startClientPoll(resourceId, bindings, interval) {
         const intervalTimer = setTimeout(() => {
-          const resource = bindings[resourceId].resource;
+          const resource = bindings[resourceId]? bindings[resourceId].resource : undefined;
           if (!resource) {
             clearTimeout(intervalTimer);
             return;

--- a/cdap-ui/cypress/integration/pipeline.plugin.multipleendpoints.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.plugin.multipleendpoints.spec.ts
@@ -67,7 +67,7 @@ describe('Pipelines with plugins having more than one endpoints', () => {
       .clear()
       .type(unionConditionPipeline)
       .type('{enter}');
-  })
+  });
 
   after(() => {
     // Delete the pipeline to clean up


### PR DESCRIPTION
JIRA for empty error message: https://issues.cask.co/browse/CDAP-17138
JIRA for stopping preview: https://issues.cask.co/browse/CDAP-17137
Build: https://builds.cask.co/browse/CDAP-URUT309

- Fixed stopPreview callback so empty error message is not shown when user stops preview. 
- Changed preview status polling logic to stop polling when user tries to stop preview as long as the backend does not return error (instead of stopping polling once backend returns "KILLED" status) - this is to prevent the possibility of multiple preview runs running (and having their status polled for) at the same time
- Changed the stopPreview logic to allow user to retry stopping preview if previous attempt fails
- Fixed a few bugs in datasource (partial cherry-pick from #12017 )

