### PR TITLE
Fixes build failure because of merging #12608

### DIFF
--- a/cdap-ui/app/cdap/main.js
+++ b/cdap-ui/app/cdap/main.js
@@ -294,26 +294,6 @@ class CDAP extends Component {
                 </ErrorBoundary>
               )}
             />
-            <Route
-              exact
-              path="/schema"
-              render={(props) => {
-                const SchemaEditorDemo = Loadable({
-                  loader: () =>
-                    import(
-                      /* webpackChunkName: "SchemaEditor" */ 'components/AbstractWidget/SchemaEditor/SchemaEditorDemo'
-                    ),
-                  loading: LoadingSVGCentered,
-                });
-                return (
-                  <ToggleExperiment
-                    name="schema-editor"
-                    defaultComponent={<Page404 {...props} />}
-                    experimentalComponent={<SchemaEditorDemo />}
-                  />
-                );
-              }}
-            />
             <Route path="/lab" component={Lab} />
             <Route
               exact


### PR DESCRIPTION
Merging https://github.com/cdapio/cdap/pull/12608 PR caused builds to fail. This PR is intended to be merged after the schema editor changes which were missing in the release/6.2 branch.

Removing this change and will add it back in the Schema editor PR https://github.com/cdapio/cdap/pull/12638

Build: https://builds.cask.co/browse/CDAP-URUT327-1