### PR TITLE
[CDAP-16180] Added logic to resolve preferences as macros on plugin validation

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramTwillRunnableModuleTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramTwillRunnableModuleTest.java
@@ -39,6 +39,8 @@ import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnable;
+import io.cdap.cdap.metadata.FakePreferencesFetcher;
+import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.hadoop.conf.Configuration;
@@ -53,6 +55,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.function.Supplier;
 
 /**
@@ -62,7 +65,7 @@ import java.util.function.Supplier;
 public class ProgramTwillRunnableModuleTest {
 
   // Runs two sets of tests, one with master environment, one without
-  @Parameterized.Parameters (name = "User Master Environment = {0}")
+  @Parameterized.Parameters(name = "User Master Environment = {0}")
   public static Collection<Object[]> parameters() {
     return Arrays.asList(new Object[][]{
       {true},
@@ -89,7 +92,11 @@ public class ProgramTwillRunnableModuleTest {
         }
       }.createModule(CConfiguration.create(), new Configuration(),
                      createProgramOptions(programRunId, mode), programRunId);
-      Injector injector = Guice.createInjector(module);
+      Injector injector = Guice.createInjector(module, binder -> {
+        binder.bind(PreferencesFetcher.class)
+          .toInstance(new FakePreferencesFetcher(Collections.emptyMap()));
+      });
+      injector.getInstance(PreferencesFetcher.class);
       injector.getInstance(ServiceProgramRunner.class);
       injector.getInstance(ExploreClient.class);
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -48,6 +48,7 @@ import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.app.services.ServiceHttpServer;
 import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
@@ -80,6 +81,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final PluginFinder pluginFinder;
   private final TransactionRunner transactionRunner;
   private final FieldLineageWriter fieldLineageWriter;
+  private final PreferencesFetcher preferencesFetcher;
 
   @Inject
   public ServiceProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
@@ -90,7 +92,8 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                               ArtifactManagerFactory artifactManagerFactory,
                               MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                               NamespaceQueryAdmin namespaceQueryAdmin, PluginFinder pluginFinder,
-                              TransactionRunner transactionRunner, FieldLineageWriter fieldLineageWriter) {
+                              TransactionRunner transactionRunner, FieldLineageWriter fieldLineageWriter,
+                              PreferencesFetcher preferencesFetcher) {
     super(cConf);
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
@@ -107,6 +110,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.pluginFinder = pluginFinder;
     this.transactionRunner = transactionRunner;
     this.fieldLineageWriter = fieldLineageWriter;
+    this.preferencesFetcher = preferencesFetcher;
   }
 
   @Override
@@ -149,7 +153,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           pluginInstantiator, secureStore, secureStoreManager,
                                                           messagingService, artifactManager, metadataReader,
                                                           metadataPublisher, namespaceQueryAdmin, pluginFinder,
-                                                          transactionRunner, fieldLineageWriter);
+                                                          transactionRunner, fieldLineageWriter, preferencesFetcher);
 
       // Add a service listener to make sure the plugin instantiator is closed when the http server is finished.
       component.addListener(createRuntimeServiceListener(Collections.singleton(pluginInstantiator)),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ServiceHttpServer.java
@@ -52,6 +52,7 @@ import io.cdap.cdap.internal.app.runtime.service.http.AbstractServiceHttpServer;
 import io.cdap.cdap.internal.app.runtime.service.http.BasicHttpServiceContext;
 import io.cdap.cdap.internal.lang.Reflections;
 import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.http.NettyHttpService;
@@ -88,7 +89,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                            ArtifactManager artifactManager, MetadataReader metadataReader,
                            MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin,
                            PluginFinder pluginFinder, TransactionRunner transactionRunner,
-                           FieldLineageWriter fieldLineageWriter) {
+                           FieldLineageWriter fieldLineageWriter, PreferencesFetcher preferencesFetcher) {
     super(host, program, programOptions, instanceId, serviceAnnouncer, TransactionControl.IMPLICIT);
 
     this.cConf = cConf;
@@ -98,7 +99,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
                                                messagingService, artifactManager, metadataReader, metadataPublisher,
-                                               pluginFinder, transactionRunner, fieldLineageWriter);
+                                               pluginFinder, transactionRunner, fieldLineageWriter, preferencesFetcher);
     this.context = contextFactory.create(null);
     this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
@@ -148,13 +149,14 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                               MetadataPublisher metadataPublisher,
                                                               PluginFinder pluginFinder,
                                                               TransactionRunner transactionRunner,
-                                                              FieldLineageWriter fieldLineageWriter) {
+                                                              FieldLineageWriter fieldLineageWriter,
+                                                              PreferencesFetcher preferencesFetcher) {
     return spec -> new BasicHttpServiceContext(program, programOptions, cConf, spec, instanceId, instanceCount,
                                                metricsCollectionService, datasetFramework, discoveryServiceClient,
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
                                                messagingService, artifactManager, metadataReader, metadataPublisher,
                                                namespaceQueryAdmin, pluginFinder, transactionRunner,
-                                               fieldLineageWriter);
+                                               fieldLineageWriter, preferencesFetcher);
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/ScheduleTaskRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/ScheduleTaskRunnerTest.java
@@ -24,10 +24,9 @@ import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.ProgramStatusTrigger;
 import io.cdap.cdap.internal.app.services.PropertiesResolver;
+import io.cdap.cdap.metadata.FakePreferencesFetcher;
 import io.cdap.cdap.metadata.PreferencesFetcher;
-import io.cdap.cdap.proto.PreferencesDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
-import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.impersonation.NoOpOwnerAdmin;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
@@ -65,19 +64,4 @@ public class ScheduleTaskRunnerTest {
     Assert.assertEquals("val", userArgs.get("key"));
   }
 
-  /**
-   * Fake preferences that just returns whatever it is configured to return.
-   */
-  private static class FakePreferencesFetcher implements PreferencesFetcher {
-    private final Map<String, String> properties;
-
-    private FakePreferencesFetcher(Map<String, String> properties) {
-      this.properties = properties;
-    }
-
-    @Override
-    public PreferencesDetail get(EntityId entityId, boolean resolved) {
-      return new PreferencesDetail(properties, 0L, resolved);
-    }
-  }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/FakePreferencesFetcher.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/FakePreferencesFetcher.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metadata;
+
+import io.cdap.cdap.proto.PreferencesDetail;
+import io.cdap.cdap.proto.id.EntityId;
+
+import java.util.Map;
+
+/**
+ * Fake preferences that just returns whatever it is configured to return.
+ */
+public class FakePreferencesFetcher implements PreferencesFetcher {
+  private final Map<String, String> properties;
+
+  public FakePreferencesFetcher(Map<String, String> properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public PreferencesDetail get(EntityId entityId, boolean resolved) {
+    return new PreferencesDetail(properties, 0L, resolved);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/validation/StageValidationRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/validation/StageValidationRequest.java
@@ -28,11 +28,14 @@ import java.util.List;
 public class StageValidationRequest {
   private final ETLStage stage;
   private final List<StageSchema> inputSchemas;
+  private final Boolean resolveMacrosFromPreferences;
 
   public StageValidationRequest(ETLStage stage,
-                                List<StageSchema> inputSchemas) {
+                                List<StageSchema> inputSchemas,
+                                boolean resolveMacrosFromPreferences) {
     this.stage = stage;
     this.inputSchemas = inputSchemas;
+    this.resolveMacrosFromPreferences = resolveMacrosFromPreferences;
   }
 
   public ETLStage getStage() {
@@ -41,6 +44,10 @@ public class StageValidationRequest {
 
   public List<StageSchema> getInputSchemas() {
     return inputSchemas == null ? Collections.emptyList() : inputSchemas;
+  }
+
+  public boolean getResolveMacrosFromPreferences() {
+    return resolveMacrosFromPreferences != null ? resolveMacrosFromPreferences : false;
   }
 
   /**

--- a/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/http/SystemHttpServiceContext.java
+++ b/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/http/SystemHttpServiceContext.java
@@ -22,8 +22,8 @@ import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 
+import java.io.IOException;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A System HttpServiceContext that exposes capabilities beyond those available to service contexts for user services.
@@ -34,9 +34,9 @@ public interface SystemHttpServiceContext extends HttpServiceContext, Transactio
   /**
    * Evaluates lookup macros and the 'secure' macro function using provided macro evaluator.
    *
-   * @param namespace namespace in which macros needs to be evaluated
+   * @param namespace  namespace in which macros needs to be evaluated
    * @param properties key-value map of properties to evaluate
-   * @param evaluator macro evaluator to be used to evaluate macros
+   * @param evaluator  macro evaluator to be used to evaluate macros
    * @return map of evaluated macros
    * @throws InvalidMacroException indicates that there is an invalid macro
    */
@@ -52,13 +52,33 @@ public interface SystemHttpServiceContext extends HttpServiceContext, Transactio
   /**
    * Evaluates macros using provided macro evaluator with the provided parsing options.
    *
-   * @param namespace namespace in which macros needs to be evaluated
+   * @param namespace  namespace in which macros needs to be evaluated
    * @param properties key-value map of properties to evaluate
-   * @param evaluator macro evaluator to be used to evaluate macros
-   * @param options macro parsing options
+   * @param evaluator  macro evaluator to be used to evaluate macros
+   * @param options    macro parsing options
    * @return map of evaluated macros
    * @throws InvalidMacroException indicates that there is an invalid macro
    */
   Map<String, String> evaluateMacros(String namespace, Map<String, String> properties,
                                      MacroEvaluator evaluator, MacroParserOptions options) throws InvalidMacroException;
+
+  /**
+   * Get preferences for the given namespace.
+   * <p>
+   * This method fetches preferences for the supplied namespace when the method is unvoked, unlike {@link
+   * io.cdap.cdap.api.RuntimeContext#getRuntimeArguments()} which returns arguments at the time the context was
+   * created.
+   * <p>
+   * This might be a network call, depending on the underlying implementation.
+   *
+   * @param namespace the name of the namespace to fetch preferences for.
+   * @param resolved  true if resolved properties are desired.
+   * @return Map containing Preferences keys and values.
+   * @throws IOException is the preferences for the supplied namespace could not be fetched.
+   * @throws IllegalArgumentException if the namespace doesn't exist.
+   */
+  default Map<String, String> getPreferencesForNamespace(String namespace, boolean resolved)
+    throws IOException, IllegalArgumentException {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 }

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -72,6 +72,8 @@ import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.common.test.TestRunner;
 import io.cdap.cdap.common.twill.NoopTwillRunnerService;
 import io.cdap.cdap.common.utils.OSDetector;
+import io.cdap.cdap.config.PreferencesService;
+import io.cdap.cdap.config.PreferencesTable;
 import io.cdap.cdap.data.runtime.DataFabricModules;
 import io.cdap.cdap.data.runtime.DataSetServiceModules;
 import io.cdap.cdap.data.runtime.DataSetsModules;
@@ -103,6 +105,7 @@ import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metadata.MetadataService;
 import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.metadata.MetadataSubscriberService;
+import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.NamespaceMeta;
@@ -220,6 +223,7 @@ public class TestBase {
   private static FieldLineageAdmin fieldLineageAdmin;
   private static LineageAdmin lineageAdmin;
   private static AppFabricServer appFabricServer;
+  private static PreferencesService preferencesService;
 
   // This list is to record ApplicationManager create inside @Test method
   private static final List<ApplicationManager> applicationManagers = new ArrayList<>();
@@ -393,6 +397,7 @@ public class TestBase {
     }
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
+    preferencesService = injector.getInstance(PreferencesService.class);
 
     scheduler = injector.getInstance(Scheduler.class);
     if (scheduler instanceof Service) {
@@ -1080,6 +1085,12 @@ public class TestBase {
    */
   protected static CConfiguration getConfiguration() {
     return cConf;
+  }
+  /**
+   * Returns the {@link PreferencesService} used in tests.
+   */
+  public static PreferencesService getPreferencesService() {
+    return preferencesService;
   }
 
   /**


### PR DESCRIPTION
Added new getPreferences method in the SystemHttpServiceContext.

We use this method to get the list of preferences for the current namespace when validating the plugin configuration.

Added tests.