### PR TITLE
CDAP-16527 include field name in casting errors for records

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/data/format/StructuredRecord.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/data/format/StructuredRecord.java
@@ -223,8 +223,8 @@ public class StructuredRecord implements Serializable {
     try {
       return new BigDecimal(new BigInteger((byte[]) value), scale);
     } catch (ClassCastException e) {
-      throw new UnexpectedFormatException(String.format("Field '%s' is expected to be a %s, but is a %s.", fieldName,
-                                                        "decimal", value.getClass().getSimpleName()), e);
+      throw new ClassCastException(String.format("Field '%s' is expected to be a decimal, but is a %s.", fieldName,
+                                                 value.getClass().getSimpleName()));
     }
   }
 

--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/data/format/StructuredRecord.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/data/format/StructuredRecord.java
@@ -98,8 +98,14 @@ public class StructuredRecord implements Serializable {
   public LocalDate getDate(String fieldName) {
     Schema logicalTypeSchema = validateAndGetLogicalTypeSchema(schema.getField(fieldName),
                                                                EnumSet.of(LogicalType.DATE));
-    Integer value = (Integer) fields.get(fieldName);
-    return (value == null || logicalTypeSchema == null) ? null : LocalDate.ofEpochDay(value.longValue());
+    Object val = fields.get(fieldName);
+    try {
+      Integer value = (Integer) val;
+      return (value == null || logicalTypeSchema == null) ? null : LocalDate.ofEpochDay(value.longValue());
+    } catch (ClassCastException e) {
+      throw new ClassCastException(String.format("Field '%s' is expected to be a date, but is a %s",
+                                                 fieldName, val.getClass().getSimpleName()));
+    }
   }
 
   /**
@@ -116,16 +122,30 @@ public class StructuredRecord implements Serializable {
     Schema logicalTypeSchema = validateAndGetLogicalTypeSchema(schema.getField(fieldName),
                                                                EnumSet.of(LogicalType.TIME_MILLIS,
                                                                           LogicalType.TIME_MICROS));
-    Object value = fields.get(fieldName);
-    if (value == null || logicalTypeSchema == null) {
+    Object val = fields.get(fieldName);
+    if (val == null || logicalTypeSchema == null) {
       return null;
     }
 
     if (logicalTypeSchema.getLogicalType() == LogicalType.TIME_MILLIS) {
-      return LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(((Integer) value)));
+      try {
+        Integer value = (Integer) val;
+        return LocalTime.ofNanoOfDay(TimeUnit.MILLISECONDS.toNanos(value));
+      } catch (ClassCastException e) {
+        throw new ClassCastException(
+          String.format("Field '%s' is expected to be a time in milliseconds, but is a %s",
+                        fieldName, val.getClass().getSimpleName()));
+      }
     }
 
-    return LocalTime.ofNanoOfDay(TimeUnit.MICROSECONDS.toNanos((Long) value));
+    try {
+      Long value = (Long) val;
+      return LocalTime.ofNanoOfDay(TimeUnit.MICROSECONDS.toNanos(value));
+    } catch (ClassCastException e) {
+      throw new ClassCastException(
+        String.format("Field '%s' is expected to be a time in microseconds, but is a %s",
+                      fieldName, val.getClass().getSimpleName()));
+    }
   }
 
   /**
@@ -159,16 +179,24 @@ public class StructuredRecord implements Serializable {
     Schema logicalTypeSchema = validateAndGetLogicalTypeSchema(schema.getField(fieldName),
                                                                EnumSet.of(LogicalType.TIMESTAMP_MILLIS,
                                                                           LogicalType.TIMESTAMP_MICROS));
-    Object value = fields.get(fieldName);
-    if (value == null || logicalTypeSchema == null) {
+    Object val = fields.get(fieldName);
+    if (val == null || logicalTypeSchema == null) {
       return null;
     }
 
-    if (logicalTypeSchema.getLogicalType() == LogicalType.TIMESTAMP_MILLIS) {
-      return getZonedDateTime((long) value, TimeUnit.MILLISECONDS, zoneId);
+    Long value;
+    try {
+      value = (Long) val;
+    } catch (ClassCastException e) {
+      throw new ClassCastException(
+        String.format("Field '%s' is expected to be a timestamp, but is a %s",
+                      fieldName, val.getClass().getSimpleName()));
     }
 
-    return getZonedDateTime((long) value, TimeUnit.MICROSECONDS, zoneId);
+    if (logicalTypeSchema.getLogicalType() == LogicalType.TIMESTAMP_MILLIS) {
+      return getZonedDateTime(value, TimeUnit.MILLISECONDS, zoneId);
+    }
+    return getZonedDateTime(value, TimeUnit.MICROSECONDS, zoneId);
   }
 
   /**
@@ -192,7 +220,12 @@ public class StructuredRecord implements Serializable {
       return new BigDecimal(new BigInteger(Bytes.toBytes((ByteBuffer) value)), scale);
     }
 
-    return new BigDecimal(new BigInteger((byte[]) value), scale);
+    try {
+      return new BigDecimal(new BigInteger((byte[]) value), scale);
+    } catch (ClassCastException e) {
+      throw new UnexpectedFormatException(String.format("Field '%s' is expected to be a %s, but is a %s.", fieldName,
+                                                        "decimal", value.getClass().getSimpleName()), e);
+    }
   }
 
   /**

--- a/cdap-formats/src/test/java/io/cdap/cdap/format/StructuredRecordBuilderTest.java
+++ b/cdap-formats/src/test/java/io/cdap/cdap/format/StructuredRecordBuilderTest.java
@@ -285,4 +285,25 @@ public class StructuredRecordBuilderTest {
     Schema schema = Schema.recordOf("test", Schema.Field.of("d", Schema.decimalOf(5, 2)));
     StructuredRecord.builder(schema).setDecimal("d", new BigDecimal(new BigInteger("12341324"), 2)).build();
   }
+
+  @Test(expected = ClassCastException.class)
+  public void testUnexpectedDateType() {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("x", Schema.of(Schema.LogicalType.DATE)));
+    StructuredRecord record = StructuredRecord.builder(schema).set("x", 5L).build();
+    record.getDate("x");
+  }
+
+  @Test(expected = ClassCastException.class)
+  public void testUnexpectedTimestampType() {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("x", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)));
+    StructuredRecord record = StructuredRecord.builder(schema).set("x", "2020-01-01 12:00:00").build();
+    record.getTimestamp("x");
+  }
+
+  @Test(expected = ClassCastException.class)
+  public void testUnexpectedTimeType() {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("x", Schema.of(Schema.LogicalType.TIME_MICROS)));
+    StructuredRecord record = StructuredRecord.builder(schema).set("x", "12:00:00").build();
+    record.getTime("x");
+  }
 }

--- a/cdap-formats/src/test/java/io/cdap/cdap/format/StructuredRecordBuilderTest.java
+++ b/cdap-formats/src/test/java/io/cdap/cdap/format/StructuredRecordBuilderTest.java
@@ -20,7 +20,9 @@ import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.format.UnexpectedFormatException;
 import io.cdap.cdap.api.data.schema.Schema;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -37,6 +39,8 @@ import java.util.TimeZone;
  * Tests conversion logic
  */
 public class StructuredRecordBuilderTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testNullCheck() {
@@ -223,14 +227,15 @@ public class StructuredRecordBuilderTest {
     Assert.assertNull(StructuredRecord.builder(schema).setDate("x", date).build().getDate("y"));
   }
 
-  @Test(expected = UnexpectedFormatException.class)
+  @Test
   public void testSetNonExistentField() {
     Schema schema = Schema.recordOf("record", Schema.Field.of("x", Schema.of(Schema.LogicalType.DATE)));
     LocalDate date = LocalDate.of(2018, 11, 11);
+    thrown.expect(UnexpectedFormatException.class);
     StructuredRecord.builder(schema).setDate("y", date).build();
   }
 
-  @Test(expected = UnexpectedFormatException.class)
+  @Test
   public void testInvalidNestedUnionSchemaType() {
     Schema schema = Schema.recordOf("x", Schema.Field.of("x", Schema.unionOf(
       Schema.unionOf(Schema.nullableOf(Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)),
@@ -241,69 +246,90 @@ public class StructuredRecordBuilderTest {
       Schema.nullableOf(Schema.of(Schema.LogicalType.TIME_MILLIS)))));
 
     LocalDate date = LocalDate.of(2018, 11, 11);
-    Assert.assertEquals(date, StructuredRecord.builder(schema).setDate("x", date).build().getDate("x"));
+    thrown.expect(UnexpectedFormatException.class);
+    StructuredRecord.builder(schema).setDate("x", date).build().getDate("x");
   }
 
-  @Test(expected = UnexpectedFormatException.class)
+  @Test
   public void testInvalidDateLogicalType() {
     Schema schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
                                     Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
                                     Schema.Field.of("date", Schema.of(Schema.LogicalType.DATE)));
 
     LocalTime expected = LocalTime.now();
+    thrown.expect(UnexpectedFormatException.class);
     StructuredRecord.builder(schema).set("id", 1).set("name", "test").setTime("date", expected).build();
   }
 
-  @Test(expected = UnexpectedFormatException.class)
+  @Test
   public void testInvalidTimeLogicalType() {
     Schema schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
                                     Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
                                     Schema.Field.of("time", Schema.of(Schema.LogicalType.TIME_MILLIS)));
 
     LocalDate expected = LocalDate.now();
+    thrown.expect(UnexpectedFormatException.class);
     StructuredRecord.builder(schema).set("id", 1).set("name", "test").setDate("time", expected).build();
   }
 
-  @Test(expected = UnexpectedFormatException.class)
+  @Test
   public void testInvalidTimestampLogicalType() {
     Schema schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
                                     Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
                                     Schema.Field.of("timestamp", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)));
 
     LocalDate expected = LocalDate.now();
