### PR TITLE
[CDAP-17818] Optimize jar unpacking in PluginInstantiator

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginClassLoader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginClassLoader.java
@@ -53,6 +53,7 @@ import java.util.jar.Manifest;
 public class PluginClassLoader extends DirectoryClassLoader {
 
   private final ArtifactId artifactId;
+  private final String topLevelJar;
   private final Set<String> exportPackages;
 
   static ClassLoader createParent(ClassLoader templateClassLoader) {
@@ -77,9 +78,10 @@ public class PluginClassLoader extends DirectoryClassLoader {
     return new CombineClassLoader(programClassLoader.getParent(), filteredTemplateClassLoader);
   }
 
-  PluginClassLoader(ArtifactId artifactId, File directory, ClassLoader parent) {
-    super(directory, parent, "lib");
+  PluginClassLoader(ArtifactId artifactId, File directory, String topLevelJar, ClassLoader parent) {
+    super(directory, topLevelJar, parent, "lib");
     this.artifactId = artifactId;
+    this.topLevelJar = topLevelJar;
     this.exportPackages = ManifestFields.getExportPackages(getManifest());
   }
 
@@ -96,5 +98,13 @@ public class PluginClassLoader extends DirectoryClassLoader {
    */
   public ClassLoader getExportPackagesClassLoader() {
     return new PackageFilterClassLoader(this, exportPackages::contains);
+  }
+
+  /**
+   *
+   * @return a file name of top level plugin jar. Main plugin class should reside in this jar.
+   */
+  public String getTopLevelJar() {
+    return topLevelJar;
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -188,6 +188,31 @@ public class ArtifactInspectorTest {
     }
   }
 
+  @Test
+  public void testGetClassNameCheckPredicate() {
+    Assert.assertTrue(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+      "my.package"
+    )).test("my/package/my.class"));
+    Assert.assertTrue(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+      "blah", "my.package", "blah2"
+    )).test("my/package/my.class"));
+    Assert.assertTrue(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+      "my.package", "my.package.subpackage"
+    )).test("my/package/subpackage/my.class"));
+    Assert.assertFalse(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+      "my.package"
+    )).test("my/package/subpackage/my.class"));
+    Assert.assertFalse(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+      "my.package"
+    )).test("prefix/my/package/my.class"));
+    Assert.assertFalse(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+      "my.package"
+    )).test("prefix/my/package/my.notclass"));
+    Assert.assertFalse(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+      "my.package"
+    )).test("prefix/my/package/my.class/some.class"));
+  }
+
   private File getAppFile() throws IOException {
     Manifest manifest = new Manifest();
     manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, InspectionApp.class.getPackage().getName());


### PR DESCRIPTION
Currently we unpack all plugin jar in PluginInstantiator. In tests it takes 4+ seconds on each run to perform the unpack and removal afterwards.
Instead we should only unpack what's needed (jars and menifest) and load classes directly from the original jar.
In my tests it reduces AutoJoinerTest runtime from 6:41 by 1 minute to 5:44