### PR TITLE
[CDAP-17329] Give all popovers in the pipeline toolbar the same appearance

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineScheduleButton.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineScheduleButton.js
@@ -32,6 +32,7 @@ import {
 import T from 'i18n-react';
 import { Theme } from 'services/ThemeHelper';
 import { GLOBALS } from 'services/global-constants';
+import Popover from '@material-ui/core/Popover';
 
 const PREFIX = 'features.PipelineDetails.TopPanel';
 
@@ -60,9 +61,10 @@ export default class PipelineScheduleButton extends Component {
     }
   }
 
-  toggleScheduler = () => {
+  toggleScheduler = (e) => {
     this.setState({
       showScheduler: !this.state.showScheduler,
+      anchorEl: e && e.currentTarget,
     });
   };
 
@@ -142,7 +144,19 @@ export default class PipelineScheduleButton extends Component {
       >
         {this.renderScheduleError()}
         {this.renderScheduleButton()}
-        {this.state.showScheduler ? (
+        <Popover
+          open={this.state.showScheduler}
+          anchorEl={this.state.anchorEl}
+          onClose={this.toggleScheduler}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+        >
           <PipelineScheduler
             schedule={this.props.schedule}
             maxConcurrentRuns={this.props.maxConcurrentRuns}
@@ -153,7 +167,7 @@ export default class PipelineScheduleButton extends Component {
             schedulePipeline={schedulePipeline}
             suspendSchedule={suspendSchedule}
           />
-        ) : null}
+        </Popover>
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineScheduleButton.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineScheduleButton.js
@@ -32,7 +32,6 @@ import {
 import T from 'i18n-react';
 import { Theme } from 'services/ThemeHelper';
 import { GLOBALS } from 'services/global-constants';
-import Popover from '@material-ui/core/Popover';
 
 const PREFIX = 'features.PipelineDetails.TopPanel';
 
@@ -144,30 +143,18 @@ export default class PipelineScheduleButton extends Component {
       >
         {this.renderScheduleError()}
         {this.renderScheduleButton()}
-        <Popover
+        <PipelineScheduler
+          schedule={this.props.schedule}
+          maxConcurrentRuns={this.props.maxConcurrentRuns}
+          onClose={this.toggleScheduler}
           open={this.state.showScheduler}
           anchorEl={this.state.anchorEl}
-          onClose={this.toggleScheduler}
-          anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'center',
-          }}
-          transformOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
-          }}
-        >
-          <PipelineScheduler
-            schedule={this.props.schedule}
-            maxConcurrentRuns={this.props.maxConcurrentRuns}
-            onClose={this.toggleScheduler}
-            isDetailView={true}
-            pipelineName={this.props.pipelineName}
-            scheduleStatus={this.state.scheduleStatus}
-            schedulePipeline={schedulePipeline}
-            suspendSchedule={suspendSchedule}
-          />
-        </Popover>
+          isDetailView={true}
+          pipelineName={this.props.pipelineName}
+          scheduleStatus={this.state.scheduleStatus}
+          schedulePipeline={schedulePipeline}
+          suspendSchedule={suspendSchedule}
+        />
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineSummaryButton.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineDetailsTopPanel/PipelineDetailsButtons/PipelineSummaryButton.js
@@ -23,8 +23,18 @@ import { getCurrentNamespace } from 'services/NamespaceStore';
 import PipelineDetailStore from 'components/PipelineDetails/store';
 import { GLOBALS } from 'services/global-constants';
 import T from 'i18n-react';
+import Popover from '@material-ui/core/Popover';
+import { withStyles } from '@material-ui/core/styles';
 
 const PREFIX = 'features.PipelineDetails.TopPanel';
+
+const popoverStyles = {
+  paper: {
+    maxWidth: '100%',
+  },
+};
+
+const FullWidthPopover = withStyles(popoverStyles)(Popover);
 
 export default class PipelineSummaryButton extends Component {
   static propTypes = {
@@ -36,16 +46,17 @@ export default class PipelineSummaryButton extends Component {
     showSummary: false,
   };
 
-  toggleSummary = () => {
+  toggleSummary = (anchorEl) => {
     this.setState({
       showSummary: !this.state.showSummary,
+      anchorEl,
     });
   };
 
   renderSummaryButton() {
     return (
       <div
-        onClick={this.toggleSummary}
+        onClick={(e) => this.toggleSummary(e.currentTarget)}
         className={classnames('btn pipeline-action-btn pipeline-summary-btn', {
           'btn-select': this.state.showSummary,
         })}
@@ -70,7 +81,20 @@ export default class PipelineSummaryButton extends Component {
         })}
       >
         {this.renderSummaryButton()}
-        {this.state.showSummary ? (
+        <FullWidthPopover
+          anchorEl={this.state.anchorEl}
+          open={this.state.showSummary}
+          onClose={this.toggleSummary}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'right', // needed to use full width of page
+          }}
+          marginThreshold={0}
+        >
           <PipelineSummary
             pipelineType={pipelineType}
             namespaceId={getCurrentNamespace()}
@@ -81,7 +105,7 @@ export default class PipelineSummaryButton extends Component {
             totalRunsCount={PipelineDetailStore.getState().runs.length}
             onClose={this.toggleSummary}
           />
-        ) : null}
+        </FullWidthPopover>
       </div>
     );
   }

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineModeless/PipelineModeless.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineModeless/PipelineModeless.scss
@@ -27,8 +27,6 @@ $container-padding: 0 30px;
 // a static header and a footer and only the content scrolls.
 .pipeline-modeless-container {
   width: $modeless-width;
-  position: static;
-  z-index: 999;
   box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.5);
   color: $grey-01;
   background-color: white;
@@ -42,6 +40,7 @@ $container-padding: 0 30px;
     min-height: $modeless-header-height;
     padding: $container-padding;
     border-radius: 4px 4px 0 0;
+    border-bottom: 1px solid $grey-05;
     display: flex;
     align-items: center;
     justify-content: space-between;

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineModeless/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineModeless/index.js
@@ -54,7 +54,7 @@ export default function PipelineModeless({
         <div className="pipeline-modeless-header">
           <div className="pipeline-modeless-title">{title}</div>
           <div className="btn-group">
-            <a className="btn" onClick={onClose}>
+            <a className="btn" data-cy="pipeline-modeless-close-btn" onClick={onClose}>
               <IconSVG name="icon-close" />
             </a>
           </div>

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineModeless/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineModeless/index.js
@@ -17,27 +17,59 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import IconSVG from 'components/IconSVG';
+import Popover from '@material-ui/core/Popover';
 
 require('./PipelineModeless.scss');
 
-export default function PipelineModeless({ title, onClose, children }) {
+export default function PipelineModeless({
+  title,
+  onClose,
+  open,
+  anchorEl,
+  suppressAnimation,
+  children,
+}) {
+  let anchorElCb;
+  if (typeof anchorEl === 'string') {
+    anchorElCb = () => document.getElementById(anchorEl);
+  }
+  const transitionDuration = suppressAnimation ? 0 : 'auto';
+
   return (
-    <div className="pipeline-modeless-container">
-      <div className="pipeline-modeless-header">
-        <div className="pipeline-modeless-title">{title}</div>
-        <div className="btn-group">
-          <a className="btn" onClick={onClose}>
-            <IconSVG name="icon-close" />
-          </a>
+    <Popover
+      open={open}
+      anchorEl={anchorElCb || anchorEl}
+      onClose={onClose}
+      anchorOrigin={{
+        vertical: 'bottom',
+        horizontal: 'center',
+      }}
+      transformOrigin={{
+        vertical: 'top',
+        horizontal: 'center',
+      }}
+      transitionDuration={transitionDuration}
+    >
+      <div className="pipeline-modeless-container">
+        <div className="pipeline-modeless-header">
+          <div className="pipeline-modeless-title">{title}</div>
+          <div className="btn-group">
+            <a className="btn" onClick={onClose}>
+              <IconSVG name="icon-close" />
+            </a>
+          </div>
         </div>
+        <div className="pipeline-modeless-content">{children}</div>
       </div>
-      <div className="pipeline-modeless-content">{children}</div>
-    </div>
+    </Popover>
   );
 }
 
 PipelineModeless.propTypes = {
   title: PropTypes.node,
   onClose: PropTypes.func,
+  open: PropTypes.bool,
+  anchorEl: PropTypes.oneOf([PropTypes.element, PropTypes.string]),
+  suppressAnimation: PropTypes.bool,
   children: PropTypes.node,
 };

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/index.js
@@ -46,7 +46,7 @@ export default class PipelineRuntimeArgsDropdownBtn extends Component {
     this.setState(
       {
         showRunOptions: !this.state.showRunOptions,
-        anchorEl,
+        anchorEl: anchorEl ? anchorEl.parentElement : null,
       },
       () => {
         // FIXME: This is to when the user opens/closes the runtime args modeless.

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/index.js
@@ -19,12 +19,11 @@ import React, { Component } from 'react';
 import IconSVG from 'components/IconSVG';
 import PipelineModeless from 'components/PipelineDetails/PipelineModeless';
 import classnames from 'classnames';
-import Popover from 'components/Popover';
 import { Provider } from 'react-redux';
 import PipelineConfigurationsStore from 'components/PipelineConfigurations/Store';
 import RuntimeArgsModeless from 'components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/RuntimeArgsModeless';
 import { fetchAndUpdateRuntimeArgs } from 'components/PipelineConfigurations/Store/ActionCreator';
-import { preventPropagation } from 'services/helpers';
+import Popover from '@material-ui/core/Popover';
 
 require('./PipelineRuntimeArgsDropdownBtn.scss');
 
@@ -43,13 +42,11 @@ export default class PipelineRuntimeArgsDropdownBtn extends Component {
     showRunOptions: this.props.showRunOptions,
   };
 
-  toggleRunConfigOption = (showRunOptions) => {
-    if (showRunOptions === this.state.showRunOptions) {
-      return;
-    }
+  toggleRunConfigOption = (anchorEl) => {
     this.setState(
       {
-        showRunOptions: showRunOptions || !this.state.showRunOptions,
+        showRunOptions: !this.state.showRunOptions,
+        anchorEl,
       },
       () => {
         // FIXME: This is to when the user opens/closes the runtime args modeless.
@@ -73,60 +70,44 @@ export default class PipelineRuntimeArgsDropdownBtn extends Component {
   };
 
   render() {
-    const Btn = (
-      <div
-        className={classnames('btn pipeline-action-btn pipeline-run-btn', {
-          'btn-popover-open': this.state.showRunOptions,
-        })}
-        onClick={(e) => {
-          /*
-            ugh. This is NOT a good approach.
-            The react-popper should have had a disabled prop that
-            which passed on should just disable the popover like a button.
-            Right now I am circumventing that by preventing the propagation/bubbling the event
-            here so it looks like it is disabled.
-
-            We should upgrade react-popper and see if later versions have this prop.
-          */
-          if (this.props.disabled) {
-            preventPropagation(e);
-            return false;
-          }
-        }}
-      >
-        <IconSVG name="icon-caret-down" />
-      </div>
-    );
     return (
       <fieldset disabled={this.props.disabled}>
-        <Provider store={PipelineConfigurationsStore}>
-          <Popover
-            target={() => Btn}
-            className="arrow-btn-container"
-            placement="bottom"
-            enableInteractionInPopover={true}
-            showPopover={this.state.showRunOptions}
-            onTogglePopover={this.toggleRunConfigOption}
-            injectOnToggle={true}
-            modifiers={{
-              flip: {
-                enabled: true,
-                behavior: ['bottom'],
-              },
-              preventOverflow: {
-                enabled: true,
-                boundariesElement: 'scrollParent',
-              },
+        <div className="arrow-btn-container">
+          <div
+            className={classnames('btn pipeline-action-btn pipeline-run-btn', {
+              'btn-popover-open': this.state.showRunOptions,
+            })}
+            onClick={(e) => {
+              if (!this.props.disabled) {
+                this.toggleRunConfigOption(e.currentTarget);
+              }
             }}
           >
+            <IconSVG name="icon-caret-down" />
+          </div>
+        </div>
+        <Popover
+          open={this.state.showRunOptions}
+          onClose={this.toggleRunConfigOption}
+          anchorEl={this.state.anchorEl}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+        >
+          <Provider store={PipelineConfigurationsStore}>
             <PipelineModeless
               title="Runtime Arguments"
               onClose={this.toggleRunConfigOption.bind(this, false)}
             >
               <RuntimeArgsModeless onClose={this.toggleRunConfigOption} />
             </PipelineModeless>
-          </Popover>
-        </Provider>
+          </Provider>
+        </Popover>
       </fieldset>
     );
   }

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/index.js
@@ -23,7 +23,6 @@ import { Provider } from 'react-redux';
 import PipelineConfigurationsStore from 'components/PipelineConfigurations/Store';
 import RuntimeArgsModeless from 'components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/RuntimeArgsModeless';
 import { fetchAndUpdateRuntimeArgs } from 'components/PipelineConfigurations/Store/ActionCreator';
-import Popover from '@material-ui/core/Popover';
 
 require('./PipelineRuntimeArgsDropdownBtn.scss');
 
@@ -86,28 +85,16 @@ export default class PipelineRuntimeArgsDropdownBtn extends Component {
             <IconSVG name="icon-caret-down" />
           </div>
         </div>
-        <Popover
-          open={this.state.showRunOptions}
-          onClose={this.toggleRunConfigOption}
-          anchorEl={this.state.anchorEl}
-          anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'center',
-          }}
-          transformOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
-          }}
-        >
-          <Provider store={PipelineConfigurationsStore}>
-            <PipelineModeless
-              title="Runtime Arguments"
-              onClose={this.toggleRunConfigOption.bind(this, false)}
-            >
-              <RuntimeArgsModeless onClose={this.toggleRunConfigOption} />
-            </PipelineModeless>
-          </Provider>
-        </Popover>
+        <Provider store={PipelineConfigurationsStore}>
+          <PipelineModeless
+            title="Runtime Arguments"
+            onClose={this.toggleRunConfigOption.bind(this, false)}
+            open={this.state.showRunOptions}
+            anchorEl={this.state.anchorEl}
+          >
+            <RuntimeArgsModeless onClose={this.toggleRunConfigOption} />
+          </PipelineModeless>
+        </Provider>
       </fieldset>
     );
   }

--- a/cdap-ui/app/cdap/components/PipelineScheduler/PipelineScheduler.scss
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/PipelineScheduler.scss
@@ -20,7 +20,7 @@ $border-color: $grey-05;
 $modeless-bg-color: $grey-06;
 $modeless-header-bg-color: $grey-08;
 $modeless-width: 730px;
-$modeless-height: 455px;
+$modeless-height: 355px;
 $top-panel-height: 54px;
 $right-position: -330px;
 $regular-font: 14px;
@@ -35,7 +35,7 @@ $secondary-btn-color: $brand-primary;
   .pipeline-scheduler-body {
     .schedule-content {
       width: 100%;
-      margin: 16px 30px;
+      padding-top: 16px;
       font-size: $regular-font;
       position: relative;
       display: flex;
@@ -142,7 +142,7 @@ $secondary-btn-color: $brand-primary;
       }
 
       .schedule-navigation {
-        margin: 10px 0;
+        margin: 15px 0;
 
         .schedule-notes {
           padding-bottom: 7px;

--- a/cdap-ui/app/cdap/components/PipelineScheduler/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/index.js
@@ -37,9 +37,7 @@ import {
 import IconSVG from 'components/IconSVG';
 import { getCurrentNamespace } from 'services/NamespaceStore';
 import StatusMapper from 'services/StatusMapper';
-import { isDescendant, objectQuery } from 'services/helpers';
-import { Observable } from 'rxjs/Observable';
-import { PROFILES_DROPDOWN_DOM_CLASS } from 'components/PipelineScheduler/ProfilesForSchedule';
+import { objectQuery } from 'services/helpers';
 import { MyScheduleApi } from 'api/schedule';
 import T from 'i18n-react';
 import { GLOBALS, CLOUD } from 'services/global-constants';

--- a/cdap-ui/app/cdap/components/PipelineScheduler/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/index.js
@@ -44,6 +44,7 @@ import { MyScheduleApi } from 'api/schedule';
 import T from 'i18n-react';
 import { GLOBALS, CLOUD } from 'services/global-constants';
 import isEmpty from 'lodash/isEmpty';
+import PipelineModeless from 'components/PipelineDetails/PipelineModeless';
 
 const PREFIX = 'features.PipelineScheduler';
 
@@ -109,27 +110,6 @@ export default class PipelineScheduler extends Component {
     }
 
     getTimeBasedSchedule();
-
-    this.documentClick$ = Observable.fromEvent(document, 'click').subscribe((e) => {
-      if (!this.schedulerComponent) {
-        return;
-      }
-
-      if (
-        isDescendant(this.schedulerComponent, e.target) ||
-        // FIXME: There should be a better way to detect this.
-        // This is to detect if the click happened inside profiles dropdown
-        // We need this here as the profiles dropdown is attached to the body.
-        isDescendant(
-          document.querySelector(`body > .${PROFILES_DROPDOWN_DOM_CLASS}.dropdown`),
-          e.target
-        )
-      ) {
-        return;
-      }
-
-      this.props.onClose();
-    });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -262,19 +242,10 @@ export default class PipelineScheduler extends Component {
     setOptionalProperty('app.deploy.update.schedules', true);
   };
 
-  renderHeader() {
+  renderHeaderText() {
     return (
-      <div className="pipeline-scheduler-header modeless-header">
-        <div className="modeless-title">
-          {T.translate(`${PREFIX}.header`)}
-          {this.props.pipelineName.length ? ` ${this.props.pipelineName}` : null}
-        </div>
-        <div className="btn-group">
-          <a className="btn" onClick={this.props.onClose}>
-            <IconSVG name="icon-close" />
-          </a>
-        </div>
-      </div>
+      T.translate(`${PREFIX}.header`) +
+      (this.props.pipelineName.length ? ` ${this.props.pipelineName}` : '')
     );
   }
 
@@ -337,21 +308,22 @@ export default class PipelineScheduler extends Component {
     let isScheduled = this.state.scheduleStatus === StatusMapper.statusMap['SCHEDULED'];
     return (
       <Provider store={PipelineSchedulerStore}>
-        <div
-          className="pipeline-scheduler-content modeless-container"
-          ref={(ref) => (this.schedulerComponent = ref)}
-        >
-          {this.renderHeader()}
-          <div className="pipeline-scheduler-body modeless-content">
-            <div className="schedule-content">
-              <fieldset disabled={isScheduled}>
-                <ViewSwitch />
-                <ViewContainer isDetailView={this.props.isDetailView} />
-              </fieldset>
-              {this.renderActionButtons()}
+        <PipelineModeless title={this.renderHeaderText()} onClose={this.props.onClose}>
+          <div
+            className="pipeline-scheduler-content"
+            ref={(ref) => (this.schedulerComponent = ref)}
+          >
+            <div className="pipeline-scheduler-body">
+              <div className="schedule-content">
+                <fieldset disabled={isScheduled}>
+                  <ViewSwitch />
+                  <ViewContainer isDetailView={this.props.isDetailView} />
+                </fieldset>
+                {this.renderActionButtons()}
+              </div>
             </div>
           </div>
-        </div>
+        </PipelineModeless>
       </Provider>
     );
   }

--- a/cdap-ui/app/cdap/components/PipelineScheduler/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/index.js
@@ -306,7 +306,13 @@ export default class PipelineScheduler extends Component {
     let isScheduled = this.state.scheduleStatus === StatusMapper.statusMap['SCHEDULED'];
     return (
       <Provider store={PipelineSchedulerStore}>
-        <PipelineModeless title={this.renderHeaderText()} onClose={this.props.onClose}>
+        <PipelineModeless
+          title={this.renderHeaderText()}
+          onClose={this.props.onClose}
+          open={this.props.open}
+          anchorEl={this.props.anchorEl}
+          suppressAnimation={this.props.suppressAnimation}
+        >
           <div
             className="pipeline-scheduler-content"
             ref={(ref) => (this.schedulerComponent = ref)}
@@ -332,9 +338,12 @@ PipelineScheduler.propTypes = {
   schedule: PropTypes.string,
   maxConcurrentRuns: PropTypes.number,
   onClose: PropTypes.func,
+  open: PropTypes.bool,
+  anchorEl: PropTypes.oneOf([PropTypes.element, PropTypes.string]),
   isDetailView: PropTypes.bool,
   pipelineName: PropTypes.string,
   scheduleStatus: PropTypes.string,
   schedulePipeline: PropTypes.func,
+  suppressAnimation: PropTypes.bool,
   suspendSchedule: PropTypes.func,
 };

--- a/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummary.scss
+++ b/cdap-ui/app/cdap/components/PipelineSummary/PipelineSummary.scss
@@ -99,6 +99,7 @@ $min_height_of_graph: 340px;
     background: $summary_titlebar_bg;
     display: flex;
     border: 1px solid $summary_border_color;
+    border-radius: 4px 4px 0 0;
     > div {
       &:nth-child(1) {
         flex: 1;

--- a/cdap-ui/app/cdap/components/PipelineSummary/index.js
+++ b/cdap-ui/app/cdap/components/PipelineSummary/index.js
@@ -33,8 +33,6 @@ import { humanReadableDuration, isBatchPipeline } from 'services/helpers';
 import isNil from 'lodash/isNil';
 import Mousetrap from 'mousetrap';
 import ee from 'event-emitter';
-import { isDescendant } from 'services/helpers';
-import { Observable } from 'rxjs/Observable';
 
 const PREFIX = 'features.PipelineSummary';
 
@@ -132,9 +130,6 @@ export default class PipelineSummary extends Component {
     if (this.storeSubscription) {
       this.storeSubscription();
     }
-    if (this.documentClick$) {
-      this.documentClick$.unsubscribe();
-    }
     Mousetrap.unbind('esc');
   }
 
@@ -157,18 +152,6 @@ export default class PipelineSummary extends Component {
     });
   };
   componentDidMount() {
-    this.documentClick$ = Observable.fromEvent(document, 'click').subscribe((e) => {
-      if (!this.summaryComponent) {
-        return;
-      }
-
-      if (isDescendant(this.summaryComponent, e.target)) {
-        return;
-      }
-
-      this.props.onClose();
-    });
-
     this.fetchStats();
     Mousetrap.bind('esc', () => {
       this.eventEmitter.emit('CLOSE_HINT_TOOLTIP');
@@ -288,10 +271,7 @@ export default class PipelineSummary extends Component {
   }
   render() {
     return (
-      <div
-        className="pipeline-settings pipeline-summary"
-        ref={(ref) => (this.summaryComponent = ref)}
-      >
+      <div className="pipeline-summary" ref={(ref) => (this.summaryComponent = ref)}>
         {this.renderTitleBar()}
         <div className="filter-container">
           <span> {T.translate(`${PREFIX}.filterContainer.view`)} </span>

--- a/cdap-ui/app/directives/my-pipeline-scheduler/my-pipeline-scheduler.html
+++ b/cdap-ui/app/directives/my-pipeline-scheduler/my-pipeline-scheduler.html
@@ -19,5 +19,8 @@
   max-concurrent-runs="SchedulerCtrl.maxConcurrentRuns"
   action-creator="SchedulerCtrl.actionCreator"
   pipeline-name="SchedulerCtrl.pipelineName"
-  on-close="SchedulerCtrl.onClose">
+  on-close="SchedulerCtrl.onClose"
+  open=true
+  suppress-animation=true
+  anchor-el="SchedulerCtrl.anchorEl">
 </pipeline-scheduler>

--- a/cdap-ui/app/directives/my-pipeline-scheduler/my-pipeline-scheduler.js
+++ b/cdap-ui/app/directives/my-pipeline-scheduler/my-pipeline-scheduler.js
@@ -31,6 +31,7 @@ angular.module(PKG.name + '.commons')
       actionCreator: '=',
       pipelineName: '@',
       onClose: '&',
+      anchorEl: '@',
     },
     bindToController: true,
     controller: 'MyPipelineSchedulerCtrl',

--- a/cdap-ui/app/hydrator/templates/create/toppanel.html
+++ b/cdap-ui/app/hydrator/templates/create/toppanel.html
@@ -117,6 +117,7 @@
          tooltip-class="toppanel-tooltip"
          tooltip-append-to-body="true"
          ng-disabled="!HydratorPlusPlusTopPanelCtrl.hasNodes"
+         id="pipeline-schedule-modeless-btn"
          data-cy="pipeline-schedule-modeless-btn">
       <div class="btn-container">
         <span class="fa icon-runtimestarttime"></span>
@@ -256,11 +257,9 @@
 </div>
 <div class="pipeline-settings-backdrop"
      ng-if="HydratorPlusPlusTopPanelCtrl.viewLogs ||
-     HydratorPlusPlusTopPanelCtrl.viewConfig ||
-     HydratorPlusPlusTopPanelCtrl.viewScheduler"
+     HydratorPlusPlusTopPanelCtrl.viewConfig"
      ng-click="HydratorPlusPlusTopPanelCtrl.viewLogs =
-     HydratorPlusPlusTopPanelCtrl.viewConfig =
-     HydratorPlusPlusTopPanelCtrl.viewScheduler = false">
+     HydratorPlusPlusTopPanelCtrl.viewConfig = false">
 </div>
 <div class="pipeline-configurations" ng-if="HydratorPlusPlusTopPanelCtrl.viewConfig">
   <div
@@ -285,7 +284,8 @@
     store="HydratorPlusPlusTopPanelCtrl.HydratorPlusPlusConfigStore"
     action-creator="HydratorPlusPlusTopPanelCtrl.HydratorPlusPlusConfigActions"
     pipeline-name="{{HydratorPlusPlusTopPanelCtrl.state.metadata['name']}}"
-    on-close="HydratorPlusPlusTopPanelCtrl.viewScheduler = false">
+    on-close="HydratorPlusPlusTopPanelCtrl.viewScheduler = false"
+    anchor-el="pipeline-schedule-modeless-btn">
   </my-pipeline-scheduler>
 </div>
 <div

--- a/cdap-ui/app/hydrator/toppanel.less
+++ b/cdap-ui/app/hydrator/toppanel.less
@@ -460,7 +460,6 @@ body.theme-cdap {
       }
     }
 
-    .pipeline-scheduler-content,
     .pipeline-configurations-content {
       position: fixed;
       top: 91px;

--- a/cdap-ui/cypress/integration/pipeline.runtimeargs.spec.ts
+++ b/cdap-ui/cypress/integration/pipeline.runtimeargs.spec.ts
@@ -278,8 +278,8 @@ describe('Deploying pipeline with temporary runtime arguments', () => {
     cy.get(dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)).should('exist');
     cy.add_runtime_args_row_with_value(2, 'runtime_args_key2', 'runtime_args_value2');
     cy.add_runtime_args_row_with_value(3, 'runtime_args_key3', 'runtime_args_value3');
-    // dismissing the modeless by clicking outside.
-    cy.get('h1.pipeline-name').click();
+    // dismissing the modeless by clicking close button.
+    cy.get(dataCy('pipeline-modeless-close-btn')).click();
     cy.get('.arrow-btn-container').click();
     cy.get(dataCy(RUNTIME_ARGS_MODELESS_LOADING_SELECTOR)).should('not.exist');
     cy.get(dataCy(RUNTIME_ARGS_DEPLOYED_SELECTOR)).should('exist');


### PR DESCRIPTION
Jira: https://issues.cask.co/browse/CDAP-17329

This was a result of the material-ui upgrade. The Configuration popover had to be switched to the material-ui popover, which left it inconsistent with the other popovers. This PR converts those popovers to material-ui, and moves the Schedule popover to PipelineModeless for a bit of style sharing. 

The Configuration popover was *not* moved to PipelineModeless because it needs different styles. I don't mean for this to be the long-term material-ui implementation for this UI, so I don't think it's worth supporting that style at this time.

![image](https://user-images.githubusercontent.com/2728821/99009063-35ecc500-24fc-11eb-90c5-b718054f82c6.png)

![image](https://user-images.githubusercontent.com/2728821/99009076-3edd9680-24fc-11eb-9fd5-af5bf0f2883f.png)
