### PR TITLE
Wrap UnauthorizedException into DatasetManagementException to preserve stable API for plugins (no "throws AccessException" added)

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/DatasetManager.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/DatasetManager.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.api.dataset;
 
 import io.cdap.cdap.api.annotation.Beta;
-import io.cdap.cdap.api.security.AccessException;
 
 /**
  * Provides dataset management functions.
@@ -31,8 +30,7 @@ public interface DatasetManager {
    * @return whether a dataset of that name exists
    * @throws DatasetManagementException for any issues encountered in the dataset system
    */
-  boolean datasetExists(String name)
-    throws DatasetManagementException, AccessException;
+  boolean datasetExists(String name) throws DatasetManagementException;
 
   /**
    * Get the type of a dataset.
@@ -41,8 +39,7 @@ public interface DatasetManager {
    * @throws InstanceNotFoundException if the dataset does not exist
    * @throws DatasetManagementException for any issues encountered in the dataset system
    */
-  String getDatasetType(String name)
-    throws DatasetManagementException, AccessException;
+  String getDatasetType(String name) throws DatasetManagementException;
 
   /**
    * Get the properties with which a dataset was created or updated.
@@ -51,8 +48,7 @@ public interface DatasetManager {
    * @throws InstanceNotFoundException if the dataset does not exist
    * @throws DatasetManagementException for any issues encountered in the dataset system
    */
-  DatasetProperties getDatasetProperties(String name)
-    throws DatasetManagementException, AccessException;
+  DatasetProperties getDatasetProperties(String name) throws DatasetManagementException;
 
   /**
    * Create a new dataset instance.
@@ -63,8 +59,7 @@ public interface DatasetManager {
    * @throws DatasetManagementException for any issues encountered in the dataset system,
    *         or if the dataset type's create method fails.
    */
-  void createDataset(String name, String type, DatasetProperties properties)
-    throws DatasetManagementException, AccessException;
+  void createDataset(String name, String type, DatasetProperties properties) throws DatasetManagementException;
 
   /**
    * Update an existing dataset with new properties.
@@ -74,8 +69,7 @@ public interface DatasetManager {
    * @throws DatasetManagementException for any issues encountered in the dataset system,
    *         or if the dataset type's update method fails.
    */
-  void updateDataset(String name, DatasetProperties properties)
-    throws DatasetManagementException, AccessException;
+  void updateDataset(String name, DatasetProperties properties) throws DatasetManagementException;
 
   /**
    * Delete a dataset instance.
@@ -84,7 +78,7 @@ public interface DatasetManager {
    * @throws DatasetManagementException for any issues encountered in the dataset system,
    *         or if the dataset type's drop method fails.
    */
-  void dropDataset(String name) throws DatasetManagementException, AccessException;
+  void dropDataset(String name) throws DatasetManagementException;
 
   /**
    * Truncate a dataset, that is, delete all its data.
@@ -93,5 +87,5 @@ public interface DatasetManager {
    * @throws DatasetManagementException for any issues encountered in the dataset system,
    *         or if the dataset type's truncate method fails.
    */
-  void truncateDataset(String name) throws DatasetManagementException, AccessException;
+  void truncateDataset(String name) throws DatasetManagementException;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/NameMappedDatasetFramework.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/NameMappedDatasetFramework.java
@@ -30,7 +30,6 @@ import io.cdap.cdap.data2.metadata.lineage.AccessType;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
-import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -92,38 +91,36 @@ public class NameMappedDatasetFramework extends ForwardingProgramContextAwareDat
   @Override
   public void addInstance(String datasetTypeName, DatasetId datasetInstanceId, DatasetProperties props,
                           @Nullable KerberosPrincipalId ownerPrincipal)
-    throws IOException, DatasetManagementException, UnauthorizedException {
+    throws IOException, DatasetManagementException {
     super.addInstance(datasetTypeName, getMappedDatasetInstance(datasetInstanceId), props, ownerPrincipal);
   }
 
   @Override
   public void updateInstance(DatasetId datasetInstanceId, DatasetProperties props)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
     super.updateInstance(getMappedDatasetInstance(datasetInstanceId), props);
   }
 
   @Nullable
   @Override
-  public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId)
-    throws DatasetManagementException, UnauthorizedException {
+  public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId) throws DatasetManagementException {
     return super.getDatasetSpec(getMappedDatasetInstance(datasetInstanceId));
   }
 
   @Override
-  public boolean hasInstance(DatasetId datasetInstanceId) throws DatasetManagementException, UnauthorizedException {
+  public boolean hasInstance(DatasetId datasetInstanceId) throws DatasetManagementException {
     return super.hasInstance(getMappedDatasetInstance(datasetInstanceId));
   }
 
   @Override
-  public void deleteInstance(DatasetId datasetInstanceId)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+  public void deleteInstance(DatasetId datasetInstanceId) throws DatasetManagementException, IOException {
     super.deleteInstance(getMappedDatasetInstance(datasetInstanceId));
   }
 
   @Nullable
   @Override
   public <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, @Nullable ClassLoader classLoader)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
     return super.getAdmin(getMappedDatasetInstance(datasetInstanceId), classLoader);
   }
 
@@ -131,7 +128,7 @@ public class NameMappedDatasetFramework extends ForwardingProgramContextAwareDat
   @Override
   public <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, @Nullable ClassLoader classLoader,
                                              DatasetClassLoaderProvider classLoaderProvider)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
     return super.getAdmin(getMappedDatasetInstance(datasetInstanceId), classLoader, classLoaderProvider);
   }
 
@@ -141,7 +138,7 @@ public class NameMappedDatasetFramework extends ForwardingProgramContextAwareDat
                                           @Nullable ClassLoader classLoader,
                                           DatasetClassLoaderProvider classLoaderProvider,
                                           @Nullable Iterable<? extends EntityId> owners, AccessType accessType)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
     return super.getDataset(getMappedDatasetInstance(datasetInstanceId),
                             arguments, classLoader, classLoaderProvider, owners, accessType);
   }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingContext.java
