### PR TITLE
[CDAP-17786] Modify Error Message to use prefix "Insufficient Permissions"

### DIFF
--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetServiceAuthorizationTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetServiceAuthorizationTest.java
@@ -194,7 +194,9 @@ public class DatasetServiceAuthorizationTest extends DatasetServiceTestBase {
       dsFramework.getDatasetSpec(nonExistingInstance);
       Assert.fail();
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("is not authorized to perform any one of the actions"));
+      if (!(e instanceof UnauthorizedException)) {
+        Assert.fail();
+      }
     }
     try {
       // user will not be able to check the existence on the instance since he does not have any privilege on the
@@ -203,7 +205,9 @@ public class DatasetServiceAuthorizationTest extends DatasetServiceTestBase {
       Assert.fail();
     } catch (Exception e) {
       // expected
-      Assert.assertTrue(e.getMessage().contains("is not authorized to perform any one of the actions"));
+      if (!(e instanceof UnauthorizedException)) {
+        Assert.fail();
+      }
     }
     SecurityRequestContext.setUserId(ALICE.getName());
     // user need to have access to the dataset to do any operations, even though the dataset does not exist

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/UnauthorizedException.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/UnauthorizedException.java
@@ -84,11 +84,11 @@ public class UnauthorizedException extends RuntimeException implements HttpError
     // Construct the message.
     StringBuilder messageBuilder = new StringBuilder();
     if (includePrincipal) {
-      messageBuilder.append(String.format("Principal '%s' is ", principal));
+      messageBuilder.append(String.format("Principal '%s' has insufficient permissions ", principal));
     } else {
-      messageBuilder.append("You are ");
+      messageBuilder.append("Insufficient permissions ");
     }
-    messageBuilder.append("not authorized to ");
+    messageBuilder.append("to ");
     if (missingPermissions.isEmpty()) {
       messageBuilder.append("access ");
     } else {
@@ -102,7 +102,7 @@ public class UnauthorizedException extends RuntimeException implements HttpError
         messageBuilder.append(String.format("actions '%s' on ", missingPermissions));
       }
     }
-    messageBuilder.append(entity);
+    messageBuilder.append(entity + ".");
     if (addendum != null) {
       messageBuilder.append(addendum);
     }

