### PR TITLE
Implement ArtifactLocalizerService which runs in sidecar container

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -34,6 +34,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
+import com.google.inject.util.Providers;
 import io.cdap.cdap.app.deploy.Configurator;
 import io.cdap.cdap.app.deploy.Manager;
 import io.cdap.cdap.app.deploy.ManagerFactory;
@@ -106,6 +107,7 @@ import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
 import io.cdap.cdap.internal.app.services.RunRecordCorrectorService;
 import io.cdap.cdap.internal.app.services.ScheduledRunRecordCorrectorService;
 import io.cdap.cdap.internal.app.store.DefaultStore;
+import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
 import io.cdap.cdap.internal.bootstrap.guice.BootstrapModules;
 import io.cdap.cdap.internal.capability.CapabilityModule;
 import io.cdap.cdap.internal.pipeline.SynchronousPipelineFactory;
@@ -292,6 +294,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
     @Override
     protected void configure() {
+      bind(ArtifactLocalizerClient.class).toProvider(Providers.of(null));
       bind(PipelineFactory.class).to(SynchronousPipelineFactory.class);
 
       bind(PluginFinder.class).to(LocalPluginFinder.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepository.java
@@ -188,7 +188,7 @@ public class RemoteArtifactRepository implements ArtifactRepository {
 
   @Override
   public ArtifactDetail getArtifact(Id.Artifact artifactId) throws Exception {
-    throw new UnsupportedOperationException();
+    return artifactRepositoryReader.getArtifact(artifactId);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.internal.app.runtime.artifact;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
-import com.google.common.io.ByteStreams;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
@@ -28,8 +27,6 @@ import io.cdap.cdap.api.artifact.ArtifactVersion;
 import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.api.plugin.PluginSelector;
 import io.cdap.cdap.common.ArtifactNotFoundException;
-import io.cdap.cdap.common.BadRequestException;
-import io.cdap.cdap.common.ServiceUnavailableException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
@@ -49,18 +46,11 @@ import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.lang.reflect.Type;
-import java.net.HttpURLConnection;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -71,7 +61,6 @@ import java.util.concurrent.TimeUnit;
  * Implementation of {@link PluginFinder} that use the artifact HTTP endpoints for finding plugins.
  */
 public class RemotePluginFinder implements PluginFinder, ArtifactFinder {
-  private static final Logger LOG = LoggerFactory.getLogger(RemotePluginFinder.class);
   private static final Gson GSON = new Gson();
   private static final Type PLUGIN_INFO_LIST_TYPE = new TypeToken<List<PluginInfo>>() {
   }.getType();
@@ -84,7 +73,7 @@ public class RemotePluginFinder implements PluginFinder, ArtifactFinder {
   private final RetryStrategy retryStrategy;
 
   @Inject
-  RemotePluginFinder(CConfiguration cConf,
+  public RemotePluginFinder(CConfiguration cConf,
                      AuthenticationContext authenticationContext,
                      LocationFactory locationFactory,
                      RemoteClientFactory remoteClientFactory) {
@@ -222,74 +211,10 @@ public class RemotePluginFinder implements PluginFinder, ArtifactFinder {
 
     String path = response.getResponseBodyAsString();
     Location location = Locations.getLocationFromAbsolutePath(locationFactory, path);
-
-    // If the artifact doesn't exist locally then fetch it from app fabric and save it locally
     if (!location.exists()) {
-      LOG.debug("Artifact '{}' is not present locally at {}, attempting to fetch it from app-fabric.",
-                artifactId.getArtifact(), path);
-
-      Retries.runWithRetries(() -> getAndStoreArtifact(artifactId, location), retryStrategy);
+      throw new IOException(String.format("Artifact Location does not exist %s for artifact %s version %s",
+                                          path, artifactId.getArtifact(), artifactId.getVersion()));
     }
     return location;
-  }
-
-  private void getAndStoreArtifact(ArtifactId artifactId, Location location) throws IOException {
-    String namespaceId = artifactId.getNamespace();
-    ArtifactScope scope = ArtifactScope.USER;
-    // Cant use 'system' as the namespace in the request because that generates an error, the namespace doesnt matter
-    // as long as it exists. Using default because it will always be there
-    if (NamespaceId.SYSTEM.getNamespace().equalsIgnoreCase(namespaceId)) {
-      namespaceId = "default";
-      scope = ArtifactScope.SYSTEM;
-    }
-    String url = String.format("namespaces/%s/artifacts/%s/versions/%s/download?scope=%s",
-                               namespaceId,
-                               artifactId.getArtifact(),
-                               artifactId.getVersion(),
-                               scope);
-
-    LOG.debug("Fetching artifact from " + url);
-    HttpURLConnection connection = remoteClientInternal.openConnection(HttpMethod.GET, url);
-    try {
-      try (InputStream is = connection.getInputStream();
-           OutputStream os = location.getOutputStream()) {
-        ByteStreams.copy(is, os);
-
-        throwIfError(artifactId, connection);
-        LOG.debug("Stored artifact into {}", location.toURI());
-      } catch (BadRequestException e) {
-        // Just treat bad request as IOException since it won't be retriable
-        throw new IOException(e);
-      }
-    } finally {
-      connection.disconnect();
-    }
-  }
-
-  /**
-   * Validates the response from the given {@link HttpURLConnection} to be 200, or throws exception if it is not 200.
-   */
-  private void throwIfError(ArtifactId artifactId,
-                            HttpURLConnection urlConn) throws IOException, BadRequestException {
-    int responseCode = urlConn.getResponseCode();
-    if (responseCode == HttpURLConnection.HTTP_OK) {
-      return;
-    }
-    try (InputStream errorStream = urlConn.getErrorStream()) {
-      String errorMsg = "unknown error";
-      if (errorStream != null) {
-        errorMsg = new String(ByteStreams.toByteArray(errorStream), StandardCharsets.UTF_8);
-      }
-      switch (responseCode) {
-        case HttpURLConnection.HTTP_BAD_REQUEST:
-          throw new BadRequestException(errorMsg);
-        case HttpURLConnection.HTTP_UNAVAILABLE:
-          throw new ServiceUnavailableException(Constants.Service.APP_FABRIC_HTTP, errorMsg);
-      }
-
-      throw new IOException(
-        String.format("Failed to fetch artifact %s version %s from %s. Response code: %d. Error: %s",
-                      artifactId.getArtifact(), artifactId.getVersion(), urlConn.getURL(), responseCode, errorMsg));
-    }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTaskModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTaskModule.java
@@ -64,7 +64,7 @@ public class ConfiguratorTaskModule extends AbstractModule {
     bind(ProgramRuntimeProvider.Mode.class).toInstance(ProgramRuntimeProvider.Mode.LOCAL);
     bind(ProgramRunnerFactory.class).to(DefaultProgramRunnerFactory.class).in(Scopes.SINGLETON);
 
-    bind(PluginFinder.class).to(RemotePluginFinder.class);
+    bind(PluginFinder.class).to(RemoteWorkerPluginFinder.class);
     bind(AuthenticationContext.class).to(MasterAuthenticationContext.class);
     bind(UGIProvider.class).to(CurrentUGIProvider.class);
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/RemoteWorkerPluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/RemoteWorkerPluginFinder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.internal.app.worker;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.ArtifactNotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.internal.app.runtime.artifact.RemotePluginFinder;
+import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+
+import java.io.IOException;
+
+/**
+ * RemoteWorkerPluginFinder is an extension of {@link RemotePluginFinder} that is meant to be used exclusively in tasks
+ * running in the {@link TaskWorkerTwillRunnable}. This implementation uses the {@link ArtifactLocalizerClient} to
+ * download and cache the given artifact on the local file system.
+ */
+public class RemoteWorkerPluginFinder extends RemotePluginFinder {
+  private final ArtifactLocalizerClient artifactLocalizerClient;
+
+  @Inject
+  RemoteWorkerPluginFinder(CConfiguration cConf,
+                           AuthenticationContext authenticationContext,
+                           LocationFactory locationFactory,
+                           RemoteClientFactory remoteClientFactory,
+                           ArtifactLocalizerClient artifactLocalizerClient) {
+    super(cConf, authenticationContext, locationFactory, remoteClientFactory);
+    this.artifactLocalizerClient = artifactLocalizerClient;
+  }
+
+  @Override
+  public Location getArtifactLocation(ArtifactId artifactId)
+    throws IOException, ArtifactNotFoundException, UnauthorizedException {
+    return Locations.toLocation(artifactLocalizerClient.getArtifactLocation(artifactId));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.internal.app.worker.sidecar;
+
+import com.google.common.io.CharStreams;
+import com.google.inject.Inject;
+import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.retry.RetryableException;
+import io.cdap.cdap.common.ArtifactNotFoundException;
+import io.cdap.cdap.common.ServiceUnavailableException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.common.lang.jar.BundleJarUtil;
+import io.cdap.cdap.common.service.Retries;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.common.service.RetryStrategy;
+import io.cdap.cdap.common.utils.DirUtils;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequestConfig;
+import org.jboss.resteasy.util.HttpHeaderNames;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * ArtifactLocalizer is responsible for fetching, caching and unpacking artifacts requested by the worker pod. The HTTP
+ * endpoints are defined in {@link ArtifactLocalizerHttpHandlerInternal}. This class will run in the sidecar container
+ * that is defined by {@link ArtifactLocalizerTwillRunnable}.
+ *
+ * Artifacts will be cached using the following file structure:
+ * /DATA_DIRECTORY/artifacts/<namespace>/<artifact-name>/<artifact-version>/<last-modified-timestamp>.jar
+ *
+ * Artifacts will be unpacked using the following file structure:
+ * /DATA_DIRECTORY/unpacked/<namespace>/<artifact-name>/<artifact-version>/<last-modified-timestamp>/...
+ *
+ * The procedure for fetching an artifact is:
+ *
+ * 1. Check if there is a locally cached version of the artifact, if so fetch the lastModified timestamp from
+ * the filename.
+ * 2. Send a request to the 'download artifact' endpoint in appfabric and provide the lastModified timestamp (if
+ * available)
+ * 3. If a lastModified timestamp was not specified, or there is a newer version of the artifact: appfabric will stream
+ * the bytes for the newest version of the jar and pass the new lastModified timestamp in the response headers
+ *
+ * OR
+ *
+ * If the provided lastModified timestamp matches the newest version of the artifact: appfabric will return
+ * NOT_MODIFIED
+ *
+ * 4. If a newer version was found, delete the old cached jar and unpack directory (if it exists).
+ *
+ * 5. Return the local path to the newest version of the artifact jar.
+ *
+ * NOTE: There is no need to invalidate the cache at any point since we will always need to call appfabric to confirm
+ * that the cached version is the newest version available.
+ */
+public class ArtifactLocalizer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ArtifactLocalizer.class);
+  private static final String LAST_MODIFIED_HEADER = HttpHeaderNames.LAST_MODIFIED.toLowerCase();
+
+  private final RemoteClient remoteClient;
+  private final RetryStrategy retryStrategy;
+  private final String dataDir;
+
+  @Inject
+  public ArtifactLocalizer(CConfiguration cConf, RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(Constants.Service.APP_FABRIC_HTTP,
+                                         HttpRequestConfig.DEFAULT,
+                                         Constants.Gateway.INTERNAL_API_VERSION_3);
+    this.retryStrategy = RetryStrategies.fromConfiguration(cConf, Constants.Service.TASK_WORKER + ".");
+    this.dataDir = cConf.get(Constants.CFG_LOCAL_DATA_DIR);
+  }
+
+  /**
+   * Gets the location on the local filesystem for the given artifact. This method handles fetching the artifact as well
+   * as caching it.
+   *
+   * @param artifactId The ArtifactId of the artifact to fetch
+   * @return The Local Location for this artifact
+   * @throws ArtifactNotFoundException if the given artifact does not exist
+   * @throws IOException if there was an exception while fetching or caching the artifact
+   * @throws Exception if there was an unexpected error
+   */
+  public File getArtifact(ArtifactId artifactId) throws Exception {
+    LOG.debug("Fetching artifact info for {}", artifactId);
+    return Retries.callWithRetries(() -> fetchArtifact(artifactId), retryStrategy);
+  }
+
+  /**
+   * Gets the location on the local filesystem for the directory that contains the unpacked artifact. This method
+   * handles fetching, caching and unpacking the artifact.
+   *
+   * @param artifactId The ArtifactId of the artifact to fetch and unpack
+   * @return The Local Location of the directory that contains the unpacked artifact files
+   * @throws ArtifactNotFoundException if the given artifact does not exist
+   * @throws IOException if there was an exception while fetching, caching or unpacking the artifact
+   * @throws Exception if there was an unexpected error
+   */
+  public File getAndUnpackArtifact(ArtifactId artifactId) throws Exception {
+    LOG.debug("Unpacking artifact {}", artifactId);
+    File jarLocation = getArtifact(artifactId);
+    File unpackDir = getUnpackLocalPath(artifactId, Long.parseLong(jarLocation.getName().split("\\.")[0]));
+    LOG.debug("Got unpack directory as {}", unpackDir);
+    if (!unpackDir.exists()) {
+      LOG.debug("Unpack directory doesn't exist, unpacking into {}", unpackDir);
+
+      // Ensure the path leading to the unpack directory is created so we can create a temp directory
+      if (!unpackDir.getParentFile().exists() && !unpackDir.getParentFile().mkdirs()) {
+        throw new IOException(String.format("Failed to create one or more directories along the path %s",
+                                            unpackDir.getParentFile().getPath()));
+      }
+      File tempUnpackDir = DirUtils.createTempDir(unpackDir.getParentFile());
+      try {
+        BundleJarUtil.unJar(jarLocation, tempUnpackDir);
+        Files.move(tempUnpackDir.toPath(), unpackDir.toPath(), StandardCopyOption.ATOMIC_MOVE,
+                   StandardCopyOption.REPLACE_EXISTING);
+      } finally {
+        // This directory should only exist if something went wrong with the move command above
+        if (tempUnpackDir.exists()) {
+          DirUtils.deleteDirectoryContents(tempUnpackDir);
+        }
+      }
+    }
+    return unpackDir;
+  }
+
+  /**
+   * fetchArtifact attempts to connect to app fabric to download the given artifact. This method will throw {@link
+   * RetryableException} in certain circumstances so using this with the
+   *
+   * @param artifactId the id of the artifact to fetch
+   * @return a File pointing to the locally cached jar of the newest version
+   * @throws IOException If an unexpected error occurs while writing the artifact to the filesystem
+   * @throws ArtifactNotFoundException If the given artifact does not exist
+   */
+  private File fetchArtifact(ArtifactId artifactId) throws IOException, ArtifactNotFoundException {
+    Long lastModifiedTimestamp = getCurrentLastModifiedTimestamp(artifactId);
+    String namespaceId = artifactId.getNamespace();
+    ArtifactScope scope = ArtifactScope.USER;
+    // Cant use 'system' as the namespace in the request because that generates an error, the namespace doesnt matter
+    // as long as it exists. Using default because it will always be there
+    if (ArtifactScope.SYSTEM.toString().equalsIgnoreCase(namespaceId)) {
+      namespaceId = NamespaceId.DEFAULT.getEntityName();
+      scope = ArtifactScope.SYSTEM;
+    }
+
+    String url = String.format("namespaces/%s/artifacts/%s/versions/%s/download?scope=%s",
+                               namespaceId,
+                               artifactId.getArtifact(),
+                               artifactId.getVersion(),
+                               scope);
+
+    HttpURLConnection urlConn = remoteClient.openConnection(HttpMethod.GET, url);
+    try {
+      if (lastModifiedTimestamp != null) {
+        LOG.debug("Found existing local version for {} with timestamp {}", artifactId, lastModifiedTimestamp);
+
+        ZonedDateTime lastModifiedDate = ZonedDateTime
+          .ofInstant(Instant.ofEpochMilli(lastModifiedTimestamp), ZoneId.of("GMT"));
+        urlConn.setRequestProperty(HttpHeaderNames.IF_MODIFIED_SINCE, lastModifiedDate.format(
+          DateTimeFormatter.RFC_1123_DATE_TIME));
+      }
+
+      // If we get this response that means we already have the most up to date artifact
+      if (urlConn.getResponseCode() == HttpURLConnection.HTTP_NOT_MODIFIED) {
+        LOG.debug("Call to app fabric returned NOT_MODIFIED for {} with lastModifiedTimestamp of {}", artifactId,
+                  lastModifiedTimestamp);
+        File artifactJarLocation = getArtifactJarLocation(artifactId, lastModifiedTimestamp);
+        if (!artifactJarLocation.exists()) {
+          throw new RetryableException(
+            String.format("Locally cached artifact jar for %s is missing.",
+                          artifactId));
+        }
+        return artifactJarLocation;
+      }
+
+      throwIfError(urlConn, artifactId);
+
+      ZonedDateTime newModifiedDate = getLastModifiedHeader(urlConn);
+      long newTimestamp = newModifiedDate.toInstant().toEpochMilli();
+      File newLocation = getArtifactJarLocation(artifactId, newTimestamp);
+      DirUtils.mkdirs(newLocation.getParentFile());
+
+      // Download the artifact to a temporary file then atomically rename it to the final name to
+      // avoid race conditions with multiple threads.
+      Path tempFile = Files.createTempFile(newLocation.getParentFile().toPath(), String.valueOf(newTimestamp), ".jar");
+      try (InputStream in = urlConn.getInputStream()) {
+        Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
+        Files.move(tempFile, newLocation.toPath(), StandardCopyOption.ATOMIC_MOVE,
+                   StandardCopyOption.REPLACE_EXISTING);
+      } finally {
+        Files.deleteIfExists(tempFile);
+      }
+
+      return newLocation;
+    } finally {
+      urlConn.disconnect();
+    }
+  }
+
+  /**
+   * This checks the local cache for this artifact and retrieves the timestamp for the newest cache entry, if this
+   * artifact is not cached it returns null
+   */
+  @Nullable
+  private Long getCurrentLastModifiedTimestamp(ArtifactId artifactId) {
+    File artifactDir = getArtifactDirLocation(artifactId);
+
+    // Check if we have cached jars in the artifact directory, if so return the latest modified timestamp.
+    return DirUtils.listFiles(artifactDir, File::isFile).stream()
+      .map(File::getName)
+      .map(this::removeFileExtension)
+      .map(Long::valueOf)
+      .max(Long::compare)
+      .orElse(null);
+  }
+
+  /**
+   * Helper function for verifying, extracting and converting the Last-Modified header from the URL connection.
+   */
+  private ZonedDateTime getLastModifiedHeader(HttpURLConnection urlConn) {
+    Map<String, List<String>> headers = urlConn.getHeaderFields();
+    List<String> lastModifiedHeader = headers.entrySet().stream()
+      .filter(headerEntry -> LAST_MODIFIED_HEADER.equalsIgnoreCase(headerEntry.getKey()))
+      .map(Map.Entry::getValue)
+      .findFirst()
+      .orElse(null);
+
+    if (lastModifiedHeader == null || lastModifiedHeader.size() != 1) {
+      // This should never happen since this endpoint should always set the header.
+      // If it does happen we should retry.
+      throw new RetryableException(String.format("The response from %s did not contain the %s header.",
+                                                 urlConn.getURL(), LAST_MODIFIED_HEADER));
+    }
+
+    return ZonedDateTime
+      .parse(headers.get(LAST_MODIFIED_HEADER).get(0), DateTimeFormatter.RFC_1123_DATE_TIME);
+  }
+
+  /**
+   * Helper method for catching and throwing any errors that might have occurred when attempting to connect.
+   */
+  private void throwIfError(HttpURLConnection urlConn, ArtifactId artifactId)
+    throws IOException, ArtifactNotFoundException {
+    int responseCode = urlConn.getResponseCode();
+    if (responseCode == HttpURLConnection.HTTP_OK) {
+      return;
+    }
+
+    String errMsg = CharStreams.toString(new InputStreamReader(urlConn.getErrorStream(), StandardCharsets.UTF_8));
+    switch (responseCode) {
+      case HttpURLConnection.HTTP_NOT_FOUND:
+        throw new ArtifactNotFoundException(artifactId);
+      case HttpURLConnection.HTTP_UNAVAILABLE:
+        throw new ServiceUnavailableException(Constants.Service.APP_FABRIC_HTTP, errMsg);
+    }
+    throw new IOException(
+      String.format("Failed to fetch artifact %s from app-fabric due to %s", artifactId, errMsg));
+  }
+
+  /**
+   * Helper method for removing the file extension from a filename
+   */
+  private String removeFileExtension(String filename) {
+    return filename.substring(0, filename.lastIndexOf("."));
+  }
+
+  private Path getLocalPath(String dirName, ArtifactId artifactId) {
+    return Paths.get(dataDir, dirName, artifactId.getNamespace(), artifactId.getArtifact(),
+                     artifactId.getVersion());
+  }
+
+  /**
+   * Returns a {@link File} representing the cache directory jars for the given artifact. The file path is:
+   * /DATA_DIRECTORY/artifacts/<namespace>/<artifact-name>/<artifact-version>/
+   */
+  private File getArtifactDirLocation(ArtifactId artifactId) {
+    return getLocalPath("artifacts", artifactId).toFile();
+  }
+
+  /**
+   * Returns a {@link File} representing the cached jar for the given artifact and timestamp. The file path is:
+   * /DATA_DIRECTORY/artifacts/<namespace>/<artifact-name>/<artifact-version>/<last-modified-timestamp>.jar
+   */
+  private File getArtifactJarLocation(ArtifactId artifactId, long lastModifiedTimestamp) {
+    return getLocalPath("artifacts", artifactId).resolve(String.format("%d.jar", lastModifiedTimestamp)).toFile();
+  }
+
+  /**
+   * Returns a {@link File} representing the directory containing the unpacked contents of the jar for the given
+   * artifact and timestamp. The file path is:
+   * /DATA_DIRECTORY/unpacked/<namespace>/<artifact-name>/<artifact-version>/<last-modified-timestamp>
+   */
+  private File getUnpackLocalPath(ArtifactId artifactId, long lastModifiedTimestamp) {
+    return getLocalPath("unpacked", artifactId).resolve(String.valueOf(lastModifiedTimestamp)).toFile();
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerClient.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerClient.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.internal.app.worker.sidecar;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.ArtifactNotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+/**
+ * ArtifactLocalizerClient is used by tasks that extend {@link io.cdap.cdap.api.service.worker.RunnableTask} to fetch,
+ * cache and unpack artifacts locally.
+ */
+public class ArtifactLocalizerClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ArtifactLocalizerClient.class);
+  private final String sidecarBaseURL;
+
+  @Inject
+  ArtifactLocalizerClient(CConfiguration cConf) {
+    this.sidecarBaseURL = String
+      .format("http://localhost:%d/%s/worker", cConf.getInt(Constants.ArtifactLocalizer.PORT),
+              Constants.Gateway.INTERNAL_API_VERSION_3_TOKEN);
+  }
+
+  /**
+   * Gets the location on the local filesystem for the given artifact. This method handles fetching the artifact as well
+   * as caching it.
+   *
+   * @param artifactId The ArtifactId of the artifact to fetch
+   * @return The Local Location for this artifact
+   * @throws ArtifactNotFoundException if the given artifact does not exist
+   * @throws IOException if there was an exception while fetching or caching the artifact
+   */
+  public File getArtifactLocation(ArtifactId artifactId) throws IOException, ArtifactNotFoundException {
+    return sendRequest(artifactId, false);
+  }
+
+  /**
+   * Gets the location on the local filesystem for the directory that contains the unpacked artifact. This method
+   * handles fetching, caching and unpacking the artifact.
+   *
+   * @param artifactId The ArtifactId of the artifact to fetch and unpack
+   * @return The Local Location of the directory that contains the unpacked artifact files
+   * @throws ArtifactNotFoundException if the given artifact does not exist
+   * @throws IOException if there was an exception while fetching, caching or unpacking the artifact
+   */
+  public File getUnpackedArtifactLocation(ArtifactId artifactId) throws IOException, ArtifactNotFoundException {
+    return sendRequest(artifactId, true);
+  }
+
+  private File sendRequest(ArtifactId artifactId, boolean unpack) throws IOException, ArtifactNotFoundException {
+    String urlPath = String
+      .format("/artifact/namespaces/%s/artifacts/%s/versions/%s?unpack=%b", artifactId.getNamespace(),
+              artifactId.getArtifact(),
+              artifactId.getVersion(), unpack);
+    URL url;
+    try {
+      url = new URI(sidecarBaseURL + urlPath).toURL();
+    } catch (URISyntaxException e) {
+      throw new IOException(e);
+    }
+
+    LOG.debug("Sending request to {}", url);
+    HttpRequest httpRequest = HttpRequest.builder(HttpMethod.GET, url).build();
+    HttpResponse httpResponse = HttpRequests.execute(httpRequest);
+
+    if (httpResponse.getResponseCode() != HttpURLConnection.HTTP_OK) {
+      if (httpResponse.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+        throw new ArtifactNotFoundException(artifactId);
+      }
+      String errorMsg = httpResponse.getResponseBodyAsString();
+      throw new IOException(errorMsg);
+    }
+
+    String path = httpResponse.getResponseBodyAsString();
+    LOG.debug("ArtifactLocalizer request returned path {}", path);
+
+    return new File(path);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerHttpHandlerInternal.java
@@ -16,44 +16,47 @@
 
 package io.cdap.cdap.internal.app.worker.sidecar;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.inject.Inject;
+import avro.shaded.com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Singleton;
-import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.proto.BasicThrowable;
-import io.cdap.cdap.proto.codec.BasicThrowableCodec;
+import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpHandler;
 import io.cdap.http.HttpResponder;
 import io.netty.handler.codec.http.HttpRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
+import java.io.File;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 
 /**
- * Internal {@link HttpHandler} for File Localizer.
+ * Internal {@link HttpHandler} for Artifact Localizer.
  */
 @Singleton
 @Path(Constants.Gateway.INTERNAL_API_VERSION_3 + "/worker")
 public class ArtifactLocalizerHttpHandlerInternal extends AbstractHttpHandler {
-  private static final Logger LOG = LoggerFactory.getLogger(ArtifactLocalizerHttpHandlerInternal.class);
-  private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec()).create();
+  private final ArtifactLocalizer artifactLocalizer;
 
-  @Inject
-  public ArtifactLocalizerHttpHandlerInternal(CConfiguration cConf) {
-    super();
-
+  @VisibleForTesting
+  public ArtifactLocalizerHttpHandlerInternal(ArtifactLocalizer artifactLocalizer) {
+    this.artifactLocalizer = artifactLocalizer;
   }
 
   @GET
-  @Path("/localize")
-  public void run(HttpRequest request, HttpResponder responder) {
-    //implementation will be added in a followup PR.
-  }
+  @Path("/artifact/namespaces/{namespace-id}/artifacts/{artifact-name}/versions/{artifact-version}")
+  public void artifact(HttpRequest request, HttpResponder responder,
+                       @PathParam("namespace-id") String namespaceId,
+                       @PathParam("artifact-name") String artifactName,
+                       @PathParam("artifact-version") String artifactVersion,
+                       @QueryParam("unpack") @DefaultValue("false") boolean unpack) throws Exception {
 
+    ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersion);
+    File artifactPath = unpack ? artifactLocalizer.getAndUnpackArtifact(artifactId) :
+      artifactLocalizer.getArtifact(artifactId);
+    responder.sendString(HttpResponseStatus.OK, artifactPath.toString());
+  }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerTwillRunnable.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.KafkaClientModule;
+import io.cdap.cdap.common.guice.LocalLocationModule;
 import io.cdap.cdap.common.guice.SupplierProviderBridge;
 import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.guice.ZKDiscoveryModule;
@@ -101,6 +102,7 @@ public class ArtifactLocalizerTwillRunnable extends AbstractTwillRunnable {
         }
       });
       modules.add(new RemoteLogAppenderModule());
+      modules.add(new LocalLocationModule());
     }
 
     return Guice.createInjector(modules);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.worker.sidecar;
+
+import com.google.common.io.Files;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.common.service.RetryStrategyType;
+import io.cdap.cdap.common.test.AppJarHelper;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.worker.TaskWorkerServiceTest;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Unit test for {@link ArtifactLocalizerService}.
+ */
+public class ArtifactLocalizerServiceTest extends AppFabricTestBase {
+
+  private ArtifactLocalizerService localizerService;
+  private CConfiguration cConf;
+
+  private CConfiguration createCConf(int port) {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.TaskWorker.ADDRESS, "localhost");
+    cConf.setInt(Constants.TaskWorker.PORT, port);
+    cConf.setBoolean(Constants.Security.SSL.INTERNAL_ENABLED, false);
+
+    String prefix = "task.worker.";
+    cConf.set(prefix + Constants.Retry.TYPE, RetryStrategyType.FIXED_DELAY.toString());
+    cConf.set(prefix + Constants.Retry.MAX_RETRIES, "100");
+    cConf.set(prefix + Constants.Retry.MAX_TIME_SECS, "10");
+    cConf.set(prefix + Constants.Retry.DELAY_BASE_MS, "200");
+    return cConf;
+  }
+
+  private ArtifactLocalizerService setupArtifactLocalizerService(int port) throws IOException {
+    cConf = createCConf(port);
+
+    DiscoveryServiceClient discoveryClient = getInjector().getInstance(DiscoveryServiceClient.class);
+
+    String tempFolderPath = tmpFolder.newFolder().getPath();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, tempFolderPath);
+    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(discoveryClient,
+                                                                      new AuthenticationTestContext());
+    ArtifactLocalizerService artifactLocalizerService =
+      new ArtifactLocalizerService(cConf, new ArtifactLocalizer(cConf, remoteClientFactory));
+    // start the service
+    artifactLocalizerService.startAndWait();
+
+    return artifactLocalizerService;
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    this.localizerService = setupArtifactLocalizerService(10001);
+    getInjector().getInstance(ArtifactRepository.class).clear(NamespaceId.DEFAULT);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    this.localizerService.shutDown();
+  }
+
+  @Test
+  public void testUnpackArtifact() throws Exception {
+
+    LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);
+    ArtifactRepository artifactRepository = getInjector().getInstance(ArtifactRepository.class);
+    ArtifactLocalizerClient client = new ArtifactLocalizerClient(cConf);
+
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "some-task", "1.0.0-SNAPSHOT");
+    Location appJar = AppJarHelper.createDeploymentJar(locationFactory, TaskWorkerServiceTest.TestRunnableClass.class);
+    File appJarFile = new File(tmpFolder.newFolder(),
+                               String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
+    File newAppJarFile = new File(tmpFolder.newFolder(),
+                                  String.format("%s-%s-copy.jar", artifactId.getName(),
+                                                artifactId.getVersion().getVersion()));
+    Locations.linkOrCopy(appJar, appJarFile);
+    appJar.delete();
+    artifactRepository.addArtifact(artifactId, appJarFile);
+
+    File unpackedDir = client.getUnpackedArtifactLocation(artifactId.toEntityId());
+
+    // Make sure the artifact was actually cached
+    validateUnpackDir(unpackedDir);
+
+    // Call the sidecar again and make sure the same path was returned
+    File sameUnpackedDir = client.getUnpackedArtifactLocation(artifactId.toEntityId());
+    Assert.assertEquals(unpackedDir, sameUnpackedDir);
+
+    // Delete and recreate the artifact to update the last modified date
+    artifactRepository.deleteArtifact(artifactId);
+
+    Thread.sleep(1000);
+    Files.copy(appJarFile, newAppJarFile);
+    artifactRepository.addArtifact(artifactId, newAppJarFile);
+
+    File newUnpackDir = client.getUnpackedArtifactLocation(artifactId.toEntityId());
+
+    //Make sure the two paths arent the same and that the old one is gone
+    Assert.assertNotEquals(unpackedDir, newUnpackDir);
+    validateUnpackDir(newUnpackDir);
+  }
+
+  private void validateUnpackDir(File unpackedFile) {
+    // Make sure the directory exists
+    Assert.assertTrue(unpackedFile.exists());
+    Assert.assertTrue(unpackedFile.isDirectory());
+
+    // Make sure theres multiple files in the directory and one of them is a manifest
+    String[] fileNames = unpackedFile.list();
+    Assert.assertTrue(fileNames.length > 1);
+    Assert.assertTrue(Arrays.stream(fileNames).anyMatch(s -> s.equals("META-INF")));
+  }
+
+  @Test
+  public void testArtifact() throws Exception {
+
+    LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);
+    ArtifactRepository artifactRepository = getInjector().getInstance(ArtifactRepository.class);
+    ArtifactLocalizerClient client = new ArtifactLocalizerClient(cConf);
+
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "some-task", "1.0.0-SNAPSHOT");
+    Location appJar = AppJarHelper.createDeploymentJar(locationFactory, TaskWorkerServiceTest.TestRunnableClass.class);
+    File appJarFile = new File(tmpFolder.newFolder(),
+                               String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
+    File newAppJarFile = new File(tmpFolder.newFolder(),
+                                  String.format("%s-%s-copy.jar", artifactId.getName(),
+                                                artifactId.getVersion().getVersion()));
+    Locations.linkOrCopy(appJar, appJarFile);
+    appJar.delete();
+    artifactRepository.addArtifact(artifactId, appJarFile);
+
+    File artifactPath = client.getArtifactLocation(artifactId.toEntityId());
+
+    // Make sure the artifact was actually cached
+    Assert.assertTrue(artifactPath.exists());
+
+    // Call the sidecar again and make sure the same path was returned
+    File sameArtifactPath = client.getArtifactLocation(artifactId.toEntityId());
+    Assert.assertEquals(artifactPath, sameArtifactPath);
+
+    // Delete and recreate the artifact to update the last modified date
+    artifactRepository.deleteArtifact(artifactId);
+
+    // This sleep is needed to delay the file copy so that the lastModified time on the file is different
+    Thread.sleep(1000);
+
+    // Wait a bit before recreating the artifact to make sure the last modified time is different
+    Files.copy(appJarFile, newAppJarFile);
+    artifactRepository.addArtifact(artifactId, newAppJarFile);
+
+    File newArtifactPath = client.getArtifactLocation(artifactId.toEntityId());
+
+    //Make sure the two paths arent the same and that the old one is gone
+    Assert.assertNotEquals(artifactPath, newArtifactPath);
+    Assert.assertTrue(newArtifactPath.exists());
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -109,7 +109,6 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 import java.util.stream.Collectors;
 
-
 /**
  * Kubernetes version of a TwillRunner.
  * <p>


### PR DESCRIPTION
This PR builds on #13454 to implement the logic for the sidecar container. The changes in this PR are:

- Create `ArtifactLocalizer` class which runs in sidecar and communicates with appfabric 
- Create `ArtifactLocalizerClient` to handle communication between worker container and sidecar container
- Update `/download` artifact endpoint in appfabric to also return the last modified date
- Update `RemoteArtifactRepositoryReader` to use the new `ArtifactLocalizerClient`
- Created `RemoteWorkerPluginFinder` (extended from `RemotePluginFinder`) which uses the  `ArtifactLocalizerClient` to handle fetching/caching of artifacts