### PR TITLE
Updated SQL Engine Collection to prevent unnecessary pull operations.

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
@@ -26,10 +26,8 @@ import io.cdap.cdap.api.data.batch.InputFormatProvider;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
 import io.cdap.cdap.api.spark.JavaSparkMain;
-import io.cdap.cdap.api.spark.SparkClientContext;
 import io.cdap.cdap.api.workflow.WorkflowToken;
 import io.cdap.cdap.etl.api.JoinElement;
-import io.cdap.cdap.etl.api.batch.BatchContext;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.engine.sql.SQLEngine;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLDataset;
@@ -39,7 +37,6 @@ import io.cdap.cdap.etl.batch.BatchPhaseSpec;
 import io.cdap.cdap.etl.batch.PipelinePluginInstantiator;
 import io.cdap.cdap.etl.batch.connector.SingleConnectorFactory;
 import io.cdap.cdap.etl.common.Constants;
-import io.cdap.cdap.etl.common.PipelineRuntime;
 import io.cdap.cdap.etl.common.RecordInfo;
 import io.cdap.cdap.etl.common.SetMultimapCodec;
 import io.cdap.cdap.etl.common.StageStatisticsCollector;
@@ -248,7 +245,7 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
         String joinStageName = joinStage.getStageName();
 
         // If the input collection is already a SQL Engine collection, there's no need to push.
