### PR TITLE
CDAP-18030: Steps with multiple inputs within a condition branch are valid when condition is a source

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
@@ -713,6 +713,7 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
       stopNodes.add(currentCondition);
       Set<String> parents = dag.parentsOf(currentStage, stopNodes);
       parents.retainAll(dag.getSources());
+      parents.remove(currentCondition);
       if (parents.size() > 0) {
         String paths = "";
         for (String parent : parents) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
@@ -1030,6 +1030,32 @@ public class PipelineSpecGeneratorTest {
   }
 
   @Test
+  public void testSourceConditionWithMultipleInputStepWithinBranch() {
+    //
+    //  condition1-----source-----condition2------t1-------sink
+    //                                 |                    |
+    //                                 |----------t2---------
+    //
+
+    ETLBatchConfig etlConfig = ETLBatchConfig.builder()
+      .setTimeSchedule("* * * * *")
+      .addStage(new ETLStage("condition1", MOCK_CONDITION))
+      .addStage(new ETLStage("source", MOCK_SOURCE))
+      .addStage(new ETLStage("condition2", MOCK_CONDITION))
+      .addStage(new ETLStage("t1", MOCK_TRANSFORM_A))
+      .addStage(new ETLStage("t2", MOCK_TRANSFORM_A))
+      .addStage(new ETLStage("sink", MOCK_SINK))
+      .addConnection("condition1", "source", true)
+      .addConnection("source", "condition2")
+      .addConnection("condition2", "t1", true)
+      .addConnection("condition2", "t2", false)
+      .addConnection("t1", "sink")
+      .addConnection("t2", "sink")
+      .build();
+    specGenerator.generateSpec(etlConfig);
+  }
+
+  @Test
   public void testSimpleValidCondition() throws ValidationException {
 
     //  source--condition-----t1-----sink


### PR DESCRIPTION
When trimming the parents of a step with more than one input to determine the number of sources, also trim the current condition so that pipelines where the condition is the source do not error.

Currently, the pipeline below errors with

```
Stage in the pipeline 'Write' is on the branch of condition 'Conditional'. However it also has following incoming paths: 'Conditional->Write'. Different branches of a condition cannot be inputs to the same stage.
```

although there is only one incoming path.

<img width="1306" alt="Screen Shot 2021-05-27 at 9 16 31 PM" src="https://user-images.githubusercontent.com/5462583/119920862-a0160600-bf32-11eb-92aa-965b21ea0cc0.png">

This is because `validateSingleInput` is called recursively for outputs of "Conditional," and if any steps with multiple inputs are found ("Write"), the inputs are traversed until either source steps in the DAG or the current conditional are encountered (`stopNodes`). At that point, `parents` includes all nodes encountered including the stop nodes (all nodes in the DAG except "Write" itself. We then remove everything but the source nodes from the `parents` set, and check the size of the set. Because the current condition is also a source of the DAG, it is not removed and the `parents` count is 1, triggering the above error.

Associated [ticket](https://cdap.atlassian.net/browse/CDAP-18030).