### PR TITLE
Remove '-SNAPSHOT' from the version for cdap 6.1.4 release.

### DIFF
--- a/cdap-api-common/pom.xml
+++ b/cdap-api-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-api-common</artifactId>

--- a/cdap-api-spark/pom.xml
+++ b/cdap-api-spark/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-api-spark</artifactId>

--- a/cdap-api-spark2_2.11/pom.xml
+++ b/cdap-api-spark2_2.11/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-api-spark2_2.11</artifactId>

--- a/cdap-api/pom.xml
+++ b/cdap-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-api</artifactId>

--- a/cdap-app-fabric-tests/pom.xml
+++ b/cdap-app-fabric-tests/pom.xml
@@ -22,7 +22,7 @@ the License.
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-app-fabric-tests</artifactId>

--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-app-fabric</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-data-pipeline</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-data-pipeline2_2.11</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-data-streams/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-data-streams</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-data-streams2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams2_2.11/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-data-streams2_2.11</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-etl-api-spark</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-etl-api</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-data-pipeline-plugins-archetype/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/cdap-data-pipeline-plugins-archetype/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl-archetypes</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-data-pipeline-plugins-archetype</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-archetypes/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-archetypes/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-etl-archetypes</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-etl-batch</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-etl-core</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-etl-proto</artifactId>

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-etl-tools</artifactId>

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>hydrator-spark-core</artifactId>

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>hydrator-spark-core2_2.11</artifactId>

--- a/cdap-app-templates/cdap-etl/hydrator-test/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-etl</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>hydrator-test</artifactId>

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-app-templates</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-app-templates/cdap-program-report/pom.xml
+++ b/cdap-app-templates/cdap-program-report/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap-app-templates</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-app-templates/pom.xml
+++ b/cdap-app-templates/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-app-templates</artifactId>

--- a/cdap-cli-tests/pom.xml
+++ b/cdap-cli-tests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-cli</artifactId>

--- a/cdap-client-tests/pom.xml
+++ b/cdap-client-tests/pom.xml
@@ -22,7 +22,7 @@ the License.
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-client-tests</artifactId>

--- a/cdap-client/pom.xml
+++ b/cdap-client/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-client</artifactId>

--- a/cdap-common-unit-test/pom.xml
+++ b/cdap-common-unit-test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-common-unit-test</artifactId>

--- a/cdap-common/pom.xml
+++ b/cdap-common/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-common</artifactId>

--- a/cdap-data-fabric-tests/pom.xml
+++ b/cdap-data-fabric-tests/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-data-fabric-tests</artifactId>

--- a/cdap-data-fabric/pom.xml
+++ b/cdap-data-fabric/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-data-fabric</artifactId>

--- a/cdap-distributions/bin/build_docs_bucket.sh
+++ b/cdap-distributions/bin/build_docs_bucket.sh
@@ -44,7 +44,7 @@ TARGET_DIR=${DOCS_HOME}/target
 
 S3_BUCKET=${S3_BUCKET:-docs.cask.co}
 S3_REPO_PATH=${S3_REPO_PATH:-cdap} # No leading or trailing slashes
-VERSION=${VERSION:-6.1.4-SNAPSHOT}
+VERSION=${VERSION:-6.1.4}
 
 function die() { __code=${2:-1}; echo "[ERROR] ${1}" >&2; exit ${__code}; };
 

--- a/cdap-distributions/pom.xml
+++ b/cdap-distributions/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-distributions</artifactId>

--- a/cdap-distributions/src/emr/install.sh
+++ b/cdap-distributions/src/emr/install.sh
@@ -24,9 +24,9 @@ CDAP_BRANCH=${CDAP_BRANCH:-release/6.1}
 # Optional tag to checkout - All released versions of this script should set this
 # like this: CDAP_TAG=${CDAP_TAG:+tag} as this allows setting tag to empty/null
 # otherwise, it should be CDAP_TAG=''. This should be the next version to released from this branch.
-CDAP_TAG=${CDAP_TAG:+v6.1.4}
+CDAP_TAG=${CDAP_TAG:+v6.1.5}
 # The CDAP package version passed to Chef. This should be next version to be released from this branch.
-CDAP_VERSION=${CDAP_VERSION:-6.1.4-1}
+CDAP_VERSION=${CDAP_VERSION:-6.1.5-1}
 # The version of Chef to install
 CHEF_VERSION=${CHEF_VERSION:-13.8.5}
 # cdap-site.xml configuration parameters

