### PR TITLE
[CDAP-17707] Implement reduce aggregator using Datasets

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/ReducibleAggregatorTestBase.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/ReducibleAggregatorTestBase.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.dataset.table.Table;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.etl.api.Engine;
+import io.cdap.cdap.etl.mock.batch.MockSink;
+import io.cdap.cdap.etl.mock.batch.MockSource;
+import io.cdap.cdap.etl.mock.batch.aggregator.DistinctReducibleAggregator;
+import io.cdap.cdap.etl.mock.batch.aggregator.FieldCountReducibleAggregator;
+import io.cdap.cdap.etl.mock.test.HydratorTestBase;
+import io.cdap.cdap.etl.proto.v2.ETLBatchConfig;
+import io.cdap.cdap.etl.proto.v2.ETLStage;
+import io.cdap.cdap.etl.spark.Compat;
+import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.artifact.AppRequest;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.test.ApplicationManager;
+import io.cdap.cdap.test.DataSetManager;
+import io.cdap.cdap.test.TestConfiguration;
+import io.cdap.cdap.test.WorkflowManager;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Tests for BatchReducibleAggregator plugins.
+ */
+public class ReducibleAggregatorTestBase extends HydratorTestBase {
+  private static final ArtifactId APP_ARTIFACT_ID = NamespaceId.DEFAULT.artifact("app", "1.0.0");
+  private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("app", "1.0.0");
+
+  private static int startCount = 0;
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(
+    Constants.Explore.EXPLORE_ENABLED, false,
+             Constants.Security.Store.PROVIDER, "file",
+             io.cdap.cdap.etl.common.Constants.DATASET_AGGREGATE_IGNORE_PARTITIONS, "false",
+             Constants.AppFabric.SPARK_COMPAT, Compat.SPARK_COMPAT);
+
+  @BeforeClass
+  public static void setupTest() throws Exception {
+    if (startCount++ > 0) {
+      return;
+    }
+    setupBatchArtifacts(APP_ARTIFACT_ID, DataPipelineApp.class);
+  }
+
+  protected void testSimpleAggregator(Engine engine, Map<String, String> arguments) throws Exception {
+    Schema inputSchema = Schema.recordOf(
+      "input",
+      Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("used_name", Schema.of(Schema.Type.STRING)));
+    String userInput = "inputSource-" + engine;
+    String output = "outputSink-" + engine;
+    int numPartitions = 1;
+    ETLBatchConfig config = ETLBatchConfig.builder()
+      .addStage(new ETLStage("users", MockSource.getPlugin(userInput, inputSchema)))
+      .addStage(new ETLStage("aggregator", DistinctReducibleAggregator.getPlugin("id,name", numPartitions)))
+      .addStage(new ETLStage("sink", MockSink.getPlugin(output)))
+      .addConnection("users", "aggregator")
+      .addConnection("aggregator", "sink")
+      .setEngine(engine)
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, config);
+    ApplicationId appId = NamespaceId.DEFAULT.app(UUID.randomUUID().toString());
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    List<StructuredRecord> userData = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      StructuredRecord record1 = StructuredRecord.builder(inputSchema)
+        .set("id", 1).set("name", "test").set("used_name", "test" + i).build();
+      StructuredRecord record2 = StructuredRecord.builder(inputSchema)
+        .set("id", 2).set("name", "test2").set("used_name", "test2" + i).build();
+      userData.add(record1);
+      userData.add(record2);
+    }
+
+    // write input data
+    DataSetManager<Table> inputManager = getDataset(userInput);
+    MockSource.writeInput(inputManager, userData);
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.startAndWaitForRun(arguments, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+
+    DataSetManager<Table> outputManager = getDataset(output);
+    List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
+
+    Schema expectedSchema = Schema.recordOf(
+      "record",
+      Schema.Field.of("id", Schema.of(Schema.Type.INT)),
+      Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    Set<StructuredRecord> expected = ImmutableSet.of(
+      StructuredRecord.builder(expectedSchema).set("id", 1).set("name", "test").build(),
+      StructuredRecord.builder(expectedSchema).set("id", 2).set("name", "test2").build()
+    );
+    Assert.assertEquals(expected, new HashSet<>(outputRecords));
+    validateMetric(numPartitions, appId, "sink." + MockSink.INITIALIZED_COUNT_METRIC);
+  }
+
+  protected void testFieldCountAgg(Engine engine, Map<String, String> arguments) throws Exception {
+    String source1Name = "pAggInput1-" + engine.name();
+    String source2Name = "pAggInput2-" + engine.name();
+    String sink1Name = "pAggOutput1-" + engine.name();
+    String sink2Name = "pAggOutput2-" + engine.name();
+    Schema inputSchema = Schema.recordOf(
+      "testRecord",
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("item", Schema.of(Schema.Type.LONG))
+    );
+    /*
+       source1 --|--> agg1 --> sink1
+                 |
+       source2 --|--> agg2 --> sink2
+     */
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
+      .setEngine(engine)
+      .addStage(new ETLStage("source1", MockSource.getPlugin(source1Name, inputSchema)))
+      .addStage(new ETLStage("source2", MockSource.getPlugin(source2Name, inputSchema)))
+      .addStage(new ETLStage("sink1", MockSink.getPlugin(sink1Name)))
+      .addStage(new ETLStage("sink2", MockSink.getPlugin(sink2Name)))
+      .addStage(new ETLStage("agg1", FieldCountReducibleAggregator.getPlugin("user", "string")))
+      .addStage(new ETLStage("agg2", FieldCountReducibleAggregator.getPlugin("item", "long")))
+      .addConnection("source1", "agg1")
+      .addConnection("source1", "agg2")
+      .addConnection("source2", "agg1")
+      .addConnection("source2", "agg2")
+      .addConnection("agg1", "sink1")
+      .addConnection("agg2", "sink2")
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, etlConfig);
+    ApplicationId appId = NamespaceId.DEFAULT.app("ParallelAggApp-" + engine);
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    // write few records to each source
+    DataSetManager<Table> inputManager = getDataset(NamespaceId.DEFAULT.dataset(source1Name));
+    MockSource.writeInput(inputManager, ImmutableList.of(
+      StructuredRecord.builder(inputSchema).set("user", "samuel").set("item", 1L).build(),
+      StructuredRecord.builder(inputSchema).set("user", "samuel").set("item", 2L).build()));
+
+    inputManager = getDataset(NamespaceId.DEFAULT.dataset(source2Name));
+    MockSource.writeInput(inputManager, ImmutableList.of(
+      StructuredRecord.builder(inputSchema).set("user", "samuel").set("item", 3L).build(),
+      StructuredRecord.builder(inputSchema).set("user", "john").set("item", 4L).build(),
+      StructuredRecord.builder(inputSchema).set("user", "john").set("item", 3L).build()));
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    workflowManager.start(arguments);
+    workflowManager.waitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+
+    Schema outputSchema1 = Schema.recordOf(
+      "user.count",
+      Schema.Field.of("user", Schema.of(Schema.Type.STRING)),
+      Schema.Field.of("ct", Schema.of(Schema.Type.LONG))
+    );
+    Schema outputSchema2 = Schema.recordOf(
+      "item.count",
+      Schema.Field.of("item", Schema.of(Schema.Type.LONG)),
+      Schema.Field.of("ct", Schema.of(Schema.Type.LONG))
+    );
+
+    // check output
+    DataSetManager<Table> sinkManager = getDataset(sink1Name);
+    Set<StructuredRecord> expected = ImmutableSet.of(
+      StructuredRecord.builder(outputSchema1).set("user", "all").set("ct", 5L).build(),
+      StructuredRecord.builder(outputSchema1).set("user", "samuel").set("ct", 3L).build(),
+      StructuredRecord.builder(outputSchema1).set("user", "john").set("ct", 2L).build());
+    Set<StructuredRecord> actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
+    Assert.assertEquals(expected, actual);
+
+    sinkManager = getDataset(sink2Name);
+    expected = ImmutableSet.of(
+      StructuredRecord.builder(outputSchema2).set("item", 0L).set("ct", 5L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 1L).set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 2L).set("ct", 1L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 3L).set("ct", 2L).build(),
+      StructuredRecord.builder(outputSchema2).set("item", 4L).set("ct", 1L).build());
+    actual = Sets.newHashSet(MockSink.readOutput(sinkManager));
+    Assert.assertEquals(expected, actual);
+
+    validateMetric(2, appId, "source1.records.out");
+    validateMetric(3, appId, "source2.records.out");
+    validateMetric(5, appId, "agg1.records.in");
+    // 2 users, but FieldCountReduceAggregator always emits an 'all' group
+    validateMetric(3, appId, "agg1.aggregator.groups");
+    validateMetric(3, appId, "agg1.records.out");
+    validateMetric(5, appId, "agg2.records.in");
+    // 4 items, but FieldCountReduceAggregator always emits an 'all' group
+    validateMetric(5, appId, "agg2.aggregator.groups");
+    validateMetric(5, appId, "agg2.records.out");
+    validateMetric(3, appId, "sink1.records.in");
+    validateMetric(5, appId, "sink2.records.in");
+  }
+
+  private void validateMetric(long expected, ApplicationId appId,
+                              String metric) throws TimeoutException, InterruptedException {
+    Map<String, String> tags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, appId.getNamespace(),
+                                               Constants.Metrics.Tag.APP, appId.getEntityName(),
+                                               Constants.Metrics.Tag.WORKFLOW, SmartWorkflow.NAME);
+    getMetricsManager().waitForTotalMetricCount(tags, "user." + metric, expected, 20, TimeUnit.SECONDS);
+    // wait for won't throw an exception if the metric count is greater than expected
+    Assert.assertEquals(expected, getMetricsManager().getTotalMetric(tags, "user." + metric));
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/src/test/java/io/cdap/cdap/datapipeline/ReducibleDatasetAggregatorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/src/test/java/io/cdap/cdap/datapipeline/ReducibleDatasetAggregatorTest.java
@@ -16,31 +16,29 @@
 
 package io.cdap.cdap.datapipeline;
 
