### PR TITLE
CDAP-17864 Tweaked plugin lifecycle for SQL engine.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/SerializableTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/SerializableTransform.java
@@ -14,9 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.etl.mock.batch;
-
-import io.cdap.cdap.etl.api.Transform;
+package io.cdap.cdap.etl.api;
 
 import java.io.Serializable;
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/BatchSQLEngine.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/BatchSQLEngine.java
@@ -16,7 +16,9 @@
 
 package io.cdap.cdap.etl.api.engine.sql;
 
+import io.cdap.cdap.api.RuntimeContext;
 import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.StageContext;
 import io.cdap.cdap.etl.api.batch.BatchContext;
 
 /**
@@ -36,12 +38,12 @@ public abstract class BatchSQLEngine<KEY_IN, VALUE_IN, KEY_OUT, VALUE_OUT>
   }
 
   @Override
-  public void prepareRun(BatchContext context) throws Exception {
+  public void prepareRun(RuntimeContext context) throws Exception {
     // no-op
   }
 
   @Override
-  public void onRunFinish(boolean succeeded, BatchContext context) {
+  public void onRunFinish(boolean succeeded, RuntimeContext context) {
     // no-op
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngine.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngine.java
@@ -16,11 +16,12 @@
 
 package io.cdap.cdap.etl.api.engine.sql;
 
+import io.cdap.cdap.api.RuntimeContext;
 import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.etl.api.PipelineConfigurable;
+import io.cdap.cdap.etl.api.StageContext;
 import io.cdap.cdap.etl.api.SubmitterLifecycle;
-import io.cdap.cdap.etl.api.batch.BatchContext;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLDataset;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPullDataset;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPushDataset;
@@ -46,7 +47,7 @@ import io.cdap.cdap.etl.api.engine.sql.request.SQLPushRequest;
  */
 @Beta
 public interface SQLEngine<KEY_IN, VALUE_IN, KEY_OUT, VALUE_OUT>
-  extends PipelineConfigurable, SubmitterLifecycle<BatchContext> {
+  extends PipelineConfigurable, SubmitterLifecycle<RuntimeContext> {
 
   /**
    * Creates an Output Format Provided that can be used to push records into a SQL Engine.

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngineException.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngineException.java
@@ -21,8 +21,15 @@ package io.cdap.cdap.etl.api.engine.sql;
  */
 public class SQLEngineException extends RuntimeException {
 
+  public SQLEngineException(String message) {
+    super(message);
+  }
+
   public SQLEngineException(Throwable cause) {
     super("Error when executing operation on SQL Engine", cause);
   }
 
+  public SQLEngineException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockPullDataset.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockPullDataset.java
@@ -22,10 +22,10 @@ import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.lib.KeyValue;
 import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.SerializableTransform;
 import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPullDataset;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPullRequest;
-import io.cdap.cdap.etl.api.engine.sql.request.SQLPushRequest;
 import io.cdap.cdap.format.StructuredRecordStringConverter;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockPushDataset.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockPushDataset.java
@@ -17,22 +17,19 @@
 package io.cdap.cdap.etl.mock.batch;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.Gson;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.lib.KeyValue;
 import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.SerializableTransform;
 import io.cdap.cdap.etl.api.Transform;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPushDataset;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPushRequest;
 import io.cdap.cdap.format.StructuredRecordStringConverter;
-import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
-import org.apache.hadoop.mapreduce.lib.output.NullOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 
 import java.io.File;
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;


### PR DESCRIPTION
Since the SQL engine runs on the driver, lifecycle is different from other plugins.

We will use the Spark Execution Context to execute the prepareRun and onRunFinish methods of the lifecycle for the SQL engine plugin.

This ensures we have access to the pipeline Runtime arguments within the SQL Engine.