### PR TITLE
[CDAP-17156] Experiments page changes

### DIFF
--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -100,11 +100,6 @@ const FieldLevelLineage = Loadable({
   loading: LoadingSVGCentered,
 });
 
-const Lab = Loadable({
-  loader: () => import(/* webpackChunkMame: "Lab" */ 'components/Lab'),
-  loading: LoadingSVGCentered,
-});
-
 const Replicator = Loadable({
   loader: () => import(/* webpackChunkMame: "Replicator" */ 'components/Replicator'),
   loading: LoadingSVGCentered,
@@ -190,28 +185,10 @@ export default class Home extends Component {
           <Route path="/ns/:namespace/securekeys" component={SecureKeys} />
           <Route path="/ns/:namespace/kitchen" component={ConfigurationGroupKitchenSync} />
           <Route path="/ns/:namespace/replication" component={Replicator} />
-          <Route path="/ns/:namespace/lab" component={Lab} />
           <Route
             exact
             path="/ns/:namespace/logs/program/:appId/:programType/:programId/:runId"
             component={LogViewerPage}
-          />
-          <Route
-            exact
-            path="/ns/:namespace/lab-experiment-test"
-            render={(props) => {
-              if (!window.parent.Cypress) {
-                return <Page404 {...props} />;
-              }
-              const LabExperimentTestComp = Loadable({
-                loader: () =>
-                  import(
-                    /* webpackChunkName: "LabExperimentTest" */ 'components/Lab/LabExperimentTest'
-                  ),
-                loading: LoadingSVGCentered,
-              });
-              return <LabExperimentTestComp {...props} />;
-            }}
           />
           <Route
             path="/ns/:namespace/ingestion"

--- a/cdap-ui/app/cdap/components/Lab/index.tsx
+++ b/cdap-ui/app/cdap/components/Lab/index.tsx
@@ -32,11 +32,20 @@ const styles = (): StyleRules => {
   return {
     root: {
       display: 'flex',
-      justifyContent: 'center',
+      alignItems: 'center',
+      flexDirection: 'column',
       paddingTop: '5%',
     },
     paperContainer: {
       display: 'flex',
+      height: 'fit-content',
+    },
+    pageDescription: {
+      display: 'flex',
+      alignItems: 'flex-start',
+      maxWidth: 900,
+      width: '100%',
+      margin: '20px 0px',
     },
     experimentsTable: {
       maxWidth: 900,
@@ -91,18 +100,19 @@ class Lab extends React.Component<ILabProps, ILabState> {
 
     return (
       <div className={classes.root}>
+        <div className={classes.pageDescription}>
+          <Typography variant="h3">Lab - Experimental Features</Typography>
+        </div>
         <Paper className={classes.paperContainer}>
           <Table className={classes.experimentsTable}>
             <TableHead>
               <TableRow>
-                <TableCell>
-                  <Typography variant="h5">Image</Typography>
-                </TableCell>
+                <TableCell></TableCell>
                 <TableCell>
                   <Typography variant="h5">Experiment</Typography>
                 </TableCell>
                 <TableCell>
-                  <Typography variant="h5">Status</Typography>
+                  <Typography variant="h5">Enable/Disable</Typography>
                 </TableCell>
               </TableRow>
             </TableHead>

--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -83,6 +83,11 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
   introspectionQueryResultData,
 });
 
+const Lab = Loadable({
+  loader: () => import(/* webpackChunkMame: "Lab" */ 'components/Lab'),
+  loading: LoadingSVGCentered,
+});
+
 const client = new ApolloClient({
   uri: '/graphql',
   cache: new InMemoryCache({ fragmentMatcher }),
@@ -288,6 +293,44 @@ class CDAP extends Component {
                   <DAG {...props} />
                 </ErrorBoundary>
               )}
+            />
+            <Route
+              exact
+              path="/schema"
+              render={(props) => {
+                const SchemaEditorDemo = Loadable({
+                  loader: () =>
+                    import(
+                      /* webpackChunkName: "SchemaEditor" */ 'components/AbstractWidget/SchemaEditor/SchemaEditorDemo'
+                    ),
+                  loading: LoadingSVGCentered,
+                });
+                return (
+                  <ToggleExperiment
+                    name="schema-editor"
+                    defaultComponent={<Page404 {...props} />}
+                    experimentalComponent={<SchemaEditorDemo />}
+                  />
+                );
+              }}
+            />
+            <Route path="/lab" component={Lab} />
+            <Route
+              exact
+              path="/lab-experiment-test"
+              render={(props) => {
+                if (!window.parent.Cypress) {
+                  return <Page404 {...props} />;
+                }
+                const LabExperimentTestComp = Loadable({
+                  loader: () =>
+                    import(
+                      /* webpackChunkName: "LabExperimentTest" */ 'components/Lab/LabExperimentTest'
+                    ),
+                  loading: LoadingSVGCentered,
+                });
+                return <LabExperimentTestComp {...props} />;
+              }}
             />
             {/*
               Eventually handling 404 should move to the error boundary and all container components will have the error object.

--- a/cdap-ui/cypress/integration/lab.spec.ts
+++ b/cdap-ui/cypress/integration/lab.spec.ts
@@ -19,43 +19,43 @@ describe('Lab ', () => {
   });
 
   it('should have cdap-common-experiment disabled by default', () => {
-    cy.visit('/cdap/ns/default/lab');
+    cy.visit('/cdap/lab');
     cy.get(`${dataCy('cdap-common-experiment-switch')} input`).should('have.value', 'false');
   });
 
   describe(' toggle experiment wrapper ', () => {
     it('should show default component when cdap-common-experiment is disabled', () => {
-      cy.visit('/cdap/ns/default/lab-experiment-test');
+      cy.visit('/cdap/lab-experiment-test');
       cy.get(dataCy('default-feature-toggle-selector')).should('have.text', 'This is default component for the toggle.');
     });
 
     it('show experimental component when cdap-common-experiment is enabled', () => {
-      cy.visit('/cdap/ns/default/lab');
+      cy.visit('/cdap/lab');
       cy.get(`${dataCy('cdap-common-experiment-switch')} input`).should('have.value', 'false');
       cy.get(`${dataCy('cdap-common-experiment-switch')}`).click();
       cy.get(`${dataCy('cdap-common-experiment-switch')} input`).should('have.value', 'true');
 
-      cy.visit('/cdap/ns/default/lab-experiment-test');
+      cy.visit('/cdap/lab-experiment-test');
       cy.get(dataCy('experimental-feature-toggle-selector')).should('have.text', 'This is experimental component for the toggle.');
 
-      cy.visit('/cdap/ns/default/lab');
+      cy.visit('/cdap/lab');
       cy.get(`${dataCy('cdap-common-experiment-switch')}`).click();
     });
   });
 
   describe(' experiment wrapper ', () => {
     it('should not show experimental component when cdap-common-experiment is disabled', () => {
-      cy.visit('/cdap/ns/default/lab-experiment-test');
+      cy.visit('/cdap/lab-experiment-test');
       cy.get(dataCy('experimental-feature-selector')).should('not.exist');
     });
 
     it('should show experimental component when cdap-common-experiment is enabled', () => {
-      cy.visit('/cdap/ns/default/lab');
+      cy.visit('/cdap/lab');
       cy.get(`${dataCy('cdap-common-experiment-switch')} input`).should('have.value', 'false');
       cy.get(`${dataCy('cdap-common-experiment-switch')}`).click();
       cy.get(`${dataCy('cdap-common-experiment-switch')} input`).should('have.value', 'true');
 
-      cy.visit('/cdap/ns/default/lab-experiment-test');
+      cy.visit('/cdap/lab-experiment-test');
       cy.get(dataCy('experimental-feature-selector')).should('have.text','This is an experimental component.');
     });
   });

--- a/cdap-ui/cypress/integration/systemdelay.spec.ts
+++ b/cdap-ui/cypress/integration/systemdelay.spec.ts
@@ -1,0 +1,72 @@
+import { loginIfRequired } from '../helpers';
+import { dataCy } from '../helpers';
+import { getExperimentValue, isExperimentEnabled } from '../../app/cdap/services/helpers';
+
+let headers = {};
+const EXPERIMENT_ID='system-delay-notification';
+
+describe('System delay notification ', () => {
+    // Uses API call to login instead of logging in manually through UI
+    before(() => {
+        loginIfRequired().then(() => {
+            cy.getCookie('CDAP_Auth_Token').then((cookie) => {
+                if (!cookie) {
+                    return;
+                }
+                headers = {
+                    Authorization: 'Bearer ' + cookie.value,
+                };
+            });
+        });
+    });
+
+    beforeEach(() => {
+        cy.visit('/cdap/lab');
+        cy.get(`${dataCy(`${EXPERIMENT_ID}-switch`)} input`).should('have.value', 'true');
+        // Makes max allowed delay for requests to be 0 i.e all requests would be considered slow.
+        cy.get(dataCy(`${EXPERIMENT_ID}-field`)).type('0');
+    });
+
+    it('should be visible when there is a delay', () => {
+        cy.visit('/cdap/ns/default');
+        expect(getExperimentValue(EXPERIMENT_ID)).to.be.eq('0');
+        expect(isExperimentEnabled(EXPERIMENT_ID)).to.be.true;
+        cy.get(dataCy('system-delay-snackbar')).should('be.visible');
+        cy.visit('/pipelines/ns/default/studio');
+        cy.get(dataCy('system-delay-snackbar')).should('be.visible');
+        // Waiting to check that the notification is persistent
+        cy.wait(13000);
+        cy.get(dataCy('system-delay-snackbar')).should('be.visible');
+    });
+
+    it('should not be visible when there is no delay', () => {
+        // Removes the '0' set for max delay of requests
+        expect(getExperimentValue(EXPERIMENT_ID)).to.be.eq('0');
+        cy.visit('/cdap/ns/default');
+        window.localStorage.removeItem(`${EXPERIMENT_ID}-value`);
+        window.localStorage.removeItem(EXPERIMENT_ID);
+        expect(getExperimentValue(`${EXPERIMENT_ID}-value`)).to.be.eq(null);
+        expect(window.localStorage.getItem('system-delay-notification')).to.be.eq(null);
+        cy.get(dataCy('system-delay-snackbar')).should('not.be.visible');
+        // Waiting to check that the snackbar does not appear on the next health check
+        cy.wait(13000);
+        cy.get(dataCy('system-delay-snackbar')).should('not.be.visible');
+    });
+    
+    it('should not be visible when user asks to not see again', () => {
+        cy.visit('/cdap/ns/default');
+        cy.get(dataCy('navbar-hamburger-icon')).should('be.visible');
+        expect(getExperimentValue(EXPERIMENT_ID)).to.be.eq('0');
+        expect(isExperimentEnabled(EXPERIMENT_ID)).to.be.true;
+        cy.get(dataCy('system-delay-snackbar')).should('be.visible');
+        cy.get(dataCy('do-not-show-delay-btn')).should('be.visible');
+        cy.get(dataCy('do-not-show-delay-btn')).click({ force: true });
+        cy.get(dataCy('system-delay-snackbar')).should('not.be.visible');
+        cy.then(() => {
+            expect(getExperimentValue(EXPERIMENT_ID)).to.be.eq(null);
+            expect(isExperimentEnabled(EXPERIMENT_ID)).to.be.false;
+        });
+        cy.visit('/cdap/lab');
+        cy.get(`${dataCy(`${EXPERIMENT_ID}-switch`)} input`).should('have.value', 'false');
+    });
+});


### PR DESCRIPTION
Cherry-pick of #12579 

JIRA: https://issues.cask.co/browse/CDAP-17156

- Change the URL to be at cdap level instead of namespace level
- Add Heading for the experiments page.
- Removed 'Image' table header and changed 'Status' header to 'Enable/Disable'.
