### PR TITLE
CDAP-17225-fix-pipeline-comments

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLBatchConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLBatchConfig.java
@@ -59,7 +59,7 @@ public final class ETLBatchConfig extends ETLConfig {
                          @Nullable Integer numOfRecordsPreview,
                          @Nullable Integer maxConcurrentRuns,
                          Map<String, String> engineProperties,
-                         Boolean service, List<String> comments) {
+                         Boolean service, List<Object> comments) {
     super(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled, processTimingEnabled,
           numOfRecordsPreview, engineProperties, comments);
     this.postActions = ImmutableList.copyOf(postActions);
@@ -206,7 +206,7 @@ public final class ETLBatchConfig extends ETLConfig {
     private List<ETLStage> endingActions;
     private Integer maxConcurrentRuns;
     // Only used for upgrade purpose.
-    private List<String> comments;
+    private List<Object> comments;
 
     private Builder() {
       this(null);

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLConfig.java
@@ -57,7 +57,7 @@ public class ETLConfig extends Config implements UpgradeableConfig {
   protected List<io.cdap.cdap.etl.proto.v1.ETLStage> transforms;
 
   // For serialization purpose for upgrade compatibility.
-  protected List<String> comments;
+  protected List<Object> comments;
 
   protected ETLConfig(Set<ETLStage> stages, Set<Connection> connections, Resources resources,
                       Resources driverResources, Resources clientResources,
@@ -83,7 +83,7 @@ public class ETLConfig extends Config implements UpgradeableConfig {
   protected ETLConfig(Set<ETLStage> stages, Set<Connection> connections,
                       Resources resources, Resources driverResources, Resources clientResources,
                       @Nullable Boolean stageLoggingEnabled, @Nullable Boolean processTimingEnabled,
-                      @Nullable Integer numOfRecordsPreview, Map<String, String> properties, List<String> comments) {
+                      @Nullable Integer numOfRecordsPreview, Map<String, String> properties, List<Object> comments) {
     this(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled, processTimingEnabled,
         numOfRecordsPreview, properties);
     this.comments = comments;


### PR DESCRIPTION
comments are objects and not strings. Fixes errors that occur
when a pipeline with comments is deployed.