### PR TITLE
CDAP-17538 fix cdap broken on kerberos cluster

### DIFF
--- a/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/SecurityUtil.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/SecurityUtil.java
@@ -139,13 +139,16 @@ public final class SecurityUtil {
     return principal;
   }
 
-  public static File getMasterKeytabFile(CConfiguration cConf) {
+  public static String getMasterKeytabURI(CConfiguration cConf) {
     String uri = cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH);
     if (uri == null) {
       throw new IllegalArgumentException(Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH + " is not configured");
     }
+    return uri;
+  }
 
-    File keytabFile = new File(uri);
+  public static File getMasterKeytabFile(CConfiguration cConf) {
+    File keytabFile = new File(getMasterKeytabURI(cConf));
     if (!Files.isReadable(keytabFile.toPath())) {
       throw new IllegalArgumentException("Keytab file is not a readable file " + keytabFile);
     }
@@ -229,7 +232,8 @@ public final class SecurityUtil {
                                                           NamespacedEntityId entityId) throws IOException {
     ImpersonationInfo impersonationInfo = ownerAdmin.getImpersonationInfo(entityId);
     if (impersonationInfo == null) {
-      return new ImpersonationInfo(getMasterPrincipal(cConf), getMasterKeytabFile(cConf).toURI().toString());
+      // here we don't need to get the keytab file since we use delegation tokens accross system containers
+      return new ImpersonationInfo(getMasterPrincipal(cConf), getMasterKeytabURI(cConf));
     }
     return impersonationInfo;
   }


### PR DESCRIPTION
We recently introduced some validations for keytab when supporting kerberos for remote hadoop provisioner. This validation checks the keytab file is readable when it tries to get the file. 
This change breaks distributed kerberos cluster since cdap keytab is only needed by the cdap-master service process (/etc/init.d/cdap-master). The system containers running in yarn will run on datanodes and they will use delegation tokens, so the file is not required to be distributed on all the nodes. 
Check https://cdap.atlassian.net/browse/CDAP-17538 for more details.