### PR TITLE
(CDAP-17439) Added runtime support for Hadoop + Spark 3

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/program/ManifestFields.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/program/ManifestFields.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.app.program;
 
 import com.google.common.collect.ImmutableSet;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -70,7 +71,7 @@ public final class ManifestFields {
    */
   public static Set<String> getExportPackages(@Nullable Manifest manifest) {
     if (manifest == null) {
-      return ImmutableSet.of();
+      return Collections.emptySet();
     }
 
     ImmutableSet.Builder<String> result = ImmutableSet.builder();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramClassLoader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramClassLoader.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.internal.app.runtime;
 
-import com.google.common.base.Function;
 import io.cdap.cdap.api.dataset.Dataset;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
@@ -33,6 +32,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * ClassLoader that implements bundle jar feature, in which the application jar contains

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -25,8 +25,6 @@ public final class ProgramOptionConstants {
 
   public static final String PROGRAM_JAR = "programJar";
 
-  public static final String EXPANDED_PROGRAM_JAR = "expandedProgramJar";
-
   public static final String CDAP_CONF_FILE = "cConfFile";
 
   public static final String HADOOP_CONF_FILE = "hConfFile";

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -41,6 +41,7 @@ import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.app.runtime.ProgramRunner;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.common.lang.jar.BundleJarUtil;
 import io.cdap.cdap.common.logging.LoggingContextAccessor;
 import io.cdap.cdap.common.logging.common.UncaughtExceptionHandler;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
@@ -223,9 +224,14 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
       Locations.toLocation(new File(systemArgs.getOption(ProgramOptionConstants.PROGRAM_JAR)));
     ApplicationSpecification appSpec = readJsonFile(
       new File(systemArgs.getOption(ProgramOptionConstants.APP_SPEC_FILE)), ApplicationSpecification.class);
+
+    // Expand the program jar for creating classloader
+    File programJarDir = BundleJarUtil.unJar(
+      programJarLocation, new File("expanded." + System.currentTimeMillis() + programJarLocation.getName()));
+
     program = Programs.create(cConf, programRunner,
                               new ProgramDescriptor(programOptions.getProgramId(), appSpec), programJarLocation,
-                              new File(systemArgs.getOption(ProgramOptionConstants.EXPANDED_PROGRAM_JAR)));
+                              programJarDir);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -216,11 +216,7 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
       // Localize the program jar
       Location programJarLocation = program.getJarLocation();
       final String programJarName = programJarLocation.getName();
-      localizeResources.put(programJarName, new LocalizeResource(program.getJarLocation().toURI(), false));
-
-      // Localize an expanded program jar
-      final String expandedProgramJarName = "expanded." + programJarName;
-      localizeResources.put(expandedProgramJarName, new LocalizeResource(program.getJarLocation().toURI(), true));
+      localizeResources.put(programJarName, new LocalizeResource(programJarLocation.toURI(), false));
 
       // Localize the app spec
       localizeResources.put(APP_SPEC_FILE_NAME,
@@ -238,7 +234,6 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
       // and runs it in the remote container
       Map<String, String> extraSystemArgs = new HashMap<>(launchConfig.getExtraSystemArguments());
       extraSystemArgs.put(ProgramOptionConstants.PROGRAM_JAR, programJarName);
-      extraSystemArgs.put(ProgramOptionConstants.EXPANDED_PROGRAM_JAR, expandedProgramJarName);
       extraSystemArgs.put(ProgramOptionConstants.HADOOP_CONF_FILE, HADOOP_CONF_FILE_NAME);
       extraSystemArgs.put(ProgramOptionConstants.CDAP_CONF_FILE, CDAP_CONF_FILE_NAME);
       extraSystemArgs.put(ProgramOptionConstants.APP_SPEC_FILE, APP_SPEC_FILE_NAME);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginClassLoader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginClassLoader.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.internal.app.runtime.plugin;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicates;
 import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.app.program.ManifestFields;
 import io.cdap.cdap.common.lang.CombineClassLoader;
@@ -52,6 +51,7 @@ import java.util.jar.Manifest;
  * ClassLoader as the Combine ClassLoader.
  */
 public class PluginClassLoader extends DirectoryClassLoader {
+
   private final ArtifactId artifactId;
   private final Set<String> exportPackages;
 
@@ -68,7 +68,7 @@ public class PluginClassLoader extends DirectoryClassLoader {
     Manifest manifest = ((ProgramClassLoader) programClassLoader).getManifest();
     Set<String> exportPackages = ManifestFields.getExportPackages(manifest);
     ClassLoader filteredTemplateClassLoader = new PackageFilterClassLoader(templateClassLoader,
-                                                                           Predicates.in(exportPackages));
+                                                                           exportPackages::contains);
 
     // The lib Classloader needs to be able to see all cdap api classes as well.
     // In this way, parent ClassLoader of the plugin ClassLoader will load class from the parent of the
@@ -95,6 +95,6 @@ public class PluginClassLoader extends DirectoryClassLoader {
    * in the manifest.
    */
   public ClassLoader getExportPackagesClassLoader() {
-    return new PackageFilterClassLoader(this, Predicates.in(exportPackages));
+    return new PackageFilterClassLoader(this, exportPackages::contains);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/HttpHandlerGenerator.java
@@ -58,11 +58,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.invoke.CallSite;
 import java.lang.invoke.LambdaMetafactory;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -127,12 +123,6 @@ final class HttpHandlerGenerator {
   private static final Type EXCEPTION_TYPE = Type.getType(Exception.class);
   private static final Type DELAYED_HTTP_SERVICE_RESPONDER_TYPE = Type.getType(DelayedHttpServiceResponder.class);
   private static final Type HTTP_CONTENT_CONSUMER_TYPE = Type.getType(HttpContentConsumer.class);
-
-  // Method descriptor of the LambdaMetafactory.metafactory method.
-  private static final String LAMBDA_META_FACTORY_METHOD_DESC =
-    MethodType.methodType(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class,
-                          MethodType.class, MethodHandle.class, MethodType.class).toMethodDescriptorString();
-
 
   private final TransactionControl defaultTxControl;
 
@@ -674,9 +664,9 @@ final class HttpHandlerGenerator {
       // Perform the lambda invocation.
       Handle metaFactoryHandle = new Handle(Opcodes.H_INVOKESTATIC,
                                             Type.getType(LambdaMetafactory.class).getInternalName(),
-                                            "metafactory", LAMBDA_META_FACTORY_METHOD_DESC);
+                                            "metafactory", Methods.LAMBDA_META_FACTORY_METHOD_DESC, false);
       Handle lambdaMethodHandle = new Handle(Opcodes.H_INVOKESTATIC, classType.getInternalName(),
-                                             lambdaMethod.getName(), lambdaMethod.getDescriptor());
+                                             lambdaMethod.getName(), lambdaMethod.getDescriptor(), false);
 
       // Signature of the ThrowingRunnable.run() method
       Type samMethodType = Type.getType(Type.getMethodDescriptor(Type.VOID_TYPE));

--- a/cdap-common/src/main/java/io/cdap/cdap/common/lang/GuavaClassRewriter.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/lang/GuavaClassRewriter.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.lang;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.cdap.cdap.internal.asm.Methods;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.GeneratorAdapter;
+import org.objectweb.asm.commons.Method;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.invoke.LambdaMetafactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link ClassRewriter} for rewriting Guava library classes to add missing functions that are available in
+ * later Guava library. Those new methods are being used by Hadoop 3 until 3.4 (HADOOP-17288).
+ *
+ * In particular, in the Preconditions class, there are new checkState and checkArgument methods that take different
+ * number of arguments for error message formatting purpose, instead of just the generic vararg method.
+ * Also, in the MoreExecutors class, there is a new directExecutor() method that replace the functionality of
+ * the the sameThreadExecutor().
+ */
+public class GuavaClassRewriter implements ClassRewriter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GuavaClassRewriter.class);
+  private static final String PRECONDTIONS_CLASS_NAME = "com.google.common.base.Preconditions";
+  private static final String MORE_EXECUTORS_CLASS_NAME = "com.google.common.util.concurrent.MoreExecutors";
+  private static final Type OBJECT_TYPE = Type.getType(Object.class);
+  private static final Type STRING_TYPE = Type.getType(String.class);
+  private static final Type RUNNABLE_TYPE = Type.getType(Runnable.class);
+
+  /**
+   * Returns {@code true} if the given class needs to be rewritten.
+   */
+  public boolean needRewrite(String className) {
+    return PRECONDTIONS_CLASS_NAME.equals(className) || MORE_EXECUTORS_CLASS_NAME.equals(className);
+  }
+
+  @Nullable
+  @Override
+  public byte[] rewriteClass(String className, InputStream input) throws IOException {
+    if (PRECONDTIONS_CLASS_NAME.equals(className)) {
+      return rewritePreconditions(input);
+    }
+    if (MORE_EXECUTORS_CLASS_NAME.equals(className)) {
+      return rewriteMoreExecutors(input);
+    }
+    return null;
+  }
+
+  /**
+   * Rewrites the {@link Preconditions} class to add various {@code checkArgument} and {@code checkState} methods
+   * that are missing in earlier Guava library.
+   *
+   * @param input the bytecode stream of the Preconditions class
+   * @return the rewritten bytecode
+   * @throws IOException if failed to rewrite
+   */
+  private byte[] rewritePreconditions(InputStream input) throws IOException {
+    Type[] types = new Type[] {
+      OBJECT_TYPE,
+      Type.CHAR_TYPE,
+      Type.INT_TYPE,
+      Type.LONG_TYPE
+    };
+
+    // Generates all the methods that we need to add to the Preconditions class
+    // There are multiple of them, each take one or combinations of two parameters of type Object, char, int, and long
+    // for the string formatting template to use
+    List<Method> methods = new ArrayList<>();
+    for (String methodName : Arrays.asList("checkArgument", "checkState")) {
+      for (Type type : types) {
+        methods.add(new Method(methodName, Type.VOID_TYPE,
+                               new Type[] { Type.BOOLEAN_TYPE, STRING_TYPE, type }));
+        for (Type type2 : types) {
+          methods.add(new Method(methodName, Type.VOID_TYPE,
+                                 new Type[] { Type.BOOLEAN_TYPE, STRING_TYPE, type, type2 }));
+        }
+      }
+
+      // Later version of Preconditions class also added methods that take three and four Objects
+      methods.add(new Method(methodName, Type.VOID_TYPE,
+                             new Type[] { Type.BOOLEAN_TYPE, STRING_TYPE, OBJECT_TYPE, OBJECT_TYPE, OBJECT_TYPE}));
+      methods.add(new Method(methodName, Type.VOID_TYPE,
+                             new Type[] { Type.BOOLEAN_TYPE, STRING_TYPE,
+                               OBJECT_TYPE, OBJECT_TYPE, OBJECT_TYPE, OBJECT_TYPE}));
+    }
+
+    ClassReader cr = new ClassReader(input);
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+    cr.accept(new PreconditionsRewriter(Opcodes.ASM7, cw, methods), ClassReader.EXPAND_FRAMES);
+    return cw.toByteArray();
+  }
+
+  /**
+   * Rewrites the {@link MoreExecutors} class to add the {@code directExecutor} method.
+   *
+   * @param input the bytecode stream of the MoreExecutors class
+   * @return the rewritten bytecode
+   * @throws IOException if failed to rewrite
+   */
+  private byte[] rewriteMoreExecutors(InputStream input) throws IOException {
+    ClassReader cr = new ClassReader(input);
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+
+    Method method = new Method("directExecutor", Type.getType(Executor.class), new Type[0]);
+    cr.accept(new ClassVisitor(Opcodes.ASM7, cw) {
+
+      private boolean hasMethod;
+
+      @Override
+      public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+        // Rewrite the class to 1.7 format so that we can use lambda to implement the directExecutor() method
+        super.visit(Opcodes.V1_7, access, name, signature, superName, interfaces);
+      }
+
+      @Override
+      public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                       String signature, String[] exceptions) {
+        if (method.equals(new Method(name, descriptor))
+          && (access & Opcodes.ACC_PUBLIC) == Opcodes.ACC_PUBLIC
+          && (access & Opcodes.ACC_STATIC) == Opcodes.ACC_STATIC) {
+          hasMethod = true;
+        }
+        return super.visitMethod(access, name, descriptor, signature, exceptions);
+      }
+
+      @Override
+      public void visitEnd() {
+        if (hasMethod) {
+          super.visitEnd();
+          return;
+        }
+
+        // Generate the method
+        // public static Executor directExecutor() {
+        //   return Runnable::run;
+        // }
+        MethodVisitor mv = super.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                                             method.getName(), method.getDescriptor(), null, null);
+        GeneratorAdapter adapter = new GeneratorAdapter(mv, Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                                                        method.getName(), method.getDescriptor());
+        // Perform the lambda invocation.
+        Handle metaFactoryHandle = new Handle(Opcodes.H_INVOKESTATIC,
+                                              Type.getType(LambdaMetafactory.class).getInternalName(),
+                                              "metafactory", Methods.LAMBDA_META_FACTORY_METHOD_DESC, false);
+        Handle lambdaMethodHandle = new Handle(Opcodes.H_INVOKEINTERFACE, RUNNABLE_TYPE.getInternalName(),
+                                               "run", Type.getMethodDescriptor(Type.VOID_TYPE), true);
+
+        // Signature of the Executor.execute(Runnable)
+        Type samMethodType = Type.getType(Type.getMethodDescriptor(Type.VOID_TYPE, RUNNABLE_TYPE));
+        adapter.invokeDynamic("execute", Type.getMethodDescriptor(Type.getType(Executor.class)),
+                              metaFactoryHandle, samMethodType, lambdaMethodHandle, samMethodType);
+        adapter.returnValue();
+        adapter.endMethod();
+        super.visitEnd();
+      }
+    }, ClassReader.EXPAND_FRAMES);
+
+    return cw.toByteArray();
+  }
+
+  /**
+   * A {@link ClassVisitor} to add a set of missing methods to the {@link Preconditions} class.
+   */
+  private static final class PreconditionsRewriter extends ClassVisitor {
+
+    private final Set<Method> methods;
+
+    PreconditionsRewriter(int api, ClassVisitor classVisitor, Collection<Method> methods) {
+      super(api, classVisitor);
+      this.methods = new LinkedHashSet<>(methods);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                     String signature, String[] exceptions) {
+      Method method = new Method(name, descriptor);
+      if (methods.contains(method)
+          && (access & Opcodes.ACC_PUBLIC) == Opcodes.ACC_PUBLIC
+          && (access & Opcodes.ACC_STATIC) == Opcodes.ACC_STATIC) {
+        methods.remove(method);
+      }
+      return super.visitMethod(access, name, descriptor, signature, exceptions);
+    }
+
+    @Override
+    public void visitEnd() {
+      for (Method method : methods) {
+        LOG.trace("{}.{} not found. Rewriting class to inject the missing method",
+                  PRECONDTIONS_CLASS_NAME, method);
+
+        // Generate the missing method that calls the version with varargs
+        // For example,
+        //
+        // public static void checkArgument(boolean expression, String template, Object arg) {
+        //   checkArgument(expression, template, new Object[] { arg });
+        // }
+        MethodVisitor mv = super.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                                             method.getName(), method.getDescriptor(), null, null);
+        GeneratorAdapter adapter = new GeneratorAdapter(mv, Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                                                        method.getName(), method.getDescriptor());
+        adapter.loadArg(0);
+        adapter.loadArg(1);
+
+        // New an array of size based on the number of parameters
+        int objectArray = adapter.newLocal(Type.getType(Object[].class));
+
+        Type[] argTypes = method.getArgumentTypes();
+        adapter.push(argTypes.length - 2);
+        adapter.newArray(OBJECT_TYPE);
+        adapter.storeLocal(objectArray);
+
+        // Put the arguments into the Object array
+        for (int i = 0; i < argTypes.length - 2; i++) {
+          Type argType = argTypes[i + 2];
+          adapter.loadLocal(objectArray);
+          adapter.push(i);
+          adapter.loadArg(i + 2);
+          // If the given argument is not Object, turn it into a String
+          if (argType.getSort() != Type.OBJECT) {
+            adapter.invokeStatic(STRING_TYPE, new Method("valueOf", STRING_TYPE, new Type[] { argType }));
+          }
+          adapter.arrayStore(OBJECT_TYPE);
+        }
+        adapter.loadLocal(objectArray);
+
+        // Call the varargs method
+        adapter.invokeStatic(Type.getObjectType(PRECONDTIONS_CLASS_NAME.replace('.', '/')),
+                             new Method(method.getName(), Type.VOID_TYPE,
+                                        new Type[] {
+                                          Type.BOOLEAN_TYPE,
+                                          STRING_TYPE,
+                                          Type.getType(Object[].class)
+                                        }));
+        adapter.returnValue();
+        adapter.endMethod();
+      }
+
+      super.visitEnd();
+    }
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/internal/asm/Classes.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/internal/asm/Classes.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.internal.asm;
 
-import com.google.common.base.Function;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -32,6 +31,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * A util class to help on class inspections and manipulations through bytecode.

--- a/cdap-common/src/main/java/io/cdap/cdap/internal/asm/Methods.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/internal/asm/Methods.java
@@ -18,12 +18,20 @@ package io.cdap.cdap.internal.asm;
 
 import org.objectweb.asm.commons.Method;
 
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 
 /**
  * Util class containing helper functions to interact with ASM {@link Method}.
  */
 public final class Methods {
+
+  // Method descriptor of the LambdaMetafactory.metafactory method. It is for invokeDynamic lambda call.
+  public static final String LAMBDA_META_FACTORY_METHOD_DESC =
+    MethodType.methodType(CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class,
+                          MethodType.class, MethodHandle.class, MethodType.class).toMethodDescriptorString();
 
   public static Method getMethod(Class<?> returnType, String name, Class<?>...args) {
     return new Method(name, MethodType.methodType(returnType, args).toMethodDescriptorString());

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterAuditLookUp.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterAuditLookUp.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.gateway.router;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Function;
 import io.cdap.cdap.common.internal.guava.ClassPath;
 import io.cdap.cdap.common.lang.ClassLoaders;
 import io.cdap.cdap.common.logging.AuditLogConfig;
@@ -39,6 +38,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.HeaderParam;

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -76,7 +76,7 @@ public final class DataprocUtils {
                                             Storage.BlobListOption.prefix(path + "/"));
       boolean addedToDelete = false;
       for (Blob blob : blobs.iterateAll()) {
-        LOG.debug("Added path to be deleted {}", blob.getName());
+        LOG.trace("Added path to be deleted {}", blob.getName());
         batch.delete(blob.getBlobId());
         addedToDelete = true;
       }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeEnvironment.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeEnvironment.java
@@ -103,6 +103,9 @@ public class DataprocRuntimeEnvironment implements RuntimeJobEnvironment {
     if (yarnTwillRunnerService != null) {
       yarnTwillRunnerService.stop();
     }
+    if (zkServer != null) {
+      zkServer.stopAndWait();
+    }
     if (locationFactory != null) {
       Location location = locationFactory.create("/");
       try {
@@ -110,9 +113,6 @@ public class DataprocRuntimeEnvironment implements RuntimeJobEnvironment {
       } catch (IOException e) {
         LOG.warn("Failed to delete location {}", location, e);
       }
-    }
-    if (zkServer != null) {
-      zkServer.stopAndWait();
     }
   }
 

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -114,7 +114,7 @@ public final class SparkRuntimeContextProvider {
   static final String CCONF_FILE_NAME = "cConf.xml";
   static final String HCONF_FILE_NAME = "hConf.xml";
   // The suffix has to be .jar, otherwise YARN don't expand it
-  static final String PROGRAM_JAR_EXPANDED_NAME = "program.expanded.jar";
+  static final String PROGRAM_JAR_EXPANDED_NAME = "program.jar.expanded.zip";
   static final String PROGRAM_JAR_NAME = "program.jar";
   static final String EXECUTOR_CLASSLOADER_NAME = "org.apache.spark.repl.ExecutorClassLoader";
 

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -482,7 +482,8 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     File jarFile = new File(tempDir, CDAP_LAUNCHER_JAR);
     ContainerLauncherGenerator.generateLauncherJar(
       Arrays.asList("org.apache.spark.deploy.yarn.ApplicationMaster",
-                    "org.apache.spark.executor.CoarseGrainedExecutorBackend"),
+                    "org.apache.spark.executor.CoarseGrainedExecutorBackend",
+                    "org.apache.spark.executor.YarnCoarseGrainedExecutorBackend"),
       SparkContainerLauncher.class, jarFile);
     return jarFile;
   }

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SparkRuntimeEnv.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SparkRuntimeEnv.scala
@@ -17,7 +17,6 @@
 package io.cdap.cdap.app.runtime.spark
 
 import com.google.common.reflect.TypeToken
-import javax.annotation.Nullable
 import org.apache.spark.SparkConf
 import org.apache.spark.SparkContext
 import org.apache.spark.scheduler.SparkListener
@@ -32,6 +31,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
+import javax.annotation.Nullable
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/LogAppenderInitializer.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/LogAppenderInitializer.java
@@ -25,14 +25,15 @@ import ch.qos.logback.core.status.StatusManager;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterators;
 import com.google.inject.Inject;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 
 /**
@@ -40,7 +41,7 @@ import javax.annotation.Nullable;
  */
 public class LogAppenderInitializer implements Closeable {
   private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(LogAppenderInitializer.class);
-  private final Set<String> loggerNames = new ConcurrentHashSet<>();
+  private final Set<String> loggerNames = Collections.newSetFromMap(new ConcurrentHashMap<>());
   private final LogAppender logAppender;
 
   @Inject

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <apache.jdbm1.version>2.0.0-M2</apache.jdbm1.version>
     <asm.version>7.1</asm.version>
     <async.http.version>1.7.18</async.http.version>
-    <avro.version>1.6.2</avro.version>
+    <avro.version>1.8.2</avro.version>
     <bouncycastle.version>1.60</bouncycastle.version>
     <cdap.common.version>0.12.0</cdap.common.version>
     <cdap.client.version>1.4.0</cdap.client.version>


### PR DESCRIPTION
Hadoop YARN
* Don’t use YARN localization to expand program jar file due to YARN bug YARN-9591
** In twill containers, expand the jar locally
** In Spark, renames the jar to .zip before localization

Guava depdendency
* Add missing methods to the Guava library
** Various missing Preconditions.checkArgument() methods
** Various missing Preconditions.checkState() methods
** MoreExecutors.directExecutor() method

Hadoop 3
* Upgrade to Avro 1.8.2
** SpecificData constructor becomes public
* Remove usage of ConcurrentHashSet from the jetty library as Hadoop 3 uses an incompatible version, and CDAP shouldn’t be using that library outside of the cdap-security module

Spark 3
* Use Reflection to alter SparkListenerApplicationStart event
** Spark 2 and 3 are binary incompatible for that class

Also, there is some small refactoring to modernize the code to use the standard Java library instead of Guava