### PR TITLE
CDAP-17981: Make FileLocalizer to load files via AppFab instead of di…

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramTwillRunnableModuleTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramTwillRunnableModuleTest.java
@@ -51,6 +51,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.function.Supplier;
@@ -177,6 +180,11 @@ public class ProgramTwillRunnableModuleTest {
     @Override
     public Supplier<TwillRunnerService> getTwillRunnerSupplier() {
       return NoopTwillRunnerService::new;
+    }
+
+    @Override
+    public void downloadFile(URI srcURI, OutputStream outputStream) throws IOException {
+      throw new IOException("Unimplemented");
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -54,6 +54,7 @@ import io.cdap.cdap.gateway.handlers.BootstrapHttpHandler;
 import io.cdap.cdap.gateway.handlers.CommonHandlers;
 import io.cdap.cdap.gateway.handlers.ConfigHandler;
 import io.cdap.cdap.gateway.handlers.ConsoleSettingsHttpHandler;
+import io.cdap.cdap.gateway.handlers.FileFetcherHttpHandlerInternal;
 import io.cdap.cdap.gateway.handlers.ImpersonationHandler;
 import io.cdap.cdap.gateway.handlers.InstanceOperationHttpHandler;
 import io.cdap.cdap.gateway.handlers.NamespaceHttpHandler;
@@ -361,6 +362,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(ProfileHttpHandler.class);
       handlerBinder.addBinding().to(ProvisionerHttpHandler.class);
       handlerBinder.addBinding().to(BootstrapHttpHandler.class);
+      handlerBinder.addBinding().to(FileFetcherHttpHandlerInternal.class);
+
 
       for (Class<? extends HttpHandler> handlerClass : handlerClasses) {
         handlerBinder.addBinding().to(handlerClass);
@@ -445,7 +448,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
   /**
    * A Guice provider for the {@link UGIProvider} class based on the CDAP configuration.
-   *
+   * <p>
    * When Kerberos is enabled, it provides {@link DefaultUGIProvider} instance. Otherwise, an
    * {@link UnsupportedUGIProvider} will be used.
    */

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/FileFetcherHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/FileFetcherHttpHandlerInternal.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers;
+
+import com.google.common.io.Closeables;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.io.Locations;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.BodyProducer;
+import io.cdap.http.HttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.mortbay.log.Log;
+
+import java.io.InputStream;
+import javax.annotation.Nullable;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+
+/**
+ * Internal {@link HttpHandler} for serving file downloading requests.
+ * <p>
+ * This is currently used by FileLocalizer to download required files from AppFabric
+ * in order to launch TwillApplication.
+ */
+@Singleton
+@Path(Constants.Gateway.INTERNAL_API_VERSION_3)
+public class FileFetcherHttpHandlerInternal extends AbstractHttpHandler {
+  private final LocationFactory locationFactory;
+
+  @Inject
+  FileFetcherHttpHandlerInternal(LocationFactory locationFactory) {
+    this.locationFactory = locationFactory;
+  }
+
+  /**
+   * Download the file specified by path based on current {@link LocationFactory}
+   *
+   * @param request {@link HttpRequest}
+   * @param responder {@link HttpResponse}
+   */
+  @GET
+  @Path("/location/**")
+  public void download(HttpRequest request, HttpResponder responder) throws Exception {
+    String prefix = String.format("%s/location/", Constants.Gateway.INTERNAL_API_VERSION_3);
+    String path = request.uri().substring(prefix.length());
+    Location location = Locations.getLocationFromAbsolutePath(locationFactory, path);
+
+    if (!location.exists()) {
+      responder.sendString(HttpResponseStatus.NOT_FOUND, String.format("File %s not found", path));
+      return;
+    }
+
+    byte[] buf = new byte[64 * 1024];
+    InputStream inputStream = location.getInputStream();
+    try {
+      responder.sendContent(HttpResponseStatus.OK, new BodyProducer() {
+        @Override
+        public ByteBuf nextChunk() throws Exception {
+          int len = inputStream.read(buf);
+          if (len == -1) {
+            return Unpooled.EMPTY_BUFFER;
+          }
+          return Unpooled.copiedBuffer(buf, 0, len);
+        }
+
+        @Override
+        public void finished() throws Exception {
+          Closeables.closeQuietly(inputStream);
+        }
+
+        @Override
+        public void handleError(@Nullable Throwable cause) {
+          Log.debug("Error when sending chunks for path {}", path, cause);
+          Closeables.closeQuietly(inputStream);
+        }
+      }, new DefaultHttpHeaders().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM));
+    } catch (Exception e) {
+      Log.warn("Exception when initiating stream download for path {}", path);
+      Closeables.closeQuietly(inputStream);
+      throw e;
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/FileFetcherHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/FileFetcherHttpHandlerInternalTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services.http.handlers;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.gateway.handlers.FileFetcherHttpHandlerInternal;
+import io.cdap.common.http.HttpContentConsumer;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import io.cdap.http.NettyHttpService;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.Random;
+
+/**
+ * Test for {@link FileFetcherHttpHandlerInternal}.
+ */
+public class FileFetcherHttpHandlerInternalTest {
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+  private static final Logger LOG = LoggerFactory.getLogger(FileFetcherHttpHandlerInternalTest.class);
+  private static NettyHttpService httpService;
+  private static URL baseURL;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    Injector injector = Guice.createInjector(
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(LocationFactory.class).to(LocalLocationFactory.class);
+        }
+      });
+
+    FileFetcherHttpHandlerInternal handler = injector.getInstance(FileFetcherHttpHandlerInternal.class);
+
+    httpService = NettyHttpService.builder("FileFetcherHttpHandlerInternalTest")
+      .setHttpHandlers(handler)
+      .build();
+
+    httpService.start();
+
+    InetSocketAddress addr = httpService.getBindAddress();
+    baseURL = new URL(String.format("http://%s:%d", addr.getHostName(), addr.getPort()));
+  }
+
+  @AfterClass
+  public static void stop() throws Exception {
+    httpService.stop();
+  }
+
+  @Test
+  public void testSuccess() throws Exception {
+    // Create a file.
+    File srcFile = TEMP_FOLDER.newFile("src_file");
+    try (FileOutputStream out = new FileOutputStream(srcFile)) {
+      byte[] bytes = new byte[256 * 1024 + 7];
+      new Random().nextBytes(bytes);
+      out.write(bytes);
+    }
+
+    // Download the file.
+    File targetFile = new File(TEMP_FOLDER.newFolder(), "dst_file");
+    Location dst = new LocalLocationFactory().create(targetFile.toURI());
+    HttpResponse httpResponse = download(srcFile, dst);
+    Assert.assertEquals(httpResponse.getResponseCode(), HttpResponseStatus.OK.code());
+
+    // Verify the source and destination files are identical.
+    byte[] orgFileContent = Files.readAllBytes(srcFile.toPath());
+    byte[] downloadedFileContent = Files.readAllBytes(targetFile.toPath());
+    Assert.assertArrayEquals(orgFileContent, downloadedFileContent);
+  }
+
+  @Test
+  public void testFileNotFound() throws Exception {
+    // A non-existent file
+    File srcFile = new File(TEMP_FOLDER.getRoot(), "file_dont_exist");
+
+    // Download the file.
+    File targetFile = new File(TEMP_FOLDER.newFolder(), "dst_file");
+    Location dst = new LocalLocationFactory().create(targetFile.toURI());
+
+    HttpResponse httpResponse = download(srcFile, dst);
+    Assert.assertEquals(httpResponse.getResponseCode(), HttpResponseStatus.NOT_FOUND.code());
+  }
+
+  private HttpResponse download(File src, Location dst) throws IOException {
+    // Make a request to download the source file.
+    URL url = new URL(String.format("%s/v3Internal/location/%s", baseURL, src.toURI().getPath()));
+    OutputStream outputStream = dst.getOutputStream();
+    HttpRequest request = HttpRequest.builder(
+      HttpMethod.GET, url).withContentConsumer(
+      new HttpContentConsumer() {
+        @Override
+        public boolean onReceived(ByteBuffer chunk) {
+          try {
+            byte[] bytes = new byte[chunk.remaining()];
+            chunk.get(bytes, 0, bytes.length);
+            outputStream.write(bytes);
+          } catch (IOException e) {
+            LOG.error("Failed to write to orgFile {}", dst.toURI());
+            return false;
+          }
+          return true;
+        }
+
+        @Override
+        public void onFinished() {
+          try {
+            outputStream.close();
+          } catch (Exception e) {
+            LOG.error("Failed to close to orgFile {}", dst.toURI());
+          }
+        }
+      }).build();
+    HttpResponse httpResponse = HttpRequests.execute(request, new DefaultHttpRequestConfig(false));
+    httpResponse.consumeContent();
+    return httpResponse;
+  }
+
+}

--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -86,6 +86,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>6.5.0-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/FileFetcher.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/FileFetcher.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.common.http.HttpContentConsumer;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+
+/**
+ * Download file from AppFabric via internal REST API calls.
+ * <p>
+ * The target file could be either residing in AppFabric's local file system or a distributed file system
+ * that AppFabric is configured to access.
+ */
+class FileFetcher {
+  private static final Logger LOG = LoggerFactory.getLogger(FileFetcher.class);
+  private final RemoteClient remoteClient;
+
+  FileFetcher(DiscoveryServiceClient discoveryClient) {
+    this.remoteClient = new RemoteClient(discoveryClient,
+                                         Constants.Service.APP_FABRIC_HTTP,
+                                         new DefaultHttpRequestConfig(false),
+                                         Constants.Gateway.INTERNAL_API_VERSION_3);
+  }
+
+  /**
+   * Download a file from AppFabric and store it in the target file.
+   *
+   * @param sourceURI uri to identity the file to download. This URI should exist in AppFabric.
+   * @param outputStream target location to store the downloaded file
+   * @throws IOException if file downloading or writing to target location fails.
+   */
+  void download(URI sourceURI, OutputStream outputStream) throws IOException {
+    HttpRequest request = remoteClient.requestBuilder(
+      HttpMethod.GET,
+      String.format("location/%s", sourceURI.getPath())).withContentConsumer(
+      new HttpContentConsumer() {
+        @Override
+        public boolean onReceived(ByteBuffer chunk) {
+          try {
+            byte[] bytes = new byte[chunk.remaining()];
+            chunk.get(bytes, 0, bytes.length);
+            outputStream.write(bytes);
+          } catch (IOException e) {
+            LOG.error("Failed to download file {} ", sourceURI, e);
+            return false;
+          }
+          return true;
+        }
+
+        @Override
+        public void onFinished() {
+          // Close output stream later, so any exception can be surfaced.
+        }
+      }).build();
+    HttpResponse httpResponse = HttpRequests.execute(request, new DefaultHttpRequestConfig(false));
+    httpResponse.consumeContent();
+
+    if (httpResponse.getResponseCode() != HttpResponseStatus.OK.code()) {
+      if (httpResponse.getResponseCode() == HttpResponseStatus.NOT_FOUND.code()) {
+        throw new FileNotFoundException(httpResponse.getResponseBodyAsString());
+      }
+      throw new IOException(httpResponse.getResponseBodyAsString());
+    }
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
@@ -98,6 +100,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private PodKillerTask podKillerTask;
   private KubeTwillRunnerService twillRunner;
   private PodInfo podInfo;
+  private FileFetcher fileFetcher;
 
   @Override
   public void initialize(MasterEnvironmentContext context) throws IOException, ApiException {
@@ -155,6 +158,9 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     twillRunner = new KubeTwillRunnerService(context, namespace, discoveryService,
                                              podInfo, resourcePrefix,
                                              Collections.singletonMap(instanceLabel, instanceName));
+
+    fileFetcher = new FileFetcher(discoveryService);
+
     LOG.info("Kubernetes environment initialized with pod labels {}", podLabels);
   }
 
@@ -182,6 +188,11 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   @Override
   public Supplier<TwillRunnerService> getTwillRunnerSupplier() {
     return () -> twillRunner;
+  }
+
+  @Override
+  public void downloadFile(URI srcURI, OutputStream outputStream) throws IOException {
+    fileFetcher.download(srcURI, outputStream);
   }
 
   @Override

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/MasterEnvironment.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/MasterEnvironment.java
@@ -20,6 +20,9 @@ import org.apache.twill.api.TwillRunnerService;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -85,4 +88,9 @@ public interface MasterEnvironment {
    * Returns a {@link Supplier} of {@link TwillRunnerService} for running programs.
    */
   Supplier<TwillRunnerService> getTwillRunnerSupplier();
+
+  /**
+   * Download file specified by the URI.
+   */
+  void downloadFile(URI srcURI, OutputStream outputStream) throws IOException;
 }

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/MockMasterEnvironment.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/MockMasterEnvironment.java
@@ -27,6 +27,9 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.discovery.ZKDiscoveryService;
 import org.apache.twill.zookeeper.ZKClientService;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
 import java.util.function.Supplier;
 
 /**
@@ -77,6 +80,11 @@ public class MockMasterEnvironment implements MasterEnvironment {
   @Override
   public Supplier<TwillRunnerService> getTwillRunnerSupplier() {
     return () -> twillRunnerService;
+  }
+
+  @Override
+  public void downloadFile(URI srcURI, OutputStream outputStream) throws IOException {
+    throw new IOException("unimplemented");
   }
 
 


### PR DESCRIPTION
…rectly from HDFS

Why:
FileLocalizer is used to localizing files needed to run twill application in k8s env.
The file is most likely in an external distributed file system (e.g. GCS in GCP)
The pod to run twill application may or may not have permission to access distributed
file system. So this change swtiches the localization to downloading from AppFab
(essentially make AppFab proxy the file content to twill application pod)