### PR TITLE
make DataprocProvisioner accept gcp-dataproc.serviceAccount property from cdap-site.xml

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -53,6 +53,10 @@ final class DataprocConf {
   static final String IMAGE_VERSION = "imageVersion";
   static final String CUSTOM_IMAGE_URI = "customImageUri";
   static final String RUNTIME_JOB_MANAGER = "runtime.job.manager";
+  // The property name for the serviceAccount that is passed to Dataproc when creating the Dataproc Cluster
+  // Dataproc will pass it to GCE when creating the GCE cluster.
+  // It can be overridden by profile runtime arguments (system.profile.properties.serviceAccount)
+  static final String SERVICE_ACCOUNT = "serviceAccount";
 
   static final Pattern CLUSTER_PROPERTIES_PATTERN = Pattern.compile("^[a-zA-Z0-9\\-]+:");
   static final int MAX_NETWORK_TAGS = 64;
@@ -427,7 +431,7 @@ final class DataprocConf {
     long pollDeleteDelay = getLong(properties, "pollDeleteDelay", 30);
     long pollInterval = getLong(properties, "pollInterval", 2);
 
-    String serviceAccount = getString(properties, "serviceAccount");
+    String serviceAccount = getString(properties, SERVICE_ACCOUNT);
     boolean preferExternalIP = Boolean.parseBoolean(properties.get(PREFER_EXTERNAL_IP));
     // By default stackdriver is enabled. This is for backward compatibility
     boolean stackdriverLoggingEnabled = Boolean.parseBoolean(properties.getOrDefault(STACKDRIVER_LOGGING_ENABLED,

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -200,7 +200,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       DataprocConf.NETWORK_HOST_PROJECT_ID,
       DataprocConf.STACKDRIVER_LOGGING_ENABLED,
       DataprocConf.STACKDRIVER_MONITORING_ENABLED,
-      DataprocConf.IMAGE_VERSION
+      DataprocConf.IMAGE_VERSION,
+      DataprocConf.SERVICE_ACCOUNT
     ).contains(property);
   }
 

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -112,9 +112,12 @@ public class DataprocProvisionerTest {
     MockProvisionerSystemContext provisionerSystemContext = new MockProvisionerSystemContext();
     String resourceMaxPercentKey = "capacity-scheduler:yarn.scheduler.capacity.maximum-am-resource-percent";
     String resourceMaxPercentVal = "0.5";
+    String serviceAccount = "service-account-1";
+
     provisionerSystemContext.addProperty(resourceMaxPercentKey, resourceMaxPercentVal);
     provisionerSystemContext.addProperty(DataprocConf.NETWORK, "old-network");
     provisionerSystemContext.addProperty(DataprocConf.STACKDRIVER_LOGGING_ENABLED, "true");
+    provisionerSystemContext.addProperty(DataprocConf.SERVICE_ACCOUNT, serviceAccount);
 
     DataprocProvisioner provisioner = new DataprocProvisioner();
     provisioner.initialize(provisionerSystemContext);
@@ -128,6 +131,7 @@ public class DataprocProvisionerTest {
     Assert.assertEquals(properties.get(DataprocConf.NETWORK), network);
     Assert.assertEquals(properties.get(DataprocConf.STACKDRIVER_LOGGING_ENABLED), "true");
     Assert.assertEquals(properties.get(resourceMaxPercentKey), resourceMaxPercentVal);
+    Assert.assertEquals(serviceAccount, properties.get(DataprocConf.SERVICE_ACCOUNT));
   }
 
   @Test


### PR DESCRIPTION

context: Dataproc has enforced some new permission check :
https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/service-accounts
so we are allowing cdap-site.xml to configure a service account that can be passed to Dataproc when CDAP creates an ephemeral Dataproc cluster to run pipelines

changes: enable DataprocProvisioner to accept gcp-dataproc.serviceAccount property