### PR TITLE
CDAP-17202 perform MultiOutputCommitter duties in parallel

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSourceFactory.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSourceFactory.java
@@ -27,10 +27,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import scala.Tuple2;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -96,9 +96,10 @@ public final class SparkBatchSourceFactory {
         sourceName + " has no input. Please check that the source calls setInput at some input.");
     }
 
-    JavaPairRDD<K, V> inputRDD = JavaPairRDD.fromJavaRDD(jsc.<Tuple2<K, V>>emptyRDD());
-    for (String inputName : inputNames) {
-      inputRDD = inputRDD.union(createInputRDD(sec, jsc, inputName, keyClass, valueClass));
+    Iterator<String> inputsIter = inputNames.iterator();
+    JavaPairRDD<K, V> inputRDD = createInputRDD(sec, jsc, inputsIter.next(), keyClass, valueClass);
+    while (inputsIter.hasNext()) {
+      inputRDD = inputRDD.union(createInputRDD(sec, jsc, inputsIter.next(), keyClass, valueClass));
     }
     return inputRDD;
   }


### PR DESCRIPTION
setup, abort, recover, and commit jobs and tasks in parallel in
the MultiOutputCommitter.

Also added a tiny performance gain and debuggability improvement
by avoiding a union with an empty RDD in sources. This is mostly
useful for avoiding confusiong when looking at DAGs in the Spark
UI, where jobs would always start with a union between an empty
RDD and the real input RDD.