### PR TITLE
CDAP-17226 Fix Tidy button in JSON editor

### DIFF
--- a/cdap-ui/app/cdap/components/CodeEditor/index.tsx
+++ b/cdap-ui/app/cdap/components/CodeEditor/index.tsx
@@ -145,7 +145,7 @@ class CodeEditorView extends React.Component<ICodeEditorProps> {
               if (typeof this.props.prettyPrintFunction === 'function') {
                 code = this.props.prettyPrintFunction(code);
               }
-              this.props.onChange(code);
+              this.editor.getSession().setValue(code);
             }}
           >
             Tidy


### PR DESCRIPTION
Jira: https://issues.cask.co/browse/CDAP-17226
Build: https://builds.cask.co/browse/CDAP-URUT330

A previous fix (#12072) updated the CodeEditor to ignore white-space-only differences in certain situations. This broke the state update triggered by the Tidy button.