### PR TITLE
(CDAP-17939) TMS TTL cleanup logic improvement

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ScheduledRunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ScheduledRunRecordCorrectorService.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,7 @@ public class ScheduledRunRecordCorrectorService extends RunRecordCorrectorServic
   protected void startUp() throws Exception {
     super.startUp();
 
-    scheduledExecutorService = Executors.newScheduledThreadPool(1);
+    scheduledExecutorService = Executors.newScheduledThreadPool(1, Threads.createDaemonThreadFactory("run-corrector"));
     // Schedule the run record corrector with the configured initial delay and interval between runs
     scheduledExecutorService.scheduleWithFixedDelay(new RunRecordsCorrectorRunnable(),
        initialDelay, interval, TimeUnit.SECONDS);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityManagementService.java
@@ -83,16 +83,4 @@ public class CapabilityManagementService extends AbstractRetryableScheduledServi
     }
     return capabilityConfigs;
   }
-
-  @Override
-  public void doStartUp() throws Exception {
-    super.doStartUp();
-    capabilityApplier.doStartup();
-  }
-
-  @Override
-  public void doShutdown() throws Exception {
-    super.doShutdown();
-    capabilityApplier.doShutdown();
-  }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/AutoInstallTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/AutoInstallTest.java
@@ -129,10 +129,8 @@ public class AutoInstallTest {
     Mockito.doReturn("6.4.0").when(ca).getCurrentVersion();
 
     // Test plugin auto install
-    ca.doStartup();
     ca.autoInstallResources("mycapability",
                             Collections.singletonList(new URL("https://my.hub.io")));
-    ca.doShutdown();
 
     // Verify that the correct version of the plugin was installed
     Set<ArtifactRange> ranges = ImmutableSet.of(

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1381,6 +1381,7 @@ public final class Constants {
 
     public static final String LOCAL_DATA_DIR = "messaging.local.data.dir";
     public static final String LOCAL_DATA_CLEANUP_FREQUENCY = "messaging.local.data.cleanup.frequency.secs";
+    public static final String LOCAL_DATA_CLEANUP_BATCH_SIZE = "messaging.local.data.cleanup.batch.size";
 
     public static final String CACHE_SIZE_MB = "messaging.cache.size.mb";
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2142,6 +2142,14 @@
   </property>
 
   <property>
+    <name>messaging.local.data.cleanup.batch.size</name>
+    <value>1048576</value>
+    <description>
+      The maximum number of message entry deletion to batch up during the time-to-live cleanup
+    </description>
+  </property>
+
+  <property>
     <name>messaging.local.data.dir</name>
     <value>${local.data.dir}/messaging</value>
     <description>

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/MessageTable.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/MessageTable.java
@@ -20,7 +20,6 @@ import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.messaging.RollbackDetail;
 import io.cdap.cdap.messaging.TopicMetadata;
 import io.cdap.cdap.messaging.data.MessageId;
-import io.cdap.cdap.proto.id.TopicId;
 import org.apache.tephra.Transaction;
 
 import java.io.Closeable;
@@ -38,17 +37,12 @@ public interface MessageTable extends Closeable {
   /**
    * Represents an entry (row) in the message table.
    */
-  interface Entry {
+  interface Entry extends TableEntry {
 
-    /**
-     * Returns the topic id that the entry belongs to.
-     */
-    TopicId getTopicId();
-
-    /**
-     * Returns the generation id of the topic.
-     */
-    int getGeneration();
+    @Override
+    default long getTimestamp() {
+      return getPublishTimestamp();
+    }
 
     /**
      * Returns {@code true} if the entry is a reference to messages stored in payload table.

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/PayloadTable.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/PayloadTable.java
@@ -19,7 +19,6 @@ package io.cdap.cdap.messaging.store;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.messaging.TopicMetadata;
 import io.cdap.cdap.messaging.data.MessageId;
-import io.cdap.cdap.proto.id.TopicId;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -35,22 +34,12 @@ public interface PayloadTable extends Closeable {
   /**
    * Represents an entry (row) in the payload table.
    */
-  interface Entry {
+  interface Entry extends TableEntry {
 
-    /**
-     * Returns the topic id that the entry belongs to.
-     */
-    TopicId getTopicId();
-
-    /**
-     * Returns the generation id of the topic.
-     */
-    int getGeneration();
-
-    /**
-     * Returns the message payload.
-     */
-    byte[] getPayload();
+    @Override
+    default long getTimestamp() {
+      return getPayloadWriteTimestamp();
+    }
 
     /**
      * Returns the transaction write pointer for storing the payload.

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/TableEntry.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/TableEntry.java
@@ -1,0 +1,4 @@
+package io.cdap.cdap.messaging.store;/**
+ *
+ */public class TableEntry {
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/TableEntry.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/TableEntry.java
@@ -1,4 +1,45 @@
-package io.cdap.cdap.messaging.store;/**
+/*
+ * Copyright © 2021 Cask Data, Inc.
  *
- */public class TableEntry {
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.store;
+
+import io.cdap.cdap.proto.id.TopicId;
+
+/**
+ * The base class for an entry in messaging table.
+ */
+public interface TableEntry {
+
+  /**
+   * Returns the topic id that the entry belongs to.
+   */
+  TopicId getTopicId();
+
+  /**
+   * Returns the generation id of the topic.
+   */
+  int getGeneration();
+
+  /**
+   * Returns the message payload.
+   */
+  byte[] getPayload();
+
+  /**
+   * Returns the timestamp in milliseconds when this entry was written to the table.
+   */
+  long getTimestamp();
 }

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBMessageTable.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBMessageTable.java
@@ -20,13 +20,9 @@ import com.google.common.base.Preconditions;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.dataset.lib.AbstractCloseableIterator;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
-import io.cdap.cdap.messaging.MessagingUtils;
-import io.cdap.cdap.messaging.TopicMetadata;
 import io.cdap.cdap.messaging.store.AbstractMessageTable;
-import io.cdap.cdap.messaging.store.ImmutableMessageTableEntry;
 import io.cdap.cdap.messaging.store.MessageTable;
 import io.cdap.cdap.messaging.store.RawMessageTableEntry;
-import io.cdap.cdap.proto.id.TopicId;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBException;
 import org.iq80.leveldb.WriteBatch;
@@ -37,7 +33,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -65,19 +60,9 @@ final class LevelDBMessageTable extends AbstractMessageTable {
   }
 
   private final DB levelDB;
-  private final TopicMetadata topicMetadata;
 
-  LevelDBMessageTable(DB levelDB, TopicMetadata topicMetadata) {
+  LevelDBMessageTable(DB levelDB) {
     this.levelDB = levelDB;
-    this.topicMetadata = topicMetadata;
-  }
-
-  private void checkTopic(TopicId topicId, int generation) {
-    Preconditions.checkArgument(this.topicMetadata.getTopicId().equals(topicId), "Not allowed to use table with a " +
-      "different topic id. Table's topic Id: {}. Specified topic id: {}", this.topicMetadata.getTopicId(), topicId);
-    Preconditions.checkArgument(this.topicMetadata.getGeneration() == generation, "Not allowed to use table with " +
-                                  "a different generation id. Table's generation: {}. Specified generation: {}",
-                                this.topicMetadata.getGeneration(), generation);
   }
 
   @Override
@@ -148,50 +133,6 @@ final class LevelDBMessageTable extends AbstractMessageTable {
   public void close() {
     // This method has to be an no-op instead of closing the underlying LevelDB object
     // This is because a given LevelDB object instance is shared within the same JVM
-  }
-
-  /**
-   * Delete messages of a {@link TopicId} that has exceeded the TTL or if it belongs to an older generation
-   *
-   * @param currentTime current timestamp
-   * @throws IOException error occurred while trying to delete a row in LevelDB
-   */
-  void pruneMessages(long currentTime) throws IOException {
-    WriteBatch writeBatch = levelDB.createWriteBatch();
-    long ttlInMs = TimeUnit.SECONDS.toMillis(topicMetadata.getTTL());
-    byte[] startRow = MessagingUtils.toDataKeyPrefix(topicMetadata.getTopicId(),
-                                                     Integer.parseInt(MessagingUtils.Constants.DEFAULT_GENERATION));
-    byte[] stopRow = Bytes.stopKeyForPrefix(startRow);
-
-    try (CloseableIterator<Map.Entry<byte[], byte[]>> rowIterator = new DBScanIterator(levelDB, startRow, stopRow)) {
-      while (rowIterator.hasNext()) {
-        Map.Entry<byte[], byte[]> entry = rowIterator.next();
-        MessageTable.Entry messageTableEntry = new ImmutableMessageTableEntry(entry.getKey(), null, null);
-
-        int dataGeneration = messageTableEntry.getGeneration();
-        int currGeneration = topicMetadata.getGeneration();
-        checkTopic(topicMetadata.getTopicId(), topicMetadata.getGeneration());
-        if (MessagingUtils.isOlderGeneration(dataGeneration, currGeneration)) {
-          writeBatch.delete(entry.getKey());
-          continue;
-        }
-
-        if ((dataGeneration == Math.abs(currGeneration)) &&
-          ((currentTime - messageTableEntry.getPublishTimestamp()) > ttlInMs)) {
-          writeBatch.delete(entry.getKey());
-        } else {
-          // terminate scanning table once an entry with publish time after TTL is found, to avoid scanning whole table,
-          // since the entries are sorted by time.
-          break;
-        }
-      }
-    }
-
-    try {
-      levelDB.write(writeBatch, WRITE_OPTIONS);
-    } catch (DBException ex) {
-      throw new IOException(ex);
-    }
   }
 
   // Encoding:

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTableFactory.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTableFactory.java
@@ -19,20 +19,28 @@ package io.cdap.cdap.messaging.store.leveldb;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Closeables;
 import com.google.inject.Inject;
+import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.utils.DirUtils;
+import io.cdap.cdap.messaging.MessagingUtils;
 import io.cdap.cdap.messaging.TopicMetadata;
+import io.cdap.cdap.messaging.store.ImmutableMessageTableEntry;
+import io.cdap.cdap.messaging.store.ImmutablePayloadTableEntry;
 import io.cdap.cdap.messaging.store.MessageTable;
 import io.cdap.cdap.messaging.store.MetadataTable;
 import io.cdap.cdap.messaging.store.PayloadTable;
+import io.cdap.cdap.messaging.store.TableEntry;
 import io.cdap.cdap.messaging.store.TableFactory;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.TopicId;
 import org.apache.twill.common.Threads;
 import org.iq80.leveldb.DB;
+import org.iq80.leveldb.DBException;
 import org.iq80.leveldb.Options;
+import org.iq80.leveldb.WriteBatch;
+import org.iq80.leveldb.WriteOptions;
 import org.iq80.leveldb.impl.Iq80DBFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,11 +51,13 @@ import java.util.Collection;
 import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 /**
  * A {@link TableFactory} for creating tables used by the messaging system using the LevelDB implementation.
@@ -75,16 +85,19 @@ public final class LevelDBTableFactory implements TableFactory {
       .cacheSize(cConf.getLong(Constants.CFG_DATA_LEVELDB_CACHESIZE, Constants.DEFAULT_DATA_LEVELDB_CACHESIZE))
       .errorIfExists(false)
       .createIfMissing(true);
-    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
-      Threads.createDaemonThreadFactory("leveldb-tms-data-cleanup"));
-    executor.scheduleAtFixedRate(new DataCleanup(), 0L,
-                                 Long.parseLong(cConf.get(Constants.MessagingSystem.LOCAL_DATA_CLEANUP_FREQUENCY)),
-                                 TimeUnit.SECONDS);
 
     this.metadataTableName = cConf.get(Constants.MessagingSystem.METADATA_TABLE_NAME);
     this.messageTableName = cConf.get(Constants.MessagingSystem.MESSAGE_TABLE_NAME);
     this.payloadTableName = cConf.get(Constants.MessagingSystem.PAYLOAD_TABLE_NAME);
     this.levelDBs = new ConcurrentHashMap<>();
+
+    long cleanupFrequency = Long.parseLong(cConf.get(Constants.MessagingSystem.LOCAL_DATA_CLEANUP_FREQUENCY));
+    // For testing, disable automatic cleanup by having frequency set to <= 0.
+    if (cleanupFrequency > 0) {
+      ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
+        Threads.createDaemonThreadFactory("leveldb-tms-data-cleanup"));
+      executor.scheduleAtFixedRate(this::cleanup, 0L, cleanupFrequency, TimeUnit.SECONDS);
+    }
   }
 
   @Override
@@ -101,12 +114,12 @@ public final class LevelDBTableFactory implements TableFactory {
 
   @Override
   public MessageTable createMessageTable(TopicMetadata topicMetadata) throws IOException {
-    return new LevelDBMessageTable(getLevelDB(topicMetadata, messageTableName), topicMetadata);
+    return new LevelDBMessageTable(getLevelDB(topicMetadata, messageTableName));
   }
 
   @Override
   public PayloadTable createPayloadTable(TopicMetadata topicMetadata) throws IOException {
-    return new LevelDBPayloadTable(getLevelDB(topicMetadata, payloadTableName), topicMetadata);
+    return new LevelDBPayloadTable(getLevelDB(topicMetadata, payloadTableName));
   }
 
   @Override
@@ -122,6 +135,140 @@ public final class LevelDBTableFactory implements TableFactory {
     Collection<DB> dbs = levelDBs.values();
     dbs.forEach(Closeables::closeQuietly);
     dbs.clear();
+  }
+
+  private void cleanup() {
+    performCleanup(System.currentTimeMillis());
+  }
+
+  /**
+   * Performs data cleanup of LevelDB tables and table entries. It removes old topics and old topic generations,
+   * followed by removing old table entries that exceeded TTL.
+   */
+  @VisibleForTesting
+  void performCleanup(long currentTime) {
+    if (metadataTable == null) {
+      return;
+    }
+
+    // First delete all older generation files
+    try (CloseableIterator<TopicMetadata> metadataIterator = metadataTable.scanTopics()) {
+      while (metadataIterator.hasNext()) {
+        TopicMetadata metadata = metadataIterator.next();
+        int currGeneration = metadata.getGeneration();
+
+        // We can safely remove all generations that are less than `cleanOlderThan`.
+        int cleanOlderThan = currGeneration < 0 ? currGeneration * -1 + 1 : currGeneration;
+
+        // Find the generations older than `cleanOlderThan`, that have data on disk, and remove them in reverse order.
+        // We do it in reverse order, so that in case there is a failure in deleting one of them, we can repeat
+        // the same process next iteration and not lose track of generations that need to be deleted.
+        Deque<File> filesToDelete = new LinkedList<>();
+        for (int olderGeneration = cleanOlderThan - 1; olderGeneration > 0; olderGeneration--) {
+          // Message table
+          File dataDBPath = getDataDBPath(messageTableName, metadata.getTopicId(), olderGeneration);
+          if (!dataDBPath.exists()) {
+            break;
+          }
+          // We can safely remove and close the levelDB as no one should be accessing them anymore
+          Closeables.closeQuietly(levelDBs.remove(dataDBPath));
+          filesToDelete.add(dataDBPath);
+
+          // Payload table
+          dataDBPath = getDataDBPath(payloadTableName, metadata.getTopicId(), olderGeneration);
+          if (!dataDBPath.exists()) {
+            break;
+          }
+          // We can safely remove and close the levelDB as no one should be accessing them anymore
+          Closeables.closeQuietly(levelDBs.remove(dataDBPath));
+          filesToDelete.add(dataDBPath);
+        }
+
+        Iterator<File> descendingIterator = filesToDelete.descendingIterator();
+        while (descendingIterator.hasNext()) {
+          File dataDBPath = descendingIterator.next();
+          LOG.info("Deleting file: {}", dataDBPath);
+          DirUtils.deleteDirectoryContents(dataDBPath);
+        }
+
+        // Prune the current generation
+        // Message table
+        File dataDBPath = getDataDBPath(messageTableName, metadata.getTopicId(), metadata.getGeneration());
+        DB levelDB = levelDBs.get(dataDBPath);
+        if (levelDB != null && dataDBPath.exists()) {
+          // The payload is not needed for pruning, hence passing in null.
+          pruneMessages(currentTime, levelDB, metadata, e -> new ImmutableMessageTableEntry(e.getKey(), null, null));
+        }
+
+        // Payload table
+        dataDBPath = getDataDBPath(payloadTableName, metadata.getTopicId(), metadata.getGeneration());
+        levelDB = levelDBs.get(dataDBPath);
+        if (levelDB != null && dataDBPath.exists()) {
+          // The payload is not needed for pruning, hence passing in null.
+          pruneMessages(currentTime, levelDB, metadata, e -> new ImmutablePayloadTableEntry(e.getKey(),
+                                                                                            Bytes.EMPTY_BYTE_ARRAY));
+        }
+      }
+    } catch (IOException ex) {
+      LOG.debug("Unable to perform data cleanup in TMS LevelDB tables", ex);
+    }
+  }
+
+  /**
+   * Delete messages of a {@link TopicId} that has exceeded the TTL or if it belongs to an older generation
+   *
+   * @param currentTime current timestamp
+   * @throws IOException error occurred while trying to delete a row in LevelDB
+   */
+  private void pruneMessages(long currentTime, DB levelDB, TopicMetadata topicMetadata,
+                             Function<Map.Entry<byte[], byte[]>, TableEntry> tableEntryFunc) throws IOException {
+    TopicId topicId = topicMetadata.getTopicId();
+    int topicGeneration = topicMetadata.getGeneration();
+
+    WriteBatch writeBatch = levelDB.createWriteBatch();
+    long ttlInMs = TimeUnit.SECONDS.toMillis(topicMetadata.getTTL());
+    byte[] startRow = MessagingUtils.toDataKeyPrefix(topicId,
+                                                     Integer.parseInt(MessagingUtils.Constants.DEFAULT_GENERATION));
+    byte[] stopRow = Bytes.stopKeyForPrefix(startRow);
+
+    try (CloseableIterator<Map.Entry<byte[], byte[]>> rowIterator = new DBScanIterator(levelDB, startRow, stopRow)) {
+      while (rowIterator.hasNext()) {
+        Map.Entry<byte[], byte[]> entry = rowIterator.next();
+        TableEntry tableEntry = tableEntryFunc.apply(entry);
+
+        int dataGeneration = tableEntry.getGeneration();
+        if (!topicId.equals(tableEntry.getTopicId())) {
+          LOG.warn("Ignore table entry with topic '{}' that doesn't match with the topic '{}'",
+                   tableEntry.getTopicId(), topicId);
+          continue;
+        }
+        if (topicGeneration != dataGeneration) {
+          LOG.warn("Ignore table entry with topic generation '{}' that doesn't match with the topic generation '{}'",
+                   tableEntry.getGeneration(), dataGeneration);
+          continue;
+        }
+
+        if (MessagingUtils.isOlderGeneration(dataGeneration, topicGeneration)) {
+          writeBatch.delete(entry.getKey());
+          continue;
+        }
+
+        if ((dataGeneration == Math.abs(topicGeneration)) &&
+          ((currentTime - tableEntry.getTimestamp()) > ttlInMs)) {
+          writeBatch.delete(entry.getKey());
+        } else {
+          // terminate scanning table once an entry with write time after TTL is found, to avoid scanning whole table,
+          // since the entries are sorted by time.
+          break;
+        }
+      }
+    }
+
+    try {
+      levelDB.write(writeBatch, new WriteOptions().sync(true));
+    } catch (DBException ex) {
+      throw new IOException(ex);
+    }
   }
 
   /**
@@ -165,76 +312,5 @@ public final class LevelDBTableFactory implements TableFactory {
       throw new IOException("Failed to create local directory " + dir + " for the messaging system.");
     }
     return dir;
-  }
-
-  private class DataCleanup implements Runnable {
-
-    @Override
-    public void run() {
-      if (metadataTable == null) {
-        return;
-      }
-
-      long now = System.currentTimeMillis();
-
-      // First delete all older generation files
-      try (CloseableIterator<TopicMetadata> metadataIterator = metadataTable.scanTopics()) {
-        while (metadataIterator.hasNext()) {
-          TopicMetadata metadata = metadataIterator.next();
-          int currGeneration = metadata.getGeneration();
-
-          // We can safely remove all generations that are less than `cleanOlderThan`.
-          int cleanOlderThan = currGeneration < 0 ? currGeneration * -1 + 1 : currGeneration;
-
-          // Find the generations older than `cleanOlderThan`, that have data on disk, and remove them in reverse order.
-          // We do it in reverse order, so that in case there is a failure in deleting one of them, we can repeat
-          // the same process next iteration and not lose track of generations that need to be deleted.
-          Deque<File> filesToDelete = new LinkedList<>();
-          for (int olderGeneration = cleanOlderThan - 1; olderGeneration > 0; olderGeneration--) {
-            // Message table
-            File dataDBPath = getDataDBPath(messageTableName, metadata.getTopicId(), olderGeneration);
-            if (!dataDBPath.exists()) {
-              break;
-            }
-            // We can safely remove and close the levelDB as no one should be accessing them anymore
-            Closeables.closeQuietly(levelDBs.remove(dataDBPath));
-            filesToDelete.add(dataDBPath);
-
-            // Payload table
-            dataDBPath = getDataDBPath(payloadTableName, metadata.getTopicId(), olderGeneration);
-            if (!dataDBPath.exists()) {
-              break;
-            }
-            // We can safely remove and close the levelDB as no one should be accessing them anymore
-            Closeables.closeQuietly(levelDBs.remove(dataDBPath));
-            filesToDelete.add(dataDBPath);
-          }
-
-          Iterator<File> descendingIterator = filesToDelete.descendingIterator();
-          while (descendingIterator.hasNext()) {
-            File dataDBPath = descendingIterator.next();
-            LOG.info("Deleting file: {}", dataDBPath);
-            DirUtils.deleteDirectoryContents(dataDBPath);
-          }
-
-          // Prune the current generation
-          // Message table
-          File dataDBPath = getDataDBPath(messageTableName, metadata.getTopicId(), metadata.getGeneration());
-          DB levelDB = levelDBs.get(dataDBPath);
-          if (levelDB != null && dataDBPath.exists()) {
-            new LevelDBMessageTable(levelDB, metadata).pruneMessages(now);
-          }
-
-          // Payload table
-          dataDBPath = getDataDBPath(payloadTableName, metadata.getTopicId(), metadata.getGeneration());
-          levelDB = levelDBs.get(dataDBPath);
-          if (levelDB != null && dataDBPath.exists()) {
-            new LevelDBPayloadTable(levelDB, metadata).pruneMessages(now);
-          }
-        }
-      } catch (IOException ex) {
-        LOG.debug("Unable to perform data cleanup in TMS LevelDB tables", ex);
-      }
-    }
   }
 }

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTTLCleanupTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTTLCleanupTest.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.messaging.store.leveldb;
 
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.messaging.TopicMetadata;
@@ -23,11 +25,17 @@ import io.cdap.cdap.messaging.store.DataCleanupTest;
 import io.cdap.cdap.messaging.store.MessageTable;
 import io.cdap.cdap.messaging.store.MetadataTable;
 import io.cdap.cdap.messaging.store.PayloadTable;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.TopicId;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Tests for TTL Cleanup logic in LevelDB.
@@ -45,6 +53,8 @@ public class LevelDBTTLCleanupTest extends DataCleanupTest {
     // Disable the automatic cleanup
     cConf.setInt(Constants.MessagingSystem.LOCAL_DATA_CLEANUP_FREQUENCY, -1);
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
+    // Use a very small batch size
+    cConf.setInt(Constants.MessagingSystem.LOCAL_DATA_CLEANUP_BATCH_SIZE, 1);
     tableFactory = new LevelDBTableFactory(cConf);
   }
 
@@ -66,5 +76,38 @@ public class LevelDBTTLCleanupTest extends DataCleanupTest {
   @Override
   protected MessageTable getMessageTable(TopicMetadata topicMetadata) throws Exception {
     return tableFactory.createMessageTable(topicMetadata);
+  }
+
+  @Test
+  public void testCleanupBatch() throws Exception {
+    TopicId topicId = NamespaceId.DEFAULT.topic("cleanup");
+    TopicMetadata topic = new TopicMetadata(topicId, "ttl", "3", TopicMetadata.GENERATION_KEY, "1");
+    try (MetadataTable metadataTable = getMetadataTable();
+         MessageTable messageTable = getMessageTable(topic)) {
+      metadataTable.createTopic(topic);
+      List<MessageTable.Entry> entries = new ArrayList<>();
+
+      for (int i = 0; i < 100; i++) {
+        entries.add(new TestMessageEntry(topicId, 1, 1, "data" + i, 0L, (short) i));
+      }
+      messageTable.store(entries.iterator());
+
+      // Fetch the entries and make sure we are able to read it
+      try (CloseableIterator<MessageTable.Entry> iterator = messageTable.fetch(topic, 0, Integer.MAX_VALUE, null)) {
+        for (int i = 0; i < 100; i++) {
+          Assert.assertTrue(iterator.hasNext());
+          MessageTable.Entry entry = iterator.next();
+          Assert.assertEquals("data" + i, Bytes.toString(entry.getPayload()));
+        }
+      }
+
+      // Cleanup all messages. We used timestamp = 1 when publishing the data with TTL=3 seconds.
+      // So cleanup with 5 sec as current time should have all data removed
+      tableFactory.performCleanup(5000);
+
+      try (CloseableIterator<MessageTable.Entry> iterator = messageTable.fetch(topic, 0, Integer.MAX_VALUE, null)) {
+        Assert.assertFalse(iterator.hasNext());
+      }
+    }
   }
 }

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTTLCleanupTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTTLCleanupTest.java
@@ -23,37 +23,34 @@ import io.cdap.cdap.messaging.store.DataCleanupTest;
 import io.cdap.cdap.messaging.store.MessageTable;
 import io.cdap.cdap.messaging.store.MetadataTable;
 import io.cdap.cdap.messaging.store.PayloadTable;
-import io.cdap.cdap.messaging.store.TableFactory;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for TTL Cleanup logic in LevelDB.
  */
 public class LevelDBTTLCleanupTest extends DataCleanupTest {
-  private static final int CLEANUP_PERIOD_IN_SECS = 1;
 
   @ClassRule
   public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
-  private static TableFactory tableFactory;
+  private static LevelDBTableFactory tableFactory;
 
   @BeforeClass
   public static void init() throws IOException {
     CConfiguration cConf = CConfiguration.create();
-    cConf.set(Constants.MessagingSystem.LOCAL_DATA_CLEANUP_FREQUENCY, Integer.toString(CLEANUP_PERIOD_IN_SECS));
+    // Disable the automatic cleanup
+    cConf.setInt(Constants.MessagingSystem.LOCAL_DATA_CLEANUP_FREQUENCY, -1);
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
     tableFactory = new LevelDBTableFactory(cConf);
   }
 
   @Override
-  protected void forceFlushAndCompact(Table table) throws Exception {
-    // since we have a periodic thread doing the clean up, we don't/can't do much here.
-    TimeUnit.SECONDS.sleep(CLEANUP_PERIOD_IN_SECS);
+  protected void forceFlushAndCompact(Table table) {
+    tableFactory.performCleanup(System.currentTimeMillis());
   }
 
   @Override


### PR DESCRIPTION
Changes are organized into multiple commits:

1. An unrelated refactoring of the `CapabilityApplier` class to simplify the code and to provide names for threads that it creates
2. Refactoring of the TMS LevelDB table TTL cleanup code to have the pruning logic in one place instead of duplicated in different classes.
3. Introduce a new configuration `messaging.local.data.cleanup.batch.size` to allow configuring a batch size for entries deletion in the TTL cleanup logic. This is to ensure it won't go OOM due to too many keys being held in memory before issuing a batch delete.