### PR TITLE
CDAP-17559 remove Spark adaptive excecution default in app

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
@@ -103,8 +103,6 @@ public class ETLSpark extends AbstractSpark {
     // to make sure fields that are the same but different casing are treated as different fields in auto-joins
     // see CDAP-17024
     sparkConf.set("spark.sql.caseSensitive", "true");
-    // Turn on adaptive query execution for perfomance optimization in Spark 3.
-    sparkConf.set("spark.sql.adaptive.enabled", "true");
     context.setSparkConf(sparkConf);
 
     Map<String, String> properties = context.getSpecification().getProperties();


### PR DESCRIPTION
adaptive execution is meant for Spark3, but it also affects Spark2.
Since it hasn't been extensively tested with Spark2 pipelines,
removing the default in the app and relying on the provisioner
to set depending on the Spark version.

For dataproc, the images with Spark3 already default the setting
to true.