### PR TITLE
Update preview to use Table components instead of Grid

### DIFF
--- a/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/DataView/Table.tsx
@@ -15,8 +15,13 @@
  */
 
 import React from 'react';
+
+import TableBody from '@material-ui/core/TableBody';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
+
 import Paper from '@material-ui/core/Paper';
-import Grid from '@material-ui/core/Grid';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import isEmpty from 'lodash/isEmpty';
 import { PREVIEW_STATUS } from 'services/PreviewStatus';
@@ -27,6 +32,19 @@ import T from 'i18n-react';
 import classnames from 'classnames';
 
 const I18N_PREFIX = 'features.PreviewData.DataView.Table';
+
+export const CustomTableCell = withStyles((theme) => ({
+  head: {
+    backgroundColor: theme.palette.grey['300'],
+    color: theme.palette.common.white,
+    padding: 10,
+    fontSize: 14,
+  },
+  body: {
+    padding: 10,
+    fontSize: 14,
+  },
+}))(TableCell);
 
 export const messageTextStyle = {
   fontSize: '1.3rem !important',
@@ -58,21 +76,20 @@ export const styles = (theme): StyleRules => ({
   },
   cell: {
     textAlign: 'left',
-    lineHeight: '40px',
     whiteSpace: 'nowrap',
     padding: '0px 10px',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
-  },
-
-  // TO DO: Currently the width is fixed. Future plan is to let users vary the column widths
-  tableCell: {
-    width: '120px',
     borderLeft: `1px solid ${theme.palette.grey['500']}`,
-    flexGrow: 1,
+    '&:first-of-type': {
+      borderLeft: 'none',
+    },
   },
   indexCell: {
     width: '50px',
+  },
+  headerCell: {
+    borderLeft: `1px solid ${theme.palette.grey['500']}`,
   },
 });
 
@@ -115,37 +132,50 @@ const DataTableView: React.FC<IDataTableProps> = ({
     }
     return field;
   };
