### PR TITLE
[CDAP-17774]Fixes select dropdown in profile customization popover to not close the entire popover

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizeContent/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/ProfileCustomizeContent/index.js
@@ -141,10 +141,24 @@ export default class ProfileCustomizeContent extends PureComponent {
                     !propertiesFromProfileMap[property.name] ||
                     propertiesFromProfileMap[property.name].isEditable !== false
                 )
-                .map((property) => ({
-                  ...property,
-                  value: editablePropertiesMap[property.name],
-                }));
+                .map((property) => {
+                  if (property['widget-type'] === 'select') {
+                    return {
+                      ...property,
+                      value: editablePropertiesMap[property.name],
+                      ['widget-attributes']: {
+                        ...(property['widget-attributes'] || {}),
+                        MenuProps: {
+                          disablePortal: true,
+                        },
+                      },
+                    };
+                  }
+                  return {
+                    ...property,
+                    value: editablePropertiesMap[property.name],
+                  };
+                });
               return (
                 <AccordionPane id={i}>
                   <AccordionTitle>

--- a/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/index.js
+++ b/cdap-ui/app/cdap/components/PipelineDetails/ProfilesListView/ProfileCustomizePopover/index.js
@@ -70,6 +70,11 @@ export default class ProfileCustomizePopover extends PureComponent {
           open={this.state.showPopover}
           anchorEl={this.state.anchorEl}
           onClose={this.onTogglePopover}
+          style={{
+            // Default modal zindex in theme is 1300. This is added as
+            // inline style by material-ui. Hence the inline style to override it
+            zIndex: 1400,
+          }}
           anchorOrigin={{
             vertical: 'center',
             horizontal: 'left',


### PR DESCRIPTION
JIRA - https://cdap.atlassian.net/browse/CDAP-17774

**Cause**
- We refactored PipelineModeless recently and as part of the refactor we switched material popover to popper.
- Material popper content is wrapped in `ClickAwayListener` to detect clicks outside of the modeless and close the modeless.
- The select dropdown in Configure modeless is implemented using portal and is a modal under the hood.
- Opening select, opened modal and added the element at the `body` level.
- This caused `ClickAwayListener` to trigger as a click outside the modeless was registered.

**Fix**
- Render select, which is using `Menu` which is inherently using `Modal` under the hood to not use `reactPortal`.

