### PR TITLE
Fix first load of CDAP UI in k8s environment 

### DIFF
--- a/cdap-ui/server/aggregator.js
+++ b/cdap-ui/server/aggregator.js
@@ -19,7 +19,6 @@ import request from 'request';
 import fs from 'fs';
 import log4js from 'log4js';
 import { REQUEST_ORIGIN_ROUTER, REQUEST_ORIGIN_MARKET, constructUrl, deconstructUrl, isVerifiedMarketHost} from 'server/url-helper';
-import { extractConfig } from 'server/config/parser';
 import * as sessionToken from 'server/token';
 
 const log = log4js.getLogger('default');
@@ -30,15 +29,15 @@ const log = log4js.getLogger('default');
  *
  * @param {Object} SockJS connection
  */
-function Aggregator(conn) {
+function Aggregator(conn, cdapConfig) {
   // make 'new' optional
   if (!(this instanceof Aggregator)) {
     return new Aggregator(conn);
   }
-  this.cdapConfig = null;
+  this.cdapConfig = cdapConfig;
   this.connection = conn;
 
-  this.populateCdapConfig().then(this.initializeEventListeners.bind(this));
+  this.initializeEventListeners();
   this.isSessionValid = false;
 }
 
@@ -88,20 +87,6 @@ Aggregator.prototype.validateSession = function(message) {
     return false;
   }
   return true;
-};
-
-Aggregator.prototype.populateCdapConfig = async function() {
-  let cdapConfig, securityConfig;
-  try {
-    cdapConfig = await extractConfig('cdap');
-    securityConfig = await extractConfig('security');
-    this.cdapConfig = { ...cdapConfig, ...securityConfig };
-  } catch (e) {
-    log.error(
-      "[ERROR]: Unable to parse CDAP config. CDAP UI Proxy won't be able to serve any request to the client: " +
-        e
-    );
-  }
 };
 
 /**

--- a/cdap-ui/server/cdap-config.js
+++ b/cdap-ui/server/cdap-config.js
@@ -17,11 +17,11 @@
 import { extractConfig } from 'server/config/parser';
 import memoize from 'lodash/memoize';
 
-async function extractCDAPConfig() {
+async function extractCDAPConfig(param = 'cdap') {
   let cdapConfig;
 
   try {
-    cdapConfig = await extractConfig('cdap');
+    cdapConfig = await extractConfig(param);
   } catch (e) {
     return Promise.reject(e);
   }

--- a/cdap-ui/server/config/config-reader.js
+++ b/cdap-ui/server/config/config-reader.js
@@ -35,7 +35,7 @@ export default class ConfigReader {
   configReadFail(data) {
     var textChunk = decoder.write(data);
     if (textChunk) {
-      log.error(textChunk);
+      log.error('config read failed for: ' + textChunk);
     }
   }
   configRead(data) {

--- a/cdap-ui/server/config/parser.js
+++ b/cdap-ui/server/config/parser.js
@@ -44,7 +44,6 @@ export function extractUISettings() {
 export function extractConfig(param) {
   var deferred = q.defer();
   param = param || 'cdap';
-
   if (cache[param]) {
     deferred.resolve(cache[param]);
     return deferred.promise;


### PR DESCRIPTION
- Adds `SIGTERM` interrupt handler when the UI pod is terminated by k8s. This is to ensure we terminate and exit with code `0` until k8s wait (30s) to forcefully terminate the process.
- Fixes the initial load of UI. 
    The root cause this happened only the first time is,
    
    - When we start the UI server we parse the cdap config and store it in memory
    - The node server now starts to listen for any ws connections from client
    - Once UI receives a ws connection we instantiate the Aggregator module to make rest calls
    - This again requires cdap config which we again generate.
    - We start to listen to ws messages only after the cdap config is extracted
    - Between parsing the config and starting to listen, if node server receives any messages
      from any ws client it just drops them.
    
    This is why the first few requests don't reach the ws server started by nodejs server.
    
    The fix is to avoid generating cdap config multiple times and start to listen to ws messages as soon as a client ws connection is established.