### PR TITLE
Fixes cypress config to have port name. This is used for generating the session token in nodejs server

### DIFF
--- a/cdap-ui/cypress.json
+++ b/cdap-ui/cypress.json
@@ -2,6 +2,7 @@
   "baseUrl": "http://localhost:11011",
   "env": {
     "host": "localhost",
+    "port": "11011",
     "RETRIES": 3
   },
   "video": false,


### PR DESCRIPTION
**Issue**
- In this PR https://github.com/cdapio/cdap/pull/12768/files#diff-df68a7c36176e21144e1aeca2b0a6633R72 we started using port from cypress config to generate a session token. 
- However we missed to add that property to the config.
- This will lead to failures in e2e where it looks like this,
```
build	16-Sep-2020 04:11:38	
build	16-Sep-2020 04:11:38	The response we got was:
build	16-Sep-2020 04:11:38	
build	16-Sep-2020 04:11:38	Status: 500 - Server Error
build	16-Sep-2020 04:11:38	Headers: {
build	16-Sep-2020 04:11:38	  "x-powered-by": "Express",
build	16-Sep-2020 04:11:38	  "strict-transport-security": "max-age=31536000; includeSubDomains",
build	16-Sep-2020 04:11:38	  "x-frame-options": "SAMEORIGIN",
build	16-Sep-2020 04:11:38	  "content-security-policy": "img-src 'self' data: https://hub.cdap.io; script-src 'nonce-68a41cdc-8705-4d01-9a10-ba2f34b72e12' 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:; base-uri 'self'; object-src 'none'; worker-src 'self' blob:; report-uri https://csp.withgoogle.com/csp/cdap/6.0",
build	16-Sep-2020 04:11:38	  "content-type": "text/html; charset=utf-8",
build	16-Sep-2020 04:11:38	  "content-length": "26",
build	16-Sep-2020 04:11:38	  "etag": "W/\"1a-X8dVoU5G62NdnNbXE87WgwRDk0o\"",
build	16-Sep-2020 04:11:38	  "vary": "Accept-Encoding",
build	16-Sep-2020 04:11:38	  "date": "Wed, 16 Sep 2020 04:11:38 GMT",
build	16-Sep-2020 04:11:38	  "connection": "keep-alive"
build	16-Sep-2020 04:11:38	}
build	16-Sep-2020 04:11:38	Body: Unable to validate session
```

This means the session token generated by cypress is not valid when making a POST call to an API in nodejs server (in this case changing the theme).

**Note**
- It ran fine in my pull request because I was actually running CDAP UI in 11012 port and I changed the port property in cypress.json to be 11012 but didn't add that to staging changes to git.

**Solution**
- Add the property to config.
