### PR TITLE
Fix flakiness in complex schema e2e test 

### DIFF
--- a/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceAction.scss
+++ b/cdap-ui/app/cdap/components/FastAction/SetPreferenceAction/SetPreferenceAction.scss
@@ -246,7 +246,7 @@ $focused-input-color: #66afe9;
 
           .inherited-preferences-container {
             padding-bottom: 40px;
-            padding-top:  15px;
+            padding-top: 15px;
 
             table {
               border-collapse: separate;

--- a/cdap-ui/cypress/integration/pipeline.complexschema.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.complexschema.spec.ts
@@ -42,10 +42,6 @@ describe('Output Schema', () => {
     });
   });
 
-  before(() => {
-    cy.cleanup_pipelines(headers, PIPELINE_NAME);
-  })
-
   const schemaFieldSuffix = '-schema-field';
 
   const projection: INodeInfo = { nodeName: 'Projection', nodeType: 'transform' };
@@ -59,6 +55,7 @@ describe('Output Schema', () => {
 
   beforeEach(() => {
     getArtifactsPoll(headers);
+    cy.cleanup_pipelines(headers, PIPELINE_NAME);
   });
 
   after(() => {
@@ -134,7 +131,7 @@ describe('Output Schema', () => {
       });
   });
 
-  it.only('Should work if the output schema is a macro', () => {
+  it.only('Should create and deploy pipeline when output schema is a macro', () => {
     cy.visit('/pipelines/ns/default/studio');
     cy.create_simple_pipeline().then(({ sourceNodeId, transformNodeId, sinkNodeId }) => {
       const sourceProperties = {

--- a/cdap-ui/cypress/support/commands.ts
+++ b/cdap-ui/cypress/support/commands.ts
@@ -544,12 +544,14 @@ Cypress.Commands.add('get_pipeline_stage_json', (stageName: string) => {
 });
 
 Cypress.Commands.add('open_node_property', (element: INodeIdentifier) => {
+  cy.get('.hydrator-modal').should('not.be.visible');
   const { nodeName, nodeType, nodeId } = element;
   const elementId = `[data-cy="plugin-node-${nodeName}-${nodeType}-${nodeId}"]`;
   cy.get(`${elementId} .node .node-metadata .node-version`).invoke('hide');
   cy.get(`${elementId} .node .node-configure-btn`)
     .invoke('show')
     .click();
+  cy.get('.hydrator-modal').should('be.visible');
 });
 
 Cypress.Commands.add('close_node_property', () => {


### PR DESCRIPTION
Build: https://builds.cask.co/browse/CDAP-URUT321
e2e tests: https://builds.cask.co/browse/IT-UPD2176

One of the e2e tests was flaky because when the plugin properties modal was opened, there was a possibility that multiple of the same modal could be opened. This caused the test to fail when it couldn't close the modal (since it was trying to click multiple elements instead of just one). I modified the open properties modal command to check whether a modal was already open, and to verify the modal opened after clicking. 