### PR TITLE
(CDAP-17120) (CDAP-17199) Fixing concurrent program launch

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -458,9 +458,15 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
 
   @Override
   protected void startUp() throws Exception {
+    // Limits to at max poolSize number of concurrent program launch.
+    // Also don't keep a thread around if it is idle for more than 60 seconds.
     int poolSize = cConf.getInt(Constants.AppFabric.PROGRAM_LAUNCH_THREADS);
-    executor = new ThreadPoolExecutor(0, poolSize, 60, TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
-                                      new ThreadFactoryBuilder().setNameFormat("program-start-%d").build());
+    ThreadPoolExecutor executor = new ThreadPoolExecutor(poolSize, poolSize, 60, TimeUnit.SECONDS,
+                                                         new LinkedBlockingQueue<>(),
+                                                         new ThreadFactoryBuilder()
+                                                           .setNameFormat("program-start-%d").build());
+    executor.allowCoreThreadTimeOut(true);
+    this.executor = executor;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
@@ -488,7 +488,6 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
         } catch (Exception e) {
           throw new RuntimeException("Failed to create controller for " + programRunId, e);
         }
-        RemoteExecutionTwillController finalController = controller;
 
         // Execute the startup task if provided
         if (startupTask != null) {
@@ -546,8 +545,8 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
         }
 
         LOG.debug("Created controller for program run {}", programRunId);
-        controllers.put(programRunId, finalController);
-        return finalController;
+        controllers.put(programRunId, controller);
+        return controller;
       } finally {
         controllersLock.unlock();
       }


### PR DESCRIPTION
This PR contains two fixes

- CDAP-17120
  - Correctly use the concurrent program launch configuration to limit how many launches happening in parallel
- CDAP-17199
  - Fix the long running Dataproc provisioner under concurrent launch to not throw exception when it fails to update labels