### PR TITLE
[CDAP-171175] Fix artifacts not available in pipeline detail view

### DIFF
--- a/cdap-ui/app/hydrator/services/create/actions/available-plugins-action-creator.js
+++ b/cdap-ui/app/hydrator/services/create/actions/available-plugins-action-creator.js
@@ -60,16 +60,35 @@ class PipelineAvailablePluginsActions {
     let availablePluginsMap = {};
     let pluginsList = [];
 
-    stages.forEach((stage) => {
-      let pluginInfo = this._createPluginInfo(stage.plugin);
-      availablePluginsMap[pluginInfo.key] = {
-        pluginInfo: stage.plugin
-      };
+    this.api.getAllArtifacts({ namespace })
+      .$promise
+      .then((res) => {
+        // create map for all available artifacts
+        const artifactsMap = {};
+        res.forEach((artifact) => {
+          const artifactKey = this._getArtifactKey(artifact);
+          artifactsMap[artifactKey] = artifact;
+        });
 
-      pluginsList.push(pluginInfo);
-    });
+        stages.forEach((stage) => {
+          const stageArtifact = this.myHelpers.objectQuery(stage, 'plugin', 'artifact');
+          const artifactKey = this._getArtifactKey(stageArtifact);
+          if (!artifactsMap[artifactKey]) {
+            return;
+          }
 
-    this._fetchInfo(availablePluginsMap, namespace, pluginsList);
+          let pluginInfo = this._createPluginInfo(stage.plugin);
+          availablePluginsMap[pluginInfo.key] = {
+            pluginInfo: stage.plugin
+          };
+
+          pluginsList.push(pluginInfo);
+        });
+
+        this._fetchInfo(availablePluginsMap, namespace, pluginsList);
+      });
+
+
   }
 
   fetchPluginsForUpgrade(extensionsParams) {

--- a/cdap-ui/app/services/hydrator/my-pipeline-api.js
+++ b/cdap-ui/app/services/hydrator/my-pipeline-api.js
@@ -49,7 +49,7 @@ angular.module(PKG.name + '.services')
         loadArtifact: myHelpers.getConfig('POST', 'REQUEST', loadArtifactPath, false, {contentType: 'application/java-archive'}),
         loadJson: myHelpers.getConfig('PUT', 'REQUEST', loadArtifactJSON, false, {contentType: 'application/json'}),
         save: myHelpers.getConfig('PUT', 'REQUEST', pipelinePath, false, {contentType: 'application/json'}),
-        getAllArtifacts:myHelpers.getConfig('GET', 'REQUEST', artifactsBasePath, true),
+        getAllArtifacts: myHelpers.getConfig('GET', 'REQUEST', artifactsBasePath, true),
 
         fetchArtifacts: myHelpers.getConfig('GET', 'REQUEST', artifactsPath, true),
         fetchExtensions: myHelpers.getConfig('GET', 'REQUEST', extensionsFetchPath, true),


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-17175
Build: https://builds.cask.co/browse/CDAP-UDUT800

Root cause: as part of the fix for being able to support multiple version of a plugin and still have the message to the user when plugin is not available, the check for the availability of the plugin was changed from widget existence to pluginInfo. However in detail page, the pluginInfo is actually generated from the configuraiton of the pipeline, not actually fetching backend for the artifact information. The solution is to fetch the list of artifacts from the backend and check against that. 