+
+  const renderHeader = (header: string[]) => {
+    return (
+      <TableHead>
+        <TableRow className={classnames(classes.headerRow)}>
+          <CustomTableCell className={classnames(classes.indexCell, classes.headerCell)} />
+          {headers.map((fieldName, i) => {
+            const processedFieldName = format(fieldName);
+            return (
+              <CustomTableCell key={`header-cell-${i}`} className={classes.headerCell}>
+                {processedFieldName}
+              </CustomTableCell>
+            );
+          })}
+        </TableRow>
+      </TableHead>
+    );
+  };
+
   const renderList = (visibleNodeCount: number, startNode: number) => {
-    return records.slice(startNode, startNode + visibleNodeCount).map((record, i) => {
-      const rowIndex = startNode + i + 1;
+    return records.slice(startNode, startNode + visibleNodeCount).map((record, j) => {
+      const rowIndex = startNode + j + 1;
       return (
-        <React.Fragment>
-          <Grid
-            container
-            direction="row"
-            wrap="nowrap"
-            justify="space-evenly"
+        <TableBody>
+          <TableRow
+            key={`table-row-${j}`}
             className={classnames(classes.row, { oddRow: rowIndex % 2 })}
-            key={`gridrow-${i}`}
           >
-            <Grid item className={classnames(classes.cell, classes.indexCell)}>
+            <CustomTableCell
+              className={classnames(classes.indexCell, classes.cell)}
+              key={`index-cell-${j}`}
+            >
               {rowIndex}
-            </Grid>
+            </CustomTableCell>
             {headers.map((fieldName, k) => {
               const processedValue = format(record[fieldName]);
               return (
-                <Grid
-                  item
-                  className={classnames(classes.cell, classes.tableCell)}
-                  key={`table-cell-${k}`}
-                  title={processedValue}
-                >
+                <CustomTableCell key={`table-cell-${j}-${k}`} className={classes.cell}>
                   {processedValue}
-                </Grid>
+                </CustomTableCell>
               );
             })}
-          </Grid>
-        </React.Fragment>
+          </TableRow>
+        </TableBody>
       );
     });
   };
@@ -160,41 +190,14 @@ const DataTableView: React.FC<IDataTableProps> = ({
 
   return (
     <Paper className={classnames(classes.root, classes.tableContainer)}>
-      <Grid container direction="column" wrap="nowrap">
-        <Grid item>
-          <Grid
-            container
-            direction="row"
-            wrap="nowrap"
-            justify="space-evenly"
-            className={classes.headerRow}
-          >
-            <Grid item className={classnames(classes.cell, classes.indexCell)} />
-            {headers.map((fieldName, i) => {
-              const processedFieldName = format(fieldName);
-              return (
-                <Grid
-                  item
-                  key={`header-cell-${i}`}
-                  className={classnames(classes.cell, classes.tableCell)}
-                  title={processedFieldName}
-                >
-                  {processedFieldName}
-                </Grid>
-              );
-            })}
-          </Grid>
-        </Grid>
-        <Grid item>
-          <VirtualScroll
-            itemCount={() => records.length}
-            visibleChildCount={25}
-            childHeight={40}
-            renderList={renderList}
-            childrenUnderFold={10}
-          />
-        </Grid>
-      </Grid>
+      <VirtualScroll
+        itemCount={() => records.length}
+        visibleChildCount={25}
+        childHeight={40}
+        renderList={renderList}
+        childrenUnderFold={10}
+        headerEl={renderHeader(headers)}
+      />
     </Paper>
   );
 };

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordContainer.tsx
@@ -45,7 +45,7 @@ const styles = (theme): StyleRules => ({
     height: 'inherit',
     overflowX: 'hidden',
     '& .record-pane': {
-      width: '100%',
+      minWidth: '100%',
     },
     '& .cask-tab-headers': {
       overflowX: 'auto',

--- a/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/RecordView/RecordTable.tsx
@@ -15,41 +15,45 @@
  */
 
 import React from 'react';
-import VirtualScroll from 'components/VirtualScroll';
 import { PREVIEW_STATUS } from 'services/PreviewStatus';
-import Grid from '@material-ui/core/Grid';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import ThemeWrapper from 'components/ThemeWrapper';
-import { styles as tableStyles } from 'components/PreviewData/DataView/Table';
+import { CustomTableCell, styles as tableStyles } from 'components/PreviewData/DataView/Table';
 import classnames from 'classnames';
 import T from 'i18n-react';
 import Heading, { HeadingTypes } from 'components/Heading';
 
 const I18N_PREFIX = 'features.PreviewData.RecordView.RecordTable';
 
-// Info about rows in record table
-// Max number of visible rows
-const visibleChildCount = 25;
-// Height of row in px
-const childHeight = 40;
-// number of rows in dom but not in viewport
-const childrenUnderFold = 10;
-
 const styles = (theme): StyleRules => ({
   ...tableStyles(theme),
   recordCell: {
-    width: '50%',
+    minWidth: '50%',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
+    borderLeft: `1px solid ${theme.palette.grey['500']}`,
     '&:first-of-type': {
-      borderRight: `1px solid ${theme.palette.grey['500']}`,
       fontWeight: 500,
+      borderLeft: 'none',
+    },
+  },
+  recordRow: {
+    '&:nth-of-type(odd)': {
+      backgroundColor: theme.palette.grey['600'],
     },
   },
   recordContainer: {
     width: '100%',
     padding: '10px',
+    overflowX: 'auto',
+  },
+  table: {
+    backgroundColor: theme.palette.white['50'],
   },
 });
 
@@ -104,44 +108,6 @@ const RecordTableView: React.FC<IRecordTableProps> = ({
     );
   };
 
-  const renderList = (visibleNodeCount: number, startNode: number) => {
-    if (!record) {
-      return;
-    }
-    return headers.slice(startNode, startNode + visibleNodeCount).map((fieldName, i) => {
-      const processedFieldName = format(fieldName);
-      const processedValue = format(record[fieldName]);
-      return (
-        <React.Fragment>
-          <Grid
-            container
-            direction="row"
-            wrap="nowrap"
-            className={classnames(classes.row, { oddRow: (i + startNode + 1) % 2 })}
-            key={`gridrow-${i}`}
-          >
-            <Grid
-              item
-              className={classnames(classes.cell, classes.recordCell)}
-              title={processedFieldName}
-              data-cy={`fieldname-${processedFieldName}`}
-            >
-              {processedFieldName}
-            </Grid>
-            <Grid
-              item
-              className={classnames(classes.cell, classes.recordCell)}
-              title={processedValue}
-              data-cy={`value-${processedValue}`}
-            >
-              {processedValue}
-            </Grid>
-          </Grid>
-        </React.Fragment>
-      );
-    });
-  };
-
   // When the selected record number is out of range
   if (!record) {
     return noRecordMsg();
@@ -149,33 +115,32 @@ const RecordTableView: React.FC<IRecordTableProps> = ({
 
   return (
     <div className={classnames(classes.root, classes.recordContainer)}>
-      <Grid container direction="column" wrap="nowrap">
-        <Grid item>
-          <Grid
-            container
-            direction="row"
-            justify="center"
-            alignItems="center"
-            className={classes.headerRow}
-          >
-            <Grid item className={classnames(classes.cell, classes.recordCell)}>
+      <Table className={classes.table}>
+        <TableHead>
+          <TableRow className={classes.row}>
+            <CustomTableCell className={classes.recordCell}>
               {T.translate(`${I18N_PREFIX}.fieldName`)}
-            </Grid>
-            <Grid item className={classnames(classes.cell, classes.recordCell)}>
+            </CustomTableCell>
+            <CustomTableCell className={classes.recordCell}>
               {T.translate(`${I18N_PREFIX}.value`)}
-            </Grid>
-          </Grid>
-        </Grid>
-        <Grid item>
-          <VirtualScroll
-            itemCount={() => headers.length}
-            visibleChildCount={visibleChildCount}
-            childHeight={childHeight}
-            renderList={renderList}
-            childrenUnderFold={childrenUnderFold}
-          />
-        </Grid>
-      </Grid>
+            </CustomTableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {headers.map((fieldName, i) => {
+            return (
+              <TableRow className={classnames(classes.row, classes.recordRow)} key={`tr-${i}`}>
+                <CustomTableCell className={classes.recordCell}>
+                  {format(fieldName)}
+                </CustomTableCell>
+                <CustomTableCell className={classes.recordCell}>
+                  {format(record[fieldName])}
+                </CustomTableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
     </div>
   );
 };

--- a/cdap-ui/app/cdap/components/VirtualScroll/index.tsx
+++ b/cdap-ui/app/cdap/components/VirtualScroll/index.tsx
@@ -28,6 +28,7 @@ interface IVirtualScrollProps extends WithStyles<typeof styles> {
   childHeight: number;
   childrenUnderFold: number;
   childrenUnderFoldOnScroll?: number;
+  headerEl?: React.ReactNode | Promise<React.ReactNode>;
   LoadingElement?: React.ReactNode;
 }
 const styles = (): StyleRules => {
@@ -62,12 +63,14 @@ const VirtualScroll = ({
   childHeight,
   childrenUnderFold,
   childrenUnderFoldOnScroll = 50,
+  headerEl = null,
   classes,
   LoadingElement = () => 'Loading...',
 }: IVirtualScrollProps) => {
   const [scrollTop, ref] = useScroll();
   const itmCount = typeof itemCount === 'function' ? itemCount() : itemCount;
-  const totalHeight = itmCount * childHeight;
+  const headerHeight = headerEl ? childHeight : 0;
+  const totalHeight = itmCount * childHeight + headerHeight;
   const [list, setList] = useState<React.ReactNode>([]);
   const [promise, setPromise] = useState(null);
   const [scrollingChildrenUnderFold, setScrollingChildrenUnderFold] = useState(childrenUnderFold);
@@ -109,7 +112,9 @@ const VirtualScroll = ({
   }, [promise]);
 
   const containerHeight =
-    itmCount > visibleChildCount ? visibleChildCount * childHeight : itmCount * childHeight;
+    itmCount > visibleChildCount
+      ? visibleChildCount * childHeight + headerHeight
+      : itmCount * childHeight + headerHeight;
   return (
     <div style={{ height: containerHeight }} className={classes.root} ref={ref}>
       <div
@@ -124,6 +129,7 @@ const VirtualScroll = ({
             transform: `translateY(${offsetY}px)`,
           }}
         >
+          {headerEl}
           {list}
         </div>
         {promise ? <div className={classes.loading}>Loading...</div> : null}


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-17018
Build: https://builds.cask.co/browse/CDAP-URUT345

Changing from grid to table for Data and Record view to better handle showing large values. Also

- modified virtual scroll slightly to allow optional headers
- removed virtual scroll from record view where it wasn't showing a significant performance difference

The Datafusion Quick start pipeline in hub works well for testing!