### PR TITLE
(CDAP-17332) Enabling writing bytes read/written metrics in Spark

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/BasicInputFormatProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/BasicInputFormatProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.batch;
+
+import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.api.data.batch.InputFormatProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An {@link InputFormatProvider} that simply take a class name and a set of configurations.
+ */
+public class BasicInputFormatProvider implements InputFormatProvider {
+
+  private final String inputFormatClassName;
+  private final Map<String, String> configuration;
+
+  public BasicInputFormatProvider(String inputFormatClassName, Map<String, String> configuration) {
+    this.inputFormatClassName = inputFormatClassName;
+    this.configuration = ImmutableMap.copyOf(configuration);
+  }
+
+  public BasicInputFormatProvider() {
+    this.inputFormatClassName = "";
+    this.configuration = new HashMap<>();
+  }
+
+  @Override
+  public String getInputFormatClassName() {
+    return inputFormatClassName;
+  }
+
+  @Override
+  public Map<String, String> getInputFormatConfiguration() {
+    return configuration;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/BasicOutputFormatProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/BasicOutputFormatProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.batch;
+
+import io.cdap.cdap.api.data.batch.OutputFormatProvider;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An {@link OutputFormatProvider} that simply take a class name and a set of configurations.
+ */
+public class BasicOutputFormatProvider implements OutputFormatProvider {
+
+  private final String outputFormatClassName;
+  private final Map<String, String> outputFormatConfiguration;
+
+  public BasicOutputFormatProvider(String outputFormatClassName, Map<String, String> outputFormatConfiguration) {
+    this.outputFormatClassName = outputFormatClassName;
+    this.outputFormatConfiguration = Collections.unmodifiableMap(new HashMap<>(outputFormatConfiguration));
+  }
+
+  @Override
+  public String getOutputFormatClassName() {
+    return outputFormatClassName;
+  }
+
+  @Override
+  public Map<String, String> getOutputFormatConfiguration() {
+    return outputFormatConfiguration;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/DelegatingInputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/DelegatingInputFormat.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.batch;
+
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * An {@link InputFormat} that delegates to another {@link InputFormat}.
+ *
+ * @param <K> type of key to read
+ * @param <V> type of value to read
+ */
+public class DelegatingInputFormat<K, V> extends InputFormat<K, V> {
+
+  public static final String DELEGATE_CLASS_NAME = "io.cdap.pipeline.delegate.input.classname";
+
+  @Override
+  public List<InputSplit> getSplits(JobContext context) throws IOException, InterruptedException {
+    return getDelegate(context.getConfiguration()).getSplits(context);
+  }
+
+  @Override
+  public RecordReader<K, V> createRecordReader(InputSplit split,
+                                               TaskAttemptContext context) throws IOException, InterruptedException {
+    return getDelegate(context.getConfiguration()).createRecordReader(split, context);
+  }
+
+  /**
+   * Returns the delegating {@link InputFormat} based on the current configuration.
+   *
+   * @param conf the Hadoop {@link Configuration} for this input format
+   * @throws IOException if failed to instantiate the input format class
+   */
+  protected final InputFormat<K, V> getDelegate(Configuration conf) throws IOException {
+    String delegateClassName = conf.get(DELEGATE_CLASS_NAME);
+    try {
+      //noinspection unchecked
+      InputFormat<K, V> inputFormat = (InputFormat<K, V>) conf.getClassLoader().loadClass(delegateClassName)
+        .newInstance();
+      if (inputFormat instanceof Configurable) {
+        ((Configurable) inputFormat).setConf(conf);
+      }
+      return inputFormat;
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+      throw new IOException("Unable to instantiate delegate input format " + delegateClassName, e);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/DelegatingOutputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/DelegatingOutputFormat.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.batch;
+
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+
+/**
+ * An {@link OutputFormat} that delegates to another {@link OutputFormat}.
+ *
+ * @param <K> type of key to write
+ * @param <V> type of value to write
+ */
+public class DelegatingOutputFormat<K, V> extends OutputFormat<K, V> {
+
+  public static final String DELEGATE_CLASS_NAME = "io.cdap.pipeline.delegate.output.classname";
+
+  @Override
+  public RecordWriter<K, V> getRecordWriter(TaskAttemptContext context) throws IOException, InterruptedException {
+    return getDelegate(context.getConfiguration()).getRecordWriter(context);
+  }
+
+  @Override
+  public void checkOutputSpecs(JobContext context) throws IOException, InterruptedException {
+    getDelegate(context.getConfiguration()).checkOutputSpecs(context);
+  }
+
+  @Override
+  public OutputCommitter getOutputCommitter(TaskAttemptContext context) throws IOException, InterruptedException {
+    return getDelegate(context.getConfiguration()).getOutputCommitter(context);
+  }
+
+  /**
+   * Returns the delegating {@link OutputFormat} based on the configuration.
+   *
+   * @param conf the Hadoop {@link Configuration} for this output format
+   * @throws IOException if failed to instantiate the output format class
+   */
+  protected final OutputFormat<K, V> getDelegate(Configuration conf) throws IOException {
+    String delegateClassName = conf.get(DELEGATE_CLASS_NAME);
+    try {
+      //noinspection unchecked
+      OutputFormat<K, V> outputFormat = (OutputFormat<K, V>) conf.getClassLoader().loadClass(delegateClassName)
+        .newInstance();
+      if (outputFormat instanceof Configurable) {
+        ((Configurable) outputFormat).setConf(conf);
+      }
+      return outputFormat;
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+      throw new IOException("Unable to instantiate delegate output format " + delegateClassName, e);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/preview/LimitingInputFormatProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/preview/LimitingInputFormatProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2019-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,8 @@
 package io.cdap.cdap.etl.batch.preview;
 
 import io.cdap.cdap.api.data.batch.InputFormatProvider;
+import io.cdap.cdap.etl.batch.BasicInputFormatProvider;
+import io.cdap.cdap.etl.batch.DelegatingInputFormat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,24 +26,15 @@ import java.util.Map;
 /**
  * An InputFormatProvider that limits how much data is read.
  */
-public class LimitingInputFormatProvider implements InputFormatProvider {
-  private final InputFormatProvider delegate;
-  private final int maxRecords;
+public class LimitingInputFormatProvider extends BasicInputFormatProvider {
 
   public LimitingInputFormatProvider(InputFormatProvider delegate, int maxRecords) {
-    this.delegate = delegate;
-    this.maxRecords = maxRecords;
+    super(LimitingInputFormat.class.getName(), getConfiguration(delegate, maxRecords));
   }
 
-  @Override
-  public String getInputFormatClassName() {
-    return LimitingInputFormat.class.getName();
-  }
-
-  @Override
-  public Map<String, String> getInputFormatConfiguration() {
+  private static Map<String, String> getConfiguration(InputFormatProvider delegate, int maxRecords) {
     Map<String, String> config = new HashMap<>(delegate.getInputFormatConfiguration());
-    config.put(LimitingInputFormat.DELEGATE_CLASS_NAME, delegate.getInputFormatClassName());
+    config.put(DelegatingInputFormat.DELEGATE_CLASS_NAME, delegate.getInputFormatClassName());
     config.put(LimitingInputFormat.MAX_RECORDS, String.valueOf(maxRecords));
     return config;
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/batch/preview/LimitingInputFormatTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/batch/preview/LimitingInputFormatTest.java
@@ -116,7 +116,6 @@ public class LimitingInputFormatTest {
     FileInputFormat.addInputPath(job, new Path(inputDir.toURI()));
 
     LimitingInputFormat<LongWritable, Text> inputFormat = new LimitingInputFormat<>();
-    inputFormat.setConf(hConf);
 
     List<InputSplit> splits = inputFormat.getSplits(job);
     Assert.assertEquals(1, splits.size());

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/AbstractSparkCounter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/AbstractSparkCounter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark;
+
+import org.apache.hadoop.mapreduce.Counter;
+import org.apache.hadoop.mapreduce.counters.AbstractCounter;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * An abstract MapReduce {@link Counter} for sending counter to Spark metrics.
+ */
+public abstract class AbstractSparkCounter extends AbstractCounter {
+
+  private final String name;
+  private final String displayName;
+
+  public AbstractSparkCounter(String name, String displayName) {
+    this.name = name;
+    this.displayName = displayName;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  @Override
+  public Counter getUnderlyingCounter() {
+    return this;
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    // no-op
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    // no-op
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/InputFormatProviderTypeAdapter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/InputFormatProviderTypeAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,6 +25,7 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import io.cdap.cdap.api.data.batch.InputFormatProvider;
+import io.cdap.cdap.etl.batch.BasicInputFormatProvider;
 
 import java.lang.reflect.Type;
 import java.util.Map;
@@ -42,11 +43,11 @@ public class InputFormatProviderTypeAdapter implements JsonSerializer<InputForma
     JsonObject obj = json.getAsJsonObject();
     // if inputFormat is not present, return empty InputFormatProvider
     if (obj.get("inputFormatClass") == null) {
-      return new SparkBatchSourceFactory.BasicInputFormatProvider();
+      return new BasicInputFormatProvider();
     }
     String className = obj.get("inputFormatClass").getAsString();
     Map<String, String> conf = context.deserialize(obj.get("inputFormatConfig"), mapType);
-    return new SparkBatchSourceFactory.BasicInputFormatProvider(className, conf);
+    return new BasicInputFormatProvider(className, conf);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSinkFactory.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSinkFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -26,7 +26,6 @@ import io.cdap.cdap.etl.common.output.MultiOutputFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.spark.api.java.JavaPairRDD;
-import org.apache.spark.api.java.function.PairFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Tuple2;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSourceContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSourceContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015 Cask Data, Inc.
+ * Copyright © 2015-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,18 +21,23 @@ import io.cdap.cdap.api.data.batch.Input;
 import io.cdap.cdap.api.data.batch.InputFormatProvider;
 import io.cdap.cdap.api.spark.SparkClientContext;
 import io.cdap.cdap.etl.api.batch.BatchSourceContext;
+import io.cdap.cdap.etl.batch.BasicInputFormatProvider;
 import io.cdap.cdap.etl.batch.preview.LimitingInputFormatProvider;
 import io.cdap.cdap.etl.common.ExternalDatasets;
 import io.cdap.cdap.etl.common.PipelineRuntime;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 import io.cdap.cdap.etl.spark.SparkSubmitterContext;
+import io.cdap.cdap.etl.spark.io.TrackingInputFormat;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 /**
  * Default implementation of {@link BatchSourceContext} for spark contexts.
  */
 public class SparkBatchSourceContext extends SparkSubmitterContext implements BatchSourceContext {
+
   private final SparkBatchSourceFactory sourceFactory;
   private final boolean isPreviewEnabled;
 
@@ -46,6 +51,17 @@ public class SparkBatchSourceContext extends SparkSubmitterContext implements Ba
   @Override
   public void setInput(Input input) {
     Input trackableInput = input;
+
+    // Wrap the input provider with tracking counter for metrics collection via MR counter.
+    if (trackableInput instanceof Input.InputFormatProviderInput) {
+      InputFormatProvider provider = ((Input.InputFormatProviderInput) trackableInput).getInputFormatProvider();
+      Map<String, String> conf = new HashMap<>(provider.getInputFormatConfiguration());
+      conf.put(TrackingInputFormat.DELEGATE_CLASS_NAME, provider.getInputFormatClassName());
+      provider = new BasicInputFormatProvider(TrackingInputFormat.class.getName(), conf);
+      trackableInput = Input.of(trackableInput.getName(), provider).alias(trackableInput.getAlias());
+    }
+
+    // Limit preview input by wrapping the input
     if (isPreviewEnabled && trackableInput instanceof Input.InputFormatProviderInput) {
       InputFormatProvider inputFormatProvider =
         ((Input.InputFormatProviderInput) trackableInput).getInputFormatProvider();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSourceFactory.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBatchSourceFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2019 Cask Data, Inc.
+ * Copyright © 2015-2020 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,11 +18,11 @@ package io.cdap.cdap.etl.spark.batch;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.api.data.batch.Input;
 import io.cdap.cdap.api.data.batch.InputFormatProvider;
 import io.cdap.cdap.api.data.batch.Split;
 import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.etl.batch.BasicInputFormatProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.spark.api.java.JavaPairRDD;
@@ -74,7 +74,7 @@ public final class SparkBatchSourceFactory {
     addStageInput(stageName, alias);
   }
 
-  private void addInput(String stageName, String alias, BasicInputFormatProvider inputFormatProvider) {
+  private void addInput(String stageName, String alias, InputFormatProvider inputFormatProvider) {
     duplicateAliasCheck(alias);
     inputFormatProviders.put(alias, inputFormatProvider);
     addStageInput(stageName, alias);
@@ -144,29 +144,4 @@ public final class SparkBatchSourceFactory {
     sourceInputs.put(stageName, inputs);
   }
 
-  static final class BasicInputFormatProvider implements InputFormatProvider {
-
-    private final String inputFormatClassName;
-    private final Map<String, String> configuration;
-
-    BasicInputFormatProvider(String inputFormatClassName, Map<String, String> configuration) {
-      this.inputFormatClassName = inputFormatClassName;
-      this.configuration = ImmutableMap.copyOf(configuration);
-    }
-
-    BasicInputFormatProvider() {
-      this.inputFormatClassName = "";
-      this.configuration = new HashMap<>();
-    }
-
-    @Override
-    public String getInputFormatClassName() {
-      return inputFormatClassName;
-    }
-
-    @Override
-    public Map<String, String> getInputFormatConfiguration() {
-      return configuration;
-    }
-  }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingInputFormat.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingInputFormat.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.io;
+
+import io.cdap.cdap.etl.batch.DelegatingInputFormat;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+
+import java.io.IOException;
+
+/**
+ * An {@link InputFormat} that enables metrics tracking through {@link TaskAttemptContext} counters to Spark metrics.
+ *
+ * @param <K> type of key to read
+ * @param <V> type of value to read
+ */
+public class TrackingInputFormat<K, V> extends DelegatingInputFormat<K, V> {
+
+  @Override
+  public RecordReader<K, V> createRecordReader(InputSplit split,
+                                               TaskAttemptContext context) throws IOException, InterruptedException {
+    // Spark already tracking metrics for file based input, hence we don't need to track again.
+    if (split instanceof FileSplit || split instanceof CombineFileSplit) {
+      return super.createRecordReader(split, context);
+    }
+
+    return new TrackingRecordReader<>(super.createRecordReader(split, new TrackingTaskAttemptContext(context)));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingOutputCommitter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingOutputCommitter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.io;
+
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+
+/**
+ * A {@link OutputCommitter} that delegate all operations to another {@link OutputCommitter}, with counter metrics
+ * sending to Spark metrics.
+ */
+public class TrackingOutputCommitter extends OutputCommitter {
+
+  private final OutputCommitter delegate;
+
+  public TrackingOutputCommitter(OutputCommitter delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void setupJob(JobContext jobContext) throws IOException {
+    delegate.setupJob(jobContext);
+  }
+
+  @Override
+  @Deprecated
+  public void cleanupJob(JobContext jobContext) throws IOException {
+    delegate.cleanupJob(jobContext);
+  }
+
+  @Override
+  public void commitJob(JobContext jobContext) throws IOException {
+    delegate.commitJob(jobContext);
+  }
+
+  @Override
+  public void abortJob(JobContext jobContext, JobStatus.State state) throws IOException {
+    delegate.abortJob(jobContext, state);
+  }
+
+  @Override
+  public void setupTask(TaskAttemptContext taskContext) throws IOException {
+    delegate.setupTask(new TrackingTaskAttemptContext(taskContext));
+  }
+
+  @Override
+  public boolean needsTaskCommit(TaskAttemptContext taskContext) throws IOException {
+    return delegate.needsTaskCommit(new TrackingTaskAttemptContext(taskContext));
+  }
+
+  @Override
+  public void commitTask(TaskAttemptContext taskContext) throws IOException {
+    delegate.commitTask(new TrackingTaskAttemptContext(taskContext));
+  }
+
+  @Override
+  public void abortTask(TaskAttemptContext taskContext) throws IOException {
+    delegate.abortTask(new TrackingTaskAttemptContext(taskContext));
+  }
+
+  @Override
+  public boolean isRecoverySupported() {
+    return delegate.isRecoverySupported();
+  }
+
+  @Override
+  public void recoverTask(TaskAttemptContext taskContext) throws IOException {
+    delegate.recoverTask(new TrackingTaskAttemptContext(taskContext));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingOutputFormat.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingOutputFormat.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.io;
+
+import io.cdap.cdap.etl.batch.DelegatingOutputFormat;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+
+import java.io.IOException;
+
+/**
+ * An {@link OutputFormat} that enables metrics tracking through {@link TaskAttemptContext} counters to Spark metrics.
+ *
+ * @param <K> type of key to write
+ * @param <V> type of value to write
+ */
+public class TrackingOutputFormat<K, V> extends DelegatingOutputFormat<K, V> {
+
+  @Override
+  public RecordWriter<K, V> getRecordWriter(TaskAttemptContext context) throws IOException, InterruptedException {
+    OutputFormat<K, V> delegate = getDelegate(context.getConfiguration());
+
+    // Spark already emitting bytes written metrics for file base output, hence we don't want to double count
+    if (delegate instanceof FileOutputFormat) {
+      return delegate.getRecordWriter(context);
+    }
+
+    return new TrackingRecordWriter<>(delegate.getRecordWriter(new TrackingTaskAttemptContext(context)));
+  }
+
+  @Override
+  public OutputCommitter getOutputCommitter(TaskAttemptContext context) throws IOException, InterruptedException {
+    OutputFormat<K, V> delegate = getDelegate(context.getConfiguration());
+
+    // Spark already emitting bytes written metrics for file base output, hence we don't want to double count
+    if (delegate instanceof FileOutputFormat) {
+      return delegate.getOutputCommitter(context);
+    }
+
+    return new TrackingOutputCommitter(delegate.getOutputCommitter(new TrackingTaskAttemptContext(context)));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingRecordReader.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingRecordReader.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.io;
+
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+
+/**
+ * A {@link RecordReader} that delegate all operations to another {@link RecordReader}, with counter metrics
+ * sending to Spark metrics.
+ *
+ * @param <K> type of key to read
+ * @param <V> type of value to read
+ */
+public class TrackingRecordReader<K, V> extends RecordReader<K, V> {
+
+  private final RecordReader<K, V> delegate;
+
+  public TrackingRecordReader(RecordReader<K, V> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+    delegate.initialize(split, new TrackingTaskAttemptContext(context));
+  }
+
+  @Override
+  public boolean nextKeyValue() throws IOException, InterruptedException {
+    return delegate.nextKeyValue();
+  }
+
+  @Override
+  public K getCurrentKey() throws IOException, InterruptedException {
+    return delegate.getCurrentKey();
+  }
+
+  @Override
+  public V getCurrentValue() throws IOException, InterruptedException {
+    return delegate.getCurrentValue();
+  }
+
+  @Override
+  public float getProgress() throws IOException, InterruptedException {
+    return delegate.getProgress();
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingRecordWriter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingRecordWriter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.io;
+
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import java.io.IOException;
+
+/**
+ * A {@link RecordWriter} that delegate all operations to another {@link RecordWriter}, with counter metrics
+ * sending to Spark metrics.
+ *
+ * @param <K> type of key to write
+ * @param <V> type of value to write
+ */
+public class TrackingRecordWriter<K, V> extends RecordWriter<K, V> {
+
+  private final RecordWriter<K, V> delegate;
+
+  public TrackingRecordWriter(RecordWriter<K, V> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void write(K key, V value) throws IOException, InterruptedException {
+    delegate.write(key, value);
+  }
+
+  @Override
+  public void close(TaskAttemptContext context) throws IOException, InterruptedException {
+    delegate.close(new TrackingTaskAttemptContext(context));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingTaskAttemptContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingTaskAttemptContext.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.io;
+
+import io.cdap.cdap.etl.spark.batch.SparkBytesReadCounter;
+import io.cdap.cdap.etl.spark.batch.SparkBytesWrittenCounter;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.RawComparator;
+import org.apache.hadoop.mapreduce.Counter;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.JobID;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.OutputFormat;
+import org.apache.hadoop.mapreduce.Partitioner;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormatCounter;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormatCounter;
+import org.apache.hadoop.security.Credentials;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Implementation of {@link TaskAttemptContext} that support bytes read/written counter.
+ */
+final class TrackingTaskAttemptContext implements TaskAttemptContext {
+
+  private final TaskAttemptContext delegate;
+
+  TrackingTaskAttemptContext(TaskAttemptContext delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Counter getCounter(Enum<?> counterName) {
+    return getCounter(counterName.getDeclaringClass().getName(), counterName.name());
+  }
+
+  @Override
+  public Counter getCounter(String groupName, String counterName) {
+    if (FileInputFormatCounter.class.getName().equals(groupName)
+      && FileInputFormatCounter.BYTES_READ.name().equals(counterName)) {
+      return new SparkBytesReadCounter();
+    }
+    if (FileOutputFormatCounter.class.getName().equals(groupName)
+      && FileOutputFormatCounter.BYTES_WRITTEN.name().equals(counterName)) {
+      return new SparkBytesWrittenCounter();
+    }
+
+    return delegate.getCounter(groupName, counterName);
+  }
+
+  @Override
+  public TaskAttemptID getTaskAttemptID() {
+    return delegate.getTaskAttemptID();
+  }
+
+  @Override
+  public void setStatus(String msg) {
+    delegate.setStatus(msg);
+  }
+
+  @Override
+  public String getStatus() {
+    return delegate.getStatus();
+  }
+
+  @Override
+  public float getProgress() {
+    return delegate.getProgress();
+  }
+
+  @Override
+  public Configuration getConfiguration() {
+    return delegate.getConfiguration();
+  }
+
+  @Override
+  public Credentials getCredentials() {
+    return delegate.getCredentials();
+  }
+
+  @Override
+  public JobID getJobID() {
+    return delegate.getJobID();
+  }
+
+  @Override
+  public int getNumReduceTasks() {
+    return delegate.getNumReduceTasks();
+  }
+
+  @Override
+  public Path getWorkingDirectory() throws IOException {
+    return delegate.getWorkingDirectory();
+  }
+
+  @Override
+  public Class<?> getOutputKeyClass() {
+    return delegate.getOutputKeyClass();
+  }
+
+  @Override
+  public Class<?> getOutputValueClass() {
+    return delegate.getOutputValueClass();
+  }
+
+  @Override
+  public Class<?> getMapOutputKeyClass() {
+    return delegate.getMapOutputKeyClass();
+  }
+
+  @Override
+  public Class<?> getMapOutputValueClass() {
+    return delegate.getMapOutputValueClass();
+  }
+
+  @Override
+  public String getJobName() {
+    return delegate.getJobName();
+  }
+
+  @Override
+  public Class<? extends InputFormat<?, ?>> getInputFormatClass() throws ClassNotFoundException {
+    return delegate.getInputFormatClass();
+  }
+
+  @Override
+  public Class<? extends Mapper<?, ?, ?, ?>> getMapperClass() throws ClassNotFoundException {
+    return delegate.getMapperClass();
+  }
+
+  @Override
+  public Class<? extends Reducer<?, ?, ?, ?>> getCombinerClass() throws ClassNotFoundException {
+    return delegate.getCombinerClass();
+  }
+
+  @Override
+  public Class<? extends Reducer<?, ?, ?, ?>> getReducerClass() throws ClassNotFoundException {
+    return delegate.getReducerClass();
+  }
+
+  @Override
+  public Class<? extends OutputFormat<?, ?>> getOutputFormatClass() throws ClassNotFoundException {
+    return delegate.getOutputFormatClass();
+  }
+
+  @Override
+  public Class<? extends Partitioner<?, ?>> getPartitionerClass() throws ClassNotFoundException {
+    return delegate.getPartitionerClass();
+  }
+
+  @Override
+  public RawComparator<?> getSortComparator() {
+    return delegate.getSortComparator();
+  }
+
+  @Override
+  public String getJar() {
+    return delegate.getJar();
+  }
+
+  @Override
+  public RawComparator<?> getCombinerKeyGroupingComparator() {
+    return delegate.getCombinerKeyGroupingComparator();
+  }
+
+  @Override
+  public RawComparator<?> getGroupingComparator() {
+    return delegate.getGroupingComparator();
+  }
+
+  @Override
+  public boolean getJobSetupCleanupNeeded() {
+    return delegate.getJobSetupCleanupNeeded();
+  }
+
+  @Override
+  public boolean getTaskCleanupNeeded() {
+    return delegate.getTaskCleanupNeeded();
+  }
+
+  @Override
+  public boolean getProfileEnabled() {
+    return delegate.getProfileEnabled();
+  }
+
+  @Override
+  public String getProfileParams() {
+    return delegate.getProfileParams();
+  }
+
+  @Override
+  public Configuration.IntegerRanges getProfileTaskRange(boolean isMap) {
+    return delegate.getProfileTaskRange(isMap);
+  }
+
+  @Override
+  public String getUser() {
+    return delegate.getUser();
+  }
+
+  @Override
+  @Deprecated
+  public boolean getSymlink() {
+    return delegate.getSymlink();
+  }
+
+  @Override
+  public Path[] getArchiveClassPaths() {
+    return delegate.getArchiveClassPaths();
+  }
+
+  @Override
+  public URI[] getCacheArchives() throws IOException {
+    return delegate.getCacheArchives();
+  }
+
+  @Override
+  public URI[] getCacheFiles() throws IOException {
+    return delegate.getCacheFiles();
+  }
+
+  @Override
+  @Deprecated
+  public Path[] getLocalCacheArchives() throws IOException {
+    return delegate.getLocalCacheArchives();
+  }
+
+  @Override
+  @Deprecated
+  public Path[] getLocalCacheFiles() throws IOException {
+    return delegate.getLocalCacheFiles();
+  }
+
+  @Override
+  public Path[] getFileClassPaths() {
+    return delegate.getFileClassPaths();
+  }
+
+  @Override
+  public String[] getArchiveTimestamps() {
+    return delegate.getArchiveTimestamps();
+  }
+
+  @Override
+  public String[] getFileTimestamps() {
+    return delegate.getFileTimestamps();
+  }
+
+  @Override
+  public int getMaxMapAttempts() {
+    return delegate.getMaxMapAttempts();
+  }
+
+  @Override
+  public int getMaxReduceAttempts() {
+    return delegate.getMaxReduceAttempts();
+  }
+
+  @Override
+  public void progress() {
+    delegate.progress();
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBytesReadCounter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBytesReadCounter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.etl.spark.AbstractSparkCounter;
+import org.apache.hadoop.mapreduce.Counter;
+import org.apache.spark.TaskContext;
+import org.apache.spark.executor.InputMetrics;
+import org.apache.spark.executor.TaskMetrics;
+
+import java.util.Optional;
+
+/**
+ * A {@link Counter} that records bytes read values to Spark metrics.
+ */
+public class SparkBytesReadCounter extends AbstractSparkCounter {
+
+  public SparkBytesReadCounter() {
+    super("bytes.read", "Bytes Read");
+  }
+
+  @Override
+  public long getValue() {
+    return getInputMetrics().map(InputMetrics::bytesRead).orElse(0L);
+  }
+
+  @Override
+  public void setValue(long value) {
+    long currentValue = getValue();
+    getInputMetrics().ifPresent(m -> m.incBytesRead(value - currentValue));
+  }
+
+  @Override
+  public void increment(long incr) {
+    getInputMetrics().ifPresent(m -> m.incBytesRead(incr));
+  }
+
+  private Optional<InputMetrics> getInputMetrics() {
+    return Optional.ofNullable(TaskContext.get())
+      .map(TaskContext::taskMetrics)
+      .map(TaskMetrics::inputMetrics)
+      .flatMap(o -> Optional.ofNullable(o.getOrElse(null)));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBytesWrittenCounter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBytesWrittenCounter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.etl.spark.AbstractSparkCounter;
+import org.apache.hadoop.mapreduce.Counter;
+import org.apache.spark.TaskContext;
+import org.apache.spark.executor.OutputMetrics;
+import org.apache.spark.executor.TaskMetrics;
+
+import java.util.Optional;
+
+/**
+ * A {@link Counter} that records bytes written values to Spark metrics.
+ */
+public class SparkBytesWrittenCounter extends AbstractSparkCounter {
+
+  public SparkBytesWrittenCounter() {
+    super("bytes.written", "Bytes Written");
+  }
+
+  @Override
+  public long getValue() {
+    return getOutputMetrics().map(OutputMetrics::bytesWritten).orElse(0L);
+  }
+
+  @Override
+  public void setValue(long value) {
+    getOutputMetrics().ifPresent(m -> m.setBytesWritten(value));
+  }
+
+  @Override
+  public void increment(long incr) {
+    long currentValue = getValue();
+    getOutputMetrics().ifPresent(m -> m.setBytesWritten(currentValue + incr));
+  }
+
+  private Optional<OutputMetrics> getOutputMetrics() {
+    return Optional.ofNullable(TaskContext.get())
+      .map(TaskContext::taskMetrics)
+      .map(TaskMetrics::outputMetrics)
+      .flatMap(o -> Optional.ofNullable(o.getOrElse(null)));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBytesReadCounter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBytesReadCounter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.etl.spark.AbstractSparkCounter;
+import org.apache.hadoop.mapreduce.Counter;
+import org.apache.spark.TaskContext;
+import org.apache.spark.executor.InputMetrics;
+import org.apache.spark.executor.TaskMetrics;
+
+import java.util.Optional;
+
+/**
+ * A {@link Counter} that records bytes read values to Spark metrics.
+ */
+public class SparkBytesReadCounter extends AbstractSparkCounter {
+
+  public SparkBytesReadCounter() {
+    super("bytes.read", "Bytes Read");
+  }
+
+  @Override
+  public long getValue() {
+    return getInputMetrics().map(InputMetrics::bytesRead).orElse(0L);
+  }
+
+  @Override
+  public void setValue(long value) {
+    getInputMetrics().ifPresent(m -> m.setBytesRead(value));
+  }
+
+  @Override
+  public void increment(long incr) {
+    getInputMetrics().ifPresent(m -> m.incBytesRead(incr));
+  }
+
+  private Optional<InputMetrics> getInputMetrics() {
+    return Optional.ofNullable(TaskContext.get())
+      .map(TaskContext::taskMetrics)
+      .map(TaskMetrics::inputMetrics);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBytesWrittenCounter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/SparkBytesWrittenCounter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.etl.spark.AbstractSparkCounter;
+import org.apache.hadoop.mapreduce.Counter;
+import org.apache.spark.TaskContext;
+import org.apache.spark.executor.OutputMetrics;
+import org.apache.spark.executor.TaskMetrics;
+
+import java.util.Optional;
+
+/**
+ * A {@link Counter} that records bytes written values to Spark metrics.
+ */
+public class SparkBytesWrittenCounter extends AbstractSparkCounter {
+
+  public SparkBytesWrittenCounter() {
+    super("bytes.written", "Bytes Written");
+  }
+
+  @Override
+  public long getValue() {
+    return getOutputMetrics().map(OutputMetrics::bytesWritten).orElse(0L);
+  }
+
+  @Override
+  public void setValue(long value) {
+    getOutputMetrics().ifPresent(m -> m.setBytesWritten(value));
+  }
+
+  @Override
+  public void increment(long incr) {
+    long currentValue = getValue();
+    getOutputMetrics().ifPresent(m -> m.setBytesWritten(currentValue + incr));
+  }
+
+  private Optional<OutputMetrics> getOutputMetrics() {
+    return Optional.ofNullable(TaskContext.get())
+      .map(TaskContext::taskMetrics)
+      .map(TaskMetrics::outputMetrics);
+  }
+}


### PR DESCRIPTION
- Sends values written to MR Counter for bytes read/written to Spark metrics
- Rewrite the OutputMetrics in Spark to ignore setting bytes written to 0
-- This is to prevent task metrics being overwritten