### PR TITLE
[CDAP-17399] Fix importing pipelines from 6.2.x to 6.1.x.

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-factory.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-factory.js
@@ -362,7 +362,7 @@ angular.module(PKG.name + '.commons')
       graph.setDefaultEdgeLabel(function() { return {}; });
 
       nodes.forEach(function (node) {
-        var id = node.id || node.name;
+        var id = node.name;
 
         if (!graph.node(id)) {
           graph.setNode(id, { label: node.label, width: 100, height: 100 });


### PR DESCRIPTION
This broke because we were incorrectly using 'id' to refer to nodes instead of name while rendering the graph. The feature of id'ing nodes by 'id' was introduced in 6.2.x (for multiselect).

JIRA - https://issues.cask.co/browse/CDAP-17399
Build - https://builds.cask.co/browse/CDAP-URUT351-1