### PR TITLE
[CDAP-16894] Add MultiStageSelector widget for use in Joiner

### DIFF
--- a/cdap-ui/app/cdap/components/AbstractWidget/AbstractWidgetFactory.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/AbstractWidgetFactory.tsx
@@ -49,6 +49,7 @@ import SqlSelectorWidget from 'components/AbstractWidget/SqlSelectorWidget';
 import TextBox from 'components/AbstractWidget/FormInputs/TextBox';
 import ToggleSwitchWidget from 'components/AbstractWidget/ToggleSwitchWidget';
 import WranglerEditor from 'components/AbstractWidget/WranglerEditor';
+import MultiStageSelector from 'components/AbstractWidget/MultiStageSelector';
 
 /**
  * Please maintain alphabetical order of the widget factory.
@@ -68,6 +69,7 @@ export const WIDGET_FACTORY = {
   dlp: DLPCustomWidget,
   'get-schema': GetSchemaWidget,
   'input-field-selector': InputFieldDropdown,
+  'multiple-input-stage-selector': MultiStageSelector,
   'keyvalue-dropdown': KeyValueDropdownWidget,
   'keyvalue-encoded': KeyValueEncodedWidget,
   keyvalue: KeyValueWidget,

--- a/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/FormInputs/MultiSelect/index.tsx
@@ -20,6 +20,8 @@ import MenuItem from '@material-ui/core/MenuItem';
 import { IWidgetProps } from 'components/AbstractWidget';
 import { objectQuery } from 'services/helpers';
 import { WIDGET_PROPTYPES } from 'components/AbstractWidget/constants';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import ThemeWrapper from 'components/ThemeWrapper';
 
 export interface IOption {
   id: string;
@@ -30,20 +32,32 @@ interface IMultiSelectWidgetProps {
   delimiter?: string;
   options: IOption[];
   showSelectionCount?: boolean;
+  emptyPlaceholder?: string;
 }
+const styles = (theme) => {
+  return {
+    root: {
+      margin: theme.Spacing(2),
+    },
+  };
+};
 
-interface IMultiSelectProps extends IWidgetProps<IMultiSelectWidgetProps> {}
+interface IMultiSelectProps
+  extends IWidgetProps<IMultiSelectWidgetProps>,
+    WithStyles<typeof styles> {}
 
-export default function MultiSelect({
+function MultiSelectBase({
   value,
   widgetProps,
   disabled,
   onChange,
+  classes,
   dataCy,
 }: IMultiSelectProps) {
   const delimiter = objectQuery(widgetProps, 'delimiter') || ',';
   const options = objectQuery(widgetProps, 'options') || [];
   const showSelectionCount = objectQuery(widgetProps, 'showSelectionCount') || false;
+  const emptyPlaceholder = objectQuery(widgetProps, 'emptyPlaceholder') || '';
 
   const initSelection = value.toString().split(delimiter);
   const [selections, setSelections] = useState<string[]>(initSelection);
@@ -63,16 +77,26 @@ export default function MultiSelect({
 
   function renderValue(values: any) {
     if (selections.length === 0 || (selections.length === 1 && selections[0] === '')) {
-      return '';
+      return emptyPlaceholder;
     }
 
     if (!showSelectionCount) {
-      return selections
+      const selectionText = selections
         .map((sel) => {
           const element = options.find((op) => op.id === sel);
           return element ? element.label : '';
         })
         .join(', ');
+      /**
+       * TODO: Magic number alert!
+       * We right now have a flexible width for widgets and we can't really
+       * show ellipsis via css (yet).
+       */
+
+      const MAX_DISPLAY_TEXT_LENGTH = 75;
+      return selectionText.length > MAX_DISPLAY_TEXT_LENGTH
+        ? `${selectionText.slice(0, MAX_DISPLAY_TEXT_LENGTH)}...`
+        : selectionText;
     }
     const selectionID = selections.find((el) => el !== '');
     const firstSelection = options.find((op) => op.id === selectionID);
