### PR TITLE
(CDAP-17213) Use the spark-defaults.conf in the execution cluster

### DIFF
--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -145,8 +145,6 @@ public final class DistributedSparkProgramRunner extends DistributedProgramRunne
 
     Map<String, String> extraEnv = new HashMap<>();
     extraEnv.put(Constants.SPARK_COMPAT_ENV, sparkCompat.getCompat());
-    extraEnv.put(SparkPackageUtils.SPARK_YARN_MODE, "true");
-    extraEnv.putAll(SparkPackageUtils.getSparkClientEnv());
 
     if (sparkCompat.getCompat().equals(SparkCompat.SPARK2_2_11.getCompat())) {
       // No need to rewrite YARN client


### PR DESCRIPTION
- In remote cluster mode, pickup the spark-defaults.conf from the SPARK_HOME when running inside the DefaultRuntimeJob