### PR TITLE
Introduce StandardPermission.LIST, add support for parent-only permissions and migrate profiles to new permission model

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AuthorizationModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AuthorizationModule.java
@@ -42,9 +42,11 @@ import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationContextFactory;
 import io.cdap.cdap.security.authorization.AuthorizerInstantiator;
 import io.cdap.cdap.security.authorization.DefaultAuthorizationContext;
+import io.cdap.cdap.security.authorization.DelegatingPermissionManager;
 import io.cdap.cdap.security.authorization.DelegatingPrivilegeManager;
 import io.cdap.cdap.security.spi.authorization.AuthorizationContext;
 import io.cdap.cdap.security.spi.authorization.Authorizer;
+import io.cdap.cdap.security.spi.authorization.PermissionManager;
 import io.cdap.cdap.security.spi.authorization.PrivilegesManager;
 import org.apache.tephra.TransactionContext;
 import org.apache.tephra.TransactionSystemClient;
@@ -100,6 +102,8 @@ public class AuthorizationModule extends PrivateModule {
 
     bind(PrivilegesManager.class).to(DelegatingPrivilegeManager.class);
     expose(PrivilegesManager.class);
+    bind(PermissionManager.class).to(DelegatingPermissionManager.class);
+    expose(PermissionManager.class);
   }
 
   @Singleton

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/meta/RemotePrivilegesHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/meta/RemotePrivilegesHandler.java
@@ -86,8 +86,16 @@ public class RemotePrivilegesHandler extends AbstractRemoteSystemOpsHandler {
         .flatMap(set -> set.stream())
         .collect(Collectors.toSet());
     }
-    accessEnforcer.enforce(authorizationPrivilege.getEntity(), authorizationPrivilege.getPrincipal(),
-                                  permissions);
+    if (authorizationPrivilege.getChildEntityType() != null) {
+      //It's expected that we'll always have one, but let's handle generic case
+      for (Permission permission: permissions) {
+        accessEnforcer.enforceOnParent(authorizationPrivilege.getChildEntityType(), authorizationPrivilege.getEntity(),
+                                       authorizationPrivilege.getPrincipal(), permission);
+      }
+    } else {
+      accessEnforcer.enforce(authorizationPrivilege.getEntity(), authorizationPrivilege.getPrincipal(),
+                             permissions);
+    }
     responder.sendStatus(HttpResponseStatus.OK);
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/remote/RemotePrivilegesCacheTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/remote/RemotePrivilegesCacheTest.java
@@ -18,7 +18,8 @@ package io.cdap.cdap.internal.app.store.remote;
 
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.proto.security.Action;
+import io.cdap.cdap.proto.security.ApplicationPermission;
+import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.security.authorization.RemoteAccessEnforcer;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -37,12 +38,12 @@ public class RemotePrivilegesCacheTest extends RemotePrivilegesTestBase {
   }
 
   @Override
