### PR TITLE
CDAP-17939 upgrade old tms message tables

### DIFF
--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/service/CoreMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/service/CoreMessagingService.java
@@ -219,6 +219,7 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
 
   @Override
   protected void startUp() throws Exception {
+    tableFactory.init();
     Queue<TopicId> asyncCreationTopics = new LinkedList<>();
 
     Set<TopicId> systemTopics = MessagingServiceUtils.getSystemTopics(cConf, true);

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/TableFactory.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/TableFactory.java
@@ -31,4 +31,11 @@ public interface TableFactory extends Closeable {
   MessageTable createMessageTable(TopicMetadata topicMetadata) throws IOException;
 
   PayloadTable createPayloadTable(TopicMetadata topicMetadata) throws IOException;
+
+  /**
+   * Perform any initialization required. This method will be called before any other method is called.
+   */
+  default void init() throws IOException {
+    // no-op
+  }
 }

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBPartitionManager.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBPartitionManager.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
  * Manages partitions of a logical MessageTable.
  * Each partition is a physical LevelDB table in a directory structure like:
  *
- *   [base dir]/[namespace].[tablename].[topic].[generation]/part.[start].[end]
+ *   [base dir]/v2.[namespace].[tablename].[topic].[generation]/part.[start].[end]
  *
  * Each partition contains messages with a publish time between the start (inclusive) and end (exclusive) timestamps.
  */
@@ -257,8 +257,12 @@ public class LevelDBPartitionManager implements Closeable {
     return createPartition(topicDir, closestStartTime, closestEndTime);
   }
 
+  static File getPartitionDir(File topicDir, long start, long end) {
+    return new File(topicDir, String.format("%s%d.%d", PART_PREFIX, start, end));
+  }
+
   private LevelDBPartition createPartition(File topicDir, long start, long end) throws IOException {
-    File dbPath = new File(topicDir, String.format("%s%d.%d", PART_PREFIX, start, end));
+    File dbPath = getPartitionDir(topicDir, start, end);
     ensureDirExists(dbPath);
     return new LevelDBPartition(dbPath, start, end, () -> LEVEL_DB_FACTORY.open(dbPath, dbOptions));
   }

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTableFactory.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTableFactory.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.messaging.store.leveldb;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Closeables;
+import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -39,6 +40,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.Iterator;
@@ -56,6 +61,8 @@ public final class LevelDBTableFactory implements TableFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(LevelDBTableFactory.class);
   private static final Iq80DBFactory LEVEL_DB_FACTORY = Iq80DBFactory.factory;
+  private static final Gson GSON = new Gson();
+  static final String MESSAGE_TABLE_VERSION = "v2";
 
   private final File baseDir;
   private final Options dbOptions;
@@ -89,6 +96,65 @@ public final class LevelDBTableFactory implements TableFactory {
     this.levelDBs = new ConcurrentHashMap<>();
     this.partitionedLevelDBs = new ConcurrentHashMap<>();
     this.partitionSizeMillis = cConf.getLong(Constants.MessagingSystem.LOCAL_DATA_PARTITION_SECONDS) * 1000;
+  }
+
+  @Override
+  public void init() throws IOException {
+    ensureDirExists(baseDir);
+    Path metaFile = Paths.get(baseDir.getAbsolutePath(), "meta");
+    Metadata metadata = new Metadata(1);
+    if (Files.exists(metaFile)) {
+      String metaStr = new String(Files.readAllBytes(metaFile), StandardCharsets.UTF_8);
+      metadata = GSON.fromJson(metaStr, Metadata.class);
+    }
+
+    if (metadata.version > 1) {
+      return;
+    }
+
+    upgradeTables(System.currentTimeMillis());
+    Files.write(metaFile, GSON.toJson(new Metadata(2)).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private void upgradeTables(long now) throws IOException {
+    /*
+        scan directory for existing message tables. They will be of the form:
+
+          basedir/[namespace].[messageTableName].[topic].[generation]
+
+        these directories need to be moved to:
+
+          basedir/v2.[namespace].[messageTableName].[topic].[generation]/part0.[now]
+     */
+    for (File tableDir : DirUtils.listFiles(baseDir)) {
+      if (!tableDir.isDirectory()) {
+        continue;
+      }
+
+      String dirName = tableDir.getName();
+      // upgrade could have failed halfway through, skip if it was upgraded previously.
+      if (dirName.startsWith(MESSAGE_TABLE_VERSION + ".")) {
+        continue;
+      }
+      // only message tables should be moved
+      int firstDotIdx = dirName.indexOf('.');
+      int secondDotIdx = dirName.indexOf('.', firstDotIdx + 1);
+      if (firstDotIdx < 0 || secondDotIdx < 0) {
+        continue;
+      }
+      String tableName = dirName.substring(firstDotIdx + 1, secondDotIdx);
+      if (!tableName.equals(messageTableName)) {
+        continue;
+      }
+
+      File v2TopicDir = new File(baseDir, MESSAGE_TABLE_VERSION + "." + dirName);
+      File v2TopicPartitionDir = LevelDBPartitionManager.getPartitionDir(v2TopicDir, 0, now);
+      // this shouldn't happen unless somebody has been modifying the filesystem directly
+      if (v2TopicPartitionDir.exists()) {
+        DirUtils.deleteDirectoryContents(v2TopicPartitionDir);
+      }
+      Files.move(tableDir.toPath(), v2TopicPartitionDir.toPath());
+    }
   }
 
   @Override
@@ -130,11 +196,15 @@ public final class LevelDBTableFactory implements TableFactory {
     partitionedLevelDBs.clear();
   }
 
+  @VisibleForTesting
+  static File getMessageTablePath(File baseDir, TopicId topicId, int generation, String tableName) {
+    return new File(baseDir, String.format("%s.%s.%s.%s.%d", MESSAGE_TABLE_VERSION, topicId.getNamespace(),
+                                           tableName, topicId.getTopic(), generation));
+  }
+
   private LevelDBPartitionManager getPartitionedLevelDB(TopicMetadata topicMetadata,
                                                         String tableName) throws IOException {
-    TopicId topicId = topicMetadata.getTopicId();
-    File topicDir = new File(baseDir, String.format("%s.%s.%s.%d", topicId.getNamespace(), tableName,
-                                                    topicId.getTopic(), topicMetadata.getGeneration()));
+    File topicDir = getMessageTablePath(baseDir, topicMetadata.getTopicId(), topicMetadata.getGeneration(), tableName);
     LevelDBPartitionManager partitionManager = partitionedLevelDBs.get(topicDir);
     if (partitionManager != null) {
       return partitionManager;
@@ -263,6 +333,17 @@ public final class LevelDBTableFactory implements TableFactory {
       } catch (IOException ex) {
         LOG.debug("Unable to perform data cleanup in TMS LevelDB tables", ex);
       }
+    }
+  }
+
+  /**
+   * Metadata about table format versioning
+   */
+  private static class Metadata {
+    private final int version;
+
+    Metadata(int version) {
+      this.version = version;
     }
   }
 }

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/leveldb/LevelDBMessageTableTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/leveldb/LevelDBMessageTableTest.java
@@ -33,7 +33,9 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -68,6 +70,53 @@ public class LevelDBMessageTableTest extends MessageTableTest {
   @Override
   protected MetadataTable getMetadataTable() throws Exception {
     return tableFactory.createMetadataTable();
+  }
+
+  @Test
+  public void testUpgrade() throws Exception {
+    File baseDir = tmpFolder.newFolder();
+    String tableName = "messages";
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.MessagingSystem.LOCAL_DATA_DIR, baseDir.getAbsolutePath());
+    cConf.set(Constants.MessagingSystem.MESSAGE_TABLE_NAME, tableName);
+    cConf.set(Constants.MessagingSystem.LOCAL_DATA_PARTITION_SECONDS, Integer.toString(1));
+    LevelDBTableFactory tableFactory = new LevelDBTableFactory(cConf);
+
+    TopicId topicId = new TopicId("system", "upgrade-test");
+    int generation = 1;
+    TopicMetadata topicMetadata =
+      new TopicMetadata(topicId, Collections.singletonMap(TopicMetadata.GENERATION_KEY, String.valueOf(generation)));
+
+    // write a message to a table, then rename the underlying directory to the old format
+    long publishTime = 1000;
+    try (MessageTable table = tableFactory.createMessageTable(topicMetadata)) {
+      List<MessageTable.Entry> writes = new ArrayList<>();
+      writes.add(new TestMessageEntry(topicId, generation, publishTime, 0, null, new byte[]{ 0 }));
+      table.store(writes.iterator());
+    }
+    tableFactory.close();
+
+    File topicDir = LevelDBTableFactory.getMessageTablePath(baseDir, topicId, generation, tableName);
+    File partitionDir = LevelDBPartitionManager.getPartitionDir(topicDir, 0, publishTime + 1000);
+    File oldDir = new File(baseDir,
+                           topicDir.getName().substring(LevelDBTableFactory.MESSAGE_TABLE_VERSION.length() + 1));
+    Files.move(partitionDir.toPath(), oldDir.toPath());
+
+    // now run the upgrade and make sure the table is readable.
+    tableFactory = new LevelDBTableFactory(cConf);
+    tableFactory.init();
+
+    try (MessageTable table = tableFactory.createMessageTable(topicMetadata)) {
+      byte[] messageId = new byte[MessageId.RAW_ID_SIZE];
+      MessageId.putRawId(0L, (short) 0, 0L, (short) 0, messageId, 0);
+      try (CloseableIterator<MessageTable.Entry> iter =
+             table.fetch(topicMetadata, new MessageId(messageId), true, 100, null)) {
+        Assert.assertTrue(iter.hasNext());
+        MessageTable.Entry entry = iter.next();
+        Assert.assertEquals(publishTime, entry.getPublishTimestamp());
+        Assert.assertFalse(iter.hasNext());
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
Before the messaging service starts up, upgrade any message
tables that are in the old format by renaming them to the
new directory structure with partition from 0 to the current time.