### PR TITLE
[CDAP-17172] Remove stop pipeline banner when user deploys pipeline after running Preview

### DIFF
--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -145,7 +145,7 @@ class HydratorPlusPlusTopPanelCtrl {
 
     $scope.$on('$destroy', () => {
       unsub();
-      this.stopPreview();
+      this.stopPreview(true);
       this.previewStore.dispatch(
         this.previewActions.togglePreviewMode(false)
       );
@@ -669,8 +669,8 @@ class HydratorPlusPlusTopPanelCtrl {
       });
   }
 
-  stopPreview() {
-    if (!this.currentPreviewId) {
+  stopPreview(silentMode = false) {
+    if (!this.currentPreviewId || !this.previewRunning || this.loadingLabel === 'Stopping') {
       return;
     }
     let params = {
@@ -692,6 +692,9 @@ class HydratorPlusPlusTopPanelCtrl {
             this.dataSrc.stopPoll(this.pollId);
             this.pollId = null;
 
+            if (silentMode) {
+              return;
+            }
             let pipelinePreviewPlaceholder = 'The preview of the pipeline';
             const pipelineName = this.HydratorPlusPlusConfigStore.getName();
             if (pipelineName.length > 0) {
@@ -705,6 +708,9 @@ class HydratorPlusPlusTopPanelCtrl {
           (err) => {
             this.previewLoading = false;
             this.previewRunning = true;
+            if (silentMode) {
+              return;
+            }
             this.myAlertOnValium.show({type: 'danger', content: err.data});
         });
   }


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-17172
Build: https://builds.cask.co/browse/CDAP-URUT314

Root cause analysis: 
We call the stop preview run endpoint when user deploys a pipeline because $destroy calls stopPreview. Stop preview should usually show the user a success or error banner depending on backend response for the stop preview call. Prior to about two months ago (#12354 ), we weren't handling stop preview run errors, so we weren't seeing this banner. Fixing the bug to handle errors returned when stopping preview surfaced this behavior. 

Solution:
1. Added a check in $destroy to see if pipeline is still running before calling stopPreview
2. Modified stopPreview to add "silent" mode which does not show success or error banners. Used silent mode in $destroy since user does not need to know or see the results of UI stopping preview pipeline behind the scenes. 