### PR TITLE
[CDAP-17201] Change unique identifier of each request history to be uuidV4 instead of timestamp (RequestHistoryTab)

### DIFF
--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestActionDialogs/DeleteDialog/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestActionDialogs/DeleteDialog/index.tsx
@@ -16,16 +16,17 @@
 
 import ConfirmationModal from 'components/ConfirmationModal';
 import HttpExecutorActions from 'components/HttpExecutor/store/HttpExecutorActions';
+import { IRequestHistory } from 'components/HttpExecutor/RequestHistoryTab';
 import React from 'react';
 import { connect } from 'react-redux';
 
 const mapDispatch = (dispatch) => {
   return {
-    deleteRequestLog: (requestID: string) => {
+    deleteRequestLog: (request: IRequestHistory) => {
       dispatch({
         type: HttpExecutorActions.deleteRequestLog,
         payload: {
-          requestID,
+          request,
         },
       });
     },
@@ -33,20 +34,20 @@ const mapDispatch = (dispatch) => {
 };
 
 interface IDeleteDialogProps {
-  requestID: string;
+  request: IRequestHistory;
   open: boolean;
   handleClose: () => void;
-  deleteRequestLog: (requestID: string) => void;
+  deleteRequestLog: (request: IRequestHistory) => void;
 }
 
 const DeleteDialogView: React.FC<IDeleteDialogProps> = ({
-  requestID,
+  request,
   open,
   handleClose,
   deleteRequestLog,
 }) => {
   const onDeleteClick = () => {
-    deleteRequestLog(requestID);
+    deleteRequestLog(request);
     handleClose();
   };
 

--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestRow/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/RequestRow/index.tsx
@@ -146,12 +146,12 @@ const RequestRowView: React.FC<IRequestRowProps> = ({
     setRequestHistoryView(req);
   };
 
-  const isSelectedRequest = selectedRequest && request.timestamp === selectedRequest.timestamp;
+  const isSelectedRequest = selectedRequest && request.id === selectedRequest.id;
 
   return (
     <div>
       <div
-        data-cy={`request-row-${request.timestamp}`}
+        data-cy={`request-row-${request.id}`}
         className={classnames(classes.requestRow, {
           [classes.selectedRequestRow]: isSelectedRequest,
         })}
@@ -212,7 +212,7 @@ const RequestRowView: React.FC<IRequestRowProps> = ({
         </div>
       </div>
       <DeleteDialog
-        requestID={request.timestamp}
+        request={request}
         open={deleteDialogOpen}
         handleClose={() => setDeleteDialogOpen(false)}
       />

--- a/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/index.tsx
+++ b/cdap-ui/app/cdap/components/HttpExecutor/RequestHistoryTab/index.tsx
@@ -41,6 +41,7 @@ import { connect } from 'react-redux';
 export const REQUEST_HISTORY = 'RequestHistory';
 
 export interface IRequestHistory {
+  id: string;
   timestamp: string;
   method: RequestMethod;
   path: string;

--- a/cdap-ui/app/cdap/components/HttpExecutor/store/HttpExecutorStore.js
+++ b/cdap-ui/app/cdap/components/HttpExecutor/store/HttpExecutorStore.js
@@ -85,6 +85,7 @@ const addRequestLog = (state) => {
     response,
     statusCode,
     timestamp: new Date().toLocaleString(),
+    id: uuidV4(),
   };
 
   // Update the component view in real-time, since we cannot listen to local storage's change
@@ -133,16 +134,16 @@ const addRequestLog = (state) => {
   };
 };
 
-const deleteRequestLog = (state, requestID) => {
-  if (!requestID) {
+const deleteRequestLog = (state, request) => {
+  if (!request) {
     return;
   }
   const { requestLog } = state;
 
   // Delete the request log from local state
-  const dateID = getDateID(new Date(requestID));
+  const dateID = getDateID(new Date(request.timestamp));
   const requestsGroup = getRequestsByDate(requestLog, dateID);
-  const requestToDelete = requestsGroup.findIndex((data) => data.timestamp === requestID);
+  const requestToDelete = requestsGroup.findIndex((req) => req.id === request.id);
   const newRequestLog = requestLog.set(dateID, requestsGroup.delete(requestToDelete));
 
   // Delete the specified request log from local storage
@@ -231,7 +232,7 @@ const http = (state = defaultInitialState, action = defaultAction) => {
         saveCalls: !state.saveCalls,
       };
     case HttpExecutorActions.deleteRequestLog:
-      return deleteRequestLog(state, action.payload.requestID);
+      return deleteRequestLog(state, action.payload.request);
     case HttpExecutorActions.clearAllRequestLog:
       return clearAllRequestLog(state);
     default:

--- a/cdap-ui/cypress/integration/httpexecutor.requesthistorytab.spec.ts
+++ b/cdap-ui/cypress/integration/httpexecutor.requesthistorytab.spec.ts
@@ -20,34 +20,37 @@ let headers = {};
 const { dataCy } = Helpers;
 
 const MOCK_LOCAL_STORAGE = JSON.stringify([
-    {
-      method: 'GET',
-      path: 'hello.com',
-      body: 'hello',
-      headers: { pairs: [{ key: '', value: '', uniqueId: '6fd93a6e-5b2f-47aa-8143-157629bdf457' }] },
-      response: 'Problem accessing: /v3/hello.com. Reason: Not Found',
-      statusCode: 404,
-      timestamp: '7/5/2020, 6:54:19 PM',
-    },
-    {
-      method: 'DELETE',
-      path: 'hello2.com',
-      body: 'hello2',
-      headers: { pairs: [{ key: '', value: '', uniqueId: '6fd93a6e-5b2f-47aa-8143-157629bdf457' }] },
-      response: 'Problem accessing: /v3/hello2.com. Reason: Not Found',
-      statusCode: 404,
-      timestamp: '7/6/2020, 6:54:19 PM',
-    },
-    {
-      method: 'POST',
-      path: 'hello3.com',
-      body: 'hello3',
-      headers: { pairs: [{ key: '', value: '', uniqueId: '6fd93a6e-5b2f-47aa-8143-157629bdf457' }] },
-      response: 'Problem accessing: /v3/hello3.com. Reason: Not Found',
-      statusCode: 409,
-      timestamp: '7/7/2020, 6:54:19 PM',
-    }
-  ]);
+  {
+    id: '1',
+    method: 'GET',
+    path: 'hello.com',
+    body: 'hello',
+    headers: { pairs: [{ key: '', value: '', uniqueId: '6fd93a6e-5b2f-47aa-8143-157629bdf457' }] },
+    response: 'Problem accessing: /v3/hello.com. Reason: Not Found',
+    statusCode: 404,
+    timestamp: '7/5/2020, 6:54:19 PM',
+  },
+  {
+    id: '2',
+    method: 'DELETE',
+    path: 'hello2.com',
+    body: 'hello2',
+    headers: { pairs: [{ key: '', value: '', uniqueId: '6fd93a6e-5b2f-47aa-8143-157629bdf457' }] },
+    response: 'Problem accessing: /v3/hello2.com. Reason: Not Found',
+    statusCode: 404,
+    timestamp: '7/6/2020, 6:54:19 PM',
+  },
+  {
+    id: '3',
+    method: 'POST',
+    path: 'hello3.com',
+    body: 'hello3',
+    headers: { pairs: [{ key: '', value: '', uniqueId: '6fd93a6e-5b2f-47aa-8143-157629bdf457' }] },
+    response: 'Problem accessing: /v3/hello3.com. Reason: Not Found',
+    statusCode: 409,
+    timestamp: '7/7/2020, 6:54:19 PM',
+  },
+]);
 
 describe('RequestHistoryTab in httpExecutor', () => {
   // Uses API call to login instead of logging in manually through UI
@@ -73,23 +76,23 @@ describe('RequestHistoryTab in httpExecutor', () => {
 
     it('should show populate requestHistoryTab with existing items in localStorage', () => {
       JSON.parse(MOCK_LOCAL_STORAGE).forEach((req) => {
-        const timestamp = req.timestamp;
+        const ID = req.id;
 
-        cy.get(dataCy(`request-row-${timestamp}`)).should('exist');
+        cy.get(dataCy(`request-row-${ID}`)).should('exist');
 
-        cy.get(`${dataCy(`request-row-${timestamp}`)} ${dataCy('request-path')}`)
+        cy.get(`${dataCy(`request-row-${ID}`)} ${dataCy('request-path')}`)
           .invoke('text')
           .should((text) => {
             expect(text).to.eq(req.path);
           });
-        cy.get(`${dataCy(`request-row-${timestamp}`)} ${dataCy('request-method')}`)
+        cy.get(`${dataCy(`request-row-${ID}`)} ${dataCy('request-method')}`)
           .invoke('text')
           .should((text) => {
             expect(text).to.eq(req.method);
           });
 
         // Check if main page has been populated correctly
-        cy.get(dataCy(`request-row-${timestamp}`)).click();
+        cy.get(dataCy(`request-row-${ID}`)).click();
         cy.get(dataCy('request-method-selector'))
           .invoke('val')
           .should((val) => {


### PR DESCRIPTION
<img width="1792" alt="Screen Shot 2020-08-12 at 4 31 59 PM" src="https://user-images.githubusercontent.com/14116152/90073523-5c198380-dcc7-11ea-9cfc-95f1bad5e843.png">

The following error where multiple request histories have same ID happens, because we are setting the `timestamp` to be a unique identifier of each log. Change unique identifier of each request history to be generated by `uuidV4()` instead of timestamp.