### PR TITLE
CDAP-17939 partition tms topics

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1386,6 +1386,7 @@ public final class Constants {
 
     public static final String LOCAL_DATA_DIR = "messaging.local.data.dir";
     public static final String LOCAL_DATA_CLEANUP_FREQUENCY = "messaging.local.data.cleanup.frequency.secs";
+    public static final String LOCAL_DATA_PARTITION_SECONDS = "messaging.local.data.partition.secs";
 
     public static final String CACHE_SIZE_MB = "messaging.cache.size.mb";
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2151,6 +2151,14 @@
   </property>
 
   <property>
+    <name>messaging.local.data.partition.secs</name>
+    <value>86400</value>
+    <description>
+      Size of each local messaging table partition in seconds.
+    </description>
+  </property>
+
+  <property>
     <name>messaging.max.instances</name>
     <value>${master.service.max.instances}</value>
     <description>

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/MessageTableKey.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/MessageTableKey.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.cdap.messaging.store;
+
+import io.cdap.cdap.api.common.Bytes;
+
+/**
+ * Row key used for an entry in a MessageTable.
+ */
+public class MessageTableKey {
+  private final byte[] rowKey;
+  private final int topicLength;
+  private long publishTimestamp;
+  private short sequenceId;
+
+  public static MessageTableKey fromRowKey(byte[] rowKey) {
+    int topicLength = rowKey.length - Bytes.SIZEOF_LONG - Bytes.SIZEOF_SHORT;
+    short sequenceId = Bytes.toShort(rowKey, topicLength + Bytes.SIZEOF_LONG, Bytes.SIZEOF_SHORT);
+    long publishTimestamp = Bytes.toLong(rowKey, topicLength, Bytes.SIZEOF_LONG);
+    byte[] topic = Bytes.head(rowKey, topicLength);
+    MessageTableKey messageTableKey = new MessageTableKey(topic);
+    messageTableKey.set(publishTimestamp, sequenceId);
+    return messageTableKey;
+  }
+
+  public static MessageTableKey fromTopic(byte[] topic) {
+    return new MessageTableKey(topic);
+  }
+
+  private MessageTableKey(byte[] topic) {
+    this.topicLength = topic.length;
+    this.rowKey = new byte[topicLength + Bytes.SIZEOF_LONG + Bytes.SIZEOF_SHORT];
+    Bytes.putBytes(rowKey, 0, topic, 0, topic.length);
+  }
+
+  /**
+   * Set the publish timestamp and sequence id to the values set in the given row key.
+   * This method should only be used when the topic is the same, otherwise a new instance of the
+   * MessageTableKey should be created.
+   */
+  public void setFromRowKey(byte[] rowKey) {
+    long publishTimestamp = Bytes.toLong(rowKey, topicLength, Bytes.SIZEOF_LONG);
+    short sequenceId = Bytes.toShort(rowKey, topicLength + Bytes.SIZEOF_LONG, Bytes.SIZEOF_SHORT);
+    set(publishTimestamp, sequenceId);
+  }
+
+  public void set(long publishTimestamp, short sequenceId) {
+    this.publishTimestamp = publishTimestamp;
+    this.sequenceId = sequenceId;
+    Bytes.putLong(rowKey, topicLength, publishTimestamp);
+    Bytes.putShort(rowKey, topicLength + Bytes.SIZEOF_LONG, sequenceId);
+  }
+
+  public byte[] getRowKey() {
+    return rowKey;
+  }
+
+  public long getPublishTimestamp() {
+    return publishTimestamp;
+  }
+
+  public short getSequenceId() {
+    return sequenceId;
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/RawMessageTableEntry.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/RawMessageTableEntry.java
@@ -22,18 +22,18 @@ import javax.annotation.Nullable;
  * Container class that contains raw bytes corresponding to an entry in the Message Table.
  */
 public class RawMessageTableEntry {
-  private byte[] key;
+  private MessageTableKey key;
   private byte[] txPtr;
   private byte[] payload;
 
-  public RawMessageTableEntry set(byte[] key, @Nullable byte[] txPtr, @Nullable byte[] payload) {
+  public RawMessageTableEntry set(MessageTableKey key, @Nullable byte[] txPtr, @Nullable byte[] payload) {
     this.key = key;
     this.txPtr = txPtr;
     this.payload = payload;
     return this;
   }
 
-  public byte[] getKey() {
+  public MessageTableKey getKey() {
     return key;
   }
 

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/RollbackRequest.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/RollbackRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package io.cdap.cdap.messaging.store;
+
+/**
+ * Request to rollback transactionally published messages in a given key range.
+ */
+public class RollbackRequest {
+  private final byte[] startRow;
+  private final byte[] stopRow;
+  private final byte[] txWritePointer;
+  private final long startTime;
+  private final long stopTime;
+
+  public RollbackRequest(byte[] startRow, byte[] stopRow, byte[] txWritePointer, long startTime, long stopTime) {
+    this.startRow = startRow;
+    this.stopRow = stopRow;
+    this.txWritePointer = txWritePointer;
+    this.startTime = startTime;
+    this.stopTime = stopTime;
+  }
+
+  public byte[] getStartRow() {
+    return startRow;
+  }
+
+  public byte[] getStopRow() {
+    return stopRow;
+  }
+
+  public byte[] getTxWritePointer() {
+    return txWritePointer;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public long getStopTime() {
+    return stopTime;
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/ScanRequest.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/ScanRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.cdap.messaging.store;
+
+import io.cdap.cdap.messaging.TopicMetadata;
+
+/**
+ * Request to scan across a key range in a MessageTable.
+ */
+public class ScanRequest {
+  private final TopicMetadata topicMetadata;
+  private final byte[] startRow;
+  private final byte[] stopRow;
+  private final long startTime;
+
+  public ScanRequest(TopicMetadata topicMetadata, byte[] startRow, byte[] stopRow, long startTime) {
+    this.topicMetadata = topicMetadata;
+    this.startRow = startRow;
+    this.stopRow = stopRow;
+    this.startTime = startTime;
+  }
+
+  public TopicMetadata getTopicMetadata() {
+    return topicMetadata;
+  }
+
+  public byte[] getStartRow() {
+    return startRow;
+  }
+
+  public byte[] getStopRow() {
+    return stopRow;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBPartition.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBPartition.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.store.leveldb;
+
+import org.iq80.leveldb.DB;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * One partition of a MessageTable, backed by a LevelDB table.
+ */
+public class LevelDBPartition implements Closeable {
+  private final File file;
+  private final long startTime;
+  private final long endTime;
+  private final Supplier levelDBSupplier;
+  private volatile DB levelDB;
+
+  public LevelDBPartition(File file, long startTime, long endTime, Supplier levelDBSupplier) {
+    this.file = file;
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.levelDBSupplier = levelDBSupplier;
+  }
+
+  public File getFile() {
+    return file;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public long getEndTime() {
+    return endTime;
+  }
+
+  public DB getLevelDB() throws IOException {
+    if (levelDB != null) {
+      return levelDB;
+    }
+    synchronized (this) {
+      if (levelDB == null) {
+        levelDB = levelDBSupplier.get();
+      }
+    }
+    return levelDB;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (levelDB != null) {
+      levelDB.close();
+    }
+  }
+
+  /**
+   * Supplies an opened LevelDB
+   */
+  public interface Supplier {
+    DB get() throws IOException;
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBPartitionManager.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBPartitionManager.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.store.leveldb;
+
+import io.cdap.cdap.common.utils.DirUtils;
+import org.iq80.leveldb.Options;
+import org.iq80.leveldb.impl.Iq80DBFactory;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.Nullable;
+
+/**
+ * Manages partitions of a logical MessageTable.
+ * Each partition is a physical LevelDB table in a directory structure like:
+ *
+ *   [base dir]/[namespace].[tablename].[topic].[generation]/part.[start].[end]
+ *
+ * Each partition contains messages with a publish time between the start (inclusive) and end (exclusive) timestamps.
+ */
+public class LevelDBPartitionManager implements Closeable {
+  private static final Iq80DBFactory LEVEL_DB_FACTORY = Iq80DBFactory.factory;
+  private static final String PART_PREFIX = "part.";
+  private final File topicDir;
+  private final Options dbOptions;
+  private final long partitionSizeMillis;
+  private final ConcurrentNavigableMap<Long, LevelDBPartition> partitions;
+  private final AtomicBoolean initialized;
+
+  public LevelDBPartitionManager(File topicDir, Options dbOptions, long partitionSizeMillis) {
+    this.topicDir = topicDir;
+    this.dbOptions = dbOptions;
+    this.partitionSizeMillis = partitionSizeMillis;
+    this.partitions = new ConcurrentSkipListMap<>();
+    this.initialized = new AtomicBoolean(false);
+  }
+
+  /**
+   * Prune partitions that have an end timestamp older than or equal to the given threshold timestamp.
+   */
+  public int prunePartitions(long thresholdTimestamp) throws IOException {
+    File[] partitionDirs = topicDir.listFiles();
+    int numPruned = 0;
+    if (partitionDirs == null) {
+      return numPruned;
+    }
+    for (File partitionDir : partitionDirs) {
+      String partitionName = partitionDir.getName();
+      TimeInterval timeInterval = extractIntervalFromName(partitionName);
+      if (timeInterval == null) {
+        // can only happen if somebody manually created some files/directories here
+        continue;
+      }
+      if (thresholdTimestamp >= timeInterval.endMillis) {
+        LevelDBPartition partition = partitions.remove(timeInterval.startMillis);
+        if (partition != null) {
+          partition.close();
+          DirUtils.deleteDirectoryContents(partitionDir);
+        }
+        numPruned++;
+      }
+    }
+    return numPruned;
+  }
+
+  public LevelDBPartition getOrCreatePartition(long publishTime) throws IOException {
+    LevelDBPartition partition = getPartitionIfExists(publishTime);
+    if (partition != null) {
+      return partition;
+    }
+
+    synchronized (this) {
+      // Check again to make sure no new instance was being created while this thread is acquiring the lock
+      partition = getPartitionIfExists(publishTime);
+      if (partition != null) {
+        return partition;
+      }
+
+      partition = getOrCreateDBPartition(publishTime);
+      partitions.put(partition.getStartTime(), partition);
+
+      return partition;
+    }
+  }
+
+  /**
+   * Get existing partitions for publish times equal to or greater than the given timestamp.
+   */
+  public Collection<LevelDBPartition> getPartitions(long startTime) throws IOException {
+    if (initialized.compareAndSet(false, true)) {
+      initPartitions();
+    }
+    Long partitionStartTime = partitions.floorKey(startTime);
+    return partitionStartTime == null ? partitions.values() : partitions.tailMap(partitionStartTime, true).values();
+  }
+
+  /**
+   * Get the partitions responsible for data between the specified start and end times.
+   *
+   * @param startTime inclusive start time
+   * @param endTime inclusive end time
+   * @return partitions responsible for data between the specified start and end times
+   */
+  public Collection<LevelDBPartition> getPartitions(long startTime, long endTime) throws IOException {
+    if (initialized.compareAndSet(false, true)) {
+      initPartitions();
+    }
+    Long partitionEndTime = partitions.floorKey(endTime);
+    if (partitionEndTime == null) {
+      // partitionEndTime can only be null if the partitions map is empty, or the endTime is less than the
+      // start time for any existing partition. In either case, there are no partitions that contain data
+      // published between the start and end times.
+      return Collections.emptyList();
+    }
+
+    Long partitionStartTime = partitions.floorKey(startTime);
+    // partitionStartTime can be null if the startTime is less than the start time for any existing partition
+    partitionStartTime = partitionStartTime == null ? 0 : partitionStartTime;
+    return partitions.subMap(partitionStartTime, true, partitionEndTime, true).values();
+  }
+
+  public void close() throws IOException {
+    List<LevelDBPartition> partitionsToClose;
+
+    synchronized (this) {
+      partitionsToClose = new ArrayList<>(partitions.values());
+      partitions.clear();
+    }
+
+    IOException failure = null;
+    for (LevelDBPartition partition : partitionsToClose) {
+      try {
+        partition.close();
+      } catch (IOException e) {
+        if (failure == null) {
+          failure = e;
+        } else {
+          failure.addSuppressed(e);
+        }
+      }
+    }
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
+  @Nullable
+  private LevelDBPartition getPartitionIfExists(long publishTime) {
+    Map.Entry<Long, LevelDBPartition> partitionEntry = partitions.floorEntry(publishTime);
+    if (partitionEntry != null) {
+      LevelDBPartition partition = partitionEntry.getValue();
+      if (partition.getEndTime() > publishTime) {
+        return partition;
+      }
+    }
+    return null;
+  }
+
+  private synchronized void initPartitions() throws IOException {
+    ensureDirExists(topicDir);
+
+    for (File partitionDir : DirUtils.listFiles(topicDir)) {
+      if (!partitionDir.isDirectory()) {
+        continue;
+      }
+
+      String dirName = partitionDir.getName();
+      TimeInterval interval = extractIntervalFromName(dirName);
+      if (interval == null) {
+        // should not happen unless somebody manually created a directory here
+        continue;
+      }
+      LevelDBPartition partition = new LevelDBPartition(partitionDir, interval.startMillis, interval.endMillis,
+                                                        () -> LEVEL_DB_FACTORY.open(partitionDir, dbOptions));
+      partitions.put(partition.getStartTime(), partition);
+    }
+  }
+
+  private LevelDBPartition getOrCreateDBPartition(long publishTime) throws IOException {
+    if (initialized.compareAndSet(false, true)) {
+      initPartitions();
+    }
+
+    long closestEndTime = Long.MAX_VALUE;
+    long closestStartTime = Long.MAX_VALUE;
+    for (LevelDBPartition partition : partitions.values()) {
+      if (publishTime >= partition.getStartTime() && publishTime < partition.getEndTime()) {
+        // if the publish time is within the time range, return the partition
+        return partition;
+      }
+
+      long startTimeDiff = Math.abs(partition.getStartTime() - publishTime);
+      long endTimeDiff = Math.abs(partition.getEndTime() - publishTime);
+      if (Math.abs(closestStartTime - publishTime) > startTimeDiff) {
+        closestStartTime = partition.getStartTime();
+      }
+      if (Math.abs(closestEndTime - publishTime) > endTimeDiff) {
+        closestEndTime = partition.getEndTime();
+      }
+    }
+
+    // If there are no existing partitions, create a new one from [0 -> publishtime + partition size)
+    if (partitions.isEmpty()) {
+      return createPartition(topicDir, 0, publishTime + partitionSizeMillis);
+    }
+
+    /*
+        If partitions exist but the publish time is not within an existing range,
+        determine the time range of the new partition.
+
+        If the publish time is before all existing partitions, create a new partition from [0, closestStartTime)
+
+        If the publish time is after all existing partitions,
+        create a new partition from [closestEndTime, max(closestEndTime + partitionSize, publishTime))
+
+        Otherwise, the publish time is in the middle of two existing partitions, and the new partition
+        will be one that fills in the gap from [closestStartTime, closestEndTime)
+
+        For example, suppose partitions size is 1000 and existing partitions are:
+
+          [2000 -> 3000), [3000 -> 4000), [6000 -> 7000)
+
+        If the publish time is 1950, the new partition will be [0, 2000)
+        If the publish time is 7100, the new partition will be [7000, 8000)
+        If the publish time is 8100, the new partition will be [7000, 8100)
+        If the publish time is 4500, the new partition will be [4000, 6000)
+     */
+    if (publishTime < closestStartTime) {
+      return createPartition(topicDir, 0, closestStartTime);
+    }
+    if (publishTime >= closestEndTime) {
+      return createPartition(topicDir, closestEndTime, Math.max(closestEndTime + partitionSizeMillis, publishTime));
+    }
+    return createPartition(topicDir, closestStartTime, closestEndTime);
+  }
+
+  private LevelDBPartition createPartition(File topicDir, long start, long end) throws IOException {
+    File dbPath = new File(topicDir, String.format("%s%d.%d", PART_PREFIX, start, end));
+    ensureDirExists(dbPath);
+    return new LevelDBPartition(dbPath, start, end, () -> LEVEL_DB_FACTORY.open(dbPath, dbOptions));
+  }
+
+  private File ensureDirExists(File dir) throws IOException {
+    if (!DirUtils.mkdirs(dir)) {
+      throw new IOException("Failed to create local directory " + dir + " for the messaging system.");
+    }
+    return dir;
+  }
+
+  private static class TimeInterval {
+    private final long startMillis;
+    private final long endMillis;
+
+    private TimeInterval(long startMillis, long endMillis) {
+      this.startMillis = startMillis;
+      this.endMillis = endMillis;
+    }
+  }
+
+  @Nullable
+  static TimeInterval extractIntervalFromName(String name) {
+    // should always parse properly unless somebody manually created directories here
+    if (!name.startsWith(PART_PREFIX)) {
+      return null;
+    }
+    int dotIdx = name.lastIndexOf('.');
+    if (dotIdx < 0 || dotIdx == name.length() - 1) {
+      return null;
+    }
+    String endTimeStr = name.substring(dotIdx + 1);
+    String startTimeStr = name.substring(PART_PREFIX.length(), dotIdx);
+    try {
+      long endTime = Long.parseLong(endTimeStr);
+      long startTime = Long.parseLong(startTimeStr);
+      return new TimeInterval(startTime, endTime);
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/PartitionedDBScanIterator.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/PartitionedDBScanIterator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.store.leveldb;
+
+import io.cdap.cdap.api.dataset.lib.AbstractCloseableIterator;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+/**
+ * An iterator that scans over multiple partitions of a MessageTable.
+ *
+ * @param <T> type of object to scan
+ */
+public class PartitionedDBScanIterator<T> extends AbstractCloseableIterator<T> {
+  private final Iterator<LevelDBPartition> partitionIter;
+  private final byte[] startRow;
+  private final byte[] stopRow;
+  private final BiFunction<byte[], byte[], T> decodeFunction;
+  private boolean closed;
+  private CloseableIterator<Map.Entry<byte[], byte[]>> currentPartition;
+
+  public PartitionedDBScanIterator(Iterator<LevelDBPartition> partitionIter, byte[] startRow, byte[] stopRow,
+                                   BiFunction<byte[], byte[], T> decodeFunction) throws IOException {
+    this.partitionIter = partitionIter;
+    this.startRow = startRow;
+    this.stopRow = stopRow;
+    this.decodeFunction = decodeFunction;
+    this.closed = false;
+    this.currentPartition = partitionIter.hasNext() ?
+      new DBScanIterator(partitionIter.next().getLevelDB(), startRow, stopRow) : CloseableIterator.empty();
+  }
+
+  @Override
+  protected T computeNext() {
+    if (closed) {
+      return endOfData();
+    }
+
+    if (!currentPartition.hasNext()) {
+      while (partitionIter.hasNext()) {
+        try {
+          currentPartition = new DBScanIterator(partitionIter.next().getLevelDB(), startRow, stopRow);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+        if (currentPartition.hasNext()) {
+          break;
+        }
+      }
+    }
+
+    if (!currentPartition.hasNext()) {
+      return endOfData();
+    }
+
+    Map.Entry<byte[], byte[]> row = currentPartition.next();
+    return decodeFunction.apply(row.getKey(), row.getValue());
+  }
+
+  @Override
+  public void close() {
+    try {
+      currentPartition.close();
+    } finally {
+      endOfData();
+      closed = true;
+    }
+  }
+}

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/MessageTableTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/MessageTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2016-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -49,7 +49,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 
 /**
  * Base class for Message Table tests.
@@ -389,67 +388,6 @@ public abstract class MessageTableTest {
     @Override
     public int getEndSequenceId() {
       return endSeqId;
-    }
-  }
-
-  // Private class for publishing messages
-  private static class TestMessageEntry implements MessageTable.Entry {
-    private final TopicId topicId;
-    private final int generation;
-    private final Long transactionWritePointer;
-    private final byte[] payload;
-    private final long publishTimestamp;
-    private final short sequenceId;
-
-    TestMessageEntry(TopicId topicId, int generation, long publishTimestamp, int sequenceId,
-                     @Nullable Long transactionWritePointer, @Nullable byte[] payload) {
-      this.topicId = topicId;
-      this.generation = generation;
-      this.transactionWritePointer = transactionWritePointer;
-      this.publishTimestamp = publishTimestamp;
-      this.sequenceId = (short) sequenceId;
-      this.payload = payload;
-    }
-
-    @Override
-    public TopicId getTopicId() {
-      return topicId;
-    }
-
-    @Override
-    public int getGeneration() {
-      return generation;
-    }
-
-    @Override
-    public boolean isPayloadReference() {
-      return payload == null;
-    }
-
-    @Override
-    public boolean isTransactional() {
-      return transactionWritePointer != null;
-    }
-
-    @Override
-    public long getTransactionWritePointer() {
-      return transactionWritePointer == null ? -1L : transactionWritePointer;
-    }
-
-    @Nullable
-    @Override
-    public byte[] getPayload() {
-      return payload;
-    }
-
-    @Override
-    public long getPublishTimestamp() {
-      return publishTimestamp;
-    }
-
-    @Override
-    public short getSequenceId() {
-      return sequenceId;
     }
   }
 }

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/TestMessageEntry.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/TestMessageEntry.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.store;
+
+import io.cdap.cdap.proto.id.TopicId;
+
+import javax.annotation.Nullable;
+
+// class for publishing messages
+public class TestMessageEntry implements MessageTable.Entry {
+  private final TopicId topicId;
+  private final int generation;
+  private final Long transactionWritePointer;
+  private final byte[] payload;
+  private final long publishTimestamp;
+  private final short sequenceId;
+
+  public TestMessageEntry(TopicId topicId, int generation, long publishTimestamp, int sequenceId,
+                   @Nullable Long transactionWritePointer, @Nullable byte[] payload) {
+    this.topicId = topicId;
+    this.generation = generation;
+    this.transactionWritePointer = transactionWritePointer;
+    this.publishTimestamp = publishTimestamp;
+    this.sequenceId = (short) sequenceId;
+    this.payload = payload;
+  }
+
+  @Override
+  public TopicId getTopicId() {
+    return topicId;
+  }
+
+  @Override
+  public int getGeneration() {
+    return generation;
+  }
+
+  @Override
+  public boolean isPayloadReference() {
+    return payload == null;
+  }
+
+  @Override
+  public boolean isTransactional() {
+    return transactionWritePointer != null;
+  }
+
+  @Override
+  public long getTransactionWritePointer() {
+    return transactionWritePointer == null ? -1L : transactionWritePointer;
+  }
+
+  @Nullable
+  @Override
+  public byte[] getPayload() {
+    return payload;
+  }
+
+  @Override
+  public long getPublishTimestamp() {
+    return publishTimestamp;
+  }
+
+  @Override
+  public short getSequenceId() {
+    return sequenceId;
+  }
+}

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/leveldb/LevelDBPartitionManagerTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/leveldb/LevelDBPartitionManagerTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.store.leveldb;
+
+import org.iq80.leveldb.Options;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Tests for {@link LevelDBPartitionManager}.
+ */
+public class LevelDBPartitionManagerTest {
+
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  private static final Options DB_OPTIONS = new Options()
+    .errorIfExists(false)
+    .createIfMissing(true);
+
+  @Test
+  public void testPrunePartitions() throws IOException {
+    LevelDBPartitionManager partitionManager = new LevelDBPartitionManager(tmpFolder.newFolder(), DB_OPTIONS, 1000);
+
+    // create 3 partitions:
+    //   partition1: [0, 1000)
+    //   partition2: [1000, 2000)
+    //   partition3: [2000, 3000)
+    partitionManager.getOrCreatePartition(0);
+    partitionManager.getOrCreatePartition(1000);
+    partitionManager.getOrCreatePartition(2000);
+    Assert.assertEquals(3, partitionManager.getPartitions(0).size());
+
+    // should prune partition1 since 1000 is older than [0, 1000), but not partition2 or partition3
+    Assert.assertEquals(1, partitionManager.prunePartitions(1000));
+    Assert.assertEquals(new HashSet<>(Arrays.asList(1000L, 2000L)),
+                        partitionManager.getPartitions(0).stream()
+                          .map(LevelDBPartition::getStartTime)
+                          .collect(Collectors.toSet()));
+    // should not prune anything
+    Assert.assertEquals(0, partitionManager.prunePartitions(1001));
+    // should prune rest of partitions
+    Assert.assertEquals(2, partitionManager.prunePartitions(3000));
+    Assert.assertEquals(0, partitionManager.getPartitions(0).size());
+  }
+
+  @Test
+  public void testCreatePartitions() throws IOException {
+    LevelDBPartitionManager partitionManager = new LevelDBPartitionManager(tmpFolder.newFolder(), DB_OPTIONS, 1000);
+
+    // check that there are no partitions
+    Assert.assertTrue(partitionManager.getPartitions(0).isEmpty());
+
+    // first partition should be from [0, publish time + partition size)
+    LevelDBPartition partition = partitionManager.getOrCreatePartition(5000);
+    Assert.assertEquals(0, partition.getStartTime());
+    Assert.assertEquals(6000, partition.getEndTime());
+
+    // should not create new partitions for anything within [0,6000)
+    for (long i = 0; i < 6000; i += 500) {
+      partition = partitionManager.getOrCreatePartition(i);
+      Assert.assertEquals(0, partition.getStartTime());
+      Assert.assertEquals(6000, partition.getEndTime());
+    }
+
+    // new partition for publish time 7500 should fill in the gap to create [6000,7500)
+    partition = partitionManager.getOrCreatePartition(7500);
+    Assert.assertEquals(6000, partition.getStartTime());
+    Assert.assertEquals(7500, partition.getEndTime());
+
+    // new partition for publish time 8000 should be [7500,8500)
+    partition = partitionManager.getOrCreatePartition(7500);
+    Assert.assertEquals(7500, partition.getStartTime());
+    Assert.assertEquals(8500, partition.getEndTime());
+
+    // prune the [0,6000) and [6000,7500) partitions
+    Assert.assertEquals(2, partitionManager.prunePartitions(8000));
+    // adding new partition for 4000 should fill in the gap and create [0,7500)
+    partition = partitionManager.getOrCreatePartition(4000);
+    Assert.assertEquals(0, partition.getStartTime());
+    Assert.assertEquals(7500, partition.getEndTime());
+  }
+
+  @Test
+  public void testGetPartitions() throws IOException {
+    LevelDBPartitionManager partitionManager = new LevelDBPartitionManager(tmpFolder.newFolder(), DB_OPTIONS, 1000);
+
+    // create partitions [0,1000), [1000,2000), [2000,5000), [5000,8000)
+    partitionManager.getOrCreatePartition(0);
+    partitionManager.getOrCreatePartition(2000);
+    partitionManager.getOrCreatePartition(5000);
+    partitionManager.getOrCreatePartition(8000);
+
+    // test getPartitions(startTime)
+    Map<Long, Long> expectedIntervals = new HashMap<>();
+    expectedIntervals.put(0L, 1000L);
+    expectedIntervals.put(1000L, 2000L);
+    expectedIntervals.put(2000L, 5000L);
+    expectedIntervals.put(5000L, 8000L);
+    Collection<LevelDBPartition> partitions = partitionManager.getPartitions(0);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+
+    partitions = partitionManager.getPartitions(500);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+
+    expectedIntervals.remove(0L);
+    partitions = partitionManager.getPartitions(1800);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+
+    expectedIntervals.remove(1000L);
+    partitions = partitionManager.getPartitions(3333);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+
+    expectedIntervals.remove(2000L);
+    partitions = partitionManager.getPartitions(5555);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+
+    // test getPartition(startTime, endTime)
+    expectedIntervals = new HashMap<>();
+    expectedIntervals.put(0L, 1000L);
+    expectedIntervals.put(1000L, 2000L);
+    expectedIntervals.put(2000L, 5000L);
+    expectedIntervals.put(5000L, 8000L);
+    partitions = partitionManager.getPartitions(0, Long.MAX_VALUE);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+    partitions = partitionManager.getPartitions(777, Long.MAX_VALUE);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+    partitions = partitionManager.getPartitions(3, 5000);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+
+    expectedIntervals.remove(0L);
+    partitions = partitionManager.getPartitions(1000, 5000);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+    partitions = partitionManager.getPartitions(1000, 5000);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+    partitions = partitionManager.getPartitions(1999, 9999);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+
+    expectedIntervals.remove(5000L);
+    partitions = partitionManager.getPartitions(1000, 4999);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+    partitions = partitionManager.getPartitions(1337, 4999);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+    partitions = partitionManager.getPartitions(1999, 2000);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+
+    expectedIntervals.remove(2000L);
+    partitions = partitionManager.getPartitions(1000, 1999);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+    partitions = partitionManager.getPartitions(1000, 1001);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+    partitions = partitionManager.getPartitions(1000, 1000);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+
+    // prune [0,1000) partition
+    Assert.assertEquals(1, partitionManager.prunePartitions(1000));
+
+    // test getPartition(0) returns all existing partitions, even though 0 is before all existing partition start times
+    expectedIntervals.put(1000L, 2000L);
+    expectedIntervals.put(2000L, 5000L);
+    expectedIntervals.put(5000L, 8000L);
+    partitions = partitionManager.getPartitions(0);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+    partitions = partitionManager.getPartitions(0, 10000);
+    Assert.assertEquals(expectedIntervals, convertToIntervals(partitions));
+  }
+
+  @Test
+  public void testIsolation() throws IOException {
+    // test tables are isolated based on the directory given
+    LevelDBPartitionManager manager1 = new LevelDBPartitionManager(tmpFolder.newFolder(), DB_OPTIONS, 1000);
+    manager1.getOrCreatePartition(0);
+    LevelDBPartitionManager manager2 = new LevelDBPartitionManager(tmpFolder.newFolder(), DB_OPTIONS, 1000);
+    manager2.getOrCreatePartition(1000);
+
+    Assert.assertEquals(1, manager1.getPartitions(0).size());
+    Assert.assertEquals(1000L, manager1.getPartitions(0).iterator().next().getEndTime());
+
+    Assert.assertEquals(1, manager2.getPartitions(0).size());
+    Assert.assertEquals(2000L, manager2.getPartitions(0).iterator().next().getEndTime());
+  }
+
+  private Map<Long, Long> convertToIntervals(Collection<LevelDBPartition> partitions) {
+    return partitions.stream().collect(Collectors.toMap(LevelDBPartition::getStartTime, LevelDBPartition::getEndTime));
+  }
+}

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTTLCleanupTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTTLCleanupTest.java
@@ -47,6 +47,7 @@ public class LevelDBTTLCleanupTest extends DataCleanupTest {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(Constants.MessagingSystem.LOCAL_DATA_CLEANUP_FREQUENCY, Integer.toString(CLEANUP_PERIOD_IN_SECS));
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, tmpFolder.newFolder().getAbsolutePath());
+    cConf.set(Constants.MessagingSystem.LOCAL_DATA_PARTITION_SECONDS, Integer.toString(1));
     tableFactory = new LevelDBTableFactory(cConf);
   }
 


### PR DESCRIPTION
Partition the TMS topics so that each topic is partitioned into
multiple leveldb tables. This allows the implementation of TTL logic
to be much more efficient by dropping entire tables instead of
deleting contents row by row.