### PR TITLE
CDAP-15652 Log additional information when launching the Dataproc cluster.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -512,8 +512,8 @@ public class ProgramLifecycleService {
       }
     }
 
-    LOG.info("Attempt to run {} program {} as user {}", programId.getType(), programId.getProgram(),
-             authenticationContext.getPrincipal().getName());
+    LOG.info("Attempt to run {} program {} as user {} with arguments {}", programId.getType(), programId.getProgram(),
+             authenticationContext.getPrincipal().getName(), userArgs);
 
     provisionerNotifier.provisioning(programId.run(runId), programOptions, programDescriptor, userId);
     return runId;


### PR DESCRIPTION
We log it for any program run as program runtime arguments are not available in the dataproc provisioner.