--- a/cdap-security-spi/src/test/java/io/cdap/cdap/security/spi/authorization/UnauthorizedExceptionTest.java
+++ b/cdap-security-spi/src/test/java/io/cdap/cdap/security/spi/authorization/UnauthorizedExceptionTest.java
@@ -33,15 +33,15 @@ public class UnauthorizedExceptionTest {
 
   @Test
   public void testSingleActionReturnsExpectedMessage() {
-    String expected = String.format("Principal '%s' is not authorized to perform action '%s' on entity '%s'",
-                                    TEST_PRINCIPAL, Action.ADMIN, TEST_NAMESPACE_ENTITY);
+    String expected = String.format("Principal '%s' has insufficient permissions to perform action '%s' " +
+                                      "on entity '%s'.", TEST_PRINCIPAL, Action.ADMIN, TEST_NAMESPACE_ENTITY);
     String got = new UnauthorizedException(TEST_PRINCIPAL, Action.ADMIN, TEST_NAMESPACE_ENTITY).getMessage();
     Assert.assertEquals(expected, got);
   }
 
   @Test
   public void testNoActionsReturnsExpectedMessage() {
-    String expected = String.format("Principal '%s' is not authorized to access entity '%s'",
+    String expected = String.format("Principal '%s' has insufficient permissions to access entity '%s'.",
                                     TEST_PRINCIPAL, TEST_NAMESPACE_ENTITY);
     String got = new UnauthorizedException(TEST_PRINCIPAL, Collections.emptySet(), TEST_NAMESPACE_ENTITY).getMessage();
     Assert.assertEquals(expected, got);
@@ -52,8 +52,8 @@ public class UnauthorizedExceptionTest {
     Set<Action> actions = new LinkedHashSet<>();
     actions.add(Action.ADMIN);
     actions.add(Action.EXECUTE);
-    String expected = String.format("Principal '%s' is not authorized to perform actions '%s' on entity '%s'",
-                                    TEST_PRINCIPAL, actions, TEST_NAMESPACE_ENTITY);
+    String expected = String.format("Principal '%s' has insufficient permissions to perform actions '%s' on " +
+                                      "entity '%s'.", TEST_PRINCIPAL, actions, TEST_NAMESPACE_ENTITY);
     String got = new UnauthorizedException(TEST_PRINCIPAL, actions, TEST_NAMESPACE_ENTITY).getMessage();
     Assert.assertEquals(expected, got);
   }
@@ -74,8 +74,8 @@ public class UnauthorizedExceptionTest {
     Set<Action> actions = new LinkedHashSet<>();
     actions.add(Action.ADMIN);
     actions.add(Action.EXECUTE);
-    String expected = String.format("Principal '%s' is not authorized to perform any one of the actions '%s' " +
-                                      "on entity '%s'", TEST_PRINCIPAL, actions, TEST_NAMESPACE_ENTITY);
+    String expected = String.format("Principal '%s' has insufficient permissions to perform any one of the actions " +
+                                      "'%s' on entity '%s'.", TEST_PRINCIPAL, actions, TEST_NAMESPACE_ENTITY);
     String got = new UnauthorizedException(TEST_PRINCIPAL, actions, TEST_NAMESPACE_ENTITY, false).getMessage();
     Assert.assertEquals(expected, got);
   }
@@ -84,8 +84,8 @@ public class UnauthorizedExceptionTest {
   public void testOneActionWithoutMustHaveAllReturnsExpectedMessage() {
     Set<Action> actions = new LinkedHashSet<>();
     actions.add(Action.ADMIN);
-    String expected = String.format("Principal '%s' is not authorized to perform action '%s' on entity '%s'",
-                                    TEST_PRINCIPAL, Action.ADMIN, TEST_NAMESPACE_ENTITY);
+    String expected = String.format("Principal '%s' has insufficient permissions to perform action '%s' " +
+                                      "on entity '%s'.", TEST_PRINCIPAL, Action.ADMIN, TEST_NAMESPACE_ENTITY);
     String got = new UnauthorizedException(TEST_PRINCIPAL, actions, TEST_NAMESPACE_ENTITY, false).getMessage();
     Assert.assertEquals(expected, got);
   }
@@ -95,7 +95,7 @@ public class UnauthorizedExceptionTest {
     Set<String> actions = new LinkedHashSet<>();
     actions.add(Action.ADMIN.toString());
     String entityString = String.format("entity '%s'", TEST_NAMESPACE_ENTITY);
-    String expected = String.format("You are not authorized to perform action '%s' on %s", Action.ADMIN,
+    String expected = String.format("Insufficient permissions to perform action '%s' on %s.", Action.ADMIN,
                                     entityString);
     String got = new UnauthorizedException(null, actions, entityString, null, true, false, null).getMessage();
     Assert.assertEquals(expected, got);
@@ -107,7 +107,7 @@ public class UnauthorizedExceptionTest {
     permissions.add("test-permission-1");
     permissions.add("test-permissions-2");
     String entityString = "custom resource 'test-resource'";
-    String expected = String.format("You are not authorized to perform actions '%s' on %s", permissions,
+    String expected = String.format("Insufficient permissions to perform actions '%s' on %s.", permissions,
                                     entityString);
     String got = new UnauthorizedException(null, permissions, entityString, null, true, false, null).getMessage();
     Assert.assertEquals(expected, got);
@@ -119,8 +119,8 @@ public class UnauthorizedExceptionTest {
     permissions.add("test-permission-1");
     permissions.add("test-permissions-2");
     String entityString = "custom resource 'test-resource'";
-    String expected = String.format("You are not authorized to perform actions '%s' on %s test addendum", permissions,
-                                    entityString);
+    String expected = String.format("Insufficient permissions to perform actions '%s' on %s. test addendum",
+                                    permissions, entityString);
     String got = new UnauthorizedException(null, permissions, entityString, null, true, false, " test addendum")
       .getMessage();
     Assert.assertEquals(expected, got);

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java
@@ -620,7 +620,9 @@ public class AuthorizationTest extends TestBase {
     URL url = new URL(serviceManager.getServiceURL(5, TimeUnit.SECONDS), "write/data");
     HttpResponse response = executeHttp(HttpRequest.put(url).build());
     Assert.assertEquals(500, response.getResponseCode());
-    Assert.assertTrue(response.getResponseBodyAsString().contains("'" + BOB + "' is not authorized"));
+    // This is a hack that works around the fact that we cannot properly catch exceptions in the service handler.
+    // TODO: Figure out a way to stop checking error messages.
+    Assert.assertTrue(response.getResponseBodyAsString().contains("'" + BOB + "' has insufficient permissions"));
 
     serviceManager.stop();
     serviceManager.waitForStopped(10, TimeUnit.SECONDS);


### PR DESCRIPTION
Slightly modify wording of error messages to be more user friendly.