### PR TITLE
[CDAP-17206] Fixes typo in function name when preview is stopped

### DIFF
--- a/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/toppanel-ctrl.js
@@ -696,7 +696,7 @@ class HydratorPlusPlusTopPanelCtrl {
         .$promise
         .then(
           () => {
-            this.resetBtnsAndStopPoll();
+            this.resetButtonsAndStopPoll();
             this.updateTimerLabelAndTitle();
 
             if (silentMode) {


### PR DESCRIPTION
When merging [this PR](https://github.com/cdapio/cdap/pull/12609) we[ renamed a function ](https://github.com/cdapio/cdap/pull/12609#discussion_r468110335)but didn't change all occurrence of it. 

Fixing the typo so that we continue to show alert while stopping the preview.

JIRA: https://issues.cask.co/browse/CDAP-17206