### PR TITLE
[CDAP-17795] Fix authorization in datasource for polling

### DIFF
--- a/cdap-ui/app/services/data/my-cdap-datasource.js
+++ b/cdap-ui/app/services/data/my-cdap-datasource.js
@@ -31,8 +31,18 @@ angular.module(PKG.name + '.services')
       // myAuth.isAuthenticated is not used. There should be a better way to do this.
       if (window.CDAP_CONFIG.securityEnabled && $cookies.get('CDAP_Auth_Token')) {
         resource.headers = {
-          Authorization: 'Bearer '+ $cookies.get('CDAP_Auth_Token')
+          Authorization: 'Bearer ' + $cookies.get('CDAP_Auth_Token')
         };
+      } else if (
+        window.CaskCommon.CDAPHelpers.isAuthSetToManagedMode() &&
+        $rootScope.currentUser &&
+        $rootScope.currentUser.token
+      ) {
+        resource.headers = {
+          Authorization: 'Bearer ' + $rootScope.currentUser.token
+        };
+      } else {
+        resource.headers = {};
       }
 
       if (!resource.url) {
@@ -52,7 +62,11 @@ angular.module(PKG.name + '.services')
     };
 
     MyCDAPDataSource.prototype.request = function(resource, cb, errorCb) {
-      if (
+      if (window.CDAP_CONFIG.securityEnabled && $cookies.get('CDAP_Auth_Token')) {
+        resource.headers = {
+          Authorization: 'Bearer ' + $cookies.get('CDAP_Auth_Token')
+        };
+      } else if (
         window.CaskCommon.CDAPHelpers.isAuthSetToManagedMode() &&
         $rootScope.currentUser &&
         $rootScope.currentUser.token
@@ -63,6 +77,7 @@ angular.module(PKG.name + '.services')
       } else {
         resource.headers = {};
       }
+
       if (!resource.url) {
         resource.url = myCdapUrl.constructUrl(resource);
       }

--- a/cdap-ui/server/aggregator.js
+++ b/cdap-ui/server/aggregator.js
@@ -326,7 +326,10 @@ function onSocketData(message) {
         break;
       case 'request':
         r.startTs = Date.now();
-        if (r.headers && this.cdapConfig['security.authentication.mode'] === 'PROXY') {
+        if (this.cdapConfig['security.authentication.mode'] === 'PROXY') {
+          if (!r.headers) {
+            r.headers = {};
+          }
           r.headers.Authorization = this.connection.authToken;
           r.headers[this.cdapConfig['security.authentication.proxy.user.identity.header']] = this.connection.userid;
         }


### PR DESCRIPTION
JIRA: https://cdap.atlassian.net/browse/CDAP-17795
Build: https://builds.cask.co/browse/CDAP-UDUT1027


Reason:
In angular datasource, the poll is not sending the correct token. This change is making the request and poll authorization model to be consistent