### PR TITLE
[CDAP-17239] Fix Authorizer ClassLoading Bug in Standalone Cherrypick 6.2

### DIFF
--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -242,8 +242,6 @@ public class StandaloneMain {
     // Workaround for release of file descriptors opened by URLClassLoader - https://issues.cask.co/browse/CDAP-2841
     URLConnections.setDefaultUseCaches(false);
 
-    cleanupTempDir();
-
     ConfigurationLogger.logImportantConfig(cConf);
 
     if (messagingService instanceof Service) {
@@ -381,7 +379,9 @@ public class StandaloneMain {
       halt = true;
       LOG.error("Exception during shutdown", e);
     } finally {
-      cleanupTempDir();
+      File tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
+                             cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+      cleanupTempDir(tmpDir);
     }
 
     // We can't do much but exit. Because there was an exception, some non-daemon threads may still be running.
@@ -391,10 +391,7 @@ public class StandaloneMain {
     }
   }
 
-  private void cleanupTempDir() {
-    File tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
-                           cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
-
+  private static void cleanupTempDir(File tmpDir) {
     if (!tmpDir.isDirectory()) {
       return;
     }
@@ -486,6 +483,12 @@ public class StandaloneMain {
 
     //Run dataset service on random port
     List<Module> modules = createPersistentModules(cConf, hConf);
+
+    // Cleans up the temporary directory which might contain unnecessary files from previous CDAP standalone runs
+    // This happens here instead of in startup because it needs to happen before Authorizer is created, see CDAP-17239
+    File tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
+                           cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+    cleanupTempDir(tmpDir);
 
     return new StandaloneMain(modules, cConf);
   }


### PR DESCRIPTION
Cherry-pick of #12724, see [CDAP-17239](https://issues.cask.co/browse/CDAP-17239) for more information.

[CDAP-17239] Fix classloading bug where the classpath directory is deleted in StandaloneMain

[CDAP-17239] Added comment

[CDAP-17239] Moved temporary directory cleanup logic out of constructor

[CDAP-17239] Construct tmpDir outside of static method