### PR TITLE
Loop and set the SparkConf instead of calling setAll

### DIFF
--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SparkRuntimeEnv.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SparkRuntimeEnv.scala
@@ -86,7 +86,7 @@ object SparkRuntimeEnv {
   /**
     * Puts all global properties into the given [[org.apache.spark.SparkConf]].
     */
-  def setupSparkConf(sparkConf: SparkConf): Unit = sparkConf.setAll(properties)
+  def setupSparkConf(sparkConf: SparkConf): Unit = properties.foreach(t => sparkConf.set(t._1, t._2))
 
   /**
     * Adds a [[org.apache.spark.scheduler.SparkListener]].


### PR DESCRIPTION
- The setAll method signature has changed between Spark 3.0 and 3.1. Before Spark 3.1, it is setAll(Traversable), in Spark 3.1, it is setAll(Iterable)