### PR TITLE
[CDAP-18004] Add support for CDAP SA separation

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Cask Data, Inc.
+ * Copyright © 2020-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -30,6 +30,7 @@ import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
+import io.cdap.cdap.master.spi.twill.SecureTwillPreparer;
 import io.cdap.cdap.master.spi.twill.StatefulDisk;
 import io.cdap.cdap.master.spi.twill.StatefulTwillPreparer;
 import io.cdap.cdap.messaging.MessagingService;
@@ -175,6 +176,14 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
               .withStatefulRunnable(PreviewRunnerTwillRunnable.class.getSimpleName(), false,
                                     new StatefulDisk("preview-runner-data", diskSize,
                                                      cConf.get(Constants.CFG_LOCAL_DATA_DIR)));
+          }
+
+          if (twillPreparer instanceof SecureTwillPreparer) {
+            String twillUserIdentity = cConf.get(Constants.Twill.Security.IDENTITY_USER);
+            if (twillUserIdentity != null) {
+              twillPreparer = ((SecureTwillPreparer) twillPreparer)
+                .withIdentity(PreviewRunnerTwillRunnable.class.getSimpleName(), twillUserIdentity);
+            }
           }
 
           activeController = twillPreparer.start(5, TimeUnit.MINUTES);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillApplication.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.internal.app.preview;
 
-import io.cdap.cdap.common.conf.Constants;
 import org.apache.twill.api.ResourceSpecification;
 import org.apache.twill.api.TwillApplication;
 import org.apache.twill.api.TwillSpecification;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerTwillRunnable;
 import io.cdap.cdap.master.spi.twill.DependentTwillPreparer;
+import io.cdap.cdap.master.spi.twill.SecureTwillPreparer;
 import io.cdap.cdap.master.spi.twill.StatefulDisk;
 import io.cdap.cdap.master.spi.twill.StatefulTwillPreparer;
 import org.apache.hadoop.conf.Configuration;
@@ -169,6 +170,14 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
               .withStatefulRunnable(TaskWorkerTwillRunnable.class.getSimpleName(), false,
                                     new StatefulDisk("task-worker-data", diskSize,
                                                      cConf.get(Constants.CFG_LOCAL_DATA_DIR)));
+          }
+
+          if (twillPreparer instanceof SecureTwillPreparer) {
+            String twillUserIdentity = cConf.get(Constants.Twill.Security.IDENTITY_USER);
+            if (twillUserIdentity != null) {
+              twillPreparer = ((SecureTwillPreparer) twillPreparer)
+                .withIdentity(TaskWorkerTwillRunnable.class.getSimpleName(), twillUserIdentity);
+            }
           }
 
           activeController = twillPreparer.start(5, TimeUnit.MINUTES);

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1606,4 +1606,33 @@ public final class Constants {
      */
     public static final String AUTO_INSTALL_THREADS = "capability.autoinstall.threads";
   }
+
+  /**
+   * Constants for Twill.
+   */
+  public static final class Twill {
+    /**
+     * Constants for Twill's security-related extension methods.
+     */
+    public static final class Security {
+      /**
+       * User identity for Twill runnables which execute user code.
+       */
+      public static final String IDENTITY_USER = "twill.security.identity.user";
+      /**
+       * System identity for Twill runnables which do not execute user code.
+       */
+      public static final String IDENTITY_SYSTEM = "twill.security.identity.system";
+
+      /**
+       * The secret name for the cdap-security.xml disk mount.
+       */
+      public static final String SECRET_DISK_NAME = "twill.security.secret.disk.name";
+
+      /**
+       * The secret path for the cdap-security.xml disk mount.
+       */
+      public static final String SECRET_DISK_PATH = "twill.security.secret.disk.path";
+    }
+  }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -265,6 +265,22 @@
   </property>
 
   <property>
+    <name>twill.security.secret.disk.name</name>
+    <value>cdap-security</value>
+    <description>
+      The name of the Twill security disk mount which contains cdap-security.xml.
+    </description>
+  </property>
+
+  <property>
+    <name>twill.security.secret.disk.path</name>
+    <value>/etc/cdap/security</value>
+    <description>
+      The absolute directory of the Twill security disk mount which contains cdap-security.xml.
+    </description>
+  </property>
+
+  <property>
     <name>twill.yarn.am.memory.mb</name>
     <value>512</value>
     <description>

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -67,7 +67,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
 
   // Contains the list of configuration / secret names coming from the Pod information, which are
   // needed to propagate to deployments created via the KubeTwillRunnerService
-  private static final Set<String> CONFIG_NAMES = ImmutableSet.of("cdap-conf", "hadoop-conf", "cdap-security");
+  private static final Set<String> CONFIG_NAMES = ImmutableSet.of("cdap-conf", "hadoop-conf");
   private static final Set<String> CUSTOM_VOLUME_PREFIX = ImmutableSet.of("cdap-cm-vol-", "cdap-se-vol-");
 
   private static final String MASTER_MAX_INSTANCES = "master.service.max.instances";

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/SecretDisk.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/SecretDisk.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.spi.twill;
+
+/**
+ * Represents information about a file-based secret used by a twill runnable.
+ */
+public class SecretDisk {
+  private final String name;
+  private final String path;
+
+  public SecretDisk(String name, String path) {
+    this.name = name;
+    this.path = path;
+  }
+
+  /**
+   * Returns the secret name.
+   * @return the secret name
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Returns the secret filepath directory.
+   * @return the secret filepath directory
+   */
+  public String getPath() {
+    return path;
+  }
+}

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/SecureTwillPreparer.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/SecureTwillPreparer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.spi.twill;
+
+import org.apache.twill.api.TwillPreparer;
+import org.apache.twill.api.TwillRunnable;
+
+/**
+ * Extension interface for {@link TwillPreparer} to implement if it supports execution of a {@link TwillRunnable}
+ * under secure contexts.
+ */
+public interface SecureTwillPreparer extends TwillPreparer {
+  /**
+   * Runs the given runnable as a certain identity.
+   * In this case, the concept of identity is up to the preparer to define.
+   *
+   * @param runnableName name of the {@link TwillRunnable}
+   * @param identity the identity to run as
+   * @return this {@link TwillPreparer}
+   */
+  SecureTwillPreparer withIdentity(String runnableName, String identity);
+
+  /**
+   * Runs the given runnable with the specified secret disks.
+   *
+   * @param runnableName name of the {@link TwillRunnable}
+   * @param secretDisks the secret disks to use
+   * @return this {@link TwillPreparer}
+   */
+  SecureTwillPreparer withSecretDisk(String runnableName, SecretDisk... secretDisks);
+}


### PR DESCRIPTION
Support SA separation for preview and task runners.

This PR adds an interface to the TwillPreparer which allows callers to specify an identity to run as. For KubeTwillPreparer, the identity used will be the the Kubernetes service account name. For unspecified identities, the identity of the creating pod will be used.