### PR TITLE
[CDAP-12429][CDAP-17463] Wrangler: Warn about problems with column names

### DIFF
--- a/cdap-ui/app/cdap/components/TextboxOnValium/index.js
+++ b/cdap-ui/app/cdap/components/TextboxOnValium/index.js
@@ -58,7 +58,12 @@ export default class TextboxOnValium extends Component {
         textValue,
       },
       () => {
-        if (this.state.originalValue !== this.state.textValue && this.props.onWarning) {
+        // If a warning is already shown and the user has set the input text back to the original value,
+        // we must allow this block to run
+        if (
+          (this.state.originalValue !== this.state.textValue || this.state.isWarning) &&
+          this.props.onWarning
+        ) {
           let isWarning = this.props.onWarning(this.state.textValue);
           if (isWarning || (!isWarning && this.state.isWarning)) {
             this.setState({

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -402,7 +402,7 @@ features:
       DataType:
         unknown: unknown
       copyToNewColumn:
-        inputDuplicate: A column with the same name already exists. Pick a new name, or click “Apply” to overwrite.
+        inputDuplicate: A column with the same name already exists. Pick a new name, or click "Ok" to cancel.
         inputLabel: Name new column
         inputPlaceholder: Destination column
         inputSuffix: _copy
@@ -410,6 +410,7 @@ features:
       dataErrorMessageTitle: Unable to load data.
       dataErrorMessageTitle2: Unable to load data for "{workspaceName}".
       emptyWorkspace: No data
+      invalidCharacterWarning: The name you have entered is invalid. It must contain only letters, numbers, and underscores (_). Pick a new name, or click "Ok" to cancel.
       noData: No data. Try removing some transformation steps.
     DataPrepBrowser:
       BigQueryBrowser:
@@ -535,6 +536,7 @@ features:
             label: "{dirsCount} directories and {filesCount} files"
           selectData: Select data
     Directives:
+      accept: Ok
       apply: Apply
       cancel: Cancel
       Calculate:


### PR DESCRIPTION
Jira: https://cdap.atlassian.net/browse/CDAP-12429

This adds a warning in DataPrepTable if the user enters a column name that contains invalid characters. There's no auto-fix option - clicking "Ok" will cancel the edit. This is based on feedback from the PM.

![image](https://user-images.githubusercontent.com/2728821/102558250-e44ad380-4081-11eb-9b1f-2e651f085506.png)


Jira: https://cdap.atlassian.net/browse/CDAP-17463

This removes the "Apply" button from the duplicate name warning, which wasn't working anymore anyway. Clicking "Ok" will cancel the edit.

![image](https://user-images.githubusercontent.com/2728821/102558267-ef9dff00-4081-11eb-8679-b607b070c7fc.png)

This replaces #12892 