### PR TITLE
CDAP-17906 add pipeline connection relation

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/app/AbstractApplication.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/app/AbstractApplication.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.api.app;
 
 import io.cdap.cdap.api.Config;
 import io.cdap.cdap.api.mapreduce.MapReduce;
+import io.cdap.cdap.api.metadata.Metadata;
 import io.cdap.cdap.api.schedule.ScheduleBuilder;
 import io.cdap.cdap.api.schedule.TriggerFactory;
 import io.cdap.cdap.api.service.BasicService;
@@ -163,6 +164,15 @@ public abstract class AbstractApplication<T extends Config> extends AbstractPlug
    */
   protected void schedule(ScheduleCreationSpec scheduleCreationSpec) {
     configurer.schedule(scheduleCreationSpec);
+  }
+
+  /**
+   * Emit the given {@link Metadata} for the application in user scope
+   *
+   * @param metadata the metadata to emit
+   */
+  protected void emitMetadata(Metadata metadata) {
+    configurer.emitMetadata(metadata);
   }
 
   /**

--- a/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationConfigurer.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationConfigurer.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.api.app;
 
 import io.cdap.cdap.api.DatasetConfigurer;
 import io.cdap.cdap.api.mapreduce.MapReduce;
+import io.cdap.cdap.api.metadata.Metadata;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.api.schedule.ScheduleBuilder;
 import io.cdap.cdap.api.schedule.TriggerFactory;
@@ -99,6 +100,13 @@ public interface ApplicationConfigurer extends PluginConfigurer, DatasetConfigur
    * @param scheduleCreationSpec defines the schedule.
    */
   void schedule(ScheduleCreationSpec scheduleCreationSpec);
+
+  /**
+   * Emit the given {@link Metadata} for the application in user scope
+   *
+   * @param metadata the metadata to emit
+   */
+  void emitMetadata(Metadata metadata);
 
   /**
    * Get a TriggerFactory to get triggers.

--- a/cdap-api/src/main/java/io/cdap/cdap/api/plugin/PluginConfigurer.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/plugin/PluginConfigurer.java
@@ -16,11 +16,17 @@
 
 package io.cdap.cdap.api.plugin;
 
+import io.cdap.cdap.api.macro.InvalidMacroException;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
+
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
  * This interface provides methods to register plugin usage in a CDAP Program. The registered plugins will be
- * available at the runtime of the Program.
+ * available at the runtime of the Program. Additionally, it provides methods to evaluate the plugin properties if
+ * it contains macro.
  */
 public interface PluginConfigurer {
   /**
@@ -95,4 +101,29 @@ public interface PluginConfigurer {
   @Nullable
   <T> Class<T> usePluginClass(String pluginType, String pluginName,
                               String pluginId, PluginProperties properties, PluginSelector selector);
+
+  /**
+   * Evaluates lookup macros and macro functions using provided macro evaluator.
+   *
+   * @param properties key-value map of properties to evaluate
+   * @param evaluator  macro evaluator to be used to evaluate macros
+   * @return map of evaluated macros
+   * @throws InvalidMacroException indicates that there is an invalid macro
+   */
+  default Map<String, String> evaluateMacros(Map<String, String> properties,
+                                             MacroEvaluator evaluator) throws InvalidMacroException {
+    return evaluateMacros(properties, evaluator, MacroParserOptions.DEFAULT);
+  }
+
+  /**
+   * Evaluates macros using provided macro evaluator with the provided parsing options.
+   *
+   * @param properties key-value map of properties to evaluate
+   * @param evaluator  macro evaluator to be used to evaluate macros
+   * @param options    macro parsing options
+   * @return map of evaluated macros
+   * @throws InvalidMacroException indicates that there is an invalid macro
+   */
+  Map<String, String> evaluateMacros(Map<String, String> properties,
+                                     MacroEvaluator evaluator, MacroParserOptions options) throws InvalidMacroException;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/DefaultAppConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/DefaultAppConfigurer.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.mapreduce.MapReduce;
 import io.cdap.cdap.api.mapreduce.MapReduceSpecification;
+import io.cdap.cdap.api.metadata.Metadata;
 import io.cdap.cdap.api.schedule.ScheduleBuilder;
 import io.cdap.cdap.api.schedule.TriggerFactory;
 import io.cdap.cdap.api.service.Service;
@@ -63,8 +64,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -87,6 +91,7 @@ public class DefaultAppConfigurer extends AbstractConfigurer implements Applicat
   private final Map<StructuredTableId, StructuredTableSpecification> systemTables = new HashMap<>();
   private final TriggerFactory triggerFactory;
   private String name;
+  private Metadata appMetadata;
   private String description;
 
   // passed app to be used to resolve default name and description
@@ -105,6 +110,7 @@ public class DefaultAppConfigurer extends AbstractConfigurer implements Applicat
     this.artifactId = artifactId;
     this.pluginFinder = pluginFinder;
     this.pluginInstantiator = pluginInstantiator;
+    this.appMetadata = new Metadata(Collections.emptyMap(), Collections.emptySet());
     this.triggerFactory = new DefaultTriggerFactory(namespace.toEntityId());
   }
 
@@ -227,6 +233,15 @@ public class DefaultAppConfigurer extends AbstractConfigurer implements Applicat
   }
 
   @Override
+  public void emitMetadata(Metadata metadata) {
+    Map<String, String> properties = new HashMap<>(appMetadata.getProperties());
+    properties.putAll(metadata.getProperties());
+    Set<String> tags = new HashSet<>(appMetadata.getTags());
+    tags.addAll(metadata.getTags());
+    appMetadata = new Metadata(properties, tags);
+  }
+
+  @Override
   public TriggerFactory getTriggerFactory() {
     return triggerFactory;
   }
