### PR TITLE
[CDAP-17709] Adds support for PROXY authentication mode in UI

### DIFF
--- a/cdap-ui/app/cdap/components/AppHeader/AppToolBar/AppToolbarMenu.tsx
+++ b/cdap-ui/app/cdap/components/AppHeader/AppToolBar/AppToolbarMenu.tsx
@@ -34,6 +34,7 @@ import Divider from '@material-ui/core/Divider';
 import AccessTokenModal from 'components/AppHeader/AccessTokenModal';
 import Cookies from 'universal-cookie';
 import RedirectToLogin from 'services/redirect-to-login';
+import { isAuthSetToManagedMode } from 'services/helpers';
 
 const cookie = new Cookies();
 
@@ -179,7 +180,7 @@ class AppToolbarMenu extends React.Component<IAppToolbarMenuProps, IAppToolbarSt
                         </a>
                       </MenuItem>
                     </If>
-                    <If condition={this.state.username && window.CDAP_CONFIG.securityEnabled}>
+                    <If condition={isAuthSetToManagedMode() && this.state.username !== ''}>
                       <React.Fragment>
                         <Divider />
                         <MenuItem
@@ -214,7 +215,7 @@ class AppToolbarMenu extends React.Component<IAppToolbarMenuProps, IAppToolbarSt
             </Grow>
           )}
         </Popper>
-        <If condition={this.state.username && window.CDAP_CONFIG.securityEnabled}>
+        <If condition={isAuthSetToManagedMode() && this.state.username !== ''}>
           <AccessTokenModal
             cdapVersion={cdapVersion}
             isOpen={this.state.accessTokenModalOpen}

--- a/cdap-ui/app/cdap/services/datasource/index.js
+++ b/cdap-ui/app/cdap/services/datasource/index.js
@@ -95,6 +95,7 @@ export default class Datasource {
           // be considered delayed because the timestamp is from last
           // request-poll which does not matter anymore.
           this.bindings[hash].resource.requestTime = null;
+          clearTimeout(this.bindings[hash].resource.interval);
           this.bindings[hash].resource.interval = this.startClientPoll(hash);
         }
       }

--- a/cdap-ui/app/cdap/services/helpers.js
+++ b/cdap-ui/app/cdap/services/helpers.js
@@ -705,6 +705,17 @@ function setupExperiments() {
   });
 };
 
