### PR TITLE
[CDAP-17487] Fix Runtime Args for completed Pipeline runs

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineModelessOld/PipelineModelessOld.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineModelessOld/PipelineModelessOld.scss
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+*/
+
+@import '../../../styles/variables.scss';
+
+$modeless-width: 730px;
+$sidepanel-width: 170px;
+$modeless-header-height: 60px;
+$header-close-icon-size: 16px;
+$container-padding: 0 30px;
+
+// The modeless-container doesn't have an overflow property defined here
+// In all our usecases we don't have the entire modeless scrolling since we have
+// a static header and a footer and only the content scrolls.
+.pipeline-modeless-old-container {
+  width: $modeless-width;
+  position: static;
+  z-index: 999;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.5);
+  color: $grey-01;
+  background-color: white;
+  max-height: 510px;
+  display: flex;
+  flex-direction: column;
+
+  .pipeline-modeless-header {
+    background-color: $grey-08;
+    height: $modeless-header-height;
+    min-height: $modeless-header-height;
+    padding: $container-padding;
+    border-radius: 4px 4px 0 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-radius: 0;
+
+    .pipeline-modeless-title {
+      color: $grey-01;
+      max-width: 80%;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+      font-weight: 500;
+      margin: 0 auto 0 0;
+      font-size: $header-close-icon-size;
+      line-height: 20px;
+    }
+    .btn {
+      padding: 0;
+    }
+
+    .btn .fa-remove,
+    .btn .icon-close {
+      color: $grey-01;
+      width: $header-close-icon-size;
+      height: $header-close-icon-size;
+    }
+  }
+
+  .pipeline-modeless-content {
+    display: flex;
+    padding: $container-padding 30px;
+  }
+  .cask-configurable-tab {
+    height: 100%;
+    width: 100%;
+
+    .cask-tabs.vertical {
+      min-height: inherit;
+      max-height: inherit;
+
+      > div {
+        &:nth-child(2) {
+          width: calc(100% - #{$sidepanel-width});
+        }
+        &:first-child {
+          width: $sidepanel-width;
+          padding: 0;
+          background: transparent;
+          border-right: 1px solid $grey-05;
+        }
+
+        &.cask-tab-headers {
+          text-align: left;
+          .cask-tab-head {
+            border-bottom: 1px solid $grey-05;
+            padding: 10px 10px 10px 20px;
+            &.active-tab {
+              color: var(--brand-primary-color);
+              background: $grey-07;
+              border-left: 0;
+            }
+            span {
+              &.tab-header-icon {
+                margin: 0 5px;
+                .icon-sliders.icon-svg {
+                  transform: rotate(90deg);
+                }
+              }
+            }
+          }
+        }
+        &.tab-content {
+          .tab-pane {
+            width: 100%;
+            margin: 16px 30px 40px 50px;
+            font-size: 14px;
+            position: relative;
+            text-align: left;
+          }
+        }
+      }
+    }
+  }
+}

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineModelessOld/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineModelessOld/index.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2018 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import IconSVG from 'components/IconSVG';
+
+require('./PipelineModelessOld.scss');
+
+export default function PipelineModelessOld({ title, onClose, children }) {
+  return (
+    <div className="pipeline-modeless-old-container">
+      <div className="pipeline-modeless-header">
+        <div className="pipeline-modeless-title">{title}</div>
+        <div className="btn-group">
+          <a className="btn" onClick={onClose}>
+            <IconSVG name="icon-close" />
+          </a>
+        </div>
+      </div>
+      <div className="pipeline-modeless-content">{children}</div>
+    </div>
+  );
+}
+
+PipelineModelessOld.propTypes = {
+  title: PropTypes.node,
+  onClose: PropTypes.func,
+  children: PropTypes.node,
+};

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunConfigs.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunConfigs.js
@@ -30,7 +30,7 @@ import {
 } from 'services/helpers';
 import classnames from 'classnames';
 import Popover from 'components/Popover';
-import PipelineModeless from 'components/PipelineDetails/PipelineModeless';
+import PipelineModelessOld from 'components/PipelineDetails/PipelineModelessOld';
 import T from 'i18n-react';
 import { Provider } from 'react-redux';
 import findIndex from 'lodash/findIndex';
@@ -210,7 +210,7 @@ export default class RunConfigs extends Component {
         }}
       >
         <Provider store={PipelineConfigurationsStore}>
-          <PipelineModeless title={title} onClose={this.toggleModeless.bind(this, false)}>
+          <PipelineModelessOld title={title} onClose={this.toggleModeless.bind(this, false)}>
             <div className="historical-runtime-args-wrapper">
               {this.renderRuntimeArgs()}
               <div className="runconfig-tab-footer">
@@ -219,7 +219,7 @@ export default class RunConfigs extends Component {
                 )}
               </div>
             </div>
-          </PipelineModeless>
+          </PipelineModelessOld>
         </Provider>
       </Popover>
     );

--- a/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunLevelInfo.scss
+++ b/cdap-ui/app/cdap/components/PipelineDetails/RunLevelInfo/RunLevelInfo.scss
@@ -188,7 +188,7 @@ $border-color: $grey-05;
         margin-top: 50px;
         margin-bottom: 100px;
       }
-      .pipeline-modeless-content {
+      .pipeline-modeless-old-container .pipeline-modeless-content {
         .historical-runtime-args-wrapper {
           display: flex;
           flex-direction: column;


### PR DESCRIPTION
Cherry pick of #12976

Restores the old PipelineModeless as PipelineModelessOld because material-ui doesn't have easy support for an arrow
CDAP-17488 added to remove PipelineModelessOld in the future