### PR TITLE
[CDAP-17288] Added Path rewrite for temporary Checkpoint file.

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3238,6 +3238,15 @@
   </property>
 
   <property>
+    <name>spark.streaming.checkpoint.rewrite.enabled</name>
+    <value>false</value>
+    <description>
+      Specify whether to rewrite the temporary checkpoint file name by adding the checkpoint timestamp to the temporary
+      file name. This is useful when using object storage as the checkpoint directory.
+    </description>
+  </property>
+
+  <property>
     <name>system.log.process.retry.policy.base.delay.ms</name>
     <value>1000</value>
     <description>

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -527,6 +527,13 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
       }
     }
 
+    //Configuration options for CDAP
+    String sparkCheckpointTempRewrite =
+      String.format("-D%s=%s", SparkRuntimeUtils.STREAMING_CHECKPOINT_REWRITE_ENABLED,
+                    cConf.get(SparkRuntimeUtils.SPARK_STREAMING_CHECKPOINT_REWRITE_ENABLED));
+    prependConfig(configs, "spark.driver.extraJavaOptions", sparkCheckpointTempRewrite, " ");
+    prependConfig(configs, "spark.executor.extraJavaOptions", sparkCheckpointTempRewrite, " ");
+
     // CDAP-5854: On Windows * is a reserved character which cannot be used in paths. So adding the below to
     // classpaths will fail. Please see CDAP-5854.
     // In local mode spark program runs under the same jvm as cdap master and these jars will already be in the

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeUtils.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeUtils.java
@@ -84,6 +84,13 @@ public final class SparkRuntimeUtils {
   public static final String PYSPARK_PORT_FILE_NAME = "cdap.py4j.gateway.port.txt";
   public static final String PYSPARK_SECRET_FILE_NAME = "cdap.py4j.gateway.secret.txt";
 
+  // Configuration option used to supply rewriting behavior in Drivers and Executors.
+  // This configuration option is used in the SparkRuntimeService
+  public static final String STREAMING_CHECKPOINT_REWRITE_ENABLED = "streaming.checkpoint.rewrite.enabled";
+  // Configuration option used to control rewriting behavior in the cdap-site.xml file.
+  public static final String SPARK_STREAMING_CHECKPOINT_REWRITE_ENABLED =
+    "spark." + STREAMING_CHECKPOINT_REWRITE_ENABLED;
+
   private static final String LOCALIZED_RESOURCES = "spark.cdap.localized.resources";
   private static final int CHUNK_SIZE = 1 << 15;  // 32K
   private static final Logger LOG = LoggerFactory.getLogger(SparkRuntimeUtils.class);

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/classloader/SparkContainerClassLoader.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/classloader/SparkContainerClassLoader.java
@@ -38,9 +38,10 @@ public class SparkContainerClassLoader extends MainClassLoader {
    * @param urls the URLs from which to load classes and resources
    * @param parent the parent classloader for delegation
    */
-  public SparkContainerClassLoader(URL[] urls, ClassLoader parent) {
+  public SparkContainerClassLoader(URL[] urls, ClassLoader parent, boolean rewriteCheckpointTempFileName) {
     super(urls, parent);
-    this.sparkClassRewriter = new SparkClassRewriter(name -> ClassLoaders.openResource(this, name), false);
+    this.sparkClassRewriter = new SparkClassRewriter(name -> ClassLoaders.openResource(this, name), false,
+                                                     rewriteCheckpointTempFileName);
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/classloader/SparkRunnerClassLoader.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/classloader/SparkRunnerClassLoader.java
@@ -82,12 +82,15 @@ public final class SparkRunnerClassLoader extends URLClassLoader {
     API_CLASSES = Collections.unmodifiableSet(apiClasses);
   }
 
-  public SparkRunnerClassLoader(URL[] urls, @Nullable ClassLoader parent, boolean rewriteYarnClient) {
+  public SparkRunnerClassLoader(URL[] urls, @Nullable ClassLoader parent, boolean rewriteYarnClient,
+                                boolean rewriteCheckpointTempFileName) {
     super(urls, parent);
     // Copy from URLClassLoader, which also uses WeakHashMap
     this.closeables = new WeakHashMap<>();
     this.closeablesLock = new ReentrantLock();
-    this.rewriter = new SparkClassRewriter(name -> ClassLoaders.openResource(this, name), rewriteYarnClient);
+    this.rewriter = new SparkClassRewriter(name -> ClassLoaders.openResource(this, name),
+                                           rewriteYarnClient,
+                                           rewriteCheckpointTempFileName);
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.app.runtime.spark.SparkRuntimeContextProvider;
 import io.cdap.cdap.app.runtime.spark.SparkRuntimeUtils;
 import io.cdap.cdap.app.runtime.spark.classloader.SparkContainerClassLoader;
 import io.cdap.cdap.app.runtime.spark.python.SparkPythonUtil;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.lang.ClassLoaders;
 import io.cdap.cdap.common.lang.FilterClassLoader;
 import io.cdap.cdap.common.logging.StandardOutErrorRedirector;
@@ -87,10 +88,14 @@ public final class SparkContainerLauncher {
     // This is to isolate the scala library from children
     ClassLoader parentClassLoader = new FilterClassLoader(systemClassLoader, KAFKA_FILTER);
 
+    boolean rewriteCheckpointTempFileName = Boolean.parseBoolean(
+      System.getProperty(SparkRuntimeUtils.STREAMING_CHECKPOINT_REWRITE_ENABLED, "false"));
+
     // Creates the SparkRunnerClassLoader for class rewriting and it will be used for the rest of the execution.
     // Use the extension classloader as the parent instead of the system classloader because
     // Spark classes are in the system classloader which we want to rewrite.
-    ClassLoader classLoader = new SparkContainerClassLoader(urls.toArray(new URL[urls.size()]), parentClassLoader);
+    ClassLoader classLoader = new SparkContainerClassLoader(urls.toArray(new URL[urls.size()]), parentClassLoader,
+                                                            rewriteCheckpointTempFileName);
 
     // Sets the context classloader and launch the actual Spark main class.
     Thread.currentThread().setContextClassLoader(classLoader);

--- a/cdap-spark-core-base/src/test/java/io/cdap/cdap/app/runtime/spark/classloader/SparkRunnerClassLoaderTest.java
+++ b/cdap-spark-core-base/src/test/java/io/cdap/cdap/app/runtime/spark/classloader/SparkRunnerClassLoaderTest.java
@@ -49,7 +49,7 @@ public class SparkRunnerClassLoaderTest {
       final URL[] urlArray = urls.toArray(new URL[urls.size()]);
 
       SparkRunnerClassLoader firstCL = new SparkRunnerClassLoader(urlArray,
-                                                                  getClass().getClassLoader(), false);
+                                                                  getClass().getClassLoader(), false, false);
       // Load a class from the first CL.
       firstCL.loadClass("org.apache.spark.SparkContext");
 
@@ -60,7 +60,9 @@ public class SparkRunnerClassLoaderTest {
         @Override
         public void run() {
           SparkRunnerClassLoader secondCL = new SparkRunnerClassLoader(urlArray,
-                                                                       getClass().getClassLoader(), false);
+                                                                       getClass().getClassLoader(),
+                                                                       false,
+                                                                       false);
           try {
             latch.countDown();
             secondCL.loadClass("org.apache.spark.SparkContext");
@@ -98,7 +100,10 @@ public class SparkRunnerClassLoaderTest {
         List<URL> urls = ClassLoaders.getClassLoaderURLs(getClass().getClassLoader(), new ArrayList<URL>());
         final URL[] urlArray = urls.toArray(new URL[urls.size()]);
 
-        SparkRunnerClassLoader classLoader = new SparkRunnerClassLoader(urlArray, getClass().getClassLoader(), false);
+        SparkRunnerClassLoader classLoader = new SparkRunnerClassLoader(urlArray,
+                                                                        getClass().getClassLoader(),
+                                                                        false,
+                                                                        false);
 
         // Load the same class concurrently from two threads.
         CyclicBarrier barrier = new CyclicBarrier(2);
@@ -129,7 +134,7 @@ public class SparkRunnerClassLoaderTest {
     List<URL> urls = ClassLoaders.getClassLoaderURLs(getClass().getClassLoader(), new ArrayList<URL>());
     URL[] urlArray = urls.toArray(new URL[urls.size()]);
 
-    SparkRunnerClassLoader cl = new SparkRunnerClassLoader(urlArray, getClass().getClassLoader(), false);
+    SparkRunnerClassLoader cl = new SparkRunnerClassLoader(urlArray, getClass().getClassLoader(), false, false);
     InputStream is = cl.getResourceAsStream("org/apache/spark/SparkContext.class");
     Assert.assertNotNull(is);
 


### PR DESCRIPTION
Added class rewriting logic to add a timestamp to the temporary file used by Spark when creating a checkpoint.