### PR TITLE
[CDAP-17591] Don't round completion percentage for Wrangler DataQuality bar and ColumnsTabRow

### DIFF
--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabRow.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepSidePanel/ColumnsTab/ColumnsTabRow.js
@@ -62,11 +62,14 @@ class ColumnsTabRow extends Component {
   }
 
   render() {
-    let rowInfo = this.props.rowInfo || {};
-    let general = rowInfo.general || {};
-    let { empty: empty = 0, 'non-null': nonEmpty = 100 } = general;
+    const rowInfo = this.props.rowInfo || {};
+    const general = rowInfo.general || {};
+    const { empty: empty = 0, 'non-null': nonEmpty = 100 } = general;
 
-    let nonNull = Math.ceil(nonEmpty - empty);
+    // Round number to next lowest .1%
+    // Number.toFixed() can round up and leave .0 on integers
+    const nonNull = Math.floor((nonEmpty - empty) * 10) / 10;
+
     return (
       <CSSTransition in={this.props.isNew} timeout={4000} classNames="is-new" appear>
         <tr

--- a/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/DataQuality/index.js
+++ b/cdap-ui/app/cdap/components/DataPrep/DataPrepTable/DataQuality/index.js
@@ -28,7 +28,7 @@ export default function DataQuality({ columnInfo }) {
   let nonNull = columnInfo.general['non-null'] || 0,
     empty = columnInfo.general['empty'] || 0;
 
-  let filled = Math.round(nonNull - empty);
+  let filled = nonNull - empty;
 
   return (
     <div className="quality-bar">


### PR DESCRIPTION
Jira: https://cdap.atlassian.net/browse/CDAP-17591

Don't round for DataQuality bar; round to next lowest .1% for ColumnsTabRow

![image](https://user-images.githubusercontent.com/2728821/107560466-3f84d800-6b92-11eb-89f7-d97e2398d1fa.png)
