### PR TITLE
[CDAP-17290] Change default value for Checkpoint Temp File Rewrite config value

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3248,7 +3248,7 @@
 
   <property>
     <name>spark.streaming.checkpoint.rewrite.enabled</name>
-    <value>false</value>
+    <value>true</value>
     <description>
       Specify whether to rewrite the temporary checkpoint file name by adding the checkpoint timestamp to the temporary
       file name. This is useful when using object storage as the checkpoint directory.


### PR DESCRIPTION
Enabled the Streaming Pipeline Checkpoint Temp File Rewrite feature by default in 6.4 and later.