### PR TITLE
(CDAP-17853) Multiple fixes around runtime service

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractTwillProgramController.java
@@ -63,51 +63,45 @@ public abstract class AbstractTwillProgramController extends AbstractProgramCont
    * @return this instance.
    */
   public ProgramController startListen() {
-    twillController.onRunning(new Runnable() {
-      @Override
-      public void run() {
-        LOG.info("Twill program running: {}, twill runId: {}", getProgramRunId(), twillController.getRunId());
-        started();
-      }
+    twillController.onRunning(() -> {
+      LOG.info("Twill program running: {}, twill runId: {}", getProgramRunId(), twillController.getRunId());
+      started();
     }, Threads.SAME_THREAD_EXECUTOR);
 
-    twillController.onTerminated(new Runnable() {
-      @Override
-      public void run() {
-        LOG.info("Twill program terminated: {}, twill runId: {}", getProgramRunId(), twillController.getRunId());
-        if (stopRequested) {
-          // Service was killed
-          stop();
-          return;
+    twillController.onTerminated(() -> {
+      ServiceController.TerminationStatus terminationStatus = twillController.getTerminationStatus();
+      LOG.info("Twill program terminated: {}, twill runId: {}, status: {}",
+               getProgramRunId(), twillController.getRunId(), terminationStatus);
+      if (stopRequested) {
+        // Service was killed
+        stop();
+        return;
+      }
+      // The terminationStatus shouldn't be null when the twillController state is terminated
+      // In case it does (e.g. bug or twill changes), rely on the termination future to determine the state
+      if (terminationStatus == null) {
+        try {
+          Futures.getUnchecked(twillController.terminate());
+          complete();
+        } catch (Exception e) {
+          complete(State.ERROR);
         }
-        ServiceController.TerminationStatus terminationStatus = twillController.getTerminationStatus();
-        LOG.debug("Twill program termination status: {}", terminationStatus);
-        // The terminationStatus shouldn't be null when the twillController state is terminated
-        // In case it does (e.g. bug or twill changes), rely on the termination future to determine the state
-        if (terminationStatus == null) {
-          try {
-            Futures.getUnchecked(twillController.terminate());
-            complete();
-          } catch (Exception e) {
-            complete(State.ERROR);
-          }
-          return;
-        }
-        // Based on the terminationStatus to set the completion state of the program controller.
-        switch (terminationStatus) {
-          case SUCCEEDED:
-            complete();
-            break;
-          case FAILED:
-            complete(State.ERROR);
-            break;
-          case KILLED:
-            complete(State.KILLED);
-            break;
-          default:
-            // This is just to protect against if more status are added in Twill in future
-            complete();
-        }
+        return;
+      }
+      // Based on the terminationStatus to set the completion state of the program controller.
+      switch (terminationStatus) {
+        case SUCCEEDED:
+          complete();
+          break;
+        case FAILED:
+          complete(State.ERROR);
+          break;
+        case KILLED:
+          complete(State.KILLED);
+          break;
+        default:
+          // This is just to protect against if more status are added in Twill in future
+          complete();
       }
     }, Threads.SAME_THREAD_EXECUTOR);
     return this;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
@@ -426,7 +426,7 @@ public class AbstractProgramRuntimeServiceTest {
       }
 
       if (extraInfo != null) {
-        updateRuntimeInfo(programId.getType(), runId, extraInfo);
+        updateRuntimeInfo(extraInfo);
         return extraInfo;
       }
       return null;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.internal.app.services;
 
-import io.cdap.cdap.AllProgramsApp;
 import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.app.runtime.Arguments;
@@ -58,10 +57,10 @@ public class SystemProgramManagementServiceTest extends AppFabricTestBase {
   private static ArtifactRepository artifactRepository;
 
   private static final String VERSION = "1.0.0";
-  private static final String APP_NAME = AllProgramsApp.NAME;
+  private static final String APP_NAME = SystemProgramManagementTestApp.NAME;
   private static final String NAMESPACE = "system";
-  private static final String PROGRAM_NAME = AllProgramsApp.NoOpService.NAME;
-  private static final Class<AllProgramsApp> APP_CLASS = AllProgramsApp.class;
+  private static final String PROGRAM_NAME = SystemProgramManagementTestApp.IdleWorkflow.NAME;
+  private static final Class<?> APP_CLASS = SystemProgramManagementTestApp.class;
 
   @BeforeClass
   public static void setup() {
@@ -86,7 +85,7 @@ public class SystemProgramManagementServiceTest extends AppFabricTestBase {
     deployTestApp();
     //Set this app as an enabled service
     ApplicationId applicationId = new ApplicationId(NAMESPACE, APP_NAME, VERSION);
-    ProgramId programId = new ProgramId(applicationId, ProgramType.SERVICE, PROGRAM_NAME);
+    ProgramId programId = new ProgramId(applicationId, ProgramType.WORKFLOW, PROGRAM_NAME);
     Map<ProgramId, Arguments> enabledServices = new HashMap<>();
     enabledServices.put(programId, new BasicArguments(new HashMap<>()));
     progmMgmtSvc.setProgramsEnabled(enabledServices);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementTestApp.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementTestApp.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services;
+
+import io.cdap.cdap.api.app.AbstractApplication;
+import io.cdap.cdap.api.customaction.AbstractCustomAction;
+import io.cdap.cdap.api.customaction.CustomAction;
+import io.cdap.cdap.api.workflow.AbstractWorkflow;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * An application for testing {@link SystemProgramManagementService}.
+ */
+public class SystemProgramManagementTestApp extends AbstractApplication {
+
+  public static final String NAME = SystemProgramManagementTestApp.class.getSimpleName();
+
+  @Override
+  public void configure() {
+    addWorkflow(new IdleWorkflow());
+  }
+
+  public static final class IdleWorkflow extends AbstractWorkflow {
+
+    public static final String NAME = IdleWorkflow.class.getSimpleName();
+
+    @Override
+    protected void configure() {
+      addAction(new IdleAction());
+    }
+  }
+
+  /**
+   * A {@link CustomAction} that just stay idle until interrupted.
+   */
+  public static final class IdleAction extends AbstractCustomAction {
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+
+    @Override
+    public void run() throws Exception {
+      try {
+        // Just wait indefinitely until interrupted
+        latch.await();
+      } catch (InterruptedException e) {
+        // Ignore
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Fix the temp directory creation in DistributedProgramRunner
- Reduce synchronization scope in DistributedProgramRuntimeService
- Simplify the AbstractProgramRuntimeService logic
   - Simplify resource cleanup logic
   - Avoid creating multiple RuntimeInfo
- Modify the SystemProgramManagementServiceTest so that it doesn't depend on race condition to pass