-        if (inputDataCollections.get(joinStageName) instanceof SQLEngineCollection) {
+        if (inputDataCollections.get(joinStageName) instanceof SQLBackedCollection) {
           continue;
         }
 
@@ -288,7 +285,7 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
         // If there is a broadcast stage in this join, this is a potential reason to not execute the join in the SQL
         // engine.
         containsBroadcastStage = true;
-      } else if (inputDataCollections.get(stage.getStageName()) instanceof SQLEngineCollection) {
+      } else if (inputDataCollections.get(stage.getStageName()) instanceof SQLBackedCollection) {
         // If any of the existing non-broadcast input collections already exists on the SQL engine, we should
         // execute this operation in the SQL engine.
         return true;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLBackedCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLBackedCollection.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.etl.spark.SparkCollection;
+
+/**
+ * Interface to denote collections where the underlying records are stored in a SQL engine.
+ *
+ * @param <T> type of elements in the spark collection
+ */
+public interface SQLBackedCollection<T> extends SparkCollection<T> {
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineCollection.java
@@ -49,7 +49,7 @@ import javax.annotation.Nullable;
  * Records will be pulled into Spark and operations delegated to an RDDCollection as needed.
  * @param <T> type of records stored in this {@link SparkCollection}.
  */
-public class SQLEngineCollection<T> implements SparkCollection<T> {
+public class SQLEngineCollection<T> implements SQLBackedCollection<T> {
   private final JavaSparkExecutionContext sec;
   private final JavaSparkContext jsc;
   private final SQLContext sqlContext;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/WrappedSQLEngineCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/WrappedSQLEngineCollection.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.etl.api.batch.SparkCompute;
+import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.api.streaming.Windower;
+import io.cdap.cdap.etl.common.PhaseSpec;
+import io.cdap.cdap.etl.common.RecordInfo;
+import io.cdap.cdap.etl.common.StageStatisticsCollector;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.SparkCollection;
+import io.cdap.cdap.etl.spark.SparkPairCollection;
+import io.cdap.cdap.etl.spark.join.JoinExpressionRequest;
+import io.cdap.cdap.etl.spark.join.JoinRequest;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * SQLEngineBackedCollection that wraps another SQLEngineBackedCollection in order to delay the execution of a
+ * mapping function.
+ *
+ * This is currently used to prevent SQL Engine pull operations uniless absolutely needed.
+ * @param <T> Type of the wrapped collection records.
+ * @param <U> Type of the output collection records.
+ */
+public class WrappedSQLEngineCollection<T, U> implements SQLBackedCollection<U> {
+  private final java.util.function.Function<SparkCollection<T>, SparkCollection<U>> mapper;
+  private final SQLBackedCollection<T> wrapped;
+  private SparkCollection<U> unwrapped = null;
+
+  public WrappedSQLEngineCollection(SQLBackedCollection<T> wrapped,
+                                    java.util.function.Function<SparkCollection<T>, SparkCollection<U>> mapper) {
+    this.wrapped = wrapped;
+    this.mapper = mapper;
+  }
+  
+  private SparkCollection<U> unwrap() {
+    if (unwrapped == null) {
+      unwrapped = mapper.apply(wrapped);
+    }
+
+    return unwrapped;
+  }
+
+  @Override
+  public <C> C getUnderlying() {
+    return unwrap().getUnderlying();
+  }
+
+  @Override
+  public SparkCollection<U> cache() {
+    return unwrap().cache();
+  }
+
+  @Override
+  public SparkCollection<U> union(SparkCollection<U> other) {
+    return unwrap().union(other);
+  }
+
+  @Override
+  public SparkCollection<RecordInfo<Object>> transform(StageSpec stageSpec, StageStatisticsCollector collector) {
+    return unwrap().transform(stageSpec, collector);
+  }
+
+  @Override
+  public SparkCollection<RecordInfo<Object>> multiOutputTransform(StageSpec stageSpec,
+                                                                  StageStatisticsCollector collector) {
+    return unwrap().transform(stageSpec, collector);
+  }
+
+  @Override
+  public <U1> SparkCollection<U1> map(Function<U, U1> function) {
+    return unwrap().map(function);
+  }
+
+  @Override
+  public <U1> SparkCollection<U1> flatMap(StageSpec stageSpec, FlatMapFunction<U, U1> function) {
+    return unwrap().flatMap(stageSpec, function);
+  }
+
+  @Override
+  public SparkCollection<RecordInfo<Object>> aggregate(StageSpec stageSpec,
+                                                       @Nullable Integer partitions,
+                                                       StageStatisticsCollector collector) {
+    return unwrap().aggregate(stageSpec, partitions, collector);
+  }
+
+  @Override
+  public SparkCollection<RecordInfo<Object>> reduceAggregate(StageSpec stageSpec,
+                                                             @Nullable Integer partitions,
+                                                             StageStatisticsCollector collector) {
+    return unwrap().reduceAggregate(stageSpec, partitions, collector);
+  }
+
+  @Override
+  public <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<U, K, V> function) {
+    return unwrap().flatMapToPair(function);
+  }
+
+  @Override
+  public <U1> SparkCollection<U1> compute(StageSpec stageSpec, SparkCompute<U, U1> compute) throws Exception {
+    return unwrap().compute(stageSpec, compute);
+  }
+
+  @Override
+  public Runnable createStoreTask(StageSpec stageSpec,
+                                  PairFlatMapFunction<U, Object, Object> sinkFunction) {
+    return unwrap().createStoreTask(stageSpec, sinkFunction);
+  }
+
+  @Override
+  public Runnable createMultiStoreTask(PhaseSpec phaseSpec,
+                                       Set<String> group,
+                                       Set<String> sinks,
+                                       Map<String, StageStatisticsCollector> collectors) {
+    return unwrap().createMultiStoreTask(phaseSpec, group, sinks, collectors);
+  }
+
+  @Override
+  public Runnable createStoreTask(StageSpec stageSpec,
+                                  SparkSink<U> sink) throws Exception {
+    return unwrap().createStoreTask(stageSpec, sink);
+  }
+
+  @Override
+  public void publishAlerts(StageSpec stageSpec,
+                            StageStatisticsCollector collector) throws Exception {
+    unwrap().publishAlerts(stageSpec, collector);
+  }
+
+  @Override
+  public SparkCollection<U> window(StageSpec stageSpec,
+                                               Windower windower) {
+    return unwrap().window(stageSpec, windower);
+  }
+
+  @Override
+  public SparkCollection<U> join(JoinRequest joinRequest) {
+    return unwrap().join(joinRequest);
+  }
+
+  @Override
+  public SparkCollection<U> join(JoinExpressionRequest joinExpressionRequest) {
+    return unwrap().join(joinExpressionRequest);
+  }
+}


### PR DESCRIPTION
Created new interface to label all collections that are stored in the SQL engine.

Wrapping the SQL Engine Collection in another collection class ensures that we do not invoke SQL engine pull operations prematurely and unless absolutely needed.