### PR TITLE
(CDAP-17207) Fix the flaky metadata test

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
@@ -193,7 +193,7 @@ public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor
                       "Ignoring the message {}", programId.getParent(), programId, message);
           return;
         }
-        if (SystemArguments.isProfileAllowed(programId.getType())) {
+        if (PROFILE_ALLOWED_PROGRAM_TYPES.contains(programId.getType())) {
           collectProgramProfileMetadata(programId, null, updates);
         }
         break;


### PR DESCRIPTION
- The unit-test itself was wrong. It was passing for most of the time was due to async writing of metadata