### PR TITLE
workaround for spark1 script

### DIFF
--- a/cdap-app-fabric/src/main/resources/setupSpark1.py
+++ b/cdap-app-fabric/src/main/resources/setupSpark1.py
@@ -1,0 +1,23 @@
+# coding=utf-8
+#
+# Copyright © 2021 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# A simple python that runs with spark-submit to grab all SPARK environment variables
+import os, time
+for key, val in os.environ.items():
+    if key.startswith("SPARK_") or key.startswith("HADOOP_"):
+        print("export {}=\"{}\"".format(key, val))
+# without this sleep, this script sometimes is not able to fetch the variables back
+time.sleep(1)


### PR DESCRIPTION
For spark1 on dataproc, the script sometimes returns empty result, which makes the pipeline super flaky. Adding a sleep will make the script always return results(at least from my 50+ testing) 