@@ -285,6 +300,10 @@ public class DefaultAppConfigurer extends AbstractConfigurer implements Applicat
 
   public Collection<StructuredTableSpecification> getSystemTables() {
     return systemTables.values();
+  }
+
+  public Metadata getMetadata() {
+    return appMetadata;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/AbstractConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/AbstractConfigurer.java
@@ -19,6 +19,9 @@ package io.cdap.cdap.internal.app;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
+import io.cdap.cdap.api.macro.InvalidMacroException;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.Plugin;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.api.plugin.PluginProperties;
@@ -85,5 +88,11 @@ public abstract class AbstractConfigurer extends DefaultDatasetConfigurer implem
   public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId, PluginProperties properties,
                                      PluginSelector selector) {
     return pluginConfigurer.usePluginClass(pluginType, pluginName, pluginId, properties, selector);
+  }
+
+  @Override
+  public Map<String, String> evaluateMacros(Map<String, String> properties, MacroEvaluator evaluator,
+                                            MacroParserOptions options) throws InvalidMacroException {
+    return pluginConfigurer.evaluateMacros(properties, evaluator, options);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultPluginConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultPluginConfigurer.java
@@ -19,6 +19,9 @@ package io.cdap.cdap.internal.app;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.macro.InvalidMacroException;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.Plugin;
 import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
@@ -27,6 +30,7 @@ import io.cdap.cdap.api.plugin.PluginSelector;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.FindPluginHelper;
+import io.cdap.cdap.internal.app.runtime.plugin.MacroParser;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginClassLoader;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginNotExistsException;
@@ -98,6 +102,15 @@ public class DefaultPluginConfigurer implements PluginConfigurer {
       // Shouldn't happen
       throw Throwables.propagate(e);
     }
+  }
+
+  @Override
+  public Map<String, String> evaluateMacros(Map<String, String> properties, MacroEvaluator evaluator,
+                                            MacroParserOptions options) throws InvalidMacroException {
+    MacroParser macroParser = new MacroParser(evaluator, options);
+    Map<String, String> evaluated = new HashMap<>();
+    properties.forEach((key, val) -> evaluated.put(key, macroParser.parse(val)));
+    return evaluated;
   }
 
   private Plugin addPlugin(String pluginType, String pluginName, String pluginId,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryConfigurator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryConfigurator.java
@@ -40,7 +40,6 @@ import io.cdap.cdap.common.lang.CombineClassLoader;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppSpecInfo;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.Artifacts;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
@@ -200,7 +199,7 @@ public final class InMemoryConfigurator implements Configurator {
       }
     }
     ApplicationSpecification specification = configurer.createSpecification(applicationName, applicationVersion);
-    AppSpecInfo appSpecInfo = new AppSpecInfo(specification, configurer.getSystemTables());
+    AppSpecInfo appSpecInfo = new AppSpecInfo(specification, configurer.getSystemTables(), configurer.getMetadata());
 
     // Convert the specification to JSON.
     // We write the Application specification to output file in JSON format.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/LocalApplicationManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/LocalApplicationManager.java
@@ -36,8 +36,8 @@ import io.cdap.cdap.internal.app.deploy.pipeline.DeletedProgramHandlerStage;
 import io.cdap.cdap.internal.app.deploy.pipeline.DeployDatasetModulesStage;
 import io.cdap.cdap.internal.app.deploy.pipeline.DeploymentCleanupStage;
 import io.cdap.cdap.internal.app.deploy.pipeline.LocalArtifactLoaderStage;
+import io.cdap.cdap.internal.app.deploy.pipeline.MetadataWriterStage;
 import io.cdap.cdap.internal.app.deploy.pipeline.ProgramGenerationStage;
