### PR TITLE
[CDAP-18022] Fix base directory parsing bug

### DIFF
--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTableFactory.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTableFactory.java
@@ -101,7 +101,7 @@ public final class LevelDBTableFactory implements TableFactory {
   @Override
   public void init() throws IOException {
     ensureDirExists(baseDir);
-    Path metaFile = Paths.get(baseDir.getAbsolutePath(), "meta");
+    Path metaFile = Paths.get(baseDir.getPath()).resolve("meta");
     Metadata metadata = new Metadata(1);
     if (Files.exists(metaFile)) {
       String metaStr = new String(Files.readAllBytes(metaFile), StandardCharsets.UTF_8);


### PR DESCRIPTION
The `getAbsolutePath()` function treats the `~` character strangely. For additional info, see [CDAP-18022](https://cdap.atlassian.net/browse/CDAP-18022).