### PR TITLE
(CDAP-16008) Added Kerberos support to Remote Hadoop provisioner

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
@@ -340,7 +340,7 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
 
     // Use SSH if there is no RuntimeJobManager
     ClusterKeyInfo clusterKeyInfo = new ClusterKeyInfo(cConf, programOpts, locationFactory);
-    return new RemoteExecutionTwillPreparer(cConf, hConf, clusterKeyInfo.getSSHConfig(),
+    return new RemoteExecutionTwillPreparer(cConf, hConf, clusterKeyInfo.getCluster(), clusterKeyInfo.getSSHConfig(),
                                             serviceProxySecretLocation,
                                             twillSpec, programRunId, programOpts,
                                             locationCache, locationFactory, controllerFactory);
@@ -637,6 +637,7 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
   private static final class ClusterKeyInfo {
 
     private final CConfiguration cConf;
+    private final Cluster cluster;
     private final Location keysDir;
     private final SSHConfig sshConfig;
     private volatile String serverProxySecret;
@@ -647,8 +648,12 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
       this.cConf = cConf;
       this.keysDir = getKeysDirLocation(programOptions, locationFactory);
 
-      Cluster cluster = GSON.fromJson(systemArgs.getOption(ProgramOptionConstants.CLUSTER), Cluster.class);
+      this.cluster = GSON.fromJson(systemArgs.getOption(ProgramOptionConstants.CLUSTER), Cluster.class);
       this.sshConfig = createSSHConfig(cluster, keysDir);
+    }
+
+    Cluster getCluster() {
+      return cluster;
     }
 
     SSHConfig getSSHConfig() {

--- a/cdap-common/src/main/java/io/cdap/cdap/common/ssh/DefaultSSHSession.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/ssh/DefaultSSHSession.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -85,7 +84,7 @@ public class DefaultSSHSession implements SSHSession {
       session.connect();
       this.session = session;
     } catch (JSchException e) {
-      throw new IOException(e);
+      throw new IOException("Failed to SSH to " + config, e);
     }
 
     this.remoteAddress = new InetSocketAddress(config.getHost(), config.getPort());
@@ -119,7 +118,7 @@ public class DefaultSSHSession implements SSHSession {
         // the InputStream that acquired later.
         SSHProcess process = new DefaultSSHProcess(channelExec, channelExec.getOutputStream(),
                                                    channelExec.getInputStream(), channelExec.getErrStream());
-        channelExec.setCommand(commands.stream().collect(Collectors.joining(";")));
+        channelExec.setCommand(String.join(";", commands));
         channelExec.connect();
 
         return process;

--- a/cdap-runtime-ext-remote-hadoop/src/main/java/io/cdap/cdap/runtime/spi/provisioner/remote/RemoteHadoopConf.java
+++ b/cdap-runtime-ext-remote-hadoop/src/main/java/io/cdap/cdap/runtime/spi/provisioner/remote/RemoteHadoopConf.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Configuration for the Remote Hadoop provisioner.
@@ -30,11 +31,16 @@ public class RemoteHadoopConf {
   private final SSHKeyPair sshKeyPair;
   private final String host;
   private final String initializationAction;
+  private final String kerberosKeytabPath;
+  private final String kerberosPrincipal;
 
-  private RemoteHadoopConf(SSHKeyPair sshKeyPair, String host, String initializationAction) {
+  private RemoteHadoopConf(SSHKeyPair sshKeyPair, String host, @Nullable String initializationAction,
+                           @Nullable String kerberosPrincipal, @Nullable String kerberosKeytabPath) {
     this.sshKeyPair = sshKeyPair;
     this.host = host;
     this.initializationAction = initializationAction;
+    this.kerberosKeytabPath = kerberosKeytabPath;
+    this.kerberosPrincipal = kerberosPrincipal;
   }
 
   public SSHKeyPair getKeyPair() {
@@ -45,8 +51,19 @@ public class RemoteHadoopConf {
     return host;
   }
 
+  @Nullable
   public String getInitializationAction() {
     return initializationAction;
+  }
+
+  @Nullable
+  public String getKerberosKeytabPath() {
+    return kerberosKeytabPath;
+  }
+
+  @Nullable
+  public String getKerberosPrincipal() {
+    return kerberosPrincipal;
   }
 
   /**
@@ -56,11 +73,13 @@ public class RemoteHadoopConf {
     String host = getString(properties, "host");
     String user = getString(properties, "user");
     String privateKey = getString(properties, "sshKey");
-    String initializationAction = getString(properties, "initializationAction");
 
     SSHKeyPair keyPair = new SSHKeyPair(new SSHPublicKey(user, ""),
                                         () -> privateKey.getBytes(StandardCharsets.UTF_8));
-    return new RemoteHadoopConf(keyPair, host, initializationAction);
+    return new RemoteHadoopConf(keyPair, host, properties.get("initializationAction"),
+                                properties.get("kerberosPrincipal"),
+                                properties.get("kerberosKeytabPath")
+    );
   }
 
   private static String getString(Map<String, String> properties, String key) {

--- a/cdap-runtime-ext-remote-hadoop/src/main/java/io/cdap/cdap/runtime/spi/provisioner/remote/RemoteHadoopProvisioner.java
+++ b/cdap-runtime-ext-remote-hadoop/src/main/java/io/cdap/cdap/runtime/spi/provisioner/remote/RemoteHadoopProvisioner.java
@@ -20,6 +20,7 @@ package io.cdap.cdap.runtime.spi.provisioner.remote;
 import com.google.common.base.Throwables;
 import io.cdap.cdap.runtime.spi.provisioner.Capabilities;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
+import io.cdap.cdap.runtime.spi.provisioner.ClusterProperties;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
 import io.cdap.cdap.runtime.spi.provisioner.Node;
 import io.cdap.cdap.runtime.spi.provisioner.PollingStrategies;
@@ -36,6 +37,7 @@ import java.net.ConnectException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -109,7 +111,15 @@ public class RemoteHadoopProvisioner implements Provisioner {
     context.getSSHContext().setSSHKeyPair(conf.getKeyPair());
     Collection<Node> nodes = Collections.singletonList(new Node(conf.getHost(), Node.Type.MASTER, conf.getHost(),
                                                                 0, Collections.emptyMap()));
-    return new Cluster(conf.getHost(), ClusterStatus.RUNNING, nodes, Collections.emptyMap());
+    Map<String, String> properties = new HashMap<>();
+    String principal = conf.getKerberosPrincipal();
+    String keytab = conf.getKerberosKeytabPath();
+    if (principal != null && keytab != null) {
+      properties.put(ClusterProperties.KERBEROS_PRINCIPAL, principal);
+      properties.put(ClusterProperties.KERBEROS_KEYTAB, keytab);
+    }
+
+    return new Cluster(conf.getHost(), ClusterStatus.RUNNING, nodes, properties);
   }
 
   @Override

--- a/cdap-runtime-ext-remote-hadoop/src/main/resources/remote-hadoop.json
+++ b/cdap-runtime-ext-remote-hadoop/src/main/resources/remote-hadoop.json
@@ -52,6 +52,24 @@
           "widget-attributes": {
             "default": ""
           }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Kerberos Principal",
+          "name": "kerberosPrincipal",
+          "description": "The Kerberos principal to use for program execution",
+          "widget-attributes": {
+            "placeholder": "Specify the Kerberos principal"
+          }
+        },
+        {
+          "widget-type": "textbox",
+          "label": "Kerberos Keytab Path",
+          "name": "kerberosKeytabPath",
+          "description": "The file path to the Kerberos keytab file. The file path must exist on the master node of the Hadoop cluster",
+          "widget-attributes": {
+            "placeholder": "Specify the Kerberos keytab path"
+          }
         }
       ]
     }

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ClusterProperties.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ClusterProperties.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner;
+
+/**
+ * Defines common constants used for cluster properties.
+ */
+public final class ClusterProperties {
+
+  /**
+   * Property key for the kerberos principal.
+   */
+  public static final String KERBEROS_PRINCIPAL = "kerberos.principal";
+
+  /**
+   * Property key for the kerberos keytab file path.
+   */
+  public static final String KERBEROS_KEYTAB = "kerberos.keytab";
+
+  private ClusterProperties() {
+    // prevent instantiation
+  }
+}

--- a/cdap-security/src/test/java/io/cdap/cdap/security/impersonation/SecurityUtilTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/impersonation/SecurityUtilTest.java
@@ -78,11 +78,11 @@ public class SecurityUtilTest {
   public void testNoKeytabPath() throws IOException {
     String user = "alice";
     CConfiguration cConf = CConfiguration.create();
-    // this should throw a null pointer exception with proper message as what to set
+    // this should throw a illegal argument exception with proper message as what to set
     try {
       SecurityUtil.getKeytabURIforPrincipal(user, cConf);
       Assert.fail();
-    } catch (NullPointerException e) {
+    } catch (IllegalArgumentException e) {
       // expected
       Assert.assertTrue(e.getMessage().contains(Constants.Security.KEYTAB_PATH));
     }


### PR DESCRIPTION
Two new fields are added to the remote Hadoop provisioner for specifying Kerberos principal and keytab file path. The keytab file has to be presented in the SSH host where the provisioner is configured to talk to.