-import io.cdap.cdap.internal.app.deploy.pipeline.SystemMetadataWriterStage;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.capability.CapabilityReader;
@@ -135,7 +135,7 @@ public class LocalApplicationManager<I, O> implements Manager<I, O> {
     pipeline.addLast(new ProgramGenerationStage());
     pipeline.addLast(new ApplicationRegistrationStage(store, usageRegistry, ownerAdmin));
     pipeline.addLast(new DeleteAndCreateSchedulesStage(programScheduler));
-    pipeline.addLast(new SystemMetadataWriterStage(metadataServiceClient));
+    pipeline.addLast(new MetadataWriterStage(metadataServiceClient));
     pipeline.setFinally(new DeploymentCleanupStage());
     return pipeline.execute(input);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppSpecInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppSpecInfo.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.internal.app.deploy.pipeline;
 
 import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.metadata.Metadata;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 
 import java.util.Collection;
@@ -28,11 +29,13 @@ import java.util.Collection;
 public class AppSpecInfo {
   private final ApplicationSpecification appSpec;
   private final Collection<StructuredTableSpecification> systemTables;
+  private final Metadata metadata;
 
   public AppSpecInfo(ApplicationSpecification appSpec,
-                     Collection<StructuredTableSpecification> systemTables) {
+                     Collection<StructuredTableSpecification> systemTables, Metadata metadata) {
     this.appSpec = appSpec;
     this.systemTables = systemTables;
+    this.metadata = metadata;
   }
 
   public ApplicationSpecification getAppSpec() {
@@ -41,5 +44,9 @@ public class AppSpecInfo {
 
   public Collection<StructuredTableSpecification> getSystemTables() {
     return systemTables;
+  }
+
+  public Metadata getMetadata() {
+    return metadata;
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
+import io.cdap.cdap.spi.metadata.MetadataMutation;
 import org.apache.twill.filesystem.Location;
 
 import java.util.Collection;
@@ -42,6 +43,7 @@ public class ApplicationDeployable {
   private final ApplicationSpecification existingAppSpec;
   private final ApplicationDeployScope applicationDeployScope;
   private final Collection<StructuredTableSpecification> systemTables;
+  private final MetadataMutation mutation;
   @SerializedName("principal")
   private final KerberosPrincipalId ownerPrincipal;
   @SerializedName("update-schedules")
@@ -53,7 +55,7 @@ public class ApplicationDeployable {
                                ApplicationDeployScope applicationDeployScope,
                                ApplicationClass applicationClass) {
     this(artifactId, artifactLocation, applicationId, specification, existingAppSpec, applicationDeployScope,
-         applicationClass, null, true, Collections.emptyList());
+         applicationClass, null, true, Collections.emptyList(), null);
   }
 
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
@@ -63,7 +65,8 @@ public class ApplicationDeployable {
                                ApplicationClass applicationClass,
                                @Nullable KerberosPrincipalId ownerPrincipal,
                                boolean updateSchedules,
-                               Collection<StructuredTableSpecification> systemTables) {
+                               Collection<StructuredTableSpecification> systemTables,
+                               @Nullable MetadataMutation mutation) {
     this.artifactId = artifactId;
     this.artifactLocation = artifactLocation;
     this.applicationId = applicationId;
@@ -74,6 +77,7 @@ public class ApplicationDeployable {
     this.updateSchedules = updateSchedules;
     this.systemTables = systemTables;
     this.applicationClass = applicationClass;
+    this.mutation = mutation;
   }
 
   /**
@@ -145,5 +149,13 @@ public class ApplicationDeployable {
    */
   public boolean canUpdateSchedules() {
     return updateSchedules;
+  }
+
+  /**
+   * Returns the metadata to emit
+   */
+  @Nullable
+  public MetadataMutation getMetadata() {
+    return mutation;
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
@@ -34,7 +34,8 @@ public class ApplicationWithPrograms extends ApplicationDeployable {
           applicationDeployable.getApplicationId(), applicationDeployable.getSpecification(),
           applicationDeployable.getExistingAppSpec(), applicationDeployable.getApplicationDeployScope(),
           applicationDeployable.getApplicationClass(), applicationDeployable.getOwnerPrincipal(),
-          applicationDeployable.canUpdateSchedules(), applicationDeployable.getSystemTables());
+          applicationDeployable.canUpdateSchedules(), applicationDeployable.getSystemTables(),
+          applicationDeployable.getMetadata());
     this.programDescriptors = ImmutableList.copyOf(programDescriptors);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
@@ -21,6 +21,9 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.metadata.Metadata;
+import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.api.metadata.MetadataScope;
 import io.cdap.cdap.app.deploy.ConfigResponse;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -31,6 +34,7 @@ import io.cdap.cdap.internal.app.deploy.LocalApplicationManager;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.capability.CapabilityReader;
+import io.cdap.cdap.metadata.MetadataValidator;
 import io.cdap.cdap.pipeline.AbstractStage;
 import io.cdap.cdap.pipeline.Context;
 import io.cdap.cdap.pipeline.Pipeline;
@@ -42,8 +46,10 @@ import io.cdap.cdap.security.impersonation.EntityImpersonator;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AuthorizationEnforcer;
+import io.cdap.cdap.spi.metadata.MetadataMutation;
 import org.apache.twill.filesystem.Location;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -57,7 +63,8 @@ import java.util.concurrent.TimeUnit;
  * It is expected a {@link Pipeline#setFinally(Stage)} stage to clean it up after the pipeline execution finished.
  */
 public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
-  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
+  private static final Gson GSON =
+    ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
   private final CConfiguration cConf;
   private final Store store;
   private final ArtifactRepository artifactRepository;
@@ -66,6 +73,7 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
   private final AuthenticationContext authenticationContext;
   private final PluginFinder pluginFinder;
   private final CapabilityReader capabilityReader;
+  private final MetadataValidator metadataValidator;
 
   /**
    * Constructor with hit for handling type.
@@ -83,6 +91,7 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
     this.authenticationContext = authenticationContext;
     this.pluginFinder = pluginFinder;
     this.capabilityReader = capabilityReader;
+    this.metadataValidator = new MetadataValidator(cConf);
   }
 
   /**
@@ -129,10 +138,23 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
     }
     authorizationEnforcer.enforce(applicationId, authenticationContext.getPrincipal(), Action.ADMIN);
     capabilityReader.checkAllEnabled(specification);
+
+    MetadataMutation.Create mutation = null;
+    Metadata metadata = appSpecInfo.getMetadata();
+    if (!metadata.getTags().isEmpty() || !metadata.getProperties().isEmpty()) {
+      MetadataEntity appEntity = applicationId.toMetadataEntity();
+      metadataValidator.validateProperties(appEntity, metadata.getProperties());
+      metadataValidator.validateTags(appEntity, metadata.getTags());
+      mutation = new MetadataMutation.Create(
+        appEntity,
+        new io.cdap.cdap.spi.metadata.Metadata(MetadataScope.USER, metadata.getTags(), metadata.getProperties()),
+        Collections.emptyMap());
+    }
+
     emit(new ApplicationDeployable(deploymentInfo.getArtifactId(), deploymentInfo.getArtifactLocation(),
                                    applicationId, specification, store.getApplication(applicationId),
                                    ApplicationDeployScope.USER, deploymentInfo.getApplicationClass(),
                                    deploymentInfo.getOwnerPrincipal(), deploymentInfo.canUpdateSchedules(),
-                                   appSpecInfo.getSystemTables()));
+                                   appSpecInfo.getSystemTables(), mutation));
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/MetadataWriterStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/MetadataWriterStage.java
@@ -32,14 +32,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Stage to write system metadata for an application.
+ * Stage to write metadata for an application.
  */
-public class SystemMetadataWriterStage extends AbstractStage<ApplicationWithPrograms> {
+public class MetadataWriterStage extends AbstractStage<ApplicationWithPrograms> {
 
   private final MetadataServiceClient metadataServiceClient;
   private String creationTime;
 
-  public SystemMetadataWriterStage(MetadataServiceClient metadataServiceClient) {
+  public MetadataWriterStage(MetadataServiceClient metadataServiceClient) {
     super(TypeToken.of(ApplicationWithPrograms.class));
     this.metadataServiceClient = metadataServiceClient;
   }
@@ -64,6 +64,11 @@ public class SystemMetadataWriterStage extends AbstractStage<ApplicationWithProg
     collectProgramSystemMetadata(appId, ProgramType.SPARK, appSpec.getSpark().values(), mutations);
     collectProgramSystemMetadata(appId, ProgramType.WORKER, appSpec.getWorkers().values(), mutations);
     collectProgramSystemMetadata(appId, ProgramType.WORKFLOW, appSpec.getWorkflows().values(), mutations);
+
+    // add the rest user defined metadata
+    if (input.getMetadata() != null) {
+      mutations.add(input.getMetadata());
+    }
 
     // write all metadata
     metadataServiceClient.batch(mutations);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/MetadataEmitApp.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/MetadataEmitApp.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.cdap.cdap.api.app.AbstractApplication;
+import io.cdap.cdap.api.metadata.Metadata;
+import io.cdap.cdap.api.worker.AbstractWorker;
+
+/**
+ * App just emit metadata
+ */
+public class MetadataEmitApp extends AbstractApplication {
+  public static final String NAME = "MetadataEmitApp";
+  public static final Metadata METADATA = new Metadata(ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4"),
+                                                       ImmutableSet.of("tag1", "tag2", "tag3", "tag4"));
+
+  @Override
+  public void configure() {
+    emitMetadata(new Metadata(ImmutableMap.of("k1", "v1", "k2", "v2"), ImmutableSet.of("tag1", "tag2")));
+    emitMetadata(new Metadata(ImmutableMap.of("k3", "v3", "k4", "v4"), ImmutableSet.of("tag3", "tag4")));
+    addWorker(new NoopWorker());
+  }
+
+  public static class NoopWorker extends AbstractWorker {
+
+    @Override
+    protected void configure() {
+      // no-op
+    }
+
+    @Override
+    public void run() {
+      // no-op
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/app/MockAppConfigurer.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/app/MockAppConfigurer.java
@@ -22,7 +22,11 @@ import io.cdap.cdap.api.app.ProgramType;
 import io.cdap.cdap.api.dataset.Dataset;
 import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.module.DatasetModule;
+import io.cdap.cdap.api.macro.InvalidMacroException;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.mapreduce.MapReduce;
+import io.cdap.cdap.api.metadata.Metadata;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.api.plugin.PluginSelector;
 import io.cdap.cdap.api.schedule.ScheduleBuilder;
@@ -36,6 +40,7 @@ import io.cdap.cdap.internal.app.runtime.schedule.trigger.DefaultTriggerFactory;
 import io.cdap.cdap.internal.schedule.ScheduleCreationSpec;
 import io.cdap.cdap.proto.id.NamespaceId;
 
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -99,6 +104,11 @@ public final class MockAppConfigurer implements ApplicationConfigurer {
   }
 
   @Override
+  public void emitMetadata(Metadata metadata) {
+
+  }
+
+  @Override
   public TriggerFactory getTriggerFactory() {
     // the result of this won't actually be used, but the returned object will have its methods called
     return new DefaultTriggerFactory(NamespaceId.DEFAULT);
@@ -123,6 +133,12 @@ public final class MockAppConfigurer implements ApplicationConfigurer {
   public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId, PluginProperties properties,
                                      PluginSelector selector) {
     throw new UnsupportedOperationException(ERROR_MSG);
+  }
+
+  @Override
+  public Map<String, String> evaluateMacros(Map<String, String> properties, MacroEvaluator evaluator,
+                                            MacroParserOptions options) throws InvalidMacroException {
+    return properties;
   }
 
   @Override

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStageTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/pipeline/SystemMetadataWriterStageTest.java
@@ -63,7 +63,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Tests for {@link SystemMetadataWriterStage}.
+ * Tests for {@link MetadataWriterStage}.
  */
 public class SystemMetadataWriterStageTest {
   @ClassRule
@@ -96,7 +96,7 @@ public class SystemMetadataWriterStageTest {
     ArtifactId artifactId = NamespaceId.DEFAULT.artifact(appId.getApplication(), "1.0");
     ApplicationWithPrograms appWithPrograms = createAppWithWorkflow(artifactId, appId, workflowName, applicationClass);
     WorkflowSpecification workflowSpec = appWithPrograms.getSpecification().getWorkflows().get(workflowName);
-    SystemMetadataWriterStage systemMetadataWriterStage = new SystemMetadataWriterStage(metadataServiceClient);
+    MetadataWriterStage systemMetadataWriterStage = new MetadataWriterStage(metadataServiceClient);
     StageContext stageContext = new StageContext(Object.class);
     systemMetadataWriterStage.process(stageContext);
     systemMetadataWriterStage.process(appWithPrograms);
@@ -131,7 +131,7 @@ public class SystemMetadataWriterStageTest {
     ApplicationWithPrograms appWithPrograms = createAppWithWorkflow(artifactId, appId, workflowName,
                                                                     new CapabilityAppWithWorkflow(), applicationClass);
     WorkflowSpecification workflowSpec = appWithPrograms.getSpecification().getWorkflows().get(workflowName);
-    SystemMetadataWriterStage systemMetadataWriterStage = new SystemMetadataWriterStage(metadataServiceClient);
+    MetadataWriterStage systemMetadataWriterStage = new MetadataWriterStage(metadataServiceClient);
     StageContext stageContext = new StageContext(Object.class);
     systemMetadataWriterStage.process(stageContext);
     systemMetadataWriterStage.process(appWithPrograms);

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/SmartWorkflow.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.api.dataset.lib.FileSet;
 import io.cdap.cdap.api.lineage.field.Operation;
 import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.metadata.Metadata;
 import io.cdap.cdap.api.metrics.Metrics;
 import io.cdap.cdap.api.plugin.PluginContext;
 import io.cdap.cdap.api.schedule.ProgramStatusTriggerInfo;
@@ -100,6 +101,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -179,6 +181,8 @@ public class SmartWorkflow extends AbstractWorkflow {
                       e.getFailures().isEmpty() ? e.getMessage() :
                         e.getFailures().iterator().next().getFullMessage()), e);
     }
+
+    applicationConfigurer.emitMetadata(new Metadata(Collections.emptyMap(), spec.getConnectionsUsed()));
 
     stageSpecs = new HashMap<>();
     useSpark = config.getEngine() == Engine.SPARK;

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionHandler.java
@@ -104,12 +104,14 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
 
       ConnectionCreationRequest creationRequest =
         GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(), ConnectionCreationRequest.class);
+      ConnectionId connectionId = new ConnectionId(namespaceSummary, connection);
 
       long now = System.currentTimeMillis();
-      Connection connectionInfo = new Connection(connection, creationRequest.getPlugin().getName(),
+      Connection connectionInfo = new Connection(connection, connectionId.getConnectionId(),
+                                                 creationRequest.getPlugin().getName(),
                                                  creationRequest.getDescription(), false,
                                                  now, now, creationRequest.getPlugin());
-      store.saveConnection(new ConnectionId(namespaceSummary, connection), connectionInfo);
+      store.saveConnection(connectionId, connectionInfo, creationRequest.overWrite());
       responder.sendStatus(HttpURLConnection.HTTP_OK);
     });
   }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/connection/ConnectionStoreTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/connection/ConnectionStoreTest.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.NamespaceSummary;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.etl.proto.ArtifactSelectorConfig;
 import io.cdap.cdap.etl.proto.connection.Connection;
+import io.cdap.cdap.etl.proto.connection.ConnectionConflictException;
 import io.cdap.cdap.etl.proto.connection.ConnectionId;
 import io.cdap.cdap.etl.proto.connection.ConnectionNotFoundException;
 import io.cdap.cdap.etl.proto.connection.PluginInfo;
@@ -31,10 +32,12 @@ import io.cdap.cdap.test.TestConfiguration;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Unit test for connection store
@@ -42,39 +45,41 @@ import java.util.Collections;
 public class ConnectionStoreTest extends SystemAppTestBase {
   @ClassRule
   public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
-  private ConnectionStore connectionStore;
+  private static ConnectionStore connectionStore;
 
-  @Before
-  public void setupTest() throws Exception {
+  @BeforeClass
+  public static void setupTest() throws Exception {
     getStructuredTableAdmin().create(ConnectionStore.CONNECTION_TABLE_SPEC);
     connectionStore = new ConnectionStore(getTransactionRunner());
   }
 
   @After
   public void cleanupTest() throws Exception {
-    getStructuredTableAdmin().drop(ConnectionStore.CONNECTION_TABLE_SPEC.getTableId());
+    // structuredadmin.drop won't actually delete the table since all entity tables use a single entity nosql table
+    // it will just remove the registry, so next test will still see old connections
+    connectionStore.clear();
   }
 
   @Test
   public void testBasicOperations() throws Exception {
     // put a connection in the store
     NamespaceSummary namespace = new NamespaceSummary("default", "", 0L);
-    ConnectionId connectionId = new ConnectionId(namespace, "myconn");
+    ConnectionId connectionId = new ConnectionId(namespace, "my_conn");
     Connection expected = new Connection(
-      "myconn", "GCS", "GCS connection", false, 0L, 0L,
+      "my_conn", "GCS", "GCS connection", false, 0L, 0L,
       new PluginInfo("GCS", "connector", "Google Cloud Platform", ImmutableMap.of("project", "abc"),
                      new ArtifactSelectorConfig("SYSTEM", "google-cloud", "1.0.0")));
-    connectionStore.saveConnection(connectionId, expected);
+    connectionStore.saveConnection(connectionId, expected, false);
     // assert the connections
     Assert.assertEquals(expected, connectionStore.getConnection(connectionId));
 
     // update the connection, the connection should be updated
     Connection updated = new Connection(
-      "myconn", "GCS", "GCS connection updated", false, 1000L, 2000L,
+      "my_conn", "GCS", "GCS connection updated", false, 1000L, 2000L,
       new PluginInfo("GCS", "connector", "Google Cloud Platform",
                      ImmutableMap.of("project", "abc", "serviceAccount", "secrect.json"),
                      new ArtifactSelectorConfig("SYSTEM", "google-cloud", "1.0.0")));
-    connectionStore.saveConnection(connectionId, updated);
+    connectionStore.saveConnection(connectionId, updated, false);
     Connection actual = connectionStore.getConnection(connectionId);
     Assert.assertEquals(updated, actual);
 
@@ -89,10 +94,25 @@ public class ConnectionStoreTest extends SystemAppTestBase {
       "mynewconn", "BigQuery", "BigQuery connection", false, 0L, 0L,
       new PluginInfo("BigQuery", "connector", "Google Cloud Platform", ImmutableMap.of("project", "myproject"),
                      new ArtifactSelectorConfig("SYSTEM", "google-cloud", "1.0.0")));
-    connectionStore.saveConnection(newConnectioId, newConnection);
+    connectionStore.saveConnection(newConnectioId, newConnection, false);
     Assert.assertEquals(newConnection, connectionStore.getConnection(newConnectioId));
 
     // list connections should have two connections
+    Assert.assertEquals(ImmutableList.of(updated, newConnection), connectionStore.listConnections(namespace));
+
+    // update first connection to a different name "my conn" which translates to same id "my_conn", with overwrite
+    // set to true, it should overwrite the connection and listing should still show two connections
+    connectionId = new ConnectionId(namespace, "my conn");
+    updated = new Connection(
+      "my conn", "GCS", "GCS connection updated", false, 1000L, 2000L,
+      new PluginInfo("GCS", "connector", "Google Cloud Platform",
+                     ImmutableMap.of("project", "abc", "serviceAccount", "secrect.json"),
+                     new ArtifactSelectorConfig("SYSTEM", "google-cloud", "1.0.0")));
+    connectionStore.saveConnection(connectionId, updated, true);
+    actual = connectionStore.getConnection(connectionId);
+    Assert.assertEquals(updated, actual);
+
+    // list should still get 2 connections
     Assert.assertEquals(ImmutableList.of(updated, newConnection), connectionStore.listConnections(namespace));
 
     // delete the first one
@@ -130,13 +150,65 @@ public class ConnectionStoreTest extends SystemAppTestBase {
       "myconn", "GCS", "GCS connection", false, 0L, 0L,
       new PluginInfo("GCS", "connector", "Google Cloud Platform", ImmutableMap.of("project", "abc"),
                      new ArtifactSelectorConfig("SYSTEM", "google-cloud", "1.0.0")));
-    connectionStore.saveConnection(id, connection);
+    connectionStore.saveConnection(id, connection, false);
 
     // get the connection with a namespace with a higher generation id should fail
     try {
       connectionStore.getConnection(new ConnectionId(new NamespaceSummary("default", "", 1L), "myconn"));
       Assert.fail();
     } catch (ConnectionNotFoundException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testConflict() throws Exception {
+    // put a connection in the store
+    NamespaceSummary namespace = new NamespaceSummary("default", "", 0L);
+    ConnectionId connectionId = new ConnectionId(namespace, "my_conn");
+    Connection connection = new Connection(
+      "my_conn", "GCS", "GCS connection", false, 0L, 0L,
+      new PluginInfo("GCS", "connector", "Google Cloud Platform", ImmutableMap.of("project", "abc"),
+                     new ArtifactSelectorConfig("SYSTEM", "google-cloud", "1.0.0")));
+    connectionStore.saveConnection(connectionId, connection, false);
+
+    // use a different name but evaluate to same id, with overwrite to false, it should fail to update
+    try {
+      connectionId = new ConnectionId(namespace, "my conn");
+      connection = new Connection(
+        "my conn", "GCS", "GCS connection", false, 0L, 0L,
+        new PluginInfo("GCS", "connector", "Google Cloud Platform", ImmutableMap.of("project", "abc"),
+                       new ArtifactSelectorConfig("SYSTEM", "google-cloud", "1.0.0")));
+      connectionStore.saveConnection(connectionId, connection, false);
+      Assert.fail();
+    } catch (ConnectionConflictException e) {
+      // expected
+    }
+
+    // check pre configured connection cannot get updated
+    connectionId = new ConnectionId(namespace, "default conn");
+    connection = new Connection(
+      "default conn", "GCS", "GCS connection", true, 0L, 0L,
+      new PluginInfo("GCS", "connector", "Google Cloud Platform", ImmutableMap.of("project", "abc"),
+                     new ArtifactSelectorConfig("SYSTEM", "google-cloud", "1.0.0")));
+
+    connectionStore.saveConnection(connectionId, connection, false);
+
+    try {
+      connection = new Connection("default conn", "BigQuery", "", false, 0L, 0L,
+                                  new PluginInfo("BigQuery", "connector", "", Collections.emptyMap(),
+                                                 new ArtifactSelectorConfig()));
+      connectionStore.saveConnection(connectionId, connection, true);
+      Assert.fail();
+    } catch (ConnectionConflictException e) {
+      // expected
+    }
+
+    // and pre-configured cannot be deleted
+    try {
+      connectionStore.deleteConnection(connectionId);
+      Assert.fail();
+    } catch (ConnectionConflictException e) {
       // expected
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpec.java
@@ -44,9 +44,9 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
                                   String extraJavaOpts, int numOfRecordsPreview,
                                   boolean stopGracefully, Map<String, String> properties,
                                   boolean checkpointsDisabled, boolean isUnitTest, String checkpointDirectory,
-                                  String pipelineId) {
+                                  String pipelineId, Set<String> connectionsUsed) {
     super(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled, processTimingEnabled,
-          numOfRecordsPreview, properties);
+          numOfRecordsPreview, properties, connectionsUsed);
     this.batchIntervalMillis = batchIntervalMillis;
     this.extraJavaOpts = extraJavaOpts;
     this.stopGracefully = stopGracefully;
@@ -181,7 +181,8 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
       return new DataStreamsPipelineSpec(stages, connections, resources, driverResources, clientResources,
                                          stageLoggingEnabled, processTimingEnabled, batchIntervalMillis, extraJavaOpts,
                                          numOfRecordsPreview, stopGracefully, properties,
-                                         checkpointsDisabled, isUnitTest, checkpointDirectory, pipelineId);
+                                         checkpointsDisabled, isUnitTest, checkpointDirectory, pipelineId,
+                                         connectionsUsed);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/BatchPipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/BatchPipelineSpec.java
@@ -46,9 +46,10 @@ public class BatchPipelineSpec extends PipelineSpec {
                             List<ActionSpec> endingActions,
                             int numOfRecordsPreview,
                             Map<String, String> properties,
+                            Set<String> connectionsUsed,
                             @Nullable StageSpec sqlEngineStageSpec) {
     super(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled, processTimingEnabled,
-          numOfRecordsPreview, properties);
+          numOfRecordsPreview, properties, connectionsUsed);
     this.endingActions = ImmutableList.copyOf(endingActions);
     this.sqlEngineStageSpec = sqlEngineStageSpec;
   }
@@ -124,7 +125,7 @@ public class BatchPipelineSpec extends PipelineSpec {
     public BatchPipelineSpec build() {
       return new BatchPipelineSpec(stages, connections, resources, driverResources, clientResources,
                                    stageLoggingEnabled, processTimingEnabled, endingActions,
-                                   numOfRecordsPreview, properties, sqlEngineStageSpec);
+                                   numOfRecordsPreview, properties, connectionsUsed, sqlEngineStageSpec);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java
@@ -92,7 +92,7 @@ abstract class AbstractServiceRetryableMacroEvaluator implements MacroEvaluator 
 
   protected String validateAndRetrieveContent(String serviceName, HttpURLConnection urlConn) throws IOException {
     if (urlConn == null) {
-      throw new RetryableException("OAuth service is not available");
+      throw new RetryableException(serviceName + " service is not available");
     }
 
     int responseCode = urlConn.getResponseCode();

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ConnectionMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ConnectionMacroEvaluator.java
@@ -40,7 +40,6 @@ public class ConnectionMacroEvaluator extends AbstractServiceRetryableMacroEvalu
   private final ServiceDiscoverer serviceDiscoverer;
   private final Gson gson;
 
-
   public ConnectionMacroEvaluator(String namespace, ServiceDiscoverer serviceDiscoverer) {
     super(FUNCTION_NAME);
     this.namespace = namespace;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ConnectionRegistryMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ConnectionRegistryMacroEvaluator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.etl.common;
+
+import io.cdap.cdap.api.macro.InvalidMacroException;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.etl.proto.connection.ConnectionId;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Connection macro evaluator to register connection usage. It shouldn't be used if for real macro evaluation
+ */
+public class ConnectionRegistryMacroEvaluator implements MacroEvaluator {
+  public static final String FUNCTION_NAME = "conn";
+
+  private final Set<String> connectionIds;
+
+  public ConnectionRegistryMacroEvaluator() {
+    this.connectionIds = new HashSet<>();
+  }
+
+  @Override
+  public String lookup(String property) throws InvalidMacroException {
+    throw new InvalidMacroException("The '" + FUNCTION_NAME
+                                      + "' macro function doesn't support direct property lookup for property '"
+                                      + property + "'");
+  }
+
+  @Override
+  public String evaluate(String macroFunction, String... args) throws InvalidMacroException {
+    if (args.length != 1) {
+      throw new InvalidMacroException("Macro '" + FUNCTION_NAME + "' should have exactly 1 arguments");
+    }
+
+    connectionIds.add(ConnectionId.getConnectionId(args[0]));
+
+    throw new InvalidMacroException("The '" + FUNCTION_NAME
+                                      + "' macro function doesn't support evaluating the connection macro " +
+                                      "for connection '" + args[0] + "'");
+  }
+
+  public Set<String> getConnectionIds() {
+    return connectionIds;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultPipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/DefaultPipelineConfigurer.java
@@ -20,6 +20,9 @@ import io.cdap.cdap.api.DatasetConfigurer;
 import io.cdap.cdap.api.dataset.Dataset;
 import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.module.DatasetModule;
+import io.cdap.cdap.api.macro.InvalidMacroException;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.api.plugin.PluginSelector;
@@ -124,7 +127,13 @@ public class DefaultPipelineConfigurer implements PipelineConfigurer, MultiInput
                                      PluginSelector selector) {
     return pluginConfigurer.usePluginClass(pluginType, pluginName, getPluginId(pluginId), properties, selector);
   }
-  
+
+  @Override
+  public Map<String, String> evaluateMacros(Map<String, String> properties, MacroEvaluator evaluator,
+                                            MacroParserOptions options) throws InvalidMacroException {
+    return pluginConfigurer.evaluateMacros(properties, evaluator, options);
+  }
+
   private String getPluginId(String childPluginId) {
     return String.format("%s%s%s", stageName, Constants.ID_SEPARATOR, childPluginId);
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/validation/ValidatingConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/validation/ValidatingConfigurer.java
@@ -21,10 +21,14 @@ import io.cdap.cdap.api.DatasetConfigurer;
 import io.cdap.cdap.api.dataset.Dataset;
 import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.module.DatasetModule;
+import io.cdap.cdap.api.macro.InvalidMacroException;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.api.plugin.PluginSelector;
 
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -80,5 +84,11 @@ public class ValidatingConfigurer implements PluginConfigurer, DatasetConfigurer
   public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId, PluginProperties properties,
                                      PluginSelector selector) {
     return delegate.usePluginClass(pluginType, pluginName, pluginId, properties, selector);
+  }
+
+  @Override
+  public Map<String, String> evaluateMacros(Map<String, String> properties, MacroEvaluator evaluator,
+                                            MacroParserOptions options) throws InvalidMacroException {
+    return delegate.evaluateMacros(properties, evaluator, options);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/MockPluginConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/MockPluginConfigurer.java
@@ -22,10 +22,14 @@ import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.api.dataset.Dataset;
 import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.module.DatasetModule;
+import io.cdap.cdap.api.macro.InvalidMacroException;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.api.plugin.PluginSelector;
+import io.cdap.cdap.internal.app.runtime.plugin.MacroParser;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -84,6 +88,15 @@ public class MockPluginConfigurer implements PluginConfigurer, DatasetConfigurer
   public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId,
                                      PluginProperties properties, PluginSelector selector) {
     return null;
+  }
+
+  @Override
+  public Map<String, String> evaluateMacros(Map<String, String> properties, MacroEvaluator evaluator,
+                                            MacroParserOptions options) throws InvalidMacroException {
+    MacroParser macroParser = new MacroParser(evaluator, options);
+    Map<String, String> evaluated = new HashMap<>();
+    properties.forEach((key, val) -> evaluated.put(key, macroParser.parse(val)));
+    return evaluated;
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/Connection.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/Connection.java
@@ -24,6 +24,7 @@ import java.util.Objects;
  */
 public class Connection {
   private final String name;
+  private final String connectionId;
   private final String connectionType;
   private final String description;
   private final boolean preConfigured;
@@ -33,7 +34,14 @@ public class Connection {
 
   public Connection(String name, String connectionType, String description, boolean preConfigured,
                     long createdTimeMillis, long updatedTimeMillis, PluginInfo plugin) {
+    this(name, ConnectionId.getConnectionId(name), connectionType, description, preConfigured, createdTimeMillis,
+         updatedTimeMillis, plugin);
+  }
+
+  public Connection(String name, String connectionId, String connectionType, String description, boolean preConfigured,
+                    long createdTimeMillis, long updatedTimeMillis, PluginInfo plugin) {
     this.name = name;
+    this.connectionId = connectionId;
     this.connectionType = connectionType;
     this.description = description;
     this.preConfigured = preConfigured;
@@ -44,6 +52,10 @@ public class Connection {
 
   public String getName() {
     return name;
+  }
+
+  public String getConnectionId() {
+    return connectionId;
   }
 
   public String getConnectionType() {
@@ -83,6 +95,7 @@ public class Connection {
     Connection that = (Connection) o;
     return preConfigured == that.preConfigured &&
       Objects.equals(name, that.name) &&
+      Objects.equals(connectionId, that.connectionId) &&
       Objects.equals(connectionType, that.connectionType) &&
       Objects.equals(description, that.description) &&
       Objects.equals(plugin, that.plugin);
@@ -90,6 +103,6 @@ public class Connection {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, connectionType, description, preConfigured, plugin);
+    return Objects.hash(name, connectionId, connectionType, description, preConfigured, plugin);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectionBadRequestException.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectionBadRequestException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.etl.proto.connection;
+
+import io.cdap.cdap.etl.proto.CodedException;
+
+import java.net.HttpURLConnection;
+
+/**
+ * Exception thrown when a connection request is bad
+ */
+public class ConnectionBadRequestException extends CodedException {
+
+  public ConnectionBadRequestException(String message) {
+    super(HttpURLConnection.HTTP_BAD_REQUEST, message);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectionConflictException.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectionConflictException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.etl.proto.connection;
+
+import io.cdap.cdap.etl.proto.CodedException;
+
+import java.net.HttpURLConnection;
+
+/**
+ * Thrown when there is a conflict on connection.
+ */
+public class ConnectionConflictException extends CodedException {
+
+  public ConnectionConflictException(String message) {
+    super(HttpURLConnection.HTTP_CONFLICT, message);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectionCreationRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectionCreationRequest.java
@@ -24,10 +24,18 @@ import java.util.Objects;
  */
 public class ConnectionCreationRequest {
   private final String description;
+  // flag indicating whether the creation request should overwrite an existing connection with same connection id
+  // but different connection name, i.e, a b and a.b both convert to id a_b
+  private final boolean overWrite;
   private final PluginInfo plugin;
 
   public ConnectionCreationRequest(String description, PluginInfo plugin) {
+    this(description, plugin, false);
+  }
+
+  public ConnectionCreationRequest(String description, PluginInfo plugin, boolean overWrite) {
     this.description = description;
+    this.overWrite = overWrite;
     this.plugin = plugin;
   }
 
@@ -37,6 +45,10 @@ public class ConnectionCreationRequest {
 
   public PluginInfo getPlugin() {
     return plugin;
+  }
+
+  public boolean overWrite() {
+    return overWrite;
   }
 
   @Override
@@ -50,12 +62,13 @@ public class ConnectionCreationRequest {
     }
 
     ConnectionCreationRequest that = (ConnectionCreationRequest) o;
-    return Objects.equals(description, that.description) &&
+    return overWrite == that.overWrite &&
+      Objects.equals(description, that.description) &&
       Objects.equals(plugin, that.plugin);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(description, plugin);
+    return Objects.hash(description, overWrite, plugin);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectionId.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectionId.java
@@ -18,19 +18,26 @@
 package io.cdap.cdap.etl.proto.connection;
 
 import io.cdap.cdap.api.NamespaceSummary;
+import jdk.nashorn.internal.runtime.regexp.RegExp;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * Connection id to identify a connection
  */
 public class ConnectionId {
+  private static final Pattern MACRO_CHARS = Pattern.compile("[${}()]");
+  private static final String REGEX = "[^a-zA-Z0-9_]";
+  private static final String REPLACED_CHAR = "_";
   private final NamespaceSummary namespace;
   private final String connection;
+  private final String connectionId;
 
-  public ConnectionId(NamespaceSummary namespace, String connection) {
+  public ConnectionId(NamespaceSummary namespace, String connectionName) {
     this.namespace = namespace;
-    this.connection = connection;
+    this.connection = connectionName;
+    this.connectionId = getConnectionId(connectionName);
   }
 
   public NamespaceSummary getNamespace() {
@@ -39,6 +46,39 @@ public class ConnectionId {
 
   public String getConnection() {
     return connection;
+  }
+
+  public String getConnectionId() {
+    return connectionId;
+  }
+
+  /**
+   * Get connection id for the given connection name. The connection name should not contain any characters specific
+   * to macro evaluation.
+   * Connection id will be lower case and only contains a-z, 0-9 and underscore.
+   * The length requirement is <=50, since the metadata tag has a restriction of 50 characters.
+   *
+   * @param name name of the connection.
+   * @return connection id.
+   */
+  public static String getConnectionId(String name) {
+    if (MACRO_CHARS.matcher(name).find()) {
+      throw new ConnectionBadRequestException(String.format("The connection name %s should not contain characters " +
+                                                              "'$', '{', '}', '(', ')'.", name));
+    }
+
+    name = name.trim();
+
+    // Filtering unwanted characters
+    name = name.replaceAll(REGEX, REPLACED_CHAR);
+    if (name.length() > 50) {
+      name = name.substring(0, 50);
+    }
+    if (name.isEmpty()) {
+      throw new ConnectionBadRequestException(
+        String.format("The connection name %s should contain at least one alphanumeric character or '_'.", name));
+    }
+    return name;
   }
 
   @Override
@@ -50,13 +90,14 @@ public class ConnectionId {
       return false;
     }
 
-    ConnectionId connectionId = (ConnectionId) o;
-    return Objects.equals(namespace, connectionId.namespace) &&
-      Objects.equals(connection, connectionId.connection);
+    ConnectionId that = (ConnectionId) o;
+    return Objects.equals(namespace, that.namespace) &&
+      Objects.equals(connection, that.connection) &&
+      Objects.equals(connectionId, that.connectionId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(namespace, connection);
+    return Objects.hash(namespace, connection, connectionId);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/spec/PipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/spec/PipelineSpec.java
@@ -48,6 +48,9 @@ public class PipelineSpec {
   private final int numOfRecordsPreview;
   private final Map<String, String> properties;
 
+  // we don't need this config after deploy time so don't serialize it
+  private final transient Set<String> connectionsUsed;
+
   protected PipelineSpec(Set<StageSpec> stages,
                          Set<Connection> connections,
                          Resources resources,
@@ -56,7 +59,8 @@ public class PipelineSpec {
                          boolean stageLoggingEnabled,
                          boolean processTimingEnabled,
                          int numOfRecordsPreview,
-                         Map<String, String> properties) {
+                         Map<String, String> properties,
+                         Set<String> connectionsUsed) {
     this.stages = ImmutableSet.copyOf(stages);
     this.connections = ImmutableSet.copyOf(connections);
     this.resources = resources;
@@ -66,6 +70,7 @@ public class PipelineSpec {
     this.processTimingEnabled = processTimingEnabled;
     this.numOfRecordsPreview = numOfRecordsPreview;
     this.properties = ImmutableMap.copyOf(properties);
+    this.connectionsUsed = connectionsUsed;
   }
 
   public Set<StageSpec> getStages() {
@@ -98,6 +103,10 @@ public class PipelineSpec {
 
   public int getNumOfRecordsPreview() {
     return numOfRecordsPreview;
+  }
+
+  public Set<String> getConnectionsUsed() {
+    return connectionsUsed;
   }
 
   public Map<String, String> getProperties() {
@@ -170,6 +179,7 @@ public class PipelineSpec {
     protected boolean processTimingEnabled;
     protected int numOfRecordsPreview;
     protected Map<String, String> properties;
+    protected Set<String> connectionsUsed;
 
     protected Builder() {
       this.stages = new HashSet<>();
@@ -178,6 +188,7 @@ public class PipelineSpec {
       this.stageLoggingEnabled = true;
       this.processTimingEnabled = true;
       this.properties = new HashMap<>();
+      this.connectionsUsed = new HashSet<>();
     }
 
     public T addStage(StageSpec stage) {
@@ -236,9 +247,20 @@ public class PipelineSpec {
       return (T) this;
     }
 
+    public T addConnectionUsed(String connection) {
+      this.connectionsUsed.add(connection);
+      return (T) this;
+    }
+
+    public T addConnectionsUsed(Set<String> connectionsUsed) {
+      this.connectionsUsed.addAll(connectionsUsed);
+      return (T) this;
+    }
+
     public PipelineSpec build() {
       return new PipelineSpec(stages, connections, resources, driverResources, clientResources,
-                              stageLoggingEnabled, processTimingEnabled, numOfRecordsPreview, properties);
+                              stageLoggingEnabled, processTimingEnabled, numOfRecordsPreview, properties,
+                              connectionsUsed);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/test/java/io/cdap/cdap/etl/proto/connection/ConnectionIdTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/test/java/io/cdap/cdap/etl/proto/connection/ConnectionIdTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.etl.proto.connection;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test connection id generation
+ */
+public class ConnectionIdTest {
+
+  @Test
+  public void testConnectionIdGeneration() throws Exception {
+    Assert.assertEquals("a_b_c", ConnectionId.getConnectionId("a.b.c"));
+    Assert.assertEquals("a_b_c", ConnectionId.getConnectionId("a^b^c"));
+    Assert.assertEquals("a_b_c", ConnectionId.getConnectionId("a b c"));
+    Assert.assertEquals("A_B_c", ConnectionId.getConnectionId("A%B%c"));
+    Assert.assertEquals("A__B__c", ConnectionId.getConnectionId("A%.B%#c"));
+    Assert.assertEquals("__A__B__c", ConnectionId.getConnectionId("&&A%.B%#c"));
+    Assert.assertEquals("__A__B__c", ConnectionId.getConnectionId("  &&A%.B%#c  "));
+
+    // test long string get truncated
+    StringBuilder longstring = new StringBuilder();
+    StringBuilder expected = new StringBuilder();
+    for (int i = 0; i < 100; i++) {
+      if (i % 2 == 0) {
+        expected.append("a");
+      }
+      longstring.append("a");
+    }
+    Assert.assertEquals(expected.toString(), ConnectionId.getConnectionId(longstring.toString()));
+
+    assertInvalidConnectionName("$");
+    assertInvalidConnectionName("(");
+    assertInvalidConnectionName(")");
+    assertInvalidConnectionName("{");
+    assertInvalidConnectionName("}");
+    assertInvalidConnectionName("${abc}");
+    assertInvalidConnectionName("${a(b)}");
+    assertInvalidConnectionName("$abcdedfg");
+  }
+
+  public void assertInvalidConnectionName(String name) {
+    try {
+      ConnectionId.getConnectionId(name);
+      Assert.fail();
+    } catch (ConnectionBadRequestException e) {
+      // expected
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/common/MockPipelineConfigurer.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/common/MockPipelineConfigurer.java
@@ -21,6 +21,9 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.Dataset;
 import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.module.DatasetModule;
+import io.cdap.cdap.api.macro.InvalidMacroException;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.api.plugin.PluginSelector;
 import io.cdap.cdap.etl.api.Engine;
@@ -109,6 +112,12 @@ public class MockPipelineConfigurer implements PipelineConfigurer, DatasetConfig
   public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId,
                                      PluginProperties pluginProperties, PluginSelector pluginSelector) {
     return (Class<T>) plugins.get(pluginId).getClass();
+  }
+
+  @Override
+  public Map<String, String> evaluateMacros(Map<String, String> properties, MacroEvaluator evaluator,
+                                            MacroParserOptions options) throws InvalidMacroException {
+    return properties;
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/service/DefaultSparkHttpServicePluginContext.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/service/DefaultSparkHttpServicePluginContext.java
@@ -27,6 +27,7 @@ import com.google.gson.stream.JsonWriter;
 import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.api.macro.InvalidMacroException;
 import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.Plugin;
 import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.api.plugin.PluginSelector;
@@ -156,6 +157,12 @@ public class DefaultSparkHttpServicePluginContext implements SparkHttpServicePlu
                                      String pluginId, PluginProperties properties, PluginSelector selector) {
     checkCanConfigure(pluginId);
     return pluginConfigurer.usePluginClass(pluginType, pluginName, pluginId, properties, selector);
+  }
+
+  @Override
+  public Map<String, String> evaluateMacros(Map<String, String> properties, MacroEvaluator evaluator,
+                                            MacroParserOptions options) throws InvalidMacroException {
+    return pluginConfigurer.evaluateMacros(properties, evaluator, options);
   }
 
   @Override

--- a/cdap-system-app-unit-test/src/main/java/io/cdap/cdap/test/SystemAppTestBase.java
+++ b/cdap-system-app-unit-test/src/main/java/io/cdap/cdap/test/SystemAppTestBase.java
@@ -37,11 +37,11 @@ public class SystemAppTestBase extends TestBase {
     }
   }
 
-  public TransactionRunner getTransactionRunner() {
+  public static TransactionRunner getTransactionRunner() {
     return transactionRunner;
   }
 
-  public StructuredTableAdmin getStructuredTableAdmin() {
+  public static StructuredTableAdmin getStructuredTableAdmin() {
     return tableAdmin;
   }
 }


### PR DESCRIPTION
Add the pipeline and connection relation using metadata: 
1. Let app configurer able to emit metadata for the application
2. Enable plugin configurer able to evaluate macros without instantiating the plugin
3. During deployment, collect the connection id and emit the them as metadata tags
4. Metadata has restrictions on the tags and properties, so we generate a connection id with these restrictions for each connection(this is also backward compatible with wrangler). 