### PR TITLE
Further optimization of file handling. 

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -214,7 +214,7 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
     try {
       File programJar = Locations.linkOrCopy(programJarLocation, new File(tempDir, "program.jar"));
       // Unpack the JAR file
-      BundleJarUtil.unJar(programJar, unpackedDir);
+      BundleJarUtil.prepareClassLoaderFolder(programJar, unpackedDir);
     } catch (IOException ioe) {
       throw ioe;
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/AbstractArtifactManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/AbstractArtifactManager.java
@@ -85,7 +85,7 @@ public abstract class AbstractArtifactManager implements ArtifactManager {
   public CloseableClassLoader createClassLoader(@Nullable String namespace, ArtifactInfo artifactInfo,
                                                 @Nullable ClassLoader parentClassLoader) throws IOException {
     File unpackedDir = DirUtils.createTempDir(tmpDir);
-    BundleJarUtil.unJar(getArtifactLocation(artifactInfo, namespace), unpackedDir);
+    BundleJarUtil.prepareClassLoaderFolder(getArtifactLocation(artifactInfo, namespace), unpackedDir);
     DirectoryClassLoader directoryClassLoader =
       new DirectoryClassLoader(unpackedDir,
                                parentClassLoader == null ? bootstrapClassLoader : parentClassLoader, "lib");

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactClassLoaderFactory.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactClassLoaderFactory.java
@@ -121,7 +121,7 @@ final class ArtifactClassLoaderFactory {
       final File unpackDir = entityImpersonator.impersonate(new Callable<File>() {
         @Override
         public File call() throws IOException {
-          return BundleJarUtil.unJar(artifactLocation, DirUtils.createTempDir(tmpDir));
+          return BundleJarUtil.prepareClassLoaderFolder(artifactLocation, DirUtils.createTempDir(tmpDir));
         }
       });
 
@@ -169,7 +169,7 @@ final class ArtifactClassLoaderFactory {
       final File unpackDir = entityImpersonator.impersonate(new Callable<File>() {
         @Override
         public File call() throws IOException {
-          return BundleJarUtil.unJar(artifactLocation, DirUtils.createTempDir(tmpDir));
+          return BundleJarUtil.prepareClassLoaderFolder(artifactLocation, DirUtils.createTempDir(tmpDir));
         }
       });
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -121,7 +121,7 @@ final class ArtifactInspector {
 
     Path stageDir = Files.createTempDirectory(tmpDir, artifactFile.getName());
     try {
-      File unpackedDir = BundleJarUtil.unJar(artifactLocation,
+      File unpackedDir = BundleJarUtil.prepareClassLoaderFolder(artifactLocation,
                                              Files.createTempDirectory(stageDir, "unpacked-").toFile());
       try (
         CloseableClassLoader artifactClassLoader = artifactClassLoaderFactory.createClassLoader(unpackedDir);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceClassLoader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceClassLoader.java
@@ -290,7 +290,7 @@ public class MapReduceClassLoader extends CombineClassLoader implements AutoClos
         File unpackDir = DirUtils.createTempDir(new File(System.getProperty("user.dir")));
         LOG.info("Create ProgramClassLoader from {}, expand to {}", programLocation, unpackDir);
 
-        BundleJarUtil.unJar(programLocation, unpackDir);
+        BundleJarUtil.prepareClassLoaderFolder(programLocation, unpackDir);
         return new ProgramClassLoader(contextConfig.getCConf(), unpackDir,
                                       FilterClassLoader.create(contextConfig.getHConf().getClassLoader()));
       } catch (IOException e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -226,7 +226,7 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
       new File(systemArgs.getOption(ProgramOptionConstants.APP_SPEC_FILE)), ApplicationSpecification.class);
 
     // Expand the program jar for creating classloader
-    File programJarDir = BundleJarUtil.unJar(
+    File programJarDir = BundleJarUtil.prepareClassLoaderFolder(
       programJarLocation, new File("expanded." + System.currentTimeMillis() + programJarLocation.getName()));
 
     program = Programs.create(cConf, programRunner,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
@@ -319,7 +319,7 @@ public class DefaultRuntimeJob implements RuntimeJob {
       new File(options.getArguments().getOption(ProgramOptionConstants.PROGRAM_JAR)));
     Locations.linkOrCopy(programJarLocation, programJarFile);
     programJarLocation = Locations.toLocation(programJarFile);
-    BundleJarUtil.unJar(programJarLocation, programDir);
+    BundleJarUtil.prepareClassLoaderFolder(programJarLocation, programDir);
 
     return Programs.create(cConf, programRunner, programDescriptor, programJarLocation, programDir);
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
@@ -339,7 +339,7 @@ public class AppFabricTestHelper {
                                        Supplier<File> folderSupplier) throws Exception {
     CConfiguration cConf = getInjector().getInstance(CConfiguration.class);
     return Programs.create(cConf, programRunner, programDescriptor, artifactLocation,
-                           BundleJarUtil.unJar(artifactLocation, folderSupplier.get()));
+                           BundleJarUtil.prepareClassLoaderFolder(artifactLocation, folderSupplier.get()));
 
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -19,7 +19,6 @@ package io.cdap.cdap.internal.app.runtime.artifact;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
 import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.api.artifact.ArtifactClasses;
 import io.cdap.cdap.api.artifact.CloseableClassLoader;
@@ -223,7 +222,7 @@ public class ArtifactInspectorTest {
     Location deploymentJar = AppJarHelper.createDeploymentJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
       cls, manifest);
     DirUtils.mkdirs(destFile.getParentFile());
-    Files.copy(Locations.newInputSupplier(deploymentJar), destFile);
+    Locations.linkOrCopyOverwrite(deploymentJar, destFile);
     return destFile;
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepositoryTest.java
@@ -537,8 +537,8 @@ public class ArtifactRepositoryTest {
     Assert.assertNotNull(plugin);
     Assert.assertEquals(new ArtifactVersion("1.0"), plugin.getKey().getArtifactId().getVersion());
     Assert.assertEquals("TestPlugin2", plugin.getValue().getName());
-    Files.copy(Locations.newInputSupplier(plugin.getKey().getLocation()),
-               new File(pluginDir, Artifacts.getFileName(plugin.getKey().getArtifactId())));
+    Locations.linkOrCopyOverwrite(plugin.getKey().getLocation(),
+                                  new File(pluginDir, Artifacts.getFileName(plugin.getKey().getArtifactId())));
 
     // Create another plugin jar with later version and update the repository
     Id.Artifact artifact2Id = Id.Artifact.from(Id.Namespace.DEFAULT, "myPlugin", "2.0");
@@ -551,8 +551,8 @@ public class ArtifactRepositoryTest {
     Assert.assertNotNull(plugin);
     Assert.assertEquals(new ArtifactVersion("2.0"), plugin.getKey().getArtifactId().getVersion());
     Assert.assertEquals("TestPlugin2", plugin.getValue().getName());
-    Files.copy(Locations.newInputSupplier(plugin.getKey().getLocation()),
-               new File(pluginDir, Artifacts.getFileName(plugin.getKey().getArtifactId())));
+    Locations.linkOrCopyOverwrite(plugin.getKey().getLocation(),
+                                  new File(pluginDir, Artifacts.getFileName(plugin.getKey().getArtifactId())));
 
     // Load the Plugin class from the classLoader.
     try (PluginInstantiator instantiator = new PluginInstantiator(cConf, appClassLoader, pluginDir)) {
@@ -765,13 +765,13 @@ public class ArtifactRepositoryTest {
   private static void copyArtifacts(File pluginDir, SortedMap<ArtifactDescriptor, Set<PluginClass>> plugins)
     throws IOException {
     ArtifactDescriptor descriptor = plugins.firstKey();
-    Files.copy(Locations.newInputSupplier(descriptor.getLocation()),
-               new File(pluginDir, Artifacts.getFileName(descriptor.getArtifactId())));
+    Locations.linkOrCopyOverwrite(descriptor.getLocation(),
+                                  new File(pluginDir, Artifacts.getFileName(descriptor.getArtifactId())));
   }
 
   private static ProgramClassLoader createAppClassLoader(File jarFile) throws IOException {
     File unpackDir = DirUtils.createTempDir(TMP_FOLDER.newFolder());
-    BundleJarUtil.unJar(jarFile, unpackDir);
+    BundleJarUtil.prepareClassLoaderFolder(jarFile, unpackDir);
     return new ProgramClassLoader(cConf, unpackDir,
                                   FilterClassLoader.create(ArtifactRepositoryTest.class.getClassLoader()));
   }
@@ -780,7 +780,7 @@ public class ArtifactRepositoryTest {
     Location deploymentJar = AppJarHelper.createDeploymentJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
                                                               cls, manifest);
     DirUtils.mkdirs(destFile.getParentFile());
-    Files.copy(Locations.newInputSupplier(deploymentJar), destFile);
+    Locations.linkOrCopyOverwrite(deploymentJar, destFile);
     return destFile;
   }
 
@@ -788,7 +788,7 @@ public class ArtifactRepositoryTest {
     Location deploymentJar = PluginJarHelper.createPluginJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
                                                              manifest, cls);
     DirUtils.mkdirs(destFile.getParentFile());
-    Files.copy(Locations.newInputSupplier(deploymentJar), destFile);
+    Locations.linkOrCopyOverwrite(deploymentJar, destFile);
     return destFile;
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/SystemArtifactsAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/SystemArtifactsAuthorizationTest.java
@@ -193,7 +193,7 @@ public class SystemArtifactsAuthorizationTest {
     Location deploymentJar = AppJarHelper.createDeploymentJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
                                                               cls, manifest);
     DirUtils.mkdirs(destFile.getParentFile());
-    Files.copy(Locations.newInputSupplier(deploymentJar), destFile);
+    Locations.linkOrCopyOverwrite(deploymentJar, destFile);
     return destFile;
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
@@ -115,7 +115,7 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, MissingMapReduceWorkflowApp.class);
     File appJarFile = new File(tmpFolder.newFolder(),
                                String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
-    Files.copy(Locations.newInputSupplier(appJar), appJarFile);
+    Locations.linkOrCopyOverwrite(appJar, appJarFile);
     appJar.delete();
 
     try {
@@ -168,7 +168,7 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, appWithWorkflowClass);
     File appJarFile = new File(tmpFolder.newFolder(),
                                String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
-    Files.copy(Locations.newInputSupplier(appJar), appJarFile);
+    Locations.linkOrCopyOverwrite(appJar, appJarFile);
     appJar.delete();
 
     //deploy app
@@ -285,7 +285,7 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     Location appJar = createDeploymentJar(locationFactory, AppWithProgramsUsingGuava.class);
     File appJarFile = new File(tmpFolder.newFolder(),
                                String.format("%s-%s.jar", artifactId.getArtifact(), artifactId.getVersion()));
-    Files.copy(Locations.newInputSupplier(appJar), appJarFile);
+    Locations.linkOrCopyOverwrite(appJar, appJarFile);
     appJar.delete();
 
     applicationLifecycleService.deployAppAndArtifact(NamespaceId.DEFAULT, "appName",

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.internal.app.services;
 
-import com.google.common.io.Files;
 import io.cdap.cdap.AllProgramsApp;
 import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
@@ -117,7 +116,7 @@ public class SystemProgramManagementServiceTest extends AppFabricTestBase {
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, APP_CLASS);
     File appJarFile = new File(tmpFolder.newFolder(),
                                String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
-    Files.copy(Locations.newInputSupplier(appJar), appJarFile);
+    Locations.linkOrCopyOverwrite(appJar, appJarFile);
     appJar.delete();
     artifactRepository.addArtifact(artifactId, appJarFile);
     ArtifactSummary summary = new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -20,7 +20,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closeables;
-import com.google.common.io.Files;
 import com.google.common.io.InputSupplier;
 import com.google.common.util.concurrent.Service;
 import com.google.gson.Gson;
@@ -551,7 +550,7 @@ public abstract class AppFabricTestBase {
 
     File artifactJar = buildAppArtifact(application, application.getSimpleName(), manifest);
     File expandDir = tmpFolder.newFolder();
-    BundleJarUtil.unJar(Locations.toLocation(artifactJar), expandDir);
+    BundleJarUtil.prepareClassLoaderFolder(Locations.toLocation(artifactJar), expandDir);
 
     String versionedApiPath = getVersionedAPIPath("apps/", apiVersion, namespace);
     HttpRequest.Builder builder = HttpRequest.post(getEndPoint(versionedApiPath).toURL())
@@ -1379,7 +1378,7 @@ public abstract class AppFabricTestBase {
 
   protected File buildAppArtifact(Class<?> cls, Manifest manifest, File destination) throws IOException {
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, cls, manifest);
-    Files.copy(Locations.newInputSupplier(appJar), destination);
+    Locations.linkOrCopyOverwrite(appJar, destination);
     return destination;
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityApplierTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityApplierTest.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.internal.capability;
 
-import com.google.common.io.Files;
 import io.cdap.cdap.CapabilityAppWithWorkflow;
 import io.cdap.cdap.WorkflowAppWithFork;
 import io.cdap.cdap.api.annotation.Requirements;
@@ -181,7 +180,7 @@ import java.util.UUID;
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, applicationClass);
     File appJarFile = new File(tmpFolder.newFolder(),
                                String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
-    Files.copy(Locations.newInputSupplier(appJar), appJarFile);
+    Locations.linkOrCopyOverwrite(appJar, appJarFile);
     appJar.delete();
     artifactRepository.addArtifact(artifactId, appJarFile);
     //deploy app

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityManagementServiceTest.java
@@ -602,7 +602,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
     Id.Artifact pluginArtifactId = Id.Artifact.from(Id.Namespace.from(namespace), pluginName, version);
     File pluginJarFile = new File(tmpFolder.newFolder(),
                                   String.format("%s-%s.jar", pluginArtifactId.getName(), version));
-    Files.copy(Locations.newInputSupplier(pluginJar), pluginJarFile);
+    Locations.linkOrCopyOverwrite(pluginJar, pluginJarFile);
     pluginJar.delete();
     artifactRepository.addArtifact(pluginArtifactId, pluginJarFile);
 
@@ -783,7 +783,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, appClass);
     File appJarFile = new File(tmpFolder.newFolder(),
                                String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
-    Files.copy(Locations.newInputSupplier(appJar), appJarFile);
+    Locations.linkOrCopyOverwrite(appJar, appJarFile);
     appJar.delete();
     artifactRepository.addArtifact(artifactId, appJarFile);
   }
@@ -793,7 +793,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, applicationClass);
     File appJarFile = new File(tmpFolder.newFolder(),
                                String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
-    Files.copy(Locations.newInputSupplier(appJar), appJarFile);
+    Locations.linkOrCopyOverwrite(appJar, appJarFile);
     appJar.delete();
     artifactRepository.addArtifact(artifactId, appJarFile);
     //deploy app

--- a/cdap-app-templates/cdap-program-report/src/test/java/io/cdap/cdap/report/ReportGenerationAppTest.java
+++ b/cdap-app-templates/cdap-program-report/src/test/java/io/cdap/cdap/report/ReportGenerationAppTest.java
@@ -306,7 +306,7 @@ public class ReportGenerationAppTest extends TestBase {
     // but spark-avro is not used directly in the application code, explicitly add a class DefaultSource
     // from spark-avro so that spark-avro and its dependencies will be included.
     bundler.createBundle(avroSparkBundle, DefaultSource.class);
-    File unJarDir = BundleJarUtil.unJar(avroSparkBundle, TEMP_FOLDER.newFolder());
+    File unJarDir = BundleJarUtil.prepareClassLoaderFolder(avroSparkBundle, TEMP_FOLDER.newFolder());
 
     ApplicationManager app = deployApplication(deployNamespace,
                                                ReportGenerationApp.class, new File(unJarDir, "lib").listFiles());

--- a/cdap-cli-tests/src/test/java/io/cdap/cdap/cli/CLITestBase.java
+++ b/cdap-cli-tests/src/test/java/io/cdap/cdap/cli/CLITestBase.java
@@ -875,7 +875,7 @@ public abstract class CLITestBase {
     Location deploymentJar = AppJarHelper.createDeploymentJar(locationFactory, cls);
     File appJarFile =
       new File(tmpFolder, String.format("%s-1.0.%d.jar", cls.getSimpleName(), System.currentTimeMillis()));
-    Files.copy(Locations.newInputSupplier(deploymentJar), appJarFile);
+    Locations.linkOrCopy(deploymentJar, appJarFile);
     return appJarFile;
   }
 
@@ -980,7 +980,7 @@ public abstract class CLITestBase {
     Location deploymentJar = AppJarHelper.createDeploymentJar(locationFactory, cls);
     File appJarFile =
       new File(tmpFolder, String.format("%s-1.0.jar", cls.getSimpleName()));
-    Files.copy(Locations.newInputSupplier(deploymentJar), appJarFile);
+    Locations.linkOrCopy(deploymentJar, appJarFile);
     return appJarFile;
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/io/Locations.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/io/Locations.java
@@ -210,11 +210,26 @@ public final class Locations {
   /**
    * Tries to create a hardlink to the given {@link Location} if it is on the local file system. If creation
    * of the hardlink failed or if the Location is not local, it will copy the the location to the given target path.
+   * Unlike {@link #linkOrCopy(Location, File)} will try to overwrite target file if it already exists.
    *
    * @param location location to hardlink or copy from
    * @param targetPath the target file path
    * @return the target path
    * @throws IOException if copying failed
+   */
+  public static File linkOrCopyOverwrite(Location location, File targetPath) throws IOException {
+    targetPath.delete();
+    return linkOrCopy(location, targetPath);
+  }
+
+  /**
+   * Tries to create a hardlink to the given {@link Location} if it is on the local file system. If creation
+   * of the hardlink failed or if the Location is not local, it will copy the the location to the given target path.
+   *
+   * @param location location to hardlink or copy from
+   * @param targetPath the target file path
+   * @return the target path
+   * @throws IOException if copying failed or file already exists
    */
   public static File linkOrCopy(Location location, File targetPath) throws IOException {
     URI uri = location.toURI();

--- a/cdap-common/src/test/java/io/cdap/cdap/common/lang/ClassLoaderTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/lang/ClassLoaderTest.java
@@ -123,7 +123,7 @@ public class ClassLoaderTest {
                                                     ClassLoaderTest.class);
     // Create a class loader that load from that jar.
     File unpackDir = TMP_FOLDER.newFolder();
-    BundleJarUtil.unJar(jar, unpackDir);
+    BundleJarUtil.prepareClassLoaderFolder(jar, unpackDir);
     ClassLoader cl = new DirectoryClassLoader(unpackDir, null, "lib");
 
     // Wrap it with the WeakReference ClassLoader
@@ -150,8 +150,8 @@ public class ClassLoaderTest {
     bundler.createBundle(gsonJar, Gson.class);
 
     // Unpack them
-    File guavaDir = BundleJarUtil.unJar(guavaJar, TMP_FOLDER.newFolder());
-    File gsonDir = BundleJarUtil.unJar(gsonJar, TMP_FOLDER.newFolder());
+    File guavaDir = BundleJarUtil.prepareClassLoaderFolder(guavaJar, TMP_FOLDER.newFolder());
+    File gsonDir = BundleJarUtil.prepareClassLoaderFolder(gsonJar, TMP_FOLDER.newFolder());
 
     // Create a DirectoryClassLoader using guava dir as the main directory, with the gson dir in the extra classpath
     String extraClassPath = gsonDir.getAbsolutePath() + File.pathSeparatorChar + gsonDir.getAbsolutePath() + "/lib/*";

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/type/DatasetTypeManager.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/type/DatasetTypeManager.java
@@ -126,7 +126,7 @@ public class DatasetTypeManager {
         try {
           // NOTE: if jarLocation is null, we assume that this is a system module, ie. always present in classpath
           if (jarLocation != null) {
-            BundleJarUtil.unJar(jarLocation, unpackedLocation);
+            BundleJarUtil.prepareClassLoaderFolder(jarLocation, unpackedLocation);
             cl = new DirectoryClassLoader(unpackedLocation, cConf.get(Constants.AppFabric.PROGRAM_EXTRA_CLASSPATH),
                                           FilterClassLoader.create(getClass().getClassLoader()), "lib");
           }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/type/DirectoryClassLoaderProvider.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/type/DirectoryClassLoaderProvider.java
@@ -134,7 +134,7 @@ public class DirectoryClassLoaderProvider implements DatasetClassLoaderProvider 
       }
       Location jarLocation = Locations.getLocationFromAbsolutePath(locationFactory, key.uri.getPath());
       File unpackedDir = DirUtils.createTempDir(tmpDir);
-      BundleJarUtil.unJar(jarLocation, unpackedDir);
+      BundleJarUtil.prepareClassLoaderFolder(jarLocation, unpackedDir);
       LOG.trace("unpacking dataset jar from {} to {}.", key.uri.toString(), unpackedDir.getAbsolutePath());
 
       return new DirectoryClassLoader(unpackedDir, key.parentClassLoader, "lib");

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -19,7 +19,6 @@ package io.cdap.cdap.data2.datafabric.dataset.service;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
@@ -309,7 +308,7 @@ public abstract class DatasetServiceTestBase {
     File[] embeddedJars = new File[bundleEmbeddedJars.length];
     for (int i = 0; i < bundleEmbeddedJars.length; i++) {
       File file = TMP_FOLDER.newFile();
-      Files.copy(Locations.newInputSupplier(bundleEmbeddedJars[i]), file);
+      Locations.linkOrCopyOverwrite(bundleEmbeddedJars[i], file);
       embeddedJars[i] = file;
     }
 

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayFastTestsSuite.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayFastTestsSuite.java
@@ -163,7 +163,7 @@ public class GatewayFastTestsSuite extends GatewayTestBase {
     LocationFactory locationFactory = new LocalLocationFactory(tmpFolder);
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, cls);
     File destination = new File(DirUtils.createTempDir(tmpFolder), name);
-    Files.copy(Locations.newInputSupplier(appJar), destination);
+    Locations.linkOrCopy(appJar, destination);
     return destination;
   }
 

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizerInstantiator.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizerInstantiator.java
@@ -201,7 +201,7 @@ public class AuthorizerInstantiator implements Closeable, Supplier<Authorizer> {
     throws IOException, InvalidAuthorizerException {
     LOG.info("Creating authorization extension using jar {}.", authorizerExtensionJar);
     try {
-      BundleJarUtil.unJar(Locations.toLocation(authorizerExtensionJar), tmpDir);
+      BundleJarUtil.prepareClassLoaderFolder(Locations.toLocation(authorizerExtensionJar), tmpDir);
       return new AuthorizerClassLoader(tmpDir, authorizerExtraClasspath);
     } catch (ZipException e) {
       throw new InvalidAuthorizerException(


### PR DESCRIPTION
https://github.com/cdapio/cdap/pull/13263 have shown great performance gains on both unit tests and performance tests. So, this are more wide optimizations in the same direction
 * Globally unpack only nested jars and manifests and use other classes/resources from the original jar as is.
 * Cache jar creation in tests as it takes significant time on test start and it can be reused between tests and even within one test that creates multiple apps (e.g. DataPipelineTest)
 * Replace file copy with hard links