@@ -20,7 +20,6 @@ import io.cdap.cdap.api.Transactional;
 import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.DatasetManagementException;
-import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
 import io.cdap.cdap.etl.api.StageContext;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
@@ -52,8 +51,7 @@ public interface StreamingContext extends StageContext, Transactional {
    * @deprecated use {@link StreamingSourceContext#registerLineage(String, Schema)} to record lineage in prepare stage
    */
   @Deprecated
-  void registerLineage(String referenceName)
-    throws DatasetManagementException, TransactionFailureException, AccessException;
+  void registerLineage(String referenceName) throws DatasetManagementException, TransactionFailureException;
 
   /**
    * Indicates whether the pipeline is running in preview.

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingSourceContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingSourceContext.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.etl.api.streaming;
 
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.DatasetManagementException;
-import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.etl.api.batch.BatchContext;
 import org.apache.tephra.TransactionFailureException;
 
@@ -38,8 +37,7 @@ public interface StreamingSourceContext extends BatchContext {
    * @throws TransactionFailureException thrown if there was an error while fetching the dataset to register usage
    */
   void registerLineage(String referenceName,
-                       @Nullable Schema schema)
-    throws DatasetManagementException, TransactionFailureException, AccessException;
+                       @Nullable Schema schema) throws DatasetManagementException, TransactionFailureException;
 
   /**
    * Indicates whether the pipeline is running in preview.

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/action/ActionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/action/ActionContext.java
@@ -19,7 +19,6 @@ package io.cdap.cdap.etl.api.action;
 import io.cdap.cdap.api.Transactional;
 import io.cdap.cdap.api.dataset.DatasetManagementException;
 import io.cdap.cdap.api.lineage.field.LineageRecorder;
-import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.api.security.store.SecureStore;
 import io.cdap.cdap.api.security.store.SecureStoreManager;
 import io.cdap.cdap.etl.api.StageContext;
@@ -69,8 +68,7 @@ public interface ActionContext extends StageContext, Transactional, SecureStore,
    * @throws TransactionFailureException thrown if there was an error while fetching the dataset to register usage
    */
  default void registerLineage(String referenceName,
-                              AccessType accessType)
-   throws DatasetManagementException, TransactionFailureException, AccessException {
+                              AccessType accessType) throws DatasetManagementException, TransactionFailureException {
    // no-op
  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/batch/BatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/batch/BatchContext.java
@@ -21,7 +21,6 @@ import io.cdap.cdap.api.data.DatasetContext;
 import io.cdap.cdap.api.dataset.DatasetManagementException;
 import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.InstanceConflictException;
-import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.etl.api.TransformContext;
 import io.cdap.cdap.etl.api.action.SettableArguments;
 
@@ -41,7 +40,7 @@ public interface BatchContext extends DatasetContext, TransformContext {
    *         or if the dataset type's create method fails.
    */
   void createDataset(String datasetName, String typeName, DatasetProperties properties)
-    throws DatasetManagementException, AccessException;
+    throws DatasetManagementException;
 
   /**
    * Check whether a dataset exists in the current namespace.
@@ -49,7 +48,7 @@ public interface BatchContext extends DatasetContext, TransformContext {
    * @return whether a dataset of that name exists
    * @throws DatasetManagementException for any issues encountered in the dataset system
    */
-  boolean datasetExists(String datasetName) throws DatasetManagementException, AccessException;
+  boolean datasetExists(String datasetName) throws DatasetManagementException;
 
   /**
    * Returns settable pipeline arguments. These arguments are shared by all pipeline stages, so plugins should be

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/customaction/BasicActionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/customaction/BasicActionContext.java
@@ -97,7 +97,7 @@ public class BasicActionContext extends AbstractStageContext implements ActionCo
 
   @Override
   public void registerLineage(String referenceName, AccessType accessType)
-    throws DatasetManagementException, AccessException {
+    throws DatasetManagementException {
     Supplier<Dataset> datasetSupplier =
       () -> Transactionals.execute(context, (TxCallable<Dataset>) ctx -> ctx.getDataset(referenceName));
     ExternalDatasets.registerLineage(admin, referenceName, accessType, null, datasetSupplier);

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/AbstractBatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/AbstractBatchContext.java
@@ -56,12 +56,12 @@ public abstract class AbstractBatchContext extends AbstractTransformContext impl
 
   @Override
   public void createDataset(String datasetName, String typeName, DatasetProperties properties)
-    throws DatasetManagementException, AccessException {
+    throws DatasetManagementException {
     admin.createDataset(datasetName, typeName, properties);
   }
 
   @Override
-  public boolean datasetExists(String datasetName) throws DatasetManagementException, AccessException {
+  public boolean datasetExists(String datasetName) throws DatasetManagementException {
     return admin.datasetExists(datasetName);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ExternalDatasets.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ExternalDatasets.java
@@ -90,7 +90,7 @@ public final class ExternalDatasets {
         }
       }
       return Input.ofDataset(inputName, Collections.unmodifiableMap(arguments)).alias(input.getAlias());
-    } catch (DatasetManagementException | AccessException e) {
+    } catch (DatasetManagementException e) {
       throw Throwables.propagate(e);
     }
   }
@@ -140,7 +140,7 @@ public final class ExternalDatasets {
         }
       }
       return Output.ofDataset(outputName, Collections.unmodifiableMap(arguments)).alias(output.getAlias());
-    } catch (DatasetManagementException | AccessException e) {
+    } catch (DatasetManagementException e) {
       throw Throwables.propagate(e);
     }
   }
@@ -155,7 +155,7 @@ public final class ExternalDatasets {
   public static void registerLineage(Admin admin, String referenceName,
                                      AccessType accessType, @Nullable Schema schema,
                                      Supplier<Dataset> datasetSupplier)
-    throws DatasetManagementException, AccessException {
+    throws DatasetManagementException {
     DatasetProperties datasetProperties;
     if (schema == null) {
       datasetProperties = DatasetProperties.EMPTY;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
@@ -264,7 +264,7 @@ public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
     try {
       ExternalDatasets.registerLineage(sec.getAdmin(), name, AccessType.WRITE, null,
                                        () -> datasetContext.getDataset(name));
-    } catch (DatasetManagementException | AccessException e) {
+    } catch (DatasetManagementException e) {
       LOG.warn("Unable to register dataset lineage for {}", name);
     }
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DefaultStreamingContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DefaultStreamingContext.java
@@ -79,7 +79,7 @@ public class DefaultStreamingContext extends AbstractStageContext implements Str
 
   @Override
   public void registerLineage(String referenceName)
-    throws DatasetManagementException, TransactionFailureException, AccessException {
+    throws DatasetManagementException, TransactionFailureException {
 
     try {
       if (!admin.datasetExists(referenceName)) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DefaultStreamingSourceContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DefaultStreamingSourceContext.java
@@ -58,7 +58,7 @@ public class DefaultStreamingSourceContext extends AbstractBatchContext implemen
   @Override
   public void registerLineage(String referenceName,
                               @Nullable Schema schema)
-    throws DatasetManagementException, TransactionFailureException, AccessException {
+    throws DatasetManagementException, TransactionFailureException {
     ExternalDatasets.registerLineage(admin, referenceName, AccessType.READ, schema, () -> getDataset(referenceName));
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -100,14 +100,15 @@ public class RemoteDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public void addModule(DatasetModuleId moduleId, DatasetModule module)
-    throws DatasetManagementException, UnauthorizedException {
+  public void addModule(DatasetModuleId moduleId, DatasetModule module) throws DatasetManagementException {
     Class<?> moduleClass = DatasetModules.getDatasetModuleClass(module);
     try {
       Location deploymentJar = createDeploymentJar(moduleClass);
       try {
         clientCache.getUnchecked(moduleId.getParent())
           .addModule(moduleId.getEntityName(), moduleClass.getName(), deploymentJar);
+      } catch (UnauthorizedException e) {
+        throw new DatasetManagementException("Access denied adding module " + moduleId, e);
       } finally {
         try {
           deploymentJar.delete();
@@ -126,95 +127,146 @@ public class RemoteDatasetFramework implements DatasetFramework {
 
   @Override
   public void addModule(DatasetModuleId moduleId, DatasetModule module,
-                        Location jarLocation) throws DatasetManagementException, UnauthorizedException {
-    clientCache.getUnchecked(moduleId.getParent())
-      .addModule(moduleId.getEntityName(), DatasetModules.getDatasetModuleClass(module).getName(), jarLocation);
+                        Location jarLocation) throws DatasetManagementException {
+    try {
+      clientCache.getUnchecked(moduleId.getParent())
+        .addModule(moduleId.getEntityName(), DatasetModules.getDatasetModuleClass(module).getName(), jarLocation);
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied adding module " + moduleId, e);
+    }
   }
 
   @Override
-  public void deleteModule(DatasetModuleId moduleId) throws DatasetManagementException, UnauthorizedException {
-    clientCache.getUnchecked(moduleId.getParent()).deleteModule(moduleId.getEntityName());
+  public void deleteModule(DatasetModuleId moduleId) throws DatasetManagementException {
+    try {
+      clientCache.getUnchecked(moduleId.getParent()).deleteModule(moduleId.getEntityName());
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied deleting module " + moduleId, e);
+    }
   }
 
   @Override
-  public void deleteAllModules(NamespaceId namespaceId) throws DatasetManagementException, UnauthorizedException {
-    clientCache.getUnchecked(namespaceId).deleteModules();
+  public void deleteAllModules(NamespaceId namespaceId) throws DatasetManagementException {
+    try {
+      clientCache.getUnchecked(namespaceId).deleteModules();
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied deleting modules from " + namespaceId, e);
+    }
   }
 
   @Override
   public void addInstance(String datasetType, DatasetId datasetInstanceId, DatasetProperties props,
                           @Nullable KerberosPrincipalId ownerPrincipal)
-    throws DatasetManagementException, UnauthorizedException {
-    clientCache.getUnchecked(datasetInstanceId.getParent())
-      .addInstance(datasetInstanceId.getEntityName(), datasetType, props, ownerPrincipal);
+    throws DatasetManagementException {
+    try {
+      clientCache.getUnchecked(datasetInstanceId.getParent())
+        .addInstance(datasetInstanceId.getEntityName(), datasetType, props, ownerPrincipal);
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied adding dataset " + datasetInstanceId, e);
+    }
   }
 
   @Override
   public void updateInstance(DatasetId datasetInstanceId, DatasetProperties props)
-    throws DatasetManagementException, UnauthorizedException {
-    clientCache.getUnchecked(datasetInstanceId.getParent())
-      .updateInstance(datasetInstanceId.getEntityName(), props);
+    throws DatasetManagementException {
+    try {
+      clientCache.getUnchecked(datasetInstanceId.getParent())
+        .updateInstance(datasetInstanceId.getEntityName(), props);
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied updating dataset " + datasetInstanceId, e);
+    }
   }
 
   @Override
   public Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId)
-    throws DatasetManagementException, UnauthorizedException {
-    return clientCache.getUnchecked(namespaceId).getAllInstances();
+    throws DatasetManagementException {
+    try {
+      return clientCache.getUnchecked(namespaceId).getAllInstances();
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied getting datasets in " + namespaceId, e);
+    }
   }
 
   @Override
   public Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId, Map<String, String> properties)
-    throws DatasetManagementException, UnauthorizedException {
-    return clientCache.getUnchecked(namespaceId).getInstances(properties);
+    throws DatasetManagementException {
+    try {
+      return clientCache.getUnchecked(namespaceId).getInstances(properties);
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied getting datasets in " + namespaceId, e);
+    }
   }
 
   @Nullable
   @Override
-  public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId)
-    throws DatasetManagementException, UnauthorizedException {
-    DatasetMeta meta = clientCache.getUnchecked(datasetInstanceId.getParent())
-      .getInstance(datasetInstanceId.getEntityName());
-    return meta == null ? null : meta.getSpec();
+  public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId) throws DatasetManagementException {
+    try {
+      DatasetMeta meta = clientCache.getUnchecked(datasetInstanceId.getParent())
+        .getInstance(datasetInstanceId.getEntityName());
+      return meta == null ? null : meta.getSpec();
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied getting dataset " + datasetInstanceId, e);
+    }
   }
 
   @Override
-  public boolean hasInstance(DatasetId datasetInstanceId) throws DatasetManagementException, UnauthorizedException {
-    return clientCache.getUnchecked(datasetInstanceId.getParent())
-      .getInstance(datasetInstanceId.getEntityName()) != null;
+  public boolean hasInstance(DatasetId datasetInstanceId) throws DatasetManagementException {
+    try {
+      return clientCache.getUnchecked(datasetInstanceId.getParent())
+        .getInstance(datasetInstanceId.getEntityName()) != null;
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied getting dataset " + datasetInstanceId, e);
+    }
   }
 
   @Override
-  public boolean hasType(DatasetTypeId datasetTypeId) throws DatasetManagementException, UnauthorizedException {
-    return clientCache.getUnchecked(datasetTypeId.getParent()).getType(datasetTypeId.getEntityName()) != null;
+  public boolean hasType(DatasetTypeId datasetTypeId) throws DatasetManagementException {
+    try {
+      return clientCache.getUnchecked(datasetTypeId.getParent()).getType(datasetTypeId.getEntityName()) != null;
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied getting dataset type " + datasetTypeId, e);
+    }
   }
 
   @Override
-  public DatasetTypeMeta getTypeInfo(DatasetTypeId datasetTypeId)
-    throws DatasetManagementException, UnauthorizedException {
-    return clientCache.getUnchecked(datasetTypeId.getParent()).getType(datasetTypeId.getEntityName());
+  public DatasetTypeMeta getTypeInfo(DatasetTypeId datasetTypeId) throws DatasetManagementException {
+    try {
+      return clientCache.getUnchecked(datasetTypeId.getParent()).getType(datasetTypeId.getEntityName());
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied getting dataset type " + datasetTypeId, e);
+    }
   }
 
   @Override
-  public void truncateInstance(DatasetId datasetInstanceId)
-    throws DatasetManagementException, UnauthorizedException {
-    clientCache.getUnchecked(datasetInstanceId.getParent()).truncateInstance(datasetInstanceId.getEntityName());
+  public void truncateInstance(DatasetId datasetInstanceId) throws DatasetManagementException {
+    try {
+      clientCache.getUnchecked(datasetInstanceId.getParent()).truncateInstance(datasetInstanceId.getEntityName());
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied truncating dataset " + datasetInstanceId, e);
+    }
   }
 
   @Override
-  public void deleteInstance(DatasetId datasetInstanceId)
-    throws DatasetManagementException, UnauthorizedException {
-    clientCache.getUnchecked(datasetInstanceId.getParent()).deleteInstance(datasetInstanceId.getEntityName());
+  public void deleteInstance(DatasetId datasetInstanceId) throws DatasetManagementException {
+    try {
+      clientCache.getUnchecked(datasetInstanceId.getParent()).deleteInstance(datasetInstanceId.getEntityName());
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied deletings dataset " + datasetInstanceId, e);
+    }
   }
 
   @Override
-  public void deleteAllInstances(NamespaceId namespaceId)
-    throws DatasetManagementException, UnauthorizedException {
-    clientCache.getUnchecked(namespaceId).deleteInstances();
+  public void deleteAllInstances(NamespaceId namespaceId) throws DatasetManagementException {
+    try {
+      clientCache.getUnchecked(namespaceId).deleteInstances();
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied deletings datasets in " + namespaceId, e);
+    }
   }
 
   @Override
   public <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, ClassLoader classLoader)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
     return getAdmin(datasetInstanceId, classLoader, new ConstantClassLoaderProvider(classLoader));
   }
 
@@ -223,15 +275,19 @@ public class RemoteDatasetFramework implements DatasetFramework {
   public <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId,
                                              @Nullable ClassLoader parentClassLoader,
                                              DatasetClassLoaderProvider classLoaderProvider)
-    throws DatasetManagementException, IOException, UnauthorizedException {
-    DatasetMeta instanceInfo = clientCache.getUnchecked(datasetInstanceId.getParent())
-      .getInstance(datasetInstanceId.getEntityName());
-    if (instanceInfo == null) {
-      return null;
-    }
+    throws DatasetManagementException, IOException {
+    try {
+      DatasetMeta instanceInfo = clientCache.getUnchecked(datasetInstanceId.getParent())
+        .getInstance(datasetInstanceId.getEntityName());
+      if (instanceInfo == null) {
+        return null;
+      }
 
-    DatasetType type = getType(instanceInfo.getType(), parentClassLoader, classLoaderProvider);
-    return (T) type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespace()), instanceInfo.getSpec());
+      DatasetType type = getType(instanceInfo.getType(), parentClassLoader, classLoaderProvider);
+      return (T) type.getAdmin(DatasetContext.from(datasetInstanceId.getNamespace()), instanceInfo.getSpec());
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied getting admin for " + datasetInstanceId, e);
+    }
   }
 
   @Nullable
@@ -240,15 +296,19 @@ public class RemoteDatasetFramework implements DatasetFramework {
                                           @Nullable ClassLoader classLoader,
                                           DatasetClassLoaderProvider classLoaderProvider,
                                           @Nullable Iterable<? extends EntityId> owners, AccessType accessType)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
 
-    DatasetMeta datasetMeta = clientCache.getUnchecked(id.getParent()).getInstance(id.getEntityName());
-    if (datasetMeta == null) {
-      return null;
+    try {
+      DatasetMeta datasetMeta = clientCache.getUnchecked(id.getParent()).getInstance(id.getEntityName());
+      if (datasetMeta == null) {
+        return null;
+      }
+
+      DatasetType type = getType(datasetMeta.getType(), classLoader, classLoaderProvider);
+      return (T) type.getDataset(DatasetContext.from(id.getNamespace()), datasetMeta.getSpec(), arguments);
+    } catch (UnauthorizedException e) {
+      throw new DatasetManagementException("Access denied getting dataset " + id, e);
     }
-
-    DatasetType type = getType(datasetMeta.getType(), classLoader, classLoaderProvider);
-    return (T) type.getDataset(DatasetContext.from(id.getNamespace()), datasetMeta.getSpec(), arguments);
   }
 
   @Override
@@ -349,8 +409,8 @@ public class RemoteDatasetFramework implements DatasetFramework {
    * @return an instance of the DatasetType
    */
   private <T extends DatasetType> T getType(DatasetTypeMeta datasetTypeMeta,
-                                           @Nullable ClassLoader classLoader,
-                                           DatasetClassLoaderProvider classLoaderProvider) {
+                                            @Nullable ClassLoader classLoader,
+                                            DatasetClassLoaderProvider classLoaderProvider) {
 
     if (classLoader == null) {
       classLoader = Objects.firstNonNull(Thread.currentThread().getContextClassLoader(), getClass().getClassLoader());

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/DatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/DatasetFramework.java
@@ -41,7 +41,6 @@ import io.cdap.cdap.proto.id.DatasetTypeId;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import org.apache.twill.filesystem.Location;
 
 import java.io.IOException;
@@ -83,8 +82,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException in case of problems
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void addModule(DatasetModuleId moduleId, DatasetModule module)
-    throws DatasetManagementException, UnauthorizedException;
+  void addModule(DatasetModuleId moduleId, DatasetModule module) throws DatasetManagementException;
 
   /**
    * Adds dataset types by adding dataset module to the system with a jar location containing all dataset classes
@@ -99,7 +97,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   void addModule(DatasetModuleId moduleId, DatasetModule module,
-                 Location jarLocation) throws DatasetManagementException, UnauthorizedException;
+                 Location jarLocation) throws DatasetManagementException;
 
   /**
    * Deletes dataset module and its types from the system.
@@ -109,7 +107,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void deleteModule(DatasetModuleId moduleId) throws DatasetManagementException, UnauthorizedException;
+  void deleteModule(DatasetModuleId moduleId) throws DatasetManagementException;
 
   /**
    * Deletes dataset modules and its types in the specified namespace.
@@ -119,7 +117,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void deleteAllModules(NamespaceId namespaceId) throws DatasetManagementException, UnauthorizedException;
+  void deleteAllModules(NamespaceId namespaceId) throws DatasetManagementException;
 
   /**
    * Adds information about dataset instance to the system.
@@ -138,8 +136,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   default void addInstance(String datasetTypeName, DatasetId datasetInstanceId,
-                           DatasetProperties props)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+                           DatasetProperties props) throws DatasetManagementException, IOException {
     addInstance(datasetTypeName, datasetInstanceId, props, null);
   }
 
@@ -164,8 +161,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   void addInstance(String datasetTypeName, DatasetId datasetInstanceId, DatasetProperties props,
-                   @Nullable KerberosPrincipalId ownerPrincipal)
-    throws DatasetManagementException, IOException, UnauthorizedException;
+                   @Nullable KerberosPrincipalId ownerPrincipal) throws DatasetManagementException, IOException;
 
   /**
    * Updates the existing dataset instance in the system.
@@ -183,7 +179,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   void updateInstance(DatasetId datasetInstanceId, DatasetProperties props)
-    throws DatasetManagementException, IOException, UnauthorizedException;
+    throws DatasetManagementException, IOException;
 
   /**
    * Get all dataset instances in the specified namespace
@@ -191,8 +187,7 @@ public interface DatasetFramework {
    * @param namespaceId the specified namespace id
    * @return a collection of {@link DatasetSpecification}s for all datasets in the specified namespace
    */
-  Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId)
-    throws DatasetManagementException, UnauthorizedException;
+  Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId) throws DatasetManagementException;
 
   /**
    * Get dataset instances in the specified namespace having specified dataset properties.
@@ -203,7 +198,7 @@ public interface DatasetFramework {
    * having specified properties
    */
   Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId, Map<String, String> properties)
-    throws DatasetManagementException, UnauthorizedException;
+    throws DatasetManagementException;
 
   /**
    * Gets the {@link DatasetSpecification} for the specified dataset instance id
@@ -212,8 +207,7 @@ public interface DatasetFramework {
    * @return {@link DatasetSpecification} of the dataset or {@code null} if dataset not not exist
    */
   @Nullable
-  DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId)
-    throws DatasetManagementException, UnauthorizedException;
+  DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId) throws DatasetManagementException;
 
   /**
    * @param datasetInstanceId the {@link DatasetId} to check for existence
@@ -221,7 +215,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  boolean hasInstance(DatasetId datasetInstanceId) throws DatasetManagementException, UnauthorizedException;
+  boolean hasInstance(DatasetId datasetInstanceId) throws DatasetManagementException;
 
   /**
    * Checks if the specified type exists in the 'system' namespace
@@ -230,7 +224,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  default boolean hasSystemType(String typeName) throws DatasetManagementException, UnauthorizedException {
+  default boolean hasSystemType(String typeName) throws DatasetManagementException {
     return hasType(NamespaceId.SYSTEM.datasetType(typeName));
   }
 
@@ -242,7 +236,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   @VisibleForTesting
-  boolean hasType(DatasetTypeId datasetTypeId) throws DatasetManagementException, UnauthorizedException;
+  boolean hasType(DatasetTypeId datasetTypeId) throws DatasetManagementException;
 
   /**
    * @return the meta data for a dataset type or null if it does not exist.
@@ -250,7 +244,7 @@ public interface DatasetFramework {
    * @throws ServiceUnavailableException when the dataset service is not running
    */
   @Nullable
