### PR TITLE
[CDAP-17416] Show correct stage name in input schema

### DIFF
--- a/cdap-ui/app/cdap/components/PluginSchemaEditor/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginSchemaEditor/index.tsx
@@ -421,7 +421,7 @@ class PluginSchemaEditorBase extends React.PureComponent<
       if (!returnSchema.schema) {
         return [
           {
-            name: 'etlSchemaBody',
+            name: returnSchema.name || 'etlSchemaBody',
             schema: !returnSchema.fields.length ? getDefaultEmptyAvroSchema() : returnSchema,
           },
         ];
@@ -437,7 +437,7 @@ class PluginSchemaEditorBase extends React.PureComponent<
         try {
           newSchema.schema = JSON.parse(s.schema);
         } catch (e) {
-          return { ...getDefaultEmptyAvroSchema() };
+          return { ...getDefaultEmptyAvroSchema(), name: s.name };
         }
       } else {
         newSchema.schema = s.schema;


### PR DESCRIPTION
JIRA - https://cdap.atlassian.net/browse/CDAP-17416

Problem:
- When multiple input stages are connected to a node (say joiner) and if some of the nodes are not configured with right schema (meaning has empty schema) the UI shows incorrect stage name in tab.

![Screen Shot 2020-11-20 at 4 46 59 PM](https://user-images.githubusercontent.com/1452845/99863016-10da0100-2b51-11eb-9836-a440e3fa096d.png)

The fix is to use the right stage name instead of overriding with default avro schema name.