### PR TITLE
Bamboo build  fails due to resource limit

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams2_2.11/pom.xml
@@ -211,6 +211,14 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <version>3.5.0</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- Bamboo runners get out of threads, reduce until after we migrate from bamboo -->
+          <forkCount>1</forkCount>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/cdap-app-templates/cdap-etl/cdap-data-streams3_2.12/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams3_2.12/pom.xml
@@ -221,6 +221,14 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <version>3.3.0</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- Bamboo runners get out of threads, reduce until after we migrate from bamboo -->
+          <forkCount>1</forkCount>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Bamboo build gets "java.lang.OutOfMemoryError: unable to create new native thread", reduce forkCount to fix