### PR TITLE
[CDAP-17717] Fixes alerts and errors with space in names to be connected properly

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -254,7 +254,7 @@ angular.module(PKG.name + '.commons')
         if (!Array.isArray(connectedNodes)) {
           return;
         }
-        const connectionsFromSource = vm.instance.getConnections({sourceId: id});
+        const connectionsFromSource = vm.instance.getAllConnections();
         connectedNodes.forEach(nodeId => {
           if (!selectedNodesMap[nodeId]) {
             return;
@@ -742,13 +742,28 @@ angular.module(PKG.name + '.commons')
 
     const addConnectionToErrorsAlerts = (conn, sourceNode, targetNode) => {
       let connObj = {
-        target: conn.to
+        target: conn.to.replace(/[ \/]/g, '-'),
       };
+      let errorSourceId = `endpoint_${sourceNode.id}_error`;
+      let alertSourceId = `endpoint_${sourceNode.id}_alert`;
 
+      let connectionExist = false;
+      if (targetNode.type === 'errortransform') {
+        connectionExist = vm.instance.getConnections('errorScope')
+          .map(connection => `${connection.sourceId}-##-${connection.targetId}`)
+          .find(connStr => connStr === `${errorSourceId}-##-${conn.to.replace(/[ \/]/g, '-')}`);
+      } else if (targetNode.type === 'alertpublisher') {
+        connectionExist = vm.instance.getConnections('alertScope')
+          .map(connection => `${connection.sourceId}-##-${connection.targetId}`)
+          .find(connStr => connStr === `${alertSourceId}-##-${conn.to.replace(/[ \/]/g, '-')}`);
+      }
+      if (connectionExist) {
+        return;
+      }
       if (targetNode.type === 'errortransform' && vm.shouldShowErrorsPort(sourceNode)) {
-        connObj.source = vm.instance.getEndpoints(`endpoint_${sourceNode.id}_error`)[0];
+        connObj.source = vm.instance.getEndpoints(errorSourceId)[0];
       } else if (targetNode.type === 'alertpublisher' && vm.shouldShowAlertsPort(sourceNode)) {
-        connObj.source = vm.instance.getEndpoints(`endpoint_${sourceNode.id}_alert`)[0];
+        connObj.source = vm.instance.getEndpoints(alertSourceId)[0];
       } else {
         connObj.source = vm.instance.getEndpoints(`endpoint_${sourceNode.id}`)[0];
         // this is for backwards compability with old pipelines where we don't specify
@@ -775,7 +790,6 @@ angular.module(PKG.name + '.commons')
         angular.forEach($scope.connections, (conn) => {
           var sourceNode = $scope.nodes.find(node => node.name === conn.from);
           var targetNode = $scope.nodes.find(node => node.name === conn.to);
-
           if (!sourceNode || !targetNode) {
             return;
           }


### PR DESCRIPTION
JIRA: https://cdap.atlassian.net/browse/CDAP-17717

**Problem**
- The original JIRA talks about missing connection to the error collector node.
- The primary reason being the usage of spaces in plugin names.(Related JIRAs : [CDAP-17246](https://cdap.atlassian.net/browse/CDAP-17246), [CDAP-17252](https://cdap.atlassian.net/browse/CDAP-17252))

**Possible Approaches**
_Modifying node names_
- There was a bigger change to replace all node names and change corresponding connections. However this was dropped since we don't know where a plugin name is used in a pipeline (plugin property of other nodes, say joiner)

_Replacing node names on the fly_
- The approach I took in this PR is a little bit safer. While rendering connection I replace the spaces with `-` (mimicking the original solution) without affecting the actual config. 
- This helps in rendering connections based on actual nodeid and not node name which can potentially have spaces

TODO:
- The way we structure the code and render nodes and connections is very confusing and is not straight forward. We need to address the broader design of the DAG which is a much bigger effort ([CDAP-14284](https://cdap.atlassian.net/browse/CDAP-14284))