### PR TITLE
(CDAP-17195) Fix test case DataprocProvisionerTest.testCustomImageURI

### DIFF
--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -137,6 +137,8 @@ public class DataprocProvisionerTest {
     props.put(DataprocConf.CUSTOM_IMAGE_URI,
         customURI);
     props.put("accountKey", "key");
+    props.put("projectId", "my project");
+    props.put("zone", "region1-a");
 
     DataprocConf conf = DataprocConf.create(props);
     Assert.assertEquals(customURI, conf.getCustomImageUri());


### PR DESCRIPTION
for fixing the bug: https://issues.cask.co/browse/CDAP-17195

The root cause is that the test case didn't set the "projectId" and "zone" in the properties for creating DataprocConf.
Thus DataprocConf will try to get projectId from metadata retrieved from host "metadata.google.internal"
So it has dependency on hosts config on the test machine