### PR TITLE
[CDAP-17549] Porting comments from React and modifying angular to fit them

### DIFF
--- a/cdap-ui/app/cdap/components/PluginContextMenu/index.tsx
+++ b/cdap-ui/app/cdap/components/PluginContextMenu/index.tsx
@@ -19,6 +19,7 @@ import { ContextMenu, IContextMenuOption } from 'components/ContextMenu';
 import PropTypes from 'prop-types';
 import { copyToClipBoard } from 'services/Clipboard';
 import IconSVG from 'components/IconSVG';
+import CommentIcon from 'components/AbstractWidget/Comment/CommentIcon';
 
 export default function PluginContextMenu({
   nodeId,
@@ -27,8 +28,17 @@ export default function PluginContextMenu({
   getSelectedNodes,
   onDelete,
   onOpen,
+  onAddComment,
 }) {
   const PluginContextMenuOptions: IContextMenuOption[] = [
+    {
+      name: 'plugin comment',
+      label: 'Add a comment',
+      icon: <CommentIcon size="small" />,
+      onClick: () => {
+        onAddComment(nodeId);
+      },
+    },
     {
       name: 'plugin copy',
       label: () => (getSelectedNodes().length > 1 ? 'Copy Plugins' : 'Copy Plugin'),
@@ -82,4 +92,5 @@ export default function PluginContextMenu({
   getSelectedNodes: PropTypes.func,
   onDelete: PropTypes.func,
   onOpen: PropTypes.func,
+  onAddComment: PropTypes.func,
 };

--- a/cdap-ui/app/common/cask-shared-components.js
+++ b/cdap-ui/app/common/cask-shared-components.js
@@ -74,7 +74,7 @@ var AuthRefresher = require('../cdap/components/AuthRefresher').default;
 var ToggleSwitch = require('../cdap/components/ToggleSwitch').default;
 var PipelineList = require('../cdap/components/PipelineList').default;
 var AppHeader = require('../cdap/components/AppHeader').default;
-var Markdown = require('../cdap/components/Markdown').MarkdownWithStyles;
+var Markdown = require('../cdap/components/Markdown').default;
 var CodeEditor = require('../cdap/components/AbstractWidget/CodeEditorWidget').default;
 var JSONEditor = require('../cdap/components/CodeEditor/JSONEditor').default;
 var TextBox = require('../cdap/components/AbstractWidget/FormInputs/TextBox').default;
@@ -128,7 +128,9 @@ var PreviewLogs = require('../cdap/components/PreviewLogs').default;
 var SchemaEditor = require('../cdap/components/AbstractWidget/SchemaEditor').SchemaEditor;
 var PluginSchemaEditor = require('../cdap/components/PluginSchemaEditor').PluginSchemaEditor;
 var ALERT_STATUS = require('../cdap/services/AlertStatus').ALERT_STATUS;
-
+var Comment = require('../cdap/components/AbstractWidget/Comment').default;
+var PipelineCommentsActionBtn = require('../cdap/components/PipelineCanvasActions/PipelineCommentsActionBtn')
+  .default;
 export {
   Store,
   NameSpaceStoreActions,
@@ -230,4 +232,6 @@ export {
   SchemaEditor,
   PluginSchemaEditor,
   ALERT_STATUS,
+  Comment,
+  PipelineCommentsActionBtn,
 };

--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -57,13 +57,17 @@ angular.module(PKG.name + '.commons')
       left: 0
     };
 
-    vm.comments = [];
     vm.nodeMenuOpen = null;
 
     vm.selectedNode = [];
 
-    var commentsTimeout,
-        nodesTimeout,
+    vm.commentsState = vm.isDisabled ? false : true;
+
+    vm.activePluginToComment = null;
+
+    vm.doesStagesHaveComments = false;
+
+    var nodesTimeout,
         fitToScreenTimeout,
         initTimeout,
         metricsPopoverTimeout,
@@ -71,6 +75,16 @@ angular.module(PKG.name + '.commons')
         highlightSelectedNodeConnectionsTimeout;
 
     var Mousetrap = window.CaskCommon.Mousetrap;
+
+    vm.checkIfAnyStageHasComment = () => {
+      const existingStages = DAGPlusPlusNodesStore.getNodes();
+      return !_.isEmpty(
+        existingStages.find(
+          (node) =>
+            Array.isArray(myHelpers.objectQuery(node, 'information', 'comments', 'list')) && node.information.comments.list.length > 0
+        )
+      );
+    };
 
     vm.clearSelectedNodes = () => {
       vm.selectedNode = [];
@@ -278,7 +292,7 @@ angular.module(PKG.name + '.commons')
       vm.selectedNode = newNodes;
       newNodes = [...$scope.nodes, ...newNodes];
       newConnections  = [...$scope.connections, ...newConnections];
-      DAGPlusPlusNodesActionsFactory.createGraphFromConfigOnPaste(newNodes, newConnections, vm.comments);
+      DAGPlusPlusNodesActionsFactory.createGraphFromConfigOnPaste(newNodes, newConnections);
       vm.instance.unbind('connection');
       vm.instance.unbind('connectionDetached');
       vm.instance.unbind('connectionMoved');
@@ -313,6 +327,7 @@ angular.module(PKG.name + '.commons')
               properties: angular.copy(node.plugin.properties),
               label: node.plugin.label,
             },
+            comments: node.comments,
           };
         })
       };
@@ -333,7 +348,6 @@ angular.module(PKG.name + '.commons')
       $scope.connections = DAGPlusPlusNodesStore.getConnections();
       vm.undoStates = DAGPlusPlusNodesStore.getUndoStates();
       vm.redoStates = DAGPlusPlusNodesStore.getRedoStates();
-      vm.comments = DAGPlusPlusNodesStore.getComments();
 
       initTimeout = $timeout(function () {
         initNodes();
@@ -395,6 +409,7 @@ angular.module(PKG.name + '.commons')
             });
           }, true);
         }