+import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.etl.api.Engine;
 import io.cdap.cdap.etl.common.Constants;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Map;
 
-public class ReducibleAggregatorTest extends ReducibleAggregatorTestBase {
+public class ReducibleDatasetAggregatorTest extends ReducibleAggregatorTestBase {
   /**
-   * Common arguments for spark 1 and 2 to test without dataset aggregation
+   * Settings to test with dataset aggregation.
    */
-  private static final Map<String, String> DEFAULT_ARGUMENTS = Collections.singletonMap(
-    Constants.DATASET_AGGREGATE_ENABLED, "false"
+  private static final Map<String, String> DATASET_AGGREGATE = ImmutableMap.of(
+    Constants.DATASET_AGGREGATE_ENABLED, "true",
+    Constants.DATASET_AGGREGATE_IGNORE_PARTITIONS, "false"
   );
 
   @Test
   public void testSimpleAggregator() throws Exception {
-    testSimpleAggregator(Engine.MAPREDUCE, DEFAULT_ARGUMENTS);
-    testSimpleAggregator(Engine.SPARK, DEFAULT_ARGUMENTS);
+    testSimpleAggregator(Engine.SPARK, DATASET_AGGREGATE);
   }
 
   @Test
   public void testFieldCountAgg() throws Exception {
-    testFieldCountAgg(Engine.MAPREDUCE, DEFAULT_ARGUMENTS);
-    testFieldCountAgg(Engine.SPARK, DEFAULT_ARGUMENTS);
+    testFieldCountAgg(Engine.SPARK, DATASET_AGGREGATE);
   }
-
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
@@ -35,6 +35,9 @@ public final class Constants {
   public static final String SPARK_PIPELINE_CACHING_STORAGE_LEVEL = "spark.cdap.pipeline.caching.storage.level";
   public static final String CONSOLIDATE_STAGES = "spark.cdap.pipeline.consolidate.stages";
   public static final String CACHE_FUNCTIONS = "spark.cdap.pipeline.functioncache.enable";
+  public static final String DATASET_AGGREGATE_ENABLED = "spark.cdap.pipeline.aggregate.dataset.enable";
+  public static final String DATASET_AGGREGATE_IGNORE_PARTITIONS =
+    "spark.cdap.pipeline.aggregate.dataset.partitions.ignore";
   public static final String DEFAULT_CACHING_STORAGE_LEVEL = "DISK_ONLY";
 
   private Constants() {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/function/DatasetAggregationAccumulator.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/function/DatasetAggregationAccumulator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/**
+ * DatasetAggregationAccumulator is used to accumulate group values into aggregation value.
+ * At given point in time it contains either source group value or (if accumulation started already)
+ * an aggregate value.
+ * @param <GROUP_VALUE> type of original value to group
+ * @param <AGG_VALUE> type of accumulated values after reduce stage
+ */
+public class DatasetAggregationAccumulator<GROUP_VALUE, AGG_VALUE> implements Serializable {
+  @Nullable
+  private final GROUP_VALUE groupValue;
+  @Nullable
+  private final AGG_VALUE aggValue;
+
+
+  private DatasetAggregationAccumulator(@Nullable GROUP_VALUE groupValue, @Nullable AGG_VALUE aggValue) {
+    this.groupValue = groupValue;
+    this.aggValue = aggValue;
+  }
+
+  public static <GROUP_VALUE, AGG_VALUE> DatasetAggregationAccumulator<GROUP_VALUE, AGG_VALUE> fromGroupValue(
+    GROUP_VALUE groupValue) {
+    return new DatasetAggregationAccumulator<>(groupValue, null);
+  }
+
+  public static <GROUP_VALUE, AGG_VALUE> DatasetAggregationAccumulator<GROUP_VALUE, AGG_VALUE> fromAggValue(
+    AGG_VALUE aggValue) {
+    return new DatasetAggregationAccumulator<>(null, aggValue);
+  }
+
+  @Nullable
+  public GROUP_VALUE getGroupValue() {
+    return groupValue;
+  }
+
+  @Nullable
+  public AGG_VALUE getAggValue() {
+    return aggValue;
+  }
+
+  public boolean hasAggValue() {
+    return aggValue != null;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/function/DatasetAggregationFinalizeFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/function/DatasetAggregationFinalizeFunction.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.Transformation;
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
+import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.common.RecordInfo;
+import io.cdap.cdap.etl.common.TrackedTransform;
+import io.cdap.cdap.etl.spark.CombinedEmitter;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import scala.Tuple2;
+
+import java.util.Iterator;
+
+/**
+ * DatasetAggregationFinalizeFunction finalizes dataset-based aggregation. First it converts into aggregate value
+ * any group values were not accumulated during reduce phase. Then it emits results for each group.
+ * @param <GROUP_KEY> group key type
+ * @param <GROUP_VALUE> type of original value to group
+ * @param <AGG_VALUE> type of accumulated values after reduce stage
+ * @param <OUT> resulting type
+ */
+public class DatasetAggregationFinalizeFunction<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT> 
+  implements FlatMapFunction<Tuple2<GROUP_KEY, DatasetAggregationAccumulator<GROUP_VALUE, AGG_VALUE>>,
+  RecordInfo<Object>> {
+
+  private final PluginFunctionContext pluginFunctionContext;
+  private final FunctionCache functionCache;
+  private transient BatchReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT> aggregator;
+  private transient TrackedTransform<Tuple2<GROUP_KEY, DatasetAggregationAccumulator<GROUP_VALUE, AGG_VALUE>>, OUT>
+    aggregateTransform;
+  private transient CombinedEmitter<OUT> emitter;
+
+  public DatasetAggregationFinalizeFunction(PluginFunctionContext pluginFunctionContext, FunctionCache functionCache) {
+    this.pluginFunctionContext = pluginFunctionContext;
+    this.functionCache = functionCache;
+  }
+
+  @Override
+  public Iterator<RecordInfo<Object>> call(
+    Tuple2<GROUP_KEY, DatasetAggregationAccumulator<GROUP_VALUE, AGG_VALUE>> input) throws Exception {
+    if (aggregator == null) {
+      aggregator = pluginFunctionContext.createAndInitializePlugin(functionCache);
+      aggregateTransform = new TrackedTransform<>(new AggregateTransform<>(aggregator),
+                                                  pluginFunctionContext.createStageMetrics(),
+                                                  Constants.Metrics.AGG_GROUPS,
+                                                  Constants.Metrics.RECORDS_OUT, pluginFunctionContext.getDataTracer(),
+                                                  pluginFunctionContext.getStageStatisticsCollector());
+      emitter = new CombinedEmitter<>(pluginFunctionContext.getStageName());
+    }
+    emitter.reset();
+    aggregateTransform.transform(input, emitter);
+    return emitter.getEmitted().iterator();
+  }
+
+  private static class AggregateTransform<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT>
+    implements Transformation<Tuple2<GROUP_KEY, DatasetAggregationAccumulator<GROUP_VALUE, AGG_VALUE>>, OUT> {
+    private final BatchReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT> aggregator;
+
+    AggregateTransform(BatchReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT> aggregator) {
+      this.aggregator = aggregator;
+    }
+
+    @Override
+    public void transform(Tuple2<GROUP_KEY, DatasetAggregationAccumulator<GROUP_VALUE, AGG_VALUE>> input,
+                          Emitter<OUT> emitter) throws Exception {
+
+      AGG_VALUE aggValue = input._2().hasAggValue()
+        ? input._2().getAggValue()
+        : aggregator.initializeAggregateValue(input._2().getGroupValue());
+      aggregator.finalize(input._1(), aggValue, emitter);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/function/DatasetAggregationGetKeyFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/function/DatasetAggregationGetKeyFunction.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.Transformation;
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
+import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.common.DefaultEmitter;
+import io.cdap.cdap.etl.common.NoErrorEmitter;
+import io.cdap.cdap.etl.common.TrackedTransform;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import scala.Tuple2;
+
+import java.util.Iterator;
+
+/**
+ * This function is used as a first step in dataset-based aggregation. It retrieves group key(s) and emits
+ * tuples with group key and an accumulator with group value in each tuple.
+ * @param <GROUP_KEY> group key type
+ * @param <GROUP_VAL> group value type
+ * @param <AGG_VALUE> type to accumulate aggregated value
+ */
+public class DatasetAggregationGetKeyFunction<GROUP_KEY, GROUP_VAL, AGG_VALUE>
+  implements FlatMapFunction<GROUP_VAL, Tuple2<GROUP_KEY, DatasetAggregationAccumulator<GROUP_VAL, AGG_VALUE>>> {
+  private final PluginFunctionContext pluginFunctionContext;
+  private final FunctionCache functionCache;
+  private transient TrackedTransform<GROUP_VAL,
+    Tuple2<GROUP_KEY, DatasetAggregationAccumulator<GROUP_VAL, AGG_VALUE>>> groupByFunction;
+  private transient DefaultEmitter<Tuple2<GROUP_KEY, DatasetAggregationAccumulator<GROUP_VAL, AGG_VALUE>>> emitter;
+
+
+  public DatasetAggregationGetKeyFunction(PluginFunctionContext pluginFunctionContext, FunctionCache functionCache) {
+    this.pluginFunctionContext = pluginFunctionContext;
+    this.functionCache = functionCache;
+  }
+
+  @Override
+  public Iterator<Tuple2<GROUP_KEY, DatasetAggregationAccumulator<GROUP_VAL, AGG_VALUE>>> call(GROUP_VAL input)
+    throws Exception {
+    if (groupByFunction == null) {
+      BatchReducibleAggregator<GROUP_KEY, GROUP_VAL, ?, ?> aggregator =
+        pluginFunctionContext.createAndInitializePlugin(functionCache);
+      groupByFunction = new TrackedTransform<>(new GroupByTransform<>(aggregator),
+                                               pluginFunctionContext.createStageMetrics(),
+                                               Constants.Metrics.RECORDS_IN,
+                                               null, pluginFunctionContext.getDataTracer(),
+                                               pluginFunctionContext.getStageStatisticsCollector());
+      emitter = new DefaultEmitter<>();
+    }
+    emitter.reset();
+    groupByFunction.transform(input, emitter);
+    return emitter.getEntries().iterator();
+  }
+
+  private static class GroupByTransform<GROUP_KEY, GROUP_VAL, AGG_VALUE>
+    implements Transformation<GROUP_VAL, Tuple2<GROUP_KEY, DatasetAggregationAccumulator<GROUP_VAL, AGG_VALUE>>> {
+    private final BatchReducibleAggregator<GROUP_KEY, GROUP_VAL, ?, ?> aggregator;
+    private final NoErrorEmitter<GROUP_KEY> keyEmitter;
+
+    GroupByTransform(BatchReducibleAggregator<GROUP_KEY, GROUP_VAL, ?, ?> aggregator) {
+      this.aggregator = aggregator;
+      this.keyEmitter =
+        new NoErrorEmitter<>("Errors and Alerts cannot be emitted from the groupBy method of an aggregator");
+    }
+
+    @Override
+    public void transform(final GROUP_VAL inputValue,
+                          Emitter<Tuple2<GROUP_KEY, DatasetAggregationAccumulator<GROUP_VAL, AGG_VALUE>>> emitter)
+      throws Exception {
+      keyEmitter.reset();
+      aggregator.groupBy(inputValue, keyEmitter);
+      for (GROUP_KEY key : keyEmitter.getEntries()) {
+        emitter.emit(new Tuple2<>(key, DatasetAggregationAccumulator.fromGroupValue(inputValue)));
+      }
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/function/DatasetAggregationReduceFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/function/DatasetAggregationReduceFunction.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.function;
+
+import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
+import org.apache.spark.api.java.function.ReduceFunction;
+
+/**
+ * Central part of aggregation that reduces pairs of accumulators. Each accumulator on input may contain either
+ * original group value or accumulated value from other reduce. This function reduces two value using
+ * mergeValues or mergePartitions and emits a single accumulator with accumulated value.
+ * @param <GROUP_VALUE> type of original value to group
+ * @param <AGG_VALUE> type of accumulated values after reduce stage
+ */
+public class DatasetAggregationReduceFunction<GROUP_VALUE, AGG_VALUE>
+  implements ReduceFunction<DatasetAggregationAccumulator<GROUP_VALUE, AGG_VALUE>> {
+  private final PluginFunctionContext pluginFunctionContext;
+  private final FunctionCache functionCache;
+  private transient BatchReducibleAggregator<?, GROUP_VALUE, AGG_VALUE, ?> aggregator;
+
+  public DatasetAggregationReduceFunction(PluginFunctionContext pluginFunctionContext, FunctionCache functionCache) {
+    this.pluginFunctionContext = pluginFunctionContext;
+    this.functionCache = functionCache;
+  }
+
+  @Override
+  public DatasetAggregationAccumulator<GROUP_VALUE, AGG_VALUE> call(
+    DatasetAggregationAccumulator<GROUP_VALUE, AGG_VALUE> a1,
+    DatasetAggregationAccumulator<GROUP_VALUE, AGG_VALUE> a2) throws Exception {
+    if (aggregator == null) {
+      aggregator = pluginFunctionContext.createAndInitializePlugin(functionCache);
+    }
+    if (a1.hasAggValue() && a2.hasAggValue()) {
+      return DatasetAggregationAccumulator.fromAggValue(aggregator.mergePartitions(a1.getAggValue(), a2.getAggValue()));
+    }
+    if (a1.hasAggValue()) {
+      return DatasetAggregationAccumulator.fromAggValue(aggregator.mergeValues(a1.getAggValue(), a2.getGroupValue()));
+    }
+    if (a2.hasAggValue()) {
+      return DatasetAggregationAccumulator.fromAggValue(aggregator.mergeValues(a2.getAggValue(), a1.getGroupValue()));
+    }
+    return DatasetAggregationAccumulator.fromAggValue(aggregator.mergeValues(
+      aggregator.initializeAggregateValue(a1.getGroupValue()),
+      a2.getGroupValue()));
+  }
+}


### PR DESCRIPTION
This would allow to use various spark3 adaptive optimization features.
It's enabled by default, but can be disabled by setting "spark.cdap.pipeline.aggregate.dataset.enable=false".

When enabled number of partitions is ignored for aggregations as spark handles it by itself. "spark.cdap.pipeline.aggregate.dataset.partitions.ignore=false" can be used to force spark to use provided number of partitions.