### PR TITLE
[CDAP-12499] Improved error message for conditional branches

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
@@ -670,8 +670,8 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
           paths += parent + "->" + currentStage;
         }
         String msg = String.format("Stage in the pipeline '%s' is on the branch of condition '%s'. However it also " +
-                                     "has following incoming paths: '%s', which is not supported.", currentStage,
-                                   currentCondition, paths);
+                                     "has following incoming paths: '%s'. Different branches of a condition cannot " +
+                                     "be inputs to the same stage.", currentStage, currentCondition, paths);
         throw new IllegalArgumentException(msg);
       }
     }


### PR DESCRIPTION
Improved error message for when conditional branches are used as inputs to a single stage.

See [CDAP-12499](https://issues.cask.co/browse/CDAP-12499).