### PR TITLE
[CDAP-16490] fix get schema button to ignore macro value 

### DIFF
--- a/cdap-ui/app/cdap/components/ConfigurationGroup/PropertyRow/index.tsx
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/PropertyRow/index.tsx
@@ -74,6 +74,10 @@ const EditorTypeWidgets = [
   'wrangler-directives',
 ];
 
+const WIDGET_TYPE = 'widget-type';
+const PLUGIN = 'plugin';
+const WIDGET_CATEGORY = 'widget-category';
+
 interface IState {
   isMacroTextbox: boolean;
 }
@@ -84,19 +88,26 @@ class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
   };
 
   public state = {
-    isMacroTextbox:
-      isMacro(this.props.value) && objectQuery(this.props.pluginProperty, 'macroSupported'),
+    isMacroTextbox: this.isMacroTextbox(),
   };
 
   public shouldComponentUpdate(nextProps) {
     const rule =
       nextProps.value !== this.props.value ||
-      nextProps.widgetProperty['widget-type'] !== this.props.widgetProperty['widget-type'];
+      nextProps.widgetProperty[WIDGET_TYPE] !== this.props.widgetProperty[WIDGET_TYPE];
     // Comparison of array of objects
     const isArrayEqual = (x: IErrorObj[], y: IErrorObj[]) => isEmpty(xorWith(x, y, isEqual));
     const errorChange = isArrayEqual(nextProps.errors, this.props.errors);
 
     return rule || !errorChange;
+  }
+
+  private isMacroTextbox() {
+    return (
+      this.props.widgetProperty[WIDGET_CATEGORY] !== PLUGIN &&
+      isMacro(this.props.value) &&
+      objectQuery(this.props.pluginProperty, 'macroSupported')
+    );
   }
 
   private toggleMacro = () => {
@@ -143,7 +154,7 @@ class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
       errors,
     } = this.props;
 
