### PR TITLE
[CDAP-16539] Honor empty values set by user for plugin properties not to be overwritten by defaults set in widget json

### DIFF
--- a/cdap-ui/app/cdap/components/AbstractWidget/StateWrapper.js
+++ b/cdap-ui/app/cdap/components/AbstractWidget/StateWrapper.js
@@ -33,7 +33,9 @@ export default class StateWrapper extends PureComponent {
   };
 
   state = {
-    value: this.props.value || objectQuery(this.props, 'widgetProps', 'default') || '',
+    value: isNil(this.props.value)
+      ? objectQuery(this.props, 'widgetProps', 'default')
+      : this.props.value,
   };
 
   componentWillReceiveProps(nextProps) {

--- a/cdap-ui/app/cdap/components/ConfigurationGroup/index.tsx
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/index.tsx
@@ -19,7 +19,8 @@ import PropTypes from 'prop-types';
 import withStyles, { WithStyles, StyleRules } from '@material-ui/core/styles/withStyles';
 import { IWidgetJson, PluginProperties } from './types';
 import { processConfigurationGroups } from './utilities';
-import { objectQuery, removeEmptyJsonValues } from 'services/helpers';
+import { objectQuery } from 'services/helpers';
+import defaults from 'lodash/defaults';
 import If from 'components/If';
 import PropertyRow from './PropertyRow';
 import { getCurrentNamespace } from 'services/NamespaceStore';
@@ -97,15 +98,13 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
     );
 
     setConfigurationGroups(processedConfigurationGroup.configurationGroups);
-
-    // set default values
-    const defaultValues = processedConfigurationGroup.defaultValues;
-    const newValues = {
-      ...defaultValues,
-      ...values,
-    };
-
-    changeParentHandler(newValues);
+    // We don't need to add default values for plugins in published pipeline
+    // as they should already have all the properties they are configured with.
+    if (!disabled) {
+      // Only add default values for plugin properties that are not already configured
+      // by user.
+      changeParentHandler(defaults(values, processedConfigurationGroup.defaultValues));
+    }
   }, [widgetJson, pluginProperties]);
 
   // Watch for changes in values to determine dynamic widget
@@ -156,7 +155,7 @@ const ConfigurationGroupView: React.FC<IConfigurationGroupProps> = ({
       return;
     }
 
-    onChange(removeEmptyJsonValues(updatedValues));
+    onChange(updatedValues);
   }
 
   const extraConfig = {

--- a/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/DynamicPluginFilters.ts
+++ b/cdap-ui/app/cdap/components/ConfigurationGroup/utilities/DynamicPluginFilters.ts
@@ -333,6 +333,5 @@ export function getPluginPropertiesForValidation(nodeInfo: any, widgetJson: IWid
       delete pluginInfo.properties[propertyName];
     }
   });
-  pluginInfo.properties = removeEmptyJsonValues(pluginInfo.properties);
   return pluginInfo;
 }


### PR DESCRIPTION
JIRA - https://issues.cask.co/browse/CDAP-16539

- We right now don't manually remove the empty values from plugin properties while building the pipeline
- At the end when the pipeline is published UI removes all empty string properties and publishes the pipeline (essentially removing the property from the plugin).