### PR TITLE
[CDAP-17400] Add plugin count metric

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/metadata/MetadataEntity.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/metadata/MetadataEntity.java
@@ -83,6 +83,8 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
   public static final String PROGRAM = "program";
   public static final String SCHEDULE = "schedule";
   public static final String PROGRAM_RUN = "program_run";
+  public static final String PLUGIN = "plugin";
+//  public static final String SCOPE = "scope";
 
   private final LinkedHashMap<String, String> details;
   private String type;
@@ -95,6 +97,7 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
     typesToKeys.put(DATASET, new String[][]{{NAMESPACE, DATASET}, {DATASET}});
     typesToKeys.put(APPLICATION, new String[][]{{NAMESPACE, APPLICATION, VERSION}, {NAMESPACE, APPLICATION}});
     typesToKeys.put(ARTIFACT, new String[][]{{NAMESPACE, ARTIFACT, VERSION}});
+    typesToKeys.put(PLUGIN, new String[][]{{NAMESPACE, ARTIFACT, VERSION, TYPE, PLUGIN}});
     typesToKeys.put(PROGRAM, new String[][]{{NAMESPACE, APPLICATION, VERSION, TYPE, PROGRAM},
       {NAMESPACE, APPLICATION, TYPE, PROGRAM}});
     typesToKeys.put(SCHEDULE, new String[][]{{NAMESPACE, APPLICATION, VERSION, SCHEDULE},

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -59,6 +59,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -206,11 +207,12 @@ public class AppFabricServer extends AbstractIdleService {
   private Map<ImmutablePair<String, String>, Long> getPluginCounts(AppMetadataStore appMetadataStore)
     throws IOException {
     return appMetadataStore.getAllApplications().stream().map(ApplicationMeta::getSpec)
-        .map(ApplicationSpecification::getPlugins)
-        .flatMap(e -> e.values().stream())
-        .map(Plugin::getPluginClass)
-        .map(e -> ImmutablePair.of(e.getName(), e.getType()))
-      .collect(Collectors.groupingByConcurrent(Function.identity(), Collectors.counting()));
+      .map(ApplicationSpecification::getPlugins)
+      .map(Map::values)
+      .flatMap(Collection::stream)
+      .map(Plugin::getPluginClass)
+      .map(e -> ImmutablePair.of(e.getName(), e.getType()))
+      .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -269,6 +269,15 @@ public class AppMetadataStore {
         StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD);
   }
 
+  public List<ApplicationMeta> getAllApplications() throws IOException {
+    return
+      scanWithRange(
+        Range.all(),
+        ApplicationMeta.class,
+        getApplicationSpecificationTable(),
+        StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD);
+  }
+
   public long getApplicationCount() throws IOException {
     // Get number of applications where namespace != SYSTEM (exclude system applications)
     Collection<Field<?>> fields = ImmutableList.of(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -298,6 +298,20 @@ public class AppMetadataStore {
       StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD);
   }
 
+  public Map<ApplicationId, ApplicationMeta> getAllAppIdsAndMeta() throws IOException {
+    HashMap<ApplicationId, ApplicationMeta> result = new HashMap<>();
+    try (CloseableIterator<StructuredRow> iterator =
+           getApplicationSpecificationTable().scan(Range.all(),
+                                                   Integer.MAX_VALUE)) {
+      while (iterator.hasNext()) {
+        StructuredRow row = iterator.next();
+        result.put(getApplicationIdFromRow(row),
+          GSON.fromJson(row.getString(StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD), ApplicationMeta.class));
+      }
+    }
+    return result;
+  }
+
   public List<ApplicationId> getAllAppVersionsAppIds(String namespaceId, String appId) throws IOException {
     List<ApplicationId> appIds = new ArrayList<>();
     try (CloseableIterator<StructuredRow> iterator =

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
@@ -65,6 +65,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -387,13 +388,14 @@ public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor
       List<ImmutablePair<String, String>> remainingPlugins = appMetadataStore.getAllApplications().stream()
         .map(ApplicationMeta::getSpec)
         .map(ApplicationSpecification::getPlugins)
-        .flatMap(e -> e.values().stream())
+        .map(Map::values)
+        .flatMap(Collection::stream)
         .map(Plugin::getPluginClass)
         .map(e -> ImmutablePair.of(e.getName(), e.getType()))
         .collect(Collectors.toList());
 
       Map<ImmutablePair<String, String>, Long> pluginCounts = remainingPlugins.stream()
-        .collect(Collectors.groupingByConcurrent(Function.identity(), Collectors.counting()));
+        .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
       for (Map.Entry<ImmutablePair<String, String>, Long> entry : pluginCounts.entrySet()) {
         Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.PLUGIN_NAME, entry.getKey().getFirst(),
                                                    Constants.Metrics.Tag.PLUGIN_TYPE, entry.getKey().getSecond());

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -727,6 +727,8 @@ public final class Constants {
       public static final String PROGRAM = "prg";
       public static final String PROGRAM_TYPE = "prt";
       public static final String PROGRAM_ENTITY = "ent";
+      public static final String PLUGIN_NAME = "plg";
+      public static final String PLUGIN_TYPE = "plt";
     }
 
     /**
@@ -784,6 +786,7 @@ public final class Constants {
       public static final String RUN_TIME_SECONDS = "program.run.seconds";
       public static final String APPLICATION_COUNT = "application.count";
       public static final String NAMESPACE_COUNT = "namespace.count";
+      public static final String PLUGIN_COUNT = "plugin.count";
     }
 
     /**

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -729,6 +729,7 @@ public final class Constants {
       public static final String PROGRAM_ENTITY = "ent";
       public static final String PLUGIN_NAME = "plg";
       public static final String PLUGIN_TYPE = "plt";
+      public static final String PLUGIN_VERSION = "plv";
     }
 
     /**
@@ -787,6 +788,7 @@ public final class Constants {
       public static final String APPLICATION_COUNT = "application.count";
       public static final String NAMESPACE_COUNT = "namespace.count";
       public static final String PLUGIN_COUNT = "plugin.count";
+      public static final String APPLICATION_PLUGIN_COUNT = "application.plugin.count";
     }
 
     /**

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/element/EntityType.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/element/EntityType.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.InstanceId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.PluginId;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
@@ -56,6 +57,7 @@ public enum EntityType {
   DATASET_MODULE(DatasetModuleId.class),
   SCHEDULE(ScheduleId.class),
   ARTIFACT(ArtifactId.class),
+  PLUGIN(PluginId.class),
   DATASET(DatasetId.class),
   SECUREKEY(SecureKeyId.class),
   TOPIC(TopicId.class),

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/EntityId.java
@@ -196,6 +196,11 @@ public abstract class EntityId {
     if (entityType == EntityType.ARTIFACT) {
       extractedParts = metadataEntity.head(MetadataEntity.VERSION);
     }
+
+    // for plugins get till plugin name
+    if (entityType == EntityType.PLUGIN) {
+      extractedParts = metadataEntity.head(MetadataEntity.PLUGIN);
+    }
     extractedParts.iterator().forEachRemaining(keyValue -> values.add(keyValue.getValue()));
     return entityType.fromIdParts(values);
   }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/PluginId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/PluginId.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.proto.id;
+
+import io.cdap.cdap.api.artifact.ArtifactVersion;
+import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.proto.element.EntityType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * Uniquely identifies a plugin.
+ */
+public class PluginId extends NamespacedEntityId implements ParentedId<ArtifactId> {
+  private final String artifact;
+  private final String version;
+  private final String plugin;
+  private final String type;
+  private transient Integer hashCode;
+
+  public PluginId(String namespace, String artifact, String version, String plugin, String type) {
+    super(namespace, EntityType.PLUGIN);
+    if (artifact == null) {
+      throw new NullPointerException("Artifact ID cannot be null.");
+    }
+    if (version == null) {
+      throw new NullPointerException("Version cannot be null.");
+    }
+    if (type == null) {
+      throw new NullPointerException("Type cannot be null.");
+    }
+    if (plugin == null) {
+      throw new NullPointerException("Plugin cannot be null.");
+    }
+
+    ensureValidArtifactId("artifact", artifact);
+    ArtifactVersion artifactVersion = new ArtifactVersion(version);
+    if (artifactVersion.getVersion() == null) {
+      throw new IllegalArgumentException("Invalid artifact version " + version);
+    }
+    this.artifact = artifact;
+    this.version = version;
+    this.plugin = plugin;
+    this.type = type;
+  }
+
+  public String getArtifact() {
+    return artifact;
+  }
+
+  public String getPlugin() {
+    return plugin;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public String getEntityName() {
+    return getPlugin();
+  }
+
+  @Override
+  public MetadataEntity toMetadataEntity() {
+    return MetadataEntity.builder()
+      .append(MetadataEntity.NAMESPACE, namespace)
+      //      .append(MetadataEntity.SCOPE, p.getArtifactId().getScope().name())
+      .append(MetadataEntity.ARTIFACT, artifact)
+      .append(MetadataEntity.VERSION, version)
+      .append(MetadataEntity.TYPE, type)
+      .appendAsType(MetadataEntity.PLUGIN, plugin)
+      .build();
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public ArtifactId getParent() {
+    return new ArtifactId(namespace, artifact, version);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    PluginId that = (PluginId) o;
+    return Objects.equals(namespace, that.namespace) &&
+      Objects.equals(artifact, that.artifact) &&
+      Objects.equals(version, that.version) &&
+      Objects.equals(type, that.type) &&
+      Objects.equals(plugin, that.plugin);
+  }
+
+  @Override
+  public int hashCode() {
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, artifact, version, type, plugin);
+    }
+    return hashCode;
+  }
+
+  @SuppressWarnings("unused")
+  public static PluginId fromIdParts(Iterable<String> idString) {
+    Iterator<String> iterator = idString.iterator();
+    return new PluginId(
+      next(iterator, "namespace"), next(iterator, "artifact"),
+      next(iterator, "version"), next(iterator, "type"), remaining(iterator, "plugin"));
+  }
+
+  @Override
+  public Iterable<String> toIdParts() {
+    return Collections.unmodifiableList(Arrays.asList(namespace, artifact, version, type, plugin));
+  }
+
+  public static PluginId fromString(String string) {
+    return EntityId.fromString(string, PluginId.class);
+  }
+}

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsQueryHelper.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsQueryHelper.java
@@ -115,6 +115,8 @@ public class MetricsQueryHelper {
       // put program related tag
       .put(Constants.Metrics.Tag.PROGRAM, "program")
       .put(Constants.Metrics.Tag.PROGRAM_TYPE, "programtype")
+      .put(Constants.Metrics.Tag.PLUGIN_NAME, "plugin")
+      .put(Constants.Metrics.Tag.PLUGIN_TYPE, "plugintype")
 
       // put profile related tag
       .put(Constants.Metrics.Tag.PROFILE, "profile")

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsQueryHelper.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsQueryHelper.java
@@ -117,6 +117,7 @@ public class MetricsQueryHelper {
       .put(Constants.Metrics.Tag.PROGRAM_TYPE, "programtype")
       .put(Constants.Metrics.Tag.PLUGIN_NAME, "plugin")
       .put(Constants.Metrics.Tag.PLUGIN_TYPE, "plugintype")
+      .put(Constants.Metrics.Tag.PLUGIN_VERSION, "pluginversion")
 
       // put profile related tag
       .put(Constants.Metrics.Tag.PROFILE, "profile")

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricStore.java
@@ -85,6 +85,7 @@ public class DefaultMetricStore implements MetricStore {
   private static final String BY_DATASET = "dataset";
   private static final String BY_PROFILE = "profile";
   private static final String BY_COMPONENT = "component";
+  private static final String BY_PLUGIN = "plugin";
   private static final Map<String, AggregationAlias> AGGREGATIONS_ALIAS_DIMENSIONS =
     ImmutableMap.of(BY_WORKFLOW,
                     new AggregationAlias(ImmutableMap.of(Constants.Metrics.Tag.RUN_ID,
@@ -193,6 +194,12 @@ public class DefaultMetricStore implements MetricStore {
                        Constants.Metrics.Tag.HANDLER, Constants.Metrics.Tag.METHOD),
       // i.e. for components only
       ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.COMPONENT)));
+
+    // Plugins:
+    aggs.put(BY_PLUGIN, new DefaultAggregation(
+      // Plugin name and plugin type are required dimensions as they uniquely identify a plugin
+      ImmutableList.of(Constants.Metrics.Tag.PLUGIN_NAME, Constants.Metrics.Tag.PLUGIN_TYPE),
+      ImmutableList.of(Constants.Metrics.Tag.PLUGIN_NAME, Constants.Metrics.Tag.PLUGIN_TYPE)));
 
     AGGREGATIONS = Collections.unmodifiableMap(aggs);
   }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricStore.java
@@ -196,10 +196,10 @@ public class DefaultMetricStore implements MetricStore {
       ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.COMPONENT)));
 
     // Plugins:
-    aggs.put(BY_PLUGIN, new DefaultAggregation(
-      // Plugin name and plugin type are required dimensions as they uniquely identify a plugin
-      ImmutableList.of(Constants.Metrics.Tag.PLUGIN_NAME, Constants.Metrics.Tag.PLUGIN_TYPE),
-      ImmutableList.of(Constants.Metrics.Tag.PLUGIN_NAME, Constants.Metrics.Tag.PLUGIN_TYPE)));
+    // Plugin name, plugin type and plugin version are required dimensions as they uniquely identify a plugin
+    ImmutableList<String> byPluginList = ImmutableList
+      .of(Constants.Metrics.Tag.PLUGIN_NAME, Constants.Metrics.Tag.PLUGIN_TYPE, Constants.Metrics.Tag.PLUGIN_VERSION);
+    aggs.put(BY_PLUGIN, new DefaultAggregation(byPluginList, byPluginList));
 
     AGGREGATIONS = Collections.unmodifiableMap(aggs);
   }
@@ -247,7 +247,7 @@ public class DefaultMetricStore implements MetricStore {
   public void setMetricsContext(MetricsContext metricsContext) {
     this.metricsContext = metricsContext;
   }
-  
+
   @Override
   public void add(MetricValues metricValues) {
     add(ImmutableList.of(metricValues));


### PR DESCRIPTION
Emit a metric for total number of deployed plugins across all pipelines and namespaces, aggregated by plugin name and plugin type.
This metric will help us gather information about plugin usage (e.g: what are the most popular plugins?).

### Implementation

Query the `application_specs` table to get a list of all deployed plugins in all namespaces, calculate plugin count grouped by plugin name, plugin type. 
Plugin count is calculated and metric is emitted when:
- a pipeline is deployed
- a pipeline is deleted
- appfabric starts up