### PR TITLE
[CDAP-17400] Backfill plugin metadata on startup 

### DIFF
--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/PluginId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/PluginId.java
@@ -14,8 +14,10 @@
 
 package io.cdap.cdap.proto.id;
 
+import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactVersion;
 import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.api.plugin.Plugin;
 import io.cdap.cdap.proto.element.EntityType;
 
 import java.util.Arrays;
@@ -45,6 +47,19 @@ public class PluginId extends NamespacedEntityId implements ParentedId<ArtifactI
     if (artifactVersion.getVersion() == null) {
       throw new IllegalArgumentException("Invalid artifact version " + version);
     }
+  }
+
+  public PluginId(String appNamespace, Plugin plugin) {
+    super(resolveNamespace(appNamespace, plugin), EntityType.PLUGIN);
+    this.artifact = Objects.requireNonNull(plugin.getArtifactId().getName(), "Artifact ID cannot be null.");
+    this.version = Objects.requireNonNull(plugin.getArtifactId().getVersion().getVersion(), "Version cannot be null.");
+    this.plugin = Objects.requireNonNull(plugin.getPluginClass().getName(), "Plugin cannot be null.");
+    this.type = Objects.requireNonNull(plugin.getPluginClass().getType(), "Type cannot be null.");
+  }
+
+  private static String resolveNamespace(String namespace, Plugin plugin) {
+    return plugin.getArtifactId().getScope() == ArtifactScope.SYSTEM ? ArtifactScope.SYSTEM
+      .toString().toLowerCase() : namespace;
   }
 
   public String getArtifact() {

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/subscriber/AbstractMessagingPollingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/subscriber/AbstractMessagingPollingService.java
@@ -115,6 +115,13 @@ public abstract class AbstractMessagingPollingService<T> extends AbstractRetryab
   protected abstract String processMessages(Iterator<ImmutablePair<String, T>> messages) throws Exception;
 
   /**
+   * Perform pre-processing before a batch of messages will be processed.
+   */
+  protected void preProcess() {
+    // no-op
+  }
+
+  /**
    * Perform post processing after a batch of messages has been processed and before the next batch of
    * messages is fetched.
    */
@@ -140,6 +147,11 @@ public abstract class AbstractMessagingPollingService<T> extends AbstractRetryab
 
   @Override
   protected final long runTask() throws Exception {
+    try {
+      preProcess();
+    } catch (Exception e) {
+      LOG.warn("Failed to perform pre-processing before processing messages.", e);
+    }
     long delayMillis = fetchAndProcessMessages();
     try {
       postProcess();


### PR DESCRIPTION
This PR is a follow up to #13121 . This change allows CDAP to backfill the newly created plugin metadata for all existing apps on startup. This is useful for newly updated instances that may want to leverage this new data.