### PR TITLE
Rename accelerators to capabilities

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/annotation/Requirements.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/annotation/Requirements.java
@@ -71,8 +71,8 @@ public @interface Requirements {
   String[] datasetTypes() default {};
 
   /**
-   * Names of associated add-ons or accelerators
-   * @return String array of accelerator names
+   * Names of associated add-ons or capabilities
+   * @return String array of capability names
    */
-  String[] accelerators() default{};
+  String[] capabilities() default{};
 }

--- a/cdap-api/src/main/java/io/cdap/cdap/api/plugin/Requirements.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/plugin/Requirements.java
@@ -33,8 +33,8 @@ public class Requirements {
   // can add more when needed in future
   private final Set<String> datasetTypes;
 
-  //Accelerators associated with this plugin
-  private final Set<String> accelerators;
+  //Capabilities associated with this plugin
+  private final Set<String> capabilities;
 
   /**
    * Creates a {@link Requirements} object from the given {@link Set}. Note: Requirements are case insensitive and all
@@ -46,11 +46,11 @@ public class Requirements {
     this(datasetTypes, Collections.emptySet());
   }
 
-  public Requirements(Set<String> datasetTypes, Set<String> accelerators) {
+  public Requirements(Set<String> datasetTypes, Set<String> capabilities) {
     this.datasetTypes = datasetTypes.isEmpty() ? Collections.emptySet() :
       Collections.unmodifiableSet(datasetTypes.stream().map(String::toLowerCase).collect(Collectors.toSet()));
-    this.accelerators = accelerators.isEmpty() ? Collections.emptySet() :
-      Collections.unmodifiableSet(accelerators.stream().map(String::toLowerCase).collect(Collectors.toSet()));
+    this.capabilities = capabilities.isEmpty() ? Collections.emptySet() :
+      Collections.unmodifiableSet(capabilities.stream().map(String::toLowerCase).collect(Collectors.toSet()));
   }
 
   /**
@@ -62,10 +62,10 @@ public class Requirements {
 
   /**
    *
-   * @return {@link Set} containing accelerator names or empty set
+   * @return {@link Set} containing capability names or empty set
    */
-  public Set<String> getAccelerators() {
-    return accelerators;
+  public Set<String> getCapabilities() {
+    return capabilities;
   }
 
   @Override
@@ -77,23 +77,23 @@ public class Requirements {
       return false;
     }
     Requirements that = (Requirements) o;
-    return Objects.equals(datasetTypes, that.datasetTypes) && Objects.equals(accelerators, that.accelerators);
+    return Objects.equals(datasetTypes, that.datasetTypes) && Objects.equals(capabilities, that.capabilities);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(datasetTypes, accelerators);
+    return Objects.hash(datasetTypes, capabilities);
   }
 
   @Override
   public String toString() {
     return "Requirements{" +
       "datasetTypes=" + datasetTypes +
-      "accelerators=" + accelerators +
+      "capabilities=" + capabilities +
       '}';
   }
 
   public boolean isEmpty() {
-    return datasetTypes.isEmpty() && accelerators.isEmpty();
+    return datasetTypes.isEmpty() && capabilities.isEmpty();
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -388,7 +388,7 @@ final class ArtifactInspector {
       return Requirements.EMPTY;
     }
     return new Requirements(getAnnotationValues(annotation.datasetTypes()),
-                            getAnnotationValues(annotation.accelerators()));
+                            getAnnotationValues(annotation.capabilities()));
   }
 
   private Set<String> getAnnotationValues(String[] field) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppStep.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppStep.java
