### PR TITLE
[CDAP-17400] Emit plugin metadata for applications

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/metadata/MetadataEntity.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/metadata/MetadataEntity.java
@@ -83,6 +83,7 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
   public static final String PROGRAM = "program";
   public static final String SCHEDULE = "schedule";
   public static final String PROGRAM_RUN = "program_run";
+  public static final String PLUGIN = "plugin";
 
   private final LinkedHashMap<String, String> details;
   private String type;
@@ -95,6 +96,7 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
     typesToKeys.put(DATASET, new String[][]{{NAMESPACE, DATASET}, {DATASET}});
     typesToKeys.put(APPLICATION, new String[][]{{NAMESPACE, APPLICATION, VERSION}, {NAMESPACE, APPLICATION}});
     typesToKeys.put(ARTIFACT, new String[][]{{NAMESPACE, ARTIFACT, VERSION}});
+    typesToKeys.put(PLUGIN, new String[][]{{NAMESPACE, ARTIFACT, VERSION, TYPE, PLUGIN}});
     typesToKeys.put(PROGRAM, new String[][]{{NAMESPACE, APPLICATION, VERSION, TYPE, PROGRAM},
       {NAMESPACE, APPLICATION, TYPE, PROGRAM}});
     typesToKeys.put(SCHEDULE, new String[][]{{NAMESPACE, APPLICATION, VERSION, SCHEDULE},

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -298,7 +298,7 @@ public class AppMetadataStore {
         appIds.add(getApplicationIdFromRow(iterator.next()));
       }
     }
-   return appIds;
+    return appIds;
   }
 
   /**
@@ -549,7 +549,7 @@ public class AppMetadataStore {
 
     if (existing == null) {
       LOG.warn("Ignoring unexpected request to transition program run {} from non-existent state to cluster state {}.",
-                programRunId, ProgramRunClusterStatus.PROVISIONED);
+               programRunId, ProgramRunClusterStatus.PROVISIONED);
       return null;
     }
     if (!isValid(existing, existing.getStatus(), ProgramRunClusterStatus.PROVISIONED, sourceId)) {
@@ -1278,7 +1278,7 @@ public class AppMetadataStore {
   private void delete(RunRecordDetail record) throws IOException {
     ProgramRunId programRunId = record.getProgramRunId();
     List<Field<?>> key = getProgramRunInvertedTimeKey(STATUS_TYPE_MAP.get(record.getStatus()), programRunId,
-                                              record.getStartTs());
+                                                      record.getStartTs());
     getRunRecordsTable().delete(key);
   }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -784,6 +784,7 @@ public final class Constants {
       public static final String RUN_TIME_SECONDS = "program.run.seconds";
       public static final String APPLICATION_COUNT = "application.count";
       public static final String NAMESPACE_COUNT = "namespace.count";
+      public static final String APPLICATION_PLUGIN_COUNT = "application.plugin.count";
     }
 
     /**

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/element/EntityType.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/element/EntityType.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.InstanceId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.PluginId;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
@@ -56,6 +57,7 @@ public enum EntityType {
   DATASET_MODULE(DatasetModuleId.class),
   SCHEDULE(ScheduleId.class),
   ARTIFACT(ArtifactId.class),
+  PLUGIN(PluginId.class),
   DATASET(DatasetId.class),
   SECUREKEY(SecureKeyId.class),
   TOPIC(TopicId.class),

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/EntityId.java
@@ -196,6 +196,11 @@ public abstract class EntityId {
     if (entityType == EntityType.ARTIFACT) {
       extractedParts = metadataEntity.head(MetadataEntity.VERSION);
     }
+
+    // for plugins get till plugin name
+    if (entityType == EntityType.PLUGIN) {
+      extractedParts = metadataEntity.head(MetadataEntity.PLUGIN);
+    }
     extractedParts.iterator().forEachRemaining(keyValue -> values.add(keyValue.getValue()));
     return entityType.fromIdParts(values);
   }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/PluginId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/PluginId.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.proto.id;
+
+import io.cdap.cdap.api.artifact.ArtifactVersion;
+import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.proto.element.EntityType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * Uniquely identifies a plugin.
+ */
+public class PluginId extends NamespacedEntityId implements ParentedId<ArtifactId> {
+  private final String artifact;
+  private final String version;
+  private final String plugin;
+  private final String type;
+  private transient Integer hashCode;
+
+  public PluginId(String namespace, String artifact, String version, String plugin, String type) {
+    super(namespace, EntityType.PLUGIN);
+    this.artifact = Objects.requireNonNull(artifact, "Artifact ID cannot be null.");
+    this.version = Objects.requireNonNull(version, "Version cannot be null.");
+    this.plugin = Objects.requireNonNull(plugin, "Plugin cannot be null.");
+    this.type = Objects.requireNonNull(type, "Type cannot be null.");
+
+    ensureValidArtifactId("artifact", artifact);
+    ArtifactVersion artifactVersion = new ArtifactVersion(version);
+    if (artifactVersion.getVersion() == null) {
+      throw new IllegalArgumentException("Invalid artifact version " + version);
+    }
+  }
+
+  public String getArtifact() {
+    return artifact;
+  }
+
+  public String getPlugin() {
+    return plugin;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  @Override
+  public String getEntityName() {
+    return getPlugin();
+  }
+
+  @Override
+  public MetadataEntity toMetadataEntity() {
+    return MetadataEntity.builder()
+      .append(MetadataEntity.NAMESPACE, namespace)
+      .append(MetadataEntity.ARTIFACT, artifact)
+      .append(MetadataEntity.VERSION, version)
+      .append(MetadataEntity.TYPE, type)
+      .appendAsType(MetadataEntity.PLUGIN, plugin)
+      .build();
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public ArtifactId getParent() {
+    return new ArtifactId(namespace, artifact, version);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    PluginId that = (PluginId) o;
+    return Objects.equals(namespace, that.namespace) &&
+      Objects.equals(artifact, that.artifact) &&
+      Objects.equals(version, that.version) &&
+      Objects.equals(type, that.type) &&
+      Objects.equals(plugin, that.plugin);
+  }
+
+  @Override
+  public int hashCode() {
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, artifact, version, type, plugin);
+    }
+    return hashCode;
+  }
+
+  @SuppressWarnings("unused")
+  public static PluginId fromIdParts(Iterable<String> idString) {
+    Iterator<String> iterator = idString.iterator();
+    return new PluginId(
+      next(iterator, "namespace"), next(iterator, "artifact"),
+      next(iterator, "version"), next(iterator, "type"), remaining(iterator, "plugin"));
+  }
+
+  @Override
+  public Iterable<String> toIdParts() {
+    return Collections.unmodifiableList(Arrays.asList(namespace, artifact, version, type, plugin));
+  }
+
+  public static PluginId fromString(String string) {
+    return EntityId.fromString(string, PluginId.class);
+  }
+}

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricStore.java
@@ -240,7 +240,7 @@ public class DefaultMetricStore implements MetricStore {
   public void setMetricsContext(MetricsContext metricsContext) {
     this.metricsContext = metricsContext;
   }
-  
+
   @Override
   public void add(MetricValues metricValues) {
     add(ImmutableList.of(metricValues));


### PR DESCRIPTION
This change adds plugins as a new MetadataEntity. Using this new entity we can track which plugins are being used in which applications. The metadata emitted serves as an index mapping from a plugin to all the applications that use that plugin. 

Example:
```
{
"metadataEntity": {
      "details": {
          "namespace": "system",
          "artifact": "wrangler-transform",
          "version": "4.4.0-SNAPSHOT",
          "type": "transform",
          "plugin": "Wrangler"
      },
      "type": "plugin"
  },
  "metadata": {
      "SYSTEM": {
          "properties": {
              "default:DataFusionQuickstart": "1"
          },
          "tags": []
      }
  }
}, {}...
```

This PR also introduces a metric that counts the number of plugins in a given application when its deployed