### PR TITLE
CDAP-17237 fix pipeline hconf clearing

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSinkFactory.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSinkFactory.java
@@ -128,7 +128,6 @@ public final class SparkBatchSinkFactory {
     }
 
     Configuration hConf = new Configuration();
-    hConf.clear();
     Map<String, Set<String>> groupSinkOutputs = new HashMap<>();
     for (String sink : sinkNames) {
       groupSinkOutputs.put(sink, sinkOutputs.get(sink));
@@ -176,7 +175,6 @@ public final class SparkBatchSinkFactory {
     }
 
     Configuration hConf = new Configuration();
-    hConf.clear();
     Map<String, Set<String>> sinkOutputs = Collections.singletonMap(sinkName, outputFormats.keySet());
     MultiOutputFormat.addOutputs(hConf, outputFormats, sinkOutputs);
     hConf.set(MRJobConfig.OUTPUT_FORMAT_CLASS_ATTR, MultiOutputFormat.class.getName());
@@ -190,7 +188,6 @@ public final class SparkBatchSinkFactory {
 
   private void saveUsingOutputFormat(OutputFormatProvider outputFormatProvider, JavaPairRDD<?, ?> rdd) {
     Configuration hConf = new Configuration();
-    hConf.clear();
     for (Map.Entry<String, String> entry : outputFormatProvider.getOutputFormatConfiguration().entrySet()) {
       hConf.set(entry.getKey(), entry.getValue());
     }


### PR DESCRIPTION
Fixed a bug where the hadoop conf is cleared before adding sink
specific properties. This ensures that cluster specific defaults
are correctly included in the conf instead of being wiped.