### PR TITLE
Fix pom to make it compatible with Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ language: java
 
 jdk:
   - openjdk8
+  - openjdk11
 
 branches:
   only:

--- a/cdap-api-spark/pom.xml
+++ b/cdap-api-spark/pom.xml
@@ -184,7 +184,9 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
+        <configuration>
+          <scalaVersion>${scala2.10.version}</scalaVersion>
+        </configuration>
       </plugin>
       <!-- copy the source from cdap-api-spark-base in order to compile everything as scala 2.10 -->
       <plugin>

--- a/cdap-api-spark2_2.11/pom.xml
+++ b/cdap-api-spark2_2.11/pom.xml
@@ -184,7 +184,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
       </plugin>
       <!-- copy the source from cdap-api-spark-base in order to compile everything as scala 2.11 -->
       <plugin>

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/pom.xml
@@ -151,7 +151,9 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
+        <configuration>
+          <scalaVersion>${scala2.10.version}</scalaVersion>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
@@ -177,7 +177,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
       </plugin>
 
       <!-- copy the source from cdap-data-pipeline in order to compile everything as scala 2.11 -->

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/pom.xml
@@ -60,7 +60,9 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
+        <configuration>
+          <scalaVersion>${scala2.10.version}</scalaVersion>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/pom.xml
@@ -148,7 +148,9 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
+        <configuration>
+          <scalaVersion>${scala2.10.version}</scalaVersion>
+        </configuration>
       </plugin>
 
       <plugin>

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/pom.xml
@@ -93,7 +93,9 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
+        <configuration>
+          <scalaVersion>${scala2.10.version}</scalaVersion>
+        </configuration>
       </plugin>
       <!-- copy the source from hydrator-spark-core-base in order to compile everything as scala 2.10 -->
       <plugin>

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/pom.xml
@@ -93,7 +93,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
       </plugin>
       <!-- copy the source from hydrator-spark-core-base in order to compile everything as scala 2.11 -->
       <plugin>

--- a/cdap-app-templates/cdap-program-report/pom.xml
+++ b/cdap-app-templates/cdap-program-report/pom.xml
@@ -338,7 +338,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/cdap-spark-core/pom.xml
+++ b/cdap-spark-core/pom.xml
@@ -194,7 +194,9 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
+        <configuration>
+          <scalaVersion>${scala2.10.version}</scalaVersion>
+        </configuration>
       </plugin>
       <!-- copy the source from cdap-spark-core-base in order to compile everything as scala 2.10 -->
       <plugin>

--- a/cdap-spark-core2_2.11/pom.xml
+++ b/cdap-spark-core2_2.11/pom.xml
@@ -194,7 +194,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
       </plugin>
       <!-- copy the source from cdap-spark-core-base in order to compile everything as scala 2.11 -->
       <plugin>

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/subscriber/AbstractMessagingPollingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/subscriber/AbstractMessagingPollingService.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import javax.annotation.Nullable;
-import javax.xml.ws.handler.MessageContext;
 
 /**
  * Abstract base class for implementing message polling logic for reading messages from TMS.
@@ -76,7 +75,7 @@ public abstract class AbstractMessagingPollingService<T> extends AbstractRetryab
   }
 
   /**
-   * Returns the {@link MessageContext} that this service used for interacting with TMS.
+   * Returns the {@link MessagingContext} that this service used for interacting with TMS.
    */
   protected abstract MessagingContext getMessagingContext();
 

--- a/cdap-unit-test-spark2_2.11/pom.xml
+++ b/cdap-unit-test-spark2_2.11/pom.xml
@@ -74,7 +74,6 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/cdap-unit-test/pom.xml
+++ b/cdap-unit-test/pom.xml
@@ -163,7 +163,9 @@
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.1</version>
+        <configuration>
+          <scalaVersion>${scala2.10.version}</scalaVersion>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -849,6 +849,10 @@
         <version>${hbase10.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>jdk.tools</groupId>
+            <artifactId>jdk.tools</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -859,6 +863,10 @@
         <artifactId>hbase-client</artifactId>
         <version>${hbase10.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>jdk.tools</groupId>
+            <artifactId>jdk.tools</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
@@ -879,6 +887,10 @@
         <version>${hbase10.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>jdk.tools</groupId>
+            <artifactId>jdk.tools</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -889,6 +901,10 @@
         <artifactId>hbase-server</artifactId>
         <version>${hbase10.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>jdk.tools</groupId>
+            <artifactId>jdk.tools</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
@@ -1290,6 +1306,10 @@
         <scope>test</scope>
         <exclusions>
           <exclusion>
+            <groupId>jdk.tools</groupId>
+            <artifactId>jdk.tools</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
@@ -1513,6 +1533,12 @@
         <artifactId>tez-api</artifactId>
         <version>${tez.version}</version>
         <scope>provided</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>jdk.tools</groupId>
+            <artifactId>jdk.tools</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.mockftpserver</groupId>
@@ -1686,11 +1712,12 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>4.4.0</version>
           <configuration>
             <args>
               <arg>-target:jvm-1.7</arg>
             </args>
+            <scala.version>2.11.12</scala.version>
           </configuration>
           <executions>
             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -590,6 +590,17 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-annotations</artifactId>
+        <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jdk.tools</groupId>
+            <artifactId>jdk.tools</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -156,8 +156,8 @@
     <quartz.version>2.2.0</quartz.version>
     <resteasy.version>3.0.8.Final</resteasy.version>
     <rs-api.version>2.0</rs-api.version>
-    <scala2.10.version>2.10.4</scala2.10.version>
-    <scala2.11.version>2.11.8</scala2.11.version>
+    <scala2.10.version>2.10.7</scala2.10.version>
+    <scala2.11.version>2.11.12</scala2.11.version>
     <servlet.api.version>3.0.1</servlet.api.version>
     <slf4j.version>1.7.5</slf4j.version>
     <snappy.version>1.1.1.7</snappy.version>
@@ -1717,7 +1717,7 @@
             <args>
               <arg>-target:jvm-1.7</arg>
             </args>
-            <scala.version>2.11.12</scala.version>
+            <scalaVersion>${scala2.11.version}</scalaVersion>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
- Excludes the JDK tools.jar dependency from HBase. CDAP doesn't need the tools.jar
- Use Scala patch versions that are compatible with Java 11 for compilation