### PR TITLE
[CDAP-17733] Do not Initialize TokenValidator when not in MANAGED mode.

### DIFF
--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/AuthenticationHandler.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/AuthenticationHandler.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.logging.AuditLogEntry;
 import io.cdap.cdap.common.utils.Networks;
-import io.cdap.cdap.security.auth.TokenValidator;
 import io.cdap.cdap.security.auth.UserIdentityExtractionResponse;
 import io.cdap.cdap.security.auth.UserIdentityExtractionState;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
@@ -82,8 +81,7 @@ public class AuthenticationHandler extends ChannelInboundHandlerAdapter {
   private final DiscoveryServiceClient discoveryServiceClient;
   private final UserIdentityExtractor userIdentityExtractor;
 
-  public AuthenticationHandler(CConfiguration cConf, TokenValidator tokenValidator,
-                               DiscoveryServiceClient discoveryServiceClient,
+  public AuthenticationHandler(CConfiguration cConf, DiscoveryServiceClient discoveryServiceClient,
                                UserIdentityExtractor userIdentityExtractor) {
     this.cConf = cConf;
     this.realm = cConf.get(Constants.Security.CFG_REALM);

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2019-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -35,6 +35,7 @@ import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.guice.SecurityModule;
 import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import org.apache.twill.zookeeper.ZKClientService;
 
 import java.util.ArrayList;
@@ -67,7 +68,7 @@ public class RouterServiceMain extends AbstractServiceMain<EnvironmentOptions> {
   }
 
   private List<Module> getSecurityModules(CConfiguration cConf) {
-    if (!cConf.getBoolean(Constants.Security.ENABLED)) {
+    if (!SecurityUtil.isManagedSecurity(cConf)) {
       return Collections.singletonList(new SecurityModules().getStandaloneModules());
     }
 


### PR DESCRIPTION
In PROXY auth mode, the TokenValidator is unused, and, as such, should not be initialized.

Also added a check to not use DistributedModules in RouterServiceMain when not using MANAGED mode.