### PR TITLE
[CDAP-8617] Fixes UI to show proper Authorization message for unauthorized users of the namespace 

### DIFF
--- a/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/NamespacesAccordion/index.js
+++ b/cdap-ui/app/cdap/components/Administration/AdminConfigTabContent/NamespacesAccordion/index.js
@@ -27,12 +27,12 @@ import globalEvents from 'services/global-events';
 import ee from 'event-emitter';
 import ViewAllLabel from 'components/ViewAllLabel';
 import T from 'i18n-react';
-import isEqual from 'lodash/isEqual';
 import SortableStickyGrid from 'components/SortableStickyGrid';
 import { Link } from 'react-router-dom';
 import uuidV4 from 'uuid/v4';
 import { Theme } from 'services/ThemeHelper';
 import If from 'components/If';
+
 require('./NamespacesAccordion.scss');
 
 const PREFIX = 'features.Administration.Accordions.Namespace';
@@ -84,7 +84,7 @@ export default class NamespacesAccordion extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!isEqual(this.props.namespaces, nextProps.namespaces)) {
+    if (nextProps.loading !== this.props.loading) {
       this.getNamespaceData(nextProps.namespaces);
     }
   }
@@ -112,6 +112,11 @@ export default class NamespacesAccordion extends Component {
     let namespacesInfo = [];
     let hasNewNamespaces = false;
 
+    if (!namespaces.length) {
+      this.setState({
+        loading: false,
+      });
+    }
     namespaces.forEach((namespace) => {
       searchParams.namespace = namespace.name;
       MySearchApi.search(searchParams).subscribe(
@@ -262,7 +267,10 @@ export default class NamespacesAccordion extends Component {
           viewAllState={this.state.viewAll}
           toggleViewAll={this.toggleViewAll}
         />
-        {this.renderGrid()}
+        <If condition={this.state.namespacesInfo.length}>{this.renderGrid()}</If>
+        <If condition={!this.state.namespacesInfo.length}>
+          <div className="grid-wrapper text-center">{T.translate(`${PREFIX}.noNamespace`)}</div>
+        </If>
         <ViewAllLabel
           arrayToLimit={this.state.namespacesInfo}
           limit={NUM_NS_TO_SHOW}

--- a/cdap-ui/app/cdap/components/AppHeader/AppToolBar/AppToolbar.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/AppToolBar/AppToolbar.tsx
@@ -27,6 +27,8 @@ import { Theme } from 'services/ThemeHelper';
 import FeatureHeading from 'components/AppHeader/AppToolBar/FeatureHeading';
 import ProductEdition from 'components/AppHeader/AppToolBar/ProductEdition';
 import AppToolbarMenu from 'components/AppHeader/AppToolBar/AppToolbarMenu';
+import ee from 'event-emitter';
+import globalEvents from 'services/global-events';
 
 const styles = (theme) => {
   return {
@@ -59,6 +61,8 @@ class AppToolbar extends React.PureComponent<IAppToolbarProps, IAppToolbarState>
     anchorEl: null,
     aboutPageOpen: false,
   };
+
+  public eventEmitter = ee(ee);
 
   public render() {
     const { onMenuIconClick, classes } = this.props;
@@ -94,6 +98,9 @@ class AppToolbar extends React.PureComponent<IAppToolbarProps, IAppToolbarState>
             featureFlag={true}
             featureName={Theme.featureNames.systemAdmin}
             featureUrl={`/administration`}
+            // This is needed here when Authorization fails for all namespaces.
+            // In this case navigating to Admin section doesn't have restriction (yet).
+            onClick={() => this.eventEmitter.emit(globalEvents.PAGE_LEVEL_ERROR, { reset: true })}
           />
         </div>
         <AppToolbarMenu />

--- a/cdap-ui/app/cdap/components/AppHeader/AppToolBar/ToolBarFeatureLink.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/AppToolBar/ToolBarFeatureLink.tsx
@@ -25,6 +25,7 @@ interface IToolBarFeatureLinkProps extends WithStyles<typeof styles> {
   featureFlag: boolean;
   featureName: string;
   featureUrl: string;
+  onClick?: () => {};
 }
 
 const styles = (theme) => {
@@ -40,7 +41,7 @@ const styles = (theme) => {
 
 class ToolBarFeatureLink extends React.PureComponent<IToolBarFeatureLinkProps> {
   public render() {
-    const { classes, featureFlag, featureName, featureUrl } = this.props;
+    const { classes, featureFlag, featureName, featureUrl, onClick } = this.props;
     if (featureFlag === false) {
       return null;
     }
@@ -59,6 +60,7 @@ class ToolBarFeatureLink extends React.PureComponent<IToolBarFeatureLinkProps> {
         className={classnames(classes.buttonLink)}
         href={`/cdap${featureUrl}`}
         data-cy={featureName}
+        onClick={onClick}
       >
         {featureName}
       </Button>

--- a/cdap-ui/app/cdap/components/AppHeader/index.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/index.tsx
@@ -43,6 +43,7 @@ require('styles/bootstrap_4_patch.scss');
 interface IMyAppHeaderState {
   toggleDrawer: boolean;
   currentNamespace: string;
+  showGlobalLoadingIcon: boolean;
 }
 const styles = (theme) => {
   return {
@@ -62,6 +63,7 @@ class MyAppHeader extends React.PureComponent<IMyAppHeaderProps, IMyAppHeaderSta
   public state: IMyAppHeaderState = {
     toggleDrawer: false,
     currentNamespace: '',
+    showGlobalLoadingIcon: true,
   };
 
   private namespacesubscription: ISubscription;
@@ -81,10 +83,10 @@ class MyAppHeader extends React.PureComponent<IMyAppHeaderProps, IMyAppHeaderSta
             },
           });
         } else {
-          // TL;DR - This is emitted for Authorization in main.js
-          // This means there is no namespace for the user to work on.
-          // which indicates she/he have no authorization for any namesapce in the system.
-          this.eventEmitter.emit(globalEvents.NONAMESPACE);
+          this.namespacesubscription.unsubscribe();
+          this.setState({
+            showGlobalLoadingIcon: false,
+          });
         }
       },
       (err) => {
@@ -101,6 +103,7 @@ class MyAppHeader extends React.PureComponent<IMyAppHeaderProps, IMyAppHeaderSta
       if (selectedNamespace !== this.state.currentNamespace) {
         this.setState({
           currentNamespace: selectedNamespace,
+          showGlobalLoadingIcon: false,
         });
       }
     });
@@ -129,12 +132,7 @@ class MyAppHeader extends React.PureComponent<IMyAppHeaderProps, IMyAppHeaderSta
       namespace: this.state.currentNamespace,
       isNativeLink: this.props.nativeLink,
     };
-    // (TODO): This still doesn't capture correctly how we handle
-    // when authorization is enabled and user has access to no namespaces.
-    if (
-      !this.state.currentNamespace ||
-      (typeof this.state.currentNamespace === 'string' && !this.state.currentNamespace.length)
-    ) {
+    if (this.state.showGlobalLoadingIcon) {
       return (
         <React.Fragment>
           <LoadingSVGCentered showFullPage />

--- a/cdap-ui/app/cdap/components/AuthorizationErrorMessage/index.js
+++ b/cdap-ui/app/cdap/components/AuthorizationErrorMessage/index.js
@@ -14,6 +14,7 @@
  * the License.
  */
 
+import PropTypes from 'prop-types';
 import React from 'react';
 require('./AuthorizationMessage.scss');
 import NamespaceStore from 'services/NamespaceStore';
@@ -22,10 +23,13 @@ import RedirectToLogin from 'services/redirect-to-login';
 import ee from 'event-emitter';
 import globalEvents from 'services/global-events';
 import T from 'i18n-react';
+import If from 'components/If';
 
 const cookie = new Cookies();
 
-export default function AuthorizationErrorMessage() {
+export default function AuthorizationErrorMessage({
+  message = T.translate('features.AuthorizationMessage.mainMessage'),
+}) {
   let eventEmitter = ee(ee);
   const logout = () => {
     cookie.remove('show-splash-screen-for-session', { path: '/' });
@@ -39,7 +43,7 @@ export default function AuthorizationErrorMessage() {
     <div className="auth-error-message">
       <h3>
         <span className="fa fa-exclamation-triangle" />
-        <span>{T.translate('features.AuthorizationMessage.mainMessage')}</span>
+        <span>{message}</span>
       </h3>
       <div className="cta-section">
         <ul>
@@ -47,9 +51,11 @@ export default function AuthorizationErrorMessage() {
             <span>{T.translate('features.AuthorizationMessage.callToAction1')}</span>
           </li>
           <li>
-            <span>
-              {T.translate('features.AuthorizationMessage.callToAction2.message1', { username })}
-            </span>
+            <If condition={username}>
+              <span>
+                {T.translate('features.AuthorizationMessage.callToAction2.message1', { username })}
+              </span>
+            </If>
             <span className="link" onClick={logout}>
               {T.translate('features.AuthorizationMessage.callToAction2.loginLabel')}
             </span>
@@ -66,3 +72,7 @@ export default function AuthorizationErrorMessage() {
     </div>
   );
 }
+
+AuthorizationErrorMessage.propTypes = {
+  message: PropTypes.string,
+};

--- a/cdap-ui/app/cdap/components/Home/index.js
+++ b/cdap-ui/app/cdap/components/Home/index.js
@@ -19,15 +19,13 @@ import React, { Component } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import Page404 from 'components/404';
 import Loadable from 'react-loadable';
-import NamespaceStore, { isValidNamespace } from 'services/NamespaceStore';
+import NamespaceStore, { validateNamespace } from 'services/NamespaceStore';
 import NamespaceActions from 'services/NamespaceStore/NamespaceActions';
 import LoadingSVGCentered from 'components/LoadingSVGCentered';
 import ConfigurationGroupKitchenSync from 'components/ConfigurationGroup/KitchenSync';
 import HomeActions from 'components/Home/HomeActions';
 import ToggleExperiment from 'components/Lab/ToggleExperiment';
-import globalEvents from 'services/global-events';
 import ee from 'event-emitter';
-import { GLOBALS } from 'services/global-constants';
 require('./Home.scss');
 
 const EntityListView = Loadable({
@@ -124,31 +122,16 @@ export default class Home extends Component {
   constructor(props) {
     super(props);
     this.eventEmitter = ee(ee);
-  }
-
-  componentWillMount() {
     NamespaceStore.dispatch({
       type: NamespaceActions.selectNamespace,
       payload: {
         selectedNamespace: this.props.match.params.namespace,
       },
     });
+    validateNamespace(this.props.match.params.namespace);
   }
-  render() {
-    const { namespace } = this.props.match.params;
-    isValidNamespace(namespace)
-      .then((isValid) => {
-        if (!isValid) {
-          this.eventEmitter.emit(globalEvents.PAGE_LEVEL_ERROR, {
-            statusCode: 404,
-            data: GLOBALS.pageLevelErrors['INVALID-NAMESPACE'](namespace),
-          });
-        }
-      })
-      .catch((err) => {
-        this.eventEmitter.emit(globalEvents.PAGE_LEVEL_ERROR, err);
-      });
 
+  render() {
     return (
       <div>
         <Switch>

--- a/cdap-ui/app/cdap/components/NamespaceDropdown/index.tsx
+++ b/cdap-ui/app/cdap/components/NamespaceDropdown/index.tsx
@@ -15,11 +15,10 @@
  */
 
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import { Dropdown, DropdownMenu, DropdownToggle } from 'reactstrap';
 import AbstractWizard from 'components/AbstractWizard';
-import NamespaceStore, { INamespace } from 'services/NamespaceStore';
+import NamespaceStore, { INamespace, fetchNamespaceDetails } from 'services/NamespaceStore';
 import SetPreferenceAction from 'components/FastAction/SetPreferenceAction';
 import { PREFERENCES_LEVEL } from 'components/FastAction/SetPreferenceAction/SetPreferenceModal';
 import IconSVG from 'components/IconSVG';
@@ -141,10 +140,14 @@ export default class NamespaceDropdown extends React.PureComponent<
         selectedNamespace: name,
       },
     });
-    this.onNamespaceChange();
+    this.onNamespaceChange(name);
   };
 
-  private onNamespaceChange = () => {
+  private onNamespaceChange = (namespace) => {
+    // On namespace change, reset if there are any existing authorization
+    // message and recheck for the newly selected namespace.
+    this.eventEmitter.emit(globalEvents.PAGE_LEVEL_ERROR, { reset: true });
+    fetchNamespaceDetails(namespace);
     if (this.props.onNamespaceChange) {
       this.props.onNamespaceChange();
     }

--- a/cdap-ui/app/cdap/components/RouteToNamespace/index.js
+++ b/cdap-ui/app/cdap/components/RouteToNamespace/index.js
@@ -16,11 +16,13 @@
 
 import React, { Component } from 'react';
 import find from 'lodash/find';
-import NamespaceStore, { isValidNamespace, getValidNamespace } from 'services/NamespaceStore';
+import NamespaceStore, {
+  fetchNamespaceList,
+  getValidNamespace,
+  validateNamespace,
+} from 'services/NamespaceStore';
 import { Redirect } from 'react-router-dom';
-import globalEvents from 'services/global-events';
 import ee from 'event-emitter';
-import { GLOBALS } from 'services/global-constants';
 
 export default class RouteToNamespace extends Component {
   constructor(props) {
@@ -46,13 +48,10 @@ export default class RouteToNamespace extends Component {
 
   async setNamespace() {
     const selectedNamespace = await getValidNamespace();
-    const isvalid = await isValidNamespace(selectedNamespace);
-    if (!isvalid) {
-      this.eventEmitter.emit(globalEvents.PAGE_LEVEL_ERROR, {
-        statusCode: 404,
-        data: GLOBALS.pageLevelErrors['INVALID-NAMESPACE'](selectedNamespace),
-      });
+    if (!selectedNamespace) {
+      return fetchNamespaceList();
     }
+    validateNamespace(selectedNamespace);
     localStorage.setItem('DefaultNamespace', selectedNamespace);
     this.setState({ selectedNamespace });
   }

--- a/cdap-ui/app/cdap/services/WindowManager/index.ts
+++ b/cdap-ui/app/cdap/services/WindowManager/index.ts
@@ -16,7 +16,6 @@
 
 import ee from 'event-emitter';
 import 'whatwg-fetch';
-import { objectQuery } from 'services/helpers';
 import ifvisible from 'ifvisible.js';
 import { objectQuery } from 'services/helpers';
 const WINDOW_ON_BLUR = 'WINDOW_BLUR_EVENT';

--- a/cdap-ui/app/cdap/services/global-constants.js
+++ b/cdap-ui/app/cdap/services/global-constants.js
@@ -26,7 +26,8 @@ const pluginLabels = {
 const NUMBER_TYPES = ['integer', 'int', 'short', 'long', 'float', 'double'];
 const GLOBALS = {
   pageLevelErrors: {
-    'INVALID-NAMESPACE': (invalidNS) => { return `\'namespace:${invalidNS}' was not found.`}
+    'UNKNOWN-NAMESPACE': (invalidNS) => { return `\'namespace:${invalidNS}' was not found.`},
+    'UNAUTHORIZED-NAMESPACE': (invalidNS) => { return `You are not authorized to access '${invalidNS}' namespace`},
   },
   etlBatch: 'cdap-etl-batch',
   etlRealtime: 'cdap-etl-realtime',

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -25,7 +25,6 @@ import uuidV4 from 'uuid/v4';
 import round from 'lodash/round';
 import React from 'react';
 import { connect } from 'react-redux';
-
 /*
   Purpose: Query a json object or an array of json objects
   Return: Returns undefined if property is not defined(never set) and

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -153,6 +153,7 @@ features:
         description: Create, view, and manage namespaces
         label: "Namespaces "
         labelWithCount: "Namespaces ({count})"
+        noNamespace: No namespace available
       SystemPrefs:
         create: Edit System Preferences
         description: Manage system preferences available as runtime arguments to programs across all namespaces

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -17,7 +17,7 @@
 import T from 'i18n-react';
 T.setTexts(require('../cdap/text/text-en.yaml'));
 var Store = require('../cdap/services/NamespaceStore').default;
-var IsValidNS = require('../cdap/services/NamespaceStore').isValidNamespace;
+var validateNamespace = require('../cdap/services/NamespaceStore').validateNamespace;
 var NameSpaceStoreActions = require('../cdap/services/NamespaceStore/NamespaceActions').default;
 var ResourceCenterButton = require('../cdap/components/ResourceCenterButton').default;
 var DataPrepHome = require('../cdap/components/DataPrepHome').default;
@@ -117,6 +117,7 @@ var SelectionBox = require('../cdap/components/SelectionBox').default;
 var Clipboard = require('../cdap/services/Clipboard');
 var Page404 = require('../cdap/components/404').default;
 var Page500 = require('../cdap/components/500').default;
+var Page403 = require('../cdap/components/AuthorizationErrorMessage').default;
 var WindowManager = require('../cdap/services/WindowManager').default;
 var { WINDOW_ON_FOCUS, WINDOW_ON_BLUR } = require('../cdap/services/WindowManager');
 var PREVIEW_STATUS = require('../cdap/services/PreviewStatus').PREVIEW_STATUS;
@@ -216,8 +217,9 @@ export {
   Clipboard,
   Page404,
   Page500,
+  Page403,
   WindowManager,
-  IsValidNS,
+  validateNamespace,
   WINDOW_ON_FOCUS,
   WINDOW_ON_BLUR,
   PREVIEW_STATUS,

--- a/cdap-ui/app/directives/react-components/index.js
+++ b/cdap-ui/app/directives/react-components/index.js
@@ -160,6 +160,9 @@ angular
   .directive('page404', function(reactDirective){
     return reactDirective(window.CaskCommon.Page404);
   })
+  .directive('page403', function(reactDirective){
+    return reactDirective(window.CaskCommon.Page403);
+  })
   .directive('page500', function(reactDirective){
     return reactDirective(window.CaskCommon.Page500);
   })

--- a/cdap-ui/app/hydrator/hydrator.html
+++ b/cdap-ui/app/hydrator/hydrator.html
@@ -36,16 +36,18 @@
 <body ng-class="bodyClass" class="cdap-body-container" ng-controller="BodyCtrl as BodyCtrl" ng-keyup="onSearch($event)">
   <my-global-navbar></my-global-navbar>
   <main class="container" id="app-container">
-    <div ui-view></div>
+    <div ng-if="!BodyCtrl.pageLevelError" ui-view></div>
+    <page403 ng-if="BodyCtrl.pageLevelError && BodyCtrl.pageLevelError.errorCode === 403"
+           message="BodyCtrl.pageLevelError.message"></page403>
+    <page404 ng-if="BodyCtrl.pageLevelError && BodyCtrl.pageLevelError.errorCode === 404"
+            message="BodyCtrl.pageLevelError.message"></page404>
+    <page500 ng-if="BodyCtrl.pageLevelError && BodyCtrl.pageLevelError.errorCode === 500"
+            message="BodyCtrl.pageLevelError.message"></page500>
   </main>
 
   <div class="alerts" id="alerts" data-cy="valium-banner-hydrator"></div>
   <loading-icon></loading-icon>
   <loading-indicator></loading-indicator>
-  <page404 ng-if="BodyCtrl.pageLevelError && BodyCtrl.pageLevelError.errorCode === 404"
-           message="BodyCtrl.pageLevelError.message"></page404>
-  <page500 ng-if="BodyCtrl.pageLevelError && BodyCtrl.pageLevelError.errorCode !== 404"
-           message="BodyCtrl.pageLevelError.message"></page500>
   <status-alert-message></status-alert-message>
   <global-footer></global-footer>
   <auth-refresher></auth-refresher>

--- a/cdap-ui/app/hydrator/main.js
+++ b/cdap-ui/app/hydrator/main.js
@@ -290,7 +290,18 @@ angular
     this.pageLevelError = null;
     const {globalEvents} = window.CaskCommon;
 
+    this.eventEmitter.on(globalEvents.NONAMESPACE, () => {
+      this.pageLevelError = {
+        errorCode: 403
+      };
+    });
     this.eventEmitter.on(globalEvents.PAGE_LEVEL_ERROR, (error) => {
+      // If we already have no namespace error thrown it trumps all other 404s
+      // and UI should show that the user does not have access to the namespace
+      // instead of specific 404s which will be misleading.
+      if (this.pageLevelError && this.pageLevelError.errorCode === 403) {
+        return;
+      }
       if (error.reset === true) {
         this.pageLevelError = null;
       }

--- a/cdap-ui/app/hydrator/routes.js
+++ b/cdap-ui/app/hydrator/routes.js
@@ -73,8 +73,8 @@ angular.module(PKG.name + '.feature.hydrator')
             window.CaskCommon.ee.emit(
               window.CaskCommon.globalEvents.PAGE_LEVEL_ERROR, { reset: true });
           },
-          rValidNamespace: function($stateParams, myNamespace, myHelpers){
-            return myHelpers.validNamespaceResolver($stateParams, myNamespace);
+          rValidNamespace: function($stateParams){
+            return window.CaskCommon.validateNamespace($stateParams.namespace);
           },
         },
         data: {
@@ -115,9 +115,6 @@ angular.module(PKG.name + '.feature.hydrator')
             rResetPreviousPageLevelError: function () {
               window.CaskCommon.ee.emit(
                 window.CaskCommon.globalEvents.PAGE_LEVEL_ERROR, { reset: true });
-            },
-            rValidNamespace: function($stateParams, myNamespace, myHelpers){
-              return myHelpers.validNamespaceResolver($stateParams, myNamespace);
             },
             rConfig: function(rCDAPVersion, $stateParams, mySettings, $q, myHelpers, $window, HydratorPlusPlusHydratorService) {
               var defer = $q.defer();
@@ -379,9 +376,6 @@ angular.module(PKG.name + '.feature.hydrator')
             rResetPreviousPageLevelError: function () {
               window.CaskCommon.ee.emit(
                 window.CaskCommon.globalEvents.PAGE_LEVEL_ERROR, { reset: true });
-            },
-            rValidNamespace: function($stateParams, myNamespace, myHelpers){
-              return myHelpers.validNamespaceResolver($stateParams, myNamespace);
             },
           },
           ncyBreadcrumb: {

--- a/cdap-ui/app/services/helpers.js
+++ b/cdap-ui/app/services/helpers.js
@@ -18,7 +18,7 @@
  * various utility functions
  */
 angular.module(PKG.name+'.services')
-  .factory('myHelpers', function(myCdapUrl, $window, GLOBALS){
+  .factory('myHelpers', function(myCdapUrl, $window){
 
    /**
     * set a property deep in an object
@@ -227,25 +227,6 @@ angular.module(PKG.name+'.services')
     return errorMsg;
   }
 
-  /* ----------------------------------------------------------------------- */
-  function validNamespaceResolver(stateParams) {
-    const { namespace } = stateParams;
-    return window.CaskCommon.IsValidNS(namespace)
-      .then(validNamespace => {
-        if (!validNamespace) {
-          // Match error.data to NotFoundException from backend
-          const error = {
-            statusCode: 404,
-            data: GLOBALS.pageLevelErrors['INVALID-NAMESPACE'](namespace)
-          };
-          window.CaskCommon.ee.emit(window.CaskCommon.globalEvents.PAGE_LEVEL_ERROR, error);
-        }
-      })
-      .catch(err => {
-        window.CaskCommon.ee.emit(window.CaskCommon.globalEvents.PAGE_LEVEL_ERROR, err);
-      });
-  }
-
   return {
     deepSet: deepSet,
     objectSetter: objectSetter,
@@ -258,6 +239,5 @@ angular.module(PKG.name+'.services')
     handlePageLevelError: handlePageLevelError,
     extractErrorMessage: extractErrorMessage,
     objHasMissingValues: objHasMissingValues,
-    validNamespaceResolver: validNamespaceResolver
   };
 });

--- a/cdap-ui/app/styles/common.less
+++ b/cdap-ui/app/styles/common.less
@@ -55,7 +55,6 @@ body {
   div.progress { margin: 1px; /* by default they have just margin-bottom: 20px */ }
 
   main.container {
-    margin-top: 90px;
     > div { margin-bottom: 80px; }
     .sidebar {
       ul li a {

--- a/cdap-ui/app/tracker/main.js
+++ b/cdap-ui/app/tracker/main.js
@@ -262,7 +262,19 @@ angular
     this.pageLevelError = null;
     const {globalEvents} = window.CaskCommon;
 
+    this.eventEmitter.on(globalEvents.NONAMESPACE, () => {
+      this.pageLevelError = {
+        errorCode: 403
+      };
+    });
+
     this.eventEmitter.on(globalEvents.PAGE_LEVEL_ERROR, (error) => {
+      // If we already have no namespace error thrown it trumps all other 404s
+      // and UI should show that the user does not have access to the namespace
+      // instead of specific 404s which will be misleading.
+      if (this.pageLevelError && this.pageLevelError.errorCode === 403) {
+        return;
+      }
       if (error.reset === true) {
         this.pageLevelError = null;
       }

--- a/cdap-ui/app/tracker/routes.js
+++ b/cdap-ui/app/tracker/routes.js
@@ -55,8 +55,8 @@ angular.module(PKG.name + '.feature.tracker')
             window.CaskCommon.ee.emit(
               window.CaskCommon.globalEvents.PAGE_LEVEL_ERROR, { reset: true });
           },
-          rValidNamespace: function ($stateParams, myNamespace, myHelpers) {
-            return myHelpers.validNamespaceResolver($stateParams, myNamespace);
+          rValidNamespace: function ($stateParams) {
+            return window.CaskCommon.validateNamespace($stateParams.namespace);
           },
         },
       })

--- a/cdap-ui/app/tracker/tracker.html
+++ b/cdap-ui/app/tracker/tracker.html
@@ -46,7 +46,9 @@
     <loading-indicator></loading-indicator>
     <page404 ng-if="BodyCtrl.pageLevelError && BodyCtrl.pageLevelError.errorCode === 404"
       message="BodyCtrl.pageLevelError.message"></page404>
-    <page500 ng-if="BodyCtrl.pageLevelError && BodyCtrl.pageLevelError.errorCode !== 404"
+    <page403 ng-if="BodyCtrl.pageLevelError && BodyCtrl.pageLevelError.errorCode === 403"
+      message="BodyCtrl.pageLevelError.message"></page403>
+    <page500 ng-if="BodyCtrl.pageLevelError && BodyCtrl.pageLevelError.errorCode === 500"
       message="BodyCtrl.pageLevelError.message"></page500>
     <status-alert-message></status-alert-message>
     <global-footer></global-footer>


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-8617

**Problem**
- When CDAP is enabled with authorization and authentication, the admin can setup the environment by creating groups and roles and grant specific users with access to specific namespaces. 
- When those users access the restricted namespaces in UI, the UI was showing incorrect message (404).

**Solution**
- Fix the logic to check invalid namespace. Previously we were checking for the presence of namespace in the namespace list API. This will check only for 404s
- Fix involves making an explicit call to `/v3/namespaces/:namespace`. This will be the source of truth (404 vs 403) to show appropriate message in UI.
- Prior to fetching namespace details we fetch list of namespaces. There might be the case where the user does not have access any namespace. In this case we show a slightly different message.
