### PR TITLE
CDAP-17077 change default cache level to disk and cache less often

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
@@ -815,14 +815,6 @@ public class DataPipelineTest extends HydratorTestBase {
      */
     validateMetric(4, appId, "source1.records.out");
     validateMetric(1, appId, "source2.records.out");
-    validateMetric(1, appId, "dropnull.records.error");
-    validateMetric(3, appId, "filter1.records.out");
-    validateMetric(1, appId, "filter1.records.error");
-    validateMetric(2, appId, "filter2.records.out");
-    validateMetric(1, appId, "filter2.records.error");
-    validateMetric(1, appId, "agg1.records.out");
-    validateMetric(1, appId, "agg1.records.error");
-    validateMetric(1, appId, "agg2.records.error");
     validateMetric(5, appId, "errorflatten.records.out");
     validateMetric(3, appId, "errorfilter.records.out");
     validateMetric(5, appId, "sink1.records.in");
@@ -2385,8 +2377,9 @@ public class DataPipelineTest extends HydratorTestBase {
     String input1Name = "source1InnerJoinInput-" + engine;
     String input2Name = "source2InnerJoinInput-" + engine;
     String input3Name = "source3InnerJoinInput-" + engine;
-    String outputName = "innerJoinOutput-" + engine;
-    String outputName2 = "innerJoinOutput2-" + engine;
+    File outputDir = TMP_FOLDER.newFolder();
+    String output1 = new File(outputDir, "output1").getAbsolutePath();
+    String output2 = new File(outputDir, "output2").getAbsolutePath();
     String joinerName = "innerJoiner-" + engine;
     String sinkName = "innerJoinSink-" + engine;
     String sinkName2 = "innerJoinSink-2" + engine;
@@ -2400,8 +2393,8 @@ public class DataPipelineTest extends HydratorTestBase {
       .addStage(new ETLStage(joinerName, MockJoiner.getPlugin("t1.customer_id=t2.cust_id=t3.c_id&" +
                                                                   "t1.customer_name=t2.cust_name=t3.c_name",
                                                                 "t1,t2,t3", "")))
-      .addStage(new ETLStage(sinkName, MockSink.getPlugin(outputName)))
-      .addStage(new ETLStage(sinkName2, MockSink.getPlugin(outputName2)))
+      .addStage(new ETLStage(sinkName, MockExternalSink.getPlugin(UUID.randomUUID().toString(), "s1", output1)))
+      .addStage(new ETLStage(sinkName2, MockExternalSink.getPlugin(UUID.randomUUID().toString(), "s2", output2)))
       .addConnection("source1", "t1")
       .addConnection("source2", "t2")
       .addConnection("source3", "t3")
@@ -2455,9 +2448,9 @@ public class DataPipelineTest extends HydratorTestBase {
     inputManager = getDataset(NamespaceId.DEFAULT.dataset(input3Name));
     MockSource.writeInput(inputManager, ImmutableList.of(recordTrasCar, recordTrasBike));
 
+    Map<String, String> args = Collections.singletonMap(io.cdap.cdap.etl.common.Constants.CONSOLIDATE_STAGES, "true");
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.start();
-    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     StructuredRecord joinRecordSamuel = StructuredRecord.builder(outSchema)
       .set("customer_id", "1").set("customer_name", "samuel")
@@ -2469,13 +2462,11 @@ public class DataPipelineTest extends HydratorTestBase {
       .set("item_id", "22").set("item_price", 100L).set("cust_id", "3").set("cust_name", "jane")
       .set("t_id", "2").set("c_id", "3").set("c_name", "jane").build();
 
-    DataSetManager<Table> sinkManager = getDataset(outputName);
     Set<StructuredRecord> expected = ImmutableSet.of(joinRecordSamuel, joinRecordJane);
-    Set<StructuredRecord> actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
+    Set<StructuredRecord> actual = Sets.newHashSet(MockExternalSink.readOutput(output1, outSchema));
     Assert.assertEquals(expected, actual);
 
-    sinkManager = getDataset(outputName2);
-    actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
+    actual = Sets.newHashSet(MockExternalSink.readOutput(output2, outSchema));
     Assert.assertEquals(expected, actual);
 
     validateMetric(2, appId, joinerName + ".records.out");
@@ -3420,14 +3411,6 @@ public class DataPipelineTest extends HydratorTestBase {
     Assert.assertEquals(expected, actual);
 
     validateMetric(4, appId, "source.records.out");
-    validateMetric(4, appId, "splitter1.records.in");
-    validateMetric(2, appId, "splitter1.records.out.null");
-    validateMetric(2, appId, "splitter1.records.out.non-null");
-    validateMetric(2, appId, "identity.records.in");
-    validateMetric(2, appId, "identity.records.out");
-    validateMetric(2, appId, "splitter2.records.in");
-    validateMetric(1, appId, "splitter2.records.out.null");
-    validateMetric(1, appId, "splitter2.records.out.non-null");
     validateMetric(1, appId, "sink1.records.in");
     validateMetric(3, appId, "sink2.records.in");
   }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/mock/NaiveBayesTrainer.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/mock/NaiveBayesTrainer.java
@@ -117,8 +117,6 @@ public final class NaiveBayesTrainer extends SparkSink<StructuredRecord> {
 
   @Override
   public void run(SparkExecutionPluginContext sparkContext, JavaRDD<StructuredRecord> input) throws Exception {
-    Preconditions.checkArgument(input.count() != 0, "Input RDD is empty.");
-
     final HashingTF tf = new HashingTF(100);
     JavaRDD<LabeledPoint> trainingData = input.map(new Function<StructuredRecord, LabeledPoint>() {
       @Override
@@ -133,7 +131,7 @@ public final class NaiveBayesTrainer extends SparkSink<StructuredRecord> {
       }
     });
 
-    trainingData.cache();
+    trainingData = trainingData.cache();
 
     final NaiveBayesModel model = NaiveBayes.train(trainingData.rdd(), 1.0);
 

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineRunner.java
@@ -26,10 +26,8 @@ import io.cdap.cdap.etl.api.JoinElement;
 import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoinerRuntimeContext;
-import io.cdap.cdap.etl.api.join.AutoJoiner;
 import io.cdap.cdap.etl.api.join.AutoJoinerContext;
 import io.cdap.cdap.etl.api.join.JoinDefinition;
-import io.cdap.cdap.etl.api.join.JoinStage;
 import io.cdap.cdap.etl.api.streaming.StreamingContext;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
 import io.cdap.cdap.etl.common.DefaultAutoJoinerContext;
@@ -60,6 +58,7 @@ import org.apache.spark.streaming.api.java.JavaStreamingContext;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Driver for running pipelines using Spark Streaming.
@@ -143,7 +142,8 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
   protected SparkCollection<Object> handleJoin(Map<String, SparkCollection<Object>> inputDataCollections,
                                                PipelinePhase pipelinePhase, PluginFunctionContext pluginFunctionContext,
                                                StageSpec stageSpec, Object plugin, Integer numPartitions,
-                                               StageStatisticsCollector collector) throws Exception {
+                                               StageStatisticsCollector collector,
+                                               Set<String> shufflers) throws Exception {
     String stageName = stageSpec.getName();
     BatchJoiner<?, ?, ?> joiner;
     if (plugin instanceof BatchAutoJoiner) {
@@ -176,6 +176,7 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
 
     BatchJoinerRuntimeContext joinerRuntimeContext = pluginFunctionContext.createBatchRuntimeContext();
     joiner.initialize(joinerRuntimeContext);
-    return handleJoin(joiner, inputDataCollections, stageSpec, numPartitions, collector).cache();
+    shufflers.add(stageName);
+    return handleJoin(joiner, inputDataCollections, stageSpec, numPartitions, collector);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
@@ -33,7 +33,7 @@ public final class Constants {
   public static final String SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG = "spark.cdap.pipeline.autocache.enable";
   public static final String SPARK_PIPELINE_CACHING_STORAGE_LEVEL = "spark.cdap.pipeline.caching.storage.level";
   public static final String CONSOLIDATE_STAGES = "spark.cdap.pipeline.consolidate.stages";
-  public static final String DEFAULT_CACHING_STORAGE_LEVEL = "MEMORY_AND_DISK";
+  public static final String DEFAULT_CACHING_STORAGE_LEVEL = "DISK_ONLY";
 
   private Constants() {
     throw new AssertionError("Suppress default constructor for noninstantiability");

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -61,6 +61,7 @@ import io.cdap.cdap.etl.common.RecordInfo;
 import io.cdap.cdap.etl.common.Schemas;
 import io.cdap.cdap.etl.common.StageStatisticsCollector;
 import io.cdap.cdap.etl.planner.CombinerDag;
+import io.cdap.cdap.etl.planner.Dag;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 import io.cdap.cdap.etl.spark.function.AlertPassFilter;
 import io.cdap.cdap.etl.spark.function.BatchSinkFunction;
@@ -151,6 +152,15 @@ public abstract class SparkPipelineRunner {
         groupNum++;
       }
     }
+    Set<String> branchers = new HashSet<>();
+    for (String stageName : groupedDag.getNodes()) {
+      if (groupedDag.getNodeOutputs(stageName).size() > 1) {
+        branchers.add(stageName);
+      }
+    }
+    Set<String> shufflers = pipelinePhase.getStagesOfType(BatchAggregator.PLUGIN_TYPE).stream()
+      .map(StageSpec::getName)
+      .collect(Collectors.toSet());
 
     Collection<Runnable> sinkRunnables = new ArrayList<>();
     for (String stageName : groupedDag.getTopologicalOrder()) {
@@ -236,7 +246,7 @@ public abstract class SparkPipelineRunner {
         if (sourcePluginType.equals(pluginType) || isConnectorSource) {
           SparkCollection<RecordInfo<Object>> combinedData = getSource(stageSpec, collector);
           emittedBuilder = addEmitted(emittedBuilder, pipelinePhase, stageSpec,
-                                      combinedData, hasErrorOutput, hasAlertOutput);
+                                      combinedData, groupedDag, branchers, shufflers, hasErrorOutput, hasAlertOutput);
         } else {
           throw new IllegalStateException(String.format("Stage '%s' has no input and is not a source.", stageName));
         }
@@ -250,13 +260,13 @@ public abstract class SparkPipelineRunner {
 
         SparkCollection<RecordInfo<Object>> combinedData = stageData.transform(stageSpec, collector);
         emittedBuilder = addEmitted(emittedBuilder, pipelinePhase, stageSpec,
-                                    combinedData, hasErrorOutput, hasAlertOutput);
+                                    combinedData, groupedDag, branchers, shufflers, hasErrorOutput, hasAlertOutput);
 
       } else if (SplitterTransform.PLUGIN_TYPE.equals(pluginType)) {
 
         SparkCollection<RecordInfo<Object>> combinedData = stageData.multiOutputTransform(stageSpec, collector);
         emittedBuilder = addEmitted(emittedBuilder, pipelinePhase, stageSpec,
-                                    combinedData, hasErrorOutput, hasAlertOutput);
+                                    combinedData, groupedDag, branchers, shufflers, hasErrorOutput, hasAlertOutput);
 
       } else if (ErrorTransform.PLUGIN_TYPE.equals(pluginType)) {
 
@@ -278,7 +288,7 @@ public abstract class SparkPipelineRunner {
           SparkCollection<RecordInfo<Object>> combinedData =
             inputErrors.flatMap(stageSpec, Compat.convert(new ErrorTransformFunction<>(pluginFunctionContext)));
           emittedBuilder = addEmitted(emittedBuilder, pipelinePhase, stageSpec,
-                                      combinedData, hasErrorOutput, hasAlertOutput);
+                                      combinedData, groupedDag, branchers, shufflers, hasErrorOutput, hasAlertOutput);
         }
 
       } else if (SparkCompute.PLUGIN_TYPE.equals(pluginType)) {
@@ -286,7 +296,7 @@ public abstract class SparkPipelineRunner {
         SparkCompute<Object, Object> sparkCompute = pluginContext.newPluginInstance(stageName, macroEvaluator);
         SparkCollection<Object> computed = stageData.compute(stageSpec, sparkCompute);
         addEmitted(emittedBuilder, pipelinePhase, stageSpec, computed.map(new RecordInfoWrapper<>(stageName)),
-                   false, false);
+                   groupedDag, branchers, shufflers, false, false);
 
       } else if (SparkSink.PLUGIN_TYPE.equals(pluginType)) {
 
@@ -302,11 +312,11 @@ public abstract class SparkPipelineRunner {
           SparkCollection<RecordInfo<Object>> combinedData = stageData.reduceAggregate(stageSpec, partitions,
                                                                                        collector);
           emittedBuilder = addEmitted(emittedBuilder, pipelinePhase, stageSpec,
-                                      combinedData, hasErrorOutput, hasAlertOutput);
+                                      combinedData, groupedDag, branchers, shufflers, hasErrorOutput, hasAlertOutput);
         } else {
           SparkCollection<RecordInfo<Object>> combinedData = stageData.aggregate(stageSpec, partitions, collector);
           emittedBuilder = addEmitted(emittedBuilder, pipelinePhase, stageSpec,
-                                      combinedData, hasErrorOutput, hasAlertOutput);
+                                      combinedData, groupedDag, branchers, shufflers, hasErrorOutput, hasAlertOutput);
         }
 
       } else if (BatchJoiner.PLUGIN_TYPE.equals(pluginType)) {
@@ -314,16 +324,16 @@ public abstract class SparkPipelineRunner {
         Integer numPartitions = stagePartitions.get(stageName);
         Object plugin = pluginContext.newPluginInstance(stageName, macroEvaluator);
         SparkCollection<Object> joined = handleJoin(inputDataCollections, pipelinePhase, pluginFunctionContext,
-                                                    stageSpec, plugin, numPartitions, collector);
+                                                    stageSpec, plugin, numPartitions, collector, shufflers);
         addEmitted(emittedBuilder, pipelinePhase, stageSpec,
-                   joined.map(new RecordInfoWrapper<>(stageName)), false, false);
+                   joined.map(new RecordInfoWrapper<>(stageName)), groupedDag, branchers, shufflers, false, false);
 
       } else if (Windower.PLUGIN_TYPE.equals(pluginType)) {
 
         Windower windower = pluginContext.newPluginInstance(stageName, macroEvaluator);
         SparkCollection<Object> windowed = stageData.window(stageSpec, windower);
         addEmitted(emittedBuilder, pipelinePhase, stageSpec, windowed.map(new RecordInfoWrapper<>(stageName)),
-                   false, false);
+                   groupedDag, branchers, shufflers, false, false);
 
       } else if (AlertPublisher.PLUGIN_TYPE.equals(pluginType)) {
 
@@ -429,14 +439,15 @@ public abstract class SparkPipelineRunner {
   protected SparkCollection<Object> handleJoin(Map<String, SparkCollection<Object>> inputDataCollections,
                                                PipelinePhase pipelinePhase, PluginFunctionContext pluginFunctionContext,
                                                StageSpec stageSpec, Object plugin, Integer numPartitions,
-                                               StageStatisticsCollector collector) throws Exception {
+                                               StageStatisticsCollector collector,
+                                               Set<String> shufflers) throws Exception {
     String stageName = stageSpec.getName();
     if (plugin instanceof BatchJoiner) {
       BatchJoiner<Object, Object, Object> joiner = (BatchJoiner<Object, Object, Object>) plugin;
       BatchJoinerRuntimeContext joinerRuntimeContext = pluginFunctionContext.createBatchRuntimeContext();
       joiner.initialize(joinerRuntimeContext);
-
-      return handleJoin(joiner, inputDataCollections, stageSpec, numPartitions, collector).cache();
+      shufflers.add(stageName);
+      return handleJoin(joiner, inputDataCollections, stageSpec, numPartitions, collector);
     } else if (plugin instanceof AutoJoiner) {
       AutoJoiner autoJoiner = (AutoJoiner) plugin;
       Map<String, Schema> inputSchemas = new HashMap<>();
@@ -451,6 +462,9 @@ public abstract class SparkPipelineRunner {
       // it is checked by PipelinePhasePreparer at the start of the run.
       JoinDefinition joinDefinition = autoJoiner.define(autoJoinerContext);
       failureCollector.getOrThrowException();
+      if (joinDefinition.getStages().stream().noneMatch(JoinStage::isBroadcast)) {
+        shufflers.add(stageName);
+      }
       return handleAutoJoin(stageName, joinDefinition, inputDataCollections, numPartitions);
     } else {
       // should never happen unless there is a bug in the code. should have failed during deployment
@@ -789,54 +803,61 @@ public abstract class SparkPipelineRunner {
     return mergeJoinResults(stageSpec, joinedInputs, collector);
   }
 
-  // return whether this stage should be cached to avoid recomputation
-  private boolean shouldCache(PipelinePhase pipelinePhase, StageSpec stageSpec) {
 
-    // cache this RDD if it has multiple outputs,
-    // otherwise computation of each output may trigger recomputing this stage
-    Set<String> outputs = pipelinePhase.getStageOutputs(stageSpec.getName());
-    if (outputs.size() > 1) {
-      return true;
+  /**
+   * A stage should be cached if it prevents a source from being recomputed. For example:
+   *
+   *                        |--> agg1 --> sink1
+   * source --> transform --|
+   *                        |--> agg2 --> sink2
+   *
+   * The output of the transform stage should be cached, otherwise the two branches would cause the source to be
+   * recomputed. However, if the pipeline was a little different:
+   *
+   *                   |--> agg1 --> sink1
+   * source --> agg0 --|
+   *                   |--> agg2 --> sink
+   *
+   * Nothing needs to be cached here because agg0 is an aggregator, which involves a data shuffle.
+   * When there is a shuffle, Spark knows to re-read from the shuffle data instead of the source.
+   * Aggregators and non-broadcast joins will shuffle data.
+   *
+   * Cache points can't be pre-computed because we don't know which joins are broadcast joins until the
+   * actual plugin is instantiated and the JoinDefinition is fetched from the plugin. This method assumes it
+   * will be called on stages in topological order, where any parent that is a joiner will be included in the
+   * provided shufflers set.
+   */
+  private boolean shouldCache(Dag dag, String stageName, Set<String> branchers, Set<String> shufflers) {
+    if (!branchers.contains(stageName) || shufflers.contains(stageName)) {
+      return false;
     }
 
-    // cache this stage if it is an input to a stage that has multiple inputs.
-    // otherwise the union computation may trigger recomputing this stage
-    for (String outputStageName : outputs) {
-      StageSpec outputStage = pipelinePhase.getStage(outputStageName);
-      //noinspection ConstantConditions
-      if (pipelinePhase.getStageInputs(outputStageName).size() > 1) {
-        return true;
-      }
-    }
-
-    return false;
+    // the stage is a non-shuffle stage with multiple outputs.
+    // check if there is a path from this stage back to a source without passing through another branch point
+    // or a shuffler. If so, this stage needs to be cached.
+    Set<String> stopNodes = new HashSet<>(branchers);
+    stopNodes.addAll(shufflers);
+    Set<String> parents = dag.parentsOf(stageName, stopNodes);
+    return !Sets.intersection(dag.getSources(), parents).isEmpty();
   }
 
   private EmittedRecords.Builder addEmitted(EmittedRecords.Builder builder, PipelinePhase pipelinePhase,
                                             StageSpec stageSpec, SparkCollection<RecordInfo<Object>> stageData,
+                                            Dag dag, Set<String> branchers, Set<String> shufflers,
                                             boolean hasErrors, boolean hasAlerts) {
-
-    if (hasErrors || hasAlerts || stageSpec.getOutputPorts().size() > 1) {
-      // need to cache, otherwise the stage can be computed once per type of emitted record
-      stageData = stageData.cache();
-    }
     builder.setRawData(stageData);
 
-    boolean shouldCache = shouldCache(pipelinePhase, stageSpec);
+    if (shouldCache(dag, stageSpec.getName(), branchers, shufflers)) {
+      stageData = stageData.cache();
+    }
 
     if (hasErrors) {
       SparkCollection<ErrorRecord<Object>> errors =
         stageData.flatMap(stageSpec, Compat.convert(new ErrorPassFilter<>()));
-      if (shouldCache) {
-        errors = errors.cache();
-      }
       builder.setErrors(errors);
     }
     if (hasAlerts) {
       SparkCollection<Alert> alerts = stageData.flatMap(stageSpec, Compat.convert(new AlertPassFilter()));
-      if (shouldCache) {
-        alerts = alerts.cache();
-      }
       builder.setAlerts(alerts);
     }
 
@@ -845,16 +866,10 @@ public abstract class SparkPipelineRunner {
       for (StageSpec.Port portSpec : stageSpec.getOutputPorts().values()) {
         String port = portSpec.getPort();
         SparkCollection<Object> portData = stageData.flatMap(stageSpec, Compat.convert(new OutputPassFilter<>(port)));
-        if (shouldCache) {
-          portData = portData.cache();
-        }
         builder.addPort(port, portData);
       }
     } else {
       SparkCollection<Object> outputs = stageData.flatMap(stageSpec, Compat.convert(new OutputPassFilter<>()));
-      if (shouldCache) {
-        outputs = outputs.cache();
-      }
       builder.setOutput(outputs);
     }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
@@ -215,9 +215,6 @@ public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
     JavaRDD<T> countedInput = rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(),
                                                               Constants.Metrics.RECORDS_IN, null));
     SparkConf sparkConf = jsc.getConf();
-    if (sparkConf.getBoolean(Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG, true)) {
-      countedInput = countedInput.cache();
-    }
 
     return wrap(compute.transform(sparkPluginContext, countedInput)
                   .map(new CountingFunction<U>(stageName, sec.getMetrics(), Constants.Metrics.RECORDS_OUT,
@@ -276,9 +273,6 @@ public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
         JavaRDD<T> countedRDD =
           rdd.map(new CountingFunction<T>(stageName, sec.getMetrics(), Constants.Metrics.RECORDS_IN, null));
         SparkConf sparkConf = jsc.getConf();
-        if (sparkConf.getBoolean(Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG, true)) {
-          countedRDD = countedRDD.cache();
-        }
         try {
           sink.run(sparkPluginContext, countedRDD);
         } catch (Exception e) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
@@ -170,9 +170,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
     return new Runnable() {
       @Override
       public void run() {
-        // cache since the streaming sink function will check if the rdd is empty, which can cause recomputation
-        // and confusing metrics if its not cached.
-        Compat.foreachRDD(stream.cache(), new StreamingBatchSinkFunction<>(sec, stageSpec));
+        Compat.foreachRDD(stream, new StreamingBatchSinkFunction<>(sec, stageSpec));
       }
     };
   }
@@ -194,7 +192,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
     return new Runnable() {
       @Override
       public void run() {
-        Compat.foreachRDD(stream.cache(), new StreamingSparkSinkFunction<T>(sec, stageSpec));
+        Compat.foreachRDD(stream, new StreamingSparkSinkFunction<T>(sec, stageSpec));
       }
     };
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
@@ -64,9 +64,6 @@ public class StreamingBatchSinkFunction<T> implements Function2<JavaRDD<T>, Time
 
   @Override
   public Void call(JavaRDD<T> data, Time batchTime) throws Exception {
-    if (data.isEmpty()) {
-      return null;
-    }
 
     final long logicalStartTime = batchTime.milliseconds();
     MacroEvaluator evaluator = new DefaultMacroEvaluator(new BasicArguments(sec),


### PR DESCRIPTION
changed the auto caching strategy so that stages are only cached
if they will prevent a source from being recomputed. Also changed
the default cache level to disk only to prevent OOM errors that
we've seen with other cache levels.