### PR TITLE
[CDAP-16566] Fix error collector in UI to show right input schema when connected to source

### DIFF
--- a/cdap-ui/app/cdap/components/PreviewData/index.tsx
+++ b/cdap-ui/app/cdap/components/PreviewData/index.tsx
@@ -107,7 +107,7 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
   };
 
   useEffect(() => {
-    if (previewId) {
+    if (previewId && selectedNode) {
       fetchPreview(
         selectedNode,
         previewId,
@@ -118,7 +118,7 @@ const PreviewDataViewBase: React.FC<IPreviewDataViewProps> = ({
         errorCb
       );
     }
-  }, [previewId]);
+  }, [previewId, selectedNode]);
 
   const getTableData = (prevData: IPreviewData) => {
     let inputs = [];

--- a/cdap-ui/app/hydrator/controllers/create/canvas-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/canvas-ctrl.js
@@ -88,27 +88,19 @@ class HydratorPlusPlusCreateCanvasCtrl {
             rDisabled: function() {
               return false;
             },
-            rPlugin: ['HydratorPlusPlusNodeService', 'HydratorPlusPlusConfigStore', 'GLOBALS', function(HydratorPlusPlusNodeService, HydratorPlusPlusConfigStore, GLOBALS) {
+            rPlugin: ['HydratorPlusPlusConfigStore', function(HydratorPlusPlusConfigStore) {
               let pluginId = pluginNode.name;
               let appType = HydratorPlusPlusConfigStore.getAppType();
               let sourceConnections = HydratorPlusPlusConfigStore.getSourceConnections(pluginId);
               let sourceNodes = HydratorPlusPlusConfigStore.getSourceNodes(pluginId);
               let artifactVersion = HydratorPlusPlusConfigStore.getArtifact().version;
-              return HydratorPlusPlusNodeService
-                .getPluginInfo(pluginNode, appType, sourceConnections, sourceNodes, artifactVersion)
-                .then((nodeWithInfo) => {
-                  let pluginType = nodeWithInfo.type || nodeWithInfo.plugin.type;
-                  return {
-                    node: nodeWithInfo,
-                    isValidPlugin: true,
-                    type: appType,
-                    isSource: GLOBALS.pluginConvert[pluginType] === 'source',
-                    isSink: GLOBALS.pluginConvert[pluginType] === 'sink',
-                    isTransform: GLOBALS.pluginConvert[pluginType] === 'transform',
-                    isAction: GLOBALS.pluginConvert[pluginType] === 'action',
-                    isCondition: GLOBALS.pluginConvert[pluginType] === 'condition',
-                  };
-                });
+              return {
+                pluginNode,
+                appType,
+                sourceConnections,
+                sourceNodes,
+                artifactVersion,
+              };
             }]
           }
         })

--- a/cdap-ui/app/hydrator/controllers/detail/canvas-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/detail/canvas-ctrl.js
@@ -100,30 +100,23 @@ angular.module(PKG.name + '.feature.hydrator')
                   programId
                 };
               },
-              rPlugin: function(HydratorPlusPlusNodeService, HydratorPlusPlusHydratorService, GLOBALS) {
+              rPlugin: function(HydratorPlusPlusHydratorService) {
                 'ngInject';
                 let pluginId = pluginNode.name;
                 let pipelineDetailStoreState = window.CaskCommon.PipelineDetailStore.getState();
                 let appType = pipelineDetailStoreState.artifact.name;
-                let artifactVersion = pipelineDetailStoreState.artifact.version;
                 let sourceConnections = pipelineDetailStoreState.config.connections.filter(conn => conn.to === pluginId);
                 let nodes = HydratorPlusPlusHydratorService.getNodesFromStages(pipelineDetailStoreState.config.stages);
                 let nodesMap = HydratorPlusPlusHydratorService.getNodesMap(nodes);
                 let sourceNodes = sourceConnections.map(conn => nodesMap[conn.from]);
-                return HydratorPlusPlusNodeService
-                  .getPluginInfo(pluginNode, appType, sourceConnections, sourceNodes, artifactVersion)
-                  .then((nodeWithInfo) => (
-                    {
-                      node: nodeWithInfo,
-                      isValidPlugin: true,
-                      type: appType,
-                      isSource: GLOBALS.pluginConvert[nodeWithInfo.type] === 'source',
-                      isSink: GLOBALS.pluginConvert[nodeWithInfo.type] === 'sink',
-                      isTransform: GLOBALS.pluginConvert[nodeWithInfo.type] === 'transform',
-                      isAction: GLOBALS.pluginConvert[nodeWithInfo.type] === 'action',
-                      isCondition: GLOBALS.pluginConvert[nodeWithInfo.type] === 'condition',
-                    }
-                  ));
+                let artifactVersion = pipelineDetailStoreState.artifact.version;
+                return {
+                  pluginNode,
+                  appType,
+                  sourceConnections,
+                  sourceNodes,
+                  artifactVersion,
+                };
               }
             }
           })


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/12849

  - Moves fetching plugin information from modal resolve promise to node config controller.
    This will help us show the modal asap with loading icon instead of waiting to fetch plugin information before showing the plugin properties/metrics/preview
  - Fixes node config controller based on plugin information passed from canvas controller. In addition also refactor some functions in controller for slight better readability

  - Fixes preview tab to expect plugin information async