### PR TITLE
CDAP-18010: Renaming ArtifactInspector to DefaultArtifactInspector

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactInspector.java
@@ -99,15 +99,15 @@ import javax.annotation.Nullable;
 /**
  * Inspects a jar file to determine metadata about the artifact.
  */
-final class ArtifactInspector {
-  private static final Logger LOG = LoggerFactory.getLogger(ArtifactInspector.class);
+final class DefaultArtifactInspector {
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultArtifactInspector.class);
 
   private final CConfiguration cConf;
   private final ArtifactClassLoaderFactory artifactClassLoaderFactory;
   private final ReflectionSchemaGenerator schemaGenerator;
   private final MetadataValidator metadataValidator;
 
-  ArtifactInspector(CConfiguration cConf, ArtifactClassLoaderFactory artifactClassLoaderFactory) {
+  DefaultArtifactInspector(CConfiguration cConf, ArtifactClassLoaderFactory artifactClassLoaderFactory) {
     this.cConf = cConf;
     this.artifactClassLoaderFactory = artifactClassLoaderFactory;
     this.schemaGenerator = new ReflectionSchemaGenerator(false);
@@ -120,12 +120,12 @@ final class ArtifactInspector {
    * @param artifactId the id of the artifact to inspect
    * @param artifactFile the artifact file
    * @param parentClassLoader the parent classloader to use when inspecting plugins contained in the artifact.
-   *                          For example, a ProgramClassLoader created from the artifact the input artifact extends
+   * For example, a ProgramClassLoader created from the artifact the input artifact extends
    * @param additionalPlugins Additional plugin classes
    * @return metadata about the classes contained in the artifact
    * @throws IOException if there was an exception opening the jar file
    * @throws InvalidArtifactException if the artifact is invalid. For example, if the application main class is not
-   *                                  actually an Application.
+   * actually an Application.
    */
   ArtifactClassesWithMetadata inspectArtifact(Id.Artifact artifactId, File artifactFile,
                                               @Nullable ClassLoader parentClassLoader,
@@ -138,8 +138,9 @@ final class ArtifactInspector {
 
     Path stageDir = Files.createTempDirectory(tmpDir, artifactFile.getName());
     try {
-      File unpackedDir = BundleJarUtil.prepareClassLoaderFolder(artifactLocation,
-                                             Files.createTempDirectory(stageDir, "unpacked-").toFile());
+      File unpackedDir = BundleJarUtil.prepareClassLoaderFolder(
+        artifactLocation,
+        Files.createTempDirectory(stageDir, "unpacked-").toFile());
       try (
         CloseableClassLoader artifactClassLoader = artifactClassLoaderFactory.createClassLoader(unpackedDir);
         PluginInstantiator pluginInstantiator =
@@ -169,7 +170,7 @@ final class ArtifactInspector {
                                                       ArtifactClasses.Builder builder,
                                                       Location artifactLocation,
                                                       ClassLoader artifactClassLoader) throws IOException,
-                                                                                              InvalidArtifactException {
+    InvalidArtifactException {
 
     // right now we force users to include the application main class as an attribute in their manifest,
     // which forces them to have a single application class.
@@ -352,6 +353,7 @@ final class ArtifactInspector {
   /**
    * Given list of packages produces a predicate that can check if a given jar file name is a class within
    * one of the packages (but not subpackages).
+   *
    * @param packages list to packages class must belong to
    * @return a predicate that would tell if class file belong to one of package names
    */
@@ -384,7 +386,6 @@ final class ArtifactInspector {
    * The requirements are case insensitive and always represented in lowercase.
    *
    * @param cls the plugin class whose requirement needs to be found
-   *
    * @return {@link Requirements} containing the requirements specified by the plugin (in lowercase). If the plugin does
    * not specify any {@link io.cdap.cdap.api.annotation.Requirements} then the {@link Requirements} will be empty.
    */

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactInspectorTest.java
@@ -59,13 +59,14 @@ import java.util.Set;
 import java.util.jar.Manifest;
 
 /**
+ *
  */
-public class ArtifactInspectorTest {
+public class DefaultArtifactInspectorTest {
   @ClassRule
   public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
 
   private static ArtifactClassLoaderFactory classLoaderFactory;
-  private static ArtifactInspector artifactInspector;
+  private static DefaultArtifactInspector artifactInspector;
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -73,7 +74,7 @@ public class ArtifactInspectorTest {
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
 
     classLoaderFactory = new ArtifactClassLoaderFactory(cConf, new DummyProgramRunnerFactory());
-    artifactInspector = new ArtifactInspector(cConf, classLoaderFactory);
+    artifactInspector = new DefaultArtifactInspector(cConf, classLoaderFactory);
   }
 
   @Test(expected = InvalidArtifactException.class)
@@ -201,9 +202,9 @@ public class ArtifactInspectorTest {
       );
 
       PluginClass expected = PluginClass.builder()
-                               .setName("nested").setType("dummy").setDescription("Nested config")
-                               .setClassName(NestedConfigPlugin.class.getName()).setConfigFieldName("config")
-                               .setProperties(expectedFields).build();
+        .setName("nested").setType("dummy").setDescription("Nested config")
+        .setClassName(NestedConfigPlugin.class.getName()).setConfigFieldName("config")
+        .setProperties(expectedFields).build();
 
       Assert.assertEquals(Collections.singleton(expected), plugins);
     }
@@ -232,25 +233,25 @@ public class ArtifactInspectorTest {
 
   @Test
   public void testGetClassNameCheckPredicate() {
-    Assert.assertTrue(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+    Assert.assertTrue(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
       "my.package"
     )).test("my/package/my.class"));
-    Assert.assertTrue(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+    Assert.assertTrue(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
       "blah", "my.package", "blah2"
     )).test("my/package/my.class"));
-    Assert.assertTrue(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+    Assert.assertTrue(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
       "my.package", "my.package.subpackage"
     )).test("my/package/subpackage/my.class"));
-    Assert.assertFalse(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+    Assert.assertFalse(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
       "my.package"
     )).test("my/package/subpackage/my.class"));
-    Assert.assertFalse(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+    Assert.assertFalse(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
       "my.package"
     )).test("prefix/my/package/my.class"));
-    Assert.assertFalse(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+    Assert.assertFalse(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
       "my.package"
     )).test("prefix/my/package/my.notclass"));
-    Assert.assertFalse(ArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
+    Assert.assertFalse(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
       "my.package"
     )).test("prefix/my/package/my.class/some.class"));
   }
@@ -263,7 +264,7 @@ public class ArtifactInspectorTest {
 
   private static File createJar(Class<?> cls, File destFile, Manifest manifest) throws IOException {
     Location deploymentJar = AppJarHelper.createDeploymentJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
-      cls, manifest);
+                                                              cls, manifest);
     DirUtils.mkdirs(destFile.getParentFile());
     Locations.linkOrCopyOverwrite(deploymentJar, destFile);
     return destFile;


### PR DESCRIPTION
Why:
Plan to introduce an interfact ArtifactInspector in a follow up change
so it can have a default implementation and remote execution implementation
which allows this to run in isolation (e.g. in task worker k8s pod),
thus better security and potentially more scalable.