### PR TITLE
[CDAP-16824] Fixes plugin configuration to show properties if widget json is not present

### DIFF
--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/configuration-tab.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/configuration-tab.html
@@ -21,10 +21,8 @@
       <div ng-if="HydratorPlusPlusNodeConfigCtrl.state.configfetched">
       
         <div ng-if="HydratorPlusPlusNodeConfigCtrl.state.noproperty !== 0">
-          <div ng-if="(HydratorPlusPlusNodeConfigCtrl.state.configfetched && !HydratorPlusPlusNodeConfigCtrl.state.noconfig)">
-            <div
-              ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-config-form.html'">
-            </div>
+          <div ng-if="(HydratorPlusPlusNodeConfigCtrl.state.configfetched)">
+            <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-config-form.html'"></div>
           </div>
         </div>
       

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-config-form.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-config-form.html
@@ -14,27 +14,27 @@
   the License.
 -->
 
-<div class="config-table source-table" ng-if="HydratorPlusPlusNodeConfigCtrl.state.isSource">
+<div ng-class="{'config-table': true, 'source-table': !HydratorPlusPlusNodeConfigCtrl.state.noconfig}" ng-if="HydratorPlusPlusNodeConfigCtrl.state.isSource">
   <div>
     <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-properties-template.html'"></div>
   </div>
 
-  <div>
+  <div ng-if="!HydratorPlusPlusNodeConfigCtrl.state.noconfig">
     <div class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
   </div>
 </div>
 
-<div class="config-table transform-table" ng-if="HydratorPlusPlusNodeConfigCtrl.state.isTransform && HydratorPlusPlusNodeConfigCtrl.state.node.plugin.name !== 'Validator'">
-  <div>
-    <div class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html'"></div>
+<div ng-class="{'config-table': true, 'transform-table': !HydratorPlusPlusNodeConfigCtrl.state.noconfig}" ng-if="HydratorPlusPlusNodeConfigCtrl.state.isTransform && HydratorPlusPlusNodeConfigCtrl.state.node.plugin.name !== 'Validator'">
+  <div ng-if="!HydratorPlusPlusNodeConfigCtrl.state.noconfig">
+    <div  class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html'"></div>
   </div>
 
   <div>
     <div ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-properties-template.html'"></div>
   </div>
 
-  <div>
-    <div class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
+  <div ng-if="!HydratorPlusPlusNodeConfigCtrl.state.noconfig">
+    <div  class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-output-schema.html'"></div>
   </div>
 </div>
 
@@ -44,8 +44,8 @@
   </div>
 </div>
 
-<div class="config-table sink-table" ng-if="HydratorPlusPlusNodeConfigCtrl.state.isSink">
-  <div>
+<div ng-class="{'config-table': true, 'sink-table': !HydratorPlusPlusNodeConfigCtrl.state.noconfig}" ng-if="HydratorPlusPlusNodeConfigCtrl.state.isSink">
+  <div ng-if="!HydratorPlusPlusNodeConfigCtrl.state.noconfig">
     <div class="output-schema-container" ng-include="'/assets/features/hydrator/templates/partial/node-config-modal/node-config/plugin-edit-input-schema.html'"></div>
   </div>
 


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-16824

**Cause**
- We migrated plugin configuration to React. During this process we removed the check when there were no config
- We removed this because we wanted the flow to go through the new implementation all the time w/o widget json for plugins
- However we still had the check for presence of widget json to go through the new flow.
- So we removed the old way of handling no widget json + retained the check for presence of widget json for new flow. This made no widget json handling to render empty page.

**Fix**
- Remove the no widget json criteria for the user flow to go through new React implementation
- Handle the templates for new implementation to hide schemas if no widget json is present.