-  public void testAuthorizationEnforcer() throws Exception {
-    super.testAuthorizationEnforcer();
+  public void testAccessEnforcer() throws Exception {
+    super.testAccessEnforcer();
 
     // The super class revokes all privileges after test is done. Since cache is enabled, enforce should still work.
-    authorizationEnforcer.enforce(APP, ALICE, Action.ADMIN);
-    authorizationEnforcer.enforce(PROGRAM, ALICE, Action.EXECUTE);
+    accessEnforcer.enforce(APP, ALICE, StandardPermission.UPDATE);
+    accessEnforcer.enforce(PROGRAM, ALICE, ApplicationPermission.EXECUTE);
   }
 
   @Override
@@ -51,15 +52,6 @@ public class RemotePrivilegesCacheTest extends RemotePrivilegesTestBase {
 
     // The super class revokes all privileges after test is done. Since cache is enabled, visibility should still work.
     Assert.assertEquals(ImmutableSet.of(NS, APP, PROGRAM),
-                        authorizationEnforcer.isVisible(ImmutableSet.of(NS, APP, PROGRAM), ALICE));
-  }
-
-  @Override
-  public void testSingleVisibility() throws Exception {
-    super.testSingleVisibility();
-
-    // The super class revokes all privileges after test is done. Since cache is enabled, visibility should still work.
-    authorizationEnforcer.isVisible(PROGRAM, ALICE);
-    shouldNotHaveVisibility(authorizationEnforcer, PROGRAM, BOB);
+                        accessEnforcer.isVisible(ImmutableSet.of(NS, APP, PROGRAM), ALICE));
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/remote/RemotePrivilegesNoCacheTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/remote/RemotePrivilegesNoCacheTest.java
@@ -18,7 +18,8 @@ package io.cdap.cdap.internal.app.store.remote;
 
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.proto.security.Action;
+import io.cdap.cdap.proto.security.ApplicationPermission;
+import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.security.authorization.RemoteAccessEnforcer;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import org.junit.Assert;
@@ -38,19 +39,19 @@ public class RemotePrivilegesNoCacheTest extends RemotePrivilegesTestBase {
   }
 
   @Override
-  public void testAuthorizationEnforcer() throws Exception {
-    super.testAuthorizationEnforcer();
+  public void testAccessEnforcer() throws Exception {
+    super.testAccessEnforcer();
 
     // The super class revokes all privileges after test is done. Since cache is disabled, all enforce should fail.
     try {
-      authorizationEnforcer.enforce(APP, ALICE, Action.ADMIN);
+      accessEnforcer.enforce(APP, ALICE, StandardPermission.UPDATE);
       Assert.fail("Enforce should have failed since cache is disabled");
     } catch (UnauthorizedException e) {
       // Expected
     }
 
     try {
-      authorizationEnforcer.enforce(PROGRAM, ALICE, Action.EXECUTE);
+      accessEnforcer.enforce(PROGRAM, ALICE, ApplicationPermission.EXECUTE);
       Assert.fail("Enforce should have failed since cache is disabled");
     } catch (UnauthorizedException e) {
       // Expected
@@ -63,15 +64,6 @@ public class RemotePrivilegesNoCacheTest extends RemotePrivilegesTestBase {
 
     // The super class revokes all privileges after test is done. Since cache is disabled, nothing should be visible.
     Assert.assertEquals(ImmutableSet.of(),
-                        authorizationEnforcer.isVisible(ImmutableSet.of(NS, APP, PROGRAM), ALICE));
-  }
-
-  @Override
-  public void testSingleVisibility() throws Exception {
-    super.testSingleVisibility();
-
-    // The super class revokes all privileges after test is done. Since cache is disabled, nothing should be visible.
-    shouldNotHaveVisibility(authorizationEnforcer, PROGRAM, ALICE);
-    shouldNotHaveVisibility(authorizationEnforcer, PROGRAM, BOB);
+                        accessEnforcer.isVisible(ImmutableSet.of(NS, APP, PROGRAM), ALICE));
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/remote/RemotePrivilegesTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/remote/RemotePrivilegesTestBase.java
@@ -19,35 +19,32 @@ package io.cdap.cdap.internal.app.store.remote;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
+import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.discovery.EndpointStrategy;
 import io.cdap.cdap.common.discovery.RandomEndpointStrategy;
-import io.cdap.cdap.common.test.AppJarHelper;
+import io.cdap.cdap.common.service.Retries;
 import io.cdap.cdap.internal.AppFabricTestHelper;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
-import io.cdap.cdap.proto.security.Action;
+import io.cdap.cdap.proto.security.ApplicationPermission;
 import io.cdap.cdap.proto.security.Authorizable;
+import io.cdap.cdap.proto.security.GrantedPermission;
 import io.cdap.cdap.proto.security.Principal;
-import io.cdap.cdap.proto.security.Privilege;
-import io.cdap.cdap.security.authorization.AccessControllerWrapper;
-import io.cdap.cdap.security.authorization.AccessEnforcerWrapper;
-import io.cdap.cdap.security.authorization.InMemoryAuthorizer;
+import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.security.authorization.RemoteAccessEnforcer;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
-import io.cdap.cdap.security.spi.authorization.AuthorizationEnforcer;
+import io.cdap.cdap.security.spi.authorization.PermissionManager;
 import io.cdap.cdap.security.spi.authorization.PrivilegesManager;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import org.apache.twill.discovery.DiscoveryServiceClient;
-import org.apache.twill.filesystem.LocalLocationFactory;
-import org.apache.twill.filesystem.Location;
-import org.apache.twill.filesystem.LocationFactory;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -60,11 +57,9 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
 
 /**
- * Tests for remote implementations of {@link AuthorizationEnforcer} and {@link PrivilegesManager}.
+ * Tests for remote implementations of {@link AccessEnforcer} and {@link PrivilegesManager}.
  * These are in app-fabric, because we need to start app-fabric in these tests.
  */
 @SuppressWarnings("WeakerAccess")
@@ -81,32 +76,23 @@ public abstract class RemotePrivilegesTestBase {
   private static final int CACHE_TIMEOUT = 3;
 
   protected static AccessEnforcer accessEnforcer;
-  protected static AuthorizationEnforcer authorizationEnforcer;
-  protected static PrivilegesManager privilegesManager;
+  protected static PermissionManager permissionManager;
   protected static CConfiguration cConf = CConfiguration.create();
 
   private static DiscoveryServiceClient discoveryService;
   private static AppFabricServer appFabricServer;
 
   protected static void setup() throws IOException, InterruptedException {
+    AppFabricTestHelper.enableAuthorization(cConf, TEMPORARY_FOLDER);
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMPORARY_FOLDER.newFolder().getAbsolutePath());
-    cConf.setBoolean(Constants.Security.ENABLED, true);
-    cConf.setBoolean(Constants.Security.KERBEROS_ENABLED, false);
-    cConf.setBoolean(Constants.Security.Authorization.ENABLED, true);
     cConf.setInt(Constants.Security.Authorization.CACHE_TTL_SECS, CACHE_TIMEOUT);
-    Manifest manifest = new Manifest();
-    manifest.getMainAttributes().put(Attributes.Name.MAIN_CLASS, InMemoryAuthorizer.class.getName());
-    LocationFactory locationFactory = new LocalLocationFactory(TEMPORARY_FOLDER.newFolder());
-    Location externalAuthJar = AppJarHelper.createDeploymentJar(locationFactory, InMemoryAuthorizer.class, manifest);
-    cConf.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, externalAuthJar.toString());
     Injector injector = AppFabricTestHelper.getInjector(cConf);
     discoveryService = injector.getInstance(DiscoveryServiceClient.class);
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
     waitForService(Constants.Service.APP_FABRIC_HTTP);
     accessEnforcer = injector.getInstance(RemoteAccessEnforcer.class);
-    authorizationEnforcer = new AccessEnforcerWrapper(accessEnforcer);
-    privilegesManager = injector.getInstance(PrivilegesManager.class);
+    permissionManager = injector.getInstance(PermissionManager.class);
   }
 
   private static void waitForService(String name) {
@@ -125,39 +111,49 @@ public abstract class RemotePrivilegesTestBase {
     // In this test, grants and revokes happen via PrivilegesManager, privilege listing and enforcement happens via
     // Authorizer. Also, since grants and revokes go directly to master and don't need a proxy, the
     // RemoteSystemOperationsService does not need to be started in this release.
-    privilegesManager.grant(Authorizable.fromEntityId(NS), ALICE, EnumSet.allOf(Action.class));
-    privilegesManager.grant(Authorizable.fromEntityId(APP), ALICE, Collections.singleton(Action.ADMIN));
-    privilegesManager.grant(Authorizable.fromEntityId(PROGRAM), ALICE, Collections.singleton(Action.EXECUTE));
-    authorizationEnforcer.enforce(NS, ALICE, EnumSet.allOf(Action.class));
-    authorizationEnforcer.enforce(APP, ALICE, Action.ADMIN);
-    authorizationEnforcer.enforce(PROGRAM, ALICE, Action.EXECUTE);
-    authorizationEnforcer.enforce(APP, ALICE, Collections.singleton(Action.ADMIN));
-    privilegesManager.revoke(Authorizable.fromEntityId(PROGRAM));
-    privilegesManager.revoke(Authorizable.fromEntityId(APP), ALICE, EnumSet.allOf(Action.class));
-    privilegesManager.revoke(Authorizable.fromEntityId(NS), ALICE, EnumSet.allOf(Action.class));
-    Set<Privilege> privileges = privilegesManager.listPrivileges(ALICE);
+    permissionManager.grant(Authorizable.fromEntityId(NS), ALICE, EnumSet.allOf(StandardPermission.class));
+    permissionManager.grant(Authorizable.fromEntityId(APP), ALICE, Collections.singleton(StandardPermission.UPDATE));
+    permissionManager.grant(Authorizable.fromEntityId(PROGRAM), ALICE,
+                            Collections.singleton(ApplicationPermission.EXECUTE));
+    permissionManager.grant(Authorizable.fromEntityId(NS, EntityType.PROFILE), ALICE,
+                            Collections.singleton(StandardPermission.LIST));
+    accessEnforcer.enforce(NS, ALICE, EnumSet.allOf(StandardPermission.class));
+    accessEnforcer.enforce(APP, ALICE, StandardPermission.UPDATE);
+    accessEnforcer.enforce(PROGRAM, ALICE, ApplicationPermission.EXECUTE);
+    accessEnforcer.enforce(APP, ALICE, Collections.singleton(StandardPermission.UPDATE));
+    accessEnforcer.enforceOnParent(EntityType.PROFILE, NS, ALICE, StandardPermission.LIST);
+    permissionManager.revoke(Authorizable.fromEntityId(PROGRAM));
+    permissionManager.revoke(Authorizable.fromEntityId(APP), ALICE, EnumSet.allOf(StandardPermission.class));
+    permissionManager.revoke(Authorizable.fromEntityId(NS), ALICE, EnumSet.allOf(StandardPermission.class));
+    permissionManager.revoke(Authorizable.fromEntityId(NS, EntityType.PROFILE), ALICE,
+                            Collections.singleton(StandardPermission.LIST));
+    Set<GrantedPermission> privileges = permissionManager.listGrants(ALICE);
     Assert.assertTrue(String.format("Expected all of alice's privileges to be revoked, but found %s", privileges),
                       privileges.isEmpty());
   }
 
   @Test
-  public void testAuthorizationEnforcer() throws Exception {
-    privilegesManager.grant(Authorizable.fromEntityId(NS), ALICE, EnumSet.allOf(Action.class));
-    privilegesManager.grant(Authorizable.fromEntityId(APP), ALICE, Collections.singleton(Action.ADMIN));
-    privilegesManager.grant(Authorizable.fromEntityId(PROGRAM), ALICE, Collections.singleton(Action.EXECUTE));
-    authorizationEnforcer.enforce(NS, ALICE, EnumSet.allOf(Action.class));
-    authorizationEnforcer.enforce(APP, ALICE, Action.ADMIN);
-    authorizationEnforcer.enforce(PROGRAM, ALICE, Action.EXECUTE);
-    try {
-      authorizationEnforcer.enforce(NS, BOB, Action.ADMIN);
-      Assert.fail();
-    } catch (UnauthorizedException e) {
-      // expected
-    }
+  public void testAccessEnforcer() throws Exception {
+    permissionManager.grant(Authorizable.fromEntityId(NS), ALICE, EnumSet.allOf(StandardPermission.class));
+    permissionManager.grant(Authorizable.fromEntityId(APP), ALICE, Collections.singleton(StandardPermission.UPDATE));
+    permissionManager.grant(Authorizable.fromEntityId(PROGRAM), ALICE,
+                            Collections.singleton(ApplicationPermission.EXECUTE));
+    permissionManager.grant(Authorizable.fromEntityId(NS, EntityType.PROFILE), ALICE,
+                            Collections.singleton(StandardPermission.LIST));
+    accessEnforcer.enforce(NS, ALICE, EnumSet.allOf(StandardPermission.class));
+    accessEnforcer.enforce(APP, ALICE, StandardPermission.UPDATE);
+    accessEnforcer.enforce(PROGRAM, ALICE, ApplicationPermission.EXECUTE);
+    accessEnforcer.enforceOnParent(EntityType.PROFILE, NS, ALICE, StandardPermission.LIST);
+    assertUnauthorized(() -> accessEnforcer.enforce(NS, BOB, StandardPermission.UPDATE));
+    assertUnauthorized(() -> accessEnforcer.enforceOnParent(EntityType.PROFILE, NS, BOB, StandardPermission.LIST));
+    assertUnauthorized(() -> accessEnforcer.enforceOnParent(EntityType.PROFILE, NS, ALICE, StandardPermission.CREATE));
+    assertUnauthorized(() -> accessEnforcer.enforceOnParent(EntityType.APPLICATION, NS, ALICE,
+                                                            StandardPermission.LIST));
 
-    privilegesManager.revoke(Authorizable.fromEntityId(PROGRAM));
-    privilegesManager.revoke(Authorizable.fromEntityId(APP));
-    privilegesManager.revoke(Authorizable.fromEntityId(NS));
+    permissionManager.revoke(Authorizable.fromEntityId(PROGRAM));
+    permissionManager.revoke(Authorizable.fromEntityId(APP));
+    permissionManager.revoke(Authorizable.fromEntityId(NS));
+    permissionManager.revoke(Authorizable.fromEntityId(NS, EntityType.PROFILE));
   }
 
   @Test
@@ -173,12 +169,16 @@ public abstract class RemotePrivilegesTestBase {
     DatasetId ds2 = NS.dataset("ds2");
 
     // Grant privileges on non-numbered entities to ALICE
-    privilegesManager.grant(Authorizable.fromEntityId(PROGRAM), ALICE, Collections.singleton(Action.EXECUTE));
-    privilegesManager.grant(Authorizable.fromEntityId(ds), ALICE, EnumSet.of(Action.READ, Action.WRITE));
+    permissionManager.grant(Authorizable.fromEntityId(PROGRAM), ALICE,
+                            Collections.singleton(ApplicationPermission.EXECUTE));
+    permissionManager.grant(Authorizable.fromEntityId(ds), ALICE,
+                            EnumSet.of(StandardPermission.GET, StandardPermission.UPDATE));
 
     // Grant privileges on entities ending with 2 to BOB
-    privilegesManager.grant(Authorizable.fromEntityId(program2), BOB, Collections.singleton(Action.ADMIN));
-    privilegesManager.grant(Authorizable.fromEntityId(ds2), BOB, EnumSet.of(Action.READ, Action.WRITE));
+    permissionManager.grant(Authorizable.fromEntityId(program2), BOB,
+                            Collections.singleton(StandardPermission.UPDATE));
+    permissionManager.grant(Authorizable.fromEntityId(ds2), BOB,
+                            EnumSet.of(StandardPermission.GET, StandardPermission.UPDATE));
 
     Set<? extends EntityId> allEntities = ImmutableSet.of(NS,
                                                           APP, PROGRAM, ds,
@@ -186,82 +186,43 @@ public abstract class RemotePrivilegesTestBase {
                                                           app2, program2, ds2);
 
     Assert.assertEquals(ImmutableSet.of(NS, APP, PROGRAM, ds),
-                        authorizationEnforcer.isVisible(allEntities, ALICE));
+                        accessEnforcer.isVisible(allEntities, ALICE));
 
     Assert.assertEquals(ImmutableSet.of(NS, app2, program2, ds2),
-                        authorizationEnforcer.isVisible(allEntities, BOB));
+                        accessEnforcer.isVisible(allEntities, BOB));
 
     Assert.assertEquals(ImmutableSet.of(),
-                        authorizationEnforcer.isVisible(allEntities, CAROL));
+                        accessEnforcer.isVisible(allEntities, CAROL));
 
     Assert.assertEquals(ImmutableSet.of(),
-                        authorizationEnforcer.isVisible(ImmutableSet.<EntityId>of(), ALICE));
+                        accessEnforcer.isVisible(ImmutableSet.<EntityId>of(), ALICE));
 
     Assert.assertEquals(ImmutableSet.of(ds, APP),
-                        authorizationEnforcer.isVisible(ImmutableSet.of(ds, APP), ALICE));
+                        accessEnforcer.isVisible(ImmutableSet.of(ds, APP), ALICE));
 
     for (EntityId entityId : allEntities) {
-      privilegesManager.revoke(Authorizable.fromEntityId(entityId));
-    }
-  }
-
-  @Test
-  public void testSingleVisibility() throws Exception {
-    ApplicationId app1 = NS.app("app1");
-    ProgramId program1 = app1.program(ProgramType.SERVICE, "service1");
-
-    ApplicationId app2 = NS.app("app2");
-    ProgramId program2 = app2.program(ProgramType.MAPREDUCE, "service2");
-
-    DatasetId ds = NS.dataset("ds");
-    DatasetId ds1 = NS.dataset("ds1");
-    DatasetId ds2 = NS.dataset("ds2");
-
-    // Grant privileges on non-numbered entities to ALICE
-    privilegesManager.grant(Authorizable.fromEntityId(PROGRAM), ALICE, Collections.singleton(Action.EXECUTE));
-    privilegesManager.grant(Authorizable.fromEntityId(ds), ALICE, EnumSet.of(Action.READ, Action.WRITE));
-
-    // Grant privileges on entities ending with 2 to BOB
-    privilegesManager.grant(Authorizable.fromEntityId(program2), BOB, Collections.singleton(Action.ADMIN));
-    privilegesManager.grant(Authorizable.fromEntityId(ds2), BOB, EnumSet.of(Action.READ, Action.WRITE));
-
-    Set<? extends EntityId> allEntities = ImmutableSet.of(NS,
-                                                          APP, PROGRAM, ds,
-                                                          app1, program1, ds1,
-                                                          app2, program2, ds2);
-
-    // Verify ALICE has the right permissions
-    authorizationEnforcer.isVisible(PROGRAM, ALICE);
-    authorizationEnforcer.isVisible(ds, ALICE);
-    shouldNotHaveVisibility(authorizationEnforcer, program2, ALICE);
-    shouldNotHaveVisibility(authorizationEnforcer, ds2, ALICE);
-
-    // Verify BOB has the right permissions
-    authorizationEnforcer.isVisible(program2, BOB);
-    authorizationEnforcer.isVisible(ds2, BOB);
-    shouldNotHaveVisibility(authorizationEnforcer, PROGRAM, BOB);
-    shouldNotHaveVisibility(authorizationEnforcer, ds, BOB);
-
-    // Verify CAROL has the right permissions
-    shouldNotHaveVisibility(authorizationEnforcer, PROGRAM, CAROL);
-    shouldNotHaveVisibility(authorizationEnforcer, ds, CAROL);
-    shouldNotHaveVisibility(authorizationEnforcer, program2, CAROL);
-    shouldNotHaveVisibility(authorizationEnforcer, ds2, CAROL);
-
-    for (EntityId entityId : allEntities) {
-      privilegesManager.revoke(Authorizable.fromEntityId(entityId));
+      permissionManager.revoke(Authorizable.fromEntityId(entityId));
     }
   }
 
   // Throws an assertion failure exception if the visibility check succeeds.
-  protected void shouldNotHaveVisibility(AuthorizationEnforcer enforcer, EntityId entityId, Principal principal)
+  protected void shouldNotHaveVisibility(AccessEnforcer enforcer, EntityId entityId, Principal principal)
     throws Exception {
     try {
-      enforcer.isVisible(entityId, principal);
+      enforcer.enforce(entityId, principal, StandardPermission.GET);
       Assert.fail(String.format("Expected principal %s to not have visibility permissions for entity '%s'.", principal,
                                 entityId));
     } catch (UnauthorizedException e) {
       // This is expected.
+    }
+  }
+
+  private void assertUnauthorized(Retries.Runnable<AccessException> runnable) throws AccessException {
+    try {
+      runnable.run();
+      Assert.fail();
+    } catch (UnauthorizedException e) {
+      // expected
     }
   }
 

--- a/cdap-cli-tests/src/test/java/io/cdap/cdap/cli/AuthorizationCLITest.java
+++ b/cdap-cli-tests/src/test/java/io/cdap/cdap/cli/AuthorizationCLITest.java
@@ -184,7 +184,7 @@ public class AuthorizationCLITest  {
                                                              principal.getName()));
     lines = Arrays.asList(output.split("\\r?\\n"));
     Assert.assertEquals(2, lines.size());
