### PR TITLE
[CDAP-17151, CDAP-16997] Add submitTime in the PreviewStatus for UI and reconcile the preview run status if pod dies because of OOM.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
@@ -107,7 +107,7 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
     this.secureStore = secureStore;
     this.discoveryService = discoveryService;
     this.transactionSystemClient = transactionSystemClient;
-    this.maxConcurrentPreviews = previewCConf.getInt(Constants.Preview.CACHE_SIZE, 10);
+    this.maxConcurrentPreviews = previewCConf.getInt(Constants.Preview.POLLER_COUNT, 10);
     this.previewRunnerServices = ConcurrentHashMap.newKeySet();
     this.previewRunnerModule = previewRunnerModule;
     this.previewLevelDBTableService = previewLevelDBTableService;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerModule.java
@@ -28,7 +28,6 @@ import io.cdap.cdap.app.deploy.Manager;
 import io.cdap.cdap.app.deploy.ManagerFactory;
 import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule;
 import io.cdap.cdap.app.store.Store;
-import io.cdap.cdap.app.store.preview.PreviewStore;
 import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.config.PreferencesService;
@@ -56,7 +55,6 @@ import io.cdap.cdap.internal.app.runtime.artifact.PluginFinderProvider;
 import io.cdap.cdap.internal.app.runtime.workflow.BasicWorkflowStateWriter;
 import io.cdap.cdap.internal.app.runtime.workflow.WorkflowStateWriter;
 import io.cdap.cdap.internal.app.store.DefaultStore;
-import io.cdap.cdap.internal.app.store.preview.DefaultPreviewStore;
 import io.cdap.cdap.internal.pipeline.SynchronousPipelineFactory;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.metadata.DefaultMetadataAdmin;
@@ -181,9 +179,6 @@ public class DefaultPreviewRunnerModule extends PrivateModule implements Preview
     bindPreviewRunner(binder());
     expose(PreviewRunner.class);
 