--- a/cdap-distributions/src/hdinsight/pkg/install.sh
+++ b/cdap-distributions/src/hdinsight/pkg/install.sh
@@ -26,7 +26,7 @@ CDAP_BRANCH='release/6.1'
 # otherwise, it should be CDAP_TAG=''. This should be next version to be released from this branch.
 CDAP_TAG=${CDAP_TAG:+hdi6.0}
 # The CDAP package version passed to Chef. This should be next version to be released from this branch.
-CDAP_VERSION='6.1.4-1'
+CDAP_VERSION='6.1.5-1'
 # The version of Chef to install
 CHEF_VERSION='13.8.5'
 # cdap-site.xml configuration parameters

--- a/cdap-distributions/src/hdinsight/pkg/mainTemplate.json
+++ b/cdap-distributions/src/hdinsight/pkg/mainTemplate.json
@@ -50,12 +50,12 @@
       },
       "installScriptActions": [{
         "name": "[concat('cdap-pageblob-configure-v0','-' ,uniquestring(variables('applicationName')))]",
-        "uri": "http://downloads.cask.co/hdinsight/pageblob-configure-6.1.4.sh",
+        "uri": "http://downloads.cask.co/hdinsight/pageblob-configure-6.1.5.sh",
         "roles": ["edgenode"]
       },
       {
         "name": "[concat('cdap-install-v0','-' ,uniquestring(variables('applicationName')))]",
-        "uri": "http://downloads.cask.co/hdinsight/install-6.1.4.sh",
+        "uri": "http://downloads.cask.co/hdinsight/install-6.1.5.sh",
         "roles": ["edgenode"]
       }],
       "uninstallScriptActions": [],

