### PR TITLE
(CDAP-17257) Wait till the TwillRunnable.run return on stopping

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -144,6 +144,7 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
 
   @Override
   public void stop() {
+    LOG.info("Stopping preview runner manager");
     previewRunnerManager.stop();
   }
 


### PR DESCRIPTION
- This fixes the preview pod get killed too fast before it can stop itself gracefully