### PR TITLE
Fix fetching preview when stage label contain a space

### DIFF
--- a/cdap-ui/app/cdap/components/LogViewer/index.tsx
+++ b/cdap-ui/app/cdap/components/LogViewer/index.tsx
@@ -22,7 +22,6 @@ import Alert from 'components/Alert';
 import DataFetcher from 'components/LogViewer/DataFetcher';
 import LogRow from 'components/LogViewer/LogRow';
 import debounce from 'lodash/debounce';
-import TopPanel, { TOP_PANEL_HEIGHT } from 'components/LogViewer/TopPanel';
 import LogLevel from 'components/LogViewer/LogLevel';
 import { extractErrorMessage } from 'services/helpers';
 import LoadingSVG from 'components/LoadingSVG';

--- a/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
@@ -62,6 +62,7 @@ export const styles = (theme): StyleRules => ({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     padding: '0 10px',
+    whiteSpace: 'nowrap',
   },
 
   // TO DO: Currently the width is fixed. Future plan is to let users vary the column widths

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -40,6 +40,9 @@ const styles = (theme): StyleRules => ({
   ...tableStyles(theme),
   recordCell: {
     width: '50%',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
     '&:first-of-type': {
       borderRight: `1px solid ${theme.palette.grey['500']}`,
       fontWeight: 500,

--- a/cdap-ui/app/cdap/components/PreviewData/utilities.ts
+++ b/cdap-ui/app/cdap/components/PreviewData/utilities.ts
@@ -30,6 +30,7 @@ export interface IConnection {
 }
 
 export interface INode {
+  name?: string;
   plugin?: any;
   isSource?: boolean;
   isSink?: boolean;
@@ -100,7 +101,7 @@ export function fetchPreview(
     previewId,
   };
 
-  const selectedStageName = selectedNode.plugin.label;
+  const selectedStageName = selectedNode.name;
 
   const adjacencyMap = getAdjacencyMap(connections);
   const { tracers, previousStages } = getTracersAndPreviousStageInfo(
@@ -186,7 +187,7 @@ function getTracersAndPreviousStageInfo(
 }
 
 function getRecords(res, selectedNode: INode, previousStages: IPreviousStageInfo) {
-  const selectedStageName = selectedNode.plugin.label;
+  const selectedStageName = selectedNode.name;
   const isSource = selectedNode.isSource;
   const isSink = selectedNode.isSink;
 

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -113,6 +113,7 @@ class HydratorPlusPlusNodeConfigCtrl {
       this.previewData = null;
       this.updatePreviewStatus();
       this.selectedNode = {
+        name: this.state.node.name,
         plugin: this.state.node.plugin,
         isSource: this.state.isSource,
         isSink: this.state.isSink,


### PR DESCRIPTION
Fixes bug that would not correctly fetch or show preview data when the stage label had a space in it (showed blank screen instead). 

Also fixes styling where long JSON values did not get wrapped properly and looked like they were getting cut off instead of showing ellipsis (this is likely from a bad merge conflict resolution). 

Example for testing: Try the Datafusion quick start pipeline in Hub, which should test both bugs. 

JIRA: https://issues.cask.co/browse/CDAP-16898
Build: https://builds.cask.co/browse/CDAP-URUT331