--- a/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
+++ b/cdap-distributions/src/packer/cdap-sdk-ubuntu16-with-uri.json
@@ -207,7 +207,7 @@
       "json": {
         "cdap": {
           "comment": "DO NOT PUT SNAPSHOT IN THE VERSION BELOW (UPDATE TO NEXT RELEASE), THIS CONTROLS CDAP COOKBOOK CODE",
-          "version": "6.1.4-1",
+          "version": "6.1.5-1",
           "sdk": {
             "comment": "COPY SDK ZIP TO files/cdap-sdk.zip BEFORE RUNNING ME",
             "url": "file:///tmp/cdap-sdk.zip",

--- a/cdap-distributions/src/packer/files/cdap-sdk.json
+++ b/cdap-distributions/src/packer/files/cdap-sdk.json
@@ -1,6 +1,6 @@
 {
   "cdap": {
-    "version": "6.1.4-1"
+    "version": "6.1.5-1"
   },
   "nodejs": {
     "install_method": "binary",

--- a/cdap-docs-gen/pom.xml
+++ b/cdap-docs-gen/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-docs-gen</artifactId>

--- a/cdap-elastic/pom.xml
+++ b/cdap-elastic/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-elastic</artifactId>

--- a/cdap-explore-client/pom.xml
+++ b/cdap-explore-client/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-explore-client</artifactId>

--- a/cdap-explore-jdbc/pom.xml
+++ b/cdap-explore-jdbc/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-explore-jdbc</artifactId>

--- a/cdap-explore/pom.xml
+++ b/cdap-explore/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-explore</artifactId>

--- a/cdap-formats/pom.xml
+++ b/cdap-formats/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-gateway/pom.xml
+++ b/cdap-gateway/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-gateway</artifactId>

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-1.0-cdh</artifactId>

--- a/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-1.0-cdh5.5.0</artifactId>

--- a/cdap-hbase-compat-1.0/pom.xml
+++ b/cdap-hbase-compat-1.0/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-1.0</artifactId>

--- a/cdap-hbase-compat-1.1/pom.xml
+++ b/cdap-hbase-compat-1.1/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-hbase-compat-1.1</artifactId>

--- a/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-hbase-compat-base/pom.xml
+++ b/cdap-hbase-compat-base/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-hbase-spi/pom.xml
+++ b/cdap-hbase-spi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-integration-test/pom.xml
+++ b/cdap-integration-test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-kafka/pom.xml
+++ b/cdap-kafka/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-kafka</artifactId>

--- a/cdap-kms/pom.xml
+++ b/cdap-kms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <properties>
     <hadoop.common.version>2.6.0</hadoop.common.version>

--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <artifactId>cdap-kubernetes</artifactId>
   <name>CDAP Kubernetes</name>

--- a/cdap-master-spi/pom.xml
+++ b/cdap-master-spi/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-master-spi</artifactId>

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-master</artifactId>

--- a/cdap-metadata-spi/pom.xml
+++ b/cdap-metadata-spi/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-operational-stats-core/pom.xml
+++ b/cdap-operational-stats-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-proto/pom.xml
+++ b/cdap-proto/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-proto</artifactId>

--- a/cdap-runtime-ext-dataproc/pom.xml
+++ b/cdap-runtime-ext-dataproc/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-runtime-ext-emr/pom.xml
+++ b/cdap-runtime-ext-emr/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-runtime-ext-remote-hadoop/pom.xml
+++ b/cdap-runtime-ext-remote-hadoop/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-runtime-spi/pom.xml
+++ b/cdap-runtime-spi/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-securestore-ext-cloudkms/pom.xml
+++ b/cdap-securestore-ext-cloudkms/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-securestore-spi/pom.xml
+++ b/cdap-securestore-spi/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-security-spi/pom.xml
+++ b/cdap-security-spi/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-security/pom.xml
+++ b/cdap-security/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-security</artifactId>

--- a/cdap-spark-core/pom.xml
+++ b/cdap-spark-core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-spark-core</artifactId>

--- a/cdap-spark-core2_2.11/pom.xml
+++ b/cdap-spark-core2_2.11/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-spark-core2_2.11</artifactId>

--- a/cdap-spark-python/pom.xml
+++ b/cdap-spark-python/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-standalone</artifactId>

--- a/cdap-storage-spi/pom.xml
+++ b/cdap-storage-spi/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-system-app-api/pom.xml
+++ b/cdap-system-app-api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-system-app-unit-test/pom.xml
+++ b/cdap-system-app-unit-test/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-system-app-unit-test</artifactId>

--- a/cdap-test/pom.xml
+++ b/cdap-test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>cdap</artifactId>
     <groupId>io.cdap.cdap</groupId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-tms-tests/pom.xml
+++ b/cdap-tms-tests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-tms-tests</artifactId>

--- a/cdap-tms/pom.xml
+++ b/cdap-tms/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-tms</artifactId>

--- a/cdap-ui/cypress/fixtures/pipeline1.json
+++ b/cdap-ui/cypress/fixtures/pipeline1.json
@@ -1,7 +1,7 @@
 {
   "artifact": {
     "name": "cdap-data-pipeline",
-    "version": "6.1.4-SNAPSHOT",
+    "version": "6.1.4",
     "scope": "SYSTEM",
     "label": "Data Pipeline - Batch"
   },

--- a/cdap-ui/package.json
+++ b/cdap-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdap-ui",
-  "version": "6.1.4-SNAPSHOT",
+  "version": "6.1.4",
   "description": "Front-end for CDAP",
   "license": "Apache-2.0",
   "scripts": {

--- a/cdap-ui/pom.xml
+++ b/cdap-ui/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-ui</artifactId>

--- a/cdap-unit-test-spark2_2.11/pom.xml
+++ b/cdap-unit-test-spark2_2.11/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-unit-test-spark2_2.11</artifactId>

--- a/cdap-unit-test/pom.xml
+++ b/cdap-unit-test/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-unit-test</artifactId>

--- a/cdap-watchdog-api/pom.xml
+++ b/cdap-watchdog-api/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-watchdog-api</artifactId>

--- a/cdap-watchdog/pom.xml
+++ b/cdap-watchdog/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>io.cdap.cdap</groupId>
     <artifactId>cdap</artifactId>
-    <version>6.1.4-SNAPSHOT</version>
+    <version>6.1.4</version>
   </parent>
 
   <artifactId>cdap-watchdog</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <groupId>io.cdap.cdap</groupId>
   <artifactId>cdap</artifactId>
-  <version>6.1.4-SNAPSHOT</version>
+  <version>6.1.4</version>
   <packaging>pom</packaging>
   <name>Cask Data Application Platform (CDAP)</name>
   <description>Data Application Platform for Hadoop</description>


### PR DESCRIPTION
Remove '-SNAPSHOT' from the version for cdap 6.1.4 release.