### PR TITLE
make DataprocProvisioner accept gcp-dataproc.serviceAccount property from cdap-site.xml

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -57,6 +57,10 @@ final class DataprocConf {
   // The property name for the GCE cluster meta data
   // It can be overridden by profile runtime arguments (system.profile.properties.clusterMetaData)
   static final String CLUSTER_MEATA_DATA = "clusterMetaData";
+  // The property name for the serviceAccount that is passed to Dataproc when creating the Dataproc Cluster
+  // Dataproc will pass it to GCE when creating the GCE cluster.
+  // It can be overridden by profile runtime arguments (system.profile.properties.serviceAccount)
+  static final String SERVICE_ACCOUNT = "serviceAccount";
 
   static final Pattern CLUSTER_PROPERTIES_PATTERN = Pattern.compile("^[a-zA-Z0-9\\-]+:");
   static final int MAX_NETWORK_TAGS = 64;

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -228,7 +228,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       DataprocConf.STACKDRIVER_MONITORING_ENABLED,
       DataprocConf.COMPONENT_GATEWAY_ENABLED,
       DataprocConf.IMAGE_VERSION,
-      DataprocConf.CLUSTER_MEATA_DATA
+      DataprocConf.CLUSTER_MEATA_DATA,
+      DataprocConf.SERVICE_ACCOUNT
     ).contains(property);
   }
 

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -117,12 +117,14 @@ public class DataprocProvisionerTest {
     String resourceMaxPercentKey = "capacity-scheduler:yarn.scheduler.capacity.maximum-am-resource-percent";
     String resourceMaxPercentVal = "0.5";
     String clusterMetaData = "metadata-key1|metadata-val1;metadata-key2|metadata-val2";
+    String serviceAccount = "service-account-1";
 
     //default system properties defined by DataprocProvisioner
     provisionerSystemContext.addProperty(DataprocConf.NETWORK, "old-network");
     provisionerSystemContext.addProperty(DataprocConf.STACKDRIVER_LOGGING_ENABLED, "true");
     provisionerSystemContext
       .addProperty(DataprocConf.CLUSTER_MEATA_DATA, clusterMetaData);
+    provisionerSystemContext.addProperty(DataprocConf.SERVICE_ACCOUNT, serviceAccount);
 
     //default system properties defined by AbstractDataprocProvisioner
     provisionerSystemContext.addProperty(resourceMaxPercentKey, resourceMaxPercentVal);
@@ -144,6 +146,7 @@ public class DataprocProvisionerTest {
     Assert.assertEquals("true", properties.get(DataprocConf.STACKDRIVER_LOGGING_ENABLED));
     Assert.assertEquals(resourceMaxPercentVal, properties.get(resourceMaxPercentKey));
     Assert.assertEquals(clusterMetaData, properties.get(DataprocConf.CLUSTER_MEATA_DATA));
+    Assert.assertEquals(serviceAccount, properties.get(DataprocConf.SERVICE_ACCOUNT));
     Assert.assertEquals("job_manager", properties.get(DataprocConf.RUNTIME_JOB_MANAGER));
     Assert.assertNull(properties.get("non-system-default-key"));
   }


### PR DESCRIPTION
context: Dataproc has enforced some new permission check :
https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/service-accounts
so we are allowing cdap-site.xml to configure a service account that can be passed to Dataproc when CDAP creates an ephemeral Dataproc cluster to run pipelines

changes: enable DataprocProvisioner to accept gcp-dataproc.serviceAccount property 

