### PR TITLE
CDAP-17718 fix advanced join metrics

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/ValidationHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/main/java/io/cdap/cdap/datapipeline/service/ValidationHandler.java
@@ -82,6 +82,7 @@ public class ValidationHandler extends AbstractSystemHttpServiceHandler {
   @GET
   @Path("v1/health")
   public void healthCheck(HttpServiceRequest request, HttpServiceResponder responder) {
+    getContext()
     responder.sendStatus(HttpURLConnection.HTTP_OK);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/AutoJoinerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline/src/test/java/io/cdap/cdap/datapipeline/AutoJoinerTest.java
@@ -1307,6 +1307,11 @@ public class AutoJoinerTest extends HydratorTestBase {
     expected.add(StructuredRecord.builder(expectedSchema).set("username", "Fred").set("age_group", "toddler").build());
 
     Assert.assertEquals(expected, new HashSet<>(outputRecords));
+
+    validateMetric(6, appId, "users.records.out");
+    validateMetric(6, appId, "age_groups.records.out");
+    validateMetric(12, appId, "join.records.in");
+    validateMetric(expected.size(), appId, "join.records.out");
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core2_2.11/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -54,6 +54,7 @@ import org.apache.spark.sql.functions;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.storage.StorageLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Tuple2;
@@ -280,6 +281,19 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
     StructType rightSchema = DataFrames.toDataType(rightInfo.getSchema());
     Dataset<Row> rightDF = toDataset(((JavaRDD<StructuredRecord>) rightData.getUnderlying()).map(recordsInCounter),
                                      rightSchema);
+
+    // if this is not a broadcast join, Spark will reprocess each side multiple times, depending on the number
+    // of partitions. If the left side has N partitions and the right side has M partitions,
+    // the left side gets reprocessed M times and the right side gets reprocessed N times.
+    // Cache the input to prevent confusing metrics and potential source re-reading.
+    // this is only necessary for inner joins, since outer joins are automatically changed to
+    // BroadcastNestedLoopJoins by Spark
+    boolean isInner = joinRequest.getLeft().isRequired() && joinRequest.getRight().isRequired();
+    boolean isBroadcast = joinRequest.getLeft().isBroadcast() || joinRequest.getRight().isBroadcast();
+    if (isInner && !isBroadcast) {
+      leftDF = leftDF.persist(StorageLevel.DISK_ONLY());
+      rightDF = rightDF.persist(StorageLevel.DISK_ONLY());
+    }
 
     // register using unique names to avoid collisions.
     String leftId = UUID.randomUUID().toString().replaceAll("-", "");


### PR DESCRIPTION
Cache join input for advanced joins when it is not a broadcast
join in order to prevent re-processing and confusing metrics.