### PR TITLE
make DataprocProvisioner accept gcp-dataproc.serviceAccount property from cdap-site.xml

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -57,6 +57,10 @@ final class DataprocConf {
   static final String STACKDRIVER_MONITORING_ENABLED = "stackdriverMonitoringEnabled";
   static final String IMAGE_VERSION = "imageVersion";
   static final String CUSTOM_IMAGE_URI = "customImageUri";
+  // The property name for the serviceAccount that is passed to Dataproc when creating the Dataproc Cluster
+  // Dataproc will pass it to GCE when creating the GCE cluster.
+  // It can be overridden by profile runtime arguments (system.profile.properties.serviceAccount)
+  static final String SERVICE_ACCOUNT = "serviceAccount";
 
   private static final Pattern CLUSTER_PROPERTIES_PATTERN = Pattern.compile("^[a-zA-Z0-9\\-]+:");
   static final int MAX_NETWORK_TAGS = 64;
@@ -418,7 +422,7 @@ final class DataprocConf {
     long pollDeleteDelay = getLong(properties, "pollDeleteDelay", 30);
     long pollInterval = getLong(properties, "pollInterval", 2);
 
-    String serviceAccount = getString(properties, "serviceAccount");
+    String serviceAccount = getString(properties, SERVICE_ACCOUNT);
     boolean preferExternalIP = Boolean.parseBoolean(properties.get(PREFER_EXTERNAL_IP));
     // By default stackdriver is enabled. This is for backward compatibility
     boolean stackdriverLoggingEnabled = Boolean.parseBoolean(properties.getOrDefault(STACKDRIVER_LOGGING_ENABLED,

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -316,7 +316,8 @@ public class DataprocProvisioner implements Provisioner {
                                       DataprocConf.NETWORK_HOST_PROJECT_ID,
                                       DataprocConf.STACKDRIVER_LOGGING_ENABLED,
                                       DataprocConf.STACKDRIVER_MONITORING_ENABLED,
-                                      DataprocConf.IMAGE_VERSION);
+                                      DataprocConf.IMAGE_VERSION,
+                                      DataprocConf.SERVICE_ACCOUNT);
     for (String key : keys) {
       if (!contextProperties.containsKey(key)) {
         String value = systemContext.getProperties().get(key);

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -101,6 +101,7 @@ public class DataprocProvisionerTest {
   public void testDataprocConf() {
     Map<String, String> props = new HashMap<>();
     props.put(DataprocConf.PROJECT_ID_KEY, "pid");
+    props.put(DataprocConf.SERVICE_ACCOUNT, "service-account-1");
     props.put("accountKey", "key");
     props.put("region", "region1");
     props.put("zone", "region1-a");
@@ -114,6 +115,7 @@ public class DataprocProvisionerTest {
     Assert.assertEquals(conf.getProjectId(), "pid");
     Assert.assertEquals(conf.getRegion(), "region1");
     Assert.assertEquals(conf.getZone(), "region1-a");
+    Assert.assertEquals("service-account-1", conf.getServiceAccount());
 
     Map<String, String> dataprocProps = conf.getDataprocProperties();
     Assert.assertEquals(3, dataprocProps.size());
@@ -121,6 +123,7 @@ public class DataprocProvisionerTest {
     Assert.assertEquals("100", dataprocProps.get("spark:spark.reducer.maxSizeInFlight"));
     Assert.assertEquals("xyz", dataprocProps.get("hadoop-env:MAPREDUCE_CLASSPATH"));
     Assert.assertEquals("true", dataprocProps.get("dataproc:am.primary_only"));
+
   }
 
   @Test


### PR DESCRIPTION
context: Dataproc has enforced some new permission check :
https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/service-accounts
so we are allowing cdap-site.xml to configure a service account that can be passed to Dataproc when CDAP creates an ephemeral Dataproc cluster to run pipelines

changes: enable DataprocProvisioner to accept gcp-dataproc.serviceAccount property