### PR TITLE
CDAP-17942 fix macros in macro functions when skip invalid is set to …

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParser.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParser.java
@@ -136,7 +136,7 @@ public class MacroParser {
 
     // determine whether to use a macro function or a property lookup
     if (argsStartIndex >= 0) {
-      return getMacroFunctionMetadata(startIndex, endIndex, macroStr, argsStartIndex);
+      return getMacroFunctionMetadata(startIndex, endIndex, macroStr, argsStartIndex, str);
     } else {
       macroStr = replaceEscapedSyntax(macroStr);
       if (lookupsEnabled) {
@@ -156,9 +156,40 @@ public class MacroParser {
     }
   }
 
-  private MacroMetadata getMacroFunctionMetadata(int startIndex, int endIndex, String macroStr, int argsStartIndex) {
+  /**
+   * Use macro function to evaluate the macro string
+   *
+   * @param startIndex the start index of the macro string "$"
+   * @param endIndex the end index of the macro string
+   * @param macroStr the macro string to evaluate, without bracelet
+   * @param argsStartIndex the index of start parenthesis
+   * @param originalString the original string
+   */
+  private MacroMetadata getMacroFunctionMetadata(int startIndex, int endIndex, String macroStr, int argsStartIndex,
+                                                 String originalString) {
     // check for closing ")" and allow escaping "\)" and doubly-escaping "\\)"
     int closingParenIndex = getFirstUnescapedTokenIndex(')', macroStr, 0);
+
+    // this can only happen if we skip invalid or disable look up, the original string will contain unevaluated
+    // macro, i.e {secure(${secure-key})}, in this case, the macroStr here will be "secure(${secure-key" and this
+    // closing index will always be < 0.
+    if ((!lookupsEnabled || skipInvalid) && closingParenIndex < 0) {
+      // get ")" index using original string starting from end index
+      int originalParenIndex = getFirstUnescapedTokenIndex(')', originalString, endIndex);
+      // if found valid one, get the new macro string without "${" and set the correct closing ")" index
+      if (originalParenIndex > endIndex) {
+        // update end index to be next character after ")"
+        endIndex = originalParenIndex + 1;
+        // macro string should skip the first 2 characters "${"
+        macroStr = originalString.substring(startIndex + 2, endIndex);
+        closingParenIndex = getFirstUnescapedTokenIndex(')', macroStr, 0);
+        // if this macro string contains unevaluated macros, there is no point to continue calling the macro function
+        if (getStartIndex(macroStr, macroStr.length()) >= 0) {
+          return new MacroMetadata(String.format("${%s}", macroStr), startIndex, endIndex, false);
+        }
+      }
+    }
+
     if (closingParenIndex < 0 || !macroStr.endsWith(")")) {
       throw new InvalidMacroException(String.format("Could not find enclosing ')' for macro arguments in '%s'.",
                                                     macroStr));

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParserTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParserTest.java
@@ -532,6 +532,17 @@ public class MacroParserTest {
     Assert.assertEquals("abc${123}", parser.parse("abc${123}"));
   }
 
+  @Test
+  public void testSkipInvalidMacrosInMacroFunctions() {
+    MacroEvaluator evaluator = new TestMacroEvaluator(Collections.emptyMap(), Collections.emptyMap(), true);
+    MacroParser parser = new MacroParser(evaluator, MacroParserOptions.builder().skipInvalidMacros().build());
+
+    // test macros in the macro function still get skipped correctly
+    Assert.assertEquals("${test(${k1})}", parser.parse("${test(${k1})}"));
+    Assert.assertEquals("${test(${k1${k2}})}", parser.parse("${test(${k1${k2}})}"));
+    Assert.assertEquals("${test(${k1})}${t(${t1})}", parser.parse("${test(${k1})}${t(${t1})}"));
+  }
+
   // Testing util methods
 
   private static void assertContainsMacroParsing(String macro, boolean expected) {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/plugin/TestMacroEvaluator.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/plugin/TestMacroEvaluator.java
@@ -28,10 +28,17 @@ public class TestMacroEvaluator implements MacroEvaluator {
 
   private final Map<String, String> propertySubstitutions;
   private final Map<String, String> macroFunctionSubstitutions;
+  private final boolean failIfEvaluated;
 
   public TestMacroEvaluator(Map<String, String> propertySubstitutions, Map<String, String> macroFunctionSubstitutions) {
+    this(propertySubstitutions, macroFunctionSubstitutions, false);
+  }
+
+  public TestMacroEvaluator(Map<String, String> propertySubstitutions, Map<String, String> macroFunctionSubstitutions,
+                            boolean failIfEvaluated) {
     this.propertySubstitutions = propertySubstitutions;
     this.macroFunctionSubstitutions = macroFunctionSubstitutions;
+    this.failIfEvaluated = failIfEvaluated;
   }
 
   @Override
@@ -48,6 +55,9 @@ public class TestMacroEvaluator implements MacroEvaluator {
 
   @Override
   public String evaluate(String macroFunction, String... arguments) {
+    if (failIfEvaluated) {
+      throw new RuntimeException("Macro function should not get evaluated");
+    }
     if (!macroFunction.equals("test") && !macroFunction.equals("t")) {
       throw new InvalidMacroException(String.format("Macro function '%s' not defined.", macroFunction));
     } else if (arguments.length > 1) {


### PR DESCRIPTION
…true

The macro evaluator will fail to set the value back and throw exception even if skipInvalid is true if a macro is used inside a macro function. 
The reason for that is the macro parser will get the wrong bracelet index in such case. 
For example, `${secure(${test})}`, 
in the first evaluation, since `${test}` is not evaluated, it still preserves the value as `${test}`
in the second evaluation, parser will try to find the '}' for the secure function, it will find the index in ${test}, and then eventually get a macro string like `secure(${test`, this macro string will fail the evaluation since it is not able to find the ')'.

Solution is to find the correct bracelet again if we know skip invalid is true 