### PR TITLE
use a different store name to avoid conflict

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/connection/ConnectionStore.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/connection/ConnectionStore.java
@@ -48,7 +48,7 @@ import javax.annotation.Nullable;
  *  [namespace][connection-id]                                  connection_data -> Connection{@link Connection}
  */
 public class ConnectionStore {
-  public static final StructuredTableId TABLE_ID = new StructuredTableId("connections");
+  public static final StructuredTableId TABLE_ID = new StructuredTableId("connections_store");
   private static final String NAMESPACE_FIELD = "namespace";
   private static final String CONNECTION_ID_FIELD = "connection_id";
   // this field is to ensure the connection information is correctly fetched if a namespace is recreated


### PR DESCRIPTION
Wrangler also has a table named `connections`. Will need to use a different name to avoid creation conflict