@@ -95,6 +119,7 @@ export default function MultiSelect({
       inputProps={{
         'data-cy': dataCy,
       }}
+      classes={classes}
     >
       {options.map((opt) => (
         <MenuItem value={opt.id} key={opt.id}>
@@ -102,6 +127,15 @@ export default function MultiSelect({
         </MenuItem>
       ))}
     </Select>
+  );
+}
+
+const StyledMultiSelect = withStyles(styles)(MultiSelectBase);
+export default function MultiSelect(props) {
+  return (
+    <ThemeWrapper>
+      <StyledMultiSelect {...props} />
+    </ThemeWrapper>
   );
 }
 

--- a/cdap-ui/app/cdap/components/AbstractWidget/InputFieldDropdown/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/InputFieldDropdown/index.tsx
@@ -18,7 +18,7 @@ import Select from 'components/AbstractWidget/FormInputs/Select';
 import { IWidgetProps, IStageSchema } from 'components/AbstractWidget';
 import { objectQuery } from 'services/helpers';
 import { WIDGET_PROPTYPES } from 'components/AbstractWidget/constants';
-import MultiSelect from '../FormInputs/MultiSelect';
+import MultiSelect from 'components/AbstractWidget/FormInputs/MultiSelect';
 
 interface IField {
   name: string;
@@ -120,6 +120,7 @@ const InputFieldDropdown: React.FC<IInputFieldProps> = ({
       delimiter,
       options: fieldValues.map((field) => ({ id: field, label: field })),
       showSelectionCount: true,
+      emptyPlaceholder: 'Select input field(s)',
     };
 
     return (

--- a/cdap-ui/app/cdap/components/AbstractWidget/MultiStageSelector/index.tsx
+++ b/cdap-ui/app/cdap/components/AbstractWidget/MultiStageSelector/index.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+import * as React from 'react';
+import { IWidgetProps, IStageSchema } from 'components/AbstractWidget';
+import { objectQuery } from 'services/helpers';
+import MultiSelect from 'components/AbstractWidget/FormInputs/MultiSelect';
+import { WIDGET_PROPTYPES } from 'components/AbstractWidget/constants';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import ThemeWrapper from 'components/ThemeWrapper';
+
+const styles = () => {
+  return {
+    emptyMessageContainer: {
+      backgroundColor: 'initial',
+      padding: 'initial',
+    },
+    emptyMessage: {
+      marginBottom: 0,
+      padding: '4px',
+    },
+  };
+};
+
+interface IMultiStageSelectorWidgetProps {
+  delimiter: string;
+}
+interface IMultiStageSelectorProps
+  extends IWidgetProps<IMultiStageSelectorWidgetProps>,
+    WithStyles<typeof styles> {}
+
+const getInputStages = (inputSchema: IStageSchema[]) => {
+  if (!Array.isArray(inputSchema)) {
+    return [];
+  }
+  return inputSchema.map((stage) => ({ id: stage.name, label: stage.name }));
+};
+
+const MultiStageSelectorBase: React.FC<IMultiStageSelectorProps> = ({
+  value,
+  onChange,
+  disabled,
+  extraConfig,
+  widgetProps,
+  classes,
+}) => {
+  const inputSchema = objectQuery(extraConfig, 'inputSchema');
+  const inputStages = getInputStages(inputSchema);
+  const { delimiter } = widgetProps;
+  const multiSelectWidgetProps = {
+    delimiter,
+    options: inputStages,
+    showSelectionCount: false,
+    emptyPlaceholder: 'Select input stage',
+  };
+  if (!inputStages.length) {
+    return (
+      <div className={classes.emptyMessageContainer}>
+        <div className={classes.emptyMessage}>No input stages</div>
+      </div>
+    );
+  }
+  return (
+    <MultiSelect
+      value={value}
+      onChange={onChange}
+      widgetProps={multiSelectWidgetProps}
+      disabled={disabled}
+    />
+  );
+};
+
+const StyledMultiStageSelector = withStyles(styles)(MultiStageSelectorBase);
+export default function MultiStageSelector(props) {
+  return (
+    <ThemeWrapper>
+      <StyledMultiStageSelector {...props} />
+    </ThemeWrapper>
+  );
+}
+(MultiStageSelector as any).propTypes = WIDGET_PROPTYPES;


### PR DESCRIPTION
  - Adds MultiStageSelector widget for selecting multiple input stages
  - Improves Multi-select widget to show proper empty message + minor css changes
  - Fixes InputFieldDropdown to handle empty selection

cherry-pick of https://github.com/cdapio/cdap/pull/12272