### PR TITLE
CDAP-18010: Run artifact inspection in isolation.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/RunnableTaskLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/RunnableTaskLauncher.java
@@ -20,6 +20,9 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.internal.worker.RunnableTask;
 import io.cdap.cdap.common.internal.worker.RunnableTaskContext;
 
+import java.net.URI;
+import javax.annotation.Nullable;
+
 /**
  * RunnableTaskLauncher launches a {@link RunnableTask} by loading its class and calling its run method.
  */
@@ -30,7 +33,7 @@ public class RunnableTaskLauncher {
     this.cConf = cConf;
   }
 
-  public byte[] launchRunnableTask(RunnableTaskRequest request) throws Exception {
+  public byte[] launchRunnableTask(RunnableTaskRequest request, @Nullable URI fileURI) throws Exception {
 
     ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
     if (classLoader == null) {
@@ -44,7 +47,7 @@ public class RunnableTaskLauncher {
       throw new ClassCastException(String.format("%s is not a RunnableTask", request.getClassName()));
     }
     RunnableTask runnableTask = (RunnableTask) obj;
-    RunnableTaskContext runnableTaskContext = new RunnableTaskContext(request.getParam());
+    RunnableTaskContext runnableTaskContext = new RunnableTaskContext(request.getParam(), fileURI);
     runnableTask.run(runnableTaskContext);
     return runnableTaskContext.getResult();
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/RunnableTaskLauncherTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/RunnableTaskLauncherTest.java
@@ -35,7 +35,7 @@ public class RunnableTaskLauncherTest {
     RunnableTaskRequest request = new RunnableTaskRequest(TestRunnableTask.class.getName(), want);
 
     RunnableTaskLauncher launcher = new RunnableTaskLauncher(CConfiguration.create());
-    byte[] got = launcher.launchRunnableTask(request);
+    byte[] got = launcher.launchRunnableTask(request, null);
     Assert.assertEquals(want, new String(got, StandardCharsets.UTF_8));
   }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/worker/RunnableTaskContext.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/worker/RunnableTaskContext.java
@@ -18,6 +18,8 @@ package io.cdap.cdap.common.internal.worker;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.net.URI;
+import javax.annotation.Nullable;
 
 /**
  * Represents a context for a {@link RunnableTask}.
@@ -26,9 +28,11 @@ import java.io.IOException;
 public class RunnableTaskContext {
   private final ByteArrayOutputStream outputStream;
   private final String param;
+  private final URI fileURI;
 
-  public RunnableTaskContext(String param) {
+  public RunnableTaskContext(String param, @Nullable URI fileURI) {
     this.param = param;
+    this.fileURI = fileURI;
     this.outputStream = new ByteArrayOutputStream();
   }
 
@@ -42,5 +46,9 @@ public class RunnableTaskContext {
 
   public String getParam() {
     return param;
+  }
+
+  public URI getFileURI() {
+    return fileURI;
   }
 }


### PR DESCRIPTION
Part 1: Add an endpoint in task worker to allow submit tasks via query params.

Why:
Artifact inspection takes places right after upload completes, it resides
in a temp dir in appfab. To run artifact inspection in worker pod, appfab
needs to send file over. Current rest endpoint "/run" use request body
to store task specification, which makes it challenging to send file
as well. Thus introducing a new endpoint to specify task specifiction
via query parameter, then file content can be streamed over via
request body.