### PR TITLE
CDAP-17078 implement stage consolidation for streaming pipelines

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.api.data.DatasetContext;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.lib.FileSet;
 import io.cdap.cdap.api.dataset.lib.FileSetProperties;
+import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
 import io.cdap.cdap.api.spark.JavaSparkMain;
 import io.cdap.cdap.etl.api.AlertPublisher;
@@ -40,12 +41,18 @@ import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
 import io.cdap.cdap.etl.api.streaming.Windower;
+import io.cdap.cdap.etl.common.BasicArguments;
 import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
 import io.cdap.cdap.etl.common.PhaseSpec;
 import io.cdap.cdap.etl.common.PipelinePhase;
+import io.cdap.cdap.etl.common.PipelineRuntime;
 import io.cdap.cdap.etl.common.plugin.PipelinePluginContext;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.SparkPipelineRuntime;
 import io.cdap.cdap.etl.spark.StreamingCompat;
+import io.cdap.cdap.etl.spark.batch.SparkPreparer;
+import io.cdap.cdap.etl.spark.streaming.SparkStreamingPreparer;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -62,6 +69,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -186,12 +194,23 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
                                    JavaSparkExecutionContext sec,
                                    @Nullable String checkpointDir,
                                    @Nullable JavaSparkContext context) throws Exception {
+
+    PipelinePluginContext pluginContext = new PipelinePluginContext(sec.getPluginContext(), sec.getMetrics(),
+                                                                    pipelineSpec.isStageLoggingEnabled(),
+                                                                    pipelineSpec.isProcessTimingEnabled());
+    PipelineRuntime pipelineRuntime = new SparkPipelineRuntime(sec);
+    MacroEvaluator evaluator = new DefaultMacroEvaluator(pipelineRuntime.getArguments(),
+                                                         sec.getLogicalStartTime(), sec,
+                                                         sec.getNamespace());
+    SparkStreamingPreparer preparer = new SparkStreamingPreparer(pluginContext, sec.getMetrics(), evaluator,
+                                                                 pipelineRuntime, sec);
     try {
-      SparkFieldLineageRecorder recorder = new SparkFieldLineageRecorder(sec, pipelinePhase, pipelineSpec);
+      SparkFieldLineageRecorder recorder = new SparkFieldLineageRecorder(sec, pipelinePhase, pipelineSpec, preparer);
       recorder.record();
     } catch (Exception e) {
       LOG.warn("Failed to emit field lineage operations for streaming pipeline", e);
     }
+    Set<String> uncombinableSinks = preparer.getUncombinableSinks();
 
     // the content in the function might not run due to spark checkpointing, currently just have the lineage logic
     // before anything is run
@@ -201,17 +220,17 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
         javaSparkContext, Durations.milliseconds(pipelineSpec.getBatchIntervalMillis()));
       SparkStreamingPipelineRunner runner = new SparkStreamingPipelineRunner(sec, jssc, pipelineSpec,
                                                                              pipelineSpec.isCheckpointsDisabled());
-      PipelinePluginContext pluginContext = new PipelinePluginContext(sec.getPluginContext(), sec.getMetrics(),
-                                                                      pipelineSpec.isStageLoggingEnabled(),
-                                                                      pipelineSpec.isProcessTimingEnabled());
+
       // TODO: figure out how to get partitions to use for aggregators and joiners.
       // Seems like they should be set at configure time instead of runtime? but that requires an API change.
       try {
         PhaseSpec phaseSpec = new PhaseSpec(sec.getApplicationSpecification().getName(), pipelinePhase,
                                             Collections.emptyMap(), pipelineSpec.isStageLoggingEnabled(),
                                             pipelineSpec.isProcessTimingEnabled());
+        boolean shouldConsolidateStages = Boolean.parseBoolean(
+          sec.getRuntimeArguments().getOrDefault(Constants.CONSOLIDATE_STAGES, Boolean.FALSE.toString()));
         runner.runPipeline(phaseSpec, StreamingSource.PLUGIN_TYPE, sec, Collections.emptyMap(),
-                           pluginContext, Collections.emptyMap(), Collections.emptySet(), false);
+                           pluginContext, Collections.emptyMap(), uncombinableSinks, shouldConsolidateStages);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
@@ -17,9 +17,11 @@
 package io.cdap.cdap.etl.spark;
 
 import io.cdap.cdap.api.dataset.lib.KeyValue;
+import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
 import io.cdap.cdap.etl.api.streaming.Windower;
