### PR TITLE
[CDAP-17283] Fixes the name of record type to conform to Avro Schema spec

### DIFF
--- a/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaGenerator.ts
+++ b/cdap-ui/app/cdap/components/AbstractWidget/SchemaEditor/Context/SchemaGenerator.ts
@@ -123,9 +123,10 @@ function generateEnumType(children: IOrderedChildren, currentNode: INode, nullab
 function generateRecordType(children: IOrderedChildren, currentNode: INode, nullable: boolean) {
   const finalType: IRecordField = {
     type: AvroSchemaTypesEnum.RECORD,
-    name: currentNode.name || `name-${uuidV4()}`,
+    name: currentNode.name || `name_${uuidV4()}`,
     fields: [],
   };
+  finalType.name = finalType.name.replace(/-/g, '');
   const { typeProperties = {} } = currentNode;
   if (typeProperties.doc) {
     finalType.doc = typeProperties.doc;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-17283
Avro Schema Name specification - http://avro.apache.org/docs/current/spec.html#names

The new schema editor added name to the record type with `-`. This doesn't conform to the avro schema which fails the pipeline to write 