### PR TITLE
[CDAP-17642] Added tracking for namespaceCount metrics and namespaces table operations to AppMetadataStore

### DIFF
--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -230,6 +230,12 @@
       <groupId>org.apache.directory.jdbm</groupId>
       <artifactId>apacheds-jdbm1</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-test</artifactId>
+      <version>6.4.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/namespace/StorageProviderNamespaceAdminTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/namespace/StorageProviderNamespaceAdminTest.java
@@ -43,6 +43,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * Tests for {@link StorageProviderNamespaceAdmin}
@@ -101,6 +102,17 @@ public class StorageProviderNamespaceAdminTest {
     Assert.assertTrue(namespaceLocation.exists());
     storageProviderNamespaceAdmin.delete(myspace);
     Assert.assertFalse(namespaceLocation.exists());
+  }
+
+  @Test
+  public void testCountNamespaces() {
+    for (String namespace : Arrays.asList("myspace1", "myspace2", "myspace3")) {
+      NamespaceId namespaceId = new NamespaceId(namespace);
+      NamespaceMeta namespaceMeta = new NamespaceMeta.Builder().setName(namespaceId.getNamespace()).build();
+      namespaceStore.create(namespaceMeta);
+    }
+
+    Assert.assertEquals(3, namespaceStore.getNamespaceCount());
   }
 
   @Test

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/SqlDefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/SqlDefaultStoreTest.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.store;
 
 import com.google.inject.Injector;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.internal.AppFabricTestHelper;
@@ -69,9 +70,10 @@ public class SqlDefaultStoreTest extends DefaultStoreTest {
     nsStore = new DefaultNamespaceStore(transactionRunner);
     nsAdmin = new DefaultNamespaceAdmin(
       nsStore, store, injector.getInstance(DatasetFramework.class),
-      injector.getProvider(NamespaceResourceDeleter.class), injector.getProvider(StorageProviderNamespaceAdmin.class),
-      injector.getInstance(CConfiguration.class), injector.getInstance(Impersonator.class),
-      injector.getInstance(AuthorizationEnforcer.class), injector.getInstance(AuthenticationContext.class));
+      injector.getInstance(MetricsCollectionService.class), injector.getProvider(NamespaceResourceDeleter.class),
+      injector.getProvider(StorageProviderNamespaceAdmin.class), injector.getInstance(CConfiguration.class),
+      injector.getInstance(Impersonator.class), injector.getInstance(AuthorizationEnforcer.class),
+      injector.getInstance(AuthenticationContext.class));
   }
 
   @AfterClass

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -783,6 +783,7 @@ public final class Constants {
       public static final String PROGRAM_PROVISIONING_DELAY_SECONDS = "program.provisioning.delay.seconds";
       public static final String RUN_TIME_SECONDS = "program.run.seconds";
       public static final String APPLICATION_COUNT = "application.count";
+      public static final String NAMESPACE_COUNT = "namespace.count";
     }
 
     /**

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/DefaultNamespaceStore.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/DefaultNamespaceStore.java
@@ -100,4 +100,11 @@ public class DefaultNamespaceStore implements NamespaceStore {
       return getNamespaceTable(context).list();
     });
   }
+
+  @Override
+  public long getNamespaceCount() {
+    return TransactionRunners.run(transactionRunner, context -> {
+      return getNamespaceTable(context).getNamespaceCount();
+    });
+  }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/NamespaceStore.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/NamespaceStore.java
@@ -74,4 +74,10 @@ public interface NamespaceStore {
    * @return a list of all registered namespaces
    */
   List<NamespaceMeta> list();
+
+  /**
+   * Counts all namespaces.
+   * @return long of the count
+   */
+  long getNamespaceCount();
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/NamespaceTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/NamespaceTable.java
@@ -31,6 +31,9 @@ import io.cdap.cdap.spi.data.table.field.Range;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -104,5 +107,24 @@ public final class NamespaceTable {
       }
     }
     return result;
+  }
+
+  /**
+   * Count all namespaces
+   * @return long of all namespaces except for system.
+   * @throws IOException from StructuredTable.count
+   */
+  public long getNamespaceCount() throws IOException {
+    return getNamespaceCount(Collections.singletonList(Range.all()));
+  }
+
+  /**
+   * Count namespaces for a particular range.
+   * @param ranges list of ranges
+   * @return long of all namespaces based on range
+   * @throws IOException from StructuredTable.count
+   */
+  public long getNamespaceCount(Collection<Range> ranges) throws IOException {
+    return table.count(ranges);
   }
 }


### PR DESCRIPTION
Similar to https://github.com/cdapio/cdap/pull/12796, except this is for namespaces instead of applications.