### PR TITLE
(CDAP-17185)read dataproc cluster creation metadata from default system context

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -54,6 +54,9 @@ final class DataprocConf {
   static final String IMAGE_VERSION = "imageVersion";
   static final String CUSTOM_IMAGE_URI = "customImageUri";
   static final String RUNTIME_JOB_MANAGER = "runtime.job.manager";
+  // The property name for the GCE cluster meta data
+  // It can be overridden by profile runtime arguments (system.profile.properties.clusterMetaData)
+  static final String CLUSTER_MEATA_DATA = "clusterMetaData";
 
   static final Pattern CLUSTER_PROPERTIES_PATTERN = Pattern.compile("^[a-zA-Z0-9\\-]+:");
   static final int MAX_NETWORK_TAGS = 64;
@@ -456,7 +459,7 @@ final class DataprocConf {
     String gcpCmekBucket = getString(properties, "gcsBucket");
 
     Map<String, String> clusterMetaData = Collections.unmodifiableMap(
-      DataprocUtils.parseKeyValueConfig(getString(properties, "clusterMetaData"), ";", "\\|"));
+      DataprocUtils.parseKeyValueConfig(getString(properties, CLUSTER_MEATA_DATA), ";", "\\|"));
 
     String networkTagsProperty = Optional.ofNullable(getString(properties, "networkTags")).orElse("");
     List<String> networkTags = Collections.unmodifiableList(Arrays.stream(networkTagsProperty.split(","))

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -201,7 +201,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       DataprocConf.STACKDRIVER_LOGGING_ENABLED,
       DataprocConf.STACKDRIVER_MONITORING_ENABLED,
       DataprocConf.COMPONENT_GATEWAY_ENABLED,
-      DataprocConf.IMAGE_VERSION
+      DataprocConf.IMAGE_VERSION,
+      DataprocConf.CLUSTER_MEATA_DATA
     ).contains(property);
   }
 


### PR DESCRIPTION
Purpose : when creating the dataproc cluster , we want to prefer zonal DNS instead of global DNS to remove the dependency on global spanner in order to enhance the availability of dataproc cluster creation.

How: need to set dataproc cluster creation meta data key-value pair : "VmDnsSetting:ZonalPreferred"
we already support reading meta data properties from profile:
https://github.com/cdapio/cdap/blob/v6.2.1/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java#L449

The property looks like :
provisioner.system.properties.gcp-dataproc.clusterMetaData: "VmDnsSetting|ZonalPreferred;otherKey:otherValue"

We need to set the meta data property as system default properties (in cdap-site.xml). So need to add the corresponding property name to the system default properties whitelist:
https://github.com/cdapio/cdap/blob/v6.2.1/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java#L197