### PR TITLE
[CDAP-17778] Fixes default canvas panning behavior in pipeline studio

### DIFF
--- a/cdap-ui/app/cdap/components/PipelineCanvasActions/PipelineCommentsActionBtn.tsx
+++ b/cdap-ui/app/cdap/components/PipelineCanvasActions/PipelineCommentsActionBtn.tsx
@@ -84,7 +84,6 @@ interface IPipelineCommentsActionBtnProps {
 
 function PipelineCommentsActionBtn({
   tooltip,
-  onCommentsToggle,
   onChange,
   comments,
   disabled,
@@ -99,18 +98,23 @@ function PipelineCommentsActionBtn({
     setLocalToggle((lt) => {
       if (lt) {
         setAnchorEl(null);
-        onCommentsToggle(true);
         return false;
       }
       setAnchorEl(e.currentTarget);
-      onCommentsToggle(false);
       return true;
     });
   };
   const onClose = () => {
-    setLocalToggle(false);
-    setAnchorEl(null);
-    onCommentsToggle(true);
+    setLocalToggle((lt) => {
+      // If the toggle is already false onClose doesn't need to do anything.
+      // This gets called by `ClickAwayListener` which seems unnecessary.
+      // Need to separate out the popover from the button
+      if (!lt) {
+        return false;
+      }
+      setAnchorEl(null);
+      return false;
+    });
   };
 
   React.useEffect(() => {

--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -1800,9 +1800,6 @@ angular.module(PKG.name + '.commons')
       vm.pipelineComments = comments;
     };
 
-    vm.togglePipelineComments = (disableCanvasPan) => {
-      vm.secondInstance.setDraggable('diagram-container', disableCanvasPan);
-    };
     $scope.$on('$destroy', cleanupOnDestroy);
     vm.initPipelineComments();
   });

--- a/cdap-ui/app/directives/dag-plus/my-dag.html
+++ b/cdap-ui/app/directives/dag-plus/my-dag.html
@@ -101,7 +101,6 @@
 
   <pipeline-comments-action-btn
     tooltip="'Show/Hide Pipeline Comments'"
-    on-comments-toggle="DAGPlusPlusCtrl.togglePipelineComments"
     comments="DAGPlusPlusCtrl.pipelineComments"
     on-change="DAGPlusPlusCtrl.setPipelineComments"
     disabled='DAGPlusPlusCtrl.isDisabled'

--- a/cdap-ui/app/directives/dag-plus/my-dag.less
+++ b/cdap-ui/app/directives/dag-plus/my-dag.less
@@ -60,7 +60,6 @@
   &.selected {
     border-color: @node-color;
     color: white;
-    z-index: 2000;
     .node {
       background-color: @node-color;
 


### PR DESCRIPTION
JIRA - https://cdap.atlassian.net/browse/CDAP-17778

**Problem**

_Canvas panning_
- While adding pipeline level comments we were toggling the canvas draggable state.
- This is unnecessary as the canvas panning shouldn't be affected by comments.


**Fix**
- Remove the unnecessary toggle

_Creating connection from source_
- When the plugin was selected creating a connection seems to drag the entire node with the cursor.
- We modified zindex of the node to have comments popout from the node when overlaping with other nodes
- This seems to have side effect in the click on connection end point.
- Because of the bump in zindex the node received the click handler which then goes on to be selected and dragged even while clicking on the endpoint.


**Fix**
- Remove the unnecessary zindex we set on node.
- This became unnecessary as the comments are now added at the body level instead of within the node.