### PR TITLE
Replication Fixes cherry-pick

### DIFF
--- a/cdap-ui/app/cdap/components/Replicator/Create/Content/Advanced/index.tsx
+++ b/cdap-ui/app/cdap/components/Replicator/Create/Content/Advanced/index.tsx
@@ -54,33 +54,6 @@ const styles = (): StyleRules => {
   };
 };
 
-const OffsetBasePathEditor = ({ onChange, value }) => {
-  const widget = {
-    label: 'Path',
-    name: 'offset',
-    'widget-type': 'textbox',
-    'widget-attributes': {
-      placeholder: 'Path for checkpoint storage location',
-    },
-  };
-
-  const property = {
-    required: false,
-    name: 'offset',
-    description:
-      'This is the directory where checkpoints for the replication pipeline are stored, so the pipeline can resume from a previous checkpoint, instead of starting from the beginning if it is restarted.',
-  };
-
-  return (
-    <WidgetWrapper
-      widgetProperty={widget}
-      pluginProperty={property}
-      value={value}
-      onChange={onChange}
-    />
-  );
-};
-
 const NumInstancesEditor = ({ onChange, value }) => {
   const widget = {
     label: 'Number of tasks',
@@ -165,11 +138,9 @@ const TASK_OPTIONS = {
 
 const AdvancedView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
   classes,
-  offsetBasePath,
   numInstances,
   setAdvanced,
 }) => {
-  const [localOffset, setLocalOffset] = React.useState(offsetBasePath);
   const [localNumInstances, setLocalNumInstances] = React.useState(numInstances);
   const [taskSelection, setTaskSelection] = React.useState(TASK_OPTIONS.calculate);
   const [dataAmount, setDataAmount] = React.useState(1);
@@ -195,7 +166,7 @@ const AdvancedView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
       selectedNumInstance = dataAmount;
     }
 
-    setAdvanced(localOffset, selectedNumInstance);
+    setAdvanced(selectedNumInstance);
   }
 
   function handleSelectTask(e) {
@@ -241,10 +212,6 @@ const AdvancedView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
           </div>
         </If>
       </div>
-
-      <Heading type={HeadingTypes.h4} label="Checkpoint" />
-      <br />
-      <OffsetBasePathEditor value={localOffset} onChange={setLocalOffset} />
 
       <StepButtons onNext={handleNext} />
     </div>

--- a/cdap-ui/app/cdap/components/Replicator/Create/Content/NameDescription/index.tsx
+++ b/cdap-ui/app/cdap/components/Replicator/Create/Content/NameDescription/index.tsx
@@ -110,7 +110,14 @@ const NameDescriptionView: React.FC<INameDescriptionProps> = ({
   function handleNameChange(value) {
     setLocalName(value);
 
-    if (!isValidEntityName(value)) {
+    if (value.length > 64) {
+      const errorArr = [
+        {
+          msg: 'Name cannot be longer than 64 characters.',
+        },
+      ];
+      setNameError(errorArr);
+    } else if (!isValidEntityName(value)) {
       const errorArr = [
         {
           msg: 'Name is required. Name may only contain alphanumeric, -, and _',

--- a/cdap-ui/app/cdap/components/Replicator/Create/Content/Summary/ActionButtons/index.tsx
+++ b/cdap-ui/app/cdap/components/Replicator/Create/Content/Summary/ActionButtons/index.tsx
@@ -45,7 +45,7 @@ const styles = (theme): StyleRules => {
 
 enum REDIRECT_TARGET {
   detail = 'detail',
-  list = 'list',
+  drafts = 'drafts',
 }
 
 const ActionButtonsView: React.FC<ICreateContext & WithStyles<typeof styles>> = ({
@@ -116,7 +116,7 @@ const ActionButtonsView: React.FC<ICreateContext & WithStyles<typeof styles>> = 
   function saveAndClose() {
     saveDraft().subscribe(
       () => {
-        setRedirect(REDIRECT_TARGET.list);
+        setRedirect(REDIRECT_TARGET.drafts);
       },
       (err) => {
         setError(err);
@@ -128,6 +128,8 @@ const ActionButtonsView: React.FC<ICreateContext & WithStyles<typeof styles>> = 
     let redirectLink = `/ns/${getCurrentNamespace()}/replication`;
     if (redirect === REDIRECT_TARGET.detail) {
       redirectLink = `${redirectLink}/detail/${name}`;
+    } else {
+      redirectLink = `${redirectLink}/drafts`;
     }
 
     return <Redirect to={redirectLink} />;

--- a/cdap-ui/app/cdap/components/Replicator/Create/index.tsx
+++ b/cdap-ui/app/cdap/components/Replicator/Create/index.tsx
@@ -109,7 +109,7 @@ interface ICreateState {
   setTargetPluginWidget: (targetPluginWidget: IWidgetJson) => void;
   setTargetConfig: (targetConfig: IPluginConfig) => void;
   setTables: (tables: ITablesStore, columns: IColumnsStore, dmlBlacklist: IDMLStore) => void;
-  setAdvanced: (offsetBasePath, numInstances) => void;
+  setAdvanced: (numInstances) => void;
   getReplicatorConfig: () => any;
   saveDraft: () => Observable<any>;
   setColumns: (columns, callback) => void;
@@ -173,8 +173,8 @@ class CreateView extends React.PureComponent<ICreateProps, ICreateContext> {
     this.setState({ tables, columns, dmlBlacklist });
   };
 
-  public setAdvanced = (offsetBasePath, numInstances) => {
-    this.setState({ offsetBasePath, numInstances });
+  public setAdvanced = (numInstances) => {
+    this.setState({ numInstances });
   };
 
   // for use in Assessment Table Mapping

--- a/cdap-ui/app/cdap/components/Replicator/Detail/Overview/TablesList/index.tsx
+++ b/cdap-ui/app/cdap/components/Replicator/Detail/Overview/TablesList/index.tsx
@@ -124,18 +124,21 @@ const TablesListView: React.FC<WithStyles<typeof styles>> = ({ classes }) => {
   useEffect(filterTableBySearch, [search, tables]);
 
   useEffect(() => {
-    if (!offsetBasePath || offsetBasePath.length === 0) {
-      return;
-    }
-
     const params = {
       namespace: getCurrentNamespace(),
     };
 
-    const body = {
+    interface IRequestBody {
+      name: string;
+      offsetBasePath?: string;
+    }
+    const body: IRequestBody = {
       name,
-      offsetBasePath,
     };
+
+    if (offsetBasePath && offsetBasePath.length > 0) {
+      body.offsetBasePath = offsetBasePath;
+    }
 
     // TODO: optimize polling
     // Don't poll when status is not running


### PR DESCRIPTION
[CDAP-17524] Fix issue where table status in replication detail view is not sending the proper query
[CDAP-17497] Add error when table is selected but no events type is selected
[CDAP-17514] Save and close redirects to drafts view
[CDAP-17511] limit replication name to 64 characters


Cherry-pick https://github.com/cdapio/cdap/pull/13013
Build: https://builds.cask.co/browse/CDAP-URUT358