### PR TITLE
Corrected logic issue with wrapped SQL engine collections.

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -965,7 +965,9 @@ public abstract class SparkPipelineRunner {
   private SparkCollection<Object> filterPortRecords(StageSpec stageSpec,
                                                     SparkCollection<RecordInfo<Object>> stageData,
                                                     @Nullable String port) {
-    if (stageData instanceof SQLBackedCollection) {
+    // Port filtering can only be applied to SQL Backed Collections when there is no output port specified.
+    // This is due to the fact that records need to be present in Spark to apply this filtering operation.
+    if (port == null && stageData instanceof SQLBackedCollection) {
       return new WrappedSQLEngineCollection<>((SQLBackedCollection<RecordInfo<Object>>) stageData,
                                               (c) -> c.flatMap(stageSpec, new OutputPassFilter<>(port)));
     }


### PR DESCRIPTION
In the previous implementation, we were prematurely pulling on successive joins.

When successive join operations are encountered, this fix ensures that the join operation re-uses a wrapped SQL engine implementation to execute, thus, we delay pulling collections until really needed.