### PR TITLE
[CDAP-17786 CDAP-17833] Properly propagate error messages throughout CDAP.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/meta/RemotePrivilegesHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/meta/RemotePrivilegesHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2019 Cask Data, Inc.
+ * Copyright © 2016-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -72,7 +72,17 @@ public class RemotePrivilegesHandler extends AbstractRemoteSystemOpsHandler {
                                                                   AuthorizationPrivilege.class);
     LOG.debug("Enforcing for {}", authorizationPrivilege);
     authorizationEnforcer.enforce(authorizationPrivilege.getEntity(), authorizationPrivilege.getPrincipal(),
-                                  authorizationPrivilege.getAction());
+                                  authorizationPrivilege.getActions());
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  @POST
+  @Path("/isSingleVisible")
+  public void isSingleVisible(FullHttpRequest request, HttpResponder responder) throws Exception {
+    AuthorizationPrivilege authorizationPrivilege = GSON.fromJson(request.content().toString(StandardCharsets.UTF_8),
+                                                                  AuthorizationPrivilege.class);
+    LOG.debug("Enforcing visibility for {}", authorizationPrivilege);
+    authorizationEnforcer.isVisible(authorizationPrivilege.getEntity(), authorizationPrivilege.getPrincipal());
     responder.sendStatus(HttpResponseStatus.OK);
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/remote/RemotePrivilegesCacheTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/remote/RemotePrivilegesCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -52,5 +52,14 @@ public class RemotePrivilegesCacheTest extends RemotePrivilegesTestBase {
     // The super class revokes all privileges after test is done. Since cache is enabled, visibility should still work.
     Assert.assertEquals(ImmutableSet.of(NS, APP, PROGRAM),
                         authorizationEnforcer.isVisible(ImmutableSet.of(NS, APP, PROGRAM), ALICE));
+  }
+
+  @Override
+  public void testSingleVisibility() throws Exception {
+    super.testSingleVisibility();
+
+    // The super class revokes all privileges after test is done. Since cache is enabled, visibility should still work.
+    authorizationEnforcer.isVisible(PROGRAM, ALICE);
+    shouldNotHaveVisibility(authorizationEnforcer, PROGRAM, BOB);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/remote/RemotePrivilegesNoCacheTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/remote/RemotePrivilegesNoCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -64,5 +64,14 @@ public class RemotePrivilegesNoCacheTest extends RemotePrivilegesTestBase {
     // The super class revokes all privileges after test is done. Since cache is disabled, nothing should be visible.
     Assert.assertEquals(ImmutableSet.of(),
                         authorizationEnforcer.isVisible(ImmutableSet.of(NS, APP, PROGRAM), ALICE));
+  }
+
+  @Override
+  public void testSingleVisibility() throws Exception {
+    super.testSingleVisibility();
+
+    // The super class revokes all privileges after test is done. Since cache is disabled, nothing should be visible.
+    shouldNotHaveVisibility(authorizationEnforcer, PROGRAM, ALICE);
+    shouldNotHaveVisibility(authorizationEnforcer, PROGRAM, BOB);
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 <!--
-  Copyright © 2014-2019 Cask Data, Inc.
+  Copyright © 2014-2021 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -3859,7 +3859,7 @@
 
   <property>
     <name>security.authorization.cache.max.entries</name>
-    <value>100000</value>
+    <value>150000</value>
     <description>
       Number of entries to hold in the container authorization cache. If set to 0, no
       caching will be performed.

--- a/cdap-security/src/main/java/io/cdap/cdap/proto/security/AuthorizationPrivilege.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/proto/security/AuthorizationPrivilege.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2017-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,20 +18,24 @@ package io.cdap.cdap.proto.security;
 
 import io.cdap.cdap.proto.id.EntityId;
 
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Key for caching Privileges on containers. This represents a specific privilege on which authorization can be
  * enforced. The cache stores whether the enforce succeeded or failed.
+ *
+ * Action may be empty in the case of isVisible checks for single entities.
  */
 public class AuthorizationPrivilege {
   private final EntityId entityId;
-  private final Action action;
+  private final Set<Action> actions;
   private final Principal principal;
 
-  public AuthorizationPrivilege(Principal principal, EntityId entityId, Action action) {
+  public AuthorizationPrivilege(Principal principal, EntityId entityId, Set<Action> actions) {
     this.entityId = entityId;
-    this.action = action;
+    this.actions = Collections.unmodifiableSet(actions);
     this.principal = principal;
   }
 
@@ -43,8 +47,8 @@ public class AuthorizationPrivilege {
     return entityId;
   }
 
-  public Action getAction() {
-    return action;
+  public Set<Action> getActions() {
+    return actions;
   }
 
   @Override
@@ -56,20 +60,20 @@ public class AuthorizationPrivilege {
       return false;
     }
     AuthorizationPrivilege that = (AuthorizationPrivilege) o;
-    return Objects.equals(entityId, that.entityId) && action == that.action &&
+    return Objects.equals(entityId, that.entityId) && actions.equals(that.actions) &&
       Objects.equals(principal, that.principal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(entityId, action, principal);
+    return Objects.hash(entityId, actions, principal);
   }
 
   @Override
   public String toString() {
     return "AuthorizationPrivilege{" +
       "entityId=" + entityId +
-      ", action=" + action +
+      ", action=" + actions +
       ", principal=" + principal +
       '}';
   }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizationUtil.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizationUtil.java
@@ -132,11 +132,14 @@ public final class AuthorizationUtil {
   /**
    * Checks if one entity is visible to the principal
    *
+   * DEPRECATED: Please use the {@link AuthorizationEnforcer#isVisible(EntityId, Principal)} method directly.
+   *
    * @param entityId entity id to be checked
    * @param authorizationEnforcer enforcer to make the authorization check
    * @param principal the principal to be checked
    * @throws UnauthorizedException if the principal does not have any privilege in the action set on the entity
    */
+  @Deprecated
   public static void ensureAccess(EntityId entityId, AuthorizationEnforcer authorizationEnforcer,
                                   Principal principal) throws Exception {
     authorizationEnforcer.isVisible(entityId, principal);

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/DefaultAuthorizationEnforcer.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/DefaultAuthorizationEnforcer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016-2017 Cask Data, Inc.
+ * Copyright © 2016-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -66,6 +66,14 @@ public class DefaultAuthorizationEnforcer extends AbstractAuthorizationEnforcer 
       return;
     }
     doEnforce(entity, principal, Collections.singleton(action));
+  }
+
+  @Override
+  public void enforce(EntityId entity, Principal principal, Set<Action> actions) throws Exception {
+    if (!isSecurityAuthorizationEnabled()) {
+      return;
+    }
+    doEnforce(entity, principal, actions);
   }
 
   @Override

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/LogHttpHandler.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/LogHttpHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2020 Cask Data, Inc.
+ * Copyright © 2014-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -28,9 +28,9 @@ import io.cdap.cdap.logging.context.LoggingContextHelper;
 import io.cdap.cdap.logging.read.LogReader;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
-import io.cdap.cdap.security.authorization.AuthorizationUtil;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AuthorizationEnforcer;
 import io.cdap.http.HttpHandler;
@@ -81,7 +81,7 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                       @QueryParam("filter") @DefaultValue("") String filterStr,
                       @QueryParam("format") @DefaultValue("text") String format,
                       @QueryParam("suppress") List<String> suppress) throws Exception {
-    ensureAccessOnProgram(namespaceId, appId, programType, programId);
+    ensureVisibilityOnProgram(namespaceId, appId, programType, programId);
     LoggingContext loggingContext =
       LoggingContextHelper.getLoggingContext(namespaceId, appId, programId,
                                              ProgramType.valueOfCategoryName(programType));
@@ -100,7 +100,7 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                            @QueryParam("filter") @DefaultValue("") String filterStr,
                            @QueryParam("format") @DefaultValue("text") String format,
                            @QueryParam("suppress") List<String> suppress) throws Exception {
-    ensureAccessOnProgram(namespaceId, appId, programType, programId);
+    ensureVisibilityOnProgram(namespaceId, appId, programType, programId);
     ProgramType type = ProgramType.valueOfCategoryName(programType);
     ProgramRunId programRunId = new ProgramRunId(namespaceId, appId, type, programId, runId);
     RunRecordDetail runRecord = getRunRecordMeta(programRunId);
@@ -121,7 +121,7 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                    @QueryParam("filter") @DefaultValue("") String filterStr,
                    @QueryParam("format") @DefaultValue("text") String format,
                    @QueryParam("suppress") List<String> suppress) throws Exception {
-    ensureAccessOnProgram(namespaceId, appId, programType, programId);
+    ensureVisibilityOnProgram(namespaceId, appId, programType, programId);
     LoggingContext loggingContext =
       LoggingContextHelper.getLoggingContext(namespaceId, appId,
                                              programId, ProgramType.valueOfCategoryName(programType));
@@ -139,7 +139,7 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                         @QueryParam("filter") @DefaultValue("") String filterStr,
                         @QueryParam("format") @DefaultValue("text") String format,
                         @QueryParam("suppress") List<String> suppress) throws Exception {
-    ensureAccessOnProgram(namespaceId, appId, programType, programId);
+    ensureVisibilityOnProgram(namespaceId, appId, programType, programId);
     ProgramType type = ProgramType.valueOfCategoryName(programType);
     ProgramRunId programRunId = new ProgramRunId(namespaceId, appId, type, programId, runId);
     RunRecordDetail runRecord = getRunRecordMeta(programRunId);
@@ -160,7 +160,7 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                    @QueryParam("filter") @DefaultValue("") String filterStr,
                    @QueryParam("format") @DefaultValue("text") String format,
                    @QueryParam("suppress") List<String> suppress) throws Exception {
-    ensureAccessOnProgram(namespaceId, appId, programType, programId);
+    ensureVisibilityOnProgram(namespaceId, appId, programType, programId);
     LoggingContext loggingContext =
       LoggingContextHelper.getLoggingContext(namespaceId, appId, programId,
                                              ProgramType.valueOfCategoryName(programType));
@@ -178,7 +178,7 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                         @QueryParam("filter") @DefaultValue("") String filterStr,
                         @QueryParam("format") @DefaultValue("text") String format,
                         @QueryParam("suppress") List<String> suppress) throws Exception {
-    ensureAccessOnProgram(namespaceId, appId, programType, programId);
+    ensureVisibilityOnProgram(namespaceId, appId, programType, programId);
     ProgramType type = ProgramType.valueOfCategoryName(programType);
     ProgramRunId programRunId = new ProgramRunId(namespaceId, appId, type, programId, runId);
     RunRecordDetail runRecord = getRunRecordMeta(programRunId);
@@ -199,6 +199,7 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                       @QueryParam("filter") @DefaultValue("") String filterStr,
                       @QueryParam("format") @DefaultValue("text") String format,
                       @QueryParam("suppress") List<String> suppress) throws Exception {
+    authorizationEnforcer.isVisible(NamespaceId.SYSTEM, authenticationContext.getPrincipal());
     LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Id.Namespace.SYSTEM.getId(), componentId,
                                                                            serviceId);
     doGetLogs(logReader, responder, loggingContext, fromTimeSecsParam,
@@ -214,6 +215,7 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                       @QueryParam("filter") @DefaultValue("") String filterStr,
                       @QueryParam("format") @DefaultValue("text") String format,
                       @QueryParam("suppress") List<String> suppress) throws Exception {
+    authorizationEnforcer.isVisible(NamespaceId.SYSTEM, authenticationContext.getPrincipal());
     LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Id.Namespace.SYSTEM.getId(), componentId,
                                                                            serviceId);
     doNext(logReader, responder, loggingContext, maxEvents,
@@ -228,7 +230,8 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                       @QueryParam("escape") @DefaultValue("true") boolean escape,
                       @QueryParam("filter") @DefaultValue("") String filterStr,
                       @QueryParam("format") @DefaultValue("text") String format,
-                      @QueryParam("suppress") List<String> suppress) {
+                      @QueryParam("suppress") List<String> suppress) throws Exception {
+    authorizationEnforcer.isVisible(NamespaceId.SYSTEM, authenticationContext.getPrincipal());
     LoggingContext loggingContext = LoggingContextHelper.getLoggingContext(Id.Namespace.SYSTEM.getId(), componentId,
                                                                            serviceId);
     doPrev(logReader, responder, loggingContext, maxEvents, fromOffsetStr, escape, filterStr, null, format, suppress);
@@ -242,10 +245,10 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
     return runRecordMeta;
   }
 
-  private void ensureAccessOnProgram(String namespace, String application, String programType, String program)
+  private void ensureVisibilityOnProgram(String namespace, String application, String programType, String program)
     throws Exception {
     ApplicationId appId = new ApplicationId(namespace, application);
     ProgramId programId = new ProgramId(appId, ProgramType.valueOfCategoryName(programType), program);
-    AuthorizationUtil.ensureAccess(programId, authorizationEnforcer, authenticationContext.getPrincipal());
+    authorizationEnforcer.isVisible(programId, authenticationContext.getPrincipal());
   }
 }


### PR DESCRIPTION
Additionally, switch system AuthorizationEnforcer implementations to default to using the batch enforcement interfaces.

Originally, in the [`DefaultAuthorizationEnforcer`](https://github.com/cdapio/cdap/blob/e1d7fcf470f2dab360728a7d5f32f851a6cf8d2c/cdap-security/src/main/java/io/cdap/cdap/security/authorization/DefaultAuthorizationEnforcer.java#L64), there is no override implementation of the batch `enforce(Principal, EntityId, Set<Action>)` method. This causes all batch enforce calls to make the single enforce calls in a loop. Something similar happens in [`RemoteAuthorizationEnforcer`](https://github.com/cdapio/cdap/blob/e1d7fcf470f2dab360728a7d5f32f851a6cf8d2c/cdap-security/src/main/java/io/cdap/cdap/security/authorization/RemoteAuthorizationEnforcer.java#L140) as well.

Thus, we reverse the implementations to call the batch method by default, and then we also add implementations for the single entity `isVisible` method overload which we added support for in #13262 to avoid [throwing a generic exception](https://github.com/cdapio/cdap/blob/e1d7fcf470f2dab360728a7d5f32f851a6cf8d2c/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AuthorizationEnforcer.java#L67).

Also added some more missing system namespace entity authorization enforcement for [CDAP-17833](https://cdap.atlassian.net/browse/CDAP-17833).