### PR TITLE
[CDAP-18023 CDAP-18024] Support Pod Privilege Reduction

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -169,7 +169,8 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
             int diskSize = cConf.getInt(Constants.Preview.CONTAINER_DISK_SIZE_GB);
             twillPreparer = ((StatefulTwillPreparer) twillPreparer)
               .withStatefulRunnable(PreviewRunnerTwillRunnable.class.getSimpleName(), false,
-                                    new StatefulDisk("preview-runner-data", diskSize, "/data"));
+                                    new StatefulDisk("preview-runner-data", diskSize,
+                                                     cConf.get(Constants.CFG_LOCAL_DATA_DIR)));
           }
 
           activeController = twillPreparer.start(5, TimeUnit.MINUTES);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
@@ -151,7 +151,8 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
             int diskSize = cConf.getInt(Constants.TaskWorker.CONTAINER_DISK_SIZE_GB);
             twillPreparer = ((StatefulTwillPreparer) twillPreparer)
               .withStatefulRunnable(TaskWorkerTwillRunnable.class.getSimpleName(), false,
-                                    new StatefulDisk("task-worker-data", diskSize, "/data"));
+                                    new StatefulDisk("task-worker-data", diskSize,
+                                                     cConf.get(Constants.CFG_LOCAL_DATA_DIR)));
           }
 
           activeController = twillPreparer.start(5, TimeUnit.MINUTES);

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -44,6 +44,7 @@ import io.kubernetes.client.models.V1ObjectMeta;
 import io.kubernetes.client.models.V1ObjectMetaBuilder;
 import io.kubernetes.client.models.V1PersistentVolumeClaim;
 import io.kubernetes.client.models.V1PersistentVolumeClaimBuilder;
+import io.kubernetes.client.models.V1PodSecurityContext;
 import io.kubernetes.client.models.V1PodSpec;
 import io.kubernetes.client.models.V1PodSpecBuilder;
 import io.kubernetes.client.models.V1ResourceRequirements;
@@ -718,6 +719,7 @@ class KubeTwillPreparer implements TwillPreparer, StatefulTwillPreparer {
       .withContainers(createContainer(runnableName, podInfo.getContainerImage(), workDir,
                                       resourceRequirements, volumeMounts, environs, KubeTwillLauncher.class,
                                       runnableName))
+      .withSecurityContext(podInfo.getSecurityContext())
       .build();
   }
 

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -277,7 +277,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
                        podNameFile.getName(), podUid, podUidFile.getName(), namespace, podLabels, ownerReferences,
                        serviceAccountName, runtimeClassName,
                        volumes, containerLabelName, container.getImage(), mounts,
-                       envs == null ? Collections.emptyList() : envs);
+                       envs == null ? Collections.emptyList() : envs, pod.getSpec().getSecurityContext());
   }
 
   /**

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/PodInfo.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/PodInfo.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.master.environment.k8s;
 
 import io.kubernetes.client.models.V1EnvVar;
 import io.kubernetes.client.models.V1OwnerReference;
+import io.kubernetes.client.models.V1PodSecurityContext;
 import io.kubernetes.client.models.V1Volume;
 import io.kubernetes.client.models.V1VolumeMount;
 
@@ -47,12 +48,13 @@ public final class PodInfo {
   private final String containerImage;
   private final List<V1VolumeMount> containerVolumeMounts;
   private final List<V1EnvVar> containerEnvironments;
+  private final V1PodSecurityContext securityContext;
 
   public PodInfo(String name, String podInfoDir, String labelsFile, String nameFile, String uid, String uidFile,
                  String namespace, Map<String, String> labels, List<V1OwnerReference> ownerReferences,
                  String serviceAccountName, String runtimeClassName, List<V1Volume> volumes, String containerLabelName,
                  String containerImage, List<V1VolumeMount> containerVolumeMounts,
-                 List<V1EnvVar> containerEnvironments) {
+                 List<V1EnvVar> containerEnvironments, V1PodSecurityContext securityContext) {
     this.name = name;
     this.podInfoDir = podInfoDir;
     this.labelsFile = labelsFile;
@@ -69,6 +71,7 @@ public final class PodInfo {
     this.containerImage = containerImage;
     this.containerVolumeMounts = Collections.unmodifiableList(new ArrayList<>(containerVolumeMounts));
     this.containerEnvironments = Collections.unmodifiableList(new ArrayList<>(containerEnvironments));
+    this.securityContext = securityContext;
   }
 
   public String getName() {
@@ -136,5 +139,9 @@ public final class PodInfo {
 
   public List<V1EnvVar> getContainerEnvironments() {
     return containerEnvironments;
+  }
+
+  public V1PodSecurityContext getSecurityContext() {
+    return securityContext;
   }
 }


### PR DESCRIPTION
This PR adds support for running CDAP as a non-root user in Kubernetes.

Currently, the stateful disks for TaskWorkerServiceLauncher and DistributedPreviewRunner are mounted statically to the hardcoded `/data` directory. To ensure this is compatible with the rest of CDAP, we should use the `local.data.dir` configuration in order to define the actual mount directory. This allows us to programmatically mount the data statefulset by configuration.

Additionally, this change also propagates the securityContext for the parent pod specification to the created worker pods as well.

For additional information, see [CDAP-18023](https://cdap.atlassian.net/browse/CDAP-18023) and [CDAP-18024](https://cdap.atlassian.net/browse/CDAP-18024).