### PR TITLE
Add logic to allow the SQL engine to validate if a join can be executed.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngine.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngine.java
@@ -20,11 +20,11 @@ import io.cdap.cdap.api.RuntimeContext;
 import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.etl.api.PipelineConfigurable;
-import io.cdap.cdap.etl.api.StageContext;
 import io.cdap.cdap.etl.api.SubmitterLifecycle;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLDataset;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPullDataset;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPushDataset;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinDefinition;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPullRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPushRequest;
@@ -83,10 +83,10 @@ public interface SQLEngine<KEY_IN, VALUE_IN, KEY_OUT, VALUE_OUT>
   /**
    * Check if the supplied Join Definition can be executed in this engine.
    *
-   * @param joinRequest the join request to validate.
+   * @param joinDefinition the join definition to validate
    * @return boolean specifying if this join operation can be executed in the SQl Engine.
    */
-  boolean canJoin(SQLJoinRequest joinRequest);
+  boolean canJoin(SQLJoinDefinition joinDefinition);
 
   /**
    * Executes the join operation defined by the supplied join request.

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLJoinDefinition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLJoinDefinition.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.engine.sql.request;
+
+import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.engine.sql.dataset.SQLDataset;
+import io.cdap.cdap.etl.api.join.JoinDefinition;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Class representing a Join Definition to execute on the SQL Engine.
+ */
+@Beta
+public class SQLJoinDefinition implements Serializable {
+  private static final long serialVersionUID = 8608629892525128233L;
+  protected final String datasetName;
+  protected final Schema datasetSchema;
+  protected final JoinDefinition joinDefinition;
+
+  public SQLJoinDefinition(String datasetName,
+                           JoinDefinition joinDefinition) {
+    this(datasetName, joinDefinition, Collections.emptyList());
+  }
+
+  public SQLJoinDefinition(String datasetName,
+                           JoinDefinition joinDefinition,
+                           Collection<SQLDataset> inputDatasets) {
+    this.datasetName = datasetName;
+    this.datasetSchema = joinDefinition.getOutputSchema();
+    this.joinDefinition = joinDefinition;
+  }
+
+  /**
+   * Get the name of the dataset which contains the result of this operation.
+   */
+  public String getDatasetName() {
+    return datasetName;
+  }
+
+  /**
+   * Get the schema for the result of this join operation.
+   */
+  public Schema getDatasetSchema() {
+    return datasetSchema;
+  }
+
+  /**
+   * Get the join definition for this request.
+   */
+  public JoinDefinition getJoinDefinition() {
+    return joinDefinition;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLJoinRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLJoinRequest.java
@@ -23,46 +23,22 @@ import io.cdap.cdap.etl.api.join.JoinDefinition;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Collections;
+import javax.annotation.Nullable;
 
 /**
  * Class representing a Request to execute as join operation on a SQL engine.
  */
 @Beta
-public class SQLJoinRequest implements Serializable {
+public class SQLJoinRequest extends SQLJoinDefinition implements Serializable {
   private static final long serialVersionUID = -5049631486914347507L;
-  private final String datasetName;
-  private final Schema datasetSchema;
-  private final JoinDefinition joinDefinition;
   private final Collection<SQLDataset> inputDatasets;
 
   public SQLJoinRequest(String datasetName,
                         JoinDefinition joinDefinition,
                         Collection<SQLDataset> inputDatasets) {
-    this.datasetName = datasetName;
-    this.datasetSchema = joinDefinition.getOutputSchema();
-    this.joinDefinition = joinDefinition;
+    super(datasetName, joinDefinition);
     this.inputDatasets = inputDatasets;
-  }
-
-  /**
-   * Get the name of the dataset which contains the result of this operation.
-   */
-  public String getDatasetName() {
-    return datasetName;
-  }
-
-  /**
-   * Get the schema for the result of this join operation.
-   */
-  public Schema getDatasetSchema() {
-    return datasetSchema;
-  }
-
-  /**
-   * Get the join definition for this request.
-   */
-  public JoinDefinition getJoinDefinition() {
-    return joinDefinition;
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriverTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/test/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriverTest.java
@@ -20,17 +20,53 @@ import io.cdap.cdap.etl.api.join.JoinDefinition;
 import io.cdap.cdap.etl.api.join.JoinStage;
 import io.cdap.cdap.etl.spark.SparkCollection;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class BatchSparkPipelineDriverTest {
+
+  private static final String STAGE_NAME = "some-stage";
+  private BatchSparkPipelineDriver driver;
+  private BatchSQLEngineAdapter adapter;
+
+  @Before
+  public void setUp() {
+    adapter = mock(BatchSQLEngineAdapter.class);
+    when(adapter.canJoin(anyString(), any(JoinDefinition.class))).thenReturn(true);
+    driver = new BatchSparkPipelineDriver(adapter);
+  }
+
+  @Test
+  public void testSQLEngineDoesNotSupportJoin() {
+    when(adapter.canJoin(anyString(), any(JoinDefinition.class))).thenReturn(false);
+
+    List<JoinStage> noneBroadcast = Arrays.asList(
+      JoinStage.builder("a", null).setBroadcast(false).build(),
+      JoinStage.builder("b", null).setBroadcast(false).build(),
+      JoinStage.builder("c", null).setBroadcast(false).build()
+    );
+
+    JoinDefinition joinDefinition = mock(JoinDefinition.class);
+    doReturn(noneBroadcast).when(joinDefinition).getStages();
+
+    Map<String, SparkCollection<Object>> collections = new HashMap<>();
+    collections.put("a", mock(RDDCollection.class));
+    collections.put("b", mock(RDDCollection.class));
+    collections.put("c", mock(RDDCollection.class));
+
+    Assert.assertFalse(driver.canJoinOnSQLEngine(STAGE_NAME, joinDefinition, collections));
+  }
 
   @Test
   public void testShouldJoinOnSQLEngineWithoutBroadcast() {
@@ -40,15 +76,15 @@ public class BatchSparkPipelineDriverTest {
       JoinStage.builder("c", null).setBroadcast(false).build()
     );
 
-    JoinDefinition joinDefinition = Mockito.mock(JoinDefinition.class);
+    JoinDefinition joinDefinition = mock(JoinDefinition.class);
     doReturn(noneBroadcast).when(joinDefinition).getStages();
 
     Map<String, SparkCollection<Object>> collections = new HashMap<>();
-    collections.put("a", Mockito.mock(RDDCollection.class));
-    collections.put("b", Mockito.mock(RDDCollection.class));
-    collections.put("c", Mockito.mock(RDDCollection.class));
+    collections.put("a", mock(RDDCollection.class));
+    collections.put("b", mock(RDDCollection.class));
+    collections.put("c", mock(RDDCollection.class));
 
-    Assert.assertTrue(BatchSparkPipelineDriver.canJoinOnSQLEngine(joinDefinition, collections));
+    Assert.assertTrue(driver.canJoinOnSQLEngine(STAGE_NAME, joinDefinition, collections));
   }
 
   @Test
@@ -59,15 +95,15 @@ public class BatchSparkPipelineDriverTest {
       JoinStage.builder("c", null).setBroadcast(true).build()
     );
 
-    JoinDefinition joinDefinition = Mockito.mock(JoinDefinition.class);
+    JoinDefinition joinDefinition = mock(JoinDefinition.class);
     doReturn(noneBroadcast).when(joinDefinition).getStages();
 
     Map<String, SparkCollection<Object>> collections = new HashMap<>();
-    collections.put("a", Mockito.mock(RDDCollection.class));
-    collections.put("b", Mockito.mock(RDDCollection.class));
-    collections.put("c", Mockito.mock(RDDCollection.class));
+    collections.put("a", mock(RDDCollection.class));
+    collections.put("b", mock(RDDCollection.class));
+    collections.put("c", mock(RDDCollection.class));
 
-    Assert.assertFalse(BatchSparkPipelineDriver.canJoinOnSQLEngine(joinDefinition, collections));
+    Assert.assertFalse(driver.canJoinOnSQLEngine(STAGE_NAME, joinDefinition, collections));
   }
 
   @Test
@@ -78,14 +114,14 @@ public class BatchSparkPipelineDriverTest {
       JoinStage.builder("c", null).setBroadcast(true).build()
     );
 
-    JoinDefinition joinDefinition = Mockito.mock(JoinDefinition.class);
+    JoinDefinition joinDefinition = mock(JoinDefinition.class);
     doReturn(noneBroadcast).when(joinDefinition).getStages();
 
     Map<String, SparkCollection<Object>> collections = new HashMap<>();
-    collections.put("a", Mockito.mock(SQLEngineCollection.class));
-    collections.put("b", Mockito.mock(RDDCollection.class));
-    collections.put("c", Mockito.mock(RDDCollection.class));
+    collections.put("a", mock(SQLEngineCollection.class));
+    collections.put("b", mock(RDDCollection.class));
+    collections.put("c", mock(RDDCollection.class));
 
-    Assert.assertTrue(BatchSparkPipelineDriver.canJoinOnSQLEngine(joinDefinition, collections));
+    Assert.assertTrue(driver.canJoinOnSQLEngine(STAGE_NAME, joinDefinition, collections));
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
@@ -43,6 +43,7 @@ import io.cdap.cdap.etl.api.engine.sql.SQLEngineException;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLDataset;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPullDataset;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPushDataset;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinDefinition;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPullRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPushRequest;
@@ -1160,7 +1161,7 @@ public class PipelineSpecGeneratorTest {
     }
 
     @Override
-    public boolean canJoin(SQLJoinRequest joinRequest) {
+    public boolean canJoin(SQLJoinDefinition joinRequest) {
       return false;
     }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSQLEngineAdapter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSQLEngineAdapter.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.etl.api.engine.sql.SQLEngineException;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLDataset;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPullDataset;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPushDataset;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinDefinition;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPullRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPushRequest;
@@ -249,6 +250,19 @@ public class BatchSQLEngineAdapter<T> implements Closeable {
     }
 
     return false;
+  }
+
+  /**
+   * Verify if a Join Definition can be executed on a SQL Engine.
+   *
+   * @param datasetName    the dataset name to use to store the result of the join operation
+   * @param joinDefinition the Join Definition
+   * @return boolean specifying if this join operation can be executed on the SQL engine.
+   */
+  public boolean canJoin(String datasetName,
+                         JoinDefinition joinDefinition) {
+    SQLJoinDefinition sqlJoinDefinition = new SQLJoinDefinition(datasetName, joinDefinition);
+    return sqlEngine.canJoin(sqlJoinDefinition);
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSQLEngine.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSQLEngine.java
@@ -30,14 +30,13 @@ import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.cdap.api.plugin.PluginPropertyField;
-import io.cdap.cdap.etl.api.PipelineConfigurer;
-import io.cdap.cdap.etl.api.batch.BatchContext;
 import io.cdap.cdap.etl.api.engine.sql.BatchSQLEngine;
 import io.cdap.cdap.etl.api.engine.sql.SQLEngine;
 import io.cdap.cdap.etl.api.engine.sql.SQLEngineException;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLDataset;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPullDataset;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLPushDataset;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinDefinition;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPullRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPushRequest;
@@ -113,7 +112,7 @@ public class MockSQLEngine extends BatchSQLEngine<Object, Object, Object, Object
   }
 
   @Override
-  public boolean canJoin(SQLJoinRequest joinRequest) {
+  public boolean canJoin(SQLJoinDefinition joinDefinition) {
     return true;
   }
 


### PR DESCRIPTION
If the SQL engine does not support a join operation (for example, if the fields involved in the join operation cannot be handled by the SQL engine), then Spark will be used for this join operation.