### PR TITLE
CDAP-17606 basic validation for join condition expressions

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
@@ -19,6 +19,8 @@ package io.cdap.cdap.datastreams;
 import io.cdap.cdap.api.DatasetConfigurer;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.etl.api.Engine;
+import io.cdap.cdap.etl.api.FailureCollector;
+import io.cdap.cdap.etl.api.join.JoinCondition;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.common.macro.TimeParser;
 import io.cdap.cdap.etl.proto.v2.DataStreamsConfig;
@@ -65,5 +67,15 @@ public class DataStreamsPipelineSpecGenerator
     }
     configureStages(config, specBuilder);
     return specBuilder.build();
+  }
+
+  @Override
+  protected void validateJoinCondition(String stageName, JoinCondition condition, FailureCollector collector) {
+    if (condition.getOp() != JoinCondition.Op.KEY_EQUALITY) {
+      collector.addFailure(
+        String.format("Join stage '%s' uses a %s condition, which is not supported in streaming pipelines.",
+                      stageName, condition.getOp()),
+        "Only basic joins on key equality are supported.");
+    }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinCondition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinCondition.java
@@ -104,9 +104,17 @@ public class JoinCondition {
       List<JoinError> errors = new ArrayList<>();
       if (joinStages.size() != 2) {
         errors.add(
-          new ExpressionConditionError("Join expressions are only supported for joins between two datasets.", null));
+          new ExpressionConditionError("Join expressions are only supported for joins between two datasets."));
       }
-      // TODO: (CDAP-17606) validate aliases, schema, etc
+      for (JoinStage stage : joinStages) {
+        if (stage.getSchema() == null) {
+          errors.add(
+            new ExpressionConditionError(
+              String.format("Input stage '%s' does not have a set schema. " +
+                              "Advanced join conditions cannot be used with dynamic or unknown input schemas.",
+                            stage.getStageName())));
+        }
+      }
       return errors;
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/error/ExpressionConditionError.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/error/ExpressionConditionError.java
@@ -23,6 +23,10 @@ import javax.annotation.Nullable;
  */
 public class ExpressionConditionError extends JoinError {
 
+  public ExpressionConditionError(String message) {
+    this(message, null);
+  }
+
   public ExpressionConditionError(String message, @Nullable String correctiveAction) {
     super(Type.INVALID_CONDITION, message, correctiveAction);
   }


### PR DESCRIPTION
Added validation to ensure that join condition expressions are
not allowed in MapReduce pipelines or streaming pipelines.
Also added validation to ensure that input schemas are always
known when using expressions.