### PR TITLE
[CDAP-16180] Cherry Pick into 6.4

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -48,6 +48,7 @@ import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.app.services.ServiceHttpServer;
 import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
@@ -80,6 +81,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final PluginFinder pluginFinder;
   private final TransactionRunner transactionRunner;
   private final FieldLineageWriter fieldLineageWriter;
+  private final PreferencesFetcher preferencesFetcher;
 
   @Inject
   public ServiceProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
@@ -90,7 +92,8 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                               ArtifactManagerFactory artifactManagerFactory,
                               MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                               NamespaceQueryAdmin namespaceQueryAdmin, PluginFinder pluginFinder,
-                              TransactionRunner transactionRunner, FieldLineageWriter fieldLineageWriter) {
+                              TransactionRunner transactionRunner, FieldLineageWriter fieldLineageWriter,
+                              PreferencesFetcher preferencesFetcher) {
     super(cConf);
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
@@ -107,6 +110,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.pluginFinder = pluginFinder;
     this.transactionRunner = transactionRunner;
     this.fieldLineageWriter = fieldLineageWriter;
+    this.preferencesFetcher = preferencesFetcher;
   }
 
   @Override
@@ -149,7 +153,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           pluginInstantiator, secureStore, secureStoreManager,
                                                           messagingService, artifactManager, metadataReader,
                                                           metadataPublisher, namespaceQueryAdmin, pluginFinder,
-                                                          transactionRunner, fieldLineageWriter);
+                                                          transactionRunner, fieldLineageWriter, preferencesFetcher);
 
       // Add a service listener to make sure the plugin instantiator is closed when the http server is finished.
       component.addListener(createRuntimeServiceListener(Collections.singleton(pluginInstantiator)),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ServiceHttpServer.java
@@ -52,6 +52,7 @@ import io.cdap.cdap.internal.app.runtime.service.http.AbstractServiceHttpServer;
 import io.cdap.cdap.internal.app.runtime.service.http.BasicHttpServiceContext;
 import io.cdap.cdap.internal.lang.Reflections;
 import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.http.NettyHttpService;
@@ -88,7 +89,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                            ArtifactManager artifactManager, MetadataReader metadataReader,
                            MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin,
                            PluginFinder pluginFinder, TransactionRunner transactionRunner,
-                           FieldLineageWriter fieldLineageWriter) {
+                           FieldLineageWriter fieldLineageWriter, PreferencesFetcher preferencesFetcher) {
     super(host, program, programOptions, instanceId, serviceAnnouncer, TransactionControl.IMPLICIT);
 
     this.cConf = cConf;
@@ -98,7 +99,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
                                                messagingService, artifactManager, metadataReader, metadataPublisher,
-                                               pluginFinder, transactionRunner, fieldLineageWriter);
+                                               pluginFinder, transactionRunner, fieldLineageWriter, preferencesFetcher);
     this.context = contextFactory.create(null);
     this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
@@ -148,13 +149,14 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                               MetadataPublisher metadataPublisher,
                                                               PluginFinder pluginFinder,
                                                               TransactionRunner transactionRunner,
