### PR TITLE
[CDAP-17706] Allow to disable function cache

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -41,7 +41,6 @@ import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
 import io.cdap.cdap.etl.api.streaming.Windower;
-import io.cdap.cdap.etl.common.BasicArguments;
 import io.cdap.cdap.etl.common.Constants;
 import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
 import io.cdap.cdap.etl.common.PhaseSpec;
@@ -51,7 +50,6 @@ import io.cdap.cdap.etl.common.plugin.PipelinePluginContext;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 import io.cdap.cdap.etl.spark.SparkPipelineRuntime;
 import io.cdap.cdap.etl.spark.StreamingCompat;
-import io.cdap.cdap.etl.spark.batch.SparkPreparer;
 import io.cdap.cdap.etl.spark.streaming.SparkStreamingPreparer;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import org.apache.hadoop.conf.Configuration;
@@ -69,7 +67,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -229,8 +226,11 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
                                             pipelineSpec.isProcessTimingEnabled());
         boolean shouldConsolidateStages = Boolean.parseBoolean(
           sec.getRuntimeArguments().getOrDefault(Constants.CONSOLIDATE_STAGES, Boolean.TRUE.toString()));
+        boolean shouldCacheFunctions = Boolean.parseBoolean(
+          sec.getRuntimeArguments().getOrDefault(Constants.CACHE_FUNCTIONS, Boolean.TRUE.toString()));
         runner.runPipeline(phaseSpec, StreamingSource.PLUGIN_TYPE, sec, Collections.emptyMap(),
-                           pluginContext, Collections.emptyMap(), uncombinableSinks, shouldConsolidateStages);
+                           pluginContext, Collections.emptyMap(), uncombinableSinks, shouldConsolidateStages,
+                           shouldCacheFunctions);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
@@ -33,6 +33,7 @@ public final class Constants {
   public static final String SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG = "spark.cdap.pipeline.autocache.enable";
   public static final String SPARK_PIPELINE_CACHING_STORAGE_LEVEL = "spark.cdap.pipeline.caching.storage.level";
   public static final String CONSOLIDATE_STAGES = "spark.cdap.pipeline.consolidate.stages";
+  public static final String CACHE_FUNCTIONS = "spark.cdap.pipeline.functioncache.enable";
   public static final String DEFAULT_CACHING_STORAGE_LEVEL = "DISK_ONLY";
 
   private Constants() {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -106,18 +106,17 @@ public abstract class SparkPipelineRunner {
     BatchJoiner.PLUGIN_TYPE, BatchAggregator.PLUGIN_TYPE, Constants.Connector.PLUGIN_TYPE,
     SparkCompute.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE, AlertPublisher.PLUGIN_TYPE);
 
-  protected final FunctionCache.Factory functionCacheFactory = FunctionCache.Factory.newInstance();
-
   protected abstract SparkCollection<RecordInfo<Object>> getSource(StageSpec stageSpec,
+                                                                   FunctionCache.Factory functionCacheFactory,
                                                                    StageStatisticsCollector collector) throws Exception;
 
   protected abstract SparkPairCollection<Object, Object> addJoinKey(
-    StageSpec stageSpec, String inputStageName,
+    StageSpec stageSpec, FunctionCache.Factory functionCacheFactory, String inputStageName,
     SparkCollection<Object> inputCollection, StageStatisticsCollector collector) throws Exception;
 
   protected abstract SparkCollection<Object> mergeJoinResults(
     StageSpec stageSpec,
-    SparkPairCollection<Object, List<JoinElement<Object>>> joinedInputs,
+    FunctionCache.Factory functionCacheFactory, SparkPairCollection<Object, List<JoinElement<Object>>> joinedInputs,
     StageStatisticsCollector collector) throws Exception;
 
   public void runPipeline(PhaseSpec phaseSpec, String sourcePluginType,
@@ -126,9 +125,11 @@ public abstract class SparkPipelineRunner {
                           PluginContext pluginContext,
                           Map<String, StageStatisticsCollector> collectors,
                           Set<String> uncombinableSinks,
-                          boolean consolidateStages) throws Exception {
+                          boolean consolidateStages,
+                          boolean cacheFunctions) throws Exception {
     PipelinePhase pipelinePhase = phaseSpec.getPhase();
     BasicArguments arguments = new BasicArguments(sec);
+    FunctionCache.Factory functionCacheFactory = FunctionCache.Factory.newInstance(cacheFunctions);
     MacroEvaluator macroEvaluator =
       new DefaultMacroEvaluator(arguments, sec.getLogicalStartTime(), sec, sec.getNamespace());
     Map<String, EmittedRecords> emittedRecords = new HashMap<>();
@@ -247,7 +248,7 @@ public abstract class SparkPipelineRunner {
         // this if-else is nested inside the stageRDD null check to avoid warnings about stageRDD possibly being
         // null in the other else-if conditions
         if (sourcePluginType.equals(pluginType) || isConnectorSource) {
-          SparkCollection<RecordInfo<Object>> combinedData = getSource(stageSpec, collector);
+          SparkCollection<RecordInfo<Object>> combinedData = getSource(stageSpec, functionCacheFactory, collector);
           emittedBuilder = addEmitted(emittedBuilder, pipelinePhase, stageSpec,
                                       combinedData, groupedDag, branchers, shufflers, hasErrorOutput, hasAlertOutput);
         } else {
@@ -327,7 +328,8 @@ public abstract class SparkPipelineRunner {
         Integer numPartitions = stagePartitions.get(stageName);
         Object plugin = pluginContext.newPluginInstance(stageName, macroEvaluator);
         SparkCollection<Object> joined = handleJoin(inputDataCollections, pipelinePhase, pluginFunctionContext,
-                                                    stageSpec, plugin, numPartitions, collector, shufflers);
+                                                    stageSpec, functionCacheFactory, plugin,
+                                                    numPartitions, collector, shufflers);
         addEmitted(emittedBuilder, pipelinePhase, stageSpec,
                    joined.map(new RecordInfoWrapper<>(stageName)), groupedDag, branchers, shufflers, false, false);
 
@@ -441,7 +443,8 @@ public abstract class SparkPipelineRunner {
 
   protected SparkCollection<Object> handleJoin(Map<String, SparkCollection<Object>> inputDataCollections,
                                                PipelinePhase pipelinePhase, PluginFunctionContext pluginFunctionContext,
-                                               StageSpec stageSpec, Object plugin, Integer numPartitions,
+                                               StageSpec stageSpec, FunctionCache.Factory functionCacheFactory,
+                                               Object plugin, Integer numPartitions,
                                                StageStatisticsCollector collector,
                                                Set<String> shufflers) throws Exception {
     String stageName = stageSpec.getName();
@@ -450,7 +453,7 @@ public abstract class SparkPipelineRunner {
       BatchJoinerRuntimeContext joinerRuntimeContext = pluginFunctionContext.createBatchRuntimeContext();
       joiner.initialize(joinerRuntimeContext);
       shufflers.add(stageName);
-      return handleJoin(joiner, inputDataCollections, stageSpec, numPartitions, collector);
+      return handleJoin(joiner, inputDataCollections, stageSpec, functionCacheFactory, numPartitions, collector);
     } else if (plugin instanceof AutoJoiner) {
       AutoJoiner autoJoiner = (AutoJoiner) plugin;
       Map<String, Schema> inputSchemas = new HashMap<>();
@@ -746,13 +749,15 @@ public abstract class SparkPipelineRunner {
 
   protected SparkCollection<Object> handleJoin(BatchJoiner<?, ?, ?> joiner,
                                                Map<String, SparkCollection<Object>> inputDataCollections,
-                                               StageSpec stageSpec, Integer numPartitions,
+                                               StageSpec stageSpec,
+                                               FunctionCache.Factory functionCacheFactory,
+                                               Integer numPartitions,
                                                StageStatisticsCollector collector) throws Exception {
     Map<String, SparkPairCollection<Object, Object>> preJoinStreams = new HashMap<>();
     for (Map.Entry<String, SparkCollection<Object>> inputStreamEntry : inputDataCollections.entrySet()) {
       String inputStage = inputStreamEntry.getKey();
       SparkCollection<Object> inputStream = inputStreamEntry.getValue();
-      preJoinStreams.put(inputStage, addJoinKey(stageSpec, inputStage, inputStream, collector));
+      preJoinStreams.put(inputStage, addJoinKey(stageSpec, functionCacheFactory, inputStage, inputStream, collector));
     }
 
     Set<String> remainingInputs = new HashSet<>();
@@ -803,7 +808,7 @@ public abstract class SparkPipelineRunner {
       throw new IllegalStateException("There are no inputs into join stage " + stageSpec.getName());
     }
 
-    return mergeJoinResults(stageSpec, joinedInputs, collector);
+    return mergeJoinResults(stageSpec, functionCacheFactory, joinedInputs, collector);
   }
 
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
@@ -99,15 +99,17 @@ public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
   protected final JavaRDD<T> rdd;
   protected final FunctionCache.Factory functionCacheFactory;
 
-  protected BaseRDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, SQLContext sqlContext,
-                              DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory, JavaRDD<T> rdd) {
+  protected BaseRDDCollection(JavaSparkExecutionContext sec, FunctionCache.Factory functionCacheFactory,
+                              JavaSparkContext jsc, SQLContext sqlContext,
+                              DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory,
+                              JavaRDD<T> rdd) {
     this.sec = sec;
     this.jsc = jsc;
     this.sqlContext = sqlContext;
     this.datasetContext = datasetContext;
     this.sinkFactory = sinkFactory;
+    this.functionCacheFactory = functionCacheFactory;
     this.rdd = rdd;
-    this.functionCacheFactory = FunctionCache.Factory.newInstance();
   }
 
   @SuppressWarnings("unchecked")
@@ -210,7 +212,9 @@ public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
 
   @Override
   public <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function) {
-    return new PairRDDCollection<>(sec, jsc, sqlContext, datasetContext, sinkFactory, rdd.flatMapToPair(function));
+    return new PairRDDCollection<>(sec, functionCacheFactory, jsc,
+                                   sqlContext, datasetContext, sinkFactory,
+                                   rdd.flatMapToPair(function));
   }
 
   @Override
@@ -313,7 +317,7 @@ public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
   }
 
   protected <U> RDDCollection<U> wrap(JavaRDD<U> rdd) {
-    return new RDDCollection<>(sec, jsc, sqlContext, datasetContext, sinkFactory, rdd);
+    return new RDDCollection<>(sec, functionCacheFactory, jsc, sqlContext, datasetContext, sinkFactory, rdd);
   }
 
   protected Column eq(Column left, Column right, boolean isNullSafe) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
@@ -74,10 +74,12 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   private final JavaDStream<T> stream;
   private final FunctionCache.Factory functionCacheFactory;
 
-  public DStreamCollection(JavaSparkExecutionContext sec, JavaDStream<T> stream) {
+  public DStreamCollection(JavaSparkExecutionContext sec,
+                           FunctionCache.Factory functionCacheFactory,
+                           JavaDStream<T> stream) {
     this.sec = sec;
+    this.functionCacheFactory = functionCacheFactory;
     this.stream = stream;
-    this.functionCacheFactory = FunctionCache.Factory.newInstance();
   }
 
   @SuppressWarnings("unchecked")
@@ -134,7 +136,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
 
   @Override
   public <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function) {
-    return new PairDStreamCollection<>(sec, stream.flatMapToPair(function));
+    return new PairDStreamCollection<>(sec, functionCacheFactory, stream.flatMapToPair(function));
   }
 
   @Override
@@ -228,6 +230,6 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   }
 
   private <U> SparkCollection<U> wrap(JavaDStream<U> stream) {
-    return new DStreamCollection<>(sec, stream);
+    return new DStreamCollection<>(sec, functionCacheFactory, stream);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/function/FunctionCacheTest.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/function/FunctionCacheTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Unit tests for {@link FunctionCache}
+ */
+public class FunctionCacheTest {
+  @Test
+  public void testEnabledCache() throws Exception {
+    FunctionCache.Factory factory = FunctionCache.Factory.newInstance(true);
+    FunctionCache cache1 = factory.newCache();
+    FunctionCache cache2 = factory.newCache();
+    FunctionCache movedCache1Copy1 = SerializationUtils.clone(cache1);
+    FunctionCache movedCache1Copy2 = SerializationUtils.clone(cache1);
+    FunctionCache movedCache2Copy1 = SerializationUtils.clone(cache2);
+
+    Callable<Object> throwingLoader = () -> {
+      throw new IllegalStateException("Must use cached value");
+    };
+
+    Assert.assertEquals("Test", movedCache1Copy1.getValue(() -> "Test"));
+    Assert.assertEquals("Test", movedCache1Copy1.getValue(throwingLoader));
+    Assert.assertEquals("Test", movedCache1Copy2.getValue(throwingLoader));
+    Assert.assertEquals("Test", cache1.getValue(throwingLoader));
+
+    Assert.assertEquals("OtherValue", movedCache2Copy1.getValue(() -> "OtherValue"));
+    Assert.assertEquals("OtherThreadValue",
+                        CompletableFuture.supplyAsync(() -> {
+                          try {
+                            return movedCache1Copy1.getValue(() -> "OtherThreadValue");
+                          } catch (Exception e) {
+                            throw new IllegalStateException(e);
+                          }
+                        }).get());
+  }
+
+  @Test
+  public void testDisabledCache() throws Exception {
+    FunctionCache.Factory factory = FunctionCache.Factory.newInstance(false);
+    FunctionCache cache1 = factory.newCache();
+    FunctionCache movedCache1Copy1 = SerializationUtils.clone(cache1);
+    FunctionCache movedCache1Copy2 = SerializationUtils.clone(cache1);
+    Assert.assertEquals("Test", movedCache1Copy1.getValue(() -> "Test"));
+    Assert.assertEquals("Test2", movedCache1Copy1.getValue(() -> "Test2"));
+    Assert.assertEquals("Test3", movedCache1Copy2.getValue(() -> "Test3"));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.etl.api.join.JoinField;
 import io.cdap.cdap.etl.common.Constants;
 import io.cdap.cdap.etl.spark.SparkCollection;
 import io.cdap.cdap.etl.spark.function.CountingFunction;
+import io.cdap.cdap.etl.spark.function.FunctionCache;
 import io.cdap.cdap.etl.spark.join.JoinCollection;
 import io.cdap.cdap.etl.spark.join.JoinRequest;
 import io.cdap.cdap.etl.spark.plugin.LiteralsBridge;
@@ -61,9 +62,10 @@ import static org.apache.spark.sql.functions.floor;
  */
 public class RDDCollection<T> extends BaseRDDCollection<T> {
 
-  public RDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, SQLContext sqlContext,
+  public RDDCollection(JavaSparkExecutionContext sec, FunctionCache.Factory functionCacheFactory,
+                       JavaSparkContext jsc, SQLContext sqlContext,
                        DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory, JavaRDD<T> rdd) {
-    super(sec, jsc, sqlContext, datasetContext, sinkFactory, rdd);
+    super(sec, functionCacheFactory, jsc, sqlContext, datasetContext, sinkFactory, rdd);
   }
 
   @SuppressWarnings("unchecked")

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.etl.api.join.JoinField;
 import io.cdap.cdap.etl.common.Constants;
 import io.cdap.cdap.etl.spark.SparkCollection;
 import io.cdap.cdap.etl.spark.function.CountingFunction;
+import io.cdap.cdap.etl.spark.function.FunctionCache;
 import io.cdap.cdap.etl.spark.join.JoinCollection;
 import io.cdap.cdap.etl.spark.join.JoinRequest;
 import io.cdap.cdap.etl.spark.plugin.LiteralsBridge;
@@ -61,9 +62,11 @@ import static org.apache.spark.sql.functions.floor;
  */
 public class RDDCollection<T> extends BaseRDDCollection<T> {
 
-  public RDDCollection(JavaSparkExecutionContext sec, JavaSparkContext jsc, SQLContext sqlContext,
-                       DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory, JavaRDD<T> rdd) {
-    super(sec, jsc, sqlContext, datasetContext, sinkFactory, rdd);
+  public RDDCollection(JavaSparkExecutionContext sec, FunctionCache.Factory functionCacheFactory,
+                       JavaSparkContext jsc, SQLContext sqlContext,
+                       DatasetContext datasetContext, SparkBatchSinkFactory sinkFactory,
+                       JavaRDD<T> rdd) {
+    super(sec, functionCacheFactory, jsc, sqlContext, datasetContext, sinkFactory, rdd);
   }
 
 


### PR DESCRIPTION
We should allow disabling function cache. This PR introduces spark.cdap.pipeline.functioncache.enable parameter (enabled by default) 