@@ -56,11 +56,11 @@ public class SystemAppStep {
    */
   public void validate() {
     if (label == null || label.isEmpty()) {
-      throw new IllegalArgumentException("An accelerator step must contain a label.");
+      throw new IllegalArgumentException("A capability step must contain a label.");
     }
 
     if (type == null) {
-      throw new IllegalArgumentException("An accelerator step must contain a type.");
+      throw new IllegalArgumentException("A capability step must contain a type.");
     }
 
     arguments.validate();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/AppWithWorkflow.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/AppWithWorkflow.java
@@ -41,7 +41,7 @@ import java.util.Map;
 /**
  * App with workflow.
  */
-@Requirements(accelerators = "cdc")
+@Requirements(capabilities = "cdc")
 public class AppWithWorkflow extends AbstractApplication {
   public static final String NAME = "AppWithWorkflow";
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStageTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStageTest.java
@@ -118,11 +118,11 @@ public class SystemMetadataWriterStageTest {
   }
 
   @Test
-  public void testAcceleratorTags() throws Exception {
+  public void testCapabilityTags() throws Exception {
     String appName = AppWithWorkflow.class.getSimpleName();
     ApplicationId appId = NamespaceId.DEFAULT.app(appName);
-    String[] acceleratorTestNames = {"cdc", "healthcare"};
-    Requirements requirements = new Requirements(Collections.emptySet(), Stream.of(acceleratorTestNames).collect(
+    String[] capabilityTestNames = {"cdc", "healthcare"};
+    Requirements requirements = new Requirements(Collections.emptySet(), Stream.of(capabilityTestNames).collect(
       Collectors.toSet()));
     ApplicationClass applicationClass = new ApplicationClass(AppWithWorkflow.class.getName(), appName, null,
                                                              requirements);
@@ -138,13 +138,13 @@ public class SystemMetadataWriterStageTest {
 
     Assert.assertEquals(false, metadataStorage.read(new Read(appId.toMetadataEntity(),
                                                              MetadataScope.SYSTEM, MetadataKind.PROPERTY)).isEmpty());
-    //Test that all test accelerators are present in the metadata
+    //Test that all test capabilities are present in the metadata
     Map<String, String> metadataProperties = metadataStorage
       .read(new Read(appId.toMetadataEntity())).getProperties(MetadataScope.SYSTEM);
-    Set<String> acceleratorNames = Arrays
-      .stream(metadataProperties.get(AppSystemMetadataWriter.ACCELERATOR_TAG)
-                .split(AppSystemMetadataWriter.ACCELERATOR_DELIMITER)).collect(Collectors.toSet());
-    Assert.assertEquals(Arrays.stream(acceleratorTestNames).collect(Collectors.toSet()), acceleratorNames);
+    Set<String> capabilityNames = Arrays
+      .stream(metadataProperties.get(AppSystemMetadataWriter.CAPABILITY_TAG)
+                .split(AppSystemMetadataWriter.CAPABILITY_DELIMITER)).collect(Collectors.toSet());
+    Assert.assertEquals(Arrays.stream(capabilityTestNames).collect(Collectors.toSet()), capabilityNames);
   }
 
   @SuppressWarnings("unchecked")

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ApplicationClassCodecTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ApplicationClassCodecTest.java
@@ -53,7 +53,7 @@ public class ApplicationClassCodecTest {
     String testApp2 = getData("ApplicationClass_6_3.json");
     ApplicationClass applicationClass63 = gson.fromJson(testApp2, ApplicationClass.class);
     Requirements requirements = applicationClass63.getRequirements();
-    Assert.assertEquals(Collections.singleton("cdc"), requirements.getAccelerators());
+    Assert.assertEquals(Collections.singleton("cdc"), requirements.getCapabilities());
 
     Assert.assertEquals(applicationClass63, gson.fromJson(gson.toJson(applicationClass63), ApplicationClass.class));
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -123,13 +123,13 @@ public class ArtifactInspectorTest {
     Assert.assertEquals(new Requirements(ImmutableSet.of(Table.TYPE, "duplicate")),
                         artifactInspector.getArtifactRequirements(InspectionApp.DuplicateRequirementsPlugin.class));
 
-    //Test that accelerators in the Requirements annotation is being captured
+    //Test that capabilities in the Requirements annotation is being captured
     Assert.assertEquals(new Requirements(ImmutableSet.of(), ImmutableSet.of("cdc")),
-                        artifactInspector.getArtifactRequirements(InspectionApp.AcceleratorPlugin.class));
+                        artifactInspector.getArtifactRequirements(InspectionApp.CapabilityPlugin.class));
     Assert.assertEquals(new Requirements(ImmutableSet.of(), ImmutableSet.of("cdc", "healthcare")),
-                        artifactInspector.getArtifactRequirements(InspectionApp.MultipleAcceleratorPlugin.class));
+                        artifactInspector.getArtifactRequirements(InspectionApp.MultipleCapabilityPlugin.class));
     Assert.assertEquals(new Requirements(ImmutableSet.of(Table.TYPE, "sometype"), ImmutableSet.of("cdc", "healthcare")),
-                        artifactInspector.getArtifactRequirements(InspectionApp.DatasetAndAcceleratorPlugin.class));
+                        artifactInspector.getArtifactRequirements(InspectionApp.DatasetAndCapabilityPlugin.class));
   }
 
   @Test

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/app/inspection/InspectionApp.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/app/inspection/InspectionApp.java
@@ -30,7 +30,7 @@ import io.cdap.cdap.api.plugin.PluginConfig;
 /**
  * App used in artifact inspector tests
  */
-@Requirements(accelerators = "cdc")
+@Requirements(capabilities = "cdc")
 public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   public static final String PLUGIN_DESCRIPTION = "some plugin";
   public static final String PLUGIN_NAME = "pluginA";
@@ -149,10 +149,11 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   }
 
   @Plugin(type = PLUGIN_TYPE)
-  @Name("AcceleratorPlugin")
+  @Name("Capability" +
+    "Plugin")
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements(accelerators = {"cdc"})
-  public static class AcceleratorPlugin {
+  @Requirements(capabilities = {"cdc"})
+  public static class CapabilityPlugin {
     private PConfig pluginConf;
 
     public double doSomething() {
@@ -161,10 +162,10 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   }
 
   @Plugin(type = PLUGIN_TYPE)
-  @Name("MultipleAcceleratorPlugin")
+  @Name("MultipleCapabilityPlugin")
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements(accelerators = {"cdc", "healthcare"})
-  public static class MultipleAcceleratorPlugin {
+  @Requirements(capabilities = {"cdc", "healthcare"})
+  public static class MultipleCapabilityPlugin {
     private PConfig pluginConf;
 
     public double doSomething() {
@@ -173,10 +174,10 @@ public class InspectionApp extends AbstractApplication<InspectionApp.AConfig> {
   }
 
   @Plugin(type = PLUGIN_TYPE)
-  @Name("DatasetAndAcceleratorPlugin")
+  @Name("DatasetAndCapabilityPlugin")
   @Description(PLUGIN_DESCRIPTION)
-  @Requirements(datasetTypes = {Table.TYPE, "sometype"}, accelerators = {"cdc", "healthcare"})
-  public static class DatasetAndAcceleratorPlugin {
+  @Requirements(datasetTypes = {Table.TYPE, "sometype"}, capabilities = {"cdc", "healthcare"})
+  public static class DatasetAndCapabilityPlugin {
     private PConfig pluginConf;
 
     public double doSomething() {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
@@ -150,10 +150,10 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
   }
 
   @Test
-  public void testAcceleratorMetaDataDeletion() throws Exception {
+  public void testCapabilityMetaDataDeletion() throws Exception {
     Class<AppWithWorkflow> appWithWorkflowClass = AppWithWorkflow.class;
     Requirements declaredAnnotation = appWithWorkflowClass.getDeclaredAnnotation(Requirements.class);
-    Set<String> expected = Arrays.stream(declaredAnnotation.accelerators()).collect(Collectors.toSet());
+    Set<String> expected = Arrays.stream(declaredAnnotation.capabilities()).collect(Collectors.toSet());
     Id.Artifact artifactId = Id.Artifact
       .from(Id.Namespace.DEFAULT, appWithWorkflowClass.getSimpleName(), "1.0.0-SNAPSHOT");
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, appWithWorkflowClass);
@@ -165,14 +165,14 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     applicationLifecycleService
       .deployAppAndArtifact(NamespaceId.DEFAULT, appWithWorkflowClass.getSimpleName(), artifactId, appJarFile, null,
                             null, programId -> { }, true);
-    //Check for the accelerator metadata
+    //Check for the capability metadata
     ApplicationId appId = NamespaceId.DEFAULT.app(appWithWorkflowClass.getSimpleName());
     Assert.assertEquals(false, metadataStorage.read(new Read(appId.toMetadataEntity(),
                                                              MetadataScope.SYSTEM, MetadataKind.PROPERTY)).isEmpty());
     Map<String, String> metadataProperties = metadataStorage
       .read(new Read(appId.toMetadataEntity())).getProperties(MetadataScope.SYSTEM);
-    String acceleratorMetaData = metadataProperties.get(AppSystemMetadataWriter.ACCELERATOR_TAG);
-    Set<String> actual = Arrays.stream(acceleratorMetaData.split(AppSystemMetadataWriter.ACCELERATOR_DELIMITER))
+    String capabilityMetaData = metadataProperties.get(AppSystemMetadataWriter.CAPABILITY_TAG);
+    Set<String> actual = Arrays.stream(capabilityMetaData.split(AppSystemMetadataWriter.CAPABILITY_DELIMITER))
       .collect(Collectors.toSet());
     Assert.assertEquals(expected, actual);
     //Remove the application and verify that all metadata is removed

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PluginExclusionTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PluginExclusionTest.java
@@ -89,8 +89,8 @@ public class PluginExclusionTest extends ArtifactHttpHandlerTestBase {
                                                            InspectionApp.EmptyRequirementPlugin.class.getName(),
                                                            InspectionApp.SingleEmptyRequirementPlugin.class.getName(),
                                                            InspectionApp.NonTransactionalPlugin.class.getName(),
-                                                           InspectionApp.AcceleratorPlugin.class.getName(),
-                                                           InspectionApp.MultipleAcceleratorPlugin.class.getName());
+                                                           InspectionApp.CapabilityPlugin.class.getName(),
+                                                           InspectionApp.MultipleCapabilityPlugin.class.getName());
     Assert.assertEquals(expectedPluginClassNames, actualPluginClassNames);
   }
 }

--- a/cdap-app-fabric/src/test/resources/ApplicationClass_6_3.json
+++ b/cdap-app-fabric/src/test/resources/ApplicationClass_6_3.json
@@ -20,7 +20,7 @@
   },
   "requirements": {
     "datasetTypes": [],
-    "accelerators": [
+    "capabilities": [
       "cdc"
     ]
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/system/AppSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/system/AppSystemMetadataWriter.java
@@ -42,8 +42,8 @@ import java.util.stream.Collectors;
  */
 public class AppSystemMetadataWriter extends AbstractSystemMetadataWriter {
 
-  public static final String ACCELERATOR_TAG = "accelerator";
-  public static final String ACCELERATOR_DELIMITER = ",";
+  public static final String CAPABILITY_TAG = "capability";
+  public static final String CAPABILITY_DELIMITER = ",";
   private final ApplicationSpecification appSpec;
   private final ApplicationId appId;
   private final ApplicationClass applicationClass;
@@ -80,26 +80,26 @@ public class AppSystemMetadataWriter extends AbstractSystemMetadataWriter {
         existingPluginClasses.add(plugin.getPluginClass());
       }
     }
-    addAccelerators(appSpec, applicationClass, properties);
+    addCapabilities(appSpec, applicationClass, properties);
     return properties.build();
   }
 
-  private void addAccelerators(ApplicationSpecification appSpec,
+  private void addCapabilities(ApplicationSpecification appSpec,
                                ApplicationClass applicationClass,
                                ImmutableMap.Builder<String, String> properties) {
     //add from all plugins
-    Set<String> acceleratorSet = appSpec.getPlugins().values().stream()
+    Set<String> capabilitiesSet = appSpec.getPlugins().values().stream()
       .map(Plugin::getPluginClass)
       .map(PluginClass::getRequirements)
-      .map(Requirements::getAccelerators)
+      .map(Requirements::getCapabilities)
       .flatMap(Set::stream)
       .collect(Collectors.toSet());
     //add from application
-    acceleratorSet.addAll(applicationClass.getRequirements().getAccelerators());
-    if (acceleratorSet.isEmpty()) {
+    capabilitiesSet.addAll(applicationClass.getRequirements().getCapabilities());
+    if (capabilitiesSet.isEmpty()) {
       return;
     }
-    properties.put(ACCELERATOR_TAG, String.join(ACCELERATOR_DELIMITER, acceleratorSet));
+    properties.put(CAPABILITY_TAG, String.join(CAPABILITY_DELIMITER, capabilitiesSet));
   }
 
   @Override


### PR DESCRIPTION
- Rename accelerators to capabilities
- Capabilities are intended to be features in CDAP that can be enabled/disabled/deleted via system app config files
