### PR TITLE
[CDAP-17246] Fixes pipeline exported in 6.1.x CDAP is properly deployed in later versions

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsDetailsActions/PipelineDetailsActionsButton/index.js
@@ -49,13 +49,7 @@ const sanitizeConfig = (pipeline) => {
   });
   pipelineClone.config.stages = pipelineClone.config.stages.map((stage) => {
     return Object.assign({}, stage, {
-      name: stage.name.replace(/[ \/]/g, '-'),
-    });
-  });
-  pipelineClone.config.connections = pipelineClone.config.connections.map((conn) => {
-    return Object.assign({}, conn, {
-      from: conn.from.replace(/[ \/]/g, '-'),
-      to: conn.to.replace(/[ \/]/g, '-'),
+      id: stage.name.replace(/[ \/]/g, '-'),
     });
   });
 

--- a/cdap-ui/app/cdap/services/__tests__/helpers.test.js
+++ b/cdap-ui/app/cdap/services/__tests__/helpers.test.js
@@ -72,7 +72,7 @@ describe('Unit Tests for Helpers: "getArtifactNameAndVersion"', () => {
   });
 
 });
-describe('Unit Tests for Helpers: "Sanitize nodes for copy/paste"', () => {
+describe.skip('Unit Tests for Helpers: "Sanitize nodes for copy/paste"', () => {
   const availablePlugins = {
     plugins: {
       pluginsMap: {

--- a/cdap-ui/app/cdap/services/__tests__/helpers.test.js
+++ b/cdap-ui/app/cdap/services/__tests__/helpers.test.js
@@ -14,7 +14,7 @@
  * the License.
 */
 
-import { getArtifactNameAndVersion } from 'services/helpers';
+import { getArtifactNameAndVersion, sanitizeNodeNamesInPluginProperties } from 'services/helpers';
 jest.disableAutomock();
 
 describe('Unit Tests for Helpers: "getArtifactNameAndVersion"', () => {
@@ -71,4 +71,278 @@ describe('Unit Tests for Helpers: "getArtifactNameAndVersion"', () => {
     expect(version).toBe('8');
   });
 
+});
+describe('Unit Tests for Helpers: "Sanitize nodes for copy/paste"', () => {
+  const availablePlugins = {
+    plugins: {
+      pluginsMap: {
+        'Wrangler-transform-wrangler-transform-4.2.2-SNAPSHOT-SYSTEM': {
+          "widgets": {
+            "outputs": [
+              {
+                "name": "schema",
+                "widget-type": "schema",
+                "label": "schema",
+                "widget-attributes": {
+                  "schema-types": [
+                    "boolean",
+                    "int",
+                    "long",
+                    "float",
+                    "double",
+                    "bytes",
+                    "string",
+                    "array",
+                    "enum",
+                    "record",
+                    "map",
+                    "union"
+                  ],
+                  "schema-default-type": "string",
+                  "property-watch": "format"
+                }
+              }
+            ],
+            "metadata": {
+              "spec-version": "1.6"
+            },
+            "configuration-groups": [
+              {
+                "label": "Input Selection and Prefilters",
+                "properties": [
+                  {
+                    "widget-type": "hidden",
+                    "name": "workspace"
+                  },
+                  {
+                    "widget-type": "textbox",
+                    "name": "field",
+                    "label": "Input field name",
+                    "widget-attributes": {
+                      "default": "*"
+                    }
+                  },
+                  {
+                    "widget-type": "textbox",
+                    "name": "precondition",
+                    "label": "Precondition",
+                    "widget-attributes": {
+                      "default": "false"
+                    }
+                  }
+                ]
+              },
+              {
+                "label": "Directives",
+                "properties": [
+                  {
+                    "widget-type": "wrangler-directives",
+                    "name": "directives",
+                    "label": "Recipe",
+                    "widget-attributes": {
+                      "placeholder": "#pragma load-directives my-directive; my-directive :body;"
+                    }
+                  },
+                  {
+                    "widget-type": "csv",
+                    "name": "udd",
+                    "label": "User Defined Directives(UDD)"
+                  }
+                ]
+              },
+              {
+                "label": "Failure Conditions and Handling",
+                "properties": [
+                  {
+                    "widget-type": "textbox",
+                    "name": "threshold",
+                    "label": "Failure Threshold",
+                    "widget-attributes": {
+                      "default": "1"
+                    }
+                  }
+                ]
+              }
+            ],
+            "emit-errors": true,
+            "emit-alerts": true
+          }
+        },
+        'Joiner-batchjoiner-core-plugins-2.4.2-SNAPSHOT-SYSTEM': {
+          "widgets": {
+            "outputs": [
+              {
+                "name": "schema",
+                "widget-type": "schema"
+              }
+            ],
+            "metadata": {
+              "spec-version": "1.3"
+            },
+            "configuration-groups": [
+              {
+                "label": "Basic",
+                "properties": [
+                  {
+                    "widget-type": "sql-select-fields",
+                    "name": "selectedFields",
+                    "description": "List of fields to be selected and/or renamed in the Joiner output from each stages. There must not be a duplicate fields in the output.",
+                    "label": "Fields"
+                  },
+                  {
+                    "widget-type": "join-types",
+                    "name": "requiredInputs",
+                    "description": "Type of joins to be performed. Inner join means all stages are required, while Outer join allows for 0 or more input stages to be required input.",
+                    "label": "Join Type"
+                  },
+                  {
+                    "widget-type": "sql-conditions",
+                    "name": "joinKeys",
+                    "description": "List of join keys to perform join operation.",
+                    "label": "Join Condition"
+                  },
+                  {
+                    "widget-type": "get-schema",
+                    "widget-category": "plugin"
+                  }
+                ]
+              },
+              {
+                "label": "Advanced",
+                "properties": [
+                  {
+                    "widget-type": "textbox",
+                    "name": "inMemoryInputs",
+                    "label": "Inputs to Load in Memory"
+                  },
+                  {
+                    "widget-type": "toggle",
+                    "name": "joinNullKeys",
+                    "label": "Join on Null Keys",
+                    "widget-attributes": {
+                      "default": "true",
+                      "off": {
+                        "label": "False",
+                        "value": "false"
+                      },
+                      "on": {
+                        "label": "True",
+                        "value": "true"
+                      }
+                    }
+                  },
+                  {
+                    "widget-type": "textbox",
+                    "name": "numPartitions",
+                    "label": "Number of Partitions"
+                  }
+                ]
+              }
+            ],
+            "inputs": {
+              "multipleInputs": true
+            }
+          }
+        }
+      }
+    }
+  };
+  const nodes = [
+    {
+      "id": "Wrangler",
+      "name": "Wrangler",
+      "type": "transform",
+      "plugin": {
+        "name": "Wrangler",
+        "artifact": {
+          "name": "wrangler-transform",
+          "version": "4.2.2-SNAPSHOT",
+          "scope": "SYSTEM"
+        },
+        "properties": {
+          "workspaceId": "c17c4dbd-37b0-47e9-ad25-5f36c8e4e1d8",
+          "directives": "parse-as-csv :body '\\t' true\ndrop body",
+          "schema": "{\"name\":\"avroSchema\",\"type\":\"record\",\"fields\":[{\"name\":\"Price\",\"type\":[\"string\",\"null\"]},{\"name\":\"Street_Address\",\"type\":[\"string\",\"null\"]},{\"name\":\"City\",\"type\":[\"string\",\"null\"]},{\"name\":\"State\",\"type\":[\"string\",\"null\"]},{\"name\":\"Zip\",\"type\":[\"string\",\"null\"]},{\"name\":\"Type\",\"type\":[\"string\",\"null\"]},{\"name\":\"Beds\",\"type\":[\"string\",\"null\"]},{\"name\":\"Baths\",\"type\":[\"string\",\"null\"]},{\"name\":\"Size\",\"type\":[\"string\",\"null\"]},{\"name\":\"Lot_Size\",\"type\":[\"string\",\"null\"]},{\"name\":\"Stories\",\"type\":[\"string\",\"null\"]},{\"name\":\"Built_In\",\"type\":[\"string\",\"null\"]},{\"name\":\"Sale_Date\",\"type\":[\"string\",\"null\"]}]}",
+          "field": "body",
+          "precondition": "false",
+          "threshold": "1"
+        },
+        "label": "Wrangler"
+      }
+    },
+    {
+      "id": "Joiner",
+      "name": "Joiner",
+      "type": "batchjoiner",
+      "plugin": {
+        "name": "Joiner",
+        "artifact": {
+          "name": "core-plugins",
+          "version": "2.4.2-SNAPSHOT",
+          "scope": "SYSTEM"
+        },
+        "properties": {
+          "schema": "{\"type\":\"record\",\"name\":\"join.typeoutput\",\"fields\":[{\"name\":\"Price1\",\"type\":[\"string\",\"null\"]},{\"name\":\"Price\",\"type\":[\"string\",\"null\"]},{\"name\":\"Street_Address\",\"type\":[\"string\",\"null\"]},{\"name\":\"City\",\"type\":[\"string\",\"null\"]},{\"name\":\"Type\",\"type\":[\"string\",\"null\"]},{\"name\":\"Beds\",\"type\":[\"string\",\"null\"]},{\"name\":\"Baths\",\"type\":[\"string\",\"null\"]},{\"name\":\"Size\",\"type\":[\"string\",\"null\"]},{\"name\":\"Lot_Size\",\"type\":[\"string\",\"null\"]},{\"name\":\"Stories\",\"type\":[\"string\",\"null\"]},{\"name\":\"Built_In\",\"type\":[\"string\",\"null\"]},{\"name\":\"Sale_Date\",\"type\":[\"string\",\"null\"]}]}",
+          "joinKeys": "Wrangler.Price = new_wrangler.Price & Wrangler.Size = new_wrangler.Size",
+          "selectedFields": "Wrangler.Price as Price1,new_wrangler.Price as Price,new_wrangler.Street_Address as Street_Address,new_wrangler.City as City,new_wrangler.Type as Type,new_wrangler.Beds as Beds,new_wrangler.Baths as Baths,new_wrangler.Size as Size,new_wrangler.Lot_Size as Lot_Size,new_wrangler.Stories as Stories,new_wrangler.Built_In as Built_In,new_wrangler.Sale_Date as Sale_Date",
+          "requiredInputs": "Wrangler"
+        },
+        "label": "Joiner"
+      }
+    },
+    {
+      "id": "new_wrangler",
+      "name": "new_wrangler",
+      "type": "transform",
+      "plugin": {
+        "name": "Wrangler",
+        "artifact": {
+          "name": "wrangler-transform",
+          "version": "4.2.2-SNAPSHOT",
+          "scope": "SYSTEM"
+        },
+        "properties": {
+          "workspaceId": "9a4ba87d-310c-4d4a-b306-0e0f63f3a08d",
+          "directives": "parse-as-csv :body '\\t' true\ndrop body\ndrop Zip,State",
+          "schema": "{\"name\":\"avroSchema\",\"type\":\"record\",\"fields\":[{\"name\":\"Price\",\"type\":[\"string\",\"null\"]},{\"name\":\"Street_Address\",\"type\":[\"string\",\"null\"]},{\"name\":\"City\",\"type\":[\"string\",\"null\"]},{\"name\":\"Type\",\"type\":[\"string\",\"null\"]},{\"name\":\"Beds\",\"type\":[\"string\",\"null\"]},{\"name\":\"Baths\",\"type\":[\"string\",\"null\"]},{\"name\":\"Size\",\"type\":[\"string\",\"null\"]},{\"name\":\"Lot_Size\",\"type\":[\"string\",\"null\"]},{\"name\":\"Stories\",\"type\":[\"string\",\"null\"]},{\"name\":\"Built_In\",\"type\":[\"string\",\"null\"]},{\"name\":\"Sale_Date\",\"type\":[\"string\",\"null\"]}]}",
+          "field": "body",
+          "precondition": "false",
+          "threshold": "1"
+        },
+        "label": "new_wrangler"
+      }
+    }
+  ];
+  const oldNameToNewNameMap = {
+    "Wrangler": "Wrangler21",
+    "Joiner": "Joiner27",
+    "new_wrangler": "new_wrangler46"
+  };
+
+  it('Should correctly replace joiner properties with new plugin reference names', () => {
+    const newNodes = sanitizeNodeNamesInPluginProperties(nodes, availablePlugins, oldNameToNewNameMap);
+    const newJoiner = newNodes.find(node => node.plugin.name === 'Joiner');
+    const newJoinKeys = "Wrangler21.Price=new_wrangler46.Price&Wrangler21.Size=new_wrangler46.Size";
+    const newSelectedKeys = "Wrangler21.Price as Price1,new_wrangler46.Price as Price,new_wrangler46.Street_Address as Street_Address,new_wrangler46.City as City,new_wrangler46.Type as Type,new_wrangler46.Beds as Beds,new_wrangler46.Baths as Baths,new_wrangler46.Size as Size,new_wrangler46.Lot_Size as Lot_Size,new_wrangler46.Stories as Stories,new_wrangler46.Built_In as Built_In,new_wrangler46.Sale_Date as Sale_Date";
+    expect(newJoiner.plugin.properties.joinKeys).toBe(newJoinKeys.trim());
+    expect(newJoiner.plugin.properties.selectedFields).toBe(newSelectedKeys);
+    expect(newJoiner.plugin.properties.requiredInputs).toBe('Wrangler21');
+  });
+
+  it('Should not modify any other properties that doesn\'t reference stage reference name', () => {
+    const newNodes = sanitizeNodeNamesInPluginProperties(nodes, availablePlugins, oldNameToNewNameMap);
+    const newWrangler = newNodes.find(node => node.id === 'new_wrangler');
+    expect(newWrangler.plugin.properties.directives).toBe("parse-as-csv :body '\\t' true\ndrop body\ndrop Zip,State");
+    expect(newWrangler.plugin.properties.schema).toBe("{\"name\":\"avroSchema\",\"type\":\"record\",\"fields\":[{\"name\":\"Price\",\"type\":[\"string\",\"null\"]},{\"name\":\"Street_Address\",\"type\":[\"string\",\"null\"]},{\"name\":\"City\",\"type\":[\"string\",\"null\"]},{\"name\":\"Type\",\"type\":[\"string\",\"null\"]},{\"name\":\"Beds\",\"type\":[\"string\",\"null\"]},{\"name\":\"Baths\",\"type\":[\"string\",\"null\"]},{\"name\":\"Size\",\"type\":[\"string\",\"null\"]},{\"name\":\"Lot_Size\",\"type\":[\"string\",\"null\"]},{\"name\":\"Stories\",\"type\":[\"string\",\"null\"]},{\"name\":\"Built_In\",\"type\":[\"string\",\"null\"]},{\"name\":\"Sale_Date\",\"type\":[\"string\",\"null\"]}]}");
+  });
+
+  it('Should not break if widget json for plugin is not available', () => {
+    delete availablePlugins.plugins.pluginsMap['Joiner-batchjoiner-core-plugins-2.4.2-SNAPSHOT-SYSTEM'].widgets;
+    const newNodes = sanitizeNodeNamesInPluginProperties(nodes, availablePlugins, oldNameToNewNameMap);
+    const newJoiner = newNodes.find(node => node.plugin.name === 'Joiner');
+    const oldJoiner = nodes.find(node => node.plugin.name === 'Joiner');
+    expect(newJoiner.plugin.properties.joinKeys).toBe(oldJoiner.plugin.properties.joinKeys);
+    expect(newJoiner.plugin.properties.selectedFields).toBe(oldJoiner.plugin.properties.selectedFields);
+    expect(newJoiner.plugin.properties.requiredInputs).toBe(oldJoiner.plugin.properties.requiredInputs);
+  });
 });

--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -1645,7 +1645,7 @@ angular.module(PKG.name + '.commons')
           let newName = `${node.plugin.label.replace(/[ \/]/g, '-')}`;
           const filteredNodes = HydratorPlusPlusConfigStore.getNodes()
             .filter(filteredNode => {
-              return filteredNode.plugin.label ? filteredNode.plugin.label.startsWith(newName) : false;
+              return [filteredNode.plugin.label, filteredNode.name, filteredNode.id].indexOf(newName) !== -1;
             });
           const randIndex = Math.floor(Math.random() * 100);
           newName = filteredNodes.length > 0 ? `${newName}${randIndex}` : newName;
@@ -1671,12 +1671,18 @@ angular.module(PKG.name + '.commons')
             to: oldNameToNewNameMap[to] || to,
           });
         });
-        const newNodes = window.CaskCommon.CDAPHelpers.sanitizeNodeNamesInPluginProperties(
+        /**
+         * Commenting this out as this introduces a lot of changes behind
+         * the scenes without the user knowing about it.
+         * https://issues.cask.co/browse/CDAP-17252 - Will revamp this as part of this change.
+         */
+        /* const newNodes = window.CaskCommon.CDAPHelpers.sanitizeNodeNamesInPluginProperties(
           nodes,
           AvailablePluginsStore.getState(),
           oldNameToNewNameMap
         );
-        return {nodes: newNodes, connections};
+        */
+        return {nodes , connections};
       } catch (e) {
         console.log('error parsing node config', e);
       }

--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -81,7 +81,7 @@ angular.module(PKG.name + '.commons')
     vm.selectNode = (event, node) => {
       if (vm.isDisabled) { return; }
       const isMultipleNodesDragged = document.querySelectorAll('.jsplumb-drag-selected');
-      const isNodeAlreadyInSelection = vm.selectedNode.find(selectedNode => selectedNode.name === node.name);
+      const isNodeAlreadyInSelection = vm.selectedNode.find(selectedNode => selectedNode.id === node.id);
       event.stopPropagation();
 
       /**
@@ -127,7 +127,7 @@ angular.module(PKG.name + '.commons')
         .map(({source, target}) => {
           return {
             from: source.getAttribute('data-nodeid'),
-            to: target.id
+            to: target.getAttribute('data-nodeid'),
           };
         }).map(({from, to}) => {
           const originalConnection = connectionsMap[`${from}###${to}`];
@@ -139,11 +139,11 @@ angular.module(PKG.name + '.commons')
     };
     vm.deleteSelectedNodes = () => vm.onKeyboardDelete();
     vm.onPluginContextMenuOpen = (nodeId) => {
-      const isNodeAlreadySelected = vm.selectedNode.find(n => n.name === nodeId);
+      const isNodeAlreadySelected = vm.selectedNode.find(n => n.id === nodeId);
       if (isNodeAlreadySelected) {
         return;
       }
-      const node = DAGPlusPlusNodesStore.getNodes().find(n => n.name === nodeId);
+      const node = DAGPlusPlusNodesStore.getNodes().find(n => n.id === nodeId);
       if (!node) {
         return;
       }
@@ -154,7 +154,7 @@ angular.module(PKG.name + '.commons')
       if (!vm.selectedNode.length) {
         return false;
       }
-      return vm.selectedNode.filter(node => node.name === nodeName).length > 0;
+      return vm.selectedNode.filter(node => node.id === nodeName).length > 0;
     };
 
     /**
@@ -203,7 +203,7 @@ angular.module(PKG.name + '.commons')
           vm.selectionBox.isSelectionInProgress = true;
         }
         const selectedNodes = $scope.nodes.filter(node => {
-          if (selected.indexOf(node.name) !== -1) {
+          if (selected.indexOf(node.id) !== -1) {
             return true;
           }
           return false;
@@ -227,7 +227,7 @@ angular.module(PKG.name + '.commons')
         vm.highlightSelectedNodeConnections();
       },
       end: () => {
-        const nodesToAddToDrag = vm.selectedNode.map(node => node.name);
+        const nodesToAddToDrag = vm.selectedNode.map(node => node.id);
         vm.instance.addToDragSelection(nodesToAddToDrag);
       },
       toggleSelectionMode: () => {
@@ -246,15 +246,15 @@ angular.module(PKG.name + '.commons')
 
     vm.highlightSelectedNodeConnections = () => {
       const selectedNodesMap = {};
-      vm.selectedNode.forEach(node => selectedNodesMap[node.name] = true);
+      vm.selectedNode.forEach(node => selectedNodesMap[node.id] = true);
       const adjacencyMap = DAGPlusPlusNodesStore.getAdjacencyMap();
       clearConnectionsSelection();
-      vm.selectedNode.forEach(({name}) => {
-        const connectedNodes = adjacencyMap[name];
+      vm.selectedNode.forEach(({id, name}) => {
+        const connectedNodes = adjacencyMap[id];
         if (!Array.isArray(connectedNodes)) {
           return;
         }
-        const connectionsFromSource = vm.instance.getConnections({sourceId: name});
+        const connectionsFromSource = vm.instance.getConnections({sourceId: id});
         connectedNodes.forEach(nodeId => {
           if (!selectedNodesMap[nodeId]) {
             return;
@@ -297,6 +297,7 @@ angular.module(PKG.name + '.commons')
       return {
         stages: this.selectedNode.map((node) => {
           return {
+            id: node.id,
             name: node.name,
             icon: node.icon,
             type: node.type,
@@ -571,7 +572,7 @@ angular.module(PKG.name + '.commons')
         node.isPluginAvailable = ispluginsMapAvailable ?
             Boolean(myHelpers.objectQuery(vm.pluginsMap, key, 'pluginInfo')) : true;
         if (node.type === 'condition') {
-          initConditionNode(node.name);
+          initConditionNode(node.id);
         } else if (node.type === 'splittertransform') {
           initSplitterNode(node);
         } else {
@@ -590,7 +591,7 @@ angular.module(PKG.name + '.commons')
           if (vm.isDisabled) {
             targetOptions.connectionsDetachable = false;
           }
-          vm.instance.makeTarget(node.name, targetOptions);
+          vm.instance.makeTarget(node.id, targetOptions);
         }
       });
     }
@@ -599,7 +600,7 @@ angular.module(PKG.name + '.commons')
       if (normalNodes.indexOf(node.name) !== -1) {
         return;
       }
-      addEndpointForNormalNode('endpoint_' + node.name);
+      addEndpointForNormalNode('endpoint_' + node.id);
       if (!_.isEmpty(vm.pluginsMap) && !vm.isDisabled) {
         addErrorAlertEndpoints(node);
       }
@@ -620,7 +621,7 @@ angular.module(PKG.name + '.commons')
         let splitterPorts = splitterNodesPorts[node.name];
         if (!_.isEmpty(splitterPorts)) {
           angular.forEach(splitterPorts, (port) => {
-            let portElId = 'endpoint_' + node.name + '_port_' + port;
+            let portElId = 'endpoint_' + node.id + '_port_' + port;
             deleteEndpoints(portElId);
           });
           DAGPlusPlusNodesActionsFactory.setConnections($scope.connections);
@@ -641,12 +642,12 @@ angular.module(PKG.name + '.commons')
       }
 
       angular.forEach(splitterPorts, (port) => {
-        let portElId = 'endpoint_' + node.name + '_port_' + port;
+        let portElId = 'endpoint_' + node.id + '_port_' + port;
         deleteEndpoints(portElId);
       });
 
       angular.forEach(node.outputSchema, (outputSchema) => {
-        addEndpointForSplitterNode('endpoint_' + node.name + '_port_' + outputSchema.name);
+        addEndpointForSplitterNode('endpoint_' + node.id + '_port_' + outputSchema.name);
       });
 
       DAGPlusPlusNodesActionsFactory.setConnections($scope.connections);
@@ -694,24 +695,24 @@ angular.module(PKG.name + '.commons')
         }
 
         let connObj = {
-          target: conn.to
+          target: targetNode.id
         };
 
         if (conn.hasOwnProperty('condition')) {
-          connObj.source = vm.instance.getEndpoints(`endpoint_${conn.from}_condition_${conn.condition}`)[0];
+          connObj.source = vm.instance.getEndpoints(`endpoint_${sourceNode.id}_condition_${conn.condition}`)[0];
         } else if (conn.hasOwnProperty('port')) {
-          connObj.source = vm.instance.getEndpoint(`endpoint_${conn.from}_port_${conn.port}`);
+          connObj.source = vm.instance.getEndpoint(`endpoint_${sourceNode.id}_port_${conn.port}`);
         } else if (targetNode.type === 'errortransform' || targetNode.type === 'alertpublisher') {
           if (!_.isEmpty(vm.pluginsMap) && !vm.isDisabled) {
             addConnectionToErrorsAlerts(conn, sourceNode, targetNode);
             return;
           }
         } else {
-          connObj.source = vm.instance.getEndpoints(`endpoint_${conn.from}`)[0];
+          connObj.source = vm.instance.getEndpoints(`endpoint_${sourceNode.id}`)[0];
         }
 
         if (connObj.source && connObj.target) {
-          connObj.cssClass = `connection-id-${conn.from}-${conn.to}`;
+          connObj.cssClass = `connection-id-${sourceNode.name}-${targetNode.name}`;
           let newConn = vm.instance.connect(connObj);
           if (
             targetNode.type === 'condition' ||
@@ -728,10 +729,10 @@ angular.module(PKG.name + '.commons')
 
     function addErrorAlertEndpoints(node) {
       if (vm.shouldShowAlertsPort(node)) {
-        addEndpointForNormalNode('endpoint_' + node.name + '_alert', vm.alertEndpointStyle);
+        addEndpointForNormalNode('endpoint_' + node.id + '_alert', vm.alertEndpointStyle);
       }
       if (vm.shouldShowErrorsPort(node)) {
-        addEndpointForNormalNode('endpoint_' + node.name + '_error', vm.errorEndpointStyle);
+        addEndpointForNormalNode('endpoint_' + node.id + '_error', vm.errorEndpointStyle);
       }
     }
 
@@ -741,11 +742,11 @@ angular.module(PKG.name + '.commons')
       };
 
       if (targetNode.type === 'errortransform' && vm.shouldShowErrorsPort(sourceNode)) {
-        connObj.source = vm.instance.getEndpoints(`endpoint_${conn.from}_error`)[0];
+        connObj.source = vm.instance.getEndpoints(`endpoint_${sourceNode.id}_error`)[0];
       } else if (targetNode.type === 'alertpublisher' && vm.shouldShowAlertsPort(sourceNode)) {
-        connObj.source = vm.instance.getEndpoints(`endpoint_${conn.from}_alert`)[0];
+        connObj.source = vm.instance.getEndpoints(`endpoint_${sourceNode.id}_alert`)[0];
       } else {
-        connObj.source = vm.instance.getEndpoints(`endpoint_${conn.from}`)[0];
+        connObj.source = vm.instance.getEndpoints(`endpoint_${sourceNode.id}`)[0];
         // this is for backwards compability with old pipelines where we don't specify
         // emit-alerts and emit-error in the plugin config yet. In those cases we should
         // still connect to the Error Collector/Alert Publisher using the normal endpoint
@@ -755,7 +756,7 @@ angular.module(PKG.name + '.commons')
       let defaultConnectorSettings = vm.defaultDagSettings.Connector;
       connObj.connector = [defaultConnectorSettings[0], Object.assign({}, defaultConnectorSettings[1], { midpoint: 0 })];
 
-      connObj.cssClass = `connection-id-${conn.from}-${conn.to}`;
+      connObj.cssClass = `connection-id-${sourceNode.name}-${targetNode.name}`;
       vm.instance.connect(connObj);
     };
 
@@ -815,16 +816,32 @@ angular.module(PKG.name + '.commons')
     };
 
     function addConnection(newConnObj) {
+      // source is always a specific endpoint on the right of the node
+      // target is always a contionous endpoint on the left of the node.
+      const sourceNodeId = newConnObj.source.getAttribute('data-nodeid');
+      const targetNodeId = newConnObj.target.getAttribute('data-nodeid');
+      const sourceDOMID = newConnObj.source.getAttribute('id');
+      const targetDOMID = newConnObj.target.getAttribute('id');
+      /**
+       * We set the connection to be between nodes which refers to the node name.
+       * we need the DOM ID for jsplumb and selecting nodes and connections
+       * We are not using name today because node names can have anything including
+       * space or any special character which is not allowed in for DOM 'id' attribute.
+       */
       let connection = {
-        from: newConnObj.sourceId,
-        to: newConnObj.targetId
+        from: sourceNodeId,
+        to: targetNodeId,
       };
 
       const source = newConnObj.source.getAttribute('data-nodetype');
-      const fromNodeId = newConnObj.source.getAttribute('data-nodeid');
-      connection.from = fromNodeId;
-      newConnObj.connection.connector.canvas.classList.add(`connection-id-${connection.from}-${connection.to}`);
+      newConnObj.connection.connector.canvas.classList.add(`connection-id-${sourceDOMID}-${targetDOMID}`);
 
+      /**
+       * If the connection is from a condition or a splitter transform
+       * we need information on the source of this connection. For condition
+       * it could yes/no ports or for the splitter transform it needs to be
+       * the port name (null/non-null or custom ports)
+       */
       if (source === 'splitter') {
         connection.port = newConnObj.source.getAttribute('data-portname');
       } else if (source.indexOf('condition') !== -1) {
@@ -839,8 +856,10 @@ angular.module(PKG.name + '.commons')
       if (!detachedConnObj.source || typeof detachedConnObj.source !== 'object') {
         return;
       }
-      const nodeId = detachedConnObj.source.getAttribute('data-nodeid');
-      connObj.sourceId = nodeId;
+      const sourceNodeId = detachedConnObj.source.getAttribute('data-nodeid');
+      const targetNodeId = detachedConnObj.target.getAttribute('data-nodeid');
+      connObj.sourceId = sourceNodeId;
+      connObj.targetId = targetNodeId;
       var connectionIndex = _.findIndex($scope.connections, function (conn) {
         return conn.from === connObj.sourceId && conn.to === connObj.targetId;
       });
@@ -997,25 +1016,25 @@ angular.module(PKG.name + '.commons')
     function disableAllEndpoints() {
       angular.forEach($scope.nodes, function (node) {
         if (node.plugin.type === 'condition') {
-          let endpoints = [`endpoint_${node.name}_condition_true`, `endpoint_${node.name}_condition_false`];
+          let endpoints = [`endpoint_${node.id}_condition_true`, `endpoint_${node.id}_condition_false`];
           angular.forEach(endpoints, (endpoint) => {
             disableEndpoints(endpoint);
           });
         } else if (node.plugin.type === 'splittertransform')  {
           let portNames = node.outputSchema.map(port => port.name);
-          let endpoints = portNames.map(portName => `endpoint_${node.name}_port_${portName}`);
+          let endpoints = portNames.map(portName => `endpoint_${node.id}_port_${portName}`);
           angular.forEach(endpoints, (endpoint) => {
             // different from others because the name here is the uuid of the splitter endpoint,
             // not the id of DOM element
             disableEndpoint(endpoint);
           });
         } else {
-          disableEndpoints('endpoint_' + node.name);
+          disableEndpoints('endpoint_' + node.id);
           if (vm.shouldShowAlertsPort(node)) {
-            disableEndpoints('endpoint_' + node.name + '_alert');
+            disableEndpoints('endpoint_' + node.id + '_alert');
           }
           if (vm.shouldShowErrorsPort(node)) {
-            disableEndpoints('endpoint_' + node.name + '_error');
+            disableEndpoints('endpoint_' + node.id + '_error');
           }
         }
       });
@@ -1062,7 +1081,7 @@ angular.module(PKG.name + '.commons')
 
       // else check if the connection is valid
       var sourceNode = $scope.nodes.find(node => node.name === connObj.sourceId);
-      var targetNode = $scope.nodes.find( node => node.name === connObj.targetId);
+      var targetNode = $scope.nodes.find( node => node.id === connObj.targetId);
 
       var valid = true;
 
@@ -1157,8 +1176,8 @@ angular.module(PKG.name + '.commons')
           localY = currentCoordinates.y;
 
           dragged = true;
-          const nodeName = drag.el.getAttribute('id');
-          const isNodeAlreadySelected = vm.selectedNode.find(selectedNode => selectedNode.name === nodeName);
+          const nodeId = drag.el.getAttribute('id');
+          const isNodeAlreadySelected = vm.selectedNode.find(selectedNode => selectedNode.id === nodeId);
           if (!isNodeAlreadySelected) {
             vm.instance.clearDragSelection();
           }
@@ -1199,7 +1218,7 @@ angular.module(PKG.name + '.commons')
       if (event.target.className.indexOf('endpoint-circle') === -1) { return; }
       vm.clearSelectedNodes();
 
-      let sourceElem = node.name;
+      let sourceElem = node.id;
       let endpoints = vm.instance.getEndpoints(sourceElem);
 
       if (!endpoints) { return; }
@@ -1327,7 +1346,7 @@ angular.module(PKG.name + '.commons')
 
       const newNodes = angular.copy(nodes);
       newNodes.forEach(node => {
-        DAGPlusPlusNodesActionsFactory.removeNode(node.name);
+        DAGPlusPlusNodesActionsFactory.removeNode(node.id);
 
         if (Object.keys(splitterNodesPorts).indexOf(node.name) !== -1) {
           delete splitterNodesPorts[node.name];
@@ -1335,7 +1354,7 @@ angular.module(PKG.name + '.commons')
         let nodeType = node.plugin.type || node.type;
         if (nodeType === 'splittertransform' && node.outputSchema && Array.isArray(node.outputSchema)) {
           let portNames = node.outputSchema.map(port => port.name);
-          let endpoints = portNames.map(portName => `endpoint_${node.name}_port_${portName}`);
+          let endpoints = portNames.map(portName => `endpoint_${node.id}_port_${portName}`);
           angular.forEach(endpoints, (endpoint) => {
             deleteEndpoints(endpoint);
           });
@@ -1345,8 +1364,8 @@ angular.module(PKG.name + '.commons')
         selectedConnections = selectedConnections.filter(function(selectedConnObj) {
           return selectedConnObj.sourceId !== node.name && selectedConnObj.targetId !== node.name;
         });
-        vm.instance.unmakeTarget(node.name);
-        vm.instance.remove(node.name);
+        vm.instance.unmakeTarget(node.id);
+        vm.instance.remove(node.id);
       });
       vm.instance.bind('connectionDetached', removeConnection);
 
@@ -1640,7 +1659,8 @@ angular.module(PKG.name + '.commons')
           oldNameToNewNameMap[node.name] = newName;
           node.plugin.label = newName;
           return Object.assign({}, node, {
-            name: oldNameToNewNameMap[node.name]
+            name: oldNameToNewNameMap[node.name],
+            id: oldNameToNewNameMap[node.name]
           }, iconConfiguration);
         });
         connections = connections.map((connection) => {
@@ -1651,7 +1671,12 @@ angular.module(PKG.name + '.commons')
             to: oldNameToNewNameMap[to] || to,
           });
         });
-        return {nodes, connections};
+        const newNodes = window.CaskCommon.CDAPHelpers.sanitizeNodeNamesInPluginProperties(
+          nodes,
+          AvailablePluginsStore.getState(),
+          oldNameToNewNameMap
+        );
+        return {nodes: newNodes, connections};
       } catch (e) {
         console.log('error parsing node config', e);
       }

--- a/cdap-ui/app/directives/dag-plus/my-dag-factory.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-factory.js
@@ -362,7 +362,7 @@ angular.module(PKG.name + '.commons')
       graph.setDefaultEdgeLabel(function() { return {}; });
 
       nodes.forEach(function (node) {
-        var id = node.id || node.name;
+        var id = node.name || node.id;
 
         if (!graph.node(id)) {
           graph.setNode(id, { label: node.label, width: 100, height: 100 });

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -121,14 +121,17 @@
           The condition on ng-click is to prevent user from being able to click
           if the DAG is disabled. It will prevent the highlighting of nodes on select
         -->
-        <div ng-repeat="node in nodes" class="box {{node.type}}" ng-style="node._uiPosition"
+        <div ng-repeat="node in nodes"
+               class="box {{node.type}}"
+               ng-style="node._uiPosition"
                data-type="{{node.type}}"
-               id="{{node.name}}"
+               id="{{node.id}}"
+               data-nodeid="{{node.name}}"
                data-cy="plugin-node-{{node.plugin.name}}-{{node.type}}-{{$index}}"
                ng-class="{
                  'wrangler': node.plugin.name === 'Wrangler',
                  'node-menu-open': DAGPlusPlusCtrl.nodeMenuOpen === node.name,
-                 'selected': DAGPlusPlusCtrl.isNodeSelected(node.name),
+                 'selected': DAGPlusPlusCtrl.isNodeSelected(node.id),
                }"
                ng-click="DAGPlusPlusCtrl.selectNode($event, node)">
           <div class="node"
@@ -138,7 +141,7 @@
             <div class="endpoint-circle"
                   ng-if="node.type !== 'splittertransform'"
                   ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled, 'endpoint-circle-right': node.type === 'condition'}"
-                  ng-attr-id="{{node.type === 'condition' ? 'endpoint_' + node.name + '_condition_true' : 'endpoint_' + node.name}}"
+                  ng-attr-id="{{node.type === 'condition' ? 'endpoint_' + node.id + '_condition_true' : 'endpoint_' + node.id}}"
                   data-nodeid="{{node.name}}"
                   data-nodetype="{{node.type === 'condition' ? 'condition-true' : 'regular'}}"
                   ng-mouseup="DAGPlusPlusCtrl.selectEndpoint($event, node)"
@@ -167,7 +170,7 @@
                   ng-if="node.type === 'condition'"
                   ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled}"
                   ng-mouseup="DAGPlusPlusCtrl.selectEndpoint($event, node)"
-                  ng-attr-id="{{'endpoint_' + node.name + '_condition_false'}}"
+                  ng-attr-id="{{'endpoint_' + node.id + '_condition_false'}}"
                   data-nodeid="{{node.name}}"
                   data-nodetype="condition-false"
                   data-cy="plugin-endpoint-{{node.plugin.name}}-{{node.type}}-false">
@@ -233,7 +236,7 @@
                 <div class="endpoint-circle endpoint-circle-bottom"
                       ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled}"
                       ng-mouseup="DAGPlusPlusCtrl.selectEndpoint($event, node)"
-                      ng-attr-id="{{'endpoint_' + node.name + '_alert'}}"
+                      ng-attr-id="{{'endpoint_' + node.id + '_alert'}}"
                       data-nodeid="{{node.name}}"
                       data-nodetype="alert">
                   <div class="endpoint-caret" ng-if="!DAGPlusPlusCtrl.isDisabled"></div>
@@ -244,7 +247,7 @@
                 <div class="endpoint-circle endpoint-circle-bottom"
                       ng-class="{'disabled': DAGPlusPlusCtrl.isDisabled}"
                       ng-mouseup="DAGPlusPlusCtrl.selectEndpoint($event, node)"
-                      ng-attr-id="{{'endpoint_' + node.name + '_error'}}"
+                      ng-attr-id="{{'endpoint_' + node.id + '_error'}}"
                       data-nodeid="{{node.name}}"
                       data-nodetype="error">
                   <div class="endpoint-caret" ng-if="!DAGPlusPlusCtrl.isDisabled"></div>
@@ -290,7 +293,7 @@
           </div>
           <div ng-if="!DAGPlusPlusCtrl.isDisabled">
             <plugin-context-menu
-              node-id="'{{node.name}}'"
+              node-id="'{{node.id}}'"
               get-plugin-configuration="DAGPlusPlusCtrl.getPluginConfiguration"
               get-selected-connections="DAGPlusPlusCtrl.getSelectedConnections"
               get-selected-nodes="DAGPlusPlusCtrl.getSelectedNodes"

--- a/cdap-ui/app/hydrator/controllers/create/partials/pipelineupgrade-modal-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/pipelineupgrade-modal-ctrl.js
@@ -99,13 +99,7 @@ angular.module(PKG.name + '.feature.hydrator')
             HydratorPlusPlusConfigStore.setState(HydratorPlusPlusConfigStore.getDefaults());
             rPipelineConfig.config.stages = rPipelineConfig.config.stages.map(stage => {
               return Object.assign({}, stage, {
-                name: stage.name.replace(/[ \/]/g, '-')
-              });
-            });
-            rPipelineConfig.config.connections = rPipelineConfig.config.connections.map(conn => {
-              return Object.assign({}, conn, {
-                from: conn.from.replace(/[ \/]/g, '-'),
-                to: conn.to.replace(/[ \/]/g, '-')
+                id: stage.name.replace(/[ \/]/g, '-')
               });
             });
             $state.go('hydrator.create', { data: rPipelineConfig });

--- a/cdap-ui/app/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/hydrator/services/create/stores/config-store.js
@@ -205,7 +205,7 @@ class HydratorPlusPlusConfigStore {
         inputSchema: node.inputSchema
       };
 
-      configObj.name = configObj.name.replace(/[ \/]/g, '-');
+      configObj.id = configObj.name.replace(/[ \/]/g, '-');
       if (node.errorDatasetName) {
         configObj.errorDatasetName = node.errorDatasetName;
       }
@@ -242,8 +242,8 @@ class HydratorPlusPlusConfigStore {
         toPluginName = toConnectionName.plugin.label || toConnectionName.name;
         toConnectionName = toPluginName;
       }
-      connection.from = fromConnectionName.replace(/[ \/]/g, '-');
-      connection.to = toConnectionName.replace(/[ \/]/g, '-');
+      connection.from = fromConnectionName;
+      connection.to = toConnectionName;
     });
     config.connections = connections;
 
