### PR TITLE
CDAP-17903 Allow reusing connection in pipeline

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/internal/io/SchemaTypeAdapter.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/internal/io/SchemaTypeAdapter.java
@@ -86,6 +86,8 @@ public final class SchemaTypeAdapter extends TypeAdapter<Schema> {
     JsonToken token = reader.peek();
     switch (token) {
       case NULL:
+        // advance the value otherwise gson won't be able to get over the null value
+        reader.nextNull();
         return null;
       case STRING: {
         // Simple type or know record type

--- a/cdap-api/src/main/java/io/cdap/cdap/api/plugin/PluginConfig.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/plugin/PluginConfig.java
@@ -25,6 +25,12 @@ import java.util.Set;
 
 /**
  * Base class for writing configuration class for template plugin.
+ * This class can also be used inside the plugin configuration class to represent a collection of configs.
+ * If it is used to represent a collection of configs:
+ * When the plugin is deployed, the configs inside this class will be inspected and represented in the same way as
+ * {@link PluginPropertyField}.
+ * The {@link PluginPropertyField} for this field will contain a collection of property names about configs inside
+ * this class.
  */
 @Beta
 public abstract class PluginConfig extends Config implements Serializable {

--- a/cdap-api/src/main/java/io/cdap/cdap/api/plugin/PluginPropertyField.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/plugin/PluginPropertyField.java
@@ -18,7 +18,9 @@ package io.cdap.cdap.api.plugin;
 
 import io.cdap.cdap.api.annotation.Beta;
 
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Contains information about a property used by a plugin.
@@ -32,9 +34,10 @@ public class PluginPropertyField {
   private final boolean required;
   private final boolean macroSupported;
   private final boolean macroEscapingEnabled;
+  private final Set<String> children;
 
   public PluginPropertyField(String name, String description, String type, boolean required, boolean macroSupported,
-                             boolean macroEscapingEnabled) {
+                             boolean macroEscapingEnabled, Set<String> children) {
     if (name == null) {
       throw new IllegalArgumentException("Plugin property name cannot be null");
     }
@@ -51,10 +54,16 @@ public class PluginPropertyField {
     this.required = required;
     this.macroSupported = macroSupported;
     this.macroEscapingEnabled = macroEscapingEnabled;
+    this.children = children;
   }
 
   public PluginPropertyField(String name, String description, String type, boolean required, boolean macroSupported) {
     this(name, description, type, required, macroSupported, false);
+  }
+
+  public PluginPropertyField(String name, String description, String type, boolean required, boolean macroSupported,
+                             boolean macroEscapingEnabled) {
+    this(name, description, type, required, macroSupported, macroEscapingEnabled, Collections.emptySet());
   }
 
   /**
@@ -93,6 +102,14 @@ public class PluginPropertyField {
   }
 
   /**
+   * Returns the list of configs inside this property, empty if it does not contain any.
+   */
+  public Set<String> getChildren() {
+    // need this check to ensure null is not returned for versions below 6.4
+    return children == null ? Collections.emptySet() : children;
+  }
+
+  /**
    * Returns the type of the property.
    */
   public String getType() {
@@ -115,11 +132,12 @@ public class PluginPropertyField {
       && description.equals(that.description)
       && type.equals(that.type)
       && macroSupported == that.macroSupported
-      && macroEscapingEnabled == that.macroEscapingEnabled;
+      && macroEscapingEnabled == that.macroEscapingEnabled
+      && Objects.equals(children, that.children);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, description, type, required, macroSupported, macroEscapingEnabled);
+    return Objects.hash(name, description, type, required, macroSupported, macroEscapingEnabled, children);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginFieldNamingStrategy.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginFieldNamingStrategy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.internal.app.runtime.plugin;
+
+import com.google.gson.FieldNamingStrategy;
+import io.cdap.cdap.api.annotation.Name;
+
+import java.lang.reflect.Field;
+
+/**
+ * Let gson use the name of the annotation when deserialize the object
+ */
+public class PluginFieldNamingStrategy implements FieldNamingStrategy {
+
+  @Override
+  public String translateName(Field field) {
+    Name nameAnnotation = field.getAnnotation(Name.class);
+    return nameAnnotation == null ? field.getName() : nameAnnotation.value();
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginInstantiator.java
@@ -29,6 +29,7 @@ import com.google.common.io.Closeables;
 import com.google.common.primitives.Primitives;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.artifact.ArtifactId;
@@ -76,6 +77,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -338,6 +340,9 @@ public class PluginInstantiator implements Closeable {
                                                       .build());
           macroParser.parse(macroValue);
           if (trackingMacroEvaluator.hasMacro()) {
+            if (!pluginField.getChildren().isEmpty()) {
+              macroFields.addAll(pluginField.getChildren());
+            }
             macroFields.add(pluginEntry.getKey());
             trackingMacroEvaluator.reset();
           }
@@ -511,7 +516,7 @@ public class PluginInstantiator implements Closeable {
       this.invalidProperties = new HashSet<>();
 
       // Don't use a static Gson object to avoid caching of classloader, which can cause classloader leakage.
-      this.gson = new Gson();
+      this.gson = new GsonBuilder().setFieldNamingStrategy(new PluginFieldNamingStrategy()).create();
     }
 
     @Override
@@ -541,22 +546,77 @@ public class PluginInstantiator implements Closeable {
       Name nameAnnotation = field.getAnnotation(Name.class);
       String name = nameAnnotation == null ? field.getName() : nameAnnotation.value();
       PluginPropertyField pluginPropertyField = pluginClass.getProperties().get(name);
-      // if the property is required and it's not a macro and the property doesn't exist
+      // if the property is required and it's not a macro and the property doesn't exist and it is not an config
+      // that is consisted of a collection of configs
+      Set<String> children = pluginPropertyField.getChildren();
       if (pluginPropertyField.isRequired()
-          && !macroFields.contains(name)
-          && properties.getProperties().get(name) == null) {
+            && !macroFields.contains(name)
+            && properties.getProperties().get(name) == null
+            && children.isEmpty()) {
         missingProperties.add(name);
         return;
       }
+
       String value = properties.getProperties().get(name);
+
+      // if the value is null but this field is consisted of children, look up all the child properties to build
+      // the config
+      if (value == null && !children.isEmpty()) {
+        Map<String, String> childProperties = new HashMap<>();
+        boolean missing = false;
+        for (String child : children) {
+          PluginPropertyField childProperty = pluginClass.getProperties().get(child);
+          // if child property is required and it is missing, add it to missing properties and continue
+          if (childProperty.isRequired() && !macroFields.contains(child) &&
+                !properties.getProperties().containsKey(child)) {
+            missingProperties.add(name);
+            missing = true;
+            continue;
+          }
+          childProperties.put(child, properties.getProperties().get(child));
+        }
+
+        // if missing any required field, return here
+        if (missing) {
+          return;
+        }
+        value = gson.toJson(childProperties);
+      }
+
       if (pluginPropertyField.isRequired() || value != null) {
         try {
-          field.set(instance, convertValue(name, declareType,
-                                           declareTypeToken.resolveType(field.getGenericType()), value));
+          Object convertedValue = convertValue(name, declareType,
+                                               declareTypeToken.resolveType(field.getGenericType()), value);
+
+          // set the remaining plugin properties field
+          if (!children.isEmpty() && convertedValue instanceof PluginConfig) {
+            PluginConfig config = (PluginConfig) convertedValue;
+            setChildPluginConfigField(config, "properties", PluginProperties.builder().addAll(
+              properties.getProperties().entrySet().stream()
+                .filter(entry -> children.contains(entry.getKey()))
+                // Collectors.toMap does not take null entry value, so use HashMap instead
+                .collect(HashMap::new, (map, entry)-> map.put(entry.getKey(),
+                                                              entry.getValue()), HashMap::putAll)).build());
+            setChildPluginConfigField(config, "rawProperties", PluginProperties.builder().addAll(
+              rawProperties.getProperties().entrySet().stream()
+                .filter(entry -> children.contains(entry.getKey()))
+                .collect(HashMap::new, (map, entry)-> map.put(entry.getKey(),
+                                                              entry.getValue()), HashMap::putAll)).build());
+            setChildPluginConfigField(config, "macroFields",
+                                      macroFields.stream().filter(children::contains).collect(Collectors.toSet()));
+          }
+          field.set(instance, convertedValue);
         } catch (Exception e) {
           invalidProperties.add(new InvalidPluginProperty(name, e));
         }
       }
+    }
+
+    private void setChildPluginConfigField(PluginConfig config, String fieldName,
+                                           Object fieldVal) throws NoSuchFieldException, IllegalAccessException {
+      Field childField = PluginConfig.class.getDeclaredField(fieldName);
+      childField.setAccessible(true);
+      childField.set(config, fieldVal);
     }
 
     /**

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -38,6 +38,7 @@ import io.cdap.cdap.common.test.AppJarHelper;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.internal.app.runtime.artifact.app.InvalidConfigApp;
 import io.cdap.cdap.internal.app.runtime.artifact.app.inspection.InspectionApp;
+import io.cdap.cdap.internal.app.runtime.artifact.plugin.nested.NestedConfigPlugin;
 import io.cdap.cdap.internal.io.ReflectionSchemaGenerator;
 import io.cdap.cdap.security.impersonation.DefaultImpersonator;
 import io.cdap.cdap.security.impersonation.EntityImpersonator;
@@ -53,6 +54,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.jar.Manifest;
 
@@ -171,6 +173,39 @@ public class ArtifactInspectorTest {
         .setDescription(InspectionApp.PLUGIN_DESCRIPTION)
         .build();
       Assert.assertTrue(classes.getPlugins().containsAll(ImmutableSet.of(expectedPlugin, multipleRequirementPlugin)));
+    }
+  }
+
+  @Test
+  public void testInspectNestedConfigPlugin() throws Exception {
+    Manifest manifest = new Manifest();
+    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, NestedConfigPlugin.class.getPackage().getName());
+    File artifactFile = createJar(NestedConfigPlugin.class, new File(TMP_FOLDER.newFolder(), "NestedPlugin-1.0.0.jar"),
+                                  manifest);
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "NestedPlugin", "1.0.0");
+    Location artifactLocation = Locations.toLocation(artifactFile);
+    try (CloseableClassLoader artifactClassLoader =
+           classLoaderFactory.createClassLoader(
+             ImmutableList.of(artifactLocation).iterator(),
+             new EntityImpersonator(artifactId.toEntityId(), new DefaultImpersonator(CConfiguration.create(), null)))) {
+      ArtifactClasses classes = artifactInspector.inspectArtifact(artifactId, artifactFile, artifactClassLoader,
+                                                                  Collections.emptySet());
+      Set<PluginClass> plugins = classes.getPlugins();
+
+      Map<String, PluginPropertyField> expectedFields = ImmutableMap.of(
+        "X", new PluginPropertyField("X", "", "int", true, false),
+        "Nested", new PluginPropertyField("Nested", "", "nestedconfig", true, true, false,
+                                          ImmutableSet.of("Nested1", "Nested2")),
+        "Nested1", new PluginPropertyField("Nested1", "", "string", true, true),
+        "Nested2", new PluginPropertyField("Nested2", "", "string", true, true)
+      );
+
+      PluginClass expected = PluginClass.builder()
+                               .setName("nested").setType("dummy").setDescription("Nested config")
+                               .setClassName(NestedConfigPlugin.class.getName()).setConfigFieldName("config")
+                               .setProperties(expectedFields).build();
+
+      Assert.assertEquals(Collections.singleton(expected), plugins);
     }
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/plugin/nested/NestedConfigPlugin.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/plugin/nested/NestedConfigPlugin.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.internal.app.runtime.artifact.plugin.nested;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.api.annotation.Description;
+import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.plugin.PluginConfig;
+
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+/**
+ * Plugin which contains nested plugin config
+ */
+@Plugin(type = "dummy")
+@Name("nested")
+@Description("Nested config")
+public class NestedConfigPlugin implements Callable<String> {
+  private Config config;
+
+  @Override
+  public String call() throws Exception {
+    return new Gson().toJson(config);
+  }
+
+  public static class Config extends PluginConfig {
+    @Name("X")
+    public int x;
+
+    @Name("Nested")
+    @Macro
+    public NestedConfig nested;
+
+    public Config(int x, NestedConfig nested) {
+      this.x = x;
+      this.nested = nested;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      Config config = (Config) o;
+      return x == config.x &&
+               Objects.equals(nested, config.nested);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(x, nested);
+    }
+  }
+
+  public static class NestedConfig extends PluginConfig {
+    @Name("Nested1")
+    @Macro
+    public String nested1;
+
+    @Name("Nested2")
+    @Macro
+    public String nested2;
+
+    public NestedConfig(String nested1, String nested2) {
+      this.nested1 = nested1;
+      this.nested2 = nested2;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      NestedConfig that = (NestedConfig) o;
+      return Objects.equals(nested1, that.nested1) &&
+               Objects.equals(nested2, that.nested2);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(nested1, nested2);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ValidationHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ValidationHandler.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.batch.BatchPipelineSpec;
 import io.cdap.cdap.etl.batch.BatchPipelineSpecGenerator;
 import io.cdap.cdap.etl.common.BasicArguments;
+import io.cdap.cdap.etl.common.ConnectionMacroEvaluator;
 import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
 import io.cdap.cdap.etl.common.DefaultPipelineConfigurer;
 import io.cdap.cdap.etl.common.DefaultStageConfigurer;
@@ -142,7 +143,8 @@ public class ValidationHandler extends AbstractSystemHttpServiceHandler {
     // evaluate secure macros
     Map<String, MacroEvaluator> evaluators = ImmutableMap.of(
       SecureStoreMacroEvaluator.FUNCTION_NAME, new SecureStoreMacroEvaluator(namespace, getContext()),
-      OAuthMacroEvaluator.FUNCTION_NAME, new OAuthMacroEvaluator(getContext())
+      OAuthMacroEvaluator.FUNCTION_NAME, new OAuthMacroEvaluator(getContext()),
+      ConnectionMacroEvaluator.FUNCTION_NAME, new ConnectionMacroEvaluator(namespace, getContext())
     );
     MacroEvaluator macroEvaluator = new DefaultMacroEvaluator(new BasicArguments(arguments), evaluators);
 

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineConnectionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineConnectionTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.datapipeline;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.dataset.table.Table;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.etl.api.Engine;
+import io.cdap.cdap.etl.mock.batch.MockSink;
+import io.cdap.cdap.etl.mock.batch.MockSource;
+import io.cdap.cdap.etl.mock.test.HydratorTestBase;
+import io.cdap.cdap.etl.proto.ArtifactSelectorConfig;
+import io.cdap.cdap.etl.proto.connection.ConnectionCreationRequest;
+import io.cdap.cdap.etl.proto.connection.PluginInfo;
+import io.cdap.cdap.etl.proto.v2.ETLBatchConfig;
+import io.cdap.cdap.etl.proto.v2.ETLStage;
+import io.cdap.cdap.etl.spark.Compat;
+import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.artifact.AppRequest;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.test.ApplicationManager;
+import io.cdap.cdap.test.DataSetManager;
+import io.cdap.cdap.test.ServiceManager;
+import io.cdap.cdap.test.TestConfiguration;
+import io.cdap.cdap.test.WorkflowManager;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test for data pipeline using connections
+ */
+public class DataPipelineConnectionTest extends HydratorTestBase {
+  private static final ArtifactId APP_ARTIFACT_ID = NamespaceId.SYSTEM.artifact("cdap-data-pipeline", "6.0.0");
+  private static final ArtifactSummary APP_ARTIFACT = new ArtifactSummary("cdap-data-pipeline", "6.0.0",
+                                                                          ArtifactScope.SYSTEM);
+  private static final Gson GSON = new Gson();
+
+  private static int startCount = 0;
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false,
+                                                                       Constants.Security.Store.PROVIDER, "file",
+                                                                       Constants.AppFabric.SPARK_COMPAT,
+                                                                       Compat.SPARK_COMPAT);
+
+  private static ServiceManager serviceManager;
+  private static ApplicationManager appManager;
+  static URI serviceURI;
+
+  @BeforeClass
+  public static void setupTest() throws Exception {
+    if (startCount++ > 0) {
+      return;
+    }
+    setupBatchArtifacts(APP_ARTIFACT_ID, DataPipelineApp.class);
+
+    enableCapability("pipeline");
+    ApplicationId pipeline = NamespaceId.SYSTEM.app("pipeline");
+    appManager = getApplicationManager(pipeline);
+    waitForAppToDeploy(appManager, pipeline);
+    serviceManager = appManager.getServiceManager(io.cdap.cdap.etl.common.Constants.STUDIO_SERVICE_NAME);
+    serviceManager.startAndWaitForRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
+    serviceURI = serviceManager.getServiceURL(1, TimeUnit.MINUTES).toURI();
+  }
+
+  @Test
+  public void testUsingConnections() throws Exception {
+    testUsingConnections(Engine.SPARK);
+    testUsingConnections(Engine.MAPREDUCE);
+  }
+
+  private void testUsingConnections(Engine engine) throws Exception {
+    String sourceConnName = "sourceConn" + engine;
+    String sinkConnName = "sinkConn" + engine;
+    String srcTableName = "src" + engine;
+    String sinkTableName = "sink" + engine;
+
+    addConnection(
+      sourceConnName, new ConnectionCreationRequest(
+        "", new PluginInfo("test", "dummy", null, Collections.singletonMap("tableName", srcTableName),
+                           new ArtifactSelectorConfig())));
+    addConnection(
+      sinkConnName, new ConnectionCreationRequest(
+        "", new PluginInfo("test", "dummy", null, Collections.singletonMap("tableName", sinkTableName),
+                           new ArtifactSelectorConfig())));
+
+    // source -> sink
+    ETLBatchConfig config = ETLBatchConfig.builder()
+                              .setEngine(engine)
+                              .addStage(new ETLStage("source", MockSource.getPluginUsingConnection(sourceConnName)))
+                              .addStage(new ETLStage("sink", MockSink.getPluginUsingConnection(sinkConnName)))
+                              .addConnection("source", "sink")
+                              .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, config);
+    ApplicationId appId = NamespaceId.DEFAULT.app("testApp" + engine);
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    Schema schema = Schema.recordOf("x", Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+    StructuredRecord samuel = StructuredRecord.builder(schema).set("name", "samuel").build();
+    StructuredRecord dwayne = StructuredRecord.builder(schema).set("name", "dwayne").build();
+
+    // add the dataset by the test, the source won't create it since table name is macro enabled
+    addDatasetInstance(NamespaceId.DEFAULT.dataset(srcTableName), Table.TYPE);
+    DataSetManager<Table> sourceTable = getDataset(srcTableName);
+    MockSource.writeInput(sourceTable, ImmutableList.of(samuel, dwayne));
+
+    WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    manager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 3, TimeUnit.MINUTES);
+
+    DataSetManager<Table> sinkTable = getDataset(sinkTableName);
+    List<StructuredRecord> outputRecords = MockSink.readOutput(sinkTable);
+    Assert.assertEquals(ImmutableSet.of(dwayne, samuel), new HashSet<>(outputRecords));
+
+    // modify the connection to use a new table name for source and sink
+    String newSrcTableName = "new" + srcTableName;
+    String newSinkTableName = "new" + sinkTableName;
+    addConnection(
+      sourceConnName, new ConnectionCreationRequest(
+        "", new PluginInfo("test", "dummy", null, Collections.singletonMap("tableName", newSrcTableName),
+                           new ArtifactSelectorConfig())));
+    addConnection(
+      sinkConnName, new ConnectionCreationRequest(
+        "", new PluginInfo("test", "dummy", null, Collections.singletonMap("tableName", newSinkTableName),
+                           new ArtifactSelectorConfig())));
+
+    addDatasetInstance(NamespaceId.DEFAULT.dataset(newSrcTableName), Table.TYPE);
+    StructuredRecord newRecord1 = StructuredRecord.builder(schema).set("name", "john").build();
+    StructuredRecord newRecord2 = StructuredRecord.builder(schema).set("name", "tom").build();
+    sourceTable = getDataset(newSrcTableName);
+    MockSource.writeInput(sourceTable, ImmutableList.of(newRecord1, newRecord2));
+
+    // run the program again, it should use the new table to read and write
+    manager.start();
+    manager.waitForRuns(ProgramRunStatus.COMPLETED, 2, 3, TimeUnit.MINUTES);
+
+    sinkTable = getDataset(newSinkTableName);
+    outputRecords = MockSink.readOutput(sinkTable);
+    Assert.assertEquals(ImmutableSet.of(newRecord1, newRecord2), new HashSet<>(outputRecords));
+  }
+
+  private void addConnection(String connection, ConnectionCreationRequest creationRequest) throws IOException {
+    URL validatePipelineURL =
+      serviceURI.resolve(String.format("v1/contexts/%s/connections/%s", NamespaceId.DEFAULT.getNamespace(),
+                                       connection)).toURL();
+    HttpRequest request = HttpRequest.builder(HttpMethod.PUT, validatePipelineURL)
+                            .withBody(GSON.toJson(creationRequest))
+                            .build();
+    HttpResponse response = HttpRequests.execute(request, new DefaultHttpRequestConfig(false));
+    Assert.assertEquals(200, response.getResponseCode());
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.etl.common;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.CharStreams;
+import io.cdap.cdap.api.macro.InvalidMacroException;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.retry.RetryableException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Class which contains common logic about retry logic
+ */
+abstract class AbstractServiceRetryableMacroEvaluator implements MacroEvaluator {
+  private static final long TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
+  private static final long RETRY_BASE_DELAY_MILLIS = 200L;
+  private static final long RETRY_MAX_DELAY_MILLIS = TimeUnit.SECONDS.toMillis(5);
+  private static final double RETRY_DELAY_MULTIPLIER = 1.2d;
+  private static final double RETRY_RANDOMIZE_FACTOR = 0.1d;
+
+  private final String functionName;
+
+  AbstractServiceRetryableMacroEvaluator(String functionName) {
+    this.functionName = functionName;
+  }
+
+  @Override
+  public String lookup(String property) throws InvalidMacroException {
+    throw new InvalidMacroException("The '" + functionName
+                                      + "' macro function doesn't support direct property lookup for property '"
+                                      + property + "'");
+  }
+
+  @Override
+  public String evaluate(String macroFunction, String... args) throws InvalidMacroException {
+    if (!functionName.equals(macroFunction)) {
+      // This shouldn't happen
+      throw new IllegalArgumentException("Invalid function name " + macroFunction
+                                           + ". Expecting " + functionName);
+    }
+
+    // Make call with exponential delay on failure retry.
+    long delay = RETRY_BASE_DELAY_MILLIS;
+    double minMultiplier = RETRY_DELAY_MULTIPLIER - RETRY_DELAY_MULTIPLIER * RETRY_RANDOMIZE_FACTOR;
+    double maxMultiplier = RETRY_DELAY_MULTIPLIER + RETRY_DELAY_MULTIPLIER * RETRY_RANDOMIZE_FACTOR;
+    Stopwatch stopWatch = new Stopwatch().start();
+    try {
+      while (stopWatch.elapsedTime(TimeUnit.MILLISECONDS) < TIMEOUT_MILLIS) {
+        try {
+          return evaluateMacro(macroFunction, args);
+        } catch (RetryableException e) {
+          TimeUnit.MILLISECONDS.sleep(delay);
+          delay = (long) (delay * (minMultiplier + Math.random() * (maxMultiplier - minMultiplier + 1)));
+          delay = Math.min(delay, RETRY_MAX_DELAY_MILLIS);
+        } catch (IOException e) {
+          throw new RuntimeException("Failed to evaluate the macro function '" + functionName
+                                       + "' with args " + Arrays.asList(args), e);
+        }
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Thread interrupted while trying to evaluate the macro function '" + functionName
+                                   + "' with args " + Arrays.asList(args), e);
+    }
+    throw new IllegalStateException("Timed out when trying to evaluate the macro function '" + functionName
+                                    + "' with args " + Arrays.asList(args));
+  }
+
+  protected String validateAndRetrieveContent(String serviceName, HttpURLConnection urlConn) throws IOException {
+    if (urlConn == null) {
+      throw new RetryableException("OAuth service is not available");
+    }
+
+    int responseCode = urlConn.getResponseCode();
+    if (responseCode != HttpURLConnection.HTTP_OK) {
+      switch (responseCode) {
+        case HttpURLConnection.HTTP_BAD_GATEWAY:
+        case HttpURLConnection.HTTP_UNAVAILABLE:
+        case HttpURLConnection.HTTP_GATEWAY_TIMEOUT:
+          throw new RetryableException(serviceName + " service is not available with status " + responseCode);
+      }
+      throw new IOException("Failed to call " + serviceName + " service with status " + responseCode + ": " +
+                              getError(urlConn));
+    }
+
+    try (Reader reader = new InputStreamReader(urlConn.getInputStream(), StandardCharsets.UTF_8)) {
+      return CharStreams.toString(reader);
+    } finally {
+      urlConn.disconnect();
+    }
+  }
+
+  abstract String evaluateMacro(String macroFunction,
+                                String... args) throws InvalidMacroException, IOException, RetryableException;
+
+  /**
+   * Returns the full content of the error stream for the given {@link HttpURLConnection}.
+   */
+  private String getError(HttpURLConnection urlConn) {
+    try (InputStream is = urlConn.getErrorStream()) {
+      if (is == null) {
+        return "Unknown error";
+      }
+      return new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      return "Unknown error due to failure to read from error output: " + e.getMessage();
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ConnectionMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ConnectionMacroEvaluator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.etl.common;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.api.ServiceDiscoverer;
+import io.cdap.cdap.api.macro.InvalidMacroException;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.retry.RetryableException;
+import io.cdap.cdap.etl.proto.connection.Connection;
+import io.cdap.cdap.proto.id.NamespaceId;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+/**
+ * A {@link MacroEvaluator} for resolving the {@code ${conn(connection-name)}} macro function. It uses
+ * the studio service for getting connection information at runtime.
+ */
+public class ConnectionMacroEvaluator extends AbstractServiceRetryableMacroEvaluator {
+  public static final String FUNCTION_NAME = "conn";
+  private static final String SERVICE_NAME = "Connection";
+
+  private final String namespace;
+  private final ServiceDiscoverer serviceDiscoverer;
+  private final Gson gson;
+
+
+  public ConnectionMacroEvaluator(String namespace, ServiceDiscoverer serviceDiscoverer) {
+    super(FUNCTION_NAME);
+    this.namespace = namespace;
+    this.serviceDiscoverer = serviceDiscoverer;
+    this.gson = new Gson();
+  }
+
+  /**
+   * Evaluates the connection macro function by calling the Connection service to retrieve the connection information.
+   *
+   * @param args should contains exactly one arguments. The argument should contain the connection name
+   * @return the json representation of the properties of the connection
+   */
+  @Override
+  String evaluateMacro(String macroFunction,
+                       String... args) throws InvalidMacroException, IOException, RetryableException {
+    if (args.length != 1) {
+      throw new InvalidMacroException("Macro '" + FUNCTION_NAME + "' should have exactly 1 arguments");
+    }
+
+    HttpURLConnection urlConn = serviceDiscoverer.openConnection(NamespaceId.SYSTEM.getNamespace(),
+                                                                 Constants.PIPELINEID,
+                                                                 Constants.STUDIO_SERVICE_NAME,
+                                                                 String.format("v1/contexts/%s/connections/%s",
+                                                                               namespace, args[0]));
+    Connection connection = gson.fromJson(validateAndRetrieveContent(SERVICE_NAME, urlConn), Connection.class);
+    return gson.toJson(connection.getPlugin().getProperties());
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultMacroEvaluator.java
@@ -39,7 +39,8 @@ public class DefaultMacroEvaluator implements MacroEvaluator {
     this(arguments, ImmutableMap.of(
       LogicalStartTimeMacroEvaluator.FUNCTION_NAME, new LogicalStartTimeMacroEvaluator(logicalStartTime),
       SecureStoreMacroEvaluator.FUNCTION_NAME, new SecureStoreMacroEvaluator(namespace, secureStore),
-      OAuthMacroEvaluator.FUNCTION_NAME, new OAuthMacroEvaluator(serviceDiscoverer)
+      OAuthMacroEvaluator.FUNCTION_NAME, new OAuthMacroEvaluator(serviceDiscoverer),
+      ConnectionMacroEvaluator.FUNCTION_NAME, new ConnectionMacroEvaluator(namespace, serviceDiscoverer)
     ));
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/OAuthMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/OAuthMacroEvaluator.java
@@ -16,9 +16,6 @@
 
 package io.cdap.cdap.etl.common;
 
-import com.google.common.base.Stopwatch;
-import com.google.common.io.ByteStreams;
-import com.google.common.io.CharStreams;
 import io.cdap.cdap.api.ServiceDiscoverer;
 import io.cdap.cdap.api.macro.InvalidMacroException;
 import io.cdap.cdap.api.macro.MacroEvaluator;
@@ -26,38 +23,22 @@ import io.cdap.cdap.api.retry.RetryableException;
 import io.cdap.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.net.HttpURLConnection;
-import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link MacroEvaluator} for resolving the {@code ${oauth(provider, credentialId)}} macro function. It uses
  * the studio service for getting oauth access token at runtime.
  */
-public class OAuthMacroEvaluator implements MacroEvaluator {
+public class OAuthMacroEvaluator extends AbstractServiceRetryableMacroEvaluator {
 
   public static final String FUNCTION_NAME = "oauth";
-
-  private static final long OAUTH_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
-  private static final long OAUTH_RETRY_BASE_DELAY_MILLIS = 200L;
-  private static final long OAUTH_RETRY_MAX_DELAY_MILLIS = TimeUnit.SECONDS.toMillis(5);
-  private static final double OAUTH_RETRY_DELAY_MULTIPLIER = 1.2d;
-  private static final double OAUTH_RETRY_RANDOMIZE_FACTOR = 0.1d;
+  private static final String SERVICE_NAME = "Oauth";
 
   private final ServiceDiscoverer serviceDiscoverer;
 
   public OAuthMacroEvaluator(ServiceDiscoverer serviceDiscoverer) {
+    super(FUNCTION_NAME);
     this.serviceDiscoverer = serviceDiscoverer;
-  }
-
-  @Override
-  public String lookup(String property) throws InvalidMacroException {
-    throw new InvalidMacroException("The '" + FUNCTION_NAME
-                                      + "' macro function doesn't support direct property lookup for property '"
-                                      + property + "'");
   }
 
   /**
@@ -68,39 +49,13 @@ public class OAuthMacroEvaluator implements MacroEvaluator {
    * @return a OAuth token
    */
   @Override
-  public String evaluate(String macroFunction, String... args) throws InvalidMacroException {
-    if (!FUNCTION_NAME.equals(macroFunction)) {
-      // This shouldn't happen
-      throw new IllegalArgumentException("Invalid function name " + macroFunction
-                                           + ". Expecting " + FUNCTION_NAME);
-    }
-
+  public String evaluateMacro(String macroFunction,
+                              String... args) throws InvalidMacroException, IOException, RetryableException {
     if (args.length != 2) {
       throw new InvalidMacroException("Macro '" + FUNCTION_NAME + "' should have exactly 2 arguments");
     }
 
-    // Make call to get OAuth token with exponential delay on failure retry.
-    long delay = OAUTH_RETRY_BASE_DELAY_MILLIS;
-    double minMultiplier = OAUTH_RETRY_DELAY_MULTIPLIER - OAUTH_RETRY_DELAY_MULTIPLIER * OAUTH_RETRY_RANDOMIZE_FACTOR;
-    double maxMultiplier = OAUTH_RETRY_DELAY_MULTIPLIER + OAUTH_RETRY_DELAY_MULTIPLIER * OAUTH_RETRY_RANDOMIZE_FACTOR;
-    Stopwatch stopWatch = new Stopwatch().start();
-    try {
-      while (stopWatch.elapsedTime(TimeUnit.MILLISECONDS) < OAUTH_TIMEOUT_MILLIS) {
-        try {
-          return getOAuthToken(args[0], args[1]);
-        } catch (RetryableException e) {
-          TimeUnit.MILLISECONDS.sleep(delay);
-          delay = (long) (delay * (minMultiplier + Math.random() * (maxMultiplier - minMultiplier + 1)));
-          delay = Math.min(delay, OAUTH_RETRY_MAX_DELAY_MILLIS);
-        } catch (IOException e) {
-          throw new RuntimeException("Failed to get OAuth token for " + args[0] + ", " + args[1], e);
-        }
-      }
-    } catch (InterruptedException e) {
-      throw new RuntimeException("Thread interrupted while trying to get the OAuth token for "
-                                   + args[0] + ", " + args[1], e);
-    }
-    throw new IllegalStateException("Timed out when trying to get the OAuth token for " + args[0] + ", " + args[1]);
+    return getOAuthToken(args[0], args[1]);
   }
 
   /**
@@ -118,39 +73,6 @@ public class OAuthMacroEvaluator implements MacroEvaluator {
                                                                  Constants.STUDIO_SERVICE_NAME,
                                                                  String.format("v1/oauth/provider/%s/credential/%s",
                                                                                provider, credentialId));
-    if (urlConn == null) {
-      throw new RetryableException("OAuth service is not available");
-    }
-
-    int responseCode = urlConn.getResponseCode();
-    if (responseCode != HttpURLConnection.HTTP_OK) {
-      switch (responseCode) {
-        case HttpURLConnection.HTTP_BAD_GATEWAY:
-        case HttpURLConnection.HTTP_UNAVAILABLE:
-        case HttpURLConnection.HTTP_GATEWAY_TIMEOUT:
-          throw new RetryableException("OAuth service is not available with status " + responseCode);
-      }
-      throw new IOException("Failed to call OAuth service with status " + responseCode + ": " + getError(urlConn));
-    }
-
-    try (Reader reader = new InputStreamReader(urlConn.getInputStream(), StandardCharsets.UTF_8)) {
-      return CharStreams.toString(reader);
-    } finally {
-      urlConn.disconnect();
-    }
-  }
-
-  /**
-   * Returns the full content of the error stream for the given {@link HttpURLConnection}.
-   */
-  private String getError(HttpURLConnection urlConn) {
-    try (InputStream is = urlConn.getErrorStream()) {
-      if (is == null) {
-        return "Unknown error";
-      }
-      return new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8);
-    } catch (IOException e) {
-      return "Unknown error due to failure to read from error output: " + e.getMessage();
-    }
+    return validateAndRetrieveContent(SERVICE_NAME, urlConn);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSource.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.common.Bytes;
@@ -51,6 +52,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -84,7 +86,8 @@ public class MockSource extends BatchSource<byte[], Row, StructuredRecord> {
    * Config for the source.
    */
   public static class Config extends PluginConfig {
-    private String tableName;
+    @Macro
+    private ConnectionConfig connectionConfig;
 
     @Nullable
     private String schema;
@@ -96,10 +99,19 @@ public class MockSource extends BatchSource<byte[], Row, StructuredRecord> {
     private Long sleepInMillis;
   }
 
+  /**
+   * Connection Config for mock source
+   */
+  public static class ConnectionConfig extends PluginConfig {
+    private String tableName;
+  }
+
   @Override
   public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
     super.configurePipeline(pipelineConfigurer);
-    pipelineConfigurer.createDataset(config.tableName, Table.class);
+    if (!config.containsMacro("tableName")) {
+      pipelineConfigurer.createDataset(config.connectionConfig.tableName, Table.class);
+    }
     if (config.schema != null) {
       try {
         pipelineConfigurer.getStageConfigurer().setOutputSchema(Schema.parseJson(config.schema));
@@ -130,7 +142,7 @@ public class MockSource extends BatchSource<byte[], Row, StructuredRecord> {
 
   @Override
   public void prepareRun(BatchSourceContext context) throws Exception {
-    context.setInput(Input.ofDataset(config.tableName));
+    context.setInput(Input.ofDataset(config.connectionConfig.tableName));
     if (config.metadataOperations != null) {
       // if there are metadata operations to be performed then apply them
       processsMetadata(context);
@@ -147,6 +159,18 @@ public class MockSource extends BatchSource<byte[], Row, StructuredRecord> {
   public static ETLPlugin getPlugin(String tableName) {
     Map<String, String> properties = new HashMap<>();
     properties.put("tableName", tableName);
+    return new ETLPlugin("Mock", BatchSource.PLUGIN_TYPE, properties, null);
+  }
+
+  /**
+   * Get the plugin config to be used in a pipeline config based on the connection name
+   *
+   * @param connectionName the connection name backing the mock source
+   * @return the plugin config to be used in a pipeline config
+   */
+  public static ETLPlugin getPluginUsingConnection(String connectionName) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("connectionConfig", String.format("${conn(%s)}", connectionName));
     return new ETLPlugin("Mock", BatchSource.PLUGIN_TYPE, properties, null);
   }
 
@@ -236,6 +260,8 @@ public class MockSource extends BatchSource<byte[], Row, StructuredRecord> {
 
   private static PluginClass getPluginClass() {
     Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("connectionConfig", new PluginPropertyField("connectionConfig", "", "connectionconfig", true, true,
+                                                               false, Collections.singleton("tableName")));
     properties.put("tableName", new PluginPropertyField("tableName", "", "string", true, false));
     properties.put("schema", new PluginPropertyField("schema", "", "string", false, false));
     properties.put("metadataOperations", new PluginPropertyField("metadataOperations", "", "string", false, false));
@@ -249,7 +275,7 @@ public class MockSource extends BatchSource<byte[], Row, StructuredRecord> {
    * Processes metadata operations
    */
   private void processsMetadata(BatchSourceContext context) throws MetadataException {
-    MetadataEntity metadataEntity = MetadataEntity.ofDataset(context.getNamespace(), config.tableName);
+    MetadataEntity metadataEntity = MetadataEntity.ofDataset(context.getNamespace(), config.connectionConfig.tableName);
     Map<MetadataScope, Metadata> currentMetadata = context.getMetadata(metadataEntity);
     Set<MetadataOperation> operations = GSON.fromJson(config.metadataOperations, SET_METADATA_OPERATION_TYPE);
     // must be to fetch metadata and there should be system metadata


### PR DESCRIPTION
Allow reusing connection in pipeline, 
this pr basically does: 
1. Add a children field if a config contains a collection of configs
2. Add deploy plugin and instantiate logic based on the above changes
3. Add ConnectionMacroEvaluator to evaluate macros at runtime