### PR TITLE
(CDAP-17355) New Drafts API

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/service/http/HttpServiceRequest.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/service/http/HttpServiceRequest.java
@@ -57,8 +57,13 @@ public interface HttpServiceRequest {
   /**
    * @param key the header to find
    * @return the value of the specified header; if the header maps to multiple values, return the first value;
-   *         if there is no such header, a {@code null} value will be returned.
+   * if there is no such header, a {@code null} value will be returned.
    */
   @Nullable
   String getHeader(String key);
+
+  /**
+   * @return The id of the user who issued this request
+   */
+  String getUserId();
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/DefaultHttpServiceRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/DefaultHttpServiceRequest.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.runtime.service.http;
 
 import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.api.service.http.HttpServiceRequest;
+import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -109,5 +110,10 @@ final class DefaultHttpServiceRequest implements HttpServiceRequest {
   public String getHeader(String key) {
     Collection<String> values = getHeaders(key);
     return values.isEmpty() ? null : values.iterator().next();
+  }
+
+  @Override
+  public String getUserId() {
+    return SecurityRequestContext.getUserId();
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/CodedException.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/CodedException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.draft;
+
+/**
+ * An exception that contains an HTTP error code.
+ */
+public class CodedException extends RuntimeException {
+  private final int code;
+
+  public CodedException(int code, String message) {
+    super(message);
+    this.code = code;
+  }
+
+  public CodedException(int code, String message, Throwable cause) {
+    super(message, cause);
+    this.code = code;
+  }
+
+  public int getCode() {
+    return code;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/Draft.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/Draft.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.draft;
+
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.etl.proto.v2.ETLConfig;
+
+import java.util.Objects;
+
+/**
+ * A pipeline draft.
+ */
+public class Draft extends DraftStoreRequest<ETLConfig> {
+
+  private final String id;
+  private final long createdTimeMillis;
+  private final long updatedTimeMillis;
+  private final int configHash;
+
+  private Draft(ETLConfig config, String previousHash, String name, String description,
+                int revision,
+                ArtifactSummary artifact, String id, long createdTimeMillis, long updatedTimeMillis) {
+    super(config, previousHash, name, description, revision, artifact);
+    this.id = id;
+    this.createdTimeMillis = createdTimeMillis;
+    this.updatedTimeMillis = updatedTimeMillis;
+    this.configHash = config == null ? 0 : config.hashCode();
+  }
+
+  // This should be the default constructor until previousHash and revision are needed
+  public Draft(ETLConfig config, String name, String description, ArtifactSummary artifact,
+               String id,
+               long createdTimeMillis, long updatedTimeMillis) {
+    this(config, "", name, description, 0, artifact, id, createdTimeMillis, updatedTimeMillis);
+  }
+
+  public int getConfigHash() {
+    return configHash;
+  }
+
+  public long getCreatedTimeMillis() {
+    return createdTimeMillis;
+  }
+
+  public long getUpdatedTimeMillis() {
+    return updatedTimeMillis;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    Draft draft = (Draft) o;
+    return createdTimeMillis == draft.createdTimeMillis &&
+      updatedTimeMillis == draft.updatedTimeMillis &&
+      configHash == draft.configHash &&
+      Objects.equals(id, draft.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), id, createdTimeMillis, updatedTimeMillis);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/DraftCollisionException.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/DraftCollisionException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.draft;
+
+import java.net.HttpURLConnection;
+
+/**
+ * Exception for draft collision
+ */
+public class DraftCollisionException extends CodedException {
+  public DraftCollisionException(DraftId draftId) {
+    super(HttpURLConnection.HTTP_CONFLICT,
+          String.format("The current version of draft '%s' in namespace '%s' conflicts with the new request.",
+                        draftId.getId(),
+                        draftId.getNamespace()));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/DraftId.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/DraftId.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.draft;
+
+import io.cdap.cdap.api.NamespaceSummary;
+
+import java.util.Objects;
+
+/**
+ * Uniquely identifies a draft.
+ */
+public class DraftId {
+  private final NamespaceSummary namespace;
+  private final String id;
+  private final String owner;
+
+  public DraftId(NamespaceSummary namespace, String id, String owner) {
+    this.namespace = namespace;
+    this.id = id;
+    this.owner = owner;
+  }
+
+  public NamespaceSummary getNamespace() {
+    return namespace;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DraftId draftId = (DraftId) o;
+    return Objects.equals(namespace, draftId.namespace) &&
+      Objects.equals(id, draftId.id) &&
+      Objects.equals(owner, draftId.owner);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, id, owner);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/DraftNotFoundException.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/DraftNotFoundException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.draft;
+
+import java.net.HttpURLConnection;
+
+/**
+ * Thrown when a draft is not found when it is expected to be found.
+ */
+public class DraftNotFoundException extends CodedException {
+
+  public DraftNotFoundException(DraftId draftId) {
+    super(HttpURLConnection.HTTP_NOT_FOUND,
+          String.format("Draft '%s' in namespace '%s' not found.", draftId.getId(), draftId.getNamespace().getName()));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/DraftService.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/DraftService.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.draft;
+
+import com.google.common.base.Strings;
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.api.metrics.Metrics;
+import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.proto.v2.ETLConfig;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+import static io.cdap.cdap.datapipeline.draft.DraftStore.TABLE_SPEC;
+
+/**
+ * Class to interact with the DraftStore
+ */
+public class DraftService {
+  private static final Logger LOG = LoggerFactory.getLogger(DraftService.class);
+  private final Metrics metrics;
+  private final DraftStore store;
+
+  public DraftService(TransactionRunner context, @Nullable Metrics metrics) {
+    this.store = new DraftStore(context);
+    this.metrics = metrics;
+    if (metrics == null) {
+      LOG.warn("Metrics collector was not injected into DraftHandler");
+    }
+  }
+
+  /**
+   * Returns a sorted and filtered list of drafts for the given namespace and owner
+   *
+   * @param namespaceSummary the namespace to fetch the drafts from
+   * @param owner the id of the owner of the drafts
+   * @param includeConfig the returned Draft objects will not include the pipeline config if this is false
+   * @param sortRequest The sorting that should be applied to the results, pass null if no sorting is required. Note
+   *   that the sortField matches against the column names in the table spec found in {@link DraftStore}
+   * @param filter string used to do case-insensitive prefix matching on the draft name
+   * @return List of {@link Draft}
+   * @throws RuntimeException when an error occurs while fetching from the table
+   */
+  public List<Draft> listDrafts(NamespaceSummary namespaceSummary, String owner,
+                                boolean includeConfig, SortRequest sortRequest,
+                                @Nullable String filter) {
+    List<Draft> drafts = store.listDrafts(namespaceSummary, owner, sortRequest, includeConfig);
+    if (!Strings.isNullOrEmpty(filter)) {
+      drafts = drafts.stream()
+        .filter(draft -> draft.getName().toLowerCase().startsWith(filter.toLowerCase()))
+        .collect(Collectors.toList());
+    }
+    return drafts;
+  }
+
+  /**
+   * Fetch the given draft
+   *
+   * @param draftId {@link DraftId} that is used to uniquely identify a draft
+   * @return the {@link Draft} object
+   * @throws RuntimeException when an error occurs while fetching from the table
+   * @throws DraftNotFoundException if the draft does not exist
+   */
+  public Draft getDraft(DraftId draftId) throws RuntimeException, DraftNotFoundException {
+    return store.getDraft(draftId).orElseThrow(() -> new DraftNotFoundException(draftId));
+  }
+
+  /**
+   * Write the given draft
+   *
+   * @param draftId {@link DraftId} that is used to uniquely identify a draft
+   * @param draftStoreRequest {@link DraftStoreRequest} that contains the rest of the draft data
+   * @throws RuntimeException when an error occurs while writing to the table
+   */
+  public <T extends ETLConfig> void writeDraft(DraftId draftId,
+                                               DraftStoreRequest<T> draftStoreRequest) {
+    // TODO(CDAP-17456): Add collision detection using the hashes
+    store.writeDraft(draftId, draftStoreRequest);
+
+    metrics.gauge(Constants.Metrics.DRAFT_COUNT, store.getDraftCount());
+  }
+
+  /**
+   * Delete the given draft
+   *
+   * @param draftId {@link DraftId} that is used to uniquely identify a draft
+   * @throws RuntimeException when an error occurs while fetching from the table
+   * @throws DraftNotFoundException if the draft does not exist
+   */
+  public void deleteDraft(DraftId draftId) {
+    // Make sure the draft exists before attempting to delete it
+    getDraft(draftId);
+    store.deleteDraft(draftId);
+
+    metrics.gauge(Constants.Metrics.DRAFT_COUNT, store.getDraftCount());
+  }
+
+  /**
+   * Checks if the given field exists in the {@link DraftStore} table spec. This should be used for validation.
+   *
+   * @param fieldName name of the field to check
+   * @return True if the field exists in the {@link DraftStore} table spec
+   */
+  public boolean fieldExists(String fieldName) {
+    return TABLE_SPEC.getFieldTypes().stream().anyMatch(f -> f.getName().equals(fieldName));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/DraftStore.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/DraftStore.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.draft;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.datapipeline.service.StudioUtil;
+import io.cdap.cdap.etl.proto.v2.DataStreamsConfig;
+import io.cdap.cdap.etl.proto.v2.ETLBatchConfig;
+import io.cdap.cdap.etl.proto.v2.ETLConfig;
+import io.cdap.cdap.spi.data.InvalidFieldException;
+import io.cdap.cdap.spi.data.StructuredRow;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.TableNotFoundException;
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.FieldType;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import org.apache.commons.lang.NotImplementedException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * Schema for draft store.
+ */
+public class DraftStore {
+  public static final StructuredTableId TABLE_ID = new StructuredTableId("drafts");
+  private static final String NAMESPACE_COL = "namespace";
+  private static final String GENERATION_COL = "generation";
+  private static final String OWNER_COL = "owner";
+  private static final String ID_COL = "id";
+  private static final String ARTIFACT_COL = "artifact";
+  private static final String NAME_COL = "name";
+  private static final String DESCRIPTION_COL = "description";
+  private static final String CREATED_COL = "createdTimeMillis";
+  private static final String UPDATED_COL = "updatedTimeMillis";
+  private static final String PIPELINE_COL = "pipeline";
+  private static final String REVISION_COL = "revision";
+  public static final StructuredTableSpecification TABLE_SPEC = new StructuredTableSpecification.Builder()
+    .withId(TABLE_ID)
+    .withFields(Fields.stringType(NAMESPACE_COL),
+                Fields.longType(GENERATION_COL),
+                Fields.stringType(OWNER_COL),
+                Fields.stringType(ID_COL),
+                Fields.stringType(ARTIFACT_COL),
+                Fields.stringType(NAME_COL),
+                Fields.stringType(DESCRIPTION_COL),
+                Fields.longType(CREATED_COL),
+                Fields.longType(UPDATED_COL),
+                Fields.stringType(PIPELINE_COL),
+                Fields.intType(REVISION_COL))
+    .withPrimaryKeys(NAMESPACE_COL, GENERATION_COL, OWNER_COL, ID_COL)
+    .build();
+  private static final Gson GSON = new Gson();
+  private final TransactionRunner transactionRunner;
+
+  public DraftStore(TransactionRunner transactionRunner) {
+    this.transactionRunner = transactionRunner;
+  }
+
+  /**
+   * @param namespace the namespace to fetch the drafts from
+   * @param owner the id of the owner of the drafts
+   * @param sortRequest The sorting that should be applied to the results, pass null if no sorting is required.
+   * @return a list of drafts
+   * @throws TableNotFoundException if the draft store table is not found
+   * @throws InvalidFieldException if the fields Namespace and owner fields do not match the fields in the
+   *   StructuredTable
+   */
+  public List<Draft> listDrafts(NamespaceSummary namespace, String owner,
+                                SortRequest sortRequest,
+                                boolean includeConfig) throws TableNotFoundException, InvalidFieldException {
+    List<Field<?>> prefix = new ArrayList<>(3);
+    prefix.add(Fields.stringField(NAMESPACE_COL, namespace.getName()));
+    prefix.add(Fields.longField(GENERATION_COL, namespace.getGeneration()));
+    prefix.add(Fields.stringField(OWNER_COL, owner));
+
+    List<StructuredRow> rows;
+    rows = TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(TABLE_ID);
+      Range range = Range.singleton(prefix);
+      List<StructuredRow> temp = new ArrayList<>();
+      try (CloseableIterator<StructuredRow> rowIter = table.scan(range, Integer.MAX_VALUE)) {
+        rowIter.forEachRemaining(temp::add);
+      }
+      return temp;
+    }, TableNotFoundException.class, InvalidFieldException.class);
+
+    List<StructuredRow> sortedResults = doSort(rows, sortRequest);
+    return sortedResults.stream().map(row -> fromRow(row, includeConfig)).collect(Collectors.toList());
+  }
+
+  /**
+   * Helper method to apply the sorting onto a list of rows. Sorting needs to take place at the store-level so it can
+   * leverage the StructuredRow to enable sorting on any field.
+   *
+   * @param rows list of {@link StructuredRow} to be sorted
+   * @param sortRequest {@link SortRequest} describing the sort to be performed
+   * @return a sorted list of {@link StructuredRow}
+   */
+  private List<StructuredRow> doSort(List<StructuredRow> rows, @Nullable SortRequest sortRequest) {
+    if (sortRequest == null) {
+      return rows;
+    }
+    String sortField = sortRequest.getFieldName();
+    FieldType field = TABLE_SPEC.getFieldTypes().stream()
+      .filter(f -> f.getName().equals(sortField))
+      .findFirst()
+      .orElse(null);
+    if (field == null) {
+      throw new IllegalArgumentException(
+        String
+          .format("Invalid value '%s' for sortBy. This field does not exist in the Drafts table.",
+                  sortField));
+    }
+
+    FieldType.Type fieldType = field.getType();
+    Comparator<StructuredRow> comparator;
+    switch (fieldType) {
+      case STRING:
+        comparator = Comparator.<StructuredRow, String>comparing(o -> o.getString(sortField));
+        break;
+      case INTEGER:
+        comparator = Comparator.<StructuredRow, Integer>comparing(o -> o.getInteger(sortField));
+        break;
+      case LONG:
+        comparator = Comparator.<StructuredRow, Long>comparing(o -> o.getLong(sortField));
+        break;
+      case FLOAT:
+        comparator = Comparator.<StructuredRow, Float>comparing(o -> o.getFloat(sortField));
+        break;
+      case DOUBLE:
+        comparator = Comparator.<StructuredRow, Double>comparing(o -> o.getDouble(sortField));
+        break;
+      case BYTES:
+        comparator = Comparator.comparing(o -> o.getBytes(sortField), Bytes.BYTES_COMPARATOR);
+        break;
+      default:
+        throw new NotImplementedException(String.format("Cannot sort field '%s' because type '%s' is not supported.",
+                                                        sortField, fieldType.toString()));
+    }
+
+    if (sortRequest.getOrder() != SortRequest.SortOrder.ASC) {
+      comparator = comparator.reversed();
+    }
+
+    rows.sort(comparator);
+
+    return rows;
+  }
+
+  /**
+   * Fetch a given draft if it exists
+   *
+   * @param id {@link DraftId} that is used to uniquely identify a draft
+   * @return an {@link Optional<Draft>} representing the requested draft
+   * @throws TableNotFoundException if the draft store table is not found
+   * @throws InvalidFieldException if the fields in the {@link DraftId} object do not match the fields in the
+   *   StructuredTable
+   */
+  public Optional<Draft> getDraft(DraftId id) throws TableNotFoundException, InvalidFieldException {
+    return TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(TABLE_ID);
+      Optional<StructuredRow> row = table.read(getKey(id));
+      return row.map(this::fromRow);
+    }, TableNotFoundException.class, InvalidFieldException.class);
+  }
+
+  /**
+   * Delete the given draft. This is a no-op if the draft does not exist
+   *
+   * @param id {@link DraftId} that is used to uniquely identify a draft
+   * @throws TableNotFoundException if the draft store table is not found
+   * @throws InvalidFieldException if the fields in the {@link Draft} object do not match the fields in the
+   *   StructuredTable
+   */
+  public void deleteDraft(DraftId id) throws TableNotFoundException, InvalidFieldException {
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(TABLE_ID);
+      table.delete(getKey(id));
+    }, TableNotFoundException.class, InvalidFieldException.class);
+  }
+
+  /**
+   * Create/update the given draft
+   *
+   * @param id {@link DraftId} that is used to uniquely identify a draft
+   * @param request {@link DraftStoreRequest} that contains the rest of the draft data
+   * @throws TableNotFoundException if the draft store table is not found
+   * @throws InvalidFieldException if the fields in the {@link Draft} or {@link DraftStoreRequest} objects do not
+   *   match the fields in the StructuredTable
+   */
+  public <T extends ETLConfig> void writeDraft(DraftId id, DraftStoreRequest<T> request)
+    throws TableNotFoundException, InvalidFieldException {
+
+    Optional<Draft> existing = getDraft(id);
+    long now = System.currentTimeMillis();
+    long createTime = existing.map(Draft::getCreatedTimeMillis).orElse(now);
+
+    Draft draft = new Draft(request.getConfig(), request.getName(), request.getDescription(), request.getArtifact(),
+                            id.getId(), createTime, now);
+
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(TABLE_ID);
+      table.upsert(getRow(id, draft));
+    }, TableNotFoundException.class, InvalidFieldException.class);
+  }
+
+  /**
+   * Returns the count of drafts in the table
+   *
+   * @return long value presenting the number of drafts in the table
+   * @throws TableNotFoundException if the draft store table is not found
+   */
+  public long getDraftCount() throws TableNotFoundException {
+    return TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable table = context.getTable(TABLE_ID);
+      return table.count(Collections.singleton(Range.all()));
+    }, TableNotFoundException.class);
+  }
+
+  private void addKeyFields(DraftId id, List<Field<?>> fields) {
+    fields.add(Fields.stringField(NAMESPACE_COL, id.getNamespace().getName()));
+    fields.add(Fields.longField(GENERATION_COL, id.getNamespace().getGeneration()));
+    fields.add(Fields.stringField(OWNER_COL, id.getOwner()));
+    fields.add(Fields.stringField(ID_COL, id.getId()));
+  }
+
+  private List<Field<?>> getKey(DraftId id) {
+    List<Field<?>> keyFields = new ArrayList<>(4);
+    addKeyFields(id, keyFields);
+    return keyFields;
+  }
+
+  private List<Field<?>> getRow(DraftId id, Draft draft) {
+    List<Field<?>> fields = new ArrayList<>(11);
+    addKeyFields(id, fields);
+    fields.add(Fields.stringField(ARTIFACT_COL, GSON.toJson(draft.getArtifact())));
+    fields.add(Fields.stringField(NAME_COL, draft.getName()));
+    fields.add(Fields.stringField(DESCRIPTION_COL, draft.getDescription()));
+    fields.add(Fields.longField(CREATED_COL, draft.getCreatedTimeMillis()));
+    fields.add(Fields.longField(UPDATED_COL, draft.getUpdatedTimeMillis()));
+    fields.add(Fields.stringField(PIPELINE_COL, GSON.toJson(draft.getConfig())));
+    fields.add(Fields.intField(REVISION_COL, draft.getRevision()));
+
+    return fields;
+  }
+
+  private Draft fromRow(StructuredRow row) {
+    return fromRow(row, true);
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private Draft fromRow(StructuredRow row, boolean includeConfig) {
+    String id = row.getString(ID_COL);
+    String name = row.getString(NAME_COL);
+    String description = row.getString(DESCRIPTION_COL);
+    long createTime = row.getLong(CREATED_COL);
+    long updateTime = row.getLong(UPDATED_COL);
+
+    String artifactStr = row.getString(ARTIFACT_COL);
+    ArtifactSummary artifact = GSON.fromJson(artifactStr, ArtifactSummary.class);
+    String configStr = row.getString(PIPELINE_COL);
+    ETLConfig config = null;
+    if (includeConfig) {
+      if (StudioUtil.isBatchPipeline(artifact)) {
+        config = GSON.fromJson(configStr, ETLBatchConfig.class);
+      } else if (StudioUtil.isStreamingPipeline(artifact)) {
+        config = GSON.fromJson(configStr, DataStreamsConfig.class);
+      } else {
+        throw new
+          IllegalArgumentException(
+          String.format("Failed to parse pipeline config string: %s is not a supported pipeline type",
+                        artifact.getName()));
+      }
+    }
+
+    return new Draft(config, name, description, artifact, id, createTime, updateTime);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/DraftStoreRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/DraftStoreRequest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.draft;
+
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Request to store a draft.
+ *
+ * @param <T> Type of config that this DraftRequest contains
+ */
+public class DraftStoreRequest<T> {
+  private final String previousHash;
+  private final String name;
+  private final String description;
+  private final int revision;
+  private final ArtifactSummary artifact;
+  private final T config;
+
+  public DraftStoreRequest(@Nullable T config, String previousHash, String name, String description, int revision,
+                           @Nullable ArtifactSummary artifact) {
+    this.config = config;
+    this.previousHash = previousHash;
+    this.name = name;
+    this.description = description;
+    this.revision = revision;
+    this.artifact = artifact;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getName() {
+    return name == null ? "" : name;
+  }
+
+  @Nullable
+  public ArtifactSummary getArtifact() {
+    return artifact;
+  }
+
+  @Nullable
+  public T getConfig() {
+    return config;
+  }
+
+  /**
+   * Getter for the revision number. This will be used later on to enable draft version tracking.
+   *
+   * @return
+   */
+  public int getRevision() {
+    return revision;
+  }
+
+  /**
+   * Getter for previousHash. This field will be used later on to detect collision in drafts. It represents the hashcode
+   * that was provided by the backend when the draft was fetched. That hashcode will be passed when the client makes a
+   * save request and the backend can check against the current hash to see if the draft has been modified since the
+   * client fetched the draft.
+   *
+   * @return
+   */
+  public String getPreviousHash() {
+    return previousHash;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DraftStoreRequest<T> that = (DraftStoreRequest<T>) o;
+    return Objects.equals(config, that.config) &&
+      Objects.equals(previousHash, that.previousHash) &&
+      Objects.equals(name, that.name) &&
+      Objects.equals(artifact, that.artifact) &&
+      revision == that.revision;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(config, previousHash, revision, artifact, name, description);
+  }
+}
+

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/SortRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/draft/SortRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.draft;
+
+import java.util.Arrays;
+
+/**
+ * Class to hold information for a sorting request in a list API
+ */
+public class SortRequest {
+  private final String fieldName;
+  private final SortOrder order;
+
+  public SortRequest(String fieldName, String sortOrder) {
+    this.fieldName = fieldName;
+    try {
+      this.order = SortOrder.valueOf(sortOrder.toUpperCase());
+    } catch (Exception e) {
+      throw new IllegalArgumentException(String.format("Sort order '%s' is not valid. Valid options are %s", sortOrder,
+                                                       Arrays.toString(SortOrder.values())));
+    }
+  }
+
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  public SortOrder getOrder() {
+    return order;
+  }
+
+  enum SortOrder {
+    ASC,
+    DESC
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/DraftHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/DraftHandler.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.metrics.Metrics;
+import io.cdap.cdap.api.service.http.AbstractSystemHttpServiceHandler;
+import io.cdap.cdap.api.service.http.HttpServiceRequest;
+import io.cdap.cdap.api.service.http.HttpServiceResponder;
+import io.cdap.cdap.api.service.http.SystemHttpServiceContext;
+import io.cdap.cdap.datapipeline.draft.CodedException;
+import io.cdap.cdap.datapipeline.draft.DraftId;
+import io.cdap.cdap.datapipeline.draft.DraftService;
+import io.cdap.cdap.datapipeline.draft.DraftStoreRequest;
+import io.cdap.cdap.datapipeline.draft.SortRequest;
+import io.cdap.cdap.etl.proto.v2.DataStreamsConfig;
+import io.cdap.cdap.etl.proto.v2.ETLBatchConfig;
+import io.cdap.cdap.etl.proto.v2.ETLConfig;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import javax.annotation.Nullable;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * Handler of drafts
+ */
+//@Path("v1/contexts/{context}")
+public class DraftHandler extends AbstractSystemHttpServiceHandler {
+  private static final String API_VERSION = "v1";
+  private static final Gson GSON = new GsonBuilder()
+    .setPrettyPrinting()
+    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+    .create();
+
+  // Injected by CDAP
+  @SuppressWarnings("unused")
+  private Metrics metrics;
+
+  private DraftService draftService;
+
+  @Override
+  public void initialize(SystemHttpServiceContext context) throws Exception {
+    super.initialize(context);
+    this.draftService = new DraftService(context, this.metrics);
+  }
+
+  /**
+   * Returns a list of drafts associated with a namespace and the current user
+   */
+  @GET
+  @Path(API_VERSION + "/contexts/{context}/drafts/")
+  public void listDrafts(HttpServiceRequest request, HttpServiceResponder responder,
+                         @PathParam("context") String namespaceName,
+                         @QueryParam("includeConfig") @DefaultValue("false") boolean includeConfig,
+                         @QueryParam("sortBy") @DefaultValue("name") String sortBy,
+                         @QueryParam("sortOrder") @DefaultValue("ASC") String sortOrder,
+                         @QueryParam("filter") @Nullable String filter) {
+
+    respond(namespaceName, responder, (namespace) -> {
+      if (!draftService.fieldExists(sortBy)) {
+        throw new IllegalArgumentException(String.format(
+          "Invalid value '%s' for sortBy. This field does not exist in the Drafts table.", sortBy));
+      }
+
+      SortRequest sortRequest = new SortRequest(sortBy, sortOrder);
+      responder.sendJson(draftService.listDrafts(namespace, request.getUserId(), includeConfig, sortRequest, filter));
+    });
+  }
+
+  /**
+   * Gets the details of a draft
+   */
+  @GET
+  @Path(API_VERSION + "/contexts/{context}/drafts/{draft}/")
+  public void getDraft(HttpServiceRequest request, HttpServiceResponder responder,
+                       @PathParam("context") String namespaceName,
+                       @PathParam("draft") String draftId) {
+    respond(namespaceName, responder, (namespace) -> {
+      DraftId id = new DraftId(namespace, draftId, request.getUserId());
+      responder.sendJson(draftService.getDraft(id));
+    });
+  }
+
+  /**
+   * Creates or updates a draft
+   */
+  @PUT
+  @Path(API_VERSION + "/contexts/{context}/drafts/{draft}/")
+  public void putDraft(HttpServiceRequest request, HttpServiceResponder responder,
+                       @PathParam("context") String namespaceName,
+                       @PathParam("draft") String draftId) {
+
+    respond(namespaceName, responder, (namespace) -> {
+
+      String requestStr = StandardCharsets.UTF_8.decode(request.getContent()).toString();
+      DraftStoreRequest<ETLConfig> draftStoreRequest = deserializeDraftStoreRequest(requestStr);
+
+      DraftId id = new DraftId(namespace, draftId, request.getUserId());
+      draftService.writeDraft(id, draftStoreRequest);
+
+      responder.sendStatus(HttpURLConnection.HTTP_OK);
+    });
+  }
+
+  /**
+   * Deletes a draft
+   */
+  @DELETE
+  @Path(API_VERSION + "/contexts/{context}/drafts/{draft}/")
+  public void deleteDraft(HttpServiceRequest request, HttpServiceResponder responder,
+                          @PathParam("context") String namespaceName,
+                          @PathParam("draft") String draftId) {
+    respond(namespaceName, responder, (namespace) -> {
+      DraftId id = new DraftId(namespace, draftId, request.getUserId());
+
+      draftService.deleteDraft(id);
+      responder.sendStatus(HttpURLConnection.HTTP_OK);
+    });
+  }
+
+  /**
+   * Utility method to correct deserialize the config field in the {@link DraftStoreRequest} object
+   *
+   * @param jsonStr the json string representing the DraftStoreRequest
+   * @return {@link DraftStoreRequest} object
+   */
+  private DraftStoreRequest<ETLConfig> deserializeDraftStoreRequest(String jsonStr) {
+    try {
+      DraftStoreRequest<ETLConfig> request = GSON
+        .fromJson(jsonStr, new TypeToken<DraftStoreRequest<ETLConfig>>() { }.getType());
+
+      if (request.getArtifact() == null) {
+        throw new IllegalArgumentException("artifact is null");
+      }
+
+      if (StudioUtil.isBatchPipeline(request.getArtifact())) {
+        return GSON.fromJson(jsonStr, new TypeToken<DraftStoreRequest<ETLBatchConfig>>() { }.getType());
+      }
+      if (StudioUtil.isStreamingPipeline(request.getArtifact())) {
+        return GSON.fromJson(jsonStr, new TypeToken<DraftStoreRequest<DataStreamsConfig>>() { }.getType());
+      }
+
+      throw new IllegalArgumentException(String.format(
+        "Invalid config: artifact '%s' is not supported, valid options are: '%s' or '%s'",
+        request.getArtifact().getName(), StudioUtil.ARTIFACT_BATCH_NAME, StudioUtil.ARTIFACT_STREAMING_NAME));
+    } catch (JsonSyntaxException e) {
+      throw new IllegalArgumentException("Unable to decode request body: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Utility method that checks that the namespace exists and fetches current user before responding.
+   */
+  private void respond(String namespaceName, HttpServiceResponder responder, NamespacedEndpoint endpoint) {
+    SystemHttpServiceContext context = getContext();
+    NamespaceSummary namespaceSummary;
+    try {
+      namespaceSummary = context.getAdmin().getNamespaceSummary(namespaceName);
+      if (namespaceSummary == null) {
+        responder.sendError(HttpURLConnection.HTTP_NOT_FOUND, String.format("Namespace '%s' not found", namespaceName));
+      }
+    } catch (IOException e) {
+      responder.sendError(HttpURLConnection.HTTP_INTERNAL_ERROR,
+                          String.format("Unable to check if namespace '%s' exists.", namespaceName));
+      return;
+    }
+
+    try {
+      endpoint.respond(namespaceSummary);
+    } catch (CodedException e) {
+      responder.sendError(e.getCode(), e.getMessage());
+    } catch (IllegalArgumentException e) {
+      responder.sendError(HttpURLConnection.HTTP_BAD_REQUEST, e.getMessage());
+    } catch (Exception e) {
+      responder.sendError(HttpURLConnection.HTTP_INTERNAL_ERROR, e.getMessage());
+    }
+  }
+
+  /**
+   * Encapsulates the core logic that needs to happen in an endpoint.
+   */
+  private interface NamespacedEndpoint {
+
+    /**
+     * Create the response that should be returned by the endpoint.
+     */
+    void respond(NamespaceSummary namespace) throws Exception;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/StudioService.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/StudioService.java
@@ -18,6 +18,7 @@
 package io.cdap.cdap.datapipeline.service;
 
 import io.cdap.cdap.api.service.AbstractSystemService;
+import io.cdap.cdap.datapipeline.draft.DraftStore;
 
 /**
  * Service that handles pipeline studio operations, like validation and schema propagation.
@@ -27,8 +28,11 @@ public class StudioService extends AbstractSystemService {
 
   @Override
   protected void configure() {
+
     setName(NAME);
     setDescription("Handles pipeline studio operations, like validation and schema propagation.");
     addHandler(new ValidationHandler());
+    addHandler(new DraftHandler());
+    createTable(DraftStore.TABLE_SPEC);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/StudioUtil.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/StudioUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+
+import javax.annotation.Nullable;
+
+/**
+ * Helper functions for handlers/services in {@link io.cdap.cdap.datapipeline.service.StudioService}
+ */
+public final class StudioUtil {
+  public static final String ARTIFACT_BATCH_NAME = "cdap-data-pipeline";
+  public static final String ARTIFACT_STREAMING_NAME = "cdap-data-streams";
+
+  private StudioUtil() {
+    // prevent instantiation of util class.
+  }
+
+  public static boolean isBatchPipeline(@Nullable ArtifactSummary artifactSummary) {
+    if (artifactSummary == null) {
+      return false;
+    }
+    return ARTIFACT_BATCH_NAME.equals(artifactSummary.getName());
+  }
+
+  public static boolean isStreamingPipeline(@Nullable ArtifactSummary artifactSummary) {
+    if (artifactSummary == null) {
+      return false;
+    }
+    return ARTIFACT_STREAMING_NAME.equals(artifactSummary.getName());
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/ValidationHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/ValidationHandler.java
@@ -72,8 +72,6 @@ public class ValidationHandler extends AbstractSystemHttpServiceHandler {
     .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
     .create();
   private static final Type APP_REQUEST_TYPE = new TypeToken<AppRequest<JsonObject>>() { }.getType();
-  private static final String ARTIFACT_BATCH_NAME = "cdap-data-pipeline";
-  private static final String ARTIFACT_STREAMING_NAME = "cdap-data-streams";
 
   @GET
   @Path("v1/health")
@@ -164,15 +162,15 @@ public class ValidationHandler extends AbstractSystemHttpServiceHandler {
     }
 
     ArtifactSummary artifactSummary = appRequest.getArtifact();
-    String artifactName = artifactSummary.getName();
-    if (ARTIFACT_BATCH_NAME.equals(artifactName)) {
+
+    if (StudioUtil.isBatchPipeline(artifactSummary)) {
       responder.sendJson(validateBatchPipeline(appRequest));
-    } else if (ARTIFACT_STREAMING_NAME.equals(artifactName)) {
+    } else if (StudioUtil.isStreamingPipeline(artifactSummary)) {
       responder.sendJson(validateStreamingPipeline(appRequest));
     } else {
       responder.sendError(HttpURLConnection.HTTP_BAD_REQUEST,
-                          String.format("Invalid artifact '%s'. Must be '%s' or '%s'.", artifactName,
-                                        ARTIFACT_BATCH_NAME, ARTIFACT_STREAMING_NAME));
+                          String.format("Invalid artifact '%s'. Must be '%s' or '%s'.", artifactSummary.getName(),
+                                        StudioUtil.ARTIFACT_BATCH_NAME, StudioUtil.ARTIFACT_STREAMING_NAME));
     }
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
@@ -89,7 +89,7 @@ public class DataPipelineServiceTest extends HydratorTestBase {
   public static final String STAGE = "stage";
 
   private static ServiceManager serviceManager;
-  private static URI serviceURI;
+  static URI serviceURI;
 
   @ClassRule
   public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false,

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DraftServiceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/DraftServiceTest.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline;
+
+import com.google.common.base.Strings;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import io.cdap.cdap.api.NamespaceSummary;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.datapipeline.draft.Draft;
+import io.cdap.cdap.datapipeline.draft.DraftId;
+import io.cdap.cdap.datapipeline.draft.DraftNotFoundException;
+import io.cdap.cdap.datapipeline.draft.DraftStoreRequest;
+import io.cdap.cdap.datapipeline.service.StudioUtil;
+import io.cdap.cdap.etl.api.Engine;
+import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.mock.batch.MockSink;
+import io.cdap.cdap.etl.mock.batch.MockSource;
+import io.cdap.cdap.etl.proto.v2.DataStreamsConfig;
+import io.cdap.cdap.etl.proto.v2.ETLBatchConfig;
+import io.cdap.cdap.etl.proto.v2.ETLConfig;
+import io.cdap.cdap.etl.proto.v2.ETLStage;
+import io.cdap.cdap.internal.guava.reflect.TypeToken;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class DraftServiceTest extends DataPipelineServiceTest {
+
+  private static final Gson GSON = new GsonBuilder()
+      .setPrettyPrinting()
+      .registerTypeAdapter(Draft.class, new DraftTypeAdapter())
+      .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+      .create();
+
+  private enum DraftType {
+    Batch,
+    Streaming
+  }
+
+  @Test
+  public void testGetDraftError() throws IOException {
+    //Attempt to fetch an invalid draft from a valid namespace
+    NamespaceSummary namespace = new NamespaceSummary(NamespaceId.DEFAULT.getNamespace(), "", 0);
+    DraftId invalidId = new DraftId(namespace, "non-existent", "");
+    HttpResponse response = fetchDraft(invalidId);
+    DraftNotFoundException draftError = new DraftNotFoundException(invalidId);
+    Assert.assertEquals(404, response.getResponseCode());
+    Assert.assertEquals(draftError.getMessage(), response.getResponseBodyAsString());
+
+    //Attempt to fetch a valid draft but invalid namespace
+    DraftId draftId = new DraftId(namespace, "test-draft", "");
+    createBatchPipelineDraft(draftId, "TestPipeline1", "This is a test pipeline.");
+    NamespaceSummary invalidNamespace = new NamespaceSummary("non-existent", "", 0);
+    response = fetchDraft(new DraftId(invalidNamespace, "test-draft", ""));
+    Assert.assertEquals(500, response.getResponseCode());
+
+    // Sanity check, get the draft we just created
+    getDraft(draftId);
+
+    //Clean up
+    deleteDraftAndCheck(draftId);
+  }
+
+  @Test
+  public void testDeleteDraftError() throws IOException {
+    //Attempt to delete a draft that does not exist
+    NamespaceSummary namespace = new NamespaceSummary(NamespaceId.DEFAULT.getNamespace(), "", 0);
+    HttpResponse response = deleteDraft(new DraftId(namespace, "non-existent", ""));
+    Assert.assertEquals(404, response.getResponseCode());
+  }
+
+  @Test
+  public void testCreateAndDeleteBatchDraft()
+      throws Exception {
+    testCreateAndDeleteDraft(DraftType.Batch);
+  }
+
+  @Test
+  public void testCreateAndDeleteStreamingDraft()
+      throws Exception {
+    testCreateAndDeleteDraft(DraftType.Streaming);
+  }
+
+  private void testCreateAndDeleteDraft(
+      DraftType draftType) throws IOException, TimeoutException, InterruptedException, ExecutionException {
+    NamespaceSummary namespace = new NamespaceSummary(NamespaceId.DEFAULT.getNamespace(), "", 0);
+
+    DraftId draftId = new DraftId(namespace, "test-1", "admin");
+    Draft expectedDraft;
+    if (draftType == DraftType.Batch) {
+      expectedDraft = createBatchPipelineDraft(draftId, "TestPipeline1",
+          "This is a test pipeline.");
+    } else {
+      expectedDraft = createStreamingPipelineDraft(draftId, "TestPipeline1",
+          "This is a test pipeline.");
+    }
+
+    Draft fetchedDraft = getDraft(draftId);
+    Assert.assertTrue(sameDraft(fetchedDraft, expectedDraft));
+    validateMetric(1, Constants.Metrics.DRAFT_COUNT);
+
+    deleteDraftAndCheck(draftId);
+    validateMetric(0, Constants.Metrics.DRAFT_COUNT);
+  }
+
+  @Test
+  public void testListBatchDraftFilter()
+      throws Exception {
+    testListDraftFilter(DraftType.Batch);
+  }
+
+  @Test
+  public void testListStreamingDraftFilter()
+      throws Exception {
+    testListDraftFilter(DraftType.Streaming);
+  }
+
+  private void testListDraftFilter(DraftType draftType)
+    throws IOException, TimeoutException, InterruptedException, ExecutionException {
+    //Create 2 drafts per namespace, each belonging to a different user
+    NamespaceSummary namespace = new NamespaceSummary(NamespaceId.DEFAULT.getNamespace(), "", 0);
+    String user = "";
+
+    List<DraftId> draftsToCleanUp = new ArrayList<>();
+    for (int i = 0; i < 4; i++) {
+      String id = String.format("draft-%d", i);
+      String name = String.format("draft-name-%d", i);
+      DraftId draftId = new DraftId(namespace, id, user);
+      draftsToCleanUp.add(draftId);
+      if (draftType == DraftType.Batch) {
+        createBatchPipelineDraft(draftId, name, "This is a test pipeline.");
+      } else {
+        createStreamingPipelineDraft(draftId, name, "This is a test pipeline.");
+      }
+    }
+
+    // Test getting drafts for the default namespace
+    List<Draft> drafts = listDrafts(NamespaceId.DEFAULT.getNamespace(), false, "", "", "");
+    Assert.assertEquals(4, drafts.size());
+    drafts.forEach(draft -> Assert.assertNull(draft.getConfig()));
+    validateMetric(4, Constants.Metrics.DRAFT_COUNT);
+
+    //Check that the default sorting is correct
+    String[] expectedOrder = new String[]{"draft-name-0", "draft-name-1", "draft-name-2",
+        "draft-name-3"};
+    Assert.assertArrayEquals(drafts.stream().map(DraftStoreRequest::getName).toArray(), expectedOrder);
+
+    // Test getting drafts for the default namespace and sorting on id column with descending order
+    drafts = listDrafts(NamespaceId.DEFAULT.getNamespace(), false, "id", "DESC", "");
+    Assert.assertEquals(4, drafts.size());
+    String[] expectedReverseOrder = new String[]{"draft-3", "draft-2", "draft-1", "draft-0"};
+    Assert.assertArrayEquals(drafts.stream().map(Draft::getId).toArray(), expectedReverseOrder);
+
+    // Test filtering on draft name using a filter with 0 matches
+    drafts = listDrafts(NamespaceId.DEFAULT.getNamespace(), false, "", "", "nomatches");
+    Assert.assertEquals(drafts.size(), 0);
+
+    // Test filtering on draft name using a filter with 1 match and include the config
+    Draft specialDraft;
+    DraftId specialDraftId = new DraftId(namespace, "newDraft", "");
+    draftsToCleanUp.add(specialDraftId);
+    if (draftType == DraftType.Batch) {
+      specialDraft = createBatchPipelineDraft(specialDraftId, "SpecialDraft",
+          "This is a special pipeline.");
+    } else {
+      specialDraft = createStreamingPipelineDraft(specialDraftId, "SpecialDraft",
+          "This is a special pipeline.");
+    }
+
+    drafts = listDrafts(NamespaceId.DEFAULT.getNamespace(), true, "", "", "spe");
+    Assert.assertEquals(drafts.size(), 1);
+    Assert.assertTrue(
+        sameDraft(drafts.get(0), specialDraft)); //This confirms that the config was included
+
+    //List with all options enabled
+    drafts = listDrafts(NamespaceId.DEFAULT.getNamespace(), true, "id", "DESC", "draft");
+    Assert.assertEquals(drafts.size(), 4); //Confirm special draft is not present
+    drafts.forEach(
+        draft -> Assert.assertNotNull(draft.getConfig())); //Confirm that config was included
+    Assert.assertArrayEquals(drafts.stream().map(Draft::getId).toArray(),
+        expectedReverseOrder); // Confirm sorting
+
+    //Cleanup
+    for (DraftId draftId : draftsToCleanUp) {
+      deleteDraftAndCheck(draftId);
+    }
+  }
+
+  private List<Draft> listDrafts(String namespaceName, boolean includeConfig, String sortBy,
+      String sortOrder,
+      String filter) throws IOException {
+    List<String> queryParams = new ArrayList<>();
+    if (includeConfig) {
+      queryParams.add("includeConfig=true");
+    }
+    if (!Strings.isNullOrEmpty(sortBy)) {
+      queryParams.add(String.format("sortBy=%s", URLEncoder.encode(sortBy, "UTF-8")));
+    }
+    if (!Strings.isNullOrEmpty(sortOrder)) {
+      queryParams.add(String.format("sortOrder=%s", URLEncoder.encode(sortOrder, "UTF-8")));
+    }
+    if (!Strings.isNullOrEmpty(filter)) {
+      queryParams.add(String.format("filter=%s", URLEncoder.encode(filter, "UTF-8")));
+    }
+
+    URL draftURL = serviceURI
+        .resolve(String
+            .format("v1/contexts/%s/drafts/?%s", namespaceName, String.join("&", queryParams)))
+        .toURL();
+    HttpRequest request = HttpRequest.builder(HttpMethod.GET, draftURL)
+        .build();
+    HttpResponse response = HttpRequests.execute(request, new DefaultHttpRequestConfig(false));
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), new TypeToken<ArrayList<Draft>>() {
+    }.getType());
+  }
+
+  private HttpResponse deleteDraft(DraftId draftId) throws IOException {
+    URL draftURL = serviceURI
+        .resolve(String
+            .format("v1/contexts/%s/drafts/%s", draftId.getNamespace().getName(), draftId.getId()))
+        .toURL();
+    HttpRequest request = HttpRequest.builder(HttpMethod.DELETE, draftURL)
+        .build();
+    HttpResponse response = HttpRequests.execute(request, new DefaultHttpRequestConfig(false));
+    return response;
+  }
+
+  private void deleteDraftAndCheck(DraftId draftId) throws IOException {
+    HttpResponse response = deleteDraft(draftId);
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  private HttpResponse fetchDraft(DraftId draftId) throws IOException {
+    URL draftURL = serviceURI
+        .resolve(String
+            .format("v1/contexts/%s/drafts/%s", draftId.getNamespace().getName(), draftId.getId()))
+        .toURL();
+    HttpRequest request = HttpRequest.builder(HttpMethod.GET, draftURL)
+        .build();
+    HttpResponse response = HttpRequests.execute(request, new DefaultHttpRequestConfig(false));
+    return response;
+  }
+
+  private Draft getDraft(DraftId draftId) throws IOException {
+    HttpResponse response = fetchDraft(draftId);
+    Assert.assertEquals(200, response.getResponseCode());
+    return GSON.fromJson(response.getResponseBodyAsString(), Draft.class);
+  }
+
+  private Draft createBatchPipelineDraft(DraftId draftId, String name, String description)
+      throws IOException {
+    ArtifactSummary artifact = new ArtifactSummary("cdap-data-pipeline", "1.0.0");
+    ETLBatchConfig config = ETLBatchConfig.builder()
+        .addStage(new ETLStage("src", MockSource.getPlugin("dummy1")))
+        .addStage(new ETLStage("sink", MockSink.getPlugin("dummy2")))
+        .addConnection("src", "sink")
+        .setEngine(Engine.SPARK)
+        .build();
+
+    DraftStoreRequest<ETLBatchConfig> batchDraftStoreRequest = new DraftStoreRequest<>(config, "", name,
+                                                                                       description, 0, artifact);
+
+    long now = System.currentTimeMillis();
+    Draft expectedDraft = new Draft(config, name, description, artifact, draftId.getId(), now, now);
+
+    createPipelineDraft(draftId, batchDraftStoreRequest);
+    return expectedDraft;
+  }
+
+  private Draft createStreamingPipelineDraft(DraftId draftId, String name, String description)
+      throws IOException {
+    ArtifactSummary artifact = new ArtifactSummary("cdap-data-streams", "1.0.0");
+    DataStreamsConfig config = DataStreamsConfig.builder()
+        .addStage(new ETLStage("src", MockSource.getPlugin("dummy1")))
+        .addStage(new ETLStage("sink", MockSink.getPlugin("dummy2")))
+        .addConnection("src", "sink")
+        .setCheckpointDir("temp/dir")
+        .build();
+
+    DraftStoreRequest<DataStreamsConfig> batchDraftStoreRequest = new DraftStoreRequest<>(config, "", name,
+                                                                                          description, 0, artifact);
+
+    long now = System.currentTimeMillis();
+    Draft expectedDraft = new Draft(config, name, description, artifact, draftId.getId(), now, now);
+
+    createPipelineDraft(draftId, batchDraftStoreRequest);
+    return expectedDraft;
+  }
+
+  private void createPipelineDraft(DraftId draftId, DraftStoreRequest draftStoreRequest) throws IOException {
+    URL createDraftURL = serviceURI
+        .resolve(String
+            .format("v1/contexts/%s/drafts/%s", draftId.getNamespace().getName(), draftId.getId()))
+        .toURL();
+    HttpRequest request = HttpRequest.builder(HttpMethod.PUT, createDraftURL)
+        .withBody(GSON.toJson(draftStoreRequest))
+        .build();
+    HttpResponse response = HttpRequests.execute(request, new DefaultHttpRequestConfig(false));
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  /**
+   * Helper method for checking if two drafts have all the same properties and create/update times
+   * that are within 1 second of each other.
+   *
+   * @param d1 draft to compare
+   * @param d2 draft to compare
+   * @return True if the drafts have all the same properties and create/update times within 1sec
+   */
+  private boolean sameDraft(Draft d1, Draft d2) {
+    boolean sameCreateTime = Math.abs(d1.getCreatedTimeMillis() - d2.getCreatedTimeMillis()) < 1000;
+    boolean sameUpdateTime = Math.abs(d1.getUpdatedTimeMillis() - d2.getUpdatedTimeMillis()) < 1000;
+    boolean sameProperties = d1.getRevision() == d2.getRevision() &&
+        Objects.equals(d1.getConfig(), d2.getConfig()) &&
+        Objects.equals(d1.getPreviousHash(), d2.getPreviousHash()) &&
+        Objects.equals(d1.getName(), d2.getName()) &&
+        Objects.equals(d1.getDescription(), d2.getDescription()) &&
+        Objects.equals(d1.getId(), d2.getId()) &&
+        Objects.equals(d1.getArtifact(), d2.getArtifact());
+
+    return sameProperties && sameCreateTime && sameUpdateTime;
+  }
+
+  private void validateMetric(long expected, String metric)
+    throws TimeoutException, InterruptedException, ExecutionException {
+
+    getMetricsManager()
+        .waitForExactMetricCount(Collections.EMPTY_MAP, "user." + metric, expected, 20,
+            TimeUnit.SECONDS);
+    Assert.assertEquals(expected,
+        getMetricsManager().getTotalMetric(Collections.EMPTY_MAP, "user." + metric));
+  }
+
+  /**
+   * Type adapter that is only needed for unit tests to deserialize drafts returned by REST API
+   */
+  private static class DraftTypeAdapter implements JsonDeserializer<Draft> {
+
+    @Override
+    public Draft deserialize(JsonElement jsonElement, Type type,
+        JsonDeserializationContext context) throws JsonParseException {
+      Gson gson = new GsonBuilder().create();
+      Draft draft = gson.fromJson(jsonElement, Draft.class);
+      ETLConfig config;
+      if (StudioUtil.isBatchPipeline(draft.getArtifact())) {
+        config = context
+            .deserialize(jsonElement.getAsJsonObject().get("config"), ETLBatchConfig.class);
+      } else if (StudioUtil.isStreamingPipeline(draft.getArtifact())) {
+        config = context
+            .deserialize(jsonElement.getAsJsonObject().get("config"), DataStreamsConfig.class);
+      } else {
+        throw new IllegalArgumentException(String
+            .format(
+                "Artifact name '%s' is not supported. Valid options are %s or %s",
+                draft.getArtifact().getName(),
+                StudioUtil.ARTIFACT_BATCH_NAME,
+                StudioUtil.ARTIFACT_STREAMING_NAME));
+      }
+      return new Draft(config, draft.getName(), draft.getDescription(), draft.getArtifact(),
+          draft.getId(),          draft.getCreatedTimeMillis(), draft.getUpdatedTimeMillis());
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
@@ -66,6 +66,7 @@ public final class Constants {
     public static final String RECORDS_ALERT = "records.alert";
     public static final String AGG_GROUPS = "aggregator.groups";
     public static final String JOIN_KEYS = "joiner.keys";
+    public static final String DRAFT_COUNT = "draft.count";
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLStage.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLStage.java
@@ -44,6 +44,7 @@ public final class ETLStage {
   private final Object inputSchema;
   private final Object outputSchema;
   private final String label;
+  private final String id;
 
   private static final Logger LOG = LoggerFactory.getLogger(ETLStage.class);
 
@@ -54,16 +55,18 @@ public final class ETLStage {
     inputSchema = null;
     outputSchema = null;
     label = null;
+    id = null;
   }
 
   // Used only for upgrade stage purpose.
-  private ETLStage(String name, ETLPlugin plugin, String label, Object inputSchema, Object outputSchema) {
+  private ETLStage(String name, ETLPlugin plugin, String label, Object inputSchema, Object outputSchema, String id) {
     this.name = name;
     this.plugin = plugin;
     this.errorDatasetName = null;
     this.inputSchema = inputSchema;
     this.outputSchema = outputSchema;
     this.label = label;
+    this.id = id;
   }
 
   public String getName() {
@@ -121,7 +124,7 @@ public final class ETLStage {
       switch (updateAction) {
         case UPGRADE_ARTIFACT:
           return new io.cdap.cdap.etl.proto.v2.ETLStage(name, upgradePlugin(updateContext), label, inputSchema,
-                                                        outputSchema);
+                                                        outputSchema, id);
         default:
           return this;
         }


### PR DESCRIPTION
This PR adds support for managing drafts within the data pipeline app.

Main changes:

Created various classes to represent drafts and draft-related exceptions
Added new draft.count metric that tracks the number of drafts across all namespaces and users
Created a new StructuredTable to store drafts
Created service class to interact with the drafts store
Create a HTTPHandler to expose various endpoints for listing, getting, creating/updating and deleting drafts
Unit tests to test 100% of all new draft related methods