### PR TITLE
Fix ellipsis for overflowing text

### DIFF
--- a/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
@@ -62,9 +62,10 @@ export const styles = (theme): StyleRules => ({
     textAlign: 'left',
     height: '40px',
     lineHeight: '40px',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
     padding: '0px 10px',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
   },
 
   // TO DO: Currently the width is fixed. Future plan is to let users vary the column widths

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -39,6 +39,8 @@ const styles = (theme): StyleRules => ({
   ...tableStyles(theme),
   recordCell: {
     width: '50%',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
     '&:first-of-type': {
       borderRight: `1px solid ${theme.palette.grey['500']}`,
       fontWeight: 500,


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-17217
Build: https://builds.cask.co/browse/CDAP-URUT322

Adding ellipses and fixing the whitespace so large JSON text does not get cutoff in Preview. 