### PR TITLE
[CDAP-16623] Simplify Connections side panel expand/hide controls

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/ADLSBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/ADLSBrowser/index.js
@@ -77,6 +77,7 @@ export default class ADLSBrowser extends Component {
     onWorkspaceCreate: PropTypes.func,
     scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     browserTitle: PropTypes.string,
+    showPanelToggle: PropTypes.bool,
   };
 
   parsePath() {
@@ -501,6 +502,7 @@ export default class ADLSBrowser extends Component {
             allowSidePanelToggle={true}
             toggle={this.props.toggle}
             browserTitle={this.props.browserTitle}
+            showPanelToggle={this.props.showPanelToggle}
           />
           <div
             className={classnames('sub-panel', { 'routing-disabled': !this.props.enableRouting })}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/BigQueryBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/BigQueryBrowser/index.js
@@ -36,6 +36,7 @@ export default class BiqQueryBrowser extends Component {
     onWorkspaceCreate: PropTypes.func,
     enableRouting: PropTypes.bool,
     scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+    showPanelToggle: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -58,6 +59,7 @@ export default class BiqQueryBrowser extends Component {
             allowSidePanelToggle={true}
             toggle={this.props.toggle}
             browserTitle={T.translate(`${PREFIX}.title`)}
+            showPanelToggle={this.props.showPanelToggle}
           />
           {this.props.enableRouting ? (
             <Switch>

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel/index.tsx
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DataPrepBrowserTopPanel/index.tsx
@@ -17,6 +17,7 @@
 import classnames from 'classnames';
 import * as React from 'react';
 import IconSVG from 'components/IconSVG';
+import If from 'components/If';
 
 require('./DataPrepBrowserTopPanel.scss');
 
@@ -24,6 +25,7 @@ interface IDataprepBrowserTopPanel {
   allowSidePanelToggle: boolean;
   toggle: (e: React.MouseEvent<HTMLElement>) => void;
   browserTitle: React.ReactNode;
+  showPanelToggle: boolean;
 }
 export default class DataprepBrowserTopPanel extends React.PureComponent<IDataprepBrowserTopPanel> {
   public render() {
@@ -31,14 +33,16 @@ export default class DataprepBrowserTopPanel extends React.PureComponent<IDatapr
       <div className="dataprep-browser-top-panel">
         <div className="title">
           <h5>
-            <span
-              className={classnames('fa fa-fw', {
-                disabled: !this.props.allowSidePanelToggle,
-              })}
-              onClick={this.props.toggle}
-            >
-              <IconSVG name="icon-bars" />
-            </span>
+            <If condition={this.props.showPanelToggle}>
+              <span
+                className={classnames('fa fa-fw', {
+                  disabled: !this.props.allowSidePanelToggle,
+                })}
+                onClick={this.props.toggle}
+              >
+                <IconSVG name="icon-chevron-right" />
+              </span>
+            </If>
 
             <span>{this.props.browserTitle}</span>
           </h5>

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/DatabaseBrowser/index.js
@@ -45,6 +45,7 @@ export default class DatabaseBrowser extends Component {
     toggle: PropTypes.func,
     onWorkspaceCreate: PropTypes.func,
     scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+    showPanelToggle: PropTypes.bool,
   };
 
   state = {
@@ -232,6 +233,7 @@ export default class DatabaseBrowser extends Component {
           allowSidePanelToggle={true}
           toggle={this.props.toggle}
           browserTitle={T.translate(`${PREFIX}.title`)}
+          showPanelToggle={this.props.showPanelToggle}
         />
         <div>
           <div className="database-browser-header">

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/GCSBrowser/index.js
@@ -47,6 +47,7 @@ export default class GCSBrowser extends Component {
     enableRouting: PropTypes.bool,
     onWorkspaceCreate: PropTypes.func,
     scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+    showPanelToggle: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -122,6 +123,7 @@ export default class GCSBrowser extends Component {
             allowSidePanelToggle={true}
             toggle={this.props.toggle}
             browserTitle={T.translate(`${PREFIX}.TopPanel.selectData`)}
+            showPanelToggle={this.props.showPanelToggle}
           />
           <div
             className={classnames('sub-panel', { 'routing-disabled': !this.props.enableRouting })}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/KafkaBrowser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/KafkaBrowser/index.js
@@ -45,6 +45,7 @@ export default class KafkaBrowser extends Component {
     enableRouting: PropTypes.bool,
     onWorkspaceCreate: PropTypes.func,
     scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+    showPanelToggle: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -233,6 +234,7 @@ export default class KafkaBrowser extends Component {
           allowSidePanelToggle={true}
           toggle={this.props.toggle}
           browserTitle={T.translate(`${PREFIX}.title`)}
+          showPanelToggle={this.props.showPanelToggle}
         />
         <If condition={!this.state.error}>
           <div className="kafka-browser-header">

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/S3Browser/index.js
@@ -46,6 +46,7 @@ export default class S3Browser extends Component {
     enableRouting: PropTypes.bool,
     onWorkspaceCreate: PropTypes.func,
     scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+    showPanelToggle: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -127,6 +128,7 @@ export default class S3Browser extends Component {
             allowSidePanelToggle={true}
             toggle={this.props.toggle}
             browserTitle={T.translate(`${PREFIX}.TopPanel.selectData`)}
+            showPanelToggle={this.props.showPanelToggle}
           />
           <div
             className={classnames('sub-panel', { 'routing-disabled': !this.props.enableRouting })}

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/SpannerBrowser/index.tsx
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepBrowser/SpannerBrowser/index.tsx
@@ -35,6 +35,7 @@ interface ISpannerBrowserProps {
   onWorkspaceCreate: () => void;
   enableRouting: boolean;
   scope: boolean | string;
+  showPanelToggle: boolean;
 }
 
 export default class SpannerBrowser extends React.PureComponent<ISpannerBrowserProps> {
@@ -62,6 +63,7 @@ export default class SpannerBrowser extends React.PureComponent<ISpannerBrowserP
             allowSidePanelToggle={true}
             toggle={this.props.toggle}
             browserTitle={T.translate(`${PREFIX}.title`)}
+            showPanelToggle={this.props.showPanelToggle}
           />
           {this.props.enableRouting ? (
             <Switch>

--- a/cdap-ui/app/cdap/components/DataPrepConnections/DataPrepConnections.scss
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/DataPrepConnections.scss
@@ -48,6 +48,11 @@ $expanded-menu-icon-width: 40px;
       h5 {
         font-size: 14px;
         font-weight: 600;
+
+        .panel-toggle-icon {
+          padding-right: 5px;
+          vertical-align: top;
+        }
       }
     }
 

--- a/cdap-ui/app/cdap/components/DataPrepConnections/NoDefaultConnection/index.tsx
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/NoDefaultConnection/index.tsx
@@ -36,12 +36,14 @@ interface INoDefaultConnectionProps {
   showAddConnectionPopover: () => void;
   toggleSidepanel: (e: React.MouseEvent<HTMLElement>) => void;
   connectionsList: IPartialConnectionType[];
+  showPanelToggle: boolean;
 }
 const NoDefaultConnection: React.SFC<INoDefaultConnectionProps> = ({
   defaultConnection,
   showAddConnectionPopover,
   connectionsList = [],
   toggleSidepanel,
+  showPanelToggle,
 }) => {
   const defaultConnectionObj = connectionsList.find((conn) => conn.id === defaultConnection);
   if (isNilOrEmpty(defaultConnection) || !defaultConnectionObj) {
@@ -51,6 +53,7 @@ const NoDefaultConnection: React.SFC<INoDefaultConnectionProps> = ({
           allowSidePanelToggle={true}
           toggle={toggleSidepanel}
           browserTitle={T.translate(`${PREFIX}.title`)}
+          showPanelToggle={showPanelToggle}
         />
 
         <EmptyMessageContainer title={T.translate(`${PREFIX}.title`)}>

--- a/cdap-ui/app/cdap/components/DataPrepConnections/UploadFile/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/UploadFile/index.js
@@ -129,6 +129,7 @@ export default class ConnectionsUpload extends Component {
           allowSidePanelToggle={true}
           toggle={this.props.toggle}
           browserTitle={T.translate(`${PREFIX}.title`)}
+          showPanelToggle={this.props.showPanelToggle}
         />
 
         <div className="upload-content-container">
@@ -173,4 +174,5 @@ export default class ConnectionsUpload extends Component {
 ConnectionsUpload.propTypes = {
   toggle: PropTypes.func,
   onWorkspaceCreate: PropTypes.func,
+  showPanelToggle: PropTypes.bool,
 };

--- a/cdap-ui/app/cdap/components/DataPrepConnections/index.js
+++ b/cdap-ui/app/cdap/components/DataPrepConnections/index.js
@@ -727,8 +727,8 @@ export default class DataPrepConnections extends Component {
       <div className="connections-panel">
         <div className="panel-title" onClick={this.toggleSidePanel}>
           <h5>
-            <span className="fa fa-fw">
-              <IconSVG name="icon-angle-double-left" />
+            <span className="fa fa-fw panel-toggle-icon">
+              <IconSVG name="icon-chevron-left" />
             </span>
 
             <span>{T.translate(`${PREFIX}.title`, { namespace })}</span>
@@ -894,7 +894,8 @@ export default class DataPrepConnections extends Component {
                 match={match}
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
-                setActiveConnection={setActiveConnection}
+                setActiveConnetion={setActiveConnection}
+                showPanelToggle={!this.state.sidePanelExpanded}
               />
             );
           }}
@@ -906,6 +907,7 @@ export default class DataPrepConnections extends Component {
               <ConnectionsUpload
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
+                showPanelToggle={!this.state.sidePanelExpanded}
               />
             );
           }}
@@ -924,6 +926,7 @@ export default class DataPrepConnections extends Component {
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
+                showPanelToggle={!this.state.sidePanelExpanded}
               />
             );
           }}
@@ -942,6 +945,7 @@ export default class DataPrepConnections extends Component {
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
+                showPanelToggle={!this.state.sidePanelExpanded}
               />
             );
           }}
@@ -962,6 +966,7 @@ export default class DataPrepConnections extends Component {
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
+                showPanelToggle={!this.state.sidePanelExpanded}
               />
             );
           }}
@@ -982,6 +987,7 @@ export default class DataPrepConnections extends Component {
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
+                showPanelToggle={!this.state.sidePanelExpanded}
               />
             );
           }}
@@ -1000,6 +1006,7 @@ export default class DataPrepConnections extends Component {
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
+                showPanelToggle={!this.state.sidePanelExpanded}
               />
             );
           }}
@@ -1018,6 +1025,7 @@ export default class DataPrepConnections extends Component {
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
+                showPanelToggle={!this.state.sidePanelExpanded}
               />
             );
           }}
@@ -1036,6 +1044,7 @@ export default class DataPrepConnections extends Component {
                 toggle={this.toggleSidePanel}
                 onWorkspaceCreate={this.onUploadSuccess}
                 setActiveConnection={setActiveConnection}
+                showPanelToggle={!this.state.sidePanelExpanded}
               />
             );
           }}
@@ -1062,6 +1071,7 @@ export default class DataPrepConnections extends Component {
                 connectionsList={this.state.connectionsList}
                 showAddConnectionPopover={this.toggleAddConnectionPopover.bind(this, true)}
                 toggleSidepanel={this.toggleSidePanel}
+                showPanelToggle={!this.state.sidePanelExpanded}
               />
             );
           }}
@@ -1076,7 +1086,11 @@ export default class DataPrepConnections extends Component {
     }
     if (this.state.showUpload) {
       return (
-        <ConnectionsUpload toggle={this.toggleSidePanel} onWorkspaceCreate={this.onUploadSuccess} />
+        <ConnectionsUpload
+          toggle={this.toggleSidePanel}
+          onWorkspaceCreate={this.onUploadSuccess}
+          showPanelToggle={!this.state.sidePanelExpanded}
+        />
       );
     }
     let { enableRouting, ...attributes } = this.props;
@@ -1191,6 +1205,7 @@ export default class DataPrepConnections extends Component {
             connectionsList={this.state.connectionsList}
             showAddConnectionPopover={this.toggleAddConnectionPopover.bind(this, true)}
             toggleSidepanel={this.toggleSidePanel}
+            showPanelToggle={!this.state.sidePanelExpanded}
           />
         );
       }
@@ -1203,6 +1218,7 @@ export default class DataPrepConnections extends Component {
         onWorkspaceCreate={!this.props.singleWorkspaceMode ? null : this.props.onWorkspaceCreate}
         enableRouting={enableRouting}
         setActiveConnection={setActiveConnection}
+        showPanelToggle={!this.state.sidePanelExpanded}
         {...attributes}
       />
     );

--- a/cdap-ui/app/cdap/components/FileBrowser/index.js
+++ b/cdap-ui/app/cdap/components/FileBrowser/index.js
@@ -73,6 +73,7 @@ export default class FileBrowser extends Component {
     onWorkspaceCreate: PropTypes.func,
     scope: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     browserTitle: PropTypes.string,
+    showPanelToggle: PropTypes.bool,
   };
 
   componentDidMount() {
@@ -491,6 +492,7 @@ export default class FileBrowser extends Component {
           allowSidePanelToggle={this.props.allowSidePanelToggle}
           toggle={this.props.toggle}
           browserTitle={this.props.browserTitle}
+          showPanelToggle={this.props.showPanelToggle}
         />
 
         <div className="sub-panel">


### PR DESCRIPTION
Jira: https://cdap.atlassian.net/browse/CDAP-16623

This changes the show/hide controls of the DataPrepBrowser and DataPrepConnections so only 1 appears at a time. It also changes the icon so the behavior should be easier to predict.

With browser open:
![image](https://user-images.githubusercontent.com/2728821/105758598-478f1780-5f04-11eb-81a9-e1cb65e239f5.png)

With connections open:
![image](https://user-images.githubusercontent.com/2728821/105758636-51187f80-5f04-11eb-8a68-43b54487afe6.png)
