### PR TITLE
Support DateTime datatype in CDAP Schema

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/data/schema/Schema.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/data/schema/Schema.java
@@ -93,6 +93,7 @@ public final class Schema implements Serializable {
    * Logical type TIME_MILLIS relies on INT as underlying primitive type
    * Logical type TIME_MICROS relies on LONG as underlying primitive type
    * Logical type DECIMAL relies on BYTES as underlying primitive type
+   * Logical type DATETIME relies on STRING as underlying primitive type
    *
    * For example, the json schema for logicaltype date will be as below:
    * {
@@ -114,6 +115,13 @@ public final class Schema implements Serializable {
    * For example,
    * An unscaled value of 102 and scale 1 represents the number 10.2 with precision 3.
    * An unscaled value of 111 and scale -1 represents the number 1110 with precision 3.
+   *
+   * Example json schema for logicaltype datetime will be as below.
+   * {
+   *   "type": "string",
+   *   "logicalType": "datetime"
+   * }
+   * Note that the string value is expected to be in ISO 8601 format without offset(timezone).
    */
   public enum LogicalType {
     DATE(Type.INT, "date"),
@@ -121,7 +129,8 @@ public final class Schema implements Serializable {
     TIMESTAMP_MICROS(Type.LONG, "timestamp-micros"),
     TIME_MILLIS(Type.INT, "time-millis"),
     TIME_MICROS(Type.LONG, "time-micros"),
-    DECIMAL(Type.BYTES, "decimal");
+    DECIMAL(Type.BYTES, "decimal"),
+    DATETIME(Type.STRING, "datetime");
 
     private final Type type;
     private final String token;
@@ -743,6 +752,7 @@ public final class Schema implements Serializable {
    * {@link LogicalType#TIMESTAMP_MILLIS} -> "timestamp in milliseconds"
    * {@link LogicalType#TIMESTAMP_MICROS} -> "timestamp in microseconds"
    * {@link LogicalType#DECIMAL} -> "decimal with precision p and scale s"
+   * {@link LogicalType#DATETIME} -> "datetime in ISO-8601 format without timezone"
    *
    * @return display name of this schema.
    */
@@ -761,6 +771,8 @@ public final class Schema implements Serializable {
           return "timestamp in microseconds";
         case DECIMAL:
           return String.format("decimal with precision %d and scale %d", precision, scale);
+        case DATETIME:
+          return String.format("datetime in ISO-8601 format without timezone");
       }
     }
 

--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/data/schema/SchemaHash.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/data/schema/SchemaHash.java
@@ -202,6 +202,9 @@ public final class SchemaHash implements Serializable {
           md5.update((byte) schema.getPrecision());
           md5.update((byte) schema.getScale());
           break;
+        case DATETIME:
+          md5.update((byte) 19);
+          break;
       }
     }
 

--- a/cdap-common/src/test/java/io/cdap/cdap/io/SchemaHashTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/io/SchemaHashTest.java
@@ -75,4 +75,14 @@ public class SchemaHashTest {
     Assert.assertNotEquals(schema1, schema2);
     Assert.assertEquals(schema1.getSchemaHash(), schema1.getSchemaHash());
   }
+
+  @Test
+  public void testDateTimeHash() {
+    //Datetime type should have a different hash than the string type
+    Schema schema1 = Schema.of(Schema.LogicalType.DATETIME);
+    Schema schema2 = Schema.of(Schema.Type.STRING);
+    Schema schema3 = Schema.of(Schema.LogicalType.DATETIME);
+    Assert.assertNotEquals(schema1.getSchemaHash(), schema2.getSchemaHash());
+    Assert.assertEquals(schema1.getSchemaHash(), schema3.getSchemaHash());
+  }
 }

--- a/cdap-formats/src/main/java/io/cdap/cdap/format/io/JsonStructuredRecordDatumWriter.java
+++ b/cdap-formats/src/main/java/io/cdap/cdap/format/io/JsonStructuredRecordDatumWriter.java
@@ -171,6 +171,10 @@ public class JsonStructuredRecordDatumWriter extends StructuredRecordDatumWriter
           }
           encoder.writeString(bigDecimal.toString());
           break;
+        case DATETIME:
+          //expecting value to be already in the correct format
+          encoder.writeString(value.toString());
+          break;
       }
       return;
     }

--- a/cdap-formats/src/test/java/io/cdap/cdap/format/StructuredRecordBuilderTest.java
+++ b/cdap-formats/src/test/java/io/cdap/cdap/format/StructuredRecordBuilderTest.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -158,6 +159,20 @@ public class StructuredRecordBuilderTest {
       .setTimestamp("timestamp", expectedMicros).build();
     actual = record.getTimestamp("timestamp");
     Assert.assertEquals(expectedMicros, actual);
+  }
+
+  @Test
+  public void testDateTimeSupport() {
+    String fieldName = "datetimefield";
+    Schema schema = Schema.recordOf("test", Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+                                    Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+                                    Schema.Field.of(fieldName, Schema.of(Schema.LogicalType.DATETIME)));
+    LocalDateTime localDateTime = LocalDateTime.now();
+    StructuredRecord record = StructuredRecord.builder(schema)
+      .set("id", 1)
+      .set("name", "test")
+      .setDateTime(fieldName, localDateTime).build();
+    Assert.assertEquals(localDateTime, record.getDateTime(fieldName));
   }
 
   @Test
@@ -322,6 +337,15 @@ public class StructuredRecordBuilderTest {
     thrown.expect(ClassCastException.class);
     thrown.expectMessage("Field 'x' is expected to be a time");
     record.getTime("x");
+  }
+
+  @Test
+  public void testUnexpectedDateTimeType() {
+    Schema schema = Schema.recordOf("test", Schema.Field.of("x", Schema.of(Schema.LogicalType.DATETIME)));
+    StructuredRecord record = StructuredRecord.builder(schema).set("x", "12:00:00").build();
+    thrown.expect(UnexpectedFormatException.class);
+    thrown.expectMessage("Field 'x' with value '12:00:00' is not a valid datetime in ISO-8601 format");
+    record.getDateTime("x");
   }
 
   @Test


### PR DESCRIPTION
Support DateTime datatype in CDAP Schema
- New DateTime logical type 
- Convenience methods for getting and setting LocalDateTime for StructuredRecord
- Structured record datetime field from/to string conversion validates the format.