### PR TITLE
CDAP-17905 support emit metadata in plugin

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/annotation/Metadata.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/annotation/Metadata.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.api.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotations can be used by entities to emit metadata when the entity is created.
+ * Currently, this can only be applied to plugins. Plugins with this annotation will have additional metadata
+ * in system scope associated with it when the plugin is deployed.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Metadata {
+
+  /**
+   * Returns the tags of the entity.
+   */
+  String[] tags() default {};
+
+  /**
+   * Return the metadata properties for the entity.
+   */
+  MetadataProperty[] properties() default {};
+}

--- a/cdap-api/src/main/java/io/cdap/cdap/api/annotation/MetadataProperty.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/annotation/MetadataProperty.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.api.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Metadata property used in {@link Metadata}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MetadataProperty {
+
+  /**
+   * Returns the key of the metadata property.
+   */
+  String key();
+
+  /**
+   * Returns the value of the metadata property.
+   */
+  String value();
+}

--- a/cdap-api/src/main/java/io/cdap/cdap/api/metadata/MetadataEntity.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/metadata/MetadataEntity.java
@@ -325,6 +325,10 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
         builder.append(String.format("%s: %s of ", MetadataEntity.PROGRAM_RUN,
                                      getValue(MetadataEntity.PROGRAM_RUN)));
         return getDescription(builder, MetadataEntity.PROGRAM);