-  DatasetTypeMeta getTypeInfo(DatasetTypeId datasetTypeId) throws DatasetManagementException, UnauthorizedException;
+  DatasetTypeMeta getTypeInfo(DatasetTypeId datasetTypeId) throws DatasetManagementException;
 
   /**
    * Truncates a dataset instance.
@@ -261,8 +255,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void truncateInstance(DatasetId datasetInstanceId)
-    throws DatasetManagementException, IOException, UnauthorizedException;
+  void truncateInstance(DatasetId datasetInstanceId) throws DatasetManagementException, IOException;
 
   /**
    * Deletes dataset instance from the system.
@@ -274,8 +267,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void deleteInstance(DatasetId datasetInstanceId)
-    throws DatasetManagementException, IOException, UnauthorizedException;
+  void deleteInstance(DatasetId datasetInstanceId) throws DatasetManagementException, IOException;
 
   /**
    * Deletes all dataset instances in the specified namespace.
@@ -285,8 +277,7 @@ public interface DatasetFramework {
    * @throws DatasetManagementException
    * @throws ServiceUnavailableException when the dataset service is not running
    */
-  void deleteAllInstances(NamespaceId namespaceId)
-    throws DatasetManagementException, IOException, UnauthorizedException;
+  void deleteAllInstances(NamespaceId namespaceId) throws DatasetManagementException, IOException;
 
   /**
    * Gets dataset instance admin to be used to perform administrative operations. The given classloader must
@@ -303,7 +294,7 @@ public interface DatasetFramework {
    */
   @Nullable
   <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, @Nullable ClassLoader classLoader)