+    thrown.expect(UnexpectedFormatException.class);
     StructuredRecord.builder(schema).set("id", 1).set("name", "test").setDate("timestamp", expected).build();
   }
 
-  @Test(expected = UnexpectedFormatException.class)
+  @Test
   public void testInvalidDecimalScale() {
     Schema schema = Schema.recordOf("test", Schema.Field.of("d", Schema.decimalOf(5, 2)));
+    thrown.expect(UnexpectedFormatException.class);
     StructuredRecord.builder(schema).setDecimal("d", new BigDecimal(new BigInteger("1234"), 1)).build();
   }
 
-  @Test(expected = UnexpectedFormatException.class)
+  @Test
   public void testInvalidPrecision() {
     Schema schema = Schema.recordOf("test", Schema.Field.of("d", Schema.decimalOf(5, 2)));
+    thrown.expect(UnexpectedFormatException.class);
     StructuredRecord.builder(schema).setDecimal("d", new BigDecimal(new BigInteger("12341324"), 2)).build();
   }
 
-  @Test(expected = ClassCastException.class)
+  @Test
   public void testUnexpectedDateType() {
     Schema schema = Schema.recordOf("test", Schema.Field.of("x", Schema.of(Schema.LogicalType.DATE)));
     StructuredRecord record = StructuredRecord.builder(schema).set("x", 5L).build();
+    thrown.expect(ClassCastException.class);
+    thrown.expectMessage("Field 'x' is expected to be a date");
     record.getDate("x");
   }
 
-  @Test(expected = ClassCastException.class)
+  @Test
   public void testUnexpectedTimestampType() {
     Schema schema = Schema.recordOf("test", Schema.Field.of("x", Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)));
     StructuredRecord record = StructuredRecord.builder(schema).set("x", "2020-01-01 12:00:00").build();
+    thrown.expect(ClassCastException.class);
+    thrown.expectMessage("Field 'x' is expected to be a timestamp");
     record.getTimestamp("x");
   }
 
-  @Test(expected = ClassCastException.class)
+  @Test
   public void testUnexpectedTimeType() {
     Schema schema = Schema.recordOf("test", Schema.Field.of("x", Schema.of(Schema.LogicalType.TIME_MICROS)));
     StructuredRecord record = StructuredRecord.builder(schema).set("x", "12:00:00").build();
+    thrown.expect(ClassCastException.class);
+    thrown.expectMessage("Field 'x' is expected to be a time");
     record.getTime("x");
+  }
+
+  @Test
+  public void testUnexpectedDecimalType() {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("x", Schema.decimalOf(5, 3)));
+    StructuredRecord record = StructuredRecord.builder(schema).set("x", "5.3").build();
+    thrown.expect(ClassCastException.class);
+    thrown.expectMessage("Field 'x' is expected to be a decimal");
+    record.getDecimal("x");
   }
 }


### PR DESCRIPTION
For logical type utility methods, including the field name when
the type is not as expected.

This is only required because the builder does not verify that
a valid type is being set for a field. If/when that verification
is added, this logic can be removed.