+        vm.doesStagesHaveComments = vm.checkIfAnyStageHasComment();
       });
 
       // This is here because the left panel is initially in the minimized mode and expands
@@ -812,11 +827,13 @@ angular.module(PKG.name + '.commons')
         vm.selectionBox.isSelectionInProgress = false;
         return;
       }
+      if (vm.activePluginToComment) {
+        vm.activePluginToComment = null;
+      }
       vm.instance.clearDragSelection();
       vm.toggleNodeMenu();
       clearConnectionsSelection();
       vm.clearSelectedNodes();
-      vm.clearCommentSelection();
     };
 
     function addConnection(newConnObj) {
@@ -1151,15 +1168,6 @@ angular.module(PKG.name + '.commons')
         addConnections();
         selectedConnections = [];
         bindJsPlumbEvents();
-
-        if (commentsTimeout) {
-          vm.comments = DAGPlusPlusNodesStore.getComments();
-          $timeout.cancel(commentsTimeout);
-        }
-
-        commentsTimeout = $timeout(function () {
-          makeCommentsDraggable();
-        });
       });
     }
 
@@ -1186,6 +1194,7 @@ angular.module(PKG.name + '.commons')
           if (!isNodeAlreadySelected) {
             vm.instance.clearDragSelection();
           }
+          vm.resetActivePluginForComment();
         },
         stop: function (dragEndEvent) {
           var config = {
@@ -1195,26 +1204,6 @@ angular.module(PKG.name + '.commons')
             }
           };
           DAGPlusPlusNodesActionsFactory.updateNode(dragEndEvent.el.id, config);
-        }
-      });
-    }
-
-    function makeCommentsDraggable() {
-      var comments = document.querySelectorAll('.comment-box');
-      vm.instance.draggable(comments, {
-        start: function () {
-          vm.clearSelectedNodes();
-          clearConnectionsSelection();
-          dragged = true;
-        },
-        stop: function (dragEndEvent) {
-          var config = {
-            _uiPosition: {
-              top: dragEndEvent.el.style.top,
-              left: dragEndEvent.el.style.left
-            }
-          };
-          DAGPlusPlusNodesActionsFactory.updateComment(dragEndEvent.el.id, config);
         }
       });
     }