-                                                              FieldLineageWriter fieldLineageWriter) {
+                                                              FieldLineageWriter fieldLineageWriter,
+                                                              PreferencesFetcher preferencesFetcher) {
     return spec -> new BasicHttpServiceContext(program, programOptions, cConf, spec, instanceId, instanceCount,
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
                                                messagingService, artifactManager, metadataReader, metadataPublisher,
                                                namespaceQueryAdmin, pluginFinder, transactionRunner,
-                                               fieldLineageWriter);
+                                               fieldLineageWriter, preferencesFetcher);
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/validation/StageValidationRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/validation/StageValidationRequest.java
@@ -28,11 +28,14 @@ import java.util.List;
 public class StageValidationRequest {
   private final ETLStage stage;
   private final List<StageSchema> inputSchemas;
+  private final Boolean resolveMacrosFromPreferences;
 
   public StageValidationRequest(ETLStage stage,
-                                List<StageSchema> inputSchemas) {
+                                List<StageSchema> inputSchemas,
+                                boolean resolveMacrosFromPreferences) {
     this.stage = stage;
     this.inputSchemas = inputSchemas;
+    this.resolveMacrosFromPreferences = resolveMacrosFromPreferences;
   }
 
   public ETLStage getStage() {
@@ -41,6 +44,10 @@ public class StageValidationRequest {
 
   public List<StageSchema> getInputSchemas() {
     return inputSchemas == null ? Collections.emptyList() : inputSchemas;
+  }
+
+  public boolean getResolveMacrosFromPreferences() {
+    return resolveMacrosFromPreferences != null ? resolveMacrosFromPreferences : false;
   }
 
   /**

--- a/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/http/SystemHttpServiceContext.java
+++ b/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/http/SystemHttpServiceContext.java
@@ -22,8 +22,8 @@ import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 
+import java.io.IOException;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A System HttpServiceContext that exposes capabilities beyond those available to service contexts for user services.
@@ -34,9 +34,9 @@ public interface SystemHttpServiceContext extends HttpServiceContext, Transactio
   /**
    * Evaluates lookup macros and the 'secure' macro function using provided macro evaluator.
    *
-   * @param namespace namespace in which macros needs to be evaluated
+   * @param namespace  namespace in which macros needs to be evaluated
    * @param properties key-value map of properties to evaluate
-   * @param evaluator macro evaluator to be used to evaluate macros
+   * @param evaluator  macro evaluator to be used to evaluate macros
    * @return map of evaluated macros
    * @throws InvalidMacroException indicates that there is an invalid macro
    */
@@ -52,13 +52,33 @@ public interface SystemHttpServiceContext extends HttpServiceContext, Transactio
   /**
    * Evaluates macros using provided macro evaluator with the provided parsing options.
    *
-   * @param namespace namespace in which macros needs to be evaluated
+   * @param namespace  namespace in which macros needs to be evaluated
    * @param properties key-value map of properties to evaluate
-   * @param evaluator macro evaluator to be used to evaluate macros
-   * @param options macro parsing options
+   * @param evaluator  macro evaluator to be used to evaluate macros
+   * @param options    macro parsing options
    * @return map of evaluated macros
    * @throws InvalidMacroException indicates that there is an invalid macro
    */
   Map<String, String> evaluateMacros(String namespace, Map<String, String> properties,
                                      MacroEvaluator evaluator, MacroParserOptions options) throws InvalidMacroException;
+
+  /**
+   * Get preferences for the given namespace.
+   * <p>
+   * This method fetches preferences for the supplied namespace when the method is unvoked, unlike {@link
+   * io.cdap.cdap.api.RuntimeContext#getRuntimeArguments()} which returns arguments at the time the context was
+   * created.
+   * <p>
+   * This might be a network call, depending on the underlying implementation.
+   *
+   * @param namespace the name of the namespace to fetch preferences for.
+   * @param resolved  true if resolved properties are desired.
+   * @return Map containing Preferences keys and values.
+   * @throws IOException is the preferences for the supplied namespace could not be fetched.
+   * @throws IllegalArgumentException if the namespace doesn't exist.
+   */
+  default Map<String, String> getPreferencesForNamespace(String namespace, boolean resolved)
+    throws IOException, IllegalArgumentException {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 }

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -72,6 +72,8 @@ import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.common.test.TestRunner;
 import io.cdap.cdap.common.twill.NoopTwillRunnerService;
 import io.cdap.cdap.common.utils.OSDetector;
+import io.cdap.cdap.config.PreferencesService;
+import io.cdap.cdap.config.PreferencesTable;
 import io.cdap.cdap.data.runtime.DataFabricModules;
 import io.cdap.cdap.data.runtime.DataSetServiceModules;
 import io.cdap.cdap.data.runtime.DataSetsModules;
@@ -103,6 +105,7 @@ import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metadata.MetadataService;
 import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.metadata.MetadataSubscriberService;
+import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.NamespaceMeta;
@@ -220,6 +223,7 @@ public class TestBase {
   private static FieldLineageAdmin fieldLineageAdmin;
   private static LineageAdmin lineageAdmin;
   private static AppFabricServer appFabricServer;
+  private static PreferencesService preferencesService;
 
   // This list is to record ApplicationManager create inside @Test method
   private static final List<ApplicationManager> applicationManagers = new ArrayList<>();
@@ -393,6 +397,7 @@ public class TestBase {
     }
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
+    preferencesService = injector.getInstance(PreferencesService.class);
 
     scheduler = injector.getInstance(Scheduler.class);
     if (scheduler instanceof Service) {
@@ -1080,6 +1085,12 @@ public class TestBase {
    */
   protected static CConfiguration getConfiguration() {
     return cConf;
+  }
+  /**
+   * Returns the {@link PreferencesService} used in tests.
+   */
+  public static PreferencesService getPreferencesService() {
+    return preferencesService;
   }
 
   /**


### PR DESCRIPTION
Added logic to resolve preferences as macros on plugin validation

Added new getPreferences method in the SystemHttpServiceContext.

We use this method to get the list of preferences for the current namespace when validating the plugin configuration.

Added tests.