### PR TITLE
(CDAP-17276) Save accelerator annotation as system metadata

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/artifact/ApplicationClass.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/artifact/ApplicationClass.java
@@ -73,6 +73,14 @@ public final class ApplicationClass {
     return configSchema;
   }
 
+  /**
+   *
+   * @return {@link io.cdap.cdap.api.plugin.Requirements} for the Application
+   */
+  public Requirements getRequirements() {
+    return requirements;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/cdap-api/src/main/java/io/cdap/cdap/api/plugin/Requirements.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/plugin/Requirements.java
@@ -60,6 +60,14 @@ public class Requirements {
     return datasetTypes;
   }
 
+  /**
+   *
+   * @return {@link Set} containing accelerator names or empty set
+   */
+  public Set<String> getAccelerators() {
+    return accelerators;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.deploy.pipeline;
 
 import com.google.gson.annotations.SerializedName;
 import io.cdap.cdap.api.app.Application;
+import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.internal.app.deploy.LocalApplicationManager;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
 import io.cdap.cdap.internal.app.runtime.artifact.Artifacts;
@@ -36,7 +37,7 @@ public class AppDeploymentInfo {
   private final ArtifactId artifactId;
   private final Location artifactLocation;
   private final NamespaceId namespaceId;
-  private final String appClassName;
+  private final ApplicationClass applicationClass;
   private final String appName;
   private final String appVersion;
   private final String configString;
@@ -46,19 +47,19 @@ public class AppDeploymentInfo {
   private final boolean updateSchedules;
 
   public AppDeploymentInfo(ArtifactDescriptor artifactDescriptor, NamespaceId namespaceId,
-                           String appClassName, @Nullable String appName, @Nullable String appVersion,
+                           ApplicationClass applicationClass, @Nullable String appName, @Nullable String appVersion,
                            @Nullable String configString) {
-    this(artifactDescriptor, namespaceId, appClassName, appName, appVersion, configString, null, true);
+    this(artifactDescriptor, namespaceId, applicationClass, appName, appVersion, configString, null, true);
   }
 
   public AppDeploymentInfo(ArtifactDescriptor artifactDescriptor, NamespaceId namespaceId,
-                           String appClassName, @Nullable String appName, @Nullable String appVersion,
+                           ApplicationClass applicationClass, @Nullable String appName, @Nullable String appVersion,
                            @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal,
                            boolean updateSchedules) {
     this.artifactId = Artifacts.toProtoArtifactId(namespaceId, artifactDescriptor.getArtifactId());
     this.artifactLocation = artifactDescriptor.getLocation();
     this.namespaceId = namespaceId;
-    this.appClassName = appClassName;
+    this.applicationClass = applicationClass;
     this.appName = appName;
     this.appVersion = appVersion;
     this.configString = configString;
@@ -88,10 +89,10 @@ public class AppDeploymentInfo {
   }
 
   /**
-   * Returns the class name of the {@link Application}.
+   * Returns the {@link io.cdap.cdap.api.artifact.ApplicationClass} associated with this {@link Application}.
    */
-  public String getAppClassName() {
-    return appClassName;
+  public ApplicationClass getApplicationClass() {
+    return applicationClass;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.deploy.pipeline;
 
 import com.google.gson.annotations.SerializedName;
 import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
@@ -36,6 +37,7 @@ public class ApplicationDeployable {
   private final ArtifactId artifactId;
   private final Location artifactLocation;
   private final ApplicationId applicationId;
+  private final ApplicationClass applicationClass;
   private final ApplicationSpecification specification;
   private final ApplicationSpecification existingAppSpec;
   private final ApplicationDeployScope applicationDeployScope;
@@ -48,15 +50,17 @@ public class ApplicationDeployable {
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
                                ApplicationId applicationId, ApplicationSpecification specification,
                                @Nullable ApplicationSpecification existingAppSpec,
-                               ApplicationDeployScope applicationDeployScope) {
+                               ApplicationDeployScope applicationDeployScope,
+                               ApplicationClass applicationClass) {
     this(artifactId, artifactLocation, applicationId, specification, existingAppSpec, applicationDeployScope,
-         null, true, Collections.emptyList());
+         applicationClass, null, true, Collections.emptyList());
   }
 
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
                                ApplicationId applicationId, ApplicationSpecification specification,
                                @Nullable ApplicationSpecification existingAppSpec,
                                ApplicationDeployScope applicationDeployScope,
+                               ApplicationClass applicationClass,
                                @Nullable KerberosPrincipalId ownerPrincipal,
                                boolean updateSchedules,
                                Collection<StructuredTableSpecification> systemTables) {
@@ -69,6 +73,7 @@ public class ApplicationDeployable {
     this.ownerPrincipal = ownerPrincipal;
     this.updateSchedules = updateSchedules;
     this.systemTables = systemTables;
+    this.applicationClass = applicationClass;
   }
 
   /**
@@ -90,6 +95,14 @@ public class ApplicationDeployable {
    */
   public ApplicationId getApplicationId() {
     return applicationId;
+  }
+
+  /**
+   *
+   * @return {@link io.cdap.cdap.api.artifact.ApplicationClass} of the Application
+   */
+  public ApplicationClass getApplicationClass() {
+    return applicationClass;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
@@ -33,8 +33,8 @@ public class ApplicationWithPrograms extends ApplicationDeployable {
     super(applicationDeployable.getArtifactId(), applicationDeployable.getArtifactLocation(),
           applicationDeployable.getApplicationId(), applicationDeployable.getSpecification(),
           applicationDeployable.getExistingAppSpec(), applicationDeployable.getApplicationDeployScope(),
-          applicationDeployable.getOwnerPrincipal(), applicationDeployable.canUpdateSchedules(),
-          applicationDeployable.getSystemTables());
+          applicationDeployable.getApplicationClass(), applicationDeployable.getOwnerPrincipal(),
+          applicationDeployable.canUpdateSchedules(), applicationDeployable.getSystemTables());
     this.programDescriptors = ImmutableList.copyOf(programDescriptors);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
@@ -92,7 +92,7 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
 
     ArtifactId artifactId = deploymentInfo.getArtifactId();
     Location artifactLocation = deploymentInfo.getArtifactLocation();
-    String appClassName = deploymentInfo.getAppClassName();
+    String appClassName = deploymentInfo.getApplicationClass().getClassName();
     String appVersion = deploymentInfo.getApplicationVersion();
     String configString = deploymentInfo.getConfigString();
 
@@ -126,7 +126,8 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
     authorizationEnforcer.enforce(applicationId, authenticationContext.getPrincipal(), Action.ADMIN);
     emit(new ApplicationDeployable(deploymentInfo.getArtifactId(), deploymentInfo.getArtifactLocation(),
                                    applicationId, specification, store.getApplication(applicationId),
-                                   ApplicationDeployScope.USER, deploymentInfo.getOwnerPrincipal(),
-                                   deploymentInfo.canUpdateSchedules(), appSpecInfo.getSystemTables()));
+                                   ApplicationDeployScope.USER, deploymentInfo.getApplicationClass(),
+                                   deploymentInfo.getOwnerPrincipal(), deploymentInfo.canUpdateSchedules(),
+                                   appSpecInfo.getSystemTables()));
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStage.java
@@ -55,7 +55,8 @@ public class SystemMetadataWriterStage extends AbstractStage<ApplicationWithProg
     List<MetadataMutation> mutations = new ArrayList<>();
 
     mutations.add(
-      new AppSystemMetadataWriter(metadataServiceClient, appId, appSpec, creationTime).getMetadataMutation());
+      new AppSystemMetadataWriter(metadataServiceClient, appId, appSpec, input.getApplicationClass(), creationTime)
+        .getMetadataMutation());
 
     // collect system metadata for programs
     collectProgramSystemMetadata(appId, ProgramType.MAPREDUCE, appSpec.getMapReduce().values(), mutations);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -563,7 +563,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
 
     // Deploy application with with potentially new app config and new artifact.
     AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(artifactDetail.getDescriptor(), appId.getParent(),
-                                                             appClass.getClassName(), appId.getApplication(),
+                                                             appClass, appId.getApplication(),
                                                              appId.getVersion(), updatedAppConfig, ownerPrincipal,
                                                              updateSchedules);
 
@@ -899,7 +899,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
 
     // deploy application with newly added artifact
     AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(artifactDetail.getDescriptor(), namespaceId,
-                                                             appClass.getClassName(), appName, appVersion,
+                                                             appClass, appName, appVersion,
                                                              configStr, ownerPrincipal, updateSchedules);
 
     Manager<AppDeploymentInfo, ApplicationWithPrograms> manager = managerFactory.create(programTerminator);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/AppWithWorkflow.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/AppWithWorkflow.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap;
 
 import com.google.common.base.Throwables;
+import io.cdap.cdap.api.annotation.Requirements;
 import io.cdap.cdap.api.app.AbstractApplication;
 import io.cdap.cdap.api.customaction.AbstractCustomAction;
 import io.cdap.cdap.api.data.schema.UnsupportedTypeException;
@@ -40,6 +41,7 @@ import java.util.Map;
 /**
  * App with workflow.
  */
+@Requirements(accelerators = "cdc")
 public class AppWithWorkflow extends AbstractApplication {
   public static final String NAME = "AppWithWorkflow";
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
@@ -30,6 +30,7 @@ import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import com.google.inject.util.Modules;
 import io.cdap.cdap.api.Config;
+import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactVersion;
@@ -284,9 +285,9 @@ public class AppFabricTestHelper {
     artifactRepository.addArtifact(Id.Artifact.fromEntityId(Artifacts.toProtoArtifactId(namespace.toEntityId(),
                                                                                         artifactId)),
                                    new File(deployedJar.toURI()));
-
+    ApplicationClass applicationClass = new ApplicationClass(appClass.getName(), "", null);
     AppDeploymentInfo info = new AppDeploymentInfo(artifactDescriptor, namespace.toEntityId(),
-                                                   appClass.getName(), null, null,
+                                                   applicationClass, null, null,
                                                    config == null ? null : new Gson().toJson(config));
     return getLocalManager().deploy(info).get();
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/LocalApplicationManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/LocalApplicationManagerTest.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import io.cdap.cdap.AllProgramsApp;
 import io.cdap.cdap.ConfigTestApp;
 import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactVersion;
@@ -95,9 +96,10 @@ public class LocalApplicationManagerTest {
 
     ArtifactId artifactId = new ArtifactId("dummy", new ArtifactVersion("1.0.0-SNAPSHOT"), ArtifactScope.USER);
     ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(artifactId, jarLoc);
-
-    AppDeploymentInfo info = new AppDeploymentInfo(artifactDescriptor, NamespaceId.DEFAULT,
-                                                   "some.class.name", null, null, null);
+    String className = "some.class.name";
+    ApplicationClass applicationClass = new ApplicationClass(className, "", null);
+    AppDeploymentInfo info = new AppDeploymentInfo(artifactDescriptor, NamespaceId.DEFAULT, applicationClass, null,
+                                                   null, null);
     AppFabricTestHelper.getLocalManager().deploy(info).get();
   }
 
@@ -109,8 +111,9 @@ public class LocalApplicationManagerTest {
     Location deployedJar = AppJarHelper.createDeploymentJar(lf, AllProgramsApp.class);
     ArtifactId artifactId = new ArtifactId("app", new ArtifactVersion("1.0.0-SNAPSHOT"), ArtifactScope.USER);
     ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(artifactId, deployedJar);
+    ApplicationClass applicationClass = new ApplicationClass(AllProgramsApp.class.getName(), "", null);
     AppDeploymentInfo info = new AppDeploymentInfo(artifactDescriptor, NamespaceId.DEFAULT,
-                                                   AllProgramsApp.class.getName(), null, null, null);
+                                                   applicationClass, null, null, null);
     ApplicationWithPrograms input = AppFabricTestHelper.getLocalManager().deploy(info).get();
 
     ApplicationSpecification appSpec = Specifications.from(new AllProgramsApp());
@@ -133,8 +136,9 @@ public class LocalApplicationManagerTest {
     ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("myTable");
     ArtifactId artifactId = new ArtifactId("configtest", new ArtifactVersion("1.0.0-SNAPSHOT"), ArtifactScope.USER);
     ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(artifactId, deployedJar);
+    ApplicationClass applicationClass = new ApplicationClass(ConfigTestApp.class.getName(), "", null);
     AppDeploymentInfo info = new AppDeploymentInfo(artifactDescriptor, NamespaceId.DEFAULT,
-                                                   ConfigTestApp.class.getName(), "MyApp", null, GSON.toJson(config));
+                                                   applicationClass, "MyApp", null, GSON.toJson(config));
     AppFabricTestHelper.getLocalManager().deploy(info).get();
   }
 
@@ -143,8 +147,9 @@ public class LocalApplicationManagerTest {
     Location deployedJar = AppJarHelper.createDeploymentJar(lf, ConfigTestApp.class);
     ArtifactId artifactId = new ArtifactId("configtest", new ArtifactVersion("1.0.0-SNAPSHOT"), ArtifactScope.USER);
     ArtifactDescriptor artifactDescriptor = new ArtifactDescriptor(artifactId, deployedJar);
+    ApplicationClass applicationClass = new ApplicationClass(ConfigTestApp.class.getName(), "", null);
     AppDeploymentInfo info = new AppDeploymentInfo(artifactDescriptor, NamespaceId.DEFAULT,
-                                                   ConfigTestApp.class.getName(), "BadApp", null,
+                                                   applicationClass, "BadApp", null,
                                                    GSON.toJson("invalid"));
     AppFabricTestHelper.getLocalManager().deploy(info).get();
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/pipeline/ProgramGenerationStageTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/pipeline/ProgramGenerationStageTest.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.deploy.pipeline;
 
 import io.cdap.cdap.AllProgramsApp;
 import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.io.Locations;
@@ -57,11 +58,12 @@ public class ProgramGenerationStageTest {
     ApplicationSpecification appSpec = Specifications.from(new AllProgramsApp());
     ApplicationSpecificationAdapter adapter = ApplicationSpecificationAdapter.create();
     ApplicationSpecification newSpec = adapter.fromJson(adapter.toJson(appSpec));
+    ApplicationClass applicationClass = new ApplicationClass(AllProgramsApp.class.getName(), "", null);
     ProgramGenerationStage pgmStage = new ProgramGenerationStage();
     pgmStage.process(new StageContext(Object.class));  // Can do better here - fixed right now to run the test.
     pgmStage.process(new ApplicationDeployable(NamespaceId.DEFAULT.artifact("AllProgramApp", "1.0"), appArchive,
                                                DefaultId.APPLICATION, newSpec, null,
-                                               ApplicationDeployScope.USER));
+                                               ApplicationDeployScope.USER, applicationClass));
     Assert.assertTrue(true);
   }
 


### PR DESCRIPTION
- Save accelerator annotation as system metadata when application is deployed.
- Accelerators from all plugins and application are consolidated and added as a comma separated list
- Deleting the application removes the metadata
- User cannot delete the metadata since the API for deleting system metadata is not exposed 