### PR TITLE
[CDAP-16714] Implement TTL for the preview data.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/preview/PreviewStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/preview/PreviewStore.java
@@ -121,4 +121,10 @@ public interface PreviewStore {
    */
   @Nullable
   byte[] getPreviewRequestPollerInfo(ApplicationId applicationId);
+
+  /**
+   * Deletes the preview data older than ttl.
+   * @param ttlInSeconds ttl in seconds
+   */
+  void deleteExpiredData(long ttlInSeconds);
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewDataCleanupService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewDataCleanupService.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.preview;
+
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.cdap.cdap.app.preview.PreviewConfigModule;
+import io.cdap.cdap.app.store.preview.PreviewStore;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
+import io.cdap.cdap.internal.app.store.preview.DefaultPreviewStore;
+import org.apache.twill.common.Threads;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The clean up service that cleans up preview data periodically.
+ */
+public class PreviewDataCleanupService extends AbstractScheduledService {
+  private final PreviewStore previewStore;
+  private final long cleanUpInterval;
+  private final long ttl;
+  private ScheduledExecutorService executor;
+
+  @Inject
+  PreviewDataCleanupService(@Named(PreviewConfigModule.PREVIEW_LEVEL_DB) LevelDBTableService previewLevelDBTableService,
+                            CConfiguration cConf) {
+    this.previewStore = new DefaultPreviewStore(previewLevelDBTableService);
+    this.cleanUpInterval = cConf.getLong(Constants.Preview.DATA_CLEANUP_INTERVAL_SECONDS);
+    this.ttl = cConf.getLong(Constants.Preview.DATA_TTL_SECONDS);
+  }
+
+  @Override
+  protected final ScheduledExecutorService executor() {
+    executor = Executors.newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("preview-cleanup"));
+    return executor;
+  }
+
+  @Override
+  protected void runOneIteration() {
+    previewStore.deleteExpiredData(ttl);
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    // Try right away if there's anything to cleanup, we will then schedule based on the minimum retention interval
+    return Scheduler.newFixedRateSchedule(1, cleanUpInterval, TimeUnit.SECONDS);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStore.java
@@ -59,6 +59,8 @@ import javax.annotation.Nullable;
  */
 public class DefaultPreviewStore implements PreviewStore {
   private static final DatasetId PREVIEW_TABLE_ID = NamespaceId.SYSTEM.dataset("preview.table");
+  private static final byte[] DATA_ROW_KEY_PREFIX = Bytes.toBytes("dr");
+  private static final byte[] META_ROW_KEY_PREFIX = Bytes.toBytes("mr");
   private static final byte[] TRACER = Bytes.toBytes("t");
   private static final byte[] PROPERTY = Bytes.toBytes("p");
   private static final byte[] VALUE = Bytes.toBytes("v");
@@ -101,8 +103,8 @@ public class DefaultPreviewStore implements PreviewStore {
     // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
     Gson gson = new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
       .registerTypeAdapter(StructuredRecord.class, new PreviewJsonSerializer()).create();
-    MDSKey mdsKey = new MDSKey.Builder().add(applicationId.getNamespace())
-      .add(applicationId.getApplication()).add(tracerName).add(counter.getAndIncrement()).build();
+    MDSKey mdsKey = getPreviewRowKeyBuilder(DATA_ROW_KEY_PREFIX, applicationId)
+      .add(tracerName).add(counter.getAndIncrement()).build();
 
     try {
       table.put(mdsKey.getKey(), TRACER, Bytes.toBytes(tracerName), 1L);
@@ -119,8 +121,8 @@ public class DefaultPreviewStore implements PreviewStore {
   public Map<String, List<JsonElement>> get(ApplicationId applicationId, String tracerName) {
     // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
     Gson gson = new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter()).create();
-    byte[] startRowKey = new MDSKey.Builder().add(applicationId.getNamespace())
-      .add(applicationId.getApplication()).add(tracerName).build().getKey();
+    byte[] startRowKey = getPreviewRowKeyBuilder(DATA_ROW_KEY_PREFIX, applicationId)
+      .add(tracerName).build().getKey();
     byte[] stopRowKey = new MDSKey(Bytes.stopKeyForPrefix(startRowKey)).getKey();
 
     Map<String, List<JsonElement>> result = new HashMap<>();
@@ -141,11 +143,8 @@ public class DefaultPreviewStore implements PreviewStore {
     return result;
   }
 
-  @Override
-  public void remove(ApplicationId applicationId) {
-    removeFromWaitingState(applicationId);
-    byte[] startRowKey = new MDSKey.Builder().add(applicationId.getNamespace())
-      .add(applicationId.getApplication()).build().getKey();
+  private void removePreviewData(byte[] prefix, ApplicationId applicationId) {
+    byte[] startRowKey = getPreviewRowKeyBuilder(prefix, applicationId).build().getKey();
     byte[] stopRowKey = new MDSKey(Bytes.stopKeyForPrefix(startRowKey)).getKey();
     try {
       table.deleteRange(startRowKey, stopRowKey, null, null);
@@ -156,10 +155,19 @@ public class DefaultPreviewStore implements PreviewStore {
   }
 
   @Override
+  public void remove(ApplicationId applicationId) {
+    removeFromWaitingState(applicationId);
+    // remove actual preview user data
+    removePreviewData(DATA_ROW_KEY_PREFIX, applicationId);
+    // remove preview metadata such as status, appid, pollerinfo
+    removePreviewData(META_ROW_KEY_PREFIX, applicationId);
+  }
+
+  @Override
   public void setProgramId(ProgramRunId programRunId) {
     // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
     Gson gson = new GsonBuilder().registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter()).create();
-    MDSKey mdsKey = new MDSKey.Builder().add(programRunId.getNamespace()).add(programRunId.getApplication()).build();
+    MDSKey mdsKey = getPreviewRowKeyBuilder(META_ROW_KEY_PREFIX, programRunId.getParent().getParent()).build();
     try {
       table.put(mdsKey.getKey(), RUN, Bytes.toBytes(gson.toJson(programRunId)), 1L);
     } catch (IOException e) {
@@ -171,7 +179,7 @@ public class DefaultPreviewStore implements PreviewStore {
   public ProgramRunId getProgramRunId(ApplicationId applicationId) {
     // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
     Gson gson = new GsonBuilder().registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter()).create();
-    MDSKey mdsKey = new MDSKey.Builder().add(applicationId.getNamespace()).add(applicationId.getApplication()).build();
+    MDSKey mdsKey = getPreviewRowKeyBuilder(META_ROW_KEY_PREFIX, applicationId).build();
 
     Map<byte[], byte[]> row = null;
     try {
@@ -190,9 +198,10 @@ public class DefaultPreviewStore implements PreviewStore {
   public void setPreviewStatus(ApplicationId applicationId, PreviewStatus previewStatus) {
     // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
     Gson gson = new GsonBuilder().registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec()).create();
-    MDSKey mdsKey = new MDSKey.Builder().add(applicationId.getNamespace()).add(applicationId.getApplication()).build();
+    MDSKey mdsKey = getPreviewRowKeyBuilder(META_ROW_KEY_PREFIX, applicationId).build();
     try {
       table.put(mdsKey.getKey(), STATUS, Bytes.toBytes(gson.toJson(previewStatus)), 1L);
+      table.put(mdsKey.getKey(), APPID, Bytes.toBytes(gson.toJson(applicationId)), 1L);
     } catch (IOException e) {
       throw new RuntimeException(String.format("Failed to put preview status %s for preview %s",
                                                previewStatus, applicationId), e);
@@ -203,7 +212,7 @@ public class DefaultPreviewStore implements PreviewStore {
   public PreviewStatus getPreviewStatus(ApplicationId applicationId) {
     // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
     Gson gson = new GsonBuilder().registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec()).create();
-    MDSKey mdsKey = new MDSKey.Builder().add(applicationId.getNamespace()).add(applicationId.getApplication()).build();
+    MDSKey mdsKey = getPreviewRowKeyBuilder(META_ROW_KEY_PREFIX, applicationId).build();
 
     Map<byte[], byte[]> row = null;
     try {
@@ -303,10 +312,7 @@ public class DefaultPreviewStore implements PreviewStore {
   private void setPollerinfo(ApplicationId applicationId, byte[] pollerInfo) {
     // PreviewStore is a singleton and we have to create gson for each operation since gson is not thread safe.
     Gson gson = new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter()).create();
-    MDSKey mdsKey = new MDSKey.Builder()
-      .add(applicationId.getNamespace())
-      .add(applicationId.getApplication())
-      .build();
+    MDSKey mdsKey = getPreviewRowKeyBuilder(META_ROW_KEY_PREFIX, applicationId).build();
 
     try {
       table.put(mdsKey.getKey(), POLLERINFO, pollerInfo, 1L);
@@ -319,7 +325,7 @@ public class DefaultPreviewStore implements PreviewStore {
 
   @Override
   public byte[] getPreviewRequestPollerInfo(ApplicationId applicationId) {
-    MDSKey mdsKey = new MDSKey.Builder().add(applicationId.getNamespace()).add(applicationId.getApplication()).build();
+    MDSKey mdsKey = getPreviewRowKeyBuilder(META_ROW_KEY_PREFIX, applicationId).build();
 
     Map<byte[], byte[]> row = null;
     try {
@@ -332,6 +338,40 @@ public class DefaultPreviewStore implements PreviewStore {
       return row.get(POLLERINFO);
     }
     return null;
+  }
+
+  @Override
+  public void deleteExpiredData(long ttlInSeconds) {
+    Gson gson = new GsonBuilder().registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter()).create();
+    byte[] startRowKey = new MDSKey.Builder().add(META_ROW_KEY_PREFIX).build().getKey();
+    byte[] stopRowKey = new MDSKey(Bytes.stopKeyForPrefix(startRowKey)).getKey();
+
+    long currentTimeInSeconds = System.currentTimeMillis() / 1000;
+    try (Scanner scanner = table.scan(startRowKey, stopRowKey, null, null, null)) {
+      Row indexRow;
+      while ((indexRow = scanner.next()) != null) {
+        Map<byte[], byte[]> columns = indexRow.getColumns();
+        String applicationIdGson = Bytes.toString(columns.get(APPID));
+        if (applicationIdGson == null) {
+          continue;
+        }
+
+        ApplicationId applicationId = gson.fromJson(applicationIdGson, ApplicationId.class);
+        long applicationSubmitTime = RunIds.getTime(applicationId.getApplication(), TimeUnit.SECONDS);
+        if ((currentTimeInSeconds - applicationSubmitTime) > ttlInSeconds) {
+          remove(applicationId);
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Error while scanning the preview requests for deletion.", e);
+    }
+  }
+
+  private MDSKey.Builder getPreviewRowKeyBuilder(byte[] prefix, ApplicationId applicationId) {
+    return new MDSKey.Builder()
+      .add(prefix)
+      .add(applicationId.getNamespace())
+      .add(applicationId.getApplication());
   }
 
   @VisibleForTesting

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRequestQueueTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRequestQueueTest.java
@@ -136,6 +136,11 @@ public class DefaultPreviewRequestQueueTest {
     public byte[] getPreviewRequestPollerInfo(ApplicationId applicationId) {
       return new byte[0];
     }
+
+    @Override
+    public void deleteExpiredData(long ttlInSeconds) {
+
+    }
   }
 
   @Test

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -355,6 +355,8 @@ public final class Constants {
     public static final String WAITING_QUEUE_CAPACITY = "preview.waiting.queue.capacity";
     public static final String WAITING_QUEUE_TIMEOUT_SECONDS = "preview.waiting.queue.timeout.seconds";
     public static final String MESSAGING_TOPIC = "preview.messaging.topic";
+    public static final String DATA_CLEANUP_INTERVAL_SECONDS = "preview.data.cleanup.interval.seconds";
+    public static final String DATA_TTL_SECONDS = "preview.data.ttl.seconds";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3058,6 +3058,22 @@
   </property>
 
   <property>
+    <name>preview.data.cleanup.interval.seconds</name>
+    <value>3600</value>
+    <description>
+      Interval in seconds for preview data cleanup process. Default is 1 hr.
+    </description>
+  </property>
+
+  <property>
+    <name>preview.data.ttl.seconds</name>
+    <value>86400</value>
+    <description>
+      TTL for the preview data, by default 1 day
+    </description>
+  </property>
+
+  <property>
     <name>preview.messaging.topic</name>
     <value>preview</value>
     <description>


### PR DESCRIPTION
This PR contains following changes:
1. Updated row key prefix for the row containing preview metadata such as status, pollerinfo. Such row is now stored with rowkey prefix: `META_ROW_KEY_PREFIX`
2. Actual user data is stored with row key prefix: `DATA_ROW_KEY_PREFIX`
3. Added the `PreviewDataCleanupService` which scans over metadata rows in PreviewStore (i.e. rows with key prefix `META_ROW_KEY_PREFIX`). While scanning we find preview id, and if TTL has happened for the current preview id, delete metadata row as well as data rows for that preview id.
4. Default cleanup interval is set to 1 hr.
5. Default preview data TTL is set to 24 hrs.