### PR TITLE
[CDAP-17145] Use submitTime when resetting preview timer

### DIFF
--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -94,7 +94,7 @@ class HydratorPlusPlusTopPanelCtrl {
         previewId : this.currentPreviewId
       }).$promise.then(
         (statusRes) => {
-          this.previewStartTime = statusRes.startTime;
+          this.previewStartTime = statusRes.submitTime;
           this.previewLoading = false;
 
           this.previewStore.dispatch({


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-17145
Build: https://builds.cask.co/browse/CDAP-URUT313

Previously we looked for the startTime in the backend response when resetting the timer in Preview. However, startTime only exists on the backend response when the run has started (i.e. not in INIT or WAITING) even though the UI timer starts before the run starts. A new field submitTime was added to the response, which can now be used by the UI to more accurately reset the timer when a user refreshes the page or otherwise navigates away from preview while it is running (or waiting). 

Related to https://github.com/cdapio/cdap/pull/12589