### PR TITLE
(CDAP-17853) Fix controller OOM

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DefaultProgramRunnerFactory.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DefaultProgramRunnerFactory.java
@@ -32,8 +32,7 @@ import io.cdap.cdap.app.runtime.ProgramStateWriter;
 import io.cdap.cdap.internal.app.program.StateChangeListener;
 import io.cdap.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
 import io.cdap.cdap.proto.ProgramType;
-import io.cdap.cdap.proto.id.ProgramId;
-import org.apache.twill.api.RunId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
@@ -48,6 +47,8 @@ import javax.annotation.Nullable;
  * The default implementation of {@link ProgramRunnerFactory} used inside app-fabric.
  */
 public final class DefaultProgramRunnerFactory implements ProgramRunnerFactory {
+
+  public static final String PUBLISH_PROGRAM_STATE = "publishProgramState";
 
   private static final Logger LOG = LoggerFactory.getLogger(DefaultProgramRunnerFactory.class);
 
@@ -71,7 +72,7 @@ public final class DefaultProgramRunnerFactory implements ProgramRunnerFactory {
   }
 
   @Inject(optional = true)
-  void setPublishProgramState(@Named("publishProgramState") boolean publishProgramState) {
+  void setPublishProgramState(@Named(PUBLISH_PROGRAM_STATE) boolean publishProgramState) {
     this.publishProgramState = publishProgramState;
   }
 
@@ -166,9 +167,8 @@ public final class DefaultProgramRunnerFactory implements ProgramRunnerFactory {
     }
 
     @Override
-    public ProgramController createProgramController(TwillController twillController,
-                                                     ProgramId programId, RunId runId) {
-      return addStateChangeListener(controllerCreator.createProgramController(twillController, programId, runId));
+    public ProgramController createProgramController(ProgramRunId programRunId, TwillController twillController) {
+      return addStateChangeListener(controllerCreator.createProgramController(programRunId, twillController));
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramRunnerModule.java
@@ -51,7 +51,9 @@ final class DistributedProgramRunnerModule extends PrivateModule {
     bind(ProgramRuntimeProvider.Mode.class).toInstance(ProgramRuntimeProvider.Mode.DISTRIBUTED);
     // Bind and expose ProgramRunnerFactory. It is used in both program deployment and program execution.
     // Should get refactory by CDAP-5506
-    bindConstant().annotatedWith(Names.named("publishProgramState")).to(publishProgramState);
+    bindConstant()
+      .annotatedWith(Names.named(DefaultProgramRunnerFactory.PUBLISH_PROGRAM_STATE))
+      .to(publishProgramState);
     bind(ProgramRunnerFactory.class).to(DefaultProgramRunnerFactory.class).in(Scopes.SINGLETON);
     expose(ProgramRunnerFactory.class);
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/RemoteExecutionProgramRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/RemoteExecutionProgramRunnerModule.java
@@ -26,6 +26,7 @@ import com.google.inject.Provider;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
 import io.cdap.cdap.app.runtime.ProgramRunner;
 import io.cdap.cdap.app.runtime.ProgramRunnerFactory;
 import io.cdap.cdap.app.runtime.ProgramRuntimeProvider;
@@ -84,6 +85,9 @@ final class RemoteExecutionProgramRunnerModule extends AbstractModule {
 
         // This set of program runners are for isolated mode
         bind(ClusterMode.class).toInstance(ClusterMode.ISOLATED);
+        // No need to publish program state for remote execution runs since they will publish states and get
+        // collected back via the runtime monitoring
+        bindConstant().annotatedWith(Names.named(DefaultProgramRunnerFactory.PUBLISH_PROGRAM_STATE)).to(false);
         // TwillRunner used by the ProgramRunner is the remote execution one
         bind(TwillRunner.class).annotatedWith(Constants.AppFabric.ProgramRunner.class).to(TWILL_RUNNER_SERVICE_KEY);
         // ProgramRunnerFactory used by ProgramRunner is the remote execution one.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/ProgramControllerCreator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/ProgramControllerCreator.java
@@ -16,8 +16,7 @@
 
 package io.cdap.cdap.app.runtime;
 
-import io.cdap.cdap.proto.id.ProgramId;
-import org.apache.twill.api.RunId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.twill.api.TwillController;
 
 /**
@@ -28,10 +27,9 @@ public interface ProgramControllerCreator {
   /**
    * Creates a {@link ProgramController} for the given program that was launched as a Twill application.
    *
+   * @param programRunId the program run id of the program being launched
    * @param twillController the {@link TwillController} to interact with the twill application
-   * @param programId the program id of the program being launched
-   * @param runId the run id of the particular execution
    * @return a new instance of {@link ProgramController}.
    */
-  ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId);
+  ProgramController createProgramController(ProgramRunId programRunId, TwillController twillController);
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractTwillProgramController.java
@@ -19,7 +19,7 @@ import com.google.common.util.concurrent.Futures;
 import io.cdap.cdap.app.runtime.LogLevelUpdater;
 import io.cdap.cdap.app.runtime.ProgramController;
 import io.cdap.cdap.internal.app.runtime.AbstractProgramController;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.ServiceController;
 import org.apache.twill.api.TwillController;
@@ -43,8 +43,8 @@ public abstract class AbstractTwillProgramController extends AbstractProgramCont
   private final TwillController twillController;
   private volatile boolean stopRequested;
 
-  protected AbstractTwillProgramController(ProgramId programId, TwillController twillController, RunId runId) {
-    super(programId.run(runId));
+  protected AbstractTwillProgramController(ProgramRunId programRunId, TwillController twillController) {
+    super(programRunId);
     this.twillController = twillController;
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
@@ -29,12 +29,11 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHelper;
 import io.cdap.cdap.proto.ProgramType;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.YarnClientProtocolProvider;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
 
@@ -56,8 +55,8 @@ public final class DistributedMapReduceProgramRunner extends DistributedProgramR
   }
 
   @Override
-  public ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId) {
-    return new MapReduceTwillProgramController(programId, twillController, runId).startListen();
+  public ProgramController createProgramController(ProgramRunId programRunId, TwillController twillController) {
+    return new MapReduceTwillProgramController(programRunId, twillController).startListen();
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -26,7 +26,6 @@ import io.cdap.cdap.api.annotation.TransactionControl;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.app.guice.ClusterMode;
 import io.cdap.cdap.app.program.Program;
-import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.app.runtime.Arguments;
 import io.cdap.cdap.app.runtime.ProgramController;
 import io.cdap.cdap.app.runtime.ProgramControllerCreator;
@@ -65,7 +64,6 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.tephra.TxConstants;
 import org.apache.twill.api.Configs;
 import org.apache.twill.api.EventHandler;
-import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillPreparer;
 import org.apache.twill.api.TwillRunner;
@@ -146,20 +144,6 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
     SystemArguments.validateTransactionTimeout(options.getUserArguments().asMap(), cConf);
   }
 
-
-  /**
-   * Creates a {@link ProgramController} for the given program that was launched as a Twill application.
-   *
-   * @param twillController the {@link TwillController} to interact with the twill application
-   * @param programDescriptor information for the Program being launched
-   * @param runId the run id of the particular execution
-   * @return a new instance of {@link ProgramController}.
-   */
-  protected ProgramController createProgramController(TwillController twillController,
-                                                      ProgramDescriptor programDescriptor, RunId runId) {
-    return createProgramController(twillController, programDescriptor.getProgramId(), runId);
-  }
-
   /**
    * Provides the configuration for launching an program container.
    *
@@ -173,17 +157,6 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
    */
   protected abstract void setupLaunchConfig(ProgramLaunchConfig launchConfig, Program program, ProgramOptions options,
                                             CConfiguration cConf, Configuration hConf, File tempDir) throws IOException;
-
-  /**
-   * The extra hook to be called right before the program is launch. This method will be called with
-   * user impersonation.
-   *
-   * @param program the program to launch
-   * @param options the program options
-   */
-  protected void beforeLaunch(Program program, ProgramOptions options) {
-    // no-op
-  }
 
   @Override
   public final ProgramController run(final Program program, ProgramOptions oldOptions) {
@@ -240,6 +213,7 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
 
       ProgramOptions options = updateProgramOptions(oldOptions, localizeResources,
                                                     DirUtils.createTempDir(tempDir), extraSystemArgs);
+      ProgramRunId programRunId = program.getId().run(ProgramRunners.getRunId(options));
 
       // Localize the serialized program options
       localizeResources.put(PROGRAM_OPTIONS_FILE_NAME,
@@ -248,7 +222,6 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
                               File.createTempFile("program.options", ".json", tempDir))));
 
       Callable<ProgramController> callable = () -> {
-        ProgramRunId programRunId = program.getId().run(ProgramRunners.getRunId(options));
         ProgramTwillApplication twillApplication = new ProgramTwillApplication(
           programRunId, options, launchConfig.getRunnables(), launchConfig.getLaunchOrder(),
           localizeResources, createEventHandler(cConf, programRunId, options));
@@ -340,9 +313,6 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
           // Use the MainClassLoader for class rewriting
           .setClassLoader(MainClassLoader.class.getName());
 
-        // Invoke the before launch hook
-        beforeLaunch(program, options);
-
         TwillController twillController;
         // Change the context classloader to the combine classloader of this ProgramRunner and
         // all the classloaders of the dependencies classes so that Twill can trace classes.
@@ -361,12 +331,10 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
         } finally {
           ClassLoaders.setContextClassLoader(oldClassLoader);
         }
-        return createProgramController(addCleanupListener(twillController, program, tempDir),
-                                       new ProgramDescriptor(program.getId(), program.getApplicationSpecification()),
-                                       ProgramRunners.getRunId(options));
+
+        return createProgramController(programRunId, addCleanupListener(twillController, program, tempDir));
       };
 
-      ProgramRunId programRunId = program.getId().run(ProgramRunners.getRunId(options));
       return impersonator.doAs(programRunId, callable);
 
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
@@ -27,11 +27,10 @@ import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.proto.ProgramType;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
 
@@ -51,8 +50,8 @@ public class DistributedServiceProgramRunner extends DistributedProgramRunner
   }
 
   @Override
-  public ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId) {
-    return new ServiceTwillProgramController(programId, twillController, runId).startListen();
+  public ProgramController createProgramController(ProgramRunId programRunId, TwillController twillController) {
+    return new ServiceTwillProgramController(programRunId, twillController).startListen();
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
@@ -28,11 +28,10 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.proto.ProgramType;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
 
@@ -51,8 +50,8 @@ public class DistributedWorkerProgramRunner extends DistributedProgramRunner
   }
 
   @Override
-  public ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId) {
-    return new WorkerTwillProgramController(programId, twillController, runId).startListen();
+  public ProgramController createProgramController(ProgramRunId programRunId, TwillController twillController) {
+    return new WorkerTwillProgramController(programRunId, twillController).startListen();
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -46,12 +46,12 @@ import io.cdap.cdap.internal.app.runtime.SimpleProgramOptions;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.ClassAcceptor;
 import org.apache.twill.api.ResourceSpecification;
-import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
 import org.slf4j.Logger;
@@ -110,8 +110,8 @@ public final class DistributedWorkflowProgramRunner extends DistributedProgramRu
   }
 
   @Override
-  public ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId) {
-    return new WorkflowTwillProgramController(programId, twillController, runId).startListen();
+  public ProgramController createProgramController(ProgramRunId programRunId, TwillController twillController) {
+    return new WorkflowTwillProgramController(programRunId, twillController).startListen();
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/MapReduceTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/MapReduceTwillProgramController.java
@@ -15,8 +15,7 @@
  */
 package io.cdap.cdap.internal.app.runtime.distributed;
 
-import io.cdap.cdap.proto.id.ProgramId;
-import org.apache.twill.api.RunId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.twill.api.TwillController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,8 +27,8 @@ public final class MapReduceTwillProgramController extends AbstractTwillProgramC
 
   private static final Logger LOG = LoggerFactory.getLogger(MapReduceTwillProgramController.class);
 
-  public MapReduceTwillProgramController(ProgramId programId, TwillController controller, RunId runId) {
-    super(programId, controller, runId);
+  public MapReduceTwillProgramController(ProgramRunId programRunId, TwillController controller) {
+    super(programRunId, controller);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/ServiceTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/ServiceTwillProgramController.java
@@ -17,8 +17,7 @@
 package io.cdap.cdap.internal.app.runtime.distributed;
 
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
-import io.cdap.cdap.proto.id.ProgramId;
-import org.apache.twill.api.RunId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.twill.api.TwillController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,8 +31,8 @@ final class ServiceTwillProgramController extends AbstractTwillProgramController
 
   private static final Logger LOG = LoggerFactory.getLogger(ServiceTwillProgramController.class);
 
-  ServiceTwillProgramController(ProgramId programId, TwillController controller, RunId runId) {
-    super(programId, controller, runId);
+  ServiceTwillProgramController(ProgramRunId programRunId, TwillController controller) {
+    super(programRunId, controller);
   }
 
   @SuppressWarnings("unchecked")

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/WorkerTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/WorkerTwillProgramController.java
@@ -17,8 +17,7 @@
 package io.cdap.cdap.internal.app.runtime.distributed;
 
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
-import io.cdap.cdap.proto.id.ProgramId;
-import org.apache.twill.api.RunId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.twill.api.TwillController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,8 +31,8 @@ public class WorkerTwillProgramController extends AbstractTwillProgramController
 
   private static final Logger LOG = LoggerFactory.getLogger(WorkerTwillProgramController.class);
 
-  WorkerTwillProgramController(ProgramId programId, TwillController controller, RunId runId) {
-    super(programId, controller, runId);
+  WorkerTwillProgramController(ProgramRunId programRunId, TwillController controller) {
+    super(programRunId, controller);
   }
 
   @SuppressWarnings("unchecked")

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/WorkflowTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/WorkflowTwillProgramController.java
@@ -15,8 +15,7 @@
  */
 package io.cdap.cdap.internal.app.runtime.distributed;
 
-import io.cdap.cdap.proto.id.ProgramId;
-import org.apache.twill.api.RunId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.twill.api.TwillController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,8 +27,8 @@ public final class WorkflowTwillProgramController extends AbstractTwillProgramCo
 
   private static final Logger LOG = LoggerFactory.getLogger(WorkflowTwillProgramController.class);
 
-  public WorkflowTwillProgramController(ProgramId programId, TwillController controller, RunId runId) {
-    super(programId, controller, runId);
+  public WorkflowTwillProgramController(ProgramRunId programRunId, TwillController controller) {
+    super(programRunId, controller);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
@@ -568,6 +568,13 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
                                                                                      processController,
                                                                                      scheduler, remoteExecutionService);
       startupTaskCompletion.thenAccept(o -> remoteExecutionService.start());
+
+      // On this controller termination, make sure it is removed from the controllers map and have resources released.
+      controller.onTerminated(() -> {
+        if (controllers.remove(programRunId, controller)) {
+          controller.complete();
+        }
+      }, scheduler);
       return controller;
     }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ScheduledRunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ScheduledRunRecordCorrectorService.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +79,7 @@ public class ScheduledRunRecordCorrectorService extends RunRecordCorrectorServic
   protected void startUp() throws Exception {
     super.startUp();
 
-    scheduledExecutorService = Executors.newScheduledThreadPool(1);
+    scheduledExecutorService = Executors.newScheduledThreadPool(1, Threads.createDaemonThreadFactory("run-corrector"));
     // Schedule the run record corrector with the configured initial delay and interval between runs
     scheduledExecutorService.scheduleWithFixedDelay(new RunRecordsCorrectorRunnable(),
        initialDelay, interval, TimeUnit.SECONDS);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityManagementService.java
@@ -83,16 +83,4 @@ public class CapabilityManagementService extends AbstractRetryableScheduledServi
     }
     return capabilityConfigs;
   }
-
-  @Override
-  public void doStartUp() throws Exception {
-    super.doStartUp();
-    capabilityApplier.doStartup();
-  }
-
-  @Override
-  public void doShutdown() throws Exception {
-    super.doShutdown();
-    capabilityApplier.doShutdown();
-  }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/AutoInstallTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/AutoInstallTest.java
@@ -129,10 +129,8 @@ public class AutoInstallTest {
     Mockito.doReturn("6.4.0").when(ca).getCurrentVersion();
 
     // Test plugin auto install
-    ca.doStartup();
     ca.autoInstallResources("mycapability",
                             Collections.singletonList(new URL("https://my.hub.io")));
-    ca.doShutdown();
 
     // Verify that the correct version of the plugin was installed
     Set<ArtifactRange> ranges = ImmutableSet.of(

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -33,7 +33,6 @@ import io.cdap.cdap.app.runtime.spark.SparkPackageUtils;
 import io.cdap.cdap.app.runtime.spark.SparkProgramRuntimeProvider;
 import io.cdap.cdap.app.runtime.spark.SparkResourceFilters;
 import io.cdap.cdap.app.runtime.spark.SparkRuntimeContextConfig;
-import io.cdap.cdap.app.runtime.spark.SparkRuntimeUtils;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.lang.FilterClassLoader;
@@ -43,7 +42,7 @@ import io.cdap.cdap.internal.app.runtime.distributed.DistributedProgramRunner;
 import io.cdap.cdap.internal.app.runtime.distributed.LocalizeResource;
 import io.cdap.cdap.internal.app.runtime.distributed.ProgramLaunchConfig;
 import io.cdap.cdap.proto.ProgramType;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.runtime.spi.SparkCompat;
 import io.cdap.cdap.security.TokenSecureStoreRenewer;
 import io.cdap.cdap.security.impersonation.Impersonator;
@@ -51,7 +50,6 @@ import io.cdap.cdap.security.impersonation.SecurityUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.ClassAcceptor;
-import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
 import org.apache.twill.filesystem.LocationFactory;
@@ -93,8 +91,8 @@ public final class DistributedSparkProgramRunner extends DistributedProgramRunne
   }
 
   @Override
-  public ProgramController createProgramController(TwillController twillController, ProgramId programId, RunId runId) {
-    return new SparkTwillProgramController(programId, twillController, runId).startListen();
+  public ProgramController createProgramController(ProgramRunId programRunId, TwillController twillController) {
+    return new SparkTwillProgramController(programRunId, twillController).startListen();
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkTwillProgramController.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkTwillProgramController.java
@@ -19,8 +19,7 @@ package io.cdap.cdap.app.runtime.spark.distributed;
 import io.cdap.cdap.api.spark.Spark;
 import io.cdap.cdap.app.runtime.ProgramController;
 import io.cdap.cdap.internal.app.runtime.distributed.AbstractTwillProgramController;
-import io.cdap.cdap.proto.id.ProgramId;
-import org.apache.twill.api.RunId;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.twill.api.TwillController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,8 +31,8 @@ final class SparkTwillProgramController extends AbstractTwillProgramController {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkTwillProgramController.class);
 
-  SparkTwillProgramController(ProgramId programId, TwillController controller, RunId runId) {
-    super(programId, controller, runId);
+  SparkTwillProgramController(ProgramRunId programRunId, TwillController controller) {
+    super(programRunId, controller);
   }
 
   @Override


### PR DESCRIPTION
There are two commits:

1. Refactoring unrelated to controller fix. Just to add thread names and refactoring to cleanup code.
2. This is the actual controller fix
   * Code refactoring to simplify the `ProgramControllerCreator` interface.
   * Disable publishing of program state messages from the app-fabric for program executed remotely.
   * Remove remote execution twill controller on program termination in addition to receiving program state change message.