### PR TITLE
Capability management fixes

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/CapabilitySleepingWorkflowPluginApp.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/CapabilitySleepingWorkflowPluginApp.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2014-2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap;
+
+import io.cdap.cdap.api.Config;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.annotation.Requirements;
+import io.cdap.cdap.api.app.AbstractApplication;
+import io.cdap.cdap.api.customaction.AbstractCustomAction;
+import io.cdap.cdap.api.plugin.PluginProperties;
+import io.cdap.cdap.api.workflow.AbstractWorkflow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Simple workflow, that sleeps inside a CustomAction
+ */
+public class CapabilitySleepingWorkflowPluginApp extends AbstractApplication<CapabilitySleepingWorkflowPluginApp.Conf> {
+
+  public static final String NAME = "CapabilitySleepingWorkflowPluginApp";
+  public static final String DESC = "CapabilitySleepingWorkflowPluginApp";
+
+  @Override
+  public void configure() {
+    setName(NAME);
+    setDescription(DESC);
+    Conf conf = getConfig();
+    usePlugin("simple", conf.pluginName, "id",
+              PluginProperties.builder().addAll(conf.pluginProperties).build());
+    addWorkflow(new SleepWorkflow());
+  }
+
+  /**
+   * Config for the plugin
+   */
+  public static class Conf extends Config {
+    private final String pluginName;
+
+    private final Map<String, String> pluginProperties;
+
+    public Conf() {
+      this.pluginName = "SimpleRunnablePlugin";
+      this.pluginProperties = new HashMap<>();
+    }
+  }
+
+  /**
+   * SleepWorkflow
+   */
+  public static class SleepWorkflow extends AbstractWorkflow {
+
+    @Override
+    public void configure() {
+      setName("SleepWorkflow");
+      setDescription("FunWorkflow description");
+      addAction(new CustomAction("verify"));
+    }
+  }
+
+  /**
+   * CustomAction
+   */
+  public static final class CustomAction extends AbstractCustomAction {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CustomAction.class);
+
+    private final String name;
+
+    public CustomAction(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public void configure() {
+      setName(name);
+      setDescription(name);
+    }
+
+    @Override
+    public void initialize() {
+      LOG.info("Custom action initialized: " + getContext().getSpecification().getName());
+    }
+
+    @Override
+    public void destroy() {
+      super.destroy();
+      LOG.info("Custom action destroyed: " + getContext().getSpecification().getName());
+    }
+
+    @Override
+    public void run() {
+      LOG.info("Custom action run");
+      try {
+        String sleepTime = getContext().getRuntimeArguments().get("sleep.ms");
+        Thread.sleep(sleepTime == null ? 2000 : Long.parseLong(sleepTime));
+      } catch (InterruptedException e) {
+        // expected if the workflow get killed
+      }
+      LOG.info("Custom run completed.");
+    }
+  }
+
+  @Plugin(type = "simple")
+  @Name("SimpleRunnablePlugin")
+  @Requirements(capabilities = "healthcare")
+  public class SimplePlugin {
+
+    public long time() {
+      return System.currentTimeMillis();
+    }
+  }
+}

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java
@@ -91,7 +91,6 @@ import io.cdap.cdap.test.app.DatasetCrossNSAccessWithMAPApp;
 import io.cdap.cdap.test.app.DummyApp;
 import io.cdap.cdap.test.artifacts.plugins.ToStringPlugin;
 import io.cdap.common.http.HttpRequest;
