### PR TITLE
Revert "switch to maintained fork of eclipse cookbook with Chef 13 fixes"

### DIFF
--- a/cdap-distributions/src/packer/scripts/eclipse-cookbook.sh
+++ b/cdap-distributions/src/packer/scripts/eclipse-cookbook.sh
@@ -22,7 +22,7 @@ cd /var/chef/cookbooks || (echo "Cannot change to cookbook directory" && exit 1)
 
 # Check out the cookbook from GitHub
 which git || (echo "Cannot locate git" && exit 1)
-git clone https://github.com/appcelerator/eclipse.git || (echo "Cannot checkout eclipse cookbook" && exit 1)
+git clone https://github.com/geocent-cookbooks/eclipse.git || (echo "Cannot checkout eclipse cookbook" && exit 1)
 
 # Remove .git, so it's no longer tracked by git
 rm -rf eclipse/.git


### PR DESCRIPTION
For some unknown reason, appcelerator org has removed the eclipse repo, that causes all the BA BUILD failures. In order to unblock this issue, we are planning to revert to previous existing cookbook. 

Reference: https://builds.cask.co/browse/CDAP-BA13-VMI-159/log