-    Assert.assertArrayEquals(new String[]{namespaceId.toString(), Action.ADMIN.name()}, lines.get(1).split(","));
+    Assert.assertArrayEquals(new String[]{namespaceId.toString(), Action.READ.name()}, lines.get(1).split(","));
 
 
     // test revoke actions

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Authorizable.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Authorizable.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Class to represent entities on which privileges can be granted/revoked.
@@ -36,16 +37,20 @@ public class Authorizable {
   private final EntityType entityType;
   // represent the parts of the entity
   private final Map<EntityType, String> entityParts;
+  // represents the type of children for parent-only permission checks
+  private final EntityType childType;
 
 
-  public Authorizable(EntityType entityType, Map<EntityType, String> entityParts) {
+  public Authorizable(EntityType entityType, Map<EntityType, String> entityParts, @Nullable EntityType childType) {
     this.entityType = entityType;
     this.entityParts = Collections.unmodifiableMap(entityParts);
+    this.childType = childType;
   }
 
   /**
    * Constructs an {@link Authorizable} from the given entityString. The entityString must be a representation of an
    * entity similar to {@link EntityId#toString()} with the exception that the string can contain wildcards (? and *).
+   * ChildType can be optionally specified after a second ":" character.
    * Note:
    * <ol>
    * <li>
@@ -67,14 +72,15 @@ public class Authorizable {
       throw new IllegalArgumentException("Null or empty entity string.");
     }
 
-    String[] typeAndId = entityString.split(EntityId.IDSTRING_TYPE_SEPARATOR, 2);
-    if (typeAndId.length != 2) {
+    String[] typeAndId = entityString.split(EntityId.IDSTRING_TYPE_SEPARATOR, 3);
+    if (typeAndId.length < 2) {
       throw new IllegalArgumentException(
         String.format("Cannot extract the entity type from %s", entityString));
     }
     String typeString = typeAndId[0];
     EntityType type = EntityType.valueOf(typeString.toUpperCase());
     String idString = typeAndId[1];
+    EntityType childType = typeAndId.length == 3 ? EntityType.valueOf(typeAndId[2].toUpperCase()) : null;
 
     List<String> idParts = Collections.emptyList();
     switch (type) {
@@ -99,7 +105,7 @@ public class Authorizable {
 
     Map<EntityType, String> entityParts = new LinkedHashMap<>();
     checkParts(type, idParts, idParts.size() - 1, entityParts);
-    return new Authorizable(type, entityParts);
+    return new Authorizable(type, entityParts, childType);
   }
 
   /**
@@ -112,6 +118,20 @@ public class Authorizable {
    * @return {@link Authorizable} representing the entity
    */
   public static Authorizable fromEntityId(EntityId entityId) {
+    return fromEntityId(entityId, null);
+  }
+  /**
+   * Creates an {@link Authorizable} which represents the given entityId with an optional child type for parent-only
+   * checks.
+   * Note: CDAP Authorization does not support authorization on versions of {@link io.cdap.cdap.proto.id.ApplicationId}
+   * and {@link io.cdap.cdap.proto.id.ArtifactId}. If an artifactId or applicationId which has version is passed to
+   * then the version will be silently dropped to construct the authorizable.
+   *
+   * @param entityId the entity
+   * @param childType optional type of child for parent-only checks
+   * @return {@link Authorizable} representing the entity
+   */
+  public static Authorizable fromEntityId(EntityId entityId, @Nullable EntityType childType) {
     if (entityId == null) {
       throw new IllegalArgumentException("EntityId is required.");
     }
@@ -131,6 +151,9 @@ public class Authorizable {
       // remove the version from the entity string
       String version = entity.substring(versionStartIndex, versionEndIndex);
       entity = entity.replace(version, "");
+    }
+    if (childType != null) {
+      entity = entity + EntityId.IDSTRING_TYPE_SEPARATOR + childType.name().toLowerCase();
     }
     return fromString(entity);
   }
@@ -155,7 +178,7 @@ public class Authorizable {
    */
   @Override
   public String toString() {
-    // the to string is done in this way to matain compatibility with EntityId.toString()
+    // the to string is done in this way to maintain compatibility with EntityId.toString()
     StringBuilder result = new StringBuilder();
     result.append(entityType.name().toLowerCase());
 
@@ -163,6 +186,9 @@ public class Authorizable {
     for (String part : entityParts.values()) {
       result.append(separator).append(part);
       separator = EntityId.IDSTRING_PART_SEPARATOR;
+    }
+    if (childType != null) {
+      result.append(EntityId.IDSTRING_TYPE_SEPARATOR).append(childType.name().toLowerCase());
     }
     return result.toString();
   }
@@ -177,12 +203,12 @@ public class Authorizable {
     }
 
     Authorizable that = (Authorizable) o;
-    return entityType == that.entityType && entityParts.equals(that.entityParts);
+    return entityType == that.entityType && childType == that.childType && entityParts.equals(that.entityParts);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(entityType, entityParts);
+    return Objects.hash(entityType, childType, entityParts);
   }
 
   private static void checkParts(EntityType entityType, List<String> parts, int index,
@@ -218,6 +244,7 @@ public class Authorizable {
       case DATASET_MODULE:
       case DATASET_TYPE:
       case SECUREKEY:
+      case PROFILE:
         if (parts.size() != 2 && index == (parts.size() - 1)) {
           throw new IllegalArgumentException("Entity value is missing some parts or containing more parts. " +
                                                "Expected: <namespace-name>.<entity-name>, given entity: " + parts);

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/security/StandardPermission.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/security/StandardPermission.java
@@ -32,6 +32,16 @@ public enum StandardPermission implements Permission {
     }
   },
   /**
+   * List permission can be used on parent entity to check if a principal has access to list specific children
+   * types.
+   */
+  LIST {
+    @Override
+    public boolean isCheckedOnParent() {
+      return true;
+    }
+  },
+  /**
    * Read access to an entity.
    */
   GET,

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AccessEnforcer.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AccessEnforcer.java
@@ -18,9 +18,12 @@ package io.cdap.cdap.security.spi.authorization;
 
 import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.api.security.AccessException;
+import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.id.ParentedId;
 import io.cdap.cdap.proto.security.Permission;
 import io.cdap.cdap.proto.security.Principal;
+import io.cdap.cdap.proto.security.StandardPermission;
 
 import java.util.Collections;
 import java.util.Set;
@@ -56,20 +59,19 @@ public interface AccessEnforcer {
   void enforce(EntityId entity, Principal principal, Set<? extends Permission> permissions) throws AccessException;
 
   /**
-   * Checks whether a single {@link EntityId} is visible to the specified {@link Principal}.
-   * An entity is visible to a principal if the principal has {@link io.cdap.cdap.proto.security.StandardPermission#GET}
-   * priviledge on the entity.
-   * However, visibility check behavior can be overwritten at the authorization extension level.
+   * Enforces specific {@link Permission#isCheckedOnParent()} permission for {@link EntityType} on it's parent
+   * {@link EntityId}. E.g. one can check if it's possible to {@link StandardPermission#LIST}
+   * {@link EntityType#PROFILE} in specific {@link io.cdap.cdap.proto.id.NamespaceId}.
    *
-   * @param entityId the entity on which the visibility check is to be performed
-   * @param principal the principal to check the visibility for
-   * @throws UnauthorizedException if the entity is not visible to the principal
+   * @param entityType the {@link EntityType} on which authorization is to be enforced
+   * @param parentId the {@link EntityId} of parent entity on which authorization is to be enforced
+   * @param principal the {@link Principal} that performs the permission
+   * @param permission the {@link Permission} being performed. Permission must return true on
+   * {@link Permission#isCheckedOnParent()}.
+   * @throws UnauthorizedException if the principal is not authorized to perform the specified permission on the entity
    */
-  default void isVisible(EntityId entityId, Principal principal) throws AccessException {
-    if (isVisible(Collections.singleton(entityId), principal).isEmpty()) {
-      throw new UnauthorizedException(principal, entityId);
-    }
-  }
+  void enforceOnParent(EntityType entityType, EntityId parentId, Principal principal,
+                       Permission permission) throws AccessException;
 
   /**
    * Checks whether the set of {@link EntityId}s are visible to the specified {@link Principal}.

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/NoOpAccessController.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/NoOpAccessController.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.security.spi.authorization;
 
+import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.security.Authorizable;
 import io.cdap.cdap.proto.security.GrantedPermission;
@@ -30,12 +31,6 @@ import java.util.Set;
  * A no-op authorizer to use when authorization is disabled.
  */
 public class NoOpAccessController implements AccessController {
-
-  @Override
-  public void enforce(EntityId entity, Principal principal, Permission permission) {
-    // no-op
-  }
-
   @Override
   public Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds, Principal principal) {
     return entityIds;
@@ -43,6 +38,11 @@ public class NoOpAccessController implements AccessController {
 
   @Override
   public void enforce(EntityId entity, Principal principal, Set<? extends Permission> permissions) {
+    // no-op
+  }
+
+  @Override
+  public void enforceOnParent(EntityType entityType, EntityId parentId, Principal principal, Permission permission) {
     // no-op
   }
 

--- a/cdap-security-spi/src/test/java/io/cdap/cdap/security/spi/authorization/UnauthorizedExceptionTest.java
+++ b/cdap-security-spi/src/test/java/io/cdap/cdap/security/spi/authorization/UnauthorizedExceptionTest.java
@@ -16,14 +16,17 @@
 
 package io.cdap.cdap.security.spi.authorization;
 
+import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.security.Action;
 import io.cdap.cdap.proto.security.Principal;
+import io.cdap.cdap.proto.security.StandardPermission;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -36,6 +39,16 @@ public class UnauthorizedExceptionTest {
     String expected = String.format("Principal '%s' has insufficient privileges to perform action '%s' " +
                                       "on entity '%s'.", TEST_PRINCIPAL, Action.ADMIN, TEST_NAMESPACE_ENTITY);
     String got = new UnauthorizedException(TEST_PRINCIPAL, Action.ADMIN, TEST_NAMESPACE_ENTITY).getMessage();
+    Assert.assertEquals(expected, got);
+  }
+
+  @Test
+  public void testSingleActionReturnsExpectedMessageWithChild() {
+    String expected = String.format("Principal '%s' has insufficient privileges to perform action '%s' " +
+                                      "on %s in entity '%s'.", TEST_PRINCIPAL, StandardPermission.CREATE,
+                                    EntityType.DATASET.name().toLowerCase(), TEST_NAMESPACE_ENTITY);
+    String got = new UnauthorizedException(TEST_PRINCIPAL, EnumSet.of(StandardPermission.CREATE),
+                                           TEST_NAMESPACE_ENTITY, EntityType.DATASET).getMessage();
     Assert.assertEquals(expected, got);
   }
 

--- a/cdap-security/src/main/java/io/cdap/cdap/proto/security/AuthorizationPrivilege.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/proto/security/AuthorizationPrivilege.java
@@ -16,7 +16,9 @@
 
 package io.cdap.cdap.proto.security;
 
+import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 
 import java.util.Collections;
 import java.util.Objects;
@@ -35,10 +37,13 @@ public class AuthorizationPrivilege {
   private final Set<Permission> actions;
   private final Set<Permission> permissions;
   private final Principal principal;
+  private final EntityType childEntityType;
 
-  public AuthorizationPrivilege(Principal principal, EntityId entityId, Set<? extends Permission> permissions) {
+  public AuthorizationPrivilege(Principal principal, EntityId entityId, Set<? extends Permission> permissions,
+                                EntityType childEntityType) {
     this.entityId = entityId;
     this.permissions = Collections.unmodifiableSet(permissions);
+    this.childEntityType = childEntityType;
     this.actions = null;
     this.principal = principal;
   }
@@ -60,6 +65,15 @@ public class AuthorizationPrivilege {
     return actions;
   }
 
+  /**
+   * @return child entity type for {@link AccessEnforcer#enforceOnParent(EntityType, EntityId, Principal, Permission)}
+   * checks.
+   */
+  @Nullable
+  public EntityType getChildEntityType() {
+    return childEntityType;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -70,12 +84,13 @@ public class AuthorizationPrivilege {
     }
     AuthorizationPrivilege that = (AuthorizationPrivilege) o;
     return Objects.equals(entityId, that.entityId) && permissions.equals(that.permissions) &&
+      Objects.equals(childEntityType, that.childEntityType) &&
       Objects.equals(actions, that.actions) && Objects.equals(principal, that.principal);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(entityId, permissions, principal);
+    return Objects.hash(entityId, permissions, principal, childEntityType);
   }
 
   @Override
@@ -85,6 +100,7 @@ public class AuthorizationPrivilege {
       ", actions=" + actions +
       ", permissions=" + permissions +
       ", principal=" + principal +
+      ", childEntityType=" + childEntityType +
       '}';
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AccessControllerWrapper.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AccessControllerWrapper.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.proto.security.Authorizable;
 import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.proto.security.Privilege;
 import io.cdap.cdap.proto.security.Role;
+import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.security.spi.authorization.AccessController;
 import io.cdap.cdap.security.spi.authorization.AuthorizationContext;
 import io.cdap.cdap.security.spi.authorization.Authorizer;
@@ -82,7 +83,7 @@ public class AccessControllerWrapper extends AccessEnforcerWrapper implements Au
 
   @Override
   public void isVisible(EntityId entityId, Principal principal) throws AccessException {
-    accessController.isVisible(entityId, principal);
+    accessController.enforce(entityId, principal, StandardPermission.GET);
   }
 
   @Override

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AccessEnforcerWrapper.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AccessEnforcerWrapper.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.security.Action;
 import io.cdap.cdap.proto.security.Permission;
 import io.cdap.cdap.proto.security.Principal;
+import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import io.cdap.cdap.security.spi.authorization.AuthorizationEnforcer;
 
@@ -54,7 +55,7 @@ public class AccessEnforcerWrapper implements AuthorizationEnforcer {
 
   @Override
   public void isVisible(EntityId entityId, Principal principal) throws AccessException {
-    accessEnforcer.isVisible(entityId, principal);
+    accessEnforcer.enforce(entityId, principal, StandardPermission.GET);
   }
 
   @Override

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/DelegatingPermissionManager.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/DelegatingPermissionManager.java
@@ -34,32 +34,32 @@ import java.util.Set;
  */
 public class DelegatingPermissionManager implements PermissionManager {
 
-  private final AccessController delegateAuthorizer;
+  private final AccessController delegateAccessController;
 
   @Inject
   DelegatingPermissionManager(AccessControllerInstantiator accessControllerInstantiator) {
-    this.delegateAuthorizer = accessControllerInstantiator.get();
+    this.delegateAccessController = accessControllerInstantiator.get();
   }
 
   @Override
   public void grant(Authorizable authorizable, Principal principal, Set<? extends Permission> permissions)
     throws AccessException {
-    delegateAuthorizer.grant(authorizable, principal, permissions);
+    delegateAccessController.grant(authorizable, principal, permissions);
   }
 
   @Override
   public void revoke(Authorizable authorizable, Principal principal, Set<? extends Permission> permissions)
     throws AccessException {
-    delegateAuthorizer.revoke(authorizable, principal, permissions);
+    delegateAccessController.revoke(authorizable, principal, permissions);
   }
 
   @Override
   public void revoke(Authorizable authorizable) throws AccessException {
-    delegateAuthorizer.revoke(authorizable);
+    delegateAccessController.revoke(authorizable);
   }
 
   @Override
   public Set<GrantedPermission> listGrants(Principal principal) throws AccessException {
-    return delegateAuthorizer.listGrants(principal);
+    return delegateAccessController.listGrants(principal);
   }
 }


### PR DESCRIPTION
All profile checks are now done on profile level, including system-level ones.
The list check is done as StandardPermission.LIST(profile) on a namespace