### PR TITLE
CDAP-17166 fix bug where num executors was being ignored

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -103,9 +103,6 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
 
     //Setting Kryo as default serializer
     sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
-    for (Map.Entry<String, String> property : spec.getProperties().entrySet()) {
-      sparkConf.set(property.getKey(), property.getValue());
-    }
 
     // spark... makes you set this to at least the number of receivers (streaming sources)
     // because it holds one thread per receiver, or one core in distributed mode.
@@ -118,11 +115,33 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
     // without this, stopping will hang on machines with few cores.
     sparkConf.set("spark.rpc.netty.dispatcher.numThreads", String.valueOf(numSources + 2));
 
-    sparkConf.set("spark.executor.instances", String.valueOf(numSources + 2));
     sparkConf.setMaster(String.format("local[%d]", numSources + 2));
+    sparkConf.set("spark.executor.instances", String.valueOf(numSources + 2));
 
     if (spec.isUnitTest()) {
       sparkConf.setMaster(String.format("local[%d]", numSources + 1));
+    }
+
+    // override defaults with any user provided engine configs
+    int minExecutors = numSources + 1;
+    for (Map.Entry<String, String> property : spec.getProperties().entrySet()) {
+      if ("spark.executor.instances".equals(property.getKey())) {
+        // don't let the user set this to something that doesn't make sense
+        try {
+          int numExecutors = Integer.parseInt(property.getValue());
+          if (numExecutors < minExecutors) {
+            LOG.warn("Number of executors {} is less than the minimum number required to run the pipeline. " +
+                       "Automatically increasing it to {}", numExecutors, minExecutors);
+            numExecutors = minExecutors;
+          }
+          sparkConf.set(property.getKey(), String.valueOf(numExecutors));
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException(
+            "Number of spark executors was set to invalid value " + property.getValue(), e);
+        }
+      } else {
+        sparkConf.set(property.getKey(), property.getValue());
+      }
     }
     context.setSparkConf(sparkConf);
 


### PR DESCRIPTION
Fixed a bug in streaming pipelines where the default number of
executors was overwriting the number explicitly set by the user.