-    throws DatasetManagementException, IOException, UnauthorizedException;
+    throws DatasetManagementException, IOException;
 
   /**
    * Gets dataset instance admin to be used to perform administrative operations. The class loader provider
@@ -323,7 +314,7 @@ public interface DatasetFramework {
   <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId,
                                       @Nullable ClassLoader classLoader,
                                       DatasetClassLoaderProvider classLoaderProvider)
-    throws DatasetManagementException, IOException, UnauthorizedException;
+    throws DatasetManagementException, IOException;
 
   /**
    * Gets dataset to be used to perform data operations.
@@ -340,7 +331,7 @@ public interface DatasetFramework {
   @Nullable
   default <T extends Dataset> T getDataset(DatasetId datasetInstanceId, Map<String, String> arguments,
                                            @Nullable ClassLoader classLoader)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
 
     return getDataset(datasetInstanceId, arguments, classLoader,
                       new ConstantClassLoaderProvider(classLoader), null, AccessType.UNKNOWN);
@@ -368,7 +359,7 @@ public interface DatasetFramework {
                                    DatasetClassLoaderProvider classLoaderProvider,
                                    @Nullable Iterable<? extends EntityId> owners,
                                    AccessType accessType)
-    throws DatasetManagementException, IOException, UnauthorizedException;
+    throws DatasetManagementException, IOException;
 
   /**
    * Write lineage for a particular dataset instance.

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/ForwardingDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/ForwardingDatasetFramework.java
@@ -32,7 +32,6 @@ import io.cdap.cdap.proto.id.DatasetTypeId;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import org.apache.twill.filesystem.Location;
 
 import java.io.IOException;
@@ -53,98 +52,92 @@ public class ForwardingDatasetFramework implements DatasetFramework {
   }
 
   @Override
-  public void addModule(DatasetModuleId moduleId, DatasetModule module)
-    throws DatasetManagementException, UnauthorizedException {
+  public void addModule(DatasetModuleId moduleId, DatasetModule module) throws DatasetManagementException {
     delegate.addModule(moduleId, module);
   }
 
   @Override
   public void addModule(DatasetModuleId moduleId, DatasetModule module, Location jarLocation)
-    throws DatasetManagementException, UnauthorizedException {
+    throws DatasetManagementException {
     delegate.addModule(moduleId, module, jarLocation);
   }
 
   @Override
-  public void deleteModule(DatasetModuleId moduleId) throws DatasetManagementException, UnauthorizedException {
+  public void deleteModule(DatasetModuleId moduleId) throws DatasetManagementException {
     delegate.deleteModule(moduleId);
   }
 
   @Override
-  public void deleteAllModules(NamespaceId namespaceId) throws DatasetManagementException, UnauthorizedException {
+  public void deleteAllModules(NamespaceId namespaceId) throws DatasetManagementException {
     delegate.deleteAllModules(namespaceId);
   }
 
   @Override
   public void addInstance(String datasetTypeName, DatasetId datasetInstanceId, DatasetProperties props,
                           @Nullable KerberosPrincipalId ownerPrincipal)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
     delegate.addInstance(datasetTypeName, datasetInstanceId, props, ownerPrincipal);
   }
 
   @Override
   public void updateInstance(DatasetId datasetInstanceId, DatasetProperties props)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
     delegate.updateInstance(datasetInstanceId, props);
   }
 
   @Override
   public Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId)
-    throws DatasetManagementException, UnauthorizedException {
+    throws DatasetManagementException {
     return delegate.getInstances(namespaceId);
   }
 
   @Override
   public Collection<DatasetSpecificationSummary> getInstances(NamespaceId namespaceId, Map<String, String> properties)
-    throws DatasetManagementException, UnauthorizedException {
+    throws DatasetManagementException {
     return delegate.getInstances(namespaceId, properties);
   }
 
   @Nullable
   @Override
-  public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId)
-    throws DatasetManagementException, UnauthorizedException {
+  public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId) throws DatasetManagementException {
     return delegate.getDatasetSpec(datasetInstanceId);
   }
 
   @Override
-  public boolean hasInstance(DatasetId datasetInstanceId) throws DatasetManagementException, UnauthorizedException {
+  public boolean hasInstance(DatasetId datasetInstanceId) throws DatasetManagementException {
     return delegate.hasInstance(datasetInstanceId);
   }
 
   @Override
-  public boolean hasType(DatasetTypeId datasetTypeId) throws DatasetManagementException, UnauthorizedException {
+  public boolean hasType(DatasetTypeId datasetTypeId) throws DatasetManagementException {
     return delegate.hasType(datasetTypeId);
   }
 
   @Nullable
   @Override
-  public DatasetTypeMeta getTypeInfo(DatasetTypeId datasetTypeId)
-    throws DatasetManagementException, UnauthorizedException {
+  public DatasetTypeMeta getTypeInfo(DatasetTypeId datasetTypeId) throws DatasetManagementException {
     return delegate.getTypeInfo(datasetTypeId);
   }
 
   @Override
-  public void truncateInstance(DatasetId datasetInstanceId)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+  public void truncateInstance(DatasetId datasetInstanceId) throws DatasetManagementException, IOException {
     delegate.truncateInstance(datasetInstanceId);
   }
 
   @Override
-  public void deleteInstance(DatasetId datasetInstanceId)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+  public void deleteInstance(DatasetId datasetInstanceId) throws DatasetManagementException, IOException {
     delegate.deleteInstance(datasetInstanceId);
   }
 
   @Override
-  public void deleteAllInstances(NamespaceId namespaceId)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+  public void deleteAllInstances(NamespaceId namespaceId) throws DatasetManagementException, IOException {
     delegate.deleteAllInstances(namespaceId);
   }
 
   @Nullable
   @Override
   public <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, @Nullable ClassLoader classLoader)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
     return delegate.getAdmin(datasetInstanceId, classLoader);
   }
 
@@ -152,7 +145,7 @@ public class ForwardingDatasetFramework implements DatasetFramework {
   @Override
   public <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, @Nullable ClassLoader classLoader,
                                              DatasetClassLoaderProvider classLoaderProvider)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
     return delegate.getAdmin(datasetInstanceId, classLoader, classLoaderProvider);
   }
 
@@ -162,7 +155,7 @@ public class ForwardingDatasetFramework implements DatasetFramework {
                                           @Nullable ClassLoader classLoader,
                                           DatasetClassLoaderProvider classLoaderProvider,
                                           @Nullable Iterable<? extends EntityId> owners, AccessType accessType)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
     return delegate.getDataset(datasetInstanceId, arguments, classLoader, classLoaderProvider, owners, accessType);
   }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/preview/PreviewDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/preview/PreviewDatasetFramework.java
@@ -34,7 +34,6 @@ import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AuthorizationEnforcer;
 import io.cdap.cdap.security.spi.authorization.NoOpAuthorizer;
-import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 
 import java.io.IOException;
 import java.util.Map;
@@ -107,8 +106,7 @@ public class PreviewDatasetFramework extends ForwardingDatasetFramework {
   @Override
   public void addInstance(String datasetTypeName, DatasetId datasetInstanceId,
                           DatasetProperties props,
-                          @Nullable KerberosPrincipalId ownerPrincipal)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+                          @Nullable KerberosPrincipalId ownerPrincipal) throws DatasetManagementException, IOException {
     if (ownerPrincipal != null) {
       throw new UnsupportedOperationException("Creating dataset instance with owner is not supported in preview, " +
                                                 "please try to start the preview without the ownership");
@@ -118,8 +116,7 @@ public class PreviewDatasetFramework extends ForwardingDatasetFramework {
 
   @Override
   public void updateInstance(DatasetId datasetInstanceId,
-                             DatasetProperties props)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+                             DatasetProperties props) throws DatasetManagementException, IOException {
     // allow updates to the datasets in preview space only
     if (delegate.hasInstance(datasetInstanceId)) {
       delegate.updateInstance(datasetInstanceId, props);
@@ -129,8 +126,7 @@ public class PreviewDatasetFramework extends ForwardingDatasetFramework {
 
   @Nullable
   @Override
-  public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId)
-    throws DatasetManagementException, UnauthorizedException {
+  public DatasetSpecification getDatasetSpec(DatasetId datasetInstanceId) throws DatasetManagementException {
     if (DatasetsUtil.isUserDataset(datasetInstanceId)) {
       DatasetSpecification datasetSpec = actualDatasetFramework.getDatasetSpec(datasetInstanceId);
       return datasetSpec != null ? datasetSpec : delegate.getDatasetSpec(datasetInstanceId);
@@ -139,8 +135,7 @@ public class PreviewDatasetFramework extends ForwardingDatasetFramework {
   }
 
   @Override
-  public boolean hasInstance(DatasetId datasetInstanceId)
-    throws DatasetManagementException, UnauthorizedException {
+  public boolean hasInstance(DatasetId datasetInstanceId) throws DatasetManagementException {
     if (DatasetsUtil.isUserDataset(datasetInstanceId)) {
       return actualDatasetFramework.hasInstance(datasetInstanceId) || delegate.hasInstance(datasetInstanceId);
     }
@@ -148,8 +143,7 @@ public class PreviewDatasetFramework extends ForwardingDatasetFramework {
   }
 
   @Override
-  public void truncateInstance(DatasetId datasetInstanceId)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+  public void truncateInstance(DatasetId datasetInstanceId) throws DatasetManagementException, IOException {
     // If dataset exists in the preview space then only truncate it otherwise its a no-op
     if (delegate.hasInstance(datasetInstanceId)) {
       delegate.truncateInstance(datasetInstanceId);
@@ -157,8 +151,7 @@ public class PreviewDatasetFramework extends ForwardingDatasetFramework {
   }
 
   @Override
-  public void deleteInstance(DatasetId datasetInstanceId)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+  public void deleteInstance(DatasetId datasetInstanceId) throws DatasetManagementException, IOException {
     // If dataset exists in the preview space then only delete it otherwise its a no-op
     if (delegate.hasInstance(datasetInstanceId)) {
       delegate.deleteInstance(datasetInstanceId);
@@ -169,7 +162,7 @@ public class PreviewDatasetFramework extends ForwardingDatasetFramework {
   @Override
   @SuppressWarnings("unchecked")
   public <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, @Nullable ClassLoader classLoader)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
     // Return the no-op admin for the dataset from the real space
     if (actualDatasetFramework.hasInstance(datasetInstanceId)) {
       return (T) NOOP_DATASET_ADMIN;
@@ -182,7 +175,7 @@ public class PreviewDatasetFramework extends ForwardingDatasetFramework {
   @SuppressWarnings("unchecked")
   public <T extends DatasetAdmin> T getAdmin(DatasetId datasetInstanceId, @Nullable ClassLoader classLoader,
                                              DatasetClassLoaderProvider classLoaderProvider)
-    throws DatasetManagementException, IOException, UnauthorizedException {
+    throws DatasetManagementException, IOException {
     // Return the no-op admin for the dataset from the real space
     if (actualDatasetFramework.hasInstance(datasetInstanceId)) {
       return (T) NOOP_DATASET_ADMIN;

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetServiceAuthorizationTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetServiceAuthorizationTest.java
@@ -139,8 +139,8 @@ public class DatasetServiceAuthorizationTest extends DatasetServiceTestBase {
     try {
       dsFramework.deleteAllInstances(NamespaceId.DEFAULT);
       Assert.fail();
-    } catch (Exception e) {
-      if (!(e instanceof UnauthorizedException)) {
+    } catch (DatasetManagementException e) {
+      if (!(e.getCause() instanceof UnauthorizedException)) {
         Assert.fail();
       }
     }
@@ -193,8 +193,8 @@ public class DatasetServiceAuthorizationTest extends DatasetServiceTestBase {
       // user will not be able to get the info about the instance since he does not have any privilege on the instance
       dsFramework.getDatasetSpec(nonExistingInstance);
       Assert.fail();
-    } catch (Exception e) {
-      if (!(e instanceof UnauthorizedException)) {
+    } catch (DatasetManagementException e) {
+      if (!(e.getCause() instanceof UnauthorizedException)) {
         Assert.fail();
       }
     }
@@ -203,9 +203,9 @@ public class DatasetServiceAuthorizationTest extends DatasetServiceTestBase {
       // instance
       dsFramework.hasInstance(nonExistingInstance);
       Assert.fail();
-    } catch (Exception e) {
+    } catch (DatasetManagementException e) {
       // expected
-      if (!(e instanceof UnauthorizedException)) {
+      if (!(e.getCause() instanceof UnauthorizedException)) {
         Assert.fail();
       }
     }
@@ -344,7 +344,8 @@ public class DatasetServiceAuthorizationTest extends DatasetServiceTestBase {
       // expected
     } catch (DatasetManagementException e) {
       // no other way to detect errors from DatasetServiceClient
-      Assert.assertTrue(e.getMessage().contains("Response code: 403, message: 'Forbidden'"));
+      Assert.assertTrue(e.getMessage().contains("Response code: 403, message: 'Forbidden'")
+                          || e.getCause() instanceof UnauthorizedException);
     }
   }
 

--- a/cdap-explore/src/main/java/io/cdap/cdap/explore/executor/ExploreExecutorHttpHandler.java
+++ b/cdap-explore/src/main/java/io/cdap/cdap/explore/executor/ExploreExecutorHttpHandler.java
@@ -136,7 +136,7 @@ public class ExploreExecutorHttpHandler extends AbstractHttpHandler {
         return null;
       }
       return datasetSpec;
-    } catch (DatasetManagementException | UnauthorizedException e) {
+    } catch (DatasetManagementException e) {
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error getting spec for dataset " + datasetId);
       return null;
     }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/DefaultAuthorizationContext.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/DefaultAuthorizationContext.java
@@ -72,39 +72,39 @@ public class DefaultAuthorizationContext implements AuthorizationContext {
   }
 
   @Override
-  public boolean datasetExists(String name) throws DatasetManagementException, AccessException {
+  public boolean datasetExists(String name) throws DatasetManagementException {
     return delegateAdmin.datasetExists(name);
   }
 
   @Override
-  public String getDatasetType(String name) throws DatasetManagementException, AccessException {
+  public String getDatasetType(String name) throws DatasetManagementException {
     return delegateAdmin.getDatasetType(name);
   }
 
   @Override
-  public DatasetProperties getDatasetProperties(String name) throws DatasetManagementException, AccessException {
+  public DatasetProperties getDatasetProperties(String name) throws DatasetManagementException {
     return delegateAdmin.getDatasetProperties(name);
   }
 
   @Override
   public void createDataset(String name, String type, DatasetProperties properties)
-    throws DatasetManagementException, AccessException {
+    throws DatasetManagementException {
     delegateAdmin.createDataset(name, type, properties);
   }
 
   @Override
   public void updateDataset(String name, DatasetProperties properties)
-    throws DatasetManagementException, AccessException {
+    throws DatasetManagementException {
     delegateAdmin.updateDataset(name, properties);
   }
 
   @Override
-  public void dropDataset(String name) throws DatasetManagementException, AccessException {
+  public void dropDataset(String name) throws DatasetManagementException {
     delegateAdmin.dropDataset(name);
   }
 
   @Override
-  public void truncateDataset(String name) throws DatasetManagementException, AccessException {
+  public void truncateDataset(String name) throws DatasetManagementException {
     delegateAdmin.truncateDataset(name);
   }
 

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/admin/AdminApp.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/admin/AdminApp.java
@@ -289,7 +289,7 @@ public class AdminApp extends AbstractApplication {
 
         admin.dropDataset("d");
       }
-    } catch (DatasetManagementException | AccessException e) {
+    } catch (DatasetManagementException e) {
       throw Throwables.propagate(e);
     }
 

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java
@@ -1197,7 +1197,9 @@ public class AuthorizationTest extends TestBase {
         } catch (UnauthorizedException e) {
           // Expected
         } catch (Exception e) {
-          Assert.fail("Getting incorrect exception");
+          if (!(e.getCause() instanceof UnauthorizedException)) {
+            throw new AssertionError("Getting incorrect exception", e);
+          }
         }
         return null;
       }


### PR DESCRIPTION
This reverts API changes introduced in https://github.com/cdapio/cdap/pull/13394