-    // This binding is temporary. Will be removed after TMS migration.
-    bind(PreviewStore.class).to(DefaultPreviewStore.class).in(Scopes.SINGLETON);
-    expose(PreviewStore.class);
     bind(Scheduler.class).to(NoOpScheduler.class);
 
     bind(DataTracerFactory.class).to(DefaultDataTracerFactory.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewManager.java
@@ -71,6 +71,7 @@ public interface PreviewManager {
    * @param applicationId the id of the preview application
    * @return the {@link ProgramRunId} associated with the preview or {@code null} if there is no run record
    */
+  @Nullable
   ProgramRunId getRunId(ApplicationId applicationId) throws Exception;
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerManagerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerManagerModule.java
@@ -60,7 +60,6 @@ public class PreviewRunnerManagerModule extends RuntimeModule {
           .annotatedWith(Names.named(DataSetsModules.BASE_DATASET_FRAMEWORK))
           .to(RemoteDatasetFramework.class);
         bind(PreviewRunnerModule.class).to(DefaultPreviewRunnerModule.class);
-
         bind(DefaultPreviewRunnerManager.class).in(Scopes.SINGLETON);
         bind(PreviewRunStopper.class).to(DefaultPreviewRunnerManager.class);
         expose(PreviewRunStopper.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewStatus.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewStatus.java
@@ -51,18 +51,20 @@ public class PreviewStatus {
 
   private final Status status;
   private final BasicThrowable throwable;
+  private final long submitTime;
   private final Long startTime;
   private final Long endTime;
   private final Integer positionInWaitingQueue;
 
-  public PreviewStatus(Status status, @Nullable BasicThrowable throwable, @Nullable Long startTime,
+  public PreviewStatus(Status status, long submitTime, @Nullable BasicThrowable throwable, @Nullable Long startTime,
                        @Nullable Long endTime) {
-    this(status, throwable, startTime, endTime, null);
+    this(status, submitTime, throwable, startTime, endTime, null);
   }
 
-  public PreviewStatus(Status status, @Nullable BasicThrowable throwable, @Nullable Long startTime,
+  public PreviewStatus(Status status, long submitTime, @Nullable BasicThrowable throwable, @Nullable Long startTime,
                        @Nullable Long endTime, @Nullable Integer positionInWaitingQueue) {
     this.status = status;
+    this.submitTime = submitTime;
     this.throwable = throwable;
     this.startTime = startTime;
     this.endTime = endTime;
@@ -71,6 +73,10 @@ public class PreviewStatus {
 
   public Status getStatus() {
     return status;
+  }
+
+  public long getSubmitTime() {
+    return submitTime;
   }
 
   /**
@@ -116,6 +122,7 @@ public class PreviewStatus {
 
     PreviewStatus status1 = (PreviewStatus) o;
     return status == status1.status &&
+      submitTime == status1.submitTime &&
       Objects.equals(throwable, status1.throwable) &&
       Objects.equals(startTime, status1.startTime) &&
       Objects.equals(endTime, status1.endTime) &&
@@ -124,6 +131,6 @@ public class PreviewStatus {
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, throwable, startTime, endTime, positionInWaitingQueue);
+    return Objects.hash(status, submitTime, throwable, startTime, endTime, positionInWaitingQueue);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/preview/PreviewHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/preview/PreviewHttpHandler.java
@@ -176,7 +176,7 @@ public class PreviewHttpHandler extends AbstractLogHttpHandler {
                              @QueryParam("filter") @DefaultValue("") String filterStr,
                              @QueryParam("format") @DefaultValue("text") String format,
                              @QueryParam("suppress") List<String> suppress) throws Exception {
-    sendLogs(namespaceId, previewId,
+    sendLogs(responder, namespaceId, previewId,
              info -> doGetLogs(info.getLogReader(), responder, info.getLoggingContext(),
                                fromTimeSecsParam, toTimeSecsParam, escape, filterStr,
                                info.getRunRecord(), format, suppress));
@@ -193,7 +193,7 @@ public class PreviewHttpHandler extends AbstractLogHttpHandler {
                                  @QueryParam("filter") @DefaultValue("") String filterStr,
                                  @QueryParam("format") @DefaultValue("text") String format,
                                  @QueryParam("suppress") List<String> suppress) throws Exception {
-    sendLogs(namespaceId, previewId,
+    sendLogs(responder, namespaceId, previewId,
              info -> doPrev(info.getLogReader(), responder, info.getLoggingContext(), maxEvents,
                             fromOffsetStr, escape, filterStr, info.getRunRecord(), format, suppress));
   }
@@ -209,14 +209,19 @@ public class PreviewHttpHandler extends AbstractLogHttpHandler {
                                  @QueryParam("filter") @DefaultValue("") String filterStr,
                                  @QueryParam("format") @DefaultValue("text") String format,
                                  @QueryParam("suppress") List<String> suppress) throws Exception {
-    sendLogs(namespaceId, previewId,
+    sendLogs(responder, namespaceId, previewId,
              info -> doNext(info.getLogReader(), responder, info.getLoggingContext(), maxEvents,
                             fromOffsetStr, escape, filterStr, info.getRunRecord(), format, suppress));
   }
 
-  private void sendLogs(String namespaceId, String previewId, Consumer<LogReaderInfo> logsResponder) throws Exception {
+  private void sendLogs(HttpResponder responder, String namespaceId, String previewId,
+                        Consumer<LogReaderInfo> logsResponder) throws Exception {
     ApplicationId applicationId = new ApplicationId(namespaceId, previewId);
     ProgramRunId programRunId = previewManager.getRunId(applicationId);
+    if (programRunId == null) {
+      responder.sendStatus(HttpResponseStatus.OK);
+      return;
+    }
     LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRunId, null);
     LogReader logReader = previewManager.getLogReader();
     logsResponder.accept(new LogReaderInfo(logReader, loggingContext, null));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -224,8 +224,8 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
         // status is WAITING but application is not present in in-memory queue
         position = 0;
       }
-      status = new PreviewStatus(status.getStatus(), status.getThrowable(), status.getStartTime(),
-                                 status.getEndTime(), position);
+      status = new PreviewStatus(status.getStatus(), status.getSubmitTime(), status.getThrowable(),
+                                 status.getStartTime(), status.getEndTime(), position);
     }
     return status;
   }
@@ -238,7 +238,8 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
                                                   status.getStatus().name()));
     }
     if (status.getStatus() == PreviewStatus.Status.WAITING) {
-      previewStore.setPreviewStatus(applicationId, new PreviewStatus(PreviewStatus.Status.KILLED, null, null, null));
+      previewStore.setPreviewStatus(applicationId, new PreviewStatus(PreviewStatus.Status.KILLED,
+                                                                     status.getSubmitTime(), null, null, null));
       return;
     }
     previewRunStopper.stop(applicationId);
@@ -251,11 +252,7 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
 
   @Override
   public ProgramRunId getRunId(ApplicationId applicationId) throws Exception {
-    ProgramRunId programRunId = previewStore.getProgramRunId(applicationId);
-    if (programRunId == null) {
-      throw new NotFoundException(applicationId);
-    }
-    return programRunId;
+    return previewStore.getProgramRunId(applicationId);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStore.java
@@ -242,7 +242,9 @@ public class DefaultPreviewStore implements PreviewStore {
     try {
       table.put(mdsKey.getKey(), APPID, Bytes.toBytes(gson.toJson(applicationId)), 1L);
       table.put(mdsKey.getKey(), CONFIG, Bytes.toBytes(gson.toJson(appRequest)), 1L);
-      setPreviewStatus(applicationId, new PreviewStatus(PreviewStatus.Status.WAITING, null, null, null));
+      long submitTimeInMillis = RunIds.getTime(applicationId.getApplication(), TimeUnit.MILLISECONDS);
+      setPreviewStatus(applicationId, new PreviewStatus(PreviewStatus.Status.WAITING, submitTimeInMillis, null, null,
+                                                        null));
     } catch (IOException e) {
       String message = String.format("Error while adding preview request with application '%s' in preview store.",
                                      applicationId);
@@ -306,7 +308,8 @@ public class DefaultPreviewStore implements PreviewStore {
                                                   "waiting state. Its current state is %s", applicationId,
                                                 previewStatus.getStatus().name()));
     }
-    setPreviewStatus(applicationId, new PreviewStatus(PreviewStatus.Status.INIT, null, null, null));
+    long submitTimeInMillis = RunIds.getTime(applicationId.getApplication(), TimeUnit.SECONDS);
+    setPreviewStatus(applicationId, new PreviewStatus(PreviewStatus.Status.INIT, submitTimeInMillis, null, null, null));
   }
 
   private void setPollerinfo(ApplicationId applicationId, byte[] pollerInfo) {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManagerTest.java
@@ -78,7 +78,7 @@ public class DefaultPreviewManagerTest {
   public static void beforeClass() throws IOException {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
-    cConf.setInt(Constants.Preview.CACHE_SIZE, 1);
+    cConf.setInt(Constants.Preview.POLLER_COUNT, 1);
 
     injector = Guice.createInjector(
       new ConfigModule(cConf, new Configuration()),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewRunnerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewRunnerServiceTest.java
@@ -114,7 +114,8 @@ public class PreviewRunnerServiceTest {
       CompletableFuture<PreviewRequest> future = new CompletableFuture<>();
       requests.put(request.getProgram(),
                    new RequestInfo(request, future, new PreviewStatus(PreviewStatus.Status.RUNNING,
-                                                                      null, System.currentTimeMillis(), null)));
+                                                                      System.currentTimeMillis(), null,
+                                                                      System.currentTimeMillis(), null)));
       return future;
     }
 
@@ -124,7 +125,7 @@ public class PreviewRunnerServiceTest {
       if (info == null) {
         throw new NotFoundException(programId);
       }
-      info.status = new PreviewStatus(PreviewStatus.Status.KILLED, null,
+      info.status = new PreviewStatus(PreviewStatus.Status.KILLED, System.currentTimeMillis(), null,
                                       info.status.getStartTime(), System.currentTimeMillis());
       info.future.complete(info.request);
     }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStoreTest.java
@@ -120,7 +120,7 @@ public class DefaultPreviewStoreTest {
     ApplicationId applicationId = new ApplicationId("ns1", "app1");
     ProgramRunId runId = new ProgramRunId("ns1", "app1", ProgramType.WORKFLOW, "test",
                                           RunIds.generate().getId());
-    PreviewStatus status = new PreviewStatus(PreviewStatus.Status.COMPLETED, null, 0L,
+    PreviewStatus status = new PreviewStatus(PreviewStatus.Status.COMPLETED, System.currentTimeMillis(), null, 0L,
                                              System.currentTimeMillis());
     store.setProgramId(runId);
     store.setPreviewStatus(applicationId, status);

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/preview/PreviewDataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/preview/PreviewDataPipelineTest.java
@@ -31,7 +31,6 @@ import io.cdap.cdap.api.metrics.MetricDataQuery;
 import io.cdap.cdap.api.metrics.MetricTimeSeries;
 import io.cdap.cdap.app.preview.PreviewManager;
 import io.cdap.cdap.app.preview.PreviewStatus;
-import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.datapipeline.DataPipelineApp;
@@ -244,13 +243,7 @@ public class PreviewDataPipelineTest extends HydratorTestBase {
     DataSetManager<Table> sinkManager = getDataset(sinkTableName);
     Assert.assertNull(sinkManager.get());
     deleteDatasetInstance(NamespaceId.DEFAULT.dataset(sourceTableName));
-    boolean exceptionThrown = false;
-    try {
-      previewManager.getRunId(previewId);
-    } catch (NotFoundException e) {
-      exceptionThrown = true;
-    }
-    Assert.assertTrue(exceptionThrown || sleepInMillis != null);
+    Assert.assertTrue(previewManager.getRunId(previewId) == null || sleepInMillis != null);
   }
 
   @Test

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -332,7 +332,7 @@ public final class Constants {
     public static final String BOSS_THREADS = "preview.boss.threads";
     public static final String WORKER_THREADS = "preview.worker.threads";
 
-    public static final String CACHE_SIZE = "preview.cache.size";
+    public static final String POLLER_COUNT = "preview.poller.count";
     public static final String REQUEST_POLL_DELAY_MILLIS = "preview.request.poll.delay.millis";
     public static final String MAX_RUNS = "preview.max.runs";
     public static final String WAITING_QUEUE_CAPACITY = "preview.waiting.queue.capacity";

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
@@ -102,7 +102,7 @@ public class MasterServiceMainTestBase {
     cConf.setInt(Constants.Router.ROUTER_PORT, 0);
     cConf.setInt(Constants.Router.ROUTER_SSL_PORT, 0);
 
-    cConf.setInt(Constants.Preview.CACHE_SIZE, 1);
+    cConf.setInt(Constants.Preview.POLLER_COUNT, 1);
 
     // Use remote fetcher for runtime server
     cConf.setClass(Constants.RuntimeMonitor.RUN_RECORD_FETCHER_CLASS,


### PR DESCRIPTION
First commit is cherry-pick #12589 from release/6.1 to develop. One conflict in `MasterServiceMainTestBase` about rename of PREVIEW_CACHE_SIZE to PREVIEW_POLLER_COUNT.

Second commit it removal of preview store binding from preview runner module which was already done in 6.1 as a part of statefulset pr.