### PR TITLE
[CDAP-17552] Fixes js error when no time based schedule exists for a pipeline

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/PipelineConfigurations/Store/ActionCreator.js
@@ -41,6 +41,7 @@ import uuidV4 from 'uuid/v4';
 import uniqBy from 'lodash/uniqBy';
 import cloneDeep from 'lodash/cloneDeep';
 import { CLOUD } from 'services/global-constants';
+import { Observable } from 'rxjs/Observable';
 
 // Filter certain preferences from being shown in the run time arguments
 // They are being represented in other places (like selected compute profile).
@@ -319,13 +320,14 @@ const fetchAndUpdateRuntimeArgs = () => {
     appId: PipelineDetailStore.getState().name,
   };
 
-  let observable$ = MyPipelineApi.fetchMacros(params).combineLatest([
+  let observable$ = Observable.forkJoin(
+    MyPipelineApi.fetchMacros(params),
     MyPreferenceApi.getAppPreferences(params),
     // This is required to resolve macros from preferences
     // Say DEFAULT_STREAM is a namespace level preference used as a macro
     // in one of the plugins in the pipeline.
-    MyPreferenceApi.getAppPreferencesResolved(params),
-  ]);
+    MyPreferenceApi.getAppPreferencesResolved(params)
+  );
 
   observable$.subscribe((res) => {
     let macrosSpec = res[0];

--- a/cdap-ui/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/PipelineRuntimeArgsDropdownBtn/index.js
@@ -57,7 +57,9 @@ export default class PipelineRuntimeArgsDropdownBtn extends Component {
         // This is to restore it to whatever is the state is in the backend.
         // This will ensure if the user clicks on the "Run" button directly
         // UI will still operate correctly discarding recently entered inputs in the session.
-        fetchAndUpdateRuntimeArgs();
+        if (!this.state.showRunOptions) {
+          fetchAndUpdateRuntimeArgs();
+        }
         if (this.props.onToggle) {
           this.props.onToggle(this.state.showRunOptions);
         }

--- a/cdap-ui/app/cdap/components/PipelineScheduler/Store/ActionCreator.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/Store/ActionCreator.js
@@ -31,6 +31,9 @@ import { GLOBALS, CLOUD } from 'services/global-constants';
 import { Observable } from 'rxjs/Observable';
 
 function setStateFromCron(cron = PipelineSchedulerStore.getState().cron) {
+  if (!cron) {
+    return;
+  }
   let cronValues = cron.split(' ');
   let payload = {};
   let converted12HourFormat = moment().hour(parseInt(cronValues[1]), 10);

--- a/cdap-ui/app/cdap/components/PipelineScheduler/Store/index.js
+++ b/cdap-ui/app/cdap/components/PipelineScheduler/Store/index.js
@@ -226,7 +226,9 @@ const schedule = (state = DEFAULT_SCHEDULE_OPTIONS, action = defaultAction) => {
         return constraint.type === 'CONCURRENCY';
       });
       let maxConcurrencyFromBackend = objectQuery(constraintFromBackend, 'maxConcurrency');
-      let cronFromBackend = objectQuery(currentBackendSchedule, 'trigger', 'cronExpression');
+      let cronFromBackend =
+        objectQuery(currentBackendSchedule, 'trigger', 'cronExpression') ||
+        HYDRATOR_DEFAULT_VALUES.schedule;
       let selectedProfile =
         profileFromBackend || profileFromPreferences || CLOUD.DEFAULT_PROFILE_NAME;
       return {


### PR DESCRIPTION
https://cdap.atlassian.net/browse/CDAP-17552

**Context**
- This issue happens in pipelines which has no time based trigger.
- UI assumes schedule with cron expression always exists which causes js error.
- This happens in older instances as well (< 6.3). Since we added loading icon in 6.3 we see this prominently.
- `fetchAndUpdateRuntimeArgs` seems to the issue which prevents opening both configure and runtime argument modals.

**TBD**: I am still not sure how the js error affects the rxjs subscription while fetching macros and preferences.