### PR TITLE
[CDAP-12429][CDAP-17463] Wrangler: Updated warning messages for duplicate column name and invalid characters in name for 6.3

### DIFF
--- a/cdap-ui/app/cdap/components/TextboxOnValium/index.js
+++ b/cdap-ui/app/cdap/components/TextboxOnValium/index.js
@@ -58,7 +58,12 @@ export default class TextboxOnValium extends Component {
         textValue,
       },
       () => {
-        if (this.state.originalValue !== this.state.textValue && this.props.onWarning) {
+        // If a warning is already shown and the user has set the input text back to the original value,
+        // we must allow this block to run
+        if (
+          (this.state.originalValue !== this.state.textValue || this.state.isWarning) &&
+          this.props.onWarning
+        ) {
           let isWarning = this.props.onWarning(this.state.textValue);
           if (isWarning || (!isWarning && this.state.isWarning)) {
             this.setState({

--- a/cdap-ui/app/cdap/text/text-en.yaml
+++ b/cdap-ui/app/cdap/text/text-en.yaml
@@ -402,7 +402,7 @@ features:
       DataType:
         unknown: unknown
       copyToNewColumn:
-        inputDuplicate: A column with the same name already exists. Pick a new name, or click “Apply” to overwrite.
+        inputDuplicate: A column with the same name already exists. Pick a new name, or click "Ok" to cancel.
         inputLabel: Name new column
         inputPlaceholder: Destination column
         inputSuffix: _copy
@@ -410,6 +410,7 @@ features:
       dataErrorMessageTitle: Unable to load data.
       dataErrorMessageTitle2: Unable to load data for "{workspaceName}".
       emptyWorkspace: No data
+      invalidCharacterWarning: The name you have entered is invalid. It must contain only letters, numbers, and underscores (_). Pick a new name, or click "Ok" to cancel.
       noData: No data. Try removing some transformation steps.
     DataPrepBrowser:
       BigQueryBrowser:
@@ -535,6 +536,7 @@ features:
             label: "{dirsCount} directories and {filesCount} files"
           selectData: Select data
     Directives:
+      accept: Ok
       apply: Apply
       cancel: Cancel
       Calculate:


### PR DESCRIPTION
Cherry-pick of #12948

CDAP-12429: Give warning for invalid characters instead of ignoring invalid inputs
CDAP-17463: A back-end change broke the Apply button for duplicate names. Remove Apply and only allow cancel from the wanring