### PR TITLE
[CDAP-17786] Authorizer Error Support

### DIFF
--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetServiceAuthorizationTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetServiceAuthorizationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2019 Cask Data, Inc.
+ * Copyright © 2014-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -140,7 +140,9 @@ public class DatasetServiceAuthorizationTest extends DatasetServiceTestBase {
       dsFramework.deleteAllInstances(NamespaceId.DEFAULT);
       Assert.fail();
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("is not authorized to perform actions"));
+      if (!(e instanceof UnauthorizedException)) {
+        Assert.fail();
+      }
     }
     // alice should still be able to see all dataset instances
     Assert.assertEquals(ImmutableSet.of(dsId1, dsId2, dsId),

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AuthorizationEnforcer.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AuthorizationEnforcer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2019 Cask Data, Inc.
+ * Copyright © 2016-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -21,6 +21,7 @@ import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.security.Action;
 import io.cdap.cdap.proto.security.Principal;
 
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -54,8 +55,25 @@ public interface AuthorizationEnforcer {
   void enforce(EntityId entity, Principal principal, Set<Action> actions) throws Exception;
 
   /**
+   * Checks whether a single {@link EntityId} is visible to the specified {@link Principal}.
+   * An entity is visible to a principal if the principal has any privileges on the entity, or any of its descendants.
+   * However, visibility check behavior can be overwritten at the authorization extension level.
+   *
+   * @param entityId the entity on which the visibility check is to be performed
+   * @param principal the principal to check the visibility for
+   * @throws UnauthorizedException if the entity is not visible to the principal
+   * @throws Exception if any errors occurred while performing the check
+   */
+  default void isVisible(EntityId entityId, Principal principal) throws Exception {
+    if (isVisible(Collections.singleton(entityId), principal).isEmpty()) {
+      throw new UnauthorizedException(principal, entityId);
+    }
+  }
+
+  /**
    * Checks whether the set of {@link EntityId}s are visible to the specified {@link Principal}.
    * An entity is visible to a principal if the principal has any privileges on the entity, or any of its descendants.
+   * However, visibility check behavior can be overwritten at the authorization extension level.
    *
    * @param entityIds the entities on which the visibility check is to be performed
    * @param principal the principal to check the visibility for

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/UnauthorizedException.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/UnauthorizedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,44 +22,152 @@ import io.cdap.cdap.proto.security.Action;
 import io.cdap.cdap.proto.security.Principal;
 
 import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Exception thrown when Authentication is successful, but a {@link Principal} is not authorized to perform an
  * {@link Action} on an {@link EntityId}.
  */
 public class UnauthorizedException extends RuntimeException implements HttpErrorStatusProvider {
+  @Nullable
+  private final String principal;
+  private final Set<String> missingPermissions;
+  @Nullable
+  private final String entity;
+  @Nullable
+  private final String addendum;
+  private final boolean includePrincipal;
+  private final String message;
 
   public UnauthorizedException(Principal principal, Action action, EntityId entityId) {
-    super(String.format("Principal '%s' is not authorized to perform action '%s' on entity '%s'",
-                        principal, action, entityId));
+    this(principal.toString(), Collections.singleton(action.toString()),
+         String.format("entity '%s'", entityId.toString()), null, true, true, null);
   }
 
   public UnauthorizedException(Principal principal, Set<Action> actions, EntityId entityId) {
-    super(String.format("Principal '%s' is not authorized to perform actions '%s' on entity '%s'",
-                        principal, actions, entityId));
+    this(principal.toString(), actions.stream().map(action -> action.toString())
+           .collect(Collectors.toCollection(LinkedHashSet::new)), String.format("entity '%s'", entityId.toString()),
+         null, true, true, null);
   }
 
   public UnauthorizedException(Principal principal, Set<Action> actions, EntityId entityId, Throwable ex) {
-    super(String.format("Principal '%s' is not authorized to perform actions '%s' on entity '%s'",
-                        principal, actions, entityId), ex);
+    this(principal.toString(), actions.stream().map(action -> action.toString())
+           .collect(Collectors.toCollection(LinkedHashSet::new)), String.format("entity '%s'", entityId.toString()),
+         ex, true, true, null);
   }
 
   public UnauthorizedException(Principal principal, EntityId entityId) {
-    super(String.format("Principal '%s' does not have privileges to access entity '%s'", principal, entityId));
+    this(principal.toString(), Collections.emptySet(), String.format("entity '%s'", entityId.toString()), null, true,
+         true, null);
   }
 
-  public UnauthorizedException(Principal principal, Set<Action> actions, EntityId entityId, boolean needHaveAll) {
-    super(String.format("Principal '%s' is not authorized to perform %sactions '%s' on entity '%s'",
-                        principal, needHaveAll ? "" : "any one of the ", actions, entityId));
+  public UnauthorizedException(Principal principal, Set<Action> actions, EntityId entityId,
+                               boolean mustHaveAllPermissions) {
+    this(principal.toString(), actions.stream().map(action -> action.toString())
+           .collect(Collectors.toCollection(LinkedHashSet::new)), String.format("entity '%s'", entityId.toString()),
+         null, mustHaveAllPermissions, true, null);
+  }
+
+  public UnauthorizedException(@Nullable String principal, Set<String> missingPermissions, @Nullable String entity,
+                               @Nullable Throwable ex, boolean requiresAllPermissions, boolean includePrincipal,
+                               @Nullable String addendum) {
+    super(ex);
+    this.principal = principal;
+    this.missingPermissions = Collections.unmodifiableSet(missingPermissions);
+    this.entity = entity;
+    this.includePrincipal = includePrincipal;
+    this.addendum = addendum;
+    // Construct the message.
+    StringBuilder messageBuilder = new StringBuilder();
+    if (includePrincipal) {
+      messageBuilder.append(String.format("Principal '%s' is ", principal));
+    } else {
+      messageBuilder.append("You are ");
+    }
+    messageBuilder.append("not authorized to ");
+    if (missingPermissions.isEmpty()) {
+      messageBuilder.append("access ");
+    } else {
+      messageBuilder.append("perform ");
+      if (missingPermissions.size() == 1) {
+        messageBuilder.append(String.format("action '%s' on ", missingPermissions.iterator().next()));
+      } else {
+        if (!requiresAllPermissions) {
+          messageBuilder.append("any one of the ");
+        }
+        messageBuilder.append(String.format("actions '%s' on ", missingPermissions));
+      }
+    }
+    messageBuilder.append(entity);
+    if (addendum != null) {
+      messageBuilder.append(addendum);
+    }
+    this.message = messageBuilder.toString();
   }
 
   public UnauthorizedException(String message) {
-    super(message);
+    this.principal = null;
+    this.missingPermissions = Collections.emptySet();
+    this.entity = null;
+    this.includePrincipal = false;
+    this.addendum = null;
+    this.message = message;
   }
 
   @Override
   public int getStatusCode() {
     return HttpURLConnection.HTTP_FORBIDDEN;
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  /**
+   * Returns the string which represents the user principal identity who failed the authorization check.
+   * @return The principal string
+   */
+  @Nullable
+  public String getPrincipal() {
+    return principal;
+  }
+
+  /**
+   * Returns all permissions which were missing for the authorization check.
+   * @return The missing permissions
+   */
+  public Set<String> getMissingPermissions() {
+    return missingPermissions;
+  }
+
+  /**
+   * Returns the string which represents the entity upon which the permission check failed.
+   * @return The entity string
+   */
+  @Nullable
+  public String getEntity() {
+    return entity;
+  }
+
+  /**
+   * Returns whether this exception includes the principal in the error message or not.
+   * @return whether to include the principal in the exception message
+   */
+  public boolean includePrincipal() {
+    return includePrincipal;
+  }
+
+  /**
+   * Returns the custom addendum message for this exception message.
+   * @return The custom addendum message
+   */
+  @Nullable
+  public String getAddendum() {
+    return addendum;
   }
 }

--- a/cdap-security-spi/src/test/java/io/cdap/cdap/security/spi/authorization/UnauthorizedExceptionTest.java
+++ b/cdap-security-spi/src/test/java/io/cdap/cdap/security/spi/authorization/UnauthorizedExceptionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.spi.authorization;
+
+import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.security.Action;
+import io.cdap.cdap.proto.security.Principal;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class UnauthorizedExceptionTest {
+  private static final Principal TEST_PRINCIPAL = new Principal("test-principal", Principal.PrincipalType.USER);
+  private static final EntityId TEST_NAMESPACE_ENTITY = new NamespaceId("test");
+
+  @Test
+  public void testSingleActionReturnsExpectedMessage() {
+    String expected = String.format("Principal '%s' is not authorized to perform action '%s' on entity '%s'",
+                                    TEST_PRINCIPAL, Action.ADMIN, TEST_NAMESPACE_ENTITY);
+    String got = new UnauthorizedException(TEST_PRINCIPAL, Action.ADMIN, TEST_NAMESPACE_ENTITY).getMessage();
+    Assert.assertEquals(expected, got);
+  }
+
+  @Test
+  public void testNoActionsReturnsExpectedMessage() {
+    String expected = String.format("Principal '%s' is not authorized to access entity '%s'",
+                                    TEST_PRINCIPAL, TEST_NAMESPACE_ENTITY);
+    String got = new UnauthorizedException(TEST_PRINCIPAL, Collections.emptySet(), TEST_NAMESPACE_ENTITY).getMessage();
+    Assert.assertEquals(expected, got);
+  }
+
+  @Test
+  public void testMultipleActionsReturnsExpectedMessage() {
+    Set<Action> actions = new LinkedHashSet<>();
+    actions.add(Action.ADMIN);
+    actions.add(Action.EXECUTE);
+    String expected = String.format("Principal '%s' is not authorized to perform actions '%s' on entity '%s'",
+                                    TEST_PRINCIPAL, actions, TEST_NAMESPACE_ENTITY);
+    String got = new UnauthorizedException(TEST_PRINCIPAL, actions, TEST_NAMESPACE_ENTITY).getMessage();
+    Assert.assertEquals(expected, got);
+  }
+
+  @Test
+  public void testMultipleActionsWithThrowableReturnsExpectedCause() {
+    Exception e = new Exception("test");
+    Set<Action> actions = new LinkedHashSet<>();
+    actions.add(Action.ADMIN);
+    actions.add(Action.EXECUTE);
+    UnauthorizedException unauthorizedException = new UnauthorizedException(TEST_PRINCIPAL, actions,
+                                                                            TEST_NAMESPACE_ENTITY, e);
+    Assert.assertEquals(e, unauthorizedException.getCause());
+  }
+
+  @Test
+  public void testMultipleActionsWithoutMustHaveAllReturnsExpectedMessage() {
+    Set<Action> actions = new LinkedHashSet<>();
+    actions.add(Action.ADMIN);
+    actions.add(Action.EXECUTE);
+    String expected = String.format("Principal '%s' is not authorized to perform any one of the actions '%s' " +
+                                      "on entity '%s'", TEST_PRINCIPAL, actions, TEST_NAMESPACE_ENTITY);
+    String got = new UnauthorizedException(TEST_PRINCIPAL, actions, TEST_NAMESPACE_ENTITY, false).getMessage();
+    Assert.assertEquals(expected, got);
+  }
+
+  @Test
+  public void testOneActionWithoutMustHaveAllReturnsExpectedMessage() {
+    Set<Action> actions = new LinkedHashSet<>();
+    actions.add(Action.ADMIN);
+    String expected = String.format("Principal '%s' is not authorized to perform action '%s' on entity '%s'",
+                                    TEST_PRINCIPAL, Action.ADMIN, TEST_NAMESPACE_ENTITY);
+    String got = new UnauthorizedException(TEST_PRINCIPAL, actions, TEST_NAMESPACE_ENTITY, false).getMessage();
+    Assert.assertEquals(expected, got);
+  }
+
+  @Test
+  public void testOneActionWithoutPrincipalReturnsExpectedMessage() {
+    Set<String> actions = new LinkedHashSet<>();
+    actions.add(Action.ADMIN.toString());
+    String entityString = String.format("entity '%s'", TEST_NAMESPACE_ENTITY);
+    String expected = String.format("You are not authorized to perform action '%s' on %s", Action.ADMIN,
+                                    entityString);
+    String got = new UnauthorizedException(null, actions, entityString, null, true, false, null).getMessage();
+    Assert.assertEquals(expected, got);
+  }
+
+  @Test
+  public void testCustomEntityWithCustomPermissionsReturnsExpectedMessage() {
+    Set<String> permissions = new LinkedHashSet<>();
+    permissions.add("test-permission-1");
+    permissions.add("test-permissions-2");
+    String entityString = "custom resource 'test-resource'";
+    String expected = String.format("You are not authorized to perform actions '%s' on %s", permissions,
+                                    entityString);
+    String got = new UnauthorizedException(null, permissions, entityString, null, true, false, null).getMessage();
+    Assert.assertEquals(expected, got);
+  }
+
+  @Test
+  public void testCustomAddendumReturnsExpectedMessage() {
+    Set<String> permissions = new LinkedHashSet<>();
+    permissions.add("test-permission-1");
+    permissions.add("test-permissions-2");
+    String entityString = "custom resource 'test-resource'";
+    String expected = String.format("You are not authorized to perform actions '%s' on %s test addendum", permissions,
+                                    entityString);
+    String got = new UnauthorizedException(null, permissions, entityString, null, true, false, " test addendum")
+      .getMessage();
+    Assert.assertEquals(expected, got);
+  }
+}


### PR DESCRIPTION
Add native support for [`ensureAccess`](https://github.com/cdapio/cdap/blob/6dc6a3fa055c8f6e99da23f047d95c44b63a1ad6/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizationUtil.java#L129) in AuthorizationEnforcer API and add support for custom error propagation from Authorizer in [`ensureOnePrivilege`](https://github.com/cdapio/cdap/blob/6dc6a3fa055c8f6e99da23f047d95c44b63a1ad6/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizationUtil.java#L73).

Context: [CDAP-17786](https://cdap.atlassian.net/browse/CDAP-17786).