+      case MetadataEntity.PLUGIN:
+        builder.append(String.format("%s: %s of %s %s in ", MetadataEntity.PLUGIN, getValue(MetadataEntity.PLUGIN),
+                                     MetadataEntity.TYPE, getValue(MetadataEntity.TYPE)));
+        return getDescription(builder, MetadataEntity.ARTIFACT);
       default:
         for (MetadataEntity.KeyValue keyValue : this) {
           builder.append(keyValue.getKey());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactClassesWithMetadata.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactClassesWithMetadata.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.internal.app.runtime.artifact;
+
+import io.cdap.cdap.api.artifact.ArtifactClasses;
+import io.cdap.cdap.spi.metadata.MetadataMutation;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Artifact classes along with metadata
+ */
+public class ArtifactClassesWithMetadata {
+  private final ArtifactClasses artifactClasses;
+  private final List<MetadataMutation> mutations;
+
+  public ArtifactClassesWithMetadata(ArtifactClasses artifactClasses, List<MetadataMutation> mutations) {
+    this.artifactClasses = artifactClasses;
+    this.mutations = mutations;
+  }
+
+  public ArtifactClasses getArtifactClasses() {
+    return artifactClasses;
+  }
+
+  public List<MetadataMutation> getMutations() {
+    return mutations;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ArtifactClassesWithMetadata that = (ArtifactClassesWithMetadata) o;
+    return Objects.equals(artifactClasses, that.artifactClasses) &&
+             Objects.equals(mutations, that.mutations);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(artifactClasses, mutations);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataSubscriberService.java
@@ -66,8 +66,6 @@ import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.spi.data.transaction.TxCallable;
 import io.cdap.cdap.spi.data.transaction.TxRunnable;
 import io.cdap.cdap.spi.metadata.Metadata;
-import io.cdap.cdap.spi.metadata.MetadataConstants;
-import io.cdap.cdap.spi.metadata.MetadataDirective;
 import io.cdap.cdap.spi.metadata.MetadataKind;
 import io.cdap.cdap.spi.metadata.MetadataMutation;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
@@ -107,15 +105,6 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
     .create();
 
   private static final String BACKFILL_SUBSCRIBER_NAME = "metadata.backfill";
-
-  // directives for (re-)creation of system metadata:
-  // - keep description if new metadata does not contain it
-  // - preserve creation-time if it exists in current metadata
-  private static final Map<ScopedNameOfKind, MetadataDirective> CREATE_DIRECTIVES = ImmutableMap.of(
-    new ScopedNameOfKind(MetadataKind.PROPERTY, MetadataScope.SYSTEM, MetadataConstants.DESCRIPTION_KEY),
-    MetadataDirective.KEEP,
-    new ScopedNameOfKind(MetadataKind.PROPERTY, MetadataScope.SYSTEM, MetadataConstants.CREATION_TIME_KEY),
-    MetadataDirective.PRESERVE);
 
   private final CConfiguration cConf;
   private final MetadataStorage metadataStorage;
@@ -474,7 +463,8 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
           // all the new metadata is in System scope - no validation
           MetadataOperation.Create create = (MetadataOperation.Create) operation;
           MetadataMutation mutation = new MetadataMutation.Create(
-            entity, new Metadata(MetadataScope.SYSTEM, create.getTags(), create.getProperties()), CREATE_DIRECTIVES);
+            entity, new Metadata(MetadataScope.SYSTEM, create.getTags(), create.getProperties()),
+            MetadataMutation.Create.CREATE_DIRECTIVES);
           metadataStorage.apply(mutation, MutationOptions.DEFAULT);
           break;
         }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataValidator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataValidator.java
@@ -30,7 +30,7 @@ import javax.annotation.Nullable;
 /**
  * Utility to validate metadata keys and values.
  */
-class MetadataValidator {
+public class MetadataValidator {
 
   private static final CharMatcher KEY_AND_TAG_MATCHER = CharMatcher.inRange('A', 'Z')
     .or(CharMatcher.inRange('a', 'z'))
@@ -50,7 +50,7 @@ class MetadataValidator {
   /**
    * Constructor only takes the configuration to determine the maximal allowed length for a key.
    */
-  MetadataValidator(CConfiguration cConf) {
+  public MetadataValidator(CConfiguration cConf) {
     maxCharacters = cConf.getInt(Constants.Metadata.MAX_CHARS_ALLOWED);
   }
 
@@ -61,8 +61,8 @@ class MetadataValidator {
    * @param properties the properties to be set
    * @throws InvalidMetadataException if any of the keys or values are invalid
    */
-  void validateProperties(MetadataEntity metadataEntity,
-                          @Nullable Map<String, String> properties) throws InvalidMetadataException {
+  public void validateProperties(MetadataEntity metadataEntity,
+                                 @Nullable Map<String, String> properties) throws InvalidMetadataException {
 
     if (null == properties || properties.isEmpty()) {
       return;
@@ -86,8 +86,8 @@ class MetadataValidator {
    * @param tags the tags to be set
    * @throws InvalidMetadataException if any of the keys or values are invalid
    */
-  void validateTags(MetadataEntity metadataEntity,
-                    @Nullable Set<String> tags) throws InvalidMetadataException {
+  public void validateTags(MetadataEntity metadataEntity,
+                           @Nullable Set<String> tags) throws InvalidMetadataException {
     if (null == tags || tags.isEmpty()) {
       return;
     }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/plugins/test/TestPlugin.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/plugins/test/TestPlugin.java
@@ -18,6 +18,8 @@ package io.cdap.cdap.internal.app.plugins.test;
 
 import com.google.common.base.Joiner;
 import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Metadata;
+import io.cdap.cdap.api.annotation.MetadataProperty;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.plugin.PluginConfig;
@@ -30,6 +32,9 @@ import javax.annotation.Nullable;
  */
 @Plugin
 @Name("TestPlugin")
+@Metadata(
+  tags = {"tag1", "tag2", "tag3"},
+  properties = {@MetadataProperty(key = "k1", value = "v1"), @MetadataProperty(key = "k2", value = "v2")})
 public class TestPlugin implements Callable<String> {
 
   protected Config config;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/plugins/test/TestPlugin2.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/plugins/test/TestPlugin2.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.internal.app.plugins.test;
 
+import io.cdap.cdap.api.annotation.Metadata;
+import io.cdap.cdap.api.annotation.MetadataProperty;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 
@@ -24,6 +26,9 @@ import io.cdap.cdap.api.annotation.Plugin;
  */
 @Plugin
 @Name("TestPlugin2")
+@Metadata(
+  tags = {"test-tag1", "test-tag2", "test-tag3"},
+  properties = {@MetadataProperty(key = "key1", value = "val1"), @MetadataProperty(key = "key2", value = "val2")})
 public class TestPlugin2 extends TestPlugin {
 
   private boolean constructed;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspectorTest.java
@@ -144,7 +144,7 @@ public class ArtifactInspectorTest {
              new EntityImpersonator(artifactId.toEntityId(), new DefaultImpersonator(CConfiguration.create(), null)))) {
 
       ArtifactClasses classes = artifactInspector.inspectArtifact(artifactId, appFile, artifactClassLoader,
-                                                                  Collections.emptySet());
+                                                                  Collections.emptySet()).getArtifactClasses();
 
       // check app classes
       Set<ApplicationClass> expectedApps = ImmutableSet.of(new ApplicationClass(
@@ -189,7 +189,7 @@ public class ArtifactInspectorTest {
              ImmutableList.of(artifactLocation).iterator(),
              new EntityImpersonator(artifactId.toEntityId(), new DefaultImpersonator(CConfiguration.create(), null)))) {
       ArtifactClasses classes = artifactInspector.inspectArtifact(artifactId, artifactFile, artifactClassLoader,
-                                                                  Collections.emptySet());
+                                                                  Collections.emptySet()).getArtifactClasses();
       Set<PluginClass> plugins = classes.getPlugins();
 
       Map<String, PluginPropertyField> expectedFields = ImmutableMap.of(

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/system/AbstractSystemMetadataWriter.java
@@ -17,17 +17,13 @@
 package io.cdap.cdap.data2.metadata.system;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.api.metadata.MetadataEntity;
 import io.cdap.cdap.api.metadata.MetadataScope;
 import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
 import io.cdap.cdap.proto.id.NamespacedEntityId;
 import io.cdap.cdap.spi.metadata.Metadata;
 import io.cdap.cdap.spi.metadata.MetadataConstants;
-import io.cdap.cdap.spi.metadata.MetadataDirective;
-import io.cdap.cdap.spi.metadata.MetadataKind;
 import io.cdap.cdap.spi.metadata.MetadataMutation;
-import io.cdap.cdap.spi.metadata.ScopedNameOfKind;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,15 +36,6 @@ public abstract class AbstractSystemMetadataWriter implements SystemMetadataWrit
 
   private final MetadataServiceClient metadataServiceClient;
   private final MetadataEntity metadataEntity;
-
-  // directives for creation of system metadata:
-  // - keep description if new metadata does not contain it
-  // - preserve creation-time if it exists in current metadata
-  private static final Map<ScopedNameOfKind, MetadataDirective> CREATE_DIRECTIVES = ImmutableMap.of(
-    new ScopedNameOfKind(MetadataKind.PROPERTY, MetadataScope.SYSTEM, MetadataConstants.DESCRIPTION_KEY),
-    MetadataDirective.KEEP,
-    new ScopedNameOfKind(MetadataKind.PROPERTY, MetadataScope.SYSTEM, MetadataConstants.CREATION_TIME_KEY),
-    MetadataDirective.PRESERVE);
 
   AbstractSystemMetadataWriter(MetadataServiceClient metadataServiceClient, NamespacedEntityId entityId) {
     this.metadataServiceClient = metadataServiceClient;
@@ -72,6 +59,6 @@ public abstract class AbstractSystemMetadataWriter implements SystemMetadataWrit
       properties.put(MetadataConstants.SCHEMA_KEY, schema);
     }
     return new MetadataMutation.Create(metadataEntity, new Metadata(MetadataScope.SYSTEM, tags, properties),
-                                       CREATE_DIRECTIVES);
+                                       MetadataMutation.Create.CREATE_DIRECTIVES);
   }
 }

--- a/cdap-metadata-spi/src/main/java/io/cdap/cdap/spi/metadata/MetadataMutation.java
+++ b/cdap-metadata-spi/src/main/java/io/cdap/cdap/spi/metadata/MetadataMutation.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.api.metadata.MetadataEntity;
 import io.cdap.cdap.api.metadata.MetadataScope;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -63,6 +64,22 @@ public abstract class MetadataMutation {
    * time, or redefined.
    */
   public static class Create extends MetadataMutation {
+    // directives for (re-)creation of system metadata:
+    // - keep description if new metadata does not contain it
+    // - preserve creation-time if it exists in current metadata
+    public static final Map<ScopedNameOfKind, MetadataDirective> CREATE_DIRECTIVES;
+
+    static {
+      Map<ScopedNameOfKind, MetadataDirective> createDirectives = new HashMap<>();
+      createDirectives.put(
+        new ScopedNameOfKind(MetadataKind.PROPERTY, MetadataScope.SYSTEM, MetadataConstants.DESCRIPTION_KEY),
+        MetadataDirective.KEEP);
+      createDirectives.put(
+        new ScopedNameOfKind(MetadataKind.PROPERTY, MetadataScope.SYSTEM, MetadataConstants.CREATION_TIME_KEY),
+        MetadataDirective.PRESERVE);
+      CREATE_DIRECTIVES = Collections.unmodifiableMap(createDirectives);
+    }
+
     private final Metadata metadata;
     private final Map<ScopedNameOfKind, MetadataDirective> directives;
 


### PR DESCRIPTION
Adds ability for a plugin to emit metadata during deployment using annotation. The annotation can be extended to apps or other entities in the future.