### PR TITLE
REVERT CDAP-16784, removing Kryo as default

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -100,9 +100,9 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
     sparkConf.set("spark.streaming.backpressure.enabled", "true");
     sparkConf.set("spark.spark.streaming.blockInterval", String.valueOf(spec.getBatchIntervalMillis() / 5));
     sparkConf.set("spark.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
-
-    //Setting Kryo as default serializer
-    sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
+    for (Map.Entry<String, String> property : spec.getProperties().entrySet()) {
+      sparkConf.set(property.getKey(), property.getValue());
+    }
 
     // spark... makes you set this to at least the number of receivers (streaming sources)
     // because it holds one thread per receiver, or one core in distributed mode.

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
@@ -102,10 +102,6 @@ public class ETLSpark extends AbstractSpark {
     // to make sure fields that are the same but different casing are treated as different fields in auto-joins
     // see CDAP-17024
     sparkConf.set("spark.sql.caseSensitive", "true");
-
-    //Setting Kryo as default serializer
-    sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
-
     context.setSparkConf(sparkConf);
 
     Map<String, String> properties = context.getSpecification().getProperties();


### PR DESCRIPTION
Discovered issues with Kryo using some plugins https://issues.cask.co/browse/CDAP-17184. It should not be used a default until these issues are resolved