### PR TITLE
[CDAP-17768] Set default concurrency settings for fixed dataproc - Cherry-pick into 6.4

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -249,6 +249,10 @@ final class DataprocConf {
     return getMachineType(workerMachineType, workerCPUs, workerMemoryMB);
   }
 
+  int getTotalWorkerCPUs() {
+    return workerCPUs * (workerNumNodes + secondaryWorkerNumNodes);
+  }
+
   @Nullable
   String getImageVersion() {
     return imageVersion;


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/13222.
This change does two things:

Sets spark.default.parallelism according to cluster size. Spark defaults it to number of current executors, but when we configure the job executors may not have started yet, so this value gets artificially low. also if cluster is very small we still was some parallelism, so minimum of 32 is set. 32 partitions won't produce much overhead, but would help to reduce partition sizes.
Sets spark.sql.adaptive.coalescePartitions.initialPartitionNum as 32x of default parallelism, but no more than 8192. This value is used only in spark 3 with adaptive execution and according to our tests spark can handle really large numbers and 32x is a reasonable default. This value is not used in spark 2 or when adaptive execution is disabled.
Both values user can override in the engine config as needed.