-    if (widgetProperty['widget-type'] === 'hidden') {
+    if (widgetProperty[WIDGET_TYPE] === 'hidden') {
       return null;
     }
 
@@ -151,10 +162,13 @@ class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
     const updatedWidgetProperty = {
       ...widgetProperty,
     };
-    if (this.state.isMacroTextbox) {
-      const currentWidget = updatedWidgetProperty['widget-type'];
+
+    const widgetCategory = updatedWidgetProperty[WIDGET_CATEGORY];
+
+    if (this.state.isMacroTextbox && widgetCategory !== PLUGIN) {
+      const currentWidget = updatedWidgetProperty[WIDGET_TYPE];
       if (EditorTypeWidgets.indexOf(currentWidget) === -1) {
-        updatedWidgetProperty['widget-type'] = 'textbox';
+        updatedWidgetProperty[WIDGET_TYPE] = 'textbox';
         updatedWidgetProperty['widget-attributes'] = {};
       }
 
@@ -164,14 +178,20 @@ class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
       };
     }
 
+    const cypressId =
+      widgetCategory !== PLUGIN ? widgetProperty.name : `${widgetCategory}-${widgetProperty.name}`;
+
     // When there is only one error and it does not have element property,
     // it is a property level error.
     const propertyLevelErrorMsg =
       errors && errors.length === 1 && !errors[0].element ? errors[0].msg : '';
     // Fix styling of error here.
     return (
-      <div className={classnames(classes.root, { [classes.macroRow]: this.state.isMacroTextbox })}>
-        <div data-cy={widgetProperty.name} className={classes.row}>
+      <div className={classes.root}>
+        <div
+          data-cy={cypressId}
+          className={classnames(classes.row, { [classes.macroRow]: this.state.isMacroTextbox })}
+        >
           <WidgetWrapper
             widgetProperty={updatedWidgetProperty}
             pluginProperty={pluginProperty}
@@ -183,7 +203,7 @@ class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
             disabled={disabled}
             errors={errors}
           />
-          <If condition={pluginProperty.macroSupported}>
+          <If condition={pluginProperty.macroSupported && widgetCategory !== PLUGIN}>
             <MacroIndicator
               onClick={this.toggleMacro}
               disabled={disabled}
@@ -191,8 +211,11 @@ class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
             />
           </If>
         </div>
-        <If condition={propertyLevelErrorMsg !== ''}>
-          <div className={classnames(classes.errorText, classes.errorRow)}>
+        <If condition={propertyLevelErrorMsg !== '' && widgetCategory !== PLUGIN}>
+          <div
+            className={classnames(classes.errorText, classes.errorRow, 'propertyError')}
+            data-cy="property-row-error"
+          >
             {propertyLevelErrorMsg}
           </div>
         </If>

--- a/cdap-ui/app/cdap/components/ConfigurationGroup/PropertyRow/index.tsx
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/PropertyRow/index.tsx
@@ -202,6 +202,7 @@ class PropertyRowView extends React.Component<IPropertyRowProps, IState> {
             classes={widgetClasses}
             disabled={disabled}
             errors={errors}
+            hideDescription={widgetCategory === PLUGIN}
           />
           <If condition={pluginProperty.macroSupported && widgetCategory !== PLUGIN}>
             <MacroIndicator

--- a/cdap-ui/cypress/integration/pipeline.joiner.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.joiner.spec.ts
@@ -14,6 +14,7 @@
  * the License.
  */
 
+<<<<<<< HEAD
 import { loginIfRequired, getArtifactsPoll, dataCy } from '../helpers';
 
 let headers = {};
@@ -27,6 +28,24 @@ const skip = () => {
   const ctx = getMochaContext();
   return ctx.skip();
 };
+=======
+import { loginIfRequired, getGenericEndpoint, getArtifactsPoll } from '../helpers';
+import { DEFAULT_GCP_PROJECTID, DEFAULT_GCP_SERVICEACCOUNT_PATH } from '../support/constants';
+import { INodeInfo, INodeIdentifier } from '../typings';
+import { dataCy } from '../helpers';
+
+let headers = {};
+
+const TEST_BQ_DATASET_PROJECT = 'datasetproject';
+const TEST_DATASET = 'joiner_test';
+const TABLE1 = 'test1';
+const TABLE2 = 'test2';
+const TABLE1_FIELDS = ['field1', 'field2', 'field3'];
+const TABLE2_FIELDS = ['field1', 'field4'];
+const ALL_FIELDS_ALIASED = ['field', 'field2', 'field3', 'field1', 'field4'];
+const joinerNode: INodeInfo = { nodeName: 'Joiner', nodeType: 'batchjoiner' };
+const joinerNodeId: INodeIdentifier = { ...joinerNode, nodeId: '2' };
+>>>>>>> 49626ab4537... [CDAP-16490] fix get schema button to ignore macro value
 
 const closeButton = '[data-testid="close-config-popover"]';
 
@@ -170,4 +189,5 @@ describe('Running preview with joiner plugin in pipeline studio', () => {
 
     cy.get(closeButton).click();
   });
+
 });

--- a/cdap-ui/cypress/integration/pipeline.joiner.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.joiner.spec.ts
@@ -14,7 +14,6 @@
  * the License.
  */
 
-<<<<<<< HEAD
 import { loginIfRequired, getArtifactsPoll, dataCy } from '../helpers';
 
 let headers = {};
@@ -28,24 +27,6 @@ const skip = () => {
   const ctx = getMochaContext();
   return ctx.skip();
 };
-=======
-import { loginIfRequired, getGenericEndpoint, getArtifactsPoll } from '../helpers';
-import { DEFAULT_GCP_PROJECTID, DEFAULT_GCP_SERVICEACCOUNT_PATH } from '../support/constants';
-import { INodeInfo, INodeIdentifier } from '../typings';
-import { dataCy } from '../helpers';
-
-let headers = {};
-
-const TEST_BQ_DATASET_PROJECT = 'datasetproject';
-const TEST_DATASET = 'joiner_test';
-const TABLE1 = 'test1';
-const TABLE2 = 'test2';
-const TABLE1_FIELDS = ['field1', 'field2', 'field3'];
-const TABLE2_FIELDS = ['field1', 'field4'];
-const ALL_FIELDS_ALIASED = ['field', 'field2', 'field3', 'field1', 'field4'];
-const joinerNode: INodeInfo = { nodeName: 'Joiner', nodeType: 'batchjoiner' };
-const joinerNodeId: INodeIdentifier = { ...joinerNode, nodeId: '2' };
->>>>>>> 49626ab4537... [CDAP-16490] fix get schema button to ignore macro value
 
 const closeButton = '[data-testid="close-config-popover"]';
 
@@ -189,5 +170,4 @@ describe('Running preview with joiner plugin in pipeline studio', () => {
 
     cy.get(closeButton).click();
   });
-
 });


### PR DESCRIPTION
Partial cherry-pick of https://github.com/cdapio/cdap/pull/12042

- Have excluded e2e tests because we rely on too many cypress commands that we introduced in 6.2+ version of CDAP UI that doesn't exist in 6.1

- In addition to that also added a check to not show description for widget category PLUGIN.