-import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.filesystem.LocalLocationFactory;
@@ -532,9 +531,10 @@ public class AuthorizationTest extends TestBase {
   public void testCrossNSService() throws Exception {
     createAuthNamespace();
     ApplicationId appId = AUTH_NAMESPACE.app(CrossNsDatasetAccessApp.APP_NAME);
+    ArtifactId artifact = AUTH_NAMESPACE.artifact(CrossNsDatasetAccessApp.class.getSimpleName(), "1.0-SNAPSHOT");
     Map<EntityId, Set<Action>> neededPrivileges = ImmutableMap.<EntityId, Set<Action>>builder()
       .put(appId, EnumSet.of(Action.ADMIN))
-      .put(AUTH_NAMESPACE.artifact(CrossNsDatasetAccessApp.class.getSimpleName(), "1.0-SNAPSHOT"),
+      .put(artifact,
            EnumSet.of(Action.ADMIN))
       .build();
 
@@ -544,6 +544,8 @@ public class AuthorizationTest extends TestBase {
     cleanUpEntities.add(programId);
     // grant bob execute on program and READ/WRITE on stream
     grantAndAssertSuccess(programId, BOB, EnumSet.of(Action.EXECUTE));
+    //new privilege required due to capability validations
+    grantAndAssertSuccess(artifact, BOB, EnumSet.of(Action.READ));
 
     ApplicationManager appManager = deployApplication(AUTH_NAMESPACE, CrossNsDatasetAccessApp.class);
 
@@ -662,9 +664,10 @@ public class AuthorizationTest extends TestBase {
     createAuthNamespace();
     ApplicationId appId = AUTH_NAMESPACE.app(DatasetCrossNSAccessWithMAPApp.class.getSimpleName());
 
+    ArtifactId artifact = AUTH_NAMESPACE.artifact(DatasetCrossNSAccessWithMAPApp.class.getSimpleName(), "1.0-SNAPSHOT");
     Map<EntityId, Set<Action>> neededPrivileges = ImmutableMap.<EntityId, Set<Action>>builder()
       .put(appId, EnumSet.of(Action.ADMIN))
-      .put(AUTH_NAMESPACE.artifact(DatasetCrossNSAccessWithMAPApp.class.getSimpleName(), "1.0-SNAPSHOT"),
+      .put(artifact,
            EnumSet.of(Action.ADMIN))
       .build();
     setUpPrivilegeAndRegisterForDeletion(ALICE, neededPrivileges);
@@ -672,6 +675,8 @@ public class AuthorizationTest extends TestBase {
     ProgramId programId = appId.program(ProgramType.MAPREDUCE, DatasetCrossNSAccessWithMAPApp.MAPREDUCE_PROGRAM);
     // bob will be executing the program
     grantAndAssertSuccess(programId, BOB, EnumSet.of(Action.EXECUTE));
+    //new privilege required due to capability validations
+    grantAndAssertSuccess(artifact, BOB, EnumSet.of(Action.READ));
     cleanUpEntities.add(programId);
 
     ApplicationManager appManager = deployApplication(AUTH_NAMESPACE, DatasetCrossNSAccessWithMAPApp.class);
@@ -815,9 +820,10 @@ public class AuthorizationTest extends TestBase {
     createAuthNamespace();
     ApplicationId appId = AUTH_NAMESPACE.app(TestSparkCrossNSDatasetApp.APP_NAME);
 
+    ArtifactId artifact = AUTH_NAMESPACE.artifact(TestSparkCrossNSDatasetApp.class.getSimpleName(), "1.0-SNAPSHOT");
     Map<EntityId, Set<Action>> neededPrivileges = ImmutableMap.<EntityId, Set<Action>>builder()
       .put(appId, EnumSet.of(Action.ADMIN))
-      .put(AUTH_NAMESPACE.artifact(TestSparkCrossNSDatasetApp.class.getSimpleName(), "1.0-SNAPSHOT"),
+      .put(artifact,
            EnumSet.of(Action.ADMIN))
       .put(AUTH_NAMESPACE.dataset(TestSparkCrossNSDatasetApp.DEFAULT_OUTPUT_DATASET), EnumSet.of(Action.ADMIN))
       .put(AUTH_NAMESPACE.datasetType(KeyValueTable.class.getName()), EnumSet.of(Action.ADMIN))
@@ -827,6 +833,8 @@ public class AuthorizationTest extends TestBase {
     ProgramId programId = appId.spark(TestSparkCrossNSDatasetApp.SPARK_PROGRAM_NAME);
     // bob will be executing the program
     grantAndAssertSuccess(programId, BOB, EnumSet.of(Action.EXECUTE));
+    //new privilege required due to capability validations
+    grantAndAssertSuccess(artifact, BOB, EnumSet.of(Action.READ));
     cleanUpEntities.add(programId);
 
     ApplicationManager appManager = deployApplication(AUTH_NAMESPACE, TestSparkCrossNSDatasetApp.class);
@@ -1103,9 +1111,10 @@ public class AuthorizationTest extends TestBase {
     ApplicationId appId = AUTH_NAMESPACE.app(PartitionTestApp.class.getSimpleName());
     DatasetId datasetId = AUTH_NAMESPACE.dataset(PartitionTestApp.PFS_NAME);
 
+    ArtifactId artifact = AUTH_NAMESPACE.artifact(PartitionTestApp.class.getSimpleName(), "1.0-SNAPSHOT");
     Map<EntityId, Set<Action>> neededPrivileges = ImmutableMap.<EntityId, Set<Action>>builder()
       .put(appId, EnumSet.of(Action.ADMIN))
-      .put(AUTH_NAMESPACE.artifact(PartitionTestApp.class.getSimpleName(), "1.0-SNAPSHOT"), EnumSet.of(Action.ADMIN))
+      .put(artifact, EnumSet.of(Action.ADMIN))
       .put(datasetId, EnumSet.of(Action.ADMIN))
       .put(AUTH_NAMESPACE.datasetType(PartitionedFileSet.class.getName()), EnumSet.of(Action.ADMIN))
       .build();
@@ -1116,6 +1125,8 @@ public class AuthorizationTest extends TestBase {
     cleanUpEntities.add(programId);
     grantAndAssertSuccess(datasetId, BOB, EnumSet.of(Action.READ));
     cleanUpEntities.add(datasetId);
+    //new privilege required due to capability validations
+    grantAndAssertSuccess(artifact, BOB, EnumSet.of(Action.READ));
 
     ApplicationManager appMgr = deployApplication(AUTH_NAMESPACE, PartitionTestApp.class);
     SecurityRequestContext.setUserId(BOB.getName());


### PR DESCRIPTION
- [CDAP-17694]( https://cdap.atlassian.net/browse/CDAP-17694) :
  Look for changes in artifact even when config has not changed
  Ignore not found exception for delete artifact
  Tested for upgrade from 6.3.0 to 6.4.0
- [CDAP-17589](https://cdap.atlassian.net/browse/CDAP-17589)
 Validate for capability tag in Application class before starting program (Currently only plugin class tags are being considered)
 Uncomment the test case for tag at Application class level
 Add test case for application with capability tag only at plugin level
 Fixed cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java with additional READ permission for artifact 