### PR TITLE
Added explicit @throws IllegalArgumentException to ValidatingOutputFormat#validate.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidatingOutputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidatingOutputFormat.java
@@ -28,6 +28,8 @@ public interface ValidatingOutputFormat extends OutputFormatProvider {
    * Validates configurations of output format.
    *
    * @param context format context
+   *
+   * @throws IllegalArgumentException incase of validation errors.
    */
   void validate(FormatContext context);
 }


### PR DESCRIPTION
This exception is thrown when validation of output formats fail.