@@ -1268,6 +1257,9 @@ angular.module(PKG.name + '.commons')
       vm.secondInstance = jsPlumb.getInstance();
       if (!vm.disableNodeClick) {
         vm.secondInstance.draggable('diagram-container', {
+          start: function() {
+            vm.resetActivePluginForComment();
+          },
           stop: function (e) {
             e.el.style.left = '0px';
             e.el.style.top = '0px';
@@ -1290,7 +1282,6 @@ angular.module(PKG.name + '.commons')
           nodesTimeout = $timeout(function () {
             makeNodesDraggable();
             initNodes();
-            makeCommentsDraggable();
             /**
              * TODO(https://issues.cask.co/browse/CDAP-16423): Need to debug why setting zoom on init doesn't set the correct zoom
              *
@@ -1329,6 +1320,7 @@ angular.module(PKG.name + '.commons')
     };
 
     vm.onNodeClick = function(event, node) {
+      vm.resetActivePluginForComment();
       closeMetricsPopover(node);
 
       window.CaskCommon.PipelineMetricsActionCreator.setMetricsTabActive(false);
@@ -1536,51 +1528,6 @@ angular.module(PKG.name + '.commons')
       repaintEverything();
     };
 
-    vm.addComment = function () {
-      var canvasPanning = DAGPlusPlusNodesStore.getCanvasPanning();
-
-      var config = {
-        content: '',
-        isActive: false,
-        id: 'comment-' + uuid.v4(),
-        _uiPosition: {
-          'top': 250 - canvasPanning.top + 'px',
-          'left': (10/100 * document.documentElement.clientWidth) - canvasPanning.left + 'px'
-        }
-      };
-
-      DAGPlusPlusNodesActionsFactory.addComment(config);
-      if (commentsTimeout) {
-        vm.comments = DAGPlusPlusNodesStore.getComments();
-        $timeout.cancel(commentsTimeout);
-      }
-      commentsTimeout = $timeout(function () {
-        makeCommentsDraggable();
-      });
-    };
-
-    vm.clearCommentSelection = function clearCommentSelection() {
-      angular.forEach(vm.comments, function (comment) {
-        comment.isActive = false;
-      });
-    };
-
-    vm.commentSelect = function (event, comment) {
-      event.stopPropagation();
-      vm.clearCommentSelection();
-
-      if (dragged) {
-        dragged = false;
-        return;
-      }
-
-      comment.isActive = true;
-    };
-
-    vm.deleteComment = function (comment) {
-      DAGPlusPlusNodesActionsFactory.deleteComment(comment);
-    };
-
     vm.undoActions = function () {
       if (!vm.isDisabled && vm.undoStates.length > 0) {
         DAGPlusPlusNodesActionsFactory.undoActions();
@@ -1606,6 +1553,9 @@ angular.module(PKG.name + '.commons')
     };
 
     vm.onKeyboardCopy = function onKeyboardCopy() {
+      if (vm.activePluginToComment) {
+        return;
+      }
       const pluginConfig = vm.getPluginConfiguration();
       if (!pluginConfig) {
         return;
@@ -1769,7 +1719,6 @@ angular.module(PKG.name + '.commons')
         $timeout.cancel(repaintTimeoutsMap[id]);
       });
 
-      $timeout.cancel(commentsTimeout);
       $timeout.cancel(nodesTimeout);
       $timeout.cancel(fitToScreenTimeout);
       $timeout.cancel(initTimeout);
@@ -1782,6 +1731,51 @@ angular.module(PKG.name + '.commons')
 
       document.body.onpaste = null;
     }
+
+    vm.toggleComments = () => {
+      vm.commentsState = !vm.commentsState;
+      if (!vm.commentsState) {
+        vm.resetActivePluginForComment();
+      }
+    };
+
+    vm.showComments = () => {
+      vm.commentsState = true;
+    };
+
+    vm.setComments = (nodeId, comments) => {
+      if (!(myHelpers.objectQuery(comments, 0, 'content') || '').length) {
+        return;
+      }
+      const existingStages = DAGPlusPlusNodesStore.getNodes();
+      DAGPlusPlusNodesStore.setNodes(existingStages.map((stage) => {
+        if (stage.id === nodeId){
+          let updatedInfo = stage.information || {};
+          updatedInfo = Object.assign({}, updatedInfo, {
+            comments: {
+              list: comments
+            }
+          });
+          stage = Object.assign({}, stage, { information: updatedInfo });
+        }
+        return stage;
+      }));
+      vm.doesStagesHaveComments = vm.checkIfAnyStageHasComment();
+      vm.showComments();
+    };
+
+    vm.setPluginActiveForComment = (nodeId) => {
+      vm.resetActivePluginForComment(nodeId);
+      if (!nodeId) {
+        vm.handleCanvasClick();
+      } else {
+        vm.onPluginContextMenuOpen(nodeId);
+      }
+    };
+
+    vm.resetActivePluginForComment = (nodeId = null) => {
+      vm.activePluginToComment = nodeId;
+    };
 
     $scope.$on('$destroy', cleanupOnDestroy);
   });

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -60,18 +60,6 @@
     <i class="icon-clean"></i>
   </button>
 
-
-  <!-- Adding Comments -->
-  <button class="btn btn-default"
-          ng-click="DAGPlusPlusCtrl.addComment()"
-          ng-if="!DAGPlusPlusCtrl.isDisabled"
-          uib-tooltip="Add Comments"
-          tooltip-append-to-body="true"
-          tooltip-placement="left"
-          tooltip-popup-delay="500">
-    <i class="fa fa-commenting"></i>
-  </button>
-
   <!-- Undo Nodes Action -->
   <button class="btn btn-default"
           ng-click="DAGPlusPlusCtrl.undoActions()"
@@ -110,6 +98,13 @@
   >
     <i class="fa fa-arrows"></i>
   </button>
+
+  <pipeline-comments-action-btn
+    does-stages-have-comments="DAGPlusPlusCtrl.doesStagesHaveComments"
+    tooltip="'Show/Hide Comments'"
+    on-comments-toggle="DAGPlusPlusCtrl.toggleComments"
+    toggle="DAGPlusPlusCtrl.commentsState"
+  ></pipeline-comments-action-btn>
 </div>
 
 <div class="my-js-dag"
@@ -131,12 +126,26 @@
                ng-class="{
                  'wrangler': node.plugin.name === 'Wrangler',
                  'node-menu-open': DAGPlusPlusCtrl.nodeMenuOpen === node.name,
-                 'selected': DAGPlusPlusCtrl.isNodeSelected(node.id),
+                 'selected': DAGPlusPlusCtrl.isNodeSelected(node.id) || DAGPlusPlusCtrl.activePluginToComment == node.id,
                }"
-               ng-click="DAGPlusPlusCtrl.selectNode($event, node)">
+        >
+          <div class="comments-wrapper"
+            ng-if="(DAGPlusPlusCtrl.commentsState == true && (node.information.comments.list && node.information.comments.list.length > 0)) || DAGPlusPlusCtrl.activePluginToComment == node.id">
+            <comment
+              comments="node.information.comments.list"
+              comments-id="node.id"
+              on-change="DAGPlusPlusCtrl.setComments"
+              placement="'bottom-start'"
+              is-open="DAGPlusPlusCtrl.activePluginToComment == node.id"
+              on-open="DAGPlusPlusCtrl.setPluginActiveForComment"
+              on-close="DAGPlusPlusCtrl.setPluginActiveForComment"
+              disabled="DAGPlusPlusCtrl.isDisabled"
+            ></comment>
+          </div>
           <div class="node"
                 ng-mouseenter="DAGPlusPlusCtrl.nodeMouseEnter(node)"
-                ng-mouseleave="DAGPlusPlusCtrl.nodeMouseLeave(node)">
+                ng-mouseleave="DAGPlusPlusCtrl.nodeMouseLeave(node)"
+                ng-click="DAGPlusPlusCtrl.selectNode($event, node)">
             <div class="inner" ng-if="['action', 'sparkprogram'].indexOf(node.type) !== -1"></div>
             <div class="endpoint-circle"
                   ng-if="node.type !== 'splittertransform'"
@@ -299,33 +308,9 @@
               get-selected-nodes="DAGPlusPlusCtrl.getSelectedNodes"
               on-delete="DAGPlusPlusCtrl.deleteSelectedNodes"
               on-open="DAGPlusPlusCtrl.onPluginContextMenuOpen"
+              on-add-comment="DAGPlusPlusCtrl.setPluginActiveForComment"
             ></plugin-context-menu>
           </div>
-        </div>
-
-        <div ng-repeat="comment in DAGPlusPlusCtrl.comments"
-              class="comment-box"
-              ng-click="!DAGPlusPlusCtrl.isDisabled && DAGPlusPlusCtrl.commentSelect($event, comment)"
-              ng-style="comment._uiPosition"
-              id="{{comment.id}}">
-          <div ng-if="comment.isActive">
-            <textarea
-              ng-model="comment.content"
-              class="form-control"
-              my-focus-watch="comment.isActive">
-            </textarea>
-          </div>
-
-          <div class="comment-content"
-               ng-if="!comment.isActive"
-               marked="comment.content">
-          </div>
-
-          <div class="fa fa-close"
-               ng-click="DAGPlusPlusCtrl.deleteComment(comment)"
-               ng-if="!DAGPlusPlusCtrl.isDisabled">
-          </div>
-
         </div>
       </div>
       <div ng-if="!DAGPlusPlusCtrl.isDisabled">

--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -60,6 +60,7 @@
   &.selected {
     border-color: @node-color;
     color: white;
+    z-index: 2000;
     .node {
       background-color: @node-color;
 
@@ -102,6 +103,24 @@ my-dag-plus {
         i.fa {
           opacity: 0.5;
         }
+      }
+    }
+    .toggle-comments-action-btn {
+      &.toggle-enabled {
+        background-color: #6a7387;
+        color: white;
+        &:before {
+          background-color: #7cd2eb;
+        }
+      }
+      &:before {
+        content: ' ';
+        position: absolute;
+        height: 5px;
+        width: 5px;
+        background: #1a73e8;
+        border-radius: 50%;
+        right: 5px;
       }
     }
   }
@@ -194,6 +213,18 @@ my-dag-plus {
 
       &.node-menu-open {
         z-index: 3;
+      }
+
+      .comments-wrapper {
+        position: absolute;
+        top: -30px;
+        right: 0;
+        color: #1a73e8;
+        z-index: 2;
+
+        [comment] {
+          display: block;
+        }
       }
 
       .node {

--- a/cdap-ui/app/directives/dag-plus/services/actions/nodes-actions.js
+++ b/cdap-ui/app/directives/dag-plus/services/actions/nodes-actions.js
@@ -110,27 +110,14 @@ class DAGPlusPlusNodesActionsFactory {
     this.nodesDispatcher.dispatch('onSetCanvasPanning', panning);
   }
 
-  createGraphFromConfig(nodes, connections, comments) {
+  createGraphFromConfig(nodes, connections) {
     this.DAGPlusPlusNodesStore.setDefaults();
-    this.nodesDispatcher.dispatch('onCreateGraphFromConfig', nodes, connections, comments);
+    this.nodesDispatcher.dispatch('onCreateGraphFromConfig', nodes, connections);
   }
 
-  createGraphFromConfigOnPaste(nodes, connections, comments) {
+  createGraphFromConfigOnPaste(nodes, connections) {
     this.DAGPlusPlusNodesStore.addStateToHistory();
-    this.nodesDispatcher.dispatch('onCreateGraphFromConfig', nodes, connections, comments);
-  }
-
-  addComment(comment) {
-    this.nodesDispatcher.dispatch('onAddComment', comment);
-  }
-  setComments(comments) {
-    this.nodesDispatcher.dispatch('onSetComments', comments);
-  }
-  deleteComment(comment) {
-    this.nodesDispatcher.dispatch('onDeleteComment', comment);
-  }
-  updateComment(commentId, config) {
-    this.nodesDispatcher.dispatch('onUpdateComment', commentId, config);
+    this.nodesDispatcher.dispatch('onCreateGraphFromConfig', nodes, connections);
   }
 
   undoActions() {

--- a/cdap-ui/app/directives/dag-plus/services/stores/nodes-store.js
+++ b/cdap-ui/app/directives/dag-plus/services/stores/nodes-store.js
@@ -37,10 +37,6 @@ class DAGPlusPlusNodesStore {
     dispatcher.register('onNodeUpdate', this.updateNode.bind(this));
     dispatcher.register('onResetPluginCount', this.resetPluginCount.bind(this));
     dispatcher.register('onSetCanvasPanning', this.setCanvasPanning.bind(this));
-    dispatcher.register('onAddComment', this.addComment.bind(this));
-    dispatcher.register('onSetComments', this.setComments.bind(this));
-    dispatcher.register('onDeleteComment', this.deleteComment.bind(this));
-    dispatcher.register('onUpdateComment', this.updateComment.bind(this));
     dispatcher.register('onUndoActions', this.undoActions.bind(this));
     dispatcher.register('onRedoActions', this.redoActions.bind(this));
     dispatcher.register('onRemovePreviousState', this.removePreviousState.bind(this));
@@ -51,7 +47,6 @@ class DAGPlusPlusNodesStore {
     let defaultState = {
       nodes: [],
       connections: [],
-      comments: [],
       activeNodeId: null,
       currentSourceCount: 0,
       currentTransformCount: 0,
@@ -297,10 +292,9 @@ class DAGPlusPlusNodesStore {
     this.emitChange();
   }
 
-  setNodesAndConnections(nodes, connections, comments) {
+  setNodesAndConnections(nodes, connections) {
     this.setNodes(nodes);
     this.state.connections = connections;
-    this.state.comments = comments ? comments : [];
     this.adjacencyMap = {};
     nodes.forEach(node => {
       let nodeId = node;
@@ -320,41 +314,6 @@ class DAGPlusPlusNodesStore {
       this.adjacencyMap[sourceNodeId].push(targetNodeId);
     });
     this.emitChange();
-  }
-
-  addComment(comment) {
-    this.addStateToHistory();
-    this.state.comments.push(comment);
-    this.emitChange();
-  }
-
-  setComments(comments) {
-    this.state.comments = comments;
-    this.emitChange();
-  }
-
-  deleteComment(comment) {
-    this.addStateToHistory();
-    let index = this.state.comments.indexOf(comment);
-    if (index > -1) {
-      this.state.comments.splice(index, 1);
-      this.emitChange();
-    }
-  }
-
-  updateComment(commentId, config) {
-    let matchComment = this.state.comments.filter( comment => comment.id === commentId);
-    if (!matchComment.length) {
-      return;
-    }
-    this.addStateToHistory();
-    matchComment = matchComment[0];
-    angular.extend(matchComment, config);
-    this.emitChange();
-  }
-
-  getComments() {
-    return this.state.comments;
   }
 
   setState(state) {

--- a/cdap-ui/app/directives/react-components/index.js
+++ b/cdap-ui/app/directives/react-components/index.js
@@ -177,4 +177,10 @@ angular
   })
   .directive('pluginSchemaEditor', function(reactDirective) {
     return reactDirective(window.CaskCommon.PluginSchemaEditor);
+  })
+  .directive('comment', function(reactDirective) {
+    return reactDirective(window.CaskCommon.Comment);
+  })
+  .directive('pipelineCommentsActionBtn', function(reactDirective) {
+    return reactDirective(window.CaskCommon.PipelineCommentsActionBtn);
   });

--- a/cdap-ui/app/hydrator/adapters.less
+++ b/cdap-ui/app/hydrator/adapters.less
@@ -153,7 +153,7 @@ body.theme-cdap {
         border-bottom: 0;
       }
       button.move-mode-selected {
-        background-color: #6a7387;
+        background-color: #4e5568;
         i.fa.fa-arrows {
           color: white;
         }

--- a/cdap-ui/app/hydrator/controllers/create/canvas-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/canvas-ctrl.js
@@ -49,7 +49,6 @@ class HydratorPlusPlusCreateCanvasCtrl {
     this.connections = this.DAGPlusPlusNodesStore.getConnections();
     this.HydratorPlusPlusConfigStore.setNodes(this.nodes);
     this.HydratorPlusPlusConfigStore.setConnections(this.connections);
-    this.HydratorPlusPlusConfigStore.setComments(this.DAGPlusPlusNodesStore.getComments());
   }
 
   setActiveNode() {

--- a/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
+++ b/cdap-ui/app/hydrator/controllers/create/partials/nodeconfig-ctrl.js
@@ -66,6 +66,7 @@ class HydratorPlusPlusNodeConfigCtrl {
     this.initializeMetrics = this.initializeMetrics.bind(this);
     this.showContents = this.showContents.bind(this);
     this.initializePreview = this.initializePreview.bind(this);
+    this.setComments = this.setComments.bind(this);
     this.tabs = [
       {
         label: 'Properties',
@@ -797,6 +798,11 @@ class HydratorPlusPlusNodeConfigCtrl {
       },
     });
     return actionsMap;
+  }
+
+  setComments(nodeId, comments) {
+    this.state.node.information = this.state.node.information || {};
+    this.state.node.information.comments = { list: comments };
   }
 }
 

--- a/cdap-ui/app/hydrator/hydrator-modal.less
+++ b/cdap-ui/app/hydrator/hydrator-modal.less
@@ -45,19 +45,16 @@
 
   .modal-dialog {
     .modal-header {
-      display: flex;
+      display: grid;
+      grid-template-columns: auto 1fr auto auto;
+      grid-template-rows: 60px;
       align-items: center;
-      justify-content: space-between;
       .modal-title {
         padding-left: 15px;
-        // 340px for all the buttons and error validation message
-        width: 100%;
-        max-width: ~"calc(100% - 340px)";
         text-overflow: ellipsis;
         white-space: nowrap;
         overflow: hidden;
         font-weight: 500;
-        margin-right: auto;
         line-height: 1.4;
 
         // Adjust max-width of modal title when my-jump-link is present
@@ -73,6 +70,12 @@
           white-space: nowrap;
           line-height: 1.4;
         }
+      }
+      .plugin-modal-btns {
+        display: grid;
+        grid-template-columns: 30px 1fr 60px;
+        grid-template-rows: inherit;
+        align-items: center;
       }
 
       div.btn-group {

--- a/cdap-ui/app/hydrator/services/create/stores/config-store.js
+++ b/cdap-ui/app/hydrator/services/create/stores/config-store.js
@@ -83,13 +83,14 @@ class HydratorPlusPlusConfigStore {
         nodes: [],
       },
       description: '',
-      name: ''
+      name: '',
     };
     Object.assign(this.state, { config: this.getDefaultConfig() });
 
     // This will be eventually used when we just pass on a config to the store to draw the dag.
     if (config) {
       angular.extend(this.state, config);
+      this.setComments(this.state.config.comments);
       this.setArtifact(this.state.artifact);
       this.setProperties(this.state.config.properties);
       this.setDriverResources(this.state.config.driverResources);
@@ -194,8 +195,9 @@ class HydratorPlusPlusConfigStore {
           label: node.plugin.label,
           artifact: node.plugin.artifact,
           properties: node.plugin.properties ,
-          _backendProperties: node._backendProperties
+          _backendProperties: node._backendProperties,
         },
+        information: node.information,
         outputSchema: node.outputSchema,
         inputSchema: node.inputSchema
       };
@@ -292,12 +294,11 @@ class HydratorPlusPlusConfigStore {
       };
     }
 
+    config.comments = this.getComments();
+
     if (this.state.description) {
       config.description = this.state.description;
     }
-
-    config.comments = this.getComments();
-
     // Removing UUID from postactions name
     let postActions = this.getPostActions();
     postActions = _.sortBy(postActions, (action) => {
@@ -361,12 +362,6 @@ class HydratorPlusPlusConfigStore {
       }
     });
     delete stateCopy.__ui__;
-
-    angular.forEach(stateCopy.config.comments, (comment) => {
-      delete comment.isActive;
-      delete comment.id;
-      delete comment._uiPosition;
-    });
 
     return stateCopy;
   }

--- a/cdap-ui/app/hydrator/templates/partial/node-config-modal/popover.html
+++ b/cdap-ui/app/hydrator/templates/partial/node-config-modal/popover.html
@@ -15,7 +15,7 @@
 -->
 <div class="modal-header clearfix">
 
-  <h5 class="modal-title pull-left"
+  <h5 class="modal-title"
       ng-class="{'with-jump': HydratorPlusPlusNodeConfigCtrl.state.groupsConfig.jumpConfig.datasets.length}">
     <span>
       {{ HydratorPlusPlusNodeConfigCtrl.state.config['display-name'] || HydratorPlusPlusNodeConfigCtrl.state.node.plugin.name }} Properties
@@ -38,7 +38,12 @@
                              'other': '{} errors found.'}">
     </ng-pluralize>
   </span>
-  <div class="btn-group pull-right">
+  <div class="plugin-modal-btns">
+    <comment
+      comments="HydratorPlusPlusNodeConfigCtrl.state.node.information.comments.list"
+      comments-id="HydratorPlusPlusNodeConfigCtrl.state.node.id"
+      on-change="HydratorPlusPlusNodeConfigCtrl.setComments"
+    ></comment>
     <button class="btn btn-primary validate-btn" type="button"
             data-cy="plugin-properties-validate-btn"
             ng-if="!isDisabled"

--- a/cdap-ui/app/styles/themes/cdap/theme.less
+++ b/cdap-ui/app/styles/themes/cdap/theme.less
@@ -414,7 +414,6 @@ body.theme-cdap {
       .modal-header {
         background-color: @body-bg;
         border-bottom: 1px solid @modal-table-border-color;
-        height: 60px;
         margin-bottom: 5px;
         padding: 0;
         .border-radius(4px 4px 0 0);


### PR DESCRIPTION
**This is part 2 of multiple changes for pipeline comments**

- This PR imports the react components to angular
- Modifies angular to make sure they work as expected. There are a lot of nuances involved in this,
  - Comments appear appear when user right clicks a plugin node and click on "Add a comment"
  - Should also show up already existing comments when user clicks on comment icon on a plugin
  - Should be able to show/hide comments based on pipeline setting (pipeline actions)
  - Should make sure the comment is closed when the user clicks away or drags the canvas or moves the node
  - Should make sure the user can select comments and copy and paste them anywhere.
  - No matter what the scale of the canvas the comments (not the icon) appear without any issues (in normal size).
- This PR also modifies the hydrator top panel structure to be a grid to be able to accommodate comments icon

TODO:
- This PR does not handle the way we show comments icon in published pipeline view inside plugin configuration. 
  - If there is no comment in the plugin we shouldn't show the icon
  - If there is a comment we should make sure the grid structure is maintained correctly. Right now it is not.