### PR TITLE
Skip PySpark test on Spark 3 with wrong python

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/spark/SparkCompatReader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/spark/SparkCompatReader.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.internal.app.spark;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.runtime.spi.SparkCompat;
@@ -75,7 +76,8 @@ public class SparkCompatReader {
       String.format("Invalid SparkCompat version '%s'. Must be one of %s", compatStr, allowedCompatStrings));
   }
 
-  private static SparkCompat getCurrentSparkCompat() {
+  @VisibleForTesting
+  public static SparkCompat getCurrentSparkCompat() {
     String sparkVersion = package$.MODULE$.SPARK_VERSION();
     switch (sparkVersion.charAt(0)) {
       case '3':


### PR DESCRIPTION
We need to skip PySpark test on Spark 3 with python before 2.7 (e.g. bamboo)