### PR TITLE
Allow system apps to do authorization checks and add checks to drafts

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/DefaultAdmin.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/DefaultAdmin.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.api.NamespaceSummary;
 import io.cdap.cdap.api.messaging.MessagingAdmin;
 import io.cdap.cdap.api.messaging.TopicAlreadyExistsException;
 import io.cdap.cdap.api.messaging.TopicNotFoundException;
+import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.api.security.store.SecureStoreManager;
 import io.cdap.cdap.common.NamespaceNotFoundException;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
@@ -166,7 +167,7 @@ public class DefaultAdmin extends DefaultDatasetManager implements Admin {
   public boolean namespaceExists(String namespace) throws IOException {
     try {
       return namespaceQueryAdmin.exists(new NamespaceId(namespace));
-    } catch (IOException e) {
+    } catch (IOException | RuntimeException e) {
       throw e;
     } catch (Exception e) {
       throw new IOException(e);
@@ -181,7 +182,7 @@ public class DefaultAdmin extends DefaultDatasetManager implements Admin {
       return new NamespaceSummary(meta.getName(), meta.getDescription(), meta.getGeneration());
     } catch (NamespaceNotFoundException e) {
       return null;
-    } catch (IOException e) {
+    } catch (IOException | RuntimeException e) {
       throw e;
     } catch (Exception e) {
       throw new IOException(e);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/AbstractServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/AbstractServiceHttpServer.java
@@ -130,12 +130,19 @@ public abstract class AbstractServiceHttpServer<T> extends AbstractIdleService {
                                                                context.getHandlerMetricsContext()));
     }
 
-    NettyHttpService.Builder builder = NettyHttpService.builder(program.getName() + "-http")
+    NettyHttpService.Builder builder = createHttpServiceBuilder(program.getName() + "-http")
       .setHost(host)
       .setPort(0)
       .setHttpHandlers(nettyHttpHandlers);
 
     return SystemArguments.configureNettyHttpService(programOptions.getUserArguments().asMap(), builder).build();
+  }
+
+  /**
+   * Create a netty http service builder. Children classes can customize is as needed
+   */
+  protected NettyHttpService.Builder createHttpServiceBuilder(String serviceName) {
+    return NettyHttpService.builder(serviceName);
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/CodedException.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/CodedException.java
@@ -16,10 +16,12 @@
 
 package io.cdap.cdap.etl.proto;
 
+import io.cdap.cdap.api.common.HttpErrorStatusProvider;
+
 /**
  * An exception that contains an HTTP error code.
  */
-public class CodedException extends RuntimeException {
+public class CodedException extends RuntimeException implements HttpErrorStatusProvider {
   private final int code;
 
   public CodedException(int code, String message) {
@@ -32,7 +34,18 @@ public class CodedException extends RuntimeException {
     this.code = code;
   }
 
+  /**
+   *
+   * @return HTTP error code
+   * @deprecated use {@link #getStatusCode()} instead
+   */
+  @Deprecated
   public int getCode() {
+    return code;
+  }
+
+  @Override
+  public int getStatusCode() {
     return code;
   }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Authorizable.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Authorizable.java
@@ -174,6 +174,13 @@ public class Authorizable {
   }
 
   /**
+   * @return the type of children for parent-only permission checks
+   */
+  public EntityType getChildType() {
+    return childType;
+  }
+
+  /**
    * @return a string representation of the authorizable which is compatible with {@link EntityId#toString()}.
    */
   @Override

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AccessEnforcer.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AccessEnforcer.java
@@ -75,7 +75,7 @@ public interface AccessEnforcer {
 
   /**
    * Checks whether the set of {@link EntityId}s are visible to the specified {@link Principal}.
-   * An entity is visible to a principal if the principal has any privileges on the entity, or any of its descendants.
+   * An entity is visible to a principal if the principal has {@link StandardPermission#GET} on the entity.
    * However, visibility check behavior can be overwritten at the authorization extension level.
    *
    * @param entityIds the entities on which the visibility check is to be performed

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizerWrapper.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizerWrapper.java
@@ -196,7 +196,11 @@ public class AuthorizerWrapper implements AccessController {
   public void enforceOnParent(EntityType entityType, EntityId parentId, Principal principal, Permission permission)
     throws AccessException {
     try {
-      authorizer.enforce(parentId, principal, Action.ADMIN);
+      if (permission == StandardPermission.LIST) {
+        authorizer.isVisible(parentId, principal);
+      } else {
+        authorizer.enforce(parentId, principal, Action.ADMIN);
+      }
     } catch (Exception e) {
       throw AuthEnforceUtil.propagateAccessException(e);
     }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/DefaultAccessEnforcer.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/DefaultAccessEnforcer.java
@@ -155,7 +155,7 @@ public class DefaultAccessEnforcer extends AbstractAccessEnforcer {
       accessControllerInstantiator.get().enforceOnParent(entityType, parentId, principal, permission);
     } finally {
       long timeTaken = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime);
-      String logLine = "Enforced permission {} on {} for principal {}. Time spent in enforcement was {} ms.";
+      String logLine = "Enforced permission {} on {} in {} for principal {}. Time spent in enforcement was {} ms.";
       if (timeTaken > logTimeTakenAsWarn) {
         LOG.warn(logLine, permission, entityType, parentId, principal, timeTaken);
       } else {

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestConfiguration.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestConfiguration.java
@@ -17,7 +17,9 @@
 package io.cdap.cdap.test;
 
 import com.google.common.base.Preconditions;
+import io.cdap.cdap.internal.AppFabricTestHelper;
 import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -31,7 +33,7 @@ import java.util.Map;
  * <pre>{@code
  * class MyUnitTest extends TestBase {
  *
- *   &#64;ClassRule
+ *   @ClassRule
  *   public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", "false");
  *
  *   ....
@@ -44,6 +46,8 @@ public class TestConfiguration extends ExternalResource {
 
   public static final String PROPERTY_PREFIX = "cdap.unit.test.";
   private final Map<String, String> configs;
+  private boolean enableAuthorization;
+  private TemporaryFolder temporaryFolder;
 
   /**
    * Creates a new instance with the give list of configurations.
@@ -73,8 +77,22 @@ public class TestConfiguration extends ExternalResource {
     this.configs = new HashMap<>(configs);
   }
 
+  /**
+   * Enables authorization for this test
+   * @return this TestConfiguration
+   * @param temporaryFolder
+   */
+  public TestConfiguration enableAuthorization(TemporaryFolder temporaryFolder) {
+    this.temporaryFolder = temporaryFolder;
+    this.enableAuthorization = true;
+    return this;
+  }
+
   @Override
   protected void before() throws Throwable {
+    if (enableAuthorization) {
+      AppFabricTestHelper.enableAuthorization((k, v) -> configs.put(PROPERTY_PREFIX + k, v), temporaryFolder);
+    }
     // Use the system properties map as a mean to communicate unit-test specific CDAP configurations to the
     // TestBase class, which it will use to setup the CConfiguration.
     // All keys set into the properties are prefixed with PROPERTY_PREFIX.


### PR DESCRIPTION
In this PR:
 * Ensure Netty service for apps installs proper authentication module. Now "default" user is only used in rare cases (e.g. system app scheduling service). Any actions done within apps are now enforced with proper principal
 * Ensure AuthorizationException is properly propagated into 403 HTTP code for apps.

Note: now READ namespace access is enough to perform any draft actions