### PR TITLE
Switch to trigger/build schema. 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+# Copyright © 2020 Cask Data, Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+# Note: Any changes to this workflow would be used only after merging into develop
+name: Build with unit tests
+
+on:
+  workflow_run:
+    workflows:
+      - Trigger build
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: k8s-runner-build
+
+    if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
+
+    steps:
+      # Pinned 1.0.0 version
+      - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94
+      - uses: actions/checkout@v2.3.4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+      - name: Cache
+        uses: actions/cache@v2.1.3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ github.workflow }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-${{ github.workflow }}
+      - name: Build with Maven
+        run: mvn clean test -fae -T 2 -B -V -P templates,skip-hbase-compat-tests -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v2.2.2
+        if: always()
+        with:
+          name: Build debug files
+          path: |
+            **/target/rat.txt
+            **/target/surefire-reports/*
+      - name: Surefire Report
+        # Pinned 1.0.5 version
+        uses: ScaCap/action-surefire-report@ad808943e6bfbd2e6acba7c53fdb5c89534da533
+        if: always()
+        with:
+          # GITHUB_TOKEN
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          commit: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/trigger.yml
+++ b/.github/workflows/trigger.yml
@@ -1,0 +1,47 @@
+# Copyright © 2021 Cask Data, Inc.
+#  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+#  use this file except in compliance with the License. You may obtain a copy of
+#  the License at
+#  http://www.apache.org/licenses/LICENSE-2.0
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations under
+#  the License.
+
+# This workflow will trigger build.yml only when needed.
+# This way we don't flood main workflow run list
+# Note that build.yml from develop will be used even for PR builds
+# Also it will have access to the proper GITHUB_SECRET
+
+name: Trigger build
+
+on:
+  push:
+    branches: [ develop, release/** ]
+  pull_request:
+    branches: [ develop, release/** ]
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+
+    # We allow builds:
+    # 1) When triggered manually
+    # 2) When it's a merge into a branch
+    # 3) For PRs that are labeled as build and
+    #  - It's a code change
+    #  - A build label was just added
+    # A bit complex, but prevents builds when other labels are manipulated
+    if: >
+      github.event_name == 'workflow_dispatch'
+      || github.event_name == 'push'
+      || (contains(github.event.pull_request.labels.*.name, 'build')
+         && (github.event.action != 'labeled' || github.event.label.name == 'build')
+         )
+
+    steps:
+      - name: Trigger build
+        run: echo Maven build will be triggered now


### PR DESCRIPTION
Trigger runs on PR and triggers build.yml from develop branch. This allows us to do next things:

 * Don't run build for unrelated tag changes. E.g. when someone adds "6.4" label this won't trigger a build anymore.
 * Run additional actions that need github token. Since it's runnign from develop it's considered safe and github provides a necessary token.

Note this is first PR to add this schema. As soon as it works I will remove an old workflow. Two-step is required since it starts to work only after merging to develop.