### PR TITLE
CDAP-17232 wait longer for program state to reduce flakiness

### DIFF
--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayTestBase.java
@@ -268,6 +268,6 @@ public abstract class GatewayTestBase {
         List<RunRecord> records = GSON.fromJson(EntityUtils.toString(response.getEntity()), RUN_RECORDS_TYPE);
         return records.size();
       }
-    }, 10, TimeUnit.SECONDS);
+    }, 30, TimeUnit.SECONDS);
   }
 }


### PR DESCRIPTION
Increase the time to wait for program state in gateway tests from
10 seconds to 30 seconds to reduce test flakiness on slow machines.