@@ -336,7 +336,7 @@ class HydratorPlusPlusConfigStore {
     state.config = angular.copy(config);
 
     var nodes = angular.copy(this.getNodes()).map( node => {
-      node.name = node.plugin.label.replace(/[ \/]/g, '-');
+      node.name = node.plugin.label;
       return node;
     });
     state.__ui__.nodes = nodes;

--- a/cdap-ui/app/hydrator/services/hydrator-upgrade-service.js
+++ b/cdap-ui/app/hydrator/services/hydrator-upgrade-service.js
@@ -288,17 +288,11 @@ class HydratorUpgradeService {
       if(stage.name.indexOf(' ') !== -1 || stage.name.indexOf('/') !== -1) {
         oldNameToNewNameMap[stage.name] = stage.name.replace(/[ \/]/g, '-');
         return Object.assign({}, stage, {
-          name: oldNameToNewNameMap[stage.name]
+          id: stage.name.replace(/[ \/]/g, '-')
         });
       }
-      return stage;
-    });
-    jsonData.config.connections = jsonData.config.connections.map((connection) => {
-      const from = connection.from;
-      const to = connection.to;
-      return Object.assign({}, connection, {
-        from: oldNameToNewNameMap[from] || from,
-        to: oldNameToNewNameMap[to] || to,
+      return Object.assign({}, stage, {
+        id: stage.name,
       });
     });
     this.$uibModal.open({

--- a/cdap-ui/cypress/support/commands.ts
+++ b/cdap-ui/cypress/support/commands.ts
@@ -391,7 +391,7 @@ Cypress.Commands.add('select_connection', (from: INodeIdentifier, to: INodeIdent
       toNodeElement = tElement;
       const sourceName = fromNodeElement[0].getAttribute('id');
       const targetName = toNodeElement[0].getAttribute('id');
-      const connectionSelector = `.jsplumb-connector.connection-id-${sourceName}-${targetName}`;
+      const connectionSelector = `.jsplumb-connector.connection-id-endpoint_${sourceName}-${targetName}`;
       cy.get(connectionSelector).then((connElement) => {
         (connElement[0] as any)._jsPlumb._jsPlumb.instance.fire(
           'click',


### PR DESCRIPTION
**TL;DR** 
- Fixes pipeline studio to import pipelines exported in older version of CDAP (<6.2). 
- Separate plugin name from being used in DOM id attribute. Prevents modifying plugin name which could be used in other plugin properties (joiner)

JIRA: https://issues.cask.co/browse/CDAP-17246

**Longer Version**

The fix involves using a unique ID that will be used in DOM node. The reason we changed the name in
the first place was to have no spaces (or other spl characters) that are not supported by DOM id attribute.
Since the same stage name could be used in other plugin properties we no longer change the name during pipeline
imports.

We however have to update the stage name when copy/pasting nodes in the pipeline studio. We need to do this as
the stage name uniquely identifies the plugin in the pipeline DAG. This change makes sure stage names modified
while copy/pasting nodes to pipeline canvas is correspondingly updated in other plugins where the plugin
name is used.

There is still a small window where users using custom plugin in which none of the widgets are used (just plain textbox) but still references previous stages. The UI won't be catch this case as of now. Corresponding JIRA for this use case - https://issues.cask.co/browse/CDAP-17252

**UPDATE:**
We decided not to auto update plugin properties with new stage names. Instead a more comprehensive approach is needed to make sure we have a clear user flow during bulk copy/paste. Given the 6.2.2 timeline we are not adding a new user flow to 6.2.2 at this point.