### PR TITLE
[CDAP-17670] Cache various transform objects  in io.cdap.cdap.etl.spark.function

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineRunner.java
@@ -122,8 +122,8 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
                                                            StageStatisticsCollector collector) throws Exception {
     DynamicDriverContext dynamicDriverContext = new DynamicDriverContext(stageSpec, sec, collector);
     JavaDStream<Object> dStream = inputCollection.getUnderlying();
-    JavaPairDStream<Object, Object> result =
-      dStream.transformToPair(new DynamicJoinOn<>(dynamicDriverContext, inputStageName));
+    JavaPairDStream<Object, Object> result = dStream.transformToPair(
+      new DynamicJoinOn<>(dynamicDriverContext, functionCacheFactory.newCache(), inputStageName));
     return new PairDStreamCollection<>(sec, result);
   }
 
@@ -134,7 +134,8 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
 
     DynamicDriverContext dynamicDriverContext = new DynamicDriverContext(stageSpec, sec, collector);
     JavaPairDStream<Object, List<JoinElement<Object>>> pairDStream = joinedInputs.getUnderlying();
-    JavaDStream<Object> result = pairDStream.transform(new DynamicJoinMerge<>(dynamicDriverContext));
+    JavaDStream<Object> result = pairDStream.transform(
+      new DynamicJoinMerge<>(dynamicDriverContext, functionCacheFactory.newCache()));
     return new DStreamCollection<>(sec, result);
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorAggregateFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorAggregateFunction.java
@@ -39,17 +39,19 @@ import scala.Tuple2;
 public class AggregatorAggregateFunction<GROUP_KEY, GROUP_VAL, OUT>
   implements FlatMapFunc<Tuple2<GROUP_KEY, Iterable<GROUP_VAL>>, RecordInfo<Object>> {
   private final PluginFunctionContext pluginFunctionContext;
+  private final FunctionCache functionCache;
   private transient TrackedTransform<Tuple2<GROUP_KEY, Iterable<GROUP_VAL>>, OUT> aggregateTransform;
   private transient CombinedEmitter<OUT> emitter;
 
-  public AggregatorAggregateFunction(PluginFunctionContext pluginFunctionContext) {
+  public AggregatorAggregateFunction(PluginFunctionContext pluginFunctionContext, FunctionCache functionCache) {
     this.pluginFunctionContext = pluginFunctionContext;
+    this.functionCache = functionCache;
   }
 
   @Override
   public Iterable<RecordInfo<Object>> call(Tuple2<GROUP_KEY, Iterable<GROUP_VAL>> input) throws Exception {
     if (aggregateTransform == null) {
-      Object plugin = pluginFunctionContext.createPlugin();
+      Object plugin = pluginFunctionContext.createAndInitializePlugin(functionCache);
       BatchAggregator<GROUP_KEY, GROUP_VAL, OUT> aggregator;
       if (plugin instanceof BatchReducibleAggregator) {
         BatchReducibleAggregator<GROUP_KEY, GROUP_VAL, ?, OUT> reducibleAggregator =
@@ -58,7 +60,6 @@ public class AggregatorAggregateFunction<GROUP_KEY, GROUP_VAL, OUT>
       } else {
         aggregator = (BatchAggregator<GROUP_KEY, GROUP_VAL, OUT>) plugin;
       }
-      aggregator.initialize(pluginFunctionContext.createBatchRuntimeContext());
       aggregateTransform = new TrackedTransform<>(new AggregateTransform<>(aggregator),
                                                   pluginFunctionContext.createStageMetrics(),
                                                   Constants.Metrics.AGG_GROUPS,

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorInitializeFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorInitializeFunction.java
@@ -29,17 +29,18 @@ import org.apache.spark.api.java.function.Function;
 public class AggregatorInitializeFunction<GROUP_VALUE, AGG_VALUE> implements Function<GROUP_VALUE, AGG_VALUE> {
 
   private final PluginFunctionContext pluginFunctionContext;
+  private final FunctionCache functionCache;
   private transient BatchReducibleAggregator<?, GROUP_VALUE, AGG_VALUE, ?> aggregator;
 
-  public AggregatorInitializeFunction(PluginFunctionContext pluginFunctionContext) {
+  public AggregatorInitializeFunction(PluginFunctionContext pluginFunctionContext, FunctionCache functionCache) {
     this.pluginFunctionContext = pluginFunctionContext;
+    this.functionCache = functionCache;
   }
 
   @Override
   public AGG_VALUE call(GROUP_VALUE value) throws Exception {
     if (aggregator == null) {
-      aggregator = pluginFunctionContext.createPlugin();
-      aggregator.initialize(pluginFunctionContext.createBatchRuntimeContext());
+      aggregator = pluginFunctionContext.createAndInitializePlugin(functionCache);
     }
     return aggregator.initializeAggregateValue(value);
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorMergePartitionFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorMergePartitionFunction.java
@@ -28,17 +28,18 @@ import org.apache.spark.api.java.function.Function2;
 public class AggregatorMergePartitionFunction<AGG_VALUE> implements Function2<AGG_VALUE, AGG_VALUE, AGG_VALUE> {
 
   private final PluginFunctionContext pluginFunctionContext;
+  private final FunctionCache functionCache;
   private transient BatchReducibleAggregator<?, ?, AGG_VALUE, ?> aggregator;
 
-  public AggregatorMergePartitionFunction(PluginFunctionContext pluginFunctionContext) {
+  public AggregatorMergePartitionFunction(PluginFunctionContext pluginFunctionContext, FunctionCache functionCache) {
     this.pluginFunctionContext = pluginFunctionContext;
+    this.functionCache = functionCache;
   }
 
   @Override
   public AGG_VALUE call(AGG_VALUE value1, AGG_VALUE value2) throws Exception {
     if (aggregator == null) {
-      aggregator = pluginFunctionContext.createPlugin();
-      aggregator.initialize(pluginFunctionContext.createBatchRuntimeContext());
+      aggregator = pluginFunctionContext.createAndInitializePlugin(functionCache);
     }
     return aggregator.mergePartitions(value1, value2);
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorMergeValueFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/AggregatorMergeValueFunction.java
@@ -29,17 +29,18 @@ import org.apache.spark.api.java.function.Function2;
 public class AggregatorMergeValueFunction<AGG_VALUE, GROUP_VALUE>
   implements Function2<AGG_VALUE, GROUP_VALUE, AGG_VALUE> {
   private final PluginFunctionContext pluginFunctionContext;
+  private final FunctionCache functionCache;
   private transient BatchReducibleAggregator<?, GROUP_VALUE, AGG_VALUE, ?> aggregator;
 
-  public AggregatorMergeValueFunction(PluginFunctionContext pluginFunctionContext) {
+  public AggregatorMergeValueFunction(PluginFunctionContext pluginFunctionContext, FunctionCache functionCache) {
     this.pluginFunctionContext = pluginFunctionContext;
+    this.functionCache = functionCache;
   }
 
   @Override
   public AGG_VALUE call(AGG_VALUE aggValue, GROUP_VALUE groupValue) throws Exception {
     if (aggregator == null) {
-      aggregator = pluginFunctionContext.createPlugin();
-      aggregator.initialize(pluginFunctionContext.createBatchRuntimeContext());
+      aggregator = pluginFunctionContext.createAndInitializePlugin(functionCache);
     }
     return aggregator.mergeValues(aggValue, groupValue);
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/BatchSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/BatchSinkFunction.java
@@ -33,18 +33,19 @@ import scala.Tuple2;
  */
 public class BatchSinkFunction<IN, OUT_KEY, OUT_VAL> implements PairFlatMapFunc<IN, OUT_KEY, OUT_VAL> {
   private final PluginFunctionContext pluginFunctionContext;
+  private final FunctionCache functionCache;
   private transient TrackedTransform<IN, KeyValue<OUT_KEY, OUT_VAL>> transform;
   private transient TransformingEmitter<KeyValue<OUT_KEY, OUT_VAL>, Tuple2<OUT_KEY, OUT_VAL>> emitter;
 
-  public BatchSinkFunction(PluginFunctionContext pluginFunctionContext) {
+  public BatchSinkFunction(PluginFunctionContext pluginFunctionContext, FunctionCache functionCache) {
     this.pluginFunctionContext = pluginFunctionContext;
+    this.functionCache = functionCache;
   }
 
   @Override
   public Iterable<Tuple2<OUT_KEY, OUT_VAL>> call(IN input) throws Exception {
     if (transform == null) {
-      BatchSink<IN, OUT_KEY, OUT_VAL> batchSink = pluginFunctionContext.createPlugin();
-      batchSink.initialize(pluginFunctionContext.createBatchRuntimeContext());
+      BatchSink<IN, OUT_KEY, OUT_VAL> batchSink = pluginFunctionContext.createAndInitializePlugin(functionCache);
       transform = new TrackedTransform<>(batchSink, pluginFunctionContext.createStageMetrics(),
                                          pluginFunctionContext.getDataTracer(),
                                          pluginFunctionContext.getStageStatisticsCollector());

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/BatchSourceFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/BatchSourceFunction.java
@@ -31,18 +31,19 @@ import scala.Tuple2;
  */
 public class BatchSourceFunction implements FlatMapFunc<Tuple2<Object, Object>, RecordInfo<Object>> {
   private final PluginFunctionContext pluginFunctionContext;
+  private final FunctionCache functionCache;
   private transient Transformation<KeyValue<Object, Object>, Object> transform;
   private transient CombinedEmitter<Object> emitter;
 
-  public BatchSourceFunction(PluginFunctionContext pluginFunctionContext) {
+  public BatchSourceFunction(PluginFunctionContext pluginFunctionContext, FunctionCache functionCache) {
     this.pluginFunctionContext = pluginFunctionContext;
+    this.functionCache = functionCache;
   }
 
   @Override
   public Iterable<RecordInfo<Object>> call(Tuple2<Object, Object> input) throws Exception {
     if (transform == null) {
-      BatchSource<Object, Object, Object> batchSource = pluginFunctionContext.createPlugin();
-      batchSource.initialize(pluginFunctionContext.createBatchRuntimeContext());
+      BatchSource<Object, Object, Object> batchSource = pluginFunctionContext.createAndInitializePlugin(functionCache);
       transform = new TrackedTransform<>(batchSource,
                                          pluginFunctionContext.createStageMetrics(),
                                          pluginFunctionContext.getDataTracer(),

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/ErrorTransformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/ErrorTransformFunction.java
@@ -31,18 +31,19 @@ import io.cdap.cdap.etl.spark.CombinedEmitter;
  */
 public class ErrorTransformFunction<T, U> implements FlatMapFunc<ErrorRecord<T>, RecordInfo<Object>> {
   private final PluginFunctionContext pluginFunctionContext;
+  private final FunctionCache functionCache;
   private transient TrackedTransform<ErrorRecord<T>, U> transform;
   private transient CombinedEmitter<U> emitter;
 
-  public ErrorTransformFunction(PluginFunctionContext pluginFunctionContext) {
+  public ErrorTransformFunction(PluginFunctionContext pluginFunctionContext, FunctionCache functionCache) {
     this.pluginFunctionContext = pluginFunctionContext;
+    this.functionCache = functionCache;
   }
 
   @Override
   public Iterable<RecordInfo<Object>> call(ErrorRecord<T> inputError) throws Exception {
     if (transform == null) {
-      ErrorTransform<T, U> plugin = pluginFunctionContext.createPlugin();
-      plugin.initialize(pluginFunctionContext.createBatchRuntimeContext());
+      ErrorTransform<T, U> plugin = pluginFunctionContext.createAndInitializePlugin(functionCache);
       transform = new TrackedTransform<>(plugin, pluginFunctionContext.createStageMetrics(),
                                          pluginFunctionContext.getDataTracer(),
                                          pluginFunctionContext.getStageStatisticsCollector());

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/FunctionCache.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/FunctionCache.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * <p>This cache allows to reuse objects that are created on executor side and have high initialization. By default
+ * spark deserializes new task for each partition, so if a single executor processes a lot of partitions it performs
+ * a lot of unnecesary work initializing all the plugins for every partition. This cache solves the problem.</p>
+ * <p>It works in the next fashion:
+ * </p>
+ * <ol>
+ *  <li>Within a driver one creates a factory that can make cache instance.</li>
+ *  <li>A separate cache instance must be created by for each value one wants to cache by calling 
+ *  {@link Factory#newCache()}. Each cache internally gets an unique id that would later be used to find objects in 
+ *  cache.</li>
+ *  <li>The cache can now be serialized and sent over to executors</li>
+ *  <li>When one needs to get a value it calls {@link #getValue} passing loader.</li>
+ *  <li>During first call for a thread a loader is invoked and must create the value to be used later</li>
+ *  <li>If the value was already created for the current thread it's returned without invoking a loader</li>
+ * </ol>
+ * <p>Note that values are reused only within a single thread. This ensures such caching won't provoke any concurrency
+ * issues. It also works good with spark since it uses thread pool to run tasks.
+ * </p>
+ * <p>Also all values are stored as weak references. It ensures that if value is not used anymore and there is 
+ * memory pressure it will be garbage collected.
+ * </p>
+ * <p>Important: One must not reuse caches for different values! New instance of cache must be created for each value
+ * </p>
+ * @see PluginFunctionContext#createAndInitializePlugin 
+ */
+public class FunctionCache implements Serializable {
+  private static final ThreadLocal<Cache<String, Object>> VALUES_CACHE = ThreadLocal.withInitial(
+    () -> CacheBuilder.newBuilder().softValues().build());
+
+  /**
+   * Defines unique key that allows to match values between partition tasks. It consist of factory key and
+   * value number.
+   */
+  private final String key;
+
+  private FunctionCache(String key) {
+    this.key = key;
+  }
+
+  /**
+   * Gets value from a thread-local cache or constructs it using loader.
+   * @param loader function to produce a value when it's not present in cache
+   * @param <T> value type
+   * @throws ExecutionException
+   */
+  public <T> T getValue(Callable<T> loader) throws ExecutionException {
+    T rc = (T) ((Cache) VALUES_CACHE.get()).get(key, loader);
+    return rc;
+  }
+
+  /**
+   * Factory class allows to create cache instances.
+   */
+  public static class Factory {
+    private static final String KEY_SEPARATOR = ":";
+    /**
+     * Key that should help to distinguish factories from different processed in the hypotetical case of constructing
+     * caches within different JVMs. Be default we should do it in driver only, so it's more of a precation measure.
+     */
+    private static final String PROCESS_KEY = UUID.randomUUID().toString();
+    /**
+     * Value that is used to differentiate factories created in same JVM.
+     */
+    private static final AtomicLong FACTORY_COUNTER = new AtomicLong();
+    /**
+     * Factory key
+     */
+    private final String key;
+    /**
+     * Value that is used to differenciate caches produces by a single factory.
+     */
+    private final AtomicInteger counter = new AtomicInteger();
+
+    private Factory(String key) {
+      this.key = key;
+    }
+
+    /**
+     *
+     * @return new instance of cache factory with unique internal id
+     */
+    public static Factory newInstance() {
+      return new Factory(PROCESS_KEY + KEY_SEPARATOR + FACTORY_COUNTER.incrementAndGet());
+    }
+
+    /**
+     *
+     * @return a cache object that can cache a single value and can be serialized.
+     */
+    public FunctionCache newCache() {
+      return new FunctionCache(key + KEY_SEPARATOR + counter.getAndIncrement());
+    }
+
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/MultiOutputTransformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/MultiOutputTransformFunction.java
@@ -29,18 +29,19 @@ import io.cdap.cdap.etl.spark.CombinedEmitter;
  */
 public class MultiOutputTransformFunction<T> implements FlatMapFunc<T, RecordInfo<Object>> {
   private final PluginFunctionContext pluginFunctionContext;
+  private final FunctionCache functionCache;
   private transient TrackedMultiOutputTransform<T, Object> transform;
   private transient CombinedEmitter<Object> emitter;
 
-  public MultiOutputTransformFunction(PluginFunctionContext pluginFunctionContext) {
+  public MultiOutputTransformFunction(PluginFunctionContext pluginFunctionContext, FunctionCache functionCache) {
     this.pluginFunctionContext = pluginFunctionContext;
+    this.functionCache = functionCache;
   }
 
   @Override
   public Iterable<RecordInfo<Object>> call(T input) throws Exception {
     if (transform == null) {
-      SplitterTransform<T, Object> plugin = pluginFunctionContext.createPlugin();
-      plugin.initialize(pluginFunctionContext.createBatchRuntimeContext());
+      SplitterTransform<T, Object> plugin = pluginFunctionContext.createAndInitializePlugin(functionCache);
       transform = new TrackedMultiOutputTransform<>(plugin, pluginFunctionContext.createStageMetrics(),
                                                     pluginFunctionContext.getDataTracer());
       emitter = new CombinedEmitter<>(pluginFunctionContext.getStageName());

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/TransformFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/function/TransformFunction.java
@@ -29,18 +29,19 @@ import io.cdap.cdap.etl.spark.CombinedEmitter;
  */
 public class TransformFunction<T> implements FlatMapFunc<T, RecordInfo<Object>> {
   private final PluginFunctionContext pluginFunctionContext;
+  private final FunctionCache functionCache;
   private transient TrackedTransform<T, Object> transform;
   private transient CombinedEmitter<Object> emitter;
 
-  public TransformFunction(PluginFunctionContext pluginFunctionContext) {
+  public TransformFunction(PluginFunctionContext pluginFunctionContext, FunctionCache functionCache) {
     this.pluginFunctionContext = pluginFunctionContext;
+    this.functionCache = functionCache;
   }
 
   @Override
   public Iterable<RecordInfo<Object>> call(T input) throws Exception {
     if (transform == null) {
-      Transform<T, Object> plugin = pluginFunctionContext.createPlugin();
-      plugin.initialize(pluginFunctionContext.createBatchRuntimeContext());
+      Transform<T, Object> plugin = pluginFunctionContext.createAndInitializePlugin(functionCache);
       transform = new TrackedTransform<>(plugin, pluginFunctionContext.createStageMetrics(),
                                          pluginFunctionContext.getDataTracer(),
                                          pluginFunctionContext.getStageStatisticsCollector());

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/DynamicTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/DynamicTransform.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.etl.spark.streaming.function;
 import io.cdap.cdap.etl.common.RecordInfo;
 import io.cdap.cdap.etl.spark.Compat;
 import io.cdap.cdap.etl.spark.function.FlatMapFunc;
+import io.cdap.cdap.etl.spark.function.FunctionCache;
 import io.cdap.cdap.etl.spark.function.MultiOutputTransformFunction;
 import io.cdap.cdap.etl.spark.function.TransformFunction;
 import io.cdap.cdap.etl.spark.streaming.DynamicDriverContext;
@@ -36,11 +37,15 @@ import org.apache.spark.streaming.Time;
  */
 public class DynamicTransform<T> implements Function2<JavaRDD<T>, Time, JavaRDD<RecordInfo<Object>>> {
   private final DynamicDriverContext dynamicDriverContext;
+  private final FunctionCache functionCache;
   private final boolean isMultiOutput;
   private transient FlatMapFunction<T, RecordInfo<Object>> function;
 
-  public DynamicTransform(DynamicDriverContext dynamicDriverContext, boolean isMultiOutput) {
+  public DynamicTransform(DynamicDriverContext dynamicDriverContext,
+                          FunctionCache functionCache,
+                          boolean isMultiOutput) {
     this.dynamicDriverContext = dynamicDriverContext;
+    this.functionCache = functionCache;
     this.isMultiOutput = isMultiOutput;
   }
 
@@ -48,8 +53,8 @@ public class DynamicTransform<T> implements Function2<JavaRDD<T>, Time, JavaRDD<
   public JavaRDD<RecordInfo<Object>> call(JavaRDD<T> input, Time batchTime) throws Exception {
     if (function == null) {
       FlatMapFunc<T, RecordInfo<Object>> flatMap = isMultiOutput ?
-        new MultiOutputTransformFunction<T>(dynamicDriverContext.getPluginFunctionContext()) :
-        new TransformFunction<T>(dynamicDriverContext.getPluginFunctionContext());
+        new MultiOutputTransformFunction<T>(dynamicDriverContext.getPluginFunctionContext(), functionCache) :
+        new TransformFunction<T>(dynamicDriverContext.getPluginFunctionContext(), functionCache);
       function = Compat.convert(flatMap);
     }
     return input.flatMap(function);


### PR DESCRIPTION
This cache allows to reuse objects that are created on executor side and have high initialization. By default spark deserializes new task for each partition, so if a single executor processes a lot of partitions it performs a lot of unnecessary work initializing all the plugins for every partition. This cache solves the problem.

It works in the next fashion:

1. Within a driver one creates a factory that can make cache instance.
2. A separate cache instance must be created by for each value one wants to cache by calling FunctionCache.Factory.newCache(). Each cache internally gets an unique id that would later be used to find objects in cache.
3. The cache can now be serialized and sent over to executors
4. When one needs to get a value it calls getValue passing loader.
5. During first call for a thread a loader is invoked and must create the value to be used later
6. If the value was already created for the current thread it's returned without invoking a loader

Note that values are reused only within a single thread. This ensures such caching won't provoke any concurrency issues. It also works good with spark since it uses thread pool to run tasks.
Also all values are stored as weak references. It ensures that if value is not used anymore and there is memory pressure it will be garbage collected.