+function isAuthSetToProxyMode() {
+  return window.CDAP_CONFIG.securityEnabled &&  window.CDAP_CONFIG.securityMode === 'PROXY';
+}
+
+function isAuthSetToManagedMode() {
+  return (
+    window.CDAP_CONFIG.securityEnabled
+    && ['', undefined, 'MANAGED'].indexOf(window.CDAP_CONFIG.securityMode) !== -1
+  );
+}
+
 export {
   objectQuery,
   convertBytesToHumanReadable,
@@ -755,4 +766,6 @@ export {
   isValidEntityName,
   setupExperiments,
   defaultEventObject,
+  isAuthSetToProxyMode,
+  isAuthSetToManagedMode,
 };

--- a/cdap-ui/app/services/auth.js
+++ b/cdap-ui/app/services/auth.js
@@ -38,7 +38,14 @@ module.constant('MYAUTH_ROLE', {
 });
 
 
-module.service('myAuth', function myAuthService (MYAUTH_EVENT, MyAuthUser, myAuthPromise, $rootScope, $localStorage, $cookies) {
+module.service('myAuth', function myAuthService (
+  MYAUTH_EVENT,
+  MyAuthUser,
+  myAuthPromise,
+  $rootScope,
+  $localStorage,
+  $cookies
+) {
 
   /**
    * private method to sync the user everywhere
@@ -82,7 +89,10 @@ module.service('myAuth', function myAuthService (MYAUTH_EVENT, MyAuthUser, myAut
    * @return {Boolean}
    */
   this.isAuthenticated = function () {
-    if (this.currentUser) {
+    if (window.CaskCommon.CDAPHelpers.isAuthSetToProxyMode()) {
+      return true;
+    }
+    if (window.CaskCommon.CDAPHelpers.isAuthSetToManagedMode() && this.currentUser) {
       return !!this.currentUser;
     }
 

--- a/cdap-ui/app/services/data/my-cdap-datasource.js
+++ b/cdap-ui/app/services/data/my-cdap-datasource.js
@@ -14,7 +14,7 @@
  * the License.
  */
 angular.module(PKG.name + '.services')
-  .factory('MyCDAPDataSource', function(MyDataSource, $rootScope, myCdapUrl) {
+  .factory('MyCDAPDataSource', function(MyDataSource, $rootScope, myCdapUrl, $cookies) {
     function MyCDAPDataSource(scope) {
       scope = scope || $rootScope.$new();
 
@@ -29,9 +29,9 @@ angular.module(PKG.name + '.services')
 
       // FIXME: There is a circular dependency and that is why
       // myAuth.isAuthenticated is not used. There should be a better way to do this.
-      if (window.CDAP_CONFIG.securityEnabled && $rootScope.currentUser && $rootScope.currentUser.token) {
+      if (window.CDAP_CONFIG.securityEnabled && $cookies.get('CDAP_Auth_Token')) {
         resource.headers = {
-          Authorization: 'Bearer '+ $rootScope.currentUser.token
+          Authorization: 'Bearer '+ $cookies.get('CDAP_Auth_Token')
         };
       }
 
@@ -52,7 +52,11 @@ angular.module(PKG.name + '.services')
     };
 
     MyCDAPDataSource.prototype.request = function(resource, cb, errorCb) {
-      if (window.CDAP_CONFIG.securityEnabled && $rootScope.currentUser && $rootScope.currentUser.token) {
+      if (
+        window.CaskCommon.CDAPHelpers.isAuthSetToManagedMode() &&
+        $rootScope.currentUser &&
+        $rootScope.currentUser.token
+      ) {
         resource.headers = {
           Authorization: 'Bearer '+ $rootScope.currentUser.token
         };

--- a/cdap-ui/app/services/file-uploader.js
+++ b/cdap-ui/app/services/file-uploader.js
@@ -19,8 +19,8 @@ angular.module(PKG.name + '.services')
     function upload(fileObj, header){
       var deferred = $q.defer();
       var path, customHeaderNames, xhr;
-      //This conditional block gets excuted - issue with auth
-      if ($window.CDAP_CONFIG.securityEnabled && !myAuth.currentUser) {
+      // If the authentication mode is MANAGED and if the current user doesn't exists then reject.
+      if (window.CaskCommon.CDAPHelpers.isAuthSetToManagedMode() && !myAuth.currentUser) {
         deferred.reject(400);
         myAlert({
           title: 'Must specify user: ',

--- a/cdap-ui/app/services/settings.js
+++ b/cdap-ui/app/services/settings.js
@@ -20,7 +20,7 @@ angular.module(PKG.name + '.services')
     return new MyPersistentStorage('user');
   })
 
-  .factory('MyPersistentStorage', function MyPersistentStorageFactory($q, MyCDAPDataSource, myHelpers, $rootScope, myAuth, MYAUTH_EVENT, MY_CONFIG) {
+  .factory('MyPersistentStorage', function MyPersistentStorageFactory($q, MyCDAPDataSource, myHelpers, $rootScope, MYAUTH_EVENT) {
 
     var data = new MyCDAPDataSource();
     function MyPersistentStorage (type) {
@@ -28,7 +28,7 @@ angular.module(PKG.name + '.services')
       this.headers = {
         'Content-Type': 'application/json'
       };
-      if (MY_CONFIG.securityEnabled) {
+      if (window.CaskCommon.CDAPHelpers.isAuthSetToManagedMode()) {
         $rootScope.$on (MYAUTH_EVENT.logoutSuccess, function () {
           this.data = [];
           delete this.headers['Authorization'];
@@ -51,7 +51,7 @@ angular.module(PKG.name + '.services')
     MyPersistentStorage.prototype.set = function (key, value) {
 
       myHelpers.deepSet(this.data, key, value);
-      if (window.CDAP_CONFIG.securityEnabled) {
+      if (window.CaskCommon.CDAPHelpers.isAuthSetToManagedMode()) {
         this.headers['Authorization'] = ($rootScope.currentUser.token ? 'Bearer ' + $rootScope.currentUser.token: null);
       }
       return data.request(
@@ -75,7 +75,7 @@ angular.module(PKG.name + '.services')
     MyPersistentStorage.prototype.get = function (key, force) {
 
       var val = myHelpers.deepGet(this.data, key, true);
-      if (window.CDAP_CONFIG.securityEnabled) {
+      if (window.CaskCommon.CDAPHelpers.isAuthSetToManagedMode()) {
         this.headers['Authorization'] = ($rootScope.currentUser.token ? 'Bearer ' + $rootScope.currentUser.token: null);
       }
 

--- a/cdap-ui/app/tracker/main.js
+++ b/cdap-ui/app/tracker/main.js
@@ -196,7 +196,7 @@ angular
 
             // This check is added because of HdInsight gateway security.
             // If we set Authorization to null, it strips off their Auth token
-            if (window.CDAP_CONFIG.securityEnabled) {
+            if (window.CaskCommon.CDAPHelpers.isAuthSetToManagedMode()) {
               // Accessing stuff from $rootScope is bad. This is done as to resolve circular dependency.
               // $http <- myAuthPromise <- myAuth <- $http <- $templateFactory <- $view <- $state
               extendConfig.headers.Authorization = 'Bearer ' + $rootScope.currentUser.token;

--- a/cdap-ui/graphql/Query/pipelinesResolver.js
+++ b/cdap-ui/graphql/Query/pipelinesResolver.js
@@ -40,6 +40,6 @@ export async function queryTypePipelinesResolver(parent, args, context) {
     return new ApolloError(error, statusCode, { errorOrigin: 'pipelines' });
   }
 
-  const apps = await requestPromiseWrapper(options, context.auth, null, errorModifiersFn);
+  const apps = await requestPromiseWrapper(options, context, null, errorModifiersFn);
   return orderBy(apps, [(app) => app.name], ['asc']);
 }

--- a/cdap-ui/graphql/Query/statusResolver.js
+++ b/cdap-ui/graphql/Query/statusResolver.js
@@ -24,14 +24,14 @@ getCDAPConfig().then(function(value) {
   cdapConfig = value;
 });
 
-export async function queryTypeStatusResolver(parent, args, context) {
+export async function queryTypeStatusResolver(parent, args, authContext) {
   const options = getGETRequestOptions();
   options.url = constructUrl(cdapConfig, '/ping');
   const errorModifiersFn = (error, statusCode) => {
     return new ApolloError(error, statusCode, { errorOrigin: 'statusPing' });
   }
 
-  const status = await requestPromiseWrapper(options, context.auth, null, errorModifiersFn);
+  const status = await requestPromiseWrapper(options, authContext, null, errorModifiersFn);
 
   return status.trim();
 }

--- a/cdap-ui/graphql/graphql.js
+++ b/cdap-ui/graphql/graphql.js
@@ -45,6 +45,11 @@ const getApolloServer = (cdapConfig, logger = console) =>
       }
       const sToken = req.headers['session-token'];
       const auth = req.headers.authorization;
+      let userIdValue, userIdProperty;
+      if (cdapConfig['security.authentication.mode'] === 'PROXY') {
+        userIdProperty = cdapConfig['security.authentication.proxy.user.identity.header'];
+        userIdValue = req.headers[userIdProperty];
+      }
 
       if (!sToken || (sToken && !sessionToken.validateToken(sToken, cdapConfig, logger, auth))) {
         throw new Error('Invalid Sesion Token');
@@ -52,7 +57,9 @@ const getApolloServer = (cdapConfig, logger = console) =>
 
       return {
         auth,
-        loaders: createLoaders(auth),
+        userIdProperty,
+        userIdValue,
+        loaders: createLoaders(auth, userIdProperty, userIdValue),
       };
     },
     introspection: env === 'production' ? false : true,

--- a/cdap-ui/graphql/helpers/BatchEndpoints/nextRuntime.js
+++ b/cdap-ui/graphql/helpers/BatchEndpoints/nextRuntime.js
@@ -24,7 +24,7 @@ getCDAPConfig().then(function(value) {
   cdapConfig = value;
 });
 
-export async function batchNextRuntime(req, auth) {
+export async function batchNextRuntime(req, auth, userIdProperty, userIdValue) {
   const namespace = req[0].namespace;
   const options = getPOSTRequestOptions();
   options.url = constructUrl(cdapConfig, `/v3/namespaces/${namespace}/nextruntime`);
@@ -33,9 +33,14 @@ export async function batchNextRuntime(req, auth) {
   const errorModifiersFn = (error, statusCode) => {
     return new ApolloError(error, statusCode, { errorOrigin: "runs" });
   };
+  const authContext = {
+    auth,
+    userIdProperty,
+    userIdValue
+  };
   let nextRuntimeInfo = await requestPromiseWrapper(
     options,
-    auth,
+    authContext,
     null,
     errorModifiersFn
   );

--- a/cdap-ui/graphql/helpers/BatchEndpoints/programRuns.js
+++ b/cdap-ui/graphql/helpers/BatchEndpoints/programRuns.js
@@ -25,7 +25,7 @@ getCDAPConfig().then(function(value) {
   cdapConfig = value;
 });
 
-export async function batchProgramRuns(req, auth) {
+export async function batchProgramRuns(req, auth, userIdProperty, userIdValue) {
   const namespace = req[0].namespace;
   const options = getPOSTRequestOptions();
   options.url = constructUrl(cdapConfig, `/v3/namespaces/${namespace}/runs`);
@@ -34,7 +34,13 @@ export async function batchProgramRuns(req, auth) {
     return new ApolloError(error, statusCode, { errorOrigin: 'programRuns' });
   }
 
-  const runInfo = await requestPromiseWrapper(options, auth, null, errorModifiersFn);
+  const authContext = {
+    auth,
+    userIdProperty,
+    userIdValue
+  };
+
+  const runInfo = await requestPromiseWrapper(options, authContext, null, errorModifiersFn);
 
   const runsMap = {};
   runInfo.forEach((run) => {

--- a/cdap-ui/graphql/helpers/BatchEndpoints/totalRuns.js
+++ b/cdap-ui/graphql/helpers/BatchEndpoints/totalRuns.js
@@ -25,7 +25,7 @@ getCDAPConfig().then(function(value) {
   cdapConfig = value;
 });
 
-export async function batchTotalRuns(req, auth) {
+export async function batchTotalRuns(req, auth, userIdProperty, userIdValue) {
   const namespace = req[0].namespace;
   const options = getPOSTRequestOptions();
   options.url = constructUrl(cdapConfig, `/v3/namespaces/${namespace}/runcount`);
@@ -43,7 +43,12 @@ export async function batchTotalRuns(req, auth) {
         ...options,
         body: reqBody,
       };
-      return requestPromiseWrapper(reqOptions, auth, null, errorModifiersFn);
+      const authContext = {
+        auth,
+        userIdProperty,
+        userIdValue
+      };
+      return requestPromiseWrapper(reqOptions, authContext, null, errorModifiersFn);
     })
   );
 

--- a/cdap-ui/graphql/helpers/createLoaders.js
+++ b/cdap-ui/graphql/helpers/createLoaders.js
@@ -19,10 +19,10 @@ import { batchProgramRuns } from 'gql/helpers/BatchEndpoints/programRuns';
 import { batchTotalRuns } from 'gql/helpers/BatchEndpoints/totalRuns';
 import { batchNextRuntime } from 'gql/helpers/BatchEndpoints/nextRuntime';
 
-export function createLoaders(auth) {
+export function createLoaders(auth, userIdProperty, userIdValue) {
   return {
-    programRuns: new DataLoader((req) => batchProgramRuns(req, auth), { cache: false }),
-    totalRuns: new DataLoader((req) => batchTotalRuns(req, auth), { cache: false }),
-    nextRuntime: new DataLoader((req) => batchNextRuntime(req, auth), { cache: false }),
+    programRuns: new DataLoader((req) => batchProgramRuns(req, auth, userIdProperty, userIdValue), { cache: false }),
+    totalRuns: new DataLoader((req) => batchTotalRuns(req, auth, userIdProperty, userIdValue), { cache: false }),
+    nextRuntime: new DataLoader((req) => batchNextRuntime(req, auth, userIdProperty, userIdValue), { cache: false }),
   };
 }

--- a/cdap-ui/graphql/resolvers-common.js
+++ b/cdap-ui/graphql/resolvers-common.js
@@ -31,11 +31,16 @@ export function getPOSTRequestOptions() {
   };
 }
 
-export function requestPromiseWrapper(options, token, bodyModifiersFn, errorModifiersFn) {
+export function requestPromiseWrapper(options, { auth: token, userIdProperty, userIdValue }, bodyModifiersFn, errorModifiersFn) {
   if (token) {
     options.headers = {
       Authorization: token,
     };
+  }
+
+  if (userIdProperty) {
+    options.headers = options.headers || {};
+    options.headers[userIdProperty] = userIdValue;
   }
 
   return new Promise((resolve, reject) => {

--- a/cdap-ui/server/config/router-check.js
+++ b/cdap-ui/server/config/router-check.js
@@ -48,7 +48,8 @@ AuthAddress.prototype.doPing = function(cdapConfig) {
     deferred = q.defer(),
     attempts = 0,
     url = cdapConfig['router.server.address'],
-    checkTimeout = cdapConfig['dashboard.router.check.timeout.secs'];
+    checkTimeout = cdapConfig['dashboard.router.check.timeout.secs'],
+    authMode = cdapConfig['security.authentication.mode'];
 
   if (cdapConfig['ssl.external.enabled'] === 'true') {
     url = 'https://' + url + ':' + cdapConfig['router.ssl.server.port'];
@@ -71,11 +72,10 @@ AuthAddress.prototype.doPing = function(cdapConfig) {
         agent: false,
       },
       function(err, response, body) {
-        if (!err && (response && response.statusCode < 500)) {
-          if (response.statusCode === 401) {
-            self.enabled = true;
-            self.addresses = JSON.parse(body).auth_uri || [];
-          }
+        if (!err && (response && response.statusCode === 401)) {
+          self.enabled = true;
+          self.addresses = JSON.parse(body).auth_uri || [];
+          log.info('Authentication mode: ' + authMode);
           log.info('Successfully connected to CDAP Router.');
           log.info('CDAP security is ' + (self.enabled ? 'enabled' : 'disabled') + '.');
           deferred.resolve(self);


### PR DESCRIPTION
JIRA - https://cdap.atlassian.net/browse/CDAP-17709

**Context**
- CDAP UI now supports both MANAGED and PROXY authentication modes
- MANAGED authentication mode is the regular type of authentication that we used to support
- PROXY mode is when the authentication happens behind a inverting proxy with client being unaware of it.

**Auth Flow for PROXY mode**
- User navigates to CDAP behind an inverting proxy.
- Inverting proxy checks for user authentication and redirects to oAuth provider if not authenticated
- If authenticated, adds auth token and user id and passes on the request to nodejs server
- Node server then passes on the UI assets for initial page load
- Subsequent HTTP requests follow the same path and nodejs server passes on the auth token and user id in the headers to the backend.

**Websockets in PROXY mode**
- Since websockets are not designed to handle authorization or authentication we need to handle it before the connection is established
- When browser initiates the initial handshake for websocket it sends a plain HTTP request which then get upgraded to websocket.
- During this upgrade call the nodejs registers the auth token and user id and on each subsequent ws connection adds them to the connection object.
- This helps us in adding them to headers in the request we make to the backend.

**Session token**
- As part of this change we are also removing the auth token to be used while generating the session token
- The reason being once a session token is tied to the auth token we then have to know to refresh the session when auth token expires
- Since session token is only to verify the client session it can be generated without auth token.