### PR TITLE
Excluding all transitive dependencies from hive-exec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1236,7 +1236,7 @@
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>  
+          </exclusion>
           <exclusion>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
@@ -1248,6 +1248,10 @@
           <exclusion>
             <groupId>stax</groupId>
             <artifactId>stax-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.pentaho</groupId>
+            <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
- It is not needed since hive-exec is an Uber-jar that contains everything it needed