### PR TITLE
(CDAP-17182) Enable content compression for runtime service

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java
@@ -44,7 +44,6 @@ import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.TopicId;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,13 +82,13 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
 
   @Inject
   RuntimeClientService(CConfiguration cConf, MessagingService messagingService,
-                       DiscoveryServiceClient discoveryServiceClient, ProgramRunId programRunId) {
+                       RuntimeClient runtimeClient, ProgramRunId programRunId) {
     super(RetryStrategies.fromConfiguration(cConf, "system.runtime.monitor."));
     this.messagingContext = new MultiThreadMessagingContext(messagingService);
     this.pollTimeMillis = cConf.getLong(Constants.RuntimeMonitor.POLL_TIME_MS);
     this.gracefulShutdownMillis = cConf.getLong(Constants.RuntimeMonitor.GRACEFUL_SHUTDOWN_MS);
     this.programRunId = programRunId;
-    this.runtimeClient = new RuntimeClient(discoveryServiceClient);
+    this.runtimeClient = runtimeClient;
     this.fetchLimit = cConf.getInt(Constants.RuntimeMonitor.BATCH_SIZE);
     this.programFinishTime = -1L;
     this.topicRelayers = RuntimeMonitors.createTopicConfigs(cConf).entrySet().stream()

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -866,6 +866,8 @@ public final class Constants {
     public static final String BIND_PORT = "app.program.runtime.monitor.server.bind.port";
     public static final String SSL_ENABLED = "app.program.runtime.monitor.server.ssl.enabled";
 
+    public static final String COMPRESSION_ENABLED = "app.program.runtime.monitor.compression.enabled";
+
     // Configuration key for specifying the base URL for sending monitoring messages.
     // If it is missing from the configuration, SSH tunnel will be used.
     public static final String MONITOR_URL = "app.program.runtime.monitor.url";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2702,6 +2702,14 @@
   </property>
 
   <property>
+    <name>app.program.runtime.monitor.compression.enabled</name>
+    <value>true</value>
+    <description>
+      Enable compression for runtime monitoring traffic
+    </description>
+  </property>
+
+  <property>
     <name>app.program.runtime.monitor.topics.configs</name>
     <value>audit.topic,data.event.topic,metadata.messaging.topic,metrics.topic.prefix:${metrics.messaging.topic.num},program.status.event.topic,log.tms.topic.prefix:${log.publish.num.partitions}</value>
     <description>


### PR DESCRIPTION
- Reduce the network traffic size for large Json metadata
- Fixed a bug in the RuntimeHandler that it didn’t consume the entire chunk, with can result in missing data
  - This doesn't affect uncompressed request since the incoming chunk would be <= a complete avro array block
  - When compression is enabled, a chunk (after decompression), may contains multiple avro array blocks