+import io.cdap.cdap.etl.common.PhaseSpec;
 import io.cdap.cdap.etl.common.RecordInfo;
 import io.cdap.cdap.etl.common.StageStatisticsCollector;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
@@ -28,6 +30,7 @@ import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -69,8 +72,8 @@ public interface SparkCollection<T> {
 
   Runnable createStoreTask(StageSpec stageSpec, PairFlatMapFunction<T, Object, Object> sinkFunction);
 
-  Runnable createMultiStoreTask(Set<String> sinkNames,
-                                PairFlatMapFunction<T, String, KeyValue<Object, Object>> multiSinkFunction);
+  Runnable createMultiStoreTask(PhaseSpec phaseSpec, Set<String> group, Set<String> sinks,
+                                Map<String, StageStatisticsCollector> collectors);
 
   Runnable createStoreTask(StageSpec stageSpec, SparkSink<T> sink) throws Exception;
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -423,9 +423,9 @@ public abstract class SparkPipelineRunner {
       fullInput = fullInput.union(inputData);
     }
 
-    Set<String> groupSinks = Sets.intersection(groupStages, phaseSpec.getPhase().getSinks());
-    return fullInput.createMultiStoreTask(
-      groupSinks, Compat.convert(new MultiSinkFunction(sec, phaseSpec, groupStages, collectors)));
+    // Sets.intersection returns an unserializable Set, so copy it into a HashSet.
+    Set<String> groupSinks = new HashSet<>(Sets.intersection(groupStages, phaseSpec.getPhase().getSinks()));
+    return fullInput.createMultiStoreTask(phaseSpec, groupStages, groupSinks, collectors);
   }
 
   protected SparkCollection<Object> handleJoin(Map<String, SparkCollection<Object>> inputDataCollections,

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/SparkStreamingPreparer.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/SparkStreamingPreparer.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.etl.spark.batch.SparkBatchSinkContext;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -49,6 +50,10 @@ public class SparkStreamingPreparer extends AbstractSparkPreparer {
                                 PipelineRuntime pipelineRuntime, JavaSparkExecutionContext context) {
     super(pluginContext, metrics, macroEvaluator, pipelineRuntime, context.getAdmin(), context);
     this.context = context;
+  }
+
+  public Set<String> getUncombinableSinks() {
+    return sinkFactory.getUncombinableSinks();
   }
 
   @Nullable

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
@@ -57,8 +57,7 @@ public class StreamingBatchSinkFunction<T> implements Function2<JavaRDD<T>, Time
   private final JavaSparkExecutionContext sec;
   private final StageSpec stageSpec;
 
-  public StreamingBatchSinkFunction(PairFlatMapFunction<T, Object, Object> sinkFunction,
-                                    JavaSparkExecutionContext sec, StageSpec stageSpec) {
+  public StreamingBatchSinkFunction(JavaSparkExecutionContext sec, StageSpec stageSpec) {
     this.sec = sec;
     this.stageSpec = stageSpec;
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingMultiSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingMultiSinkFunction.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.streaming.function;
+
+import io.cdap.cdap.api.TxRunnable;
+import io.cdap.cdap.api.data.DatasetContext;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.plugin.PluginContext;
+import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.etl.api.StageSubmitterContext;
+import io.cdap.cdap.etl.api.SubmitterLifecycle;
+import io.cdap.cdap.etl.api.batch.BatchSink;
+import io.cdap.cdap.etl.api.batch.BatchSinkContext;
+import io.cdap.cdap.etl.api.lineage.AccessType;
+import io.cdap.cdap.etl.common.BasicArguments;
+import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
+import io.cdap.cdap.etl.common.ExternalDatasets;
+import io.cdap.cdap.etl.common.PhaseSpec;
+import io.cdap.cdap.etl.common.PipelineRuntime;
+import io.cdap.cdap.etl.common.RecordInfo;
+import io.cdap.cdap.etl.common.StageStatisticsCollector;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.Compat;
+import io.cdap.cdap.etl.spark.SparkPipelineRuntime;
+import io.cdap.cdap.etl.spark.SparkSubmitterContext;
+import io.cdap.cdap.etl.spark.batch.SparkBatchSinkContext;
+import io.cdap.cdap.etl.spark.batch.SparkBatchSinkFactory;
+import io.cdap.cdap.etl.spark.function.MultiSinkFunction;
+import io.cdap.cdap.etl.spark.plugin.SparkPipelinePluginContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.Function2;
+import org.apache.spark.streaming.Time;
+import org.apache.tephra.TransactionFailureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Function used to write a batch of data to a batch sink for use with a JavaDStream.
+ * note: not using foreachRDD(VoidFunction2) method, because spark 1.3 doesn't have VoidFunction2.
+ */
+public class StreamingMultiSinkFunction implements Function2<JavaRDD<RecordInfo<Object>>, Time, Void> {
+  private static final Logger LOG = LoggerFactory.getLogger(StreamingMultiSinkFunction.class);
+  private final JavaSparkExecutionContext sec;
+  private final PhaseSpec phaseSpec;
+  private final Set<String> group;
+  private final Set<String> sinkNames;
+  private final Map<String, StageStatisticsCollector> collectors;
+
+  public StreamingMultiSinkFunction(JavaSparkExecutionContext sec, PhaseSpec phaseSpec,
+                                    Set<String> group, Set<String> sinkNames,
+                                    Map<String, StageStatisticsCollector> collectors) {
+    this.sec = sec;
+    this.phaseSpec = phaseSpec;
+    this.group = group;
+    this.sinkNames = sinkNames;
+    this.collectors = collectors;
+  }
+
+  @Override
+  public Void call(JavaRDD<RecordInfo<Object>> data, Time batchTime) throws Exception {
+    long logicalStartTime = batchTime.milliseconds();
+    MacroEvaluator evaluator = new DefaultMacroEvaluator(new BasicArguments(sec),
+                                                         logicalStartTime,
+                                                         sec.getSecureStore(),
+                                                         sec.getNamespace());
+    PluginContext pluginContext = new SparkPipelinePluginContext(sec.getPluginContext(), sec.getMetrics(),
+                                                                 phaseSpec.isStageLoggingEnabled(),
+                                                                 phaseSpec.isProcessTimingEnabled());
+    SparkBatchSinkFactory sinkFactory = new SparkBatchSinkFactory();
+    PipelineRuntime pipelineRuntime = new SparkPipelineRuntime(sec, logicalStartTime);
+
+    Map<String, SubmitterLifecycle<?>> stages = createStages(evaluator);
+
+    // call prepareRun() on all the stages in the group
+    // need to call it in an order that guarantees that inputs are called before outputs
+    // this is because plugins can call getArguments().set() in the prepareRun() method,
+    // which downstream stages should be able to read
+    List<String> traversalOrder = new ArrayList(group.size());
+    for (String stageName : phaseSpec.getPhase().getDag().getTopologicalOrder()) {
+      if (group.contains(stageName)) {
+        traversalOrder.add(stageName);
+      }
+    }
+    for (String stageName : traversalOrder) {
+      SubmitterLifecycle<?> plugin = stages.get(stageName);
+      StageSpec stageSpec = phaseSpec.getPhase().getStage(stageName);
+      try {
+        prepareRun(pipelineRuntime, sinkFactory, stageSpec, plugin);
+      } catch (Exception e) {
+        LOG.error("Error preparing sink {} for the batch for time {}.", stageName, logicalStartTime, e);
+        return null;
+      }
+    }
+
+    // run the actual transforms and sinks in this group
+    boolean ranSuccessfully = true;
+    try {
+      MultiSinkFunction multiSinkFunction = new MultiSinkFunction(sec, phaseSpec, group, collectors);
+      Set<String> outputNames = sinkFactory.writeCombinedRDD(data.flatMapToPair(Compat.convert(multiSinkFunction)),
+                                                             sec, sinkNames);
+      sec.execute(new TxRunnable() {
+        @Override
+        public void run(DatasetContext context) throws Exception {
+          for (String outputName : outputNames) {
+            ExternalDatasets.registerLineage(sec.getAdmin(), outputName, AccessType.WRITE,
+                                             null, () -> context.getDataset(outputName));
+          }
+        }
+      });
+    } catch (Exception e) {
+      LOG.error("Error writing to sinks {} for the batch for time {}.", sinkNames, logicalStartTime, e);
+      ranSuccessfully = false;
+    }
+
+    // run onRunFinish() for each sink
+    for (String stageName : traversalOrder) {
+      SubmitterLifecycle<?> plugin = stages.get(stageName);
+      StageSpec stageSpec = phaseSpec.getPhase().getStage(stageName);
+      try {
+        onRunFinish(pipelineRuntime, sinkFactory, stageSpec, plugin, ranSuccessfully);
+      } catch (Exception e) {
+        LOG.warn("Unable to execute onRunFinish for sink {}", stageName, e);
+      }
+    }
+    return null;
+  }
+
+  private Map<String, SubmitterLifecycle<?>> createStages(MacroEvaluator evaluator) throws InstantiationException {
+    PluginContext pluginContext = sec.getPluginContext();
+    Map<String, SubmitterLifecycle<?>> stages = new HashMap<>();
+    for (String stageName : group) {
+      SubmitterLifecycle<?> plugin = pluginContext.newPluginInstance(stageName, evaluator);
+      stages.put(stageName, plugin);
+    }
+    return stages;
+  }
+
+  private void prepareRun(PipelineRuntime pipelineRuntime, SparkBatchSinkFactory sinkFactory, StageSpec stageSpec,
+                          SubmitterLifecycle<?> plugin) throws TransactionFailureException {
+    sec.execute(new TxRunnable() {
+      @Override
+      public void run(DatasetContext datasetContext) throws Exception {
+        if (stageSpec.getPluginType().equals(BatchSink.PLUGIN_TYPE)) {
+          SparkBatchSinkContext context =
+            new SparkBatchSinkContext(sinkFactory, sec, datasetContext, pipelineRuntime, stageSpec);
+          ((SubmitterLifecycle<BatchSinkContext>) plugin).prepareRun(context);
+          return;
+        }
+
+        SparkSubmitterContext context = new SparkSubmitterContext(sec, pipelineRuntime, datasetContext, stageSpec);
+        ((SubmitterLifecycle<StageSubmitterContext>) plugin).prepareRun(context);
+      }
+    });
+  }
+
+  private void onRunFinish(PipelineRuntime pipelineRuntime, SparkBatchSinkFactory sinkFactory, StageSpec stageSpec,
+                           SubmitterLifecycle<?> plugin,
+                           boolean succeeded) throws TransactionFailureException {
+    sec.execute(new TxRunnable() {
+      @Override
+      public void run(DatasetContext datasetContext) throws Exception {
+        if (stageSpec.getPluginType().equals(BatchSink.PLUGIN_TYPE)) {
+          SparkBatchSinkContext sinkContext =
+            new SparkBatchSinkContext(sinkFactory, sec, datasetContext, pipelineRuntime, stageSpec);
+          ((SubmitterLifecycle<BatchSinkContext>) plugin).onRunFinish(succeeded, sinkContext);
+          return;
+        }
+
+        SparkSubmitterContext context = new SparkSubmitterContext(sec, pipelineRuntime, datasetContext, stageSpec);
+        ((SubmitterLifecycle<StageSubmitterContext>) plugin).onRunFinish(succeeded, context);
+      }
+    });
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockExternalSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockExternalSink.java
@@ -32,7 +32,6 @@ import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSinkContext;
 import io.cdap.cdap.etl.proto.v2.ETLPlugin;
 import io.cdap.cdap.format.StructuredRecordStringConverter;
-import io.cdap.cdap.internal.app.runtime.batch.BasicOutputFormatProvider;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 
@@ -72,9 +71,17 @@ public class MockExternalSink extends BatchSink<StructuredRecord, NullWritable, 
 
   @Override
   public void prepareRun(BatchSinkContext context) {
-    OutputFormatProvider outputFormatProvider =
-      new BasicOutputFormatProvider(TextOutputFormat.class.getCanonicalName(),
-                                    ImmutableMap.of(TextOutputFormat.OUTDIR, config.dirName));
+    OutputFormatProvider outputFormatProvider = new OutputFormatProvider() {
+      @Override
+      public String getOutputFormatClassName() {
+        return TextOutputFormat.class.getCanonicalName();
+      }
+
+      @Override
+      public Map<String, String> getOutputFormatConfiguration() {
+        return ImmutableMap.of(TextOutputFormat.OUTDIR, config.dirName);
+      }
+    };
 
     if (config.name != null) {
       Output output = Output.of(config.name, outputFormatProvider);


### PR DESCRIPTION
Implemented stage consolidation for streaming pipelines.
Most of the logic is in a new StreamingMultiSinkFunction that
is the multi-sink counterpart to StreamingBatchSinkFunction.

Instead of instantiating a single sink, preparing it, running it,
then finishing it, the multi function prepares all stages
in the group, executes the group using the existing
MultiSinkFunction, then finishes each stage.