### PR TITLE
CDAP-17077 change default cache level to disk and cache less often

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/mock/NaiveBayesTrainer.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/mock/NaiveBayesTrainer.java
@@ -117,8 +117,6 @@ public final class NaiveBayesTrainer extends SparkSink<StructuredRecord> {
 
   @Override
   public void run(SparkExecutionPluginContext sparkContext, JavaRDD<StructuredRecord> input) throws Exception {
-    Preconditions.checkArgument(input.count() != 0, "Input RDD is empty.");
-
     final HashingTF tf = new HashingTF(100);
     JavaRDD<LabeledPoint> trainingData = input.map(new Function<StructuredRecord, LabeledPoint>() {
       @Override
@@ -133,7 +131,7 @@ public final class NaiveBayesTrainer extends SparkSink<StructuredRecord> {
       }
     });
 
-    trainingData.cache();
+    trainingData = trainingData.cache();
 
     final NaiveBayesModel model = NaiveBayes.train(trainingData.rdd(), 1.0);
 

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineRunner.java
@@ -26,10 +26,8 @@ import io.cdap.cdap.etl.api.JoinElement;
 import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoinerRuntimeContext;
-import io.cdap.cdap.etl.api.join.AutoJoiner;
 import io.cdap.cdap.etl.api.join.AutoJoinerContext;
 import io.cdap.cdap.etl.api.join.JoinDefinition;
-import io.cdap.cdap.etl.api.join.JoinStage;
 import io.cdap.cdap.etl.api.streaming.StreamingContext;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
 import io.cdap.cdap.etl.common.DefaultAutoJoinerContext;
@@ -60,6 +58,7 @@ import org.apache.spark.streaming.api.java.JavaStreamingContext;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Driver for running pipelines using Spark Streaming.
@@ -143,7 +142,8 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
   protected SparkCollection<Object> handleJoin(Map<String, SparkCollection<Object>> inputDataCollections,
                                                PipelinePhase pipelinePhase, PluginFunctionContext pluginFunctionContext,
                                                StageSpec stageSpec, Object plugin, Integer numPartitions,
-                                               StageStatisticsCollector collector) throws Exception {
+                                               StageStatisticsCollector collector,
+                                               Set<String> shufflers) throws Exception {
     String stageName = stageSpec.getName();
     BatchJoiner<?, ?, ?> joiner;
     if (plugin instanceof BatchAutoJoiner) {
@@ -176,6 +176,7 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
 
     BatchJoinerRuntimeContext joinerRuntimeContext = pluginFunctionContext.createBatchRuntimeContext();
     joiner.initialize(joinerRuntimeContext);
-    return handleJoin(joiner, inputDataCollections, stageSpec, numPartitions, collector).cache();
+    shufflers.add(stageName);
+    return handleJoin(joiner, inputDataCollections, stageSpec, numPartitions, collector);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
@@ -33,7 +33,7 @@ public final class Constants {
   public static final String SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG = "spark.cdap.pipeline.autocache.enable";
   public static final String SPARK_PIPELINE_CACHING_STORAGE_LEVEL = "spark.cdap.pipeline.caching.storage.level";
   public static final String CONSOLIDATE_STAGES = "spark.cdap.pipeline.consolidate.stages";
-  public static final String DEFAULT_CACHING_STORAGE_LEVEL = "MEMORY_AND_DISK";
+  public static final String DEFAULT_CACHING_STORAGE_LEVEL = "DISK_ONLY";
 
   private Constants() {
     throw new AssertionError("Suppress default constructor for noninstantiability");

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
@@ -215,9 +215,6 @@ public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
     JavaRDD<T> countedInput = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(),
                                                               Constants.Metrics.RECORDS_IN, null));
     SparkConf sparkConf = jsc.getConf();
-    if (sparkConf.getBoolean(Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG, true)) {
-      countedInput = countedInput.cache();
-    }
 
     return wrap(compute.transform(sparkPluginContext, countedInput)
                   .map(new CountingFunction<U>(stageName, sec.getMetrics(), Constants.Metrics.RECORDS_OUT,
@@ -277,9 +274,6 @@ public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
         JavaRDD<T> countedRDD =
           rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), Constants.Metrics.RECORDS_IN, null));
         SparkConf sparkConf = jsc.getConf();
-        if (sparkConf.getBoolean(Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG, true)) {
-          countedRDD = countedRDD.cache();
-        }
         try {
           sink.run(sparkPluginContext, countedRDD);
         } catch (Exception e) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
@@ -171,9 +171,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
     return new Runnable() {
       @Override
       public void run() {
-        // cache since the streaming sink function will check if the rdd is empty, which can cause recomputation
-        // and confusing metrics if its not cached.
-        Compat.foreachRDD(stream.cache(), new StreamingBatchSinkFunction<>(sec, stageSpec));
+        Compat.foreachRDD(stream, new StreamingBatchSinkFunction<>(sec, stageSpec));
       }
     };
   }
@@ -195,7 +193,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
     return new Runnable() {
       @Override
       public void run() {
-        Compat.foreachRDD(stream.cache(), new StreamingSparkSinkFunction<T>(sec, stageSpec));
+        Compat.foreachRDD(stream, new StreamingSparkSinkFunction<T>(sec, stageSpec));
       }
     };
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
@@ -64,9 +64,6 @@ public class StreamingBatchSinkFunction<T> implements Function2<JavaRDD<T>, Time
 
   @Override
   public Void call(JavaRDD<T> data, Time batchTime) throws Exception {
-    if (data.isEmpty()) {
-      return null;
-    }
 
     final long logicalStartTime = batchTime.milliseconds();
     MacroEvaluator evaluator = new DefaultMacroEvaluator(new BasicArguments(sec),


### PR DESCRIPTION
changed the auto caching strategy so that stages are only cached
if they will prevent a source from being recomputed. Also changed
the default cache level to disk only to prevent OOM errors that
we've seen with other cache levels.