### PR TITLE
[CDAP-17422] Updates the Namespace Admin link in App Drawer to navigate to namespace detail instead of system admin

### DIFF
--- a/cdap-ui/app/cdap/components/AppHeader/AppDrawer/AppDrawer.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/AppDrawer/AppDrawer.tsx
@@ -238,7 +238,7 @@ class AppDrawer extends React.PureComponent<IAppDrawerProps> {
             }
           />
           <DrawerFeatureLink
-            featureUrl="/administration/configuration"
+            featureUrl={`/${nsurl}/details`}
             featureName={Theme.featureNames.projectAdmin}
             featureFlag={true}
             componentDidNavigate={componentDidNavigate}


### PR DESCRIPTION
Cherry-pick https://github.com/cdapio/cdap/pull/12882