### PR TITLE
[CDAP-17295] Fixes selection and replacing text in code editor in UI

### DIFF
--- a/cdap-ui/app/cdap/components/CodeEditor/index.tsx
+++ b/cdap-ui/app/cdap/components/CodeEditor/index.tsx
@@ -135,7 +135,7 @@ class CodeEditorView extends React.Component<ICodeEditorProps> {
   }
 
   public render() {
-    const { value, className, classes } = this.props;
+    const { value, className = 'ace-editor-ref', classes } = this.props;
     return (
       <div className={classes.root}>
         <div

--- a/cdap-ui/app/cdap/components/CodeEditor/index.tsx
+++ b/cdap-ui/app/cdap/components/CodeEditor/index.tsx
@@ -21,6 +21,7 @@ import PropTypes from 'prop-types';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import Button from '@material-ui/core/Button';
 import If from 'components/If';
+import debounce from 'lodash/debounce';
 
 const styles = (theme): StyleRules => {
   return {
@@ -92,6 +93,18 @@ class CodeEditorView extends React.Component<ICodeEditorProps> {
     this.silentOnChange = false;
   }
 
+  private valueChangeHandler = () => {
+    if (this.silentOnChange) {
+      return;
+    }
+    if (typeof this.props.onChange === 'function') {
+      const value = this.editor.getSession().getValue();
+      this.props.onChange(value);
+    }
+  };
+
+  private debouncedChangeHandler = debounce(this.valueChangeHandler, 100);
+
   public componentDidMount() {
     window.ace.config.set('basePath', '/assets/bundle/ace-editor-worker-scripts/');
     this.editor = window.ace.edit(this.aceRef);
@@ -107,19 +120,15 @@ class CodeEditorView extends React.Component<ICodeEditorProps> {
       this.editor.setReadOnly(true);
     }
 
-    this.editor.getSession().on('change', this.valueChangeHandler);
+    this.editor.getSession().on('change', this.debouncedChangeHandler);
     this.editor.setShowPrintMargin(false);
   }
 
-  private valueChangeHandler = () => {
-    if (this.silentOnChange) {
-      return;
+  public componentWillUnmount() {
+    if (this.debouncedChangeHandler) {
+      this.debouncedChangeHandler.flush();
     }
-    if (typeof this.props.onChange === 'function') {
-      const value = this.editor.getSession().getValue();
-      this.props.onChange(value);
-    }
-  };
+  }
 
   public shouldComponentUpdate() {
     return false;

--- a/cdap-ui/cypress/integration/widget.codeeditor.spec.ts
+++ b/cdap-ui/cypress/integration/widget.codeeditor.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License'); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import { loginIfRequired,  } from '../helpers';
+import { INodeInfo, INodeIdentifier } from '../typings';
+
+let headers = {};
+
+describe('Code editor widget', () => { 
+  const js: INodeInfo = { nodeName: 'JavaScript', nodeType: 'transform' };
+  const jsId: INodeIdentifier = { ...js, nodeId: '0' };
+  const defaultJsEditorVal = `
+  /**
+   * @summary Transforms the provided input record into zero or more output records or errors.
+  
+   * Input records are available in JavaScript code as JSON objects. 
+  
+   * @param input an object that contains the input record as a JSON.   e.g. to access a field called 'total' from the input record, use input.total.
+   * @param emitter an object that can be used to emit zero or more records (using the emitter.emit() method) or errors (using the emitter.emitError() method) 
+   * @param context an object that provides access to:
+   *            1. CDAP Metrics - context.getMetrics().count('output', 1);
+   *            2. CDAP Logs - context.getLogger().debug('Received a record');
+   *            3. Lookups - context.getLookup('blacklist').lookup(input.id); or
+   *            4. Runtime Arguments - context.getArguments().get('priceThreshold') 
+   */ 
+  function transform(input, emitter, context) {
+    emitter.emit(input);
+  }
+  `;
+
+  // Uses API call to login instead of logging in manually through UI
+  before(() => {
+    loginIfRequired().then(() => {
+      cy.getCookie('CDAP_Auth_Token').then((cookie) => {
+        if (!cookie) {
+          return;
+        }
+        headers = {
+          Authorization: 'Bearer ' + cookie.value,
+        };
+      });
+    });
+  });
+
+  it('Should render default value the first time', () => {
+    cy.visit('/pipelines/ns/default/studio');
+    cy.open_transform_panel();
+    cy.add_node_to_canvas(js);
+    cy.open_node_property(jsId);
+    cy.window().then((win) => {
+      cy.get('.ace-editor-ref').then((aceElement) => {
+        const jsEditorValue = win.ace.edit(aceElement[0]).getValue();
+        expect(jsEditorValue.replace(/[\n ]/g, '')).to.equal(defaultJsEditorVal.replace(/[\n ]/g, ''));
+      });
+    });
+  });
+
+  it.only('Should not jump the cursor position on selecting text and replacing them', () => {
+    cy.visit('/pipelines/ns/default/studio');
+    cy.open_transform_panel();
+    cy.add_node_to_canvas(js);
+    cy.open_node_property(jsId);
+    cy.window().then((win) => {
+      cy.get('.ace-editor-ref').then((aceElement) => {
+        const aceEditor = win.ace.edit(aceElement[0]);
+        aceEditor.gotoLine(15);
+        const rangeToReplace = {
+          start: {row: 14, column: 0},
+          end: {row: 14, column: 30}
+        };
+        aceEditor.session.doc.replace(rangeToReplace, 'console.log("newcode");');
+        const newValue = aceEditor.getValue();
+        aceEditor.resize();
+        cy.wrap(newValue).then(() => {
+          expect(newValue).contains('console.log("newcode");');
+          expect(aceEditor.getCursorPosition()).to.deep.equal({
+            row: 14,
+            column: 23
+          });
+        });
+      });
+    });
+    
+  });
+});

--- a/cdap-ui/cypress/typings/index.d.ts
+++ b/cdap-ui/cypress/typings/index.d.ts
@@ -244,6 +244,7 @@ declare global {
       sessionStorage: any;
       onbeforeunload: any;
       CDAP_CONFIG: any;
+      ace: any;
     }
   }
 }


### PR DESCRIPTION
Fixes CodeEditor to not reset the cursor when user selects portion of text and starts editing the code.

 - This happens because ace editor fires multiple events for deleting selection
text and adding new ones. 
 - This async update from ace-editor causes prop comparison
to be incorrect which results in re-rendering the entire react component
- By adding a debounce we now batch the updates from aceeditor that
happens within 100ms which prevents it from firing multiple times