### PR TITLE
(CDAP-17618) Added support for file based key manager in distributed mode

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/AbstractServiceMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/AbstractServiceMain.java
@@ -21,8 +21,10 @@ import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
+import com.google.inject.Binding;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Key;
 import com.google.inject.Module;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.preview.PreviewConfigModule;
@@ -249,8 +251,13 @@ public abstract class AbstractServiceMain<T extends EnvironmentOptions> extends 
 
   protected void initializeDataSourceConnection(CConfiguration cConf) throws SQLException {
     if (cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION).equals(Constants.Dataset.DATA_STORAGE_SQL)) {
+      Binding<DataSource> binding = injector.getExistingBinding(Key.get(DataSource.class));
+      if (binding == null) {
+        return;
+      }
+
       // instantiate the data source and create a connection
-      DataSource dataSource = injector.getInstance(DataSource.class);
+      DataSource dataSource = binding.getProvider().get();
       try (Connection connection = dataSource.getConnection()) {
         // Just to ping the connection and close it to populate the connection pool.
         connection.isValid(5);

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/CConfigurationUtil.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/CConfigurationUtil.java
@@ -157,6 +157,15 @@ public class CConfigurationUtil extends Configuration {
     assertAlphanumeric(cConf, Constants.Dataset.TABLE_PREFIX);
   }
 
+  /**
+   * Returns {@code true} if the given key is explicitly
+   * defined (i.e. not coming from cdap-default.xml) in the given configuration.
+   */
+  public static boolean isOverridden(CConfiguration cConf, String key) {
+    String[] sources = cConf.getPropertySources(key);
+    return !(sources == null || sources.length < 1 || "cdap-default.xml".equals(sources[0]));
+  }
+
   private static void assertAlphanumeric(CConfiguration cConf, String key) {
     String value = cConf.get(key);
     Preconditions.checkNotNull(value, "Entry of CConf with key: %s is null", key);

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1063,11 +1063,11 @@ public final class Constants {
        * Determines which authentication mode to use.
        * Should be chosen from the {@link io.cdap.cdap.security.auth.AuthenticationMode} enum.
        */
-      public static final String AUTHENTICATION_MODE = "security.authentication.mode";
+      public static final String MODE = "security.authentication.mode";
       /** The header from which CDAP should expect to receive the end user identity when using proxy auth mode. */
-      public static final String AUTH_PROXY_USER_ID_HEADER = "security.authentication.proxy.user.identity.header";
+      public static final String PROXY_USER_ID_HEADER = "security.authentication.proxy.user.identity.header";
       /** Determines whether to propagate the end user credential as part of the Principal. */
-      public static final String AUTH_PROPAGATE_USER_CREDENTIAL = "security.authentication.propagate.user.credentials";
+      public static final String PROPAGATE_USER_CREDENTIAL = "security.authentication.propagate.user.credentials";
     }
 
     /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3929,7 +3929,9 @@
     <name>security.data.keyfile.path</name>
     <value>${local.data.dir}/security/keyfile</value>
     <description>
-      Path to the secret key file (only used in CDAP Local Sandbox)
+      Path to the secret key file. In distributed CDAP, if the zookeeper.quorum
+      properties is overridden, then
+      Zookeeper will be used for storing secret key and this property will be ignore.
     </description>
   </property>
 

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/AuthenticationHandler.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/AuthenticationHandler.java
@@ -115,7 +115,7 @@ public class AuthenticationHandler extends ChannelInboundHandlerAdapter {
       request.headers().remove(HttpHeaderNames.AUTHORIZATION);
       String credential = userIdentityPair.getUserCredential();
       // For backwards compatibility, we continue propagating credentials by default. This may change in the future.
-      if (cConf.getBoolean(Constants.Security.Authentication.AUTH_PROPAGATE_USER_CREDENTIAL, true) &&
+      if (cConf.getBoolean(Constants.Security.Authentication.PROPAGATE_USER_CREDENTIAL, true) &&
         credential != null) {
         request.headers().set(HttpHeaderNames.AUTHORIZATION, "CDAP-verified " + credential);
       }

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/AuthServerAnnounceTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/AuthServerAnnounceTest.java
@@ -128,7 +128,7 @@ public class AuthServerAnnounceTest {
       cConf.setInt(Constants.Router.ROUTER_PORT, 0);
       cConf.setInt(Constants.Router.CONNECTION_TIMEOUT_SECS, CONNECTION_IDLE_TIMEOUT_SECS);
       cConf.setBoolean(Constants.Security.ENABLED, true);
-      cConf.setEnum(Constants.Security.Authentication.AUTHENTICATION_MODE, AuthenticationMode.MANAGED);
+      cConf.setEnum(Constants.Security.Authentication.MODE, AuthenticationMode.MANAGED);
 
       router =
         new NettyRouter(cConf, sConfiguration, InetAddresses.forString(hostname),

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/AuthenticationServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/AuthenticationServiceMainTest.java
@@ -72,8 +72,8 @@ public class AuthenticationServiceMainTest extends MasterServiceMainTestBase {
     HttpResponse response = HttpRequests.execute(HttpRequest.get(getAuthenticationBaseURI().toURL()).build()
         , new HttpRequestConfig(0, 0, false));
 
-    Assert.assertEquals("basic realm=\"null\"", response.getHeaders().get("WWW-Authenticate")
-        .stream().findFirst().get());
+    Assert.assertEquals("basic realm=\"null\"",
+                        response.getHeaders().get("WWW-Authenticate").stream().findFirst().orElse(null));
     Assert.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, response.getResponseCode());
 
     Injector injector = getServiceMainInstance(AuthenticationServiceMain.class).getInjector();

--- a/cdap-security/src/main/java/io/cdap/cdap/security/auth/DistributedKeyManager.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/auth/DistributedKeyManager.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.security.auth;
 
 import com.google.common.base.Throwables;
+import com.google.inject.Inject;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.io.Codec;
@@ -64,7 +65,8 @@ public class DistributedKeyManager extends AbstractKeyManager implements Resourc
   private ZKClient zookeeper;
   private final long maxTokenExpiration;
 
-  public DistributedKeyManager(CConfiguration conf, Codec<KeyIdentifier> codec, ZKClient zookeeper) {
+  @Inject
+  DistributedKeyManager(CConfiguration conf, Codec<KeyIdentifier> codec, ZKClient zookeeper) {
     this(conf, codec, zookeeper, getACLs(conf));
   }
 

--- a/cdap-security/src/main/java/io/cdap/cdap/security/auth/ProxyUserIdentityExtractor.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/auth/ProxyUserIdentityExtractor.java
@@ -36,7 +36,7 @@ public class ProxyUserIdentityExtractor implements UserIdentityExtractor {
 
   @Inject
   public ProxyUserIdentityExtractor(CConfiguration cConf) {
-    this.userIdentityHeader = cConf.get(Constants.Security.Authentication.AUTH_PROXY_USER_ID_HEADER);
+    this.userIdentityHeader = cConf.get(Constants.Security.Authentication.PROXY_USER_ID_HEADER);
   }
 
   /**

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/DistributedSecurityModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/DistributedSecurityModule.java
@@ -17,42 +17,23 @@
 package io.cdap.cdap.security.guice;
 
 import com.google.inject.Binder;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.google.inject.Scopes;
-import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.security.auth.DistributedKeyManager;
-import io.cdap.cdap.security.auth.KeyIdentifier;
 import io.cdap.cdap.security.auth.KeyManager;
-import org.apache.twill.zookeeper.ZKClientService;
 
 /**
  * Configures dependency injection with all security class implementations required to run in a distributed
  * environment.
  */
 final class DistributedSecurityModule extends SecurityModule {
+
   @Override
-  protected void bindKeyManager(Binder binder) {
-    binder.bind(KeyManager.class).toProvider(DistributedKeyManagerProvider.class).in(Scopes.SINGLETON);
+  public boolean requiresZKClient() {
+    return true;
   }
 
-  private static final class DistributedKeyManagerProvider implements Provider<KeyManager> {
-    private final CConfiguration cConf;
-    private final Codec<KeyIdentifier> keyCodec;
-    private final ZKClientService zkClient;
-
-
-    @Inject
-    DistributedKeyManagerProvider(CConfiguration cConf, Codec<KeyIdentifier> codec, ZKClientService zkClient) {
-      this.cConf = cConf;
-      this.keyCodec = codec;
-      this.zkClient = zkClient;
-    }
-
-    @Override
-    public KeyManager get() {
-      return new DistributedKeyManager(cConf, keyCodec, zkClient);
-    }
+  @Override
+  protected void bindKeyManager(Binder binder) {
+    binder.bind(KeyManager.class).to(DistributedKeyManager.class).in(Scopes.SINGLETON);
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/FileBasedSecurityModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/FileBasedSecurityModule.java
@@ -17,13 +17,8 @@
 package io.cdap.cdap.security.guice;
 
 import com.google.inject.Binder;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.google.inject.Scopes;
-import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.security.auth.FileBasedKeyManager;
-import io.cdap.cdap.security.auth.KeyIdentifier;
 import io.cdap.cdap.security.auth.KeyManager;
 
 /**
@@ -34,22 +29,6 @@ public class FileBasedSecurityModule extends SecurityModule {
 
   @Override
   protected void bindKeyManager(Binder binder) {
-    binder.bind(KeyManager.class).toProvider(FileBasedKeyManagerProvider.class).in(Scopes.SINGLETON);
-  }
-
-  private static final class FileBasedKeyManagerProvider implements  Provider<KeyManager> {
-    private CConfiguration cConf;
-    private Codec<KeyIdentifier> keyIdentifierCodec;
-
-    @Inject
-    FileBasedKeyManagerProvider(CConfiguration cConf, Codec<KeyIdentifier> keyIdentifierCodec) {
-      this.cConf = cConf;
-      this.keyIdentifierCodec = keyIdentifierCodec;
-    }
-
-    @Override
-    public KeyManager get() {
-      return new FileBasedKeyManager(cConf, keyIdentifierCodec);
-    }
+    binder.bind(KeyManager.class).to(FileBasedKeyManager.class).in(Scopes.SINGLETON);
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/InMemorySecurityModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/InMemorySecurityModule.java
@@ -36,7 +36,7 @@ final class InMemorySecurityModule extends SecurityModule {
   }
 
   private static final class InMemoryKeyManagerProvider implements Provider<KeyManager> {
-    private CConfiguration cConf;
+    private final CConfiguration cConf;
 
     @Inject
     InMemoryKeyManagerProvider(CConfiguration conf) {

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/SecurityModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/SecurityModule.java
@@ -58,6 +58,10 @@ public abstract class SecurityModule extends PrivateModule {
 
   private static final Logger EXTERNAL_AUTH_AUDIT_LOG = LoggerFactory.getLogger("external-auth-access");
 
+  public boolean requiresZKClient() {
+    return false;
+  }
+
   @Override
   protected final void configure() {
     bind(new TypeLiteral<Codec<AccessToken>>() { }).to(AccessTokenCodec.class).in(Scopes.SINGLETON);
@@ -128,7 +132,7 @@ public abstract class SecurityModule extends PrivateModule {
                                             Provider<UserIdentityExtractor> proxyExtractorProvider) {
       this.accessTokenExtractorProvider = accessTokenExtractorProvider;
       this.proxyExtractorProvider = proxyExtractorProvider;
-      this.mode = configuration.getEnum(Constants.Security.Authentication.AUTHENTICATION_MODE,
+      this.mode = configuration.getEnum(Constants.Security.Authentication.MODE,
                                         AuthenticationMode.MANAGED);
     }
 

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/SecurityModules.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/SecurityModules.java
@@ -17,13 +17,18 @@
 package io.cdap.cdap.security.guice;
 
 import com.google.inject.Module;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.CConfigurationUtil;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.runtime.RuntimeModule;
+import org.apache.twill.zookeeper.ZKClient;
 
 /**
  * Security guice modules
  */
 //TODO: we need to have separate implementations for inMemoryModule and standaloneModule
 public class SecurityModules extends RuntimeModule {
+
   @Override
   public Module getInMemoryModules() {
     return new InMemorySecurityModule();
@@ -34,8 +39,26 @@ public class SecurityModules extends RuntimeModule {
     return new InMemorySecurityModule();
   }
 
+  /**
+   * Deprecated, use the {@link #getDistributedModule(CConfiguration)} instead.
+   * @deprecated
+   */
   @Override
   public Module getDistributedModules() {
     return new DistributedSecurityModule();
+  }
+
+  /**
+   * Returns {@code true} if a {@link ZKClient} binding is needed for the distributed module.
+   */
+  public static SecurityModule getDistributedModule(CConfiguration cConf) {
+    // If the file based path is not set explicitly, use ZK.
+    // If ZK is set explicitly, always use ZK.
+    // This is the backward compatible behavior.
+    if (!CConfigurationUtil.isOverridden(cConf, Constants.Security.CFG_FILE_BASED_KEYFILE_PATH)
+        || CConfigurationUtil.isOverridden(cConf, Constants.Zookeeper.QUORUM)) {
+      return new DistributedSecurityModule();
+    }
+    return new FileBasedSecurityModule();
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/SecurityUtil.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/SecurityUtil.java
@@ -123,14 +123,27 @@ public final class SecurityUtil {
   }
 
   /**
+   * Check if {@link Constants.Security#KERBEROS_ENABLED} is set. The value is default to the value of
+   * {@link Constants.Security#ENABLED}.
+   *
    * @param cConf CConfiguration object.
    * @return true, if Kerberos is enabled.
    */
   public static boolean isKerberosEnabled(CConfiguration cConf) {
-    return cConf.getBoolean(Constants.Security.KERBEROS_ENABLED,
-                            cConf.getBoolean(Constants.Security.ENABLED) &&
-                              cConf.getEnum(Constants.Security.Authentication.AUTHENTICATION_MODE,
-                                            AuthenticationMode.MANAGED).equals(AuthenticationMode.MANAGED));
+    return cConf.getBoolean(Constants.Security.KERBEROS_ENABLED, cConf.getBoolean(Constants.Security.ENABLED));
+  }
+
+  /**
+   * Checks if perimeter security is enabled in managed mode.
+   *
+   * @return {@code true} if security enabled in managed mode
+   * @see Constants.Security#ENABLED
+   * @see Constants.Security.Authentication#MODE
+   */
+  public static boolean isManagedSecurity(CConfiguration cConf) {
+    return cConf.getBoolean(Constants.Security.ENABLED)
+      && cConf.getEnum(Constants.Security.Authentication.MODE,
+                       AuthenticationMode.MANAGED).equals(AuthenticationMode.MANAGED);
   }
 
   public static String getMasterPrincipal(CConfiguration cConf) {

--- a/cdap-security/src/main/java/io/cdap/cdap/security/runtime/AuthenticationServerMain.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/runtime/AuthenticationServerMain.java
@@ -28,7 +28,6 @@ import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.guice.ZKDiscoveryModule;
 import io.cdap.cdap.common.runtime.DaemonMain;
-import io.cdap.cdap.security.auth.AuthenticationMode;
 import io.cdap.cdap.security.guice.SecurityModules;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.server.ExternalAuthenticationServer;
@@ -59,9 +58,7 @@ public class AuthenticationServerMain extends DaemonMain {
                                              new SecurityModules().getDistributedModules());
     configuration = injector.getInstance(CConfiguration.class);
 
-    if (configuration.getBoolean(Constants.Security.ENABLED) &&
-      configuration.getEnum(Constants.Security.Authentication.AUTHENTICATION_MODE, AuthenticationMode.MANAGED)
-        .equals(AuthenticationMode.MANAGED)) {
+    if (SecurityUtil.isManagedSecurity(configuration)) {
       this.zkClientService = injector.getInstance(ZKClientService.class);
       this.authServer = injector.getInstance(ExternalAuthenticationServer.class);
     }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/tools/AuthenticationTool.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/tools/AuthenticationTool.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.tools;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.IOModule;
+import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.io.Codec;
+import io.cdap.cdap.security.auth.FileBasedKeyManager;
+import io.cdap.cdap.security.auth.KeyIdentifier;
+import io.cdap.cdap.security.auth.KeyIdentifierCodec;
+import io.cdap.cdap.security.guice.SecurityModules;
+import org.apache.commons.cli.BasicParser;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.security.NoSuchAlgorithmException;
+import java.util.Random;
+
+/**
+ * A command line tool for authentication.
+ */
+public class AuthenticationTool {
+
+  public static void main(String[] args) throws ParseException, NoSuchAlgorithmException, IOException {
+    Options options = new Options()
+      .addOption(new Option("h", "help", false, "Print this usage message."))
+      .addOption(new Option("g", "generateKey", true, "Generates a key and save it to a file"));
+
+    CommandLineParser parser = new BasicParser();
+    CommandLine commandLine = parser.parse(options, args);
+
+    if (commandLine.hasOption("h") || commandLine.getOptions().length == 0) {
+      printUsage(options);
+      return;
+    }
+
+    if (commandLine.hasOption("g")) {
+      String file = commandLine.getOptionValue("g");
+      if (file == null) {
+        System.out.println("Missing key file");
+        printUsage(options);
+        return;
+      }
+
+      File keyFile = new File(file);
+
+      CConfiguration cConf = CConfiguration.create();
+      cConf.set(Constants.Security.CFG_FILE_BASED_KEYFILE_PATH, keyFile.getAbsolutePath());
+      cConf.unset(Constants.Zookeeper.QUORUM);
+
+      Injector injector = Guice.createInjector(
+        new ConfigModule(cConf),
+        new IOModule(),
+        new InMemoryDiscoveryModule(),
+        SecurityModules.getDistributedModule(cConf));
+
+      Codec<KeyIdentifier> codec = injector.getInstance(Key.get(new TypeLiteral<Codec<KeyIdentifier>>() { }));
+      FileBasedKeyManager keyManager = new FileBasedKeyManager(injector.getInstance(CConfiguration.class),
+                                                               injector.getInstance(KeyIdentifierCodec.class));
+
+      KeyIdentifier keyIdentifier = keyManager.generateKey(keyManager.createKeyGenerator(),
+                                                           new Random().nextInt(Integer.MAX_VALUE));
+      try {
+        Files.write(keyFile.toPath(), codec.encode(keyIdentifier), StandardOpenOption.CREATE_NEW);
+      } catch (FileAlreadyExistsException e) {
+        System.err.println("File " + keyFile + " already exists. Please specify a different file path.");
+      }
+      return;
+    }
+
+    printUsage(options);
+  }
+
+  private static void printUsage(Options options) {
+    HelpFormatter helpFormatter = new HelpFormatter();
+    helpFormatter.printHelp(AuthenticationTool.class.getSimpleName(), options);
+  }
+}

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/DistributedKeyManagerTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/DistributedKeyManagerTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
+import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
@@ -30,6 +31,7 @@ import io.cdap.cdap.common.guice.ZKDiscoveryModule;
 import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.common.utils.ImmutablePair;
 import io.cdap.cdap.common.utils.Tasks;
+import io.cdap.cdap.security.guice.SecurityModule;
 import io.cdap.cdap.security.guice.SecurityModules;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HConstants;
@@ -43,6 +45,8 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -70,12 +74,31 @@ public class DistributedKeyManagerTest extends TestTokenManager {
 
     CConfiguration cConf2 = CConfiguration.create();
     cConf2.set(Constants.Zookeeper.QUORUM, zkConnectString);
-    injector1 = Guice.createInjector(new ConfigModule(cConf1, testUtil.getConfiguration()), new IOModule(),
-                                     new SecurityModules().getDistributedModules(), new ZKClientModule(),
-                                     new ZKDiscoveryModule());
-    injector2 = Guice.createInjector(new ConfigModule(cConf2, testUtil.getConfiguration()), new IOModule(),
-                                     new SecurityModules().getDistributedModules(), new ZKClientModule(),
-                                     new ZKDiscoveryModule());
+
+    List<Module> modules = new ArrayList<>();
+    modules.add(new ConfigModule(cConf1, testUtil.getConfiguration()));
+    modules.add(new IOModule());
+
+    SecurityModule securityModule = SecurityModules.getDistributedModule(cConf1);
+    modules.add(securityModule);
+    if (securityModule.requiresZKClient()) {
+      modules.add(new ZKClientModule());
+      modules.add(new ZKDiscoveryModule());
+    }
+    injector1 = Guice.createInjector(modules);
+
+    modules.clear();
+    modules.add(new ConfigModule(cConf2, testUtil.getConfiguration()));
+    modules.add(new IOModule());
+
+    securityModule = SecurityModules.getDistributedModule(cConf2);
+    modules.add(securityModule);
+    if (securityModule.requiresZKClient()) {
+      modules.add(new ZKClientModule());
+      modules.add(new ZKDiscoveryModule());
+    }
+
+    injector2 = Guice.createInjector(modules);
   }
 
   @AfterClass
@@ -119,7 +142,7 @@ public class DistributedKeyManagerTest extends TestTokenManager {
   public void testGetACLs() throws Exception {
     CConfiguration kerbConf = CConfiguration.create();
     kerbConf.set(Constants.Security.KERBEROS_ENABLED, "true");
-    kerbConf.set(Constants.Security.Authentication.AUTHENTICATION_MODE, "MANAGED");
+    kerbConf.set(Constants.Security.Authentication.MODE, "MANAGED");
     kerbConf.set(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL, "prinicpal@REALM.NET");
     kerbConf.set(Constants.Security.CFG_CDAP_MASTER_KRB_KEYTAB_PATH, "/path/to/keytab");
     Assert.assertEquals(ZooDefs.Ids.CREATOR_ALL_ACL, DistributedKeyManager.getACLs(kerbConf));

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/ProxyUserIdentityExtractorTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/ProxyUserIdentityExtractorTest.java
@@ -54,7 +54,7 @@ public class ProxyUserIdentityExtractorTest {
     String testUserIdHeader = "X-User-Id";
     String testAuthToken = "test-auth-token";
     CConfiguration config = Mockito.mock(CConfiguration.class);
-    when(config.get(Constants.Security.Authentication.AUTH_PROXY_USER_ID_HEADER)).thenReturn(testUserIdHeader);
+    when(config.get(Constants.Security.Authentication.PROXY_USER_ID_HEADER)).thenReturn(testUserIdHeader);
 
     ProxyUserIdentityExtractor extractor = new ProxyUserIdentityExtractor(config);
 
@@ -73,7 +73,7 @@ public class ProxyUserIdentityExtractorTest {
     String testUserIdHeader = "X-User-Id";
     String testAuthToken = "test-auth-token";
     CConfiguration config = Mockito.mock(CConfiguration.class);
-    when(config.get(Constants.Security.Authentication.AUTH_PROXY_USER_ID_HEADER)).thenReturn(testUserIdHeader);
+    when(config.get(Constants.Security.Authentication.PROXY_USER_ID_HEADER)).thenReturn(testUserIdHeader);
 
     ProxyUserIdentityExtractor extractor = new ProxyUserIdentityExtractor(config);
 
@@ -95,7 +95,7 @@ public class ProxyUserIdentityExtractorTest {
     String testUserId = "test-user-id";
     String testUserIdHeader = "X-User-Id";
     CConfiguration config = Mockito.mock(CConfiguration.class);
-    when(config.get(Constants.Security.Authentication.AUTH_PROXY_USER_ID_HEADER)).thenReturn(testUserIdHeader);
+    when(config.get(Constants.Security.Authentication.PROXY_USER_ID_HEADER)).thenReturn(testUserIdHeader);
 
     ProxyUserIdentityExtractor extractor = new ProxyUserIdentityExtractor(config);
 

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -91,11 +91,11 @@ import io.cdap.cdap.metrics.process.loader.MetricsWriterModule;
 import io.cdap.cdap.metrics.query.MetricsQueryService;
 import io.cdap.cdap.operations.OperationalStatsService;
 import io.cdap.cdap.operations.guice.OperationalStatsModule;
-import io.cdap.cdap.security.auth.AuthenticationMode;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.authorization.AuthorizerInstantiator;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.server.ExternalAuthenticationServer;
 import io.cdap.cdap.security.store.SecureStoreService;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
@@ -137,8 +137,6 @@ public class StandaloneMain {
   private final LogAppenderInitializer logAppenderInitializer;
   private final InMemoryTransactionService txService;
   private final MetadataService metadataService;
-  private final boolean securityEnabled;
-  private final AuthenticationMode authenticationMode;
   private final boolean sslEnabled;
   private final CConfiguration cConf;
   private final DatasetService datasetService;
@@ -200,10 +198,7 @@ public class StandaloneMain {
     }
 
     sslEnabled = cConf.getBoolean(Constants.Security.SSL.EXTERNAL_ENABLED);
-    securityEnabled = cConf.getBoolean(Constants.Security.ENABLED);
-    authenticationMode = cConf.getEnum(Constants.Security.Authentication.AUTHENTICATION_MODE,
-                                       AuthenticationMode.MANAGED);
-    if (securityEnabled && authenticationMode.equals(AuthenticationMode.MANAGED)) {
+    if (SecurityUtil.isManagedSecurity(cConf)) {
       externalAuthenticationServer = injector.getInstance(ExternalAuthenticationServer.class);
     }
 
@@ -217,19 +212,16 @@ public class StandaloneMain {
     metadataService = injector.getInstance(MetadataService.class);
     secureStoreService = injector.getInstance(SecureStoreService.class);
 
-    Runtime.getRuntime().addShutdownHook(new Thread() {
-      @Override
-      public void run() {
-        try {
-          shutDown();
-        } catch (Throwable e) {
-          LOG.error("Failed to shutdown", e);
-          // Because shutdown hooks execute concurrently, the logger may be closed already: thus also print it.
-          System.err.println("Failed to shutdown: " + e.getMessage());
-          e.printStackTrace(System.err);
-        }
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      try {
+        shutDown();
+      } catch (Throwable e) {
+        LOG.error("Failed to shutdown", e);
+        // Because shutdown hooks execute concurrently, the logger may be closed already: thus also print it.
+        System.err.println("Failed to shutdown: " + e.getMessage());
+        e.printStackTrace(System.err);
       }
-    });
+    }));
   }
 
   /**
@@ -285,9 +277,7 @@ public class StandaloneMain {
     }
 
     previewHttpServer.startAndWait();
-    if (previewRunnerManager instanceof Service) {
-      ((Service) previewRunnerManager).startAndWait();
-    }
+    previewRunnerManager.startAndWait();
 
     metricsQueryService.startAndWait();
     logQueryService.startAndWait();
@@ -297,7 +287,7 @@ public class StandaloneMain {
       userInterfaceService.startAndWait();
     }
 
-    if (securityEnabled && authenticationMode.equals(AuthenticationMode.MANAGED)) {
+    if (SecurityUtil.isManagedSecurity(cConf)) {
       externalAuthenticationServer.startAndWait();
     }
 
@@ -345,9 +335,7 @@ public class StandaloneMain {
       metadataService.stopAndWait();
       remoteExecutionTwillRunnerService.stop();
       serviceStore.stopAndWait();
-      if (previewRunnerManager instanceof Service) {
-        ((Service) previewRunnerManager).stopAndWait();
-      }
+      previewRunnerManager.stopAndWait();
       previewHttpServer.stopAndWait();
       // app fabric will also stop all programs
       appFabricServer.stopAndWait();
@@ -365,7 +353,7 @@ public class StandaloneMain {
         txService.stopAndWait();
       }
 
-      if (securityEnabled && authenticationMode.equals(AuthenticationMode.MANAGED)) {
+      if (SecurityUtil.isManagedSecurity(cConf)) {
         // auth service is on the side anyway
         externalAuthenticationServer.stopAndWait();
       }


### PR DESCRIPTION
- Both Authentication and Router services need to have access to the same key
- In k8s environment, Secret can be used to mount into both Auth and Router containers as a mean to share the same key
- Added a AuthenticationTool for generating authentication key file