### PR TITLE
Do not run CapabilityManagementService scheduled runs for CapabilityManagementServiceTest

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityManagementService.java
@@ -45,7 +45,6 @@ public class CapabilityManagementService extends AbstractRetryableScheduledServi
   private final long scheduleIntervalInMillis;
   private final CConfiguration cConf;
   private final CapabilityApplier capabilityApplier;
-  private final SystemProgramManagementService systemProgramManagementService;
 
   @Inject
   CapabilityManagementService(CConfiguration cConf, CapabilityApplier capabilityApplier,
@@ -54,21 +53,8 @@ public class CapabilityManagementService extends AbstractRetryableScheduledServi
             .fixDelay(cConf.getLong(Constants.Capability.DIR_SCAN_INTERVAL_MINUTES), TimeUnit.MINUTES));
     this.cConf = cConf;
     this.capabilityApplier = capabilityApplier;
-    this.systemProgramManagementService = systemProgramManagementService;
     this.scheduleIntervalInMillis = TimeUnit.MINUTES
       .toMillis(cConf.getLong(Constants.Capability.DIR_SCAN_INTERVAL_MINUTES));
-  }
-
-  @Override
-  protected void doStartUp() {
-    LOG.debug("Starting scheduled service {}", getServiceName());
-    systemProgramManagementService.start();
-  }
-
-  @Override
-  protected void doShutdown() {
-    LOG.debug("Stopping scheduled service {}", getServiceName());
-    systemProgramManagementService.stopAndWait();
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityModule.java
@@ -32,6 +32,7 @@ public class CapabilityModule extends PrivateModule {
     bind(CapabilityWriter.class).to(CapabilityStatusStore.class);
     bind(SystemProgramManagementService.class).in(Scopes.SINGLETON);
     bind(CapabilityManagementService.class).in(Scopes.SINGLETON);
+    expose(SystemProgramManagementService.class);
     expose(CapabilityManagementService.class);
     expose(CapabilityReader.class);
     expose(CapabilityWriter.class);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
@@ -73,6 +73,7 @@ public class SystemProgramManagementServiceTest extends AppFabricTestBase {
     progmMgmtSvc = new SystemProgramManagementService(getInjector().getInstance(CConfiguration.class),
                                                       getInjector().getInstance(ProgramRuntimeService.class),
                                                       programLifecycleService);
+    progmMgmtSvc.stopAndWait();
   }
 
   @AfterClass

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/bootstrap/BootstrapServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/bootstrap/BootstrapServiceTest.java
@@ -21,6 +21,7 @@ import com.google.gson.JsonObject;
 import io.cdap.cdap.api.retry.RetryableException;
 import io.cdap.cdap.common.service.RetryStrategy;
 import io.cdap.cdap.internal.AppFabricTestHelper;
+import io.cdap.cdap.internal.app.services.SystemProgramManagementService;
 import io.cdap.cdap.internal.bootstrap.executor.BaseStepExecutor;
 import io.cdap.cdap.internal.bootstrap.executor.BootstrapStepExecutor;
 import io.cdap.cdap.internal.bootstrap.executor.EmptyArguments;
@@ -78,8 +79,11 @@ public class BootstrapServiceTest {
     systemAppManagementService = AppFabricTestHelper.getInjector().getInstance(SystemAppManagementService.class);
     CapabilityManagementService capabilityManagementService = AppFabricTestHelper.getInjector()
       .getInstance(CapabilityManagementService.class);
+    SystemProgramManagementService systemProgramManagementService = AppFabricTestHelper.getInjector()
+      .getInstance(SystemProgramManagementService.class);
     bootstrapService = new BootstrapService(bootstrapConfigProvider, bootstrapStore, executors,
-                                            systemAppManagementService, capabilityManagementService);
+                                            systemAppManagementService, capabilityManagementService,
+                                            systemProgramManagementService);
     bootstrapService.reload();
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityManagementServiceTest.java
@@ -89,6 +89,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
     capabilityStatusStore = new CapabilityStatusStore(getInjector().getInstance(TransactionRunner.class));
     applicationLifecycleService = getInjector().getInstance(ApplicationLifecycleService.class);
     programLifecycleService = getInjector().getInstance(ProgramLifecycleService.class);
+    capabilityManagementService.stopAndWait();
   }
 
   @AfterClass
@@ -99,11 +100,13 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
   @After
   public void reset() throws Exception {
     // Reset all relevant stores.
-    for (ApplicationDetail appDetail : applicationLifecycleService.getApps(NamespaceId.SYSTEM, null)) {
+    for (ApplicationDetail appDetail : applicationLifecycleService
+      .getApps(NamespaceId.SYSTEM, applicationDetail -> true)) {
       programLifecycleService.stopAll(
         new ApplicationId(NamespaceId.SYSTEM.getNamespace(), appDetail.getName(), appDetail.getAppVersion()));
     }
-    for (ApplicationDetail appDetail : applicationLifecycleService.getApps(NamespaceId.DEFAULT, null)) {
+    for (ApplicationDetail appDetail : applicationLifecycleService
+      .getApps(NamespaceId.DEFAULT, applicationDetail -> true)) {
       programLifecycleService.stopAll(
         new ApplicationId(NamespaceId.DEFAULT.getNamespace(), appDetail.getName(), appDetail.getAppVersion()));
     }


### PR DESCRIPTION
- The CapabilityManagementService scheduled service run is causing race conditions with the explicit runTask call in CapabilityManagementServiceTest
- Stop the scheduled run for tests
- Make SystemProgramManagementService independent of CapabilityManagementService