### PR TITLE
Fix preview styles

### DIFF
--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -41,6 +41,7 @@ const styles = (theme): StyleRules => ({
     width: '50%',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
     '&:first-of-type': {
       borderRight: `1px solid ${theme.palette.grey['500']}`,
       fontWeight: 500,


### PR DESCRIPTION
cherry-pick of #12749  but without the change to fetching preview data. 

Fixes styling where long JSON values did not get wrapped properly and looked like they were getting cut off instead of showing ellipsis (this is likely from a bad merge conflict resolution).

Example for testing: Try the Datafusion quick start pipeline in Hub!

Build: https://builds.cask.co/browse/CDAP-UDUT827