### PR TITLE
Fixes css class name added to connection to use node id instead of node name

### DIFF
--- a/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
+++ b/cdap-ui/app/directives/dag-plus/my-dag-ctrl.js
@@ -729,7 +729,7 @@ angular.module(PKG.name + '.commons')
         }
 
         if (connObj.source && connObj.target) {
-          connObj.cssClass = `connection-id-${sourceNode.name}-${targetNode.name}`;
+          connObj.cssClass = `connection-id-${sourceNode.id}-${targetNode.id}`;
           let newConn = vm.instance.connect(connObj);
           if (
             targetNode.type === 'condition' ||
@@ -789,7 +789,7 @@ angular.module(PKG.name + '.commons')
       let defaultConnectorSettings = vm.defaultDagSettings.Connector;
       connObj.connector = [defaultConnectorSettings[0], Object.assign({}, defaultConnectorSettings[1], { midpoint: 0 })];
 
-      connObj.cssClass = `connection-id-${sourceNode.name}-${targetNode.name}`;
+      connObj.cssClass = `connection-id-${sourceNode.id}-${targetNode.id}`;
       vm.instance.connect(connObj);
     };
 


### PR DESCRIPTION
**Problem**
- We switched to using node id for a plugin in DOM while rendering nodes and connections
- But we missed out on replacing node id in css classes being applied to connections.
- This caused problems in corner cases where the stage names had spaces and css class based names, eg: `table`. 
- This plugin name with spaces and common names like `table` in class in the DOM node caused browser to render additional styles that we define under `table` css class which causes unnecessary deformation in connections.
![Screen Shot 2021-03-19 at 10 01 47 PM](https://user-images.githubusercontent.com/1452845/111859508-bb471280-88fe-11eb-8cff-e645281d276e.png)

**Fix**
- Fix css class for connections to use node id instead of node name.


