### PR TITLE
adding all gcp regions dataproc is available in

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
@@ -47,6 +47,7 @@
               "asia-northeast3",
               "asia-south1",
               "asia-southeast1",
+              "asia-southeast2",
               "australia-southeast1",
               "europe-north1",
               "europe-west1",
@@ -60,7 +61,9 @@
               "us-east1",
               "us-east4",
               "us-west1",
-              "us-west2"
+              "us-west2",
+              "us-west3",
+              "us-west4"
             ],
             "default": "us-east1",
             "size": "medium"

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-existing-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-existing-dataproc.json
@@ -43,6 +43,7 @@
               "asia-northeast3",
               "asia-south1",
               "asia-southeast1",
+              "asia-southeast2",
               "australia-southeast1",
               "europe-north1",
               "europe-west1",
@@ -56,7 +57,9 @@
               "us-east1",
               "us-east4",
               "us-west1",
-              "us-west2"
+              "us-west2",
+              "us-west3",
+              "us-west4"
             ],
             "default": "us-east1",
             "size": "medium"


### PR DESCRIPTION
Similar to #12839, adding remaining GCP regions that Dataproc is currently available in.