### PR TITLE
CDAP-17196 fix mapreduce on distributed mode

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceRuntimeService.java
@@ -790,6 +790,7 @@ final class MapReduceRuntimeService extends AbstractExecutionThreadService {
     classes.add(MapperWrapper.class);
     classes.add(ReducerWrapper.class);
     classes.add(SLF4JBridgeHandler.class);
+    classes.add(MapReduceContainerLauncher.class);
 
     // We only need to trace the Input/OutputFormat class due to MAPREDUCE-5957 so that those classes are included
     // in the job.jar and be available in the MR system classpath before our job classloader (ApplicationClassLoader)

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/distributed/MapReduceContainerLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/distributed/MapReduceContainerLauncher.java
@@ -48,7 +48,7 @@ public class MapReduceContainerLauncher {
   public static void launch(String mainClassName, String[] args) throws Exception {
     Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler());
     ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
-    List<URL> urls = ClassLoaders.getClassLoaderURLs(systemClassLoader, new ArrayList<URL>());
+    List<URL> urls = ClassLoaders.getClassLoaderURLs(systemClassLoader, new ArrayList<>());
 
     // Remove the URL that contains the given main classname to avoid infinite recursion.
     // This is needed because we generate a class with the same main classname in order to intercept the main()
@@ -114,10 +114,9 @@ public class MapReduceContainerLauncher {
       mainMethod.invoke(null, new Object[]{args});
       LOG.info("Main method returned {}", mainClassName);
     } catch (Throwable t) {
-      // LOG the exception since this exception will be propagated back to JVM
-      // and kill the main thread (hence the JVM process).
-      // If we don't log it here as ERROR, it will be logged by UncaughtExceptionHandler as DEBUG level
-      LOG.error("Exception raised when calling {}.main(String[]) method", mainClassName, t);
+      // print to System.err since the logger may not have been redirected yet
+      System.err.println(String.format("Exception raised when calling %s.main(String[]) method", mainClassName));
+      t.printStackTrace();
       throw t;
     }
   }


### PR DESCRIPTION
mapreduce was failing due to a missing asm-tree dependency.
Somehow this dependency was not getting traced since the upgrade
to asm 7, even though it is a twill dependency.

Added MainClassLoader as a class to trace for dependencies when
building the job jar since it is created in the
MapReduceContainerLauncher.

Also modified the launcher to print unexpected errors to stderr
instead of using the logger, to ensure that errors are not lost.