### PR TITLE
Fix the Spark detection via SSH

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillPreparer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillPreparer.java
@@ -449,7 +449,7 @@ class RemoteExecutionTwillPreparer implements TwillPreparer {
                                                     twillRuntimeSpec.getMinHeapRatio(runnableName));
 
           // Spark env setup script
-          session.executeAndWait(String.format("bash %s/%s/%s %s/%s/%s > %s/%s",
+          session.executeAndWait(String.format("bash %s/%s/%s %s/%s/%s %s/%s",
                                                targetPath, Constants.Files.RUNTIME_CONFIG_JAR, SETUP_SPARK_SH,
                                                targetPath, Constants.Files.RUNTIME_CONFIG_JAR, SETUP_SPARK_PY,
                                                targetPath, SPARK_ENV_SH));

--- a/cdap-app-fabric/src/main/resources/setupSpark.py
+++ b/cdap-app-fabric/src/main/resources/setupSpark.py
@@ -15,7 +15,9 @@
 # the License.
 
 # A simple python that runs with spark-submit to grab all SPARK environment variables
-import os
+import os, sys
+f = open(sys.argv[1], "w")
 for key, val in os.environ.items():
     if key.startswith("SPARK_") or key.startswith("HADOOP_"):
-        print("export {}=\"{}\"".format(key, val))
+        f.write("export {}=\"{}\"\n".format(key, val))
+f.close()

--- a/cdap-app-fabric/src/main/resources/setupSpark.sh
+++ b/cdap-app-fabric/src/main/resources/setupSpark.sh
@@ -16,5 +16,5 @@
 #!/bin/bash
 
 if [[ $(which spark-submit 2>/dev/null) ]]; then
-  spark-submit --master local[2] $1
+  spark-submit --master local[2] $@
 fi


### PR DESCRIPTION
cherrypick: #13053

Not included changes from `DefaultRuntimeJob` as that class was only added in 6.2.x releases