### PR TITLE
[CDAP-16712] Implementation of RemotePreviewRequestFetcher.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewConfigModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewConfigModule.java
@@ -76,6 +76,9 @@ public class PreviewConfigModule extends AbstractModule {
     // Don't load custom log pipelines in preview
     previewCConf.unset(Constants.Logging.PIPELINE_CONFIG_DIR);
 
+    previewCConf.set(Constants.Logging.TMS_TOPIC_PREFIX, "previewlog");
+    previewCConf.setInt(Constants.Logging.NUM_PARTITIONS, 1);
+
     // Setup Hadoop configuration
     previewHConf = new Configuration(hConf);
     previewHConf.set(MRConfig.FRAMEWORK_NAME, MRConfig.LOCAL_FRAMEWORK_NAME);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewHttpServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewHttpServer.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.metrics.MetricsReporterHook;
 import io.cdap.cdap.common.security.HttpsEnabler;
 import io.cdap.cdap.gateway.handlers.preview.PreviewHttpHandler;
+import io.cdap.cdap.gateway.handlers.preview.PreviewHttpHandlerInternal;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.http.NettyHttpService;
@@ -39,6 +40,7 @@ import org.apache.twill.discovery.DiscoveryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 /**
@@ -56,13 +58,14 @@ public class PreviewHttpServer extends AbstractIdleService {
   @Inject
   PreviewHttpServer(CConfiguration cConf, SConfiguration sConf,
                     DiscoveryService discoveryService, PreviewHttpHandler previewHttpHandler,
+                    PreviewHttpHandlerInternal previewHttpHandlerInternal,
                     MetricsCollectionService metricsCollectionService,
                     PreviewManager previewManager) {
     this.discoveryService = discoveryService;
     NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf, Constants.Service.PREVIEW_HTTP)
       .setHost(cConf.get(Constants.Preview.ADDRESS))
       .setPort(cConf.getInt(Constants.Preview.PORT))
-      .setHttpHandlers(previewHttpHandler)
+      .setHttpHandlers(Arrays.asList(previewHttpHandler, previewHttpHandlerInternal))
       .setConnectionBacklog(cConf.getInt(Constants.Preview.BACKLOG_CONNECTIONS))
       .setExecThreadPoolSize(cConf.getInt(Constants.Preview.EXEC_THREADS))
       .setBossThreadPoolSize(cConf.getInt(Constants.Preview.BOSS_THREADS))

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewManager.java
@@ -26,6 +26,8 @@ import io.cdap.cdap.proto.id.ProgramRunId;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Interface used for managing the preview runs.
@@ -82,4 +84,11 @@ public interface PreviewManager {
    * @return the {@link LogReader} for reading logs for the given preview
    */
   LogReader getLogReader();
+
+  /**
+   * Poll the next available request in the queue.
+   * @param pollerInfo information about the poller
+   * @return {@code PreviewRequest} if such request is available in the queue
+   */
+  Optional<PreviewRequest> poll(@Nullable byte[] pollerInfo);
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRequestQueue.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRequestQueue.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import net.jcip.annotations.ThreadSafe;
 
 import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Interface designed for holding {@link PreviewRequest}s that are in WAITING state.
@@ -30,10 +31,10 @@ import java.util.Optional;
 public interface PreviewRequestQueue {
   /**
    * Poll the next available request in the queue.
-   * @param pollerInfo information about the poller
+   * @param pollerInfo information about the poller.
    * @return {@code PreviewRequest} if such request is available in the queue
    */
-  Optional<PreviewRequest> poll(byte[] pollerInfo);
+  Optional<PreviewRequest> poll(@Nullable byte[] pollerInfo);
 
   /**
    * Add a preview request in the queue.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerManagerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerManagerModule.java
@@ -16,44 +16,99 @@
 
 package io.cdap.cdap.app.preview;
 
+import com.google.inject.Exposed;
+import com.google.inject.Module;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Names;
+import io.cdap.cdap.common.runtime.RuntimeModule;
 import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data2.datafabric.dataset.RemoteDatasetFramework;
 import io.cdap.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.dataset2.DefaultDatasetDefinitionRegistryFactory;
-import io.cdap.cdap.internal.app.preview.DirectPreviewRequestFetcherFactory;
-import io.cdap.cdap.internal.app.preview.PreviewRequestFetcherFactory;
-import io.cdap.cdap.internal.app.preview.PreviewRunnerServiceStopper;
+import io.cdap.cdap.internal.app.preview.DirectPreviewRequestFetcher;
+import io.cdap.cdap.internal.app.preview.PreviewRequestFetcher;
+import io.cdap.cdap.internal.app.preview.PreviewRunStopper;
+import io.cdap.cdap.internal.app.preview.PreviewRunnerService;
+import io.cdap.cdap.internal.app.preview.RemotePreviewRequestFetcher;
+import org.apache.twill.discovery.DiscoveryServiceClient;
 
 /**
  * Guice module to provide bindings for {@link PreviewRunnerManager} service.
  */
-public class PreviewRunnerManagerModule extends PrivateModule {
+public class PreviewRunnerManagerModule extends RuntimeModule {
+
   @Override
-  protected void configure() {
-    bind(DatasetDefinitionRegistryFactory.class)
-      .to(DefaultDatasetDefinitionRegistryFactory.class).in(Scopes.SINGLETON);
-
-    bind(DatasetFramework.class)
-      .annotatedWith(Names.named(DataSetsModules.BASE_DATASET_FRAMEWORK))
-      .to(RemoteDatasetFramework.class);
-    bind(PreviewRunnerModule.class).to(DefaultPreviewRunnerModule.class);
-
-    bind(DefaultPreviewRunnerManager.class).in(Scopes.SINGLETON);
-    bind(PreviewRunnerServiceStopper.class).to(DefaultPreviewRunnerManager.class);
-    expose(PreviewRunnerServiceStopper.class);
-    bind(PreviewRunnerManager.class).to(DefaultPreviewRunnerManager.class);
-    expose(PreviewRunnerManager.class);
+  public Module getInMemoryModules() {
+    return getStandaloneModules();
   }
 
-  @Provides
-  @Singleton
-  PreviewRequestFetcherFactory getPreviewRequestQueueFetcher(PreviewRequestQueue previewRequestQueue) {
-    return new DirectPreviewRequestFetcherFactory(previewRequestQueue);
+  @Override
+  public Module getStandaloneModules() {
+
+    return new PrivateModule() {
+      @Override
+      protected void configure() {
+        bind(DatasetDefinitionRegistryFactory.class)
+          .to(DefaultDatasetDefinitionRegistryFactory.class).in(Scopes.SINGLETON);
+
+        bind(DatasetFramework.class)
+          .annotatedWith(Names.named(DataSetsModules.BASE_DATASET_FRAMEWORK))
+          .to(RemoteDatasetFramework.class);
+        bind(PreviewRunnerModule.class).to(DefaultPreviewRunnerModule.class);
+
+        bind(DefaultPreviewRunnerManager.class).in(Scopes.SINGLETON);
+        bind(PreviewRunStopper.class).to(DefaultPreviewRunnerManager.class);
+        expose(PreviewRunStopper.class);
+        bind(PreviewRunnerManager.class).to(DefaultPreviewRunnerManager.class);
+        expose(PreviewRunnerManager.class);
+
+        install(new FactoryModuleBuilder()
+                  .implement(PreviewRunnerService.class, PreviewRunnerService.class)
+                  .build(PreviewRunnerServiceFactory.class));
+      }
+
+      @Provides
+      @Singleton
+      @Exposed
+      PreviewRequestFetcher getPreviewRequestQueueFetcher(PreviewRequestQueue previewRequestQueue) {
+        return new DirectPreviewRequestFetcher(previewRequestQueue);
+      }
+    };
+  }
+
+  @Override
+  public Module getDistributedModules() {
+    return new PrivateModule() {
+      @Override
+      protected void configure() {
+        bind(DatasetDefinitionRegistryFactory.class)
+          .to(DefaultDatasetDefinitionRegistryFactory.class).in(Scopes.SINGLETON);
+
+        bind(DatasetFramework.class)
+          .annotatedWith(Names.named(DataSetsModules.BASE_DATASET_FRAMEWORK))
+          .to(RemoteDatasetFramework.class);
+        bind(PreviewRunnerModule.class).to(DefaultPreviewRunnerModule.class);
+
+        bind(DefaultPreviewRunnerManager.class).in(Scopes.SINGLETON);
+        bind(PreviewRunnerManager.class).to(DefaultPreviewRunnerManager.class);
+        expose(PreviewRunnerManager.class);
+
+        install(new FactoryModuleBuilder()
+                  .implement(PreviewRunnerService.class, PreviewRunnerService.class)
+                  .build(PreviewRunnerServiceFactory.class));
+      }
+
+      @Provides
+      @Singleton
+      @Exposed
+      PreviewRequestFetcher getPreviewRequestQueueFetcher(DiscoveryServiceClient discoveryServiceClient) {
+        return new RemotePreviewRequestFetcher(discoveryServiceClient, new byte[0]);
+      }
+    };
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerServiceFactory.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerServiceFactory.java
@@ -16,10 +16,16 @@
 
 package io.cdap.cdap.app.preview;
 
-import io.cdap.cdap.internal.app.preview.PreviewRunStopper;
+import io.cdap.cdap.internal.app.preview.PreviewRunnerService;
 
 /**
- * It is just a tagging interface for guice binding of {@link DefaultPreviewRunnerManager}.
+ * Factory for creating {@link PreviewRunnerService} instances.
  */
-public interface PreviewRunnerManager extends PreviewRunStopper {
+public interface PreviewRunnerServiceFactory {
+  /**
+   * Creates an instance of {@link PreviewRunnerService}.
+   * @param runner runner used by service to run preview
+   * @return an instance of {@link PreviewRunnerService}
+   */
+  PreviewRunnerService create(PreviewRunner runner);
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/preview/PreviewHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/preview/PreviewHttpHandlerInternal.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers.preview;
+
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.app.preview.PreviewManager;
+import io.cdap.cdap.app.preview.PreviewRequest;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+
+/**
+ * Internal {@link HttpHandler} for Preview system.
+ */
+@Singleton
+@Path(Constants.Gateway.INTERNAL_API_VERSION_3 + "/previews")
+public class PreviewHttpHandlerInternal extends AbstractHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(PreviewHttpHandlerInternal.class);
+  private static final Gson GSON = new Gson();
+  private final PreviewManager previewManager;
+
+  @Inject
+  PreviewHttpHandlerInternal(PreviewManager previewManager) {
+    this.previewManager = previewManager;
+  }
+
+  @POST
+  @Path("/requests/pull")
+  public void poll(FullHttpRequest request, HttpResponder responder) throws Exception {
+    byte[] pollerInfo = Bytes.toBytes(request.content().nioBuffer());
+    Optional<PreviewRequest> previewRequestOptional = previewManager.poll(pollerInfo);
+    if (previewRequestOptional.isPresent()) {
+      LOG.info("Received poller info is {}", Bytes.toString(pollerInfo));
+      responder.sendString(HttpResponseStatus.OK, GSON.toJson(previewRequestOptional.get()));
+    } else {
+      responder.sendStatus(HttpResponseStatus.OK);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRequestQueue.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRequestQueue.java
@@ -38,6 +38,7 @@ import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Thread-safe implementation of {@link PreviewRequestQueue} backed by {@link PreviewStore}.
@@ -63,7 +64,7 @@ public class DefaultPreviewRequestQueue implements PreviewRequestQueue {
   }
 
   @Override
-  public Optional<PreviewRequest> poll(byte[] pollerInfo) {
+  public Optional<PreviewRequest> poll(@Nullable byte[] pollerInfo) {
     while (true) {
       PreviewRequest previewRequest = requestQueue.poll();
       if (previewRequest == null) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DirectPreviewRequestFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DirectPreviewRequestFetcher.java
@@ -17,22 +17,24 @@
 package io.cdap.cdap.internal.app.preview;
 
 import com.google.inject.Inject;
+import io.cdap.cdap.app.preview.PreviewRequest;
 import io.cdap.cdap.app.preview.PreviewRequestQueue;
 
-/**
- * Factory for creating {@link PreviewRequestFetcher} that fetches the requests directly from the
- * {@link PreviewRequestQueue}.
- */
-public class DirectPreviewRequestFetcherFactory implements PreviewRequestFetcherFactory {
-  private final PreviewRequestQueue requestQueue;
+import java.io.IOException;
+import java.util.Optional;
 
-  @Inject
-  public DirectPreviewRequestFetcherFactory(PreviewRequestQueue requestQueue) {
-    this.requestQueue = requestQueue;
+/**
+ * Implementation of {@link PreviewRequestFetcher} which fetches directly from {@link PreviewRequestQueue}.
+ */
+public class DirectPreviewRequestFetcher implements PreviewRequestFetcher {
+  private final PreviewRequestQueue previewRequestQueue;
+
+  public DirectPreviewRequestFetcher(PreviewRequestQueue previewRequestQueue) {
+    this.previewRequestQueue = previewRequestQueue;
   }
 
   @Override
-  public PreviewRequestFetcher create(byte[] pollerInfo) {
-    return () -> requestQueue.poll(pollerInfo);
+  public Optional<PreviewRequest> fetch() throws IOException {
+    return previewRequestQueue.poll(null);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRequestPollerInfoProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRequestPollerInfoProvider.java
@@ -14,16 +14,15 @@
  * the License.
  */
 
+
 package io.cdap.cdap.internal.app.preview;
 
 /**
- * Interface to kill the preview runner service.
+ * Interface that provides poller info used for polling the preview requests.
  */
-public interface PreviewRunnerServiceStopper {
+public interface PreviewRequestPollerInfoProvider {
   /**
-   * Stops the {@link PreviewRunnerService} identified by the runner id.
-   * @param runnerId id of the preview runner service to be stopped
-   * @throws Exception if any error while stopping
+   * @return the poller info in generic byte array
    */
-  void stop(byte[] runnerId) throws Exception;
+  byte[] get();
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunStopper.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunStopper.java
@@ -14,12 +14,18 @@
  * the License.
  */
 
-package io.cdap.cdap.app.preview;
+package io.cdap.cdap.internal.app.preview;
 
-import io.cdap.cdap.internal.app.preview.PreviewRunStopper;
+import io.cdap.cdap.proto.id.ApplicationId;
 
 /**
- * It is just a tagging interface for guice binding of {@link DefaultPreviewRunnerManager}.
+ * Interface to kill the preview runner service.
  */
-public interface PreviewRunnerManager extends PreviewRunStopper {
+public interface PreviewRunStopper {
+  /**
+   * Stops the preview as identified by the application id.
+   * @param preview id of the preview application to be stopped
+   * @throws Exception if any error while stopping
+   */
+  void stop(ApplicationId preview) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewTMSLogSubscriber.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewTMSLogSubscriber.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.preview;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.cdap.cdap.api.messaging.Message;
+import io.cdap.cdap.api.messaging.MessagingContext;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.app.preview.PreviewConfigModule;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.common.utils.ImmutablePair;
+import io.cdap.cdap.internal.app.runtime.monitor.RemoteExecutionLogProcessor;
+import io.cdap.cdap.internal.app.store.AppMetadataStore;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
+import io.cdap.cdap.messaging.subscriber.AbstractMessagingSubscriberService;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.spi.data.StructuredTableContext;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import org.apache.tephra.TxConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Iterator;
+import javax.annotation.Nullable;
+
+/**
+ * TMS Log subscriber for preview logs.
+ */
+public class PreviewTMSLogSubscriber extends AbstractMessagingSubscriberService<Iterator<byte[]>> {
+  private static final Logger LOG = LoggerFactory.getLogger(PreviewTMSLogSubscriber.class);
+  private static final String CONSUMER_NAME = "preview.log.writer";
+  private static final String TOPIC_NAME = "previewlog0";
+
+  private final MultiThreadMessagingContext messagingContext;
+  private final TransactionRunner transactionRunner;
+  private final RemoteExecutionLogProcessor logProcessor;
+  private final int maxRetriesOnError;
+  private int errorCount = 0;
+  private String erroredMessageId = null;
+
+  @Inject
+  PreviewTMSLogSubscriber(CConfiguration cConf,
+                          @Named(PreviewConfigModule.GLOBAL_TMS) MessagingService messagingService,
+                          MetricsCollectionService metricsCollectionService,
+                          TransactionRunner transactionRunner, RemoteExecutionLogProcessor logProcessor) {
+    super(
+      NamespaceId.SYSTEM.topic(TOPIC_NAME),
+      cConf.getInt(Constants.Metadata.MESSAGING_FETCH_SIZE),
+      cConf.getInt(TxConstants.Manager.CFG_TX_TIMEOUT),
+      cConf.getLong(Constants.Metadata.MESSAGING_POLL_DELAY_MILLIS),
+      RetryStrategies.fromConfiguration(cConf, "system.preview."),
+      metricsCollectionService.getContext(
+        ImmutableMap.of(Constants.Metrics.Tag.COMPONENT, Constants.Service.PREVIEW_HTTP,
+                        Constants.Metrics.Tag.INSTANCE_ID, "0",
+                        Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace(),
+                        Constants.Metrics.Tag.TOPIC, TOPIC_NAME,
+                        Constants.Metrics.Tag.CONSUMER, CONSUMER_NAME
+      )));
+
+    this.messagingContext = new MultiThreadMessagingContext(messagingService);
+    this.transactionRunner = transactionRunner;
+    this.maxRetriesOnError = cConf.getInt(Constants.Metadata.MESSAGING_RETRIES_ON_CONFLICT);
+    this.logProcessor = logProcessor;
+  }
+
+  @Override
+  protected TransactionRunner getTransactionRunner() {
+    return transactionRunner;
+  }
+
+  @Nullable
+  @Override
+  protected String loadMessageId(StructuredTableContext context) throws Exception {
+    AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
+    return appMetadataStore.retrieveSubscriberState(getTopicId().getTopic(), CONSUMER_NAME);
+  }
+
+  @Override
+  protected void storeMessageId(StructuredTableContext context, String messageId) throws Exception {
+    AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
+    appMetadataStore.persistSubscriberState(getTopicId().getTopic(), CONSUMER_NAME, messageId);
+  }
+
+  @Override
+  protected void processMessages(StructuredTableContext structuredTableContext,
+                                 Iterator<ImmutablePair<String, Iterator<byte[]>>> messages) throws Exception {
+    while (messages.hasNext()) {
+      ImmutablePair<String, Iterator<byte[]>> next = messages.next();
+      String messageId = next.getFirst();
+      Iterator<byte[]> message = next.getSecond();
+      try {
+        logProcessor.process(message);
+      } catch (Exception e) {
+        if (messageId.equals(erroredMessageId)) {
+          errorCount++;
+          if (errorCount >= maxRetriesOnError) {
+            LOG.warn("Skipping preview message {} after processing it has caused {} consecutive errors: {}",
+                     message, errorCount, e.getMessage());
+            continue;
+          }
+        } else {
+          erroredMessageId = messageId;
+          errorCount = 1;
+        }
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  protected MessagingContext getMessagingContext() {
+    return messagingContext;
+  }
+
+  @Override
+  protected Iterator<byte[]> decodeMessage(Message message) throws Exception {
+    return Collections.singletonList(message.getPayload()).iterator();
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/RemotePreviewRequestFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/RemotePreviewRequestFetcher.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.preview;
+
+import com.google.common.base.Charsets;
+import com.google.gson.Gson;
+import io.cdap.cdap.app.preview.PreviewRequest;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpResponse;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+/**
+ * Fetch preview requests from remote server.
+ */
+public class RemotePreviewRequestFetcher implements PreviewRequestFetcher {
+  private final RemoteClient remoteClientInternal;
+  private final byte[] pollerInfo;
+  private static final Gson GSON = new Gson();
+
+  public RemotePreviewRequestFetcher(DiscoveryServiceClient discoveryServiceClient, byte[] pollerInfo) {
+    this.remoteClientInternal = new RemoteClient(discoveryServiceClient, Constants.Service.PREVIEW_HTTP,
+                                                 new DefaultHttpRequestConfig(false),
+                                                 Constants.Gateway.INTERNAL_API_VERSION_3 + "/previews");
+    this.pollerInfo = pollerInfo;
+  }
+
+  @Override
+  public Optional<PreviewRequest> fetch() throws IOException {
+    HttpRequest.Builder builder = remoteClientInternal.requestBuilder(HttpMethod.POST, "requests/pull");
+    builder.withBody(ByteBuffer.wrap(pollerInfo));
+    HttpResponse httpResponse = remoteClientInternal.execute(builder.build());
+    if (httpResponse.getResponseCode() == 200) {
+      PreviewRequest previewRequest = GSON.fromJson(httpResponse.getResponseBodyAsString(), PreviewRequest.class);
+      return Optional.ofNullable(previewRequest);
+    }
+    throw new IOException(String.format("Received status code:%s and body: %s", httpResponse.getResponseCode(),
+                                        httpResponse.getResponseBodyAsString(Charsets.UTF_8)));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/k8s/PreviewRequestPollerInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/k8s/PreviewRequestPollerInfo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.k8s;
+
+/**
+ * Poller information holder.
+ */
+public class PreviewRequestPollerInfo {
+  private final int instanceId;
+  private final String instanceUid;
+
+  public PreviewRequestPollerInfo(String instanceName, String instanceUid) {
+    // Since preview runners are launched as statefulsets in K8s, container name for the
+    // preview runner is of the form preview-runner-<ordinal> where ordinal is numeric value such
+    // as 0, 1, 2..
+    // We need to just pass the ordinal as instance id so that correct pod can be killed.
+    String[] parts = instanceName.split("-");
+    this.instanceId = Integer.parseInt(parts[parts.length - 1]);
+    this.instanceUid = instanceUid;
+  }
+
+  public int getInstanceId() {
+    return instanceId;
+  }
+
+  public String getInstanceUid() {
+    return instanceUid;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/k8s/PreviewRunnerOptions.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/k8s/PreviewRunnerOptions.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (C) 2020 The Guava Authors
+ * Copyright © 2020 Cask Data, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package io.cdap.cdap.internal.app.runtime.k8s;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManagerTest.java
@@ -40,7 +40,6 @@ import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data.runtime.TransactionExecutorModule;
 import io.cdap.cdap.explore.guice.ExploreClientModule;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
-import io.cdap.cdap.logging.guice.LocalLogAppenderModule;
 import io.cdap.cdap.logging.guice.LogReaderRuntimeModules;
 import io.cdap.cdap.logging.read.LogReader;
 import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
@@ -92,7 +91,6 @@ public class DefaultPreviewManagerTest {
       new AppFabricServiceRuntimeModule().getInMemoryModules(),
       new ProgramRunnerRuntimeModule().getInMemoryModules(),
       new NonCustomLocationUnitTestModule(),
-      new LocalLogAppenderModule(),
       new LogReaderRuntimeModules().getInMemoryModules(),
       new MetricsClientRuntimeModule().getInMemoryModules(),
       new ExploreClientModule(),
@@ -112,7 +110,7 @@ public class DefaultPreviewManagerTest {
           bind(UGIProvider.class).to(UnsupportedUGIProvider.class);
           bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);
           // bind PreviewRunnerStopper to Mock implementation
-          bind(PreviewRunnerServiceStopper.class).toInstance(runnerId -> {
+          bind(PreviewRunStopper.class).toInstance(runnerId -> {
 
           });
         }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewRunnerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewRunnerServiceTest.java
@@ -56,7 +56,7 @@ public class PreviewRunnerServiceTest {
   public void testStartAndStop() throws InterruptedException, ExecutionException, TimeoutException {
     MockPreviewRunner mockRunner = new MockPreviewRunner();
     MockPreviewRequestFetcher fetcher = new MockPreviewRequestFetcher();
-    PreviewRunnerService runnerService = new PreviewRunnerService(createCConf(), mockRunner, fetcher);
+    PreviewRunnerService runnerService = new PreviewRunnerService(createCConf(), fetcher, mockRunner);
     runnerService.startAndWait();
 
     Tasks.waitFor(true, () -> fetcher.fetchCount.get() > 0, 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
@@ -68,7 +68,7 @@ public class PreviewRunnerServiceTest {
   public void testStopPreview() throws InterruptedException, ExecutionException, TimeoutException {
     MockPreviewRunner mockRunner = new MockPreviewRunner();
     MockPreviewRequestFetcher fetcher = new MockPreviewRequestFetcher();
-    PreviewRunnerService runnerService = new PreviewRunnerService(createCConf(), mockRunner, fetcher);
+    PreviewRunnerService runnerService = new PreviewRunnerService(createCConf(), fetcher, mockRunner);
     runnerService.startAndWait();
 
     ProgramId programId = NamespaceId.DEFAULT.app("app").program(ProgramType.WORKFLOW, "workflow");
@@ -89,7 +89,7 @@ public class PreviewRunnerServiceTest {
 
     MockPreviewRunner mockRunner = new MockPreviewRunner();
     MockPreviewRequestFetcher fetcher = new MockPreviewRequestFetcher();
-    PreviewRunnerService runnerService = new PreviewRunnerService(cConf, mockRunner, fetcher);
+    PreviewRunnerService runnerService = new PreviewRunnerService(cConf, fetcher, mockRunner);
     runnerService.startAndWait();
 
     ProgramId programId = NamespaceId.DEFAULT.app("app").program(ProgramType.WORKFLOW, "workflow");

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -550,6 +550,12 @@ public final class Constants {
     public static final String API_VERSION_3_TOKEN = "v3";
     public static final String API_VERSION_3 = "/" + API_VERSION_3_TOKEN;
     public static final String API_KEY = "X-ApiKey";
+
+    /**
+     * Internal API
+     */
+    public static final String INTERNAL_API_VERSION_3_TOKEN = "v3Internal";
+    public static final String INTERNAL_API_VERSION_3 = "/" + INTERNAL_API_VERSION_3_TOKEN;
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2170,7 +2170,7 @@
 
   <property>
     <name>messaging.system.topics</name>
-    <value>${audit.topic},${metadata.messaging.topic},${data.event.topic},${metrics.topic.prefix}:${metrics.messaging.topic.num},${metrics.admin.topic},${time.event.topic},${program.status.event.topic},${program.status.record.event.topic},${log.tms.topic.prefix}:${log.publish.num.partitions},${preview.messaging.topic}</value>
+    <value>${audit.topic},${metadata.messaging.topic},${data.event.topic},${metrics.topic.prefix}:${metrics.messaging.topic.num},${metrics.admin.topic},${time.event.topic},${program.status.event.topic},${program.status.record.event.topic},${log.tms.topic.prefix}:${log.publish.num.partitions},${preview.messaging.topic},previewlog0</value>
     <description>
       A comma-separated list of topics that are always available in the
       system namespace. Multiple topics sharing the same prefix and

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
@@ -93,6 +93,7 @@ public class MasterServiceMainTestBase {
     // Set router to bind to random port
     cConf.setInt(Constants.Router.ROUTER_PORT, 0);
     cConf.setInt(Constants.Router.ROUTER_SSL_PORT, 0);
+    cConf.setInt(Constants.Preview.CACHE_SIZE, 1);
 
     // Start the master main services
     serviceManagers.put(RouterServiceMain.class, runMain(cConf, sConf, RouterServiceMain.class));

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -532,7 +532,7 @@ public class StandaloneMain {
       new AuthorizationEnforcementModule().getStandaloneModules(),
       new PreviewConfigModule(cConf, new Configuration(), SConfiguration.create()),
       new PreviewHttpModule(),
-      new PreviewRunnerManagerModule(),
+      new PreviewRunnerManagerModule().getStandaloneModules(),
       new MessagingServerRuntimeModule().getStandaloneModules(),
       new AppFabricServiceRuntimeModule().getStandaloneModules(),
       new MonitorHandlerModule(false),

--- a/cdap-standalone/src/test/java/io/cdap/cdap/StandaloneMainTest.java
+++ b/cdap-standalone/src/test/java/io/cdap/cdap/StandaloneMainTest.java
@@ -21,7 +21,7 @@ import io.cdap.cdap.app.preview.PreviewManager;
 import io.cdap.cdap.app.preview.PreviewRunnerManager;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.gateway.handlers.preview.PreviewHttpHandler;
-import io.cdap.cdap.internal.app.preview.PreviewRunnerServiceStopper;
+import io.cdap.cdap.internal.app.preview.PreviewRunStopper;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionManager;
 import org.junit.Assert;
@@ -38,10 +38,10 @@ public class StandaloneMainTest {
     Assert.assertNotNull(sdk.getInjector().getInstance(PreviewHttpHandler.class));
     PreviewManager previewManager = sdk.getInjector().getInstance(PreviewManager.class);
     PreviewRunnerManager previewRunnerManager = sdk.getInjector().getInstance(PreviewRunnerManager.class);
-    PreviewRunnerServiceStopper previewRunnerServiceStopper
-      = sdk.getInjector().getInstance(PreviewRunnerServiceStopper.class);
+    PreviewRunStopper previewRunStopper
+      = sdk.getInjector().getInstance(PreviewRunStopper.class);
 
-    Assert.assertSame(previewRunnerManager, previewRunnerServiceStopper);
+    Assert.assertSame(previewRunnerManager, previewRunStopper);
     TransactionManager txManager = sdk.getInjector().getInstance(TransactionManager.class);
     txManager.startAndWait();
     ((Service) previewManager).startAndWait();

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -277,7 +277,7 @@ public class TestBase {
       new MessagingServerRuntimeModule().getInMemoryModules(),
       new PreviewConfigModule(cConf, new Configuration(), SConfiguration.create()),
       new PreviewHttpModule(),
-      new PreviewRunnerManagerModule(),
+      new PreviewRunnerManagerModule().getInMemoryModules(),
       new MockProvisionerModule(),
       new AbstractModule() {
         @Override

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/tms/PreviewTMSLogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/tms/PreviewTMSLogAppender.java
@@ -14,12 +14,21 @@
  * the License.
  */
 
-package io.cdap.cdap.app.preview;
+package io.cdap.cdap.logging.appender.tms;
 
-import io.cdap.cdap.internal.app.preview.PreviewRunStopper;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.messaging.MessagingService;
 
 /**
- * It is just a tagging interface for guice binding of {@link DefaultPreviewRunnerManager}.
+ * TMS Log Appender used for Preview. Only difference with {@link TMSLogAppender} is
+ * an instance of MessagingService it receives.
  */
-public interface PreviewRunnerManager extends PreviewRunStopper {
+public class PreviewTMSLogAppender extends TMSLogAppender  {
+  @Inject
+  PreviewTMSLogAppender(CConfiguration cConf,
+                        @Named("globalTMS") MessagingService messagingService) {
+    super(cConf, messagingService);
+  }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/tms/TMSLogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/tms/TMSLogAppender.java
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Log appender that publishes log messages to TMS.
  */
-public final class TMSLogAppender extends LogAppender {
+public class TMSLogAppender extends LogAppender {
 
   private static final String APPENDER_NAME = "TMSLogAppender";
 


### PR DESCRIPTION
Separating preview manager and preview runner to be run in different pods.

Cherry-pick #12524 to release/6.1

Conflicts in following files
```
both added:      cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/k8s/PreviewRunnerOptions.java
	both modified:   cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
	both modified:   cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
```

Took version from release/6.1 branch since mostly they were in `PreviewServiceMainTest` and which has divergence.