### PR TITLE
Clean up security context to ensure next message in same thread won't pick up the wrong credentials

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/AuthenticationChannelHandler.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/AuthenticationChannelHandler.java
@@ -47,6 +47,7 @@ public class AuthenticationChannelHandler extends ChannelInboundHandlerAdapter {
    */
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+    SecurityRequestContext.reset();
     if (msg instanceof HttpRequest) {
       // TODO: authenticate the user using user id - CDAP-688
       HttpRequest request = (HttpRequest) msg;
@@ -72,8 +73,11 @@ public class AuthenticationChannelHandler extends ChannelInboundHandlerAdapter {
       SecurityRequestContext.setUserCredential(currentUserCredential);
       SecurityRequestContext.setUserIP(currentUserIP);
     }
-
-    ctx.fireChannelRead(msg);
+    try {
+      ctx.fireChannelRead(msg);
+    } finally {
+      SecurityRequestContext.reset();
+    }
   }
 
   @Override

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authentication/SecurityRequestContext.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authentication/SecurityRequestContext.java
@@ -87,4 +87,13 @@ public final class SecurityRequestContext {
   public static Principal toPrincipal() {
     return new Principal(userId.get(), Principal.PrincipalType.USER, userCredential.get());
   }
+
+  /**
+   * Clears security state for this thread
+   */
+  public static void reset() {
+    userId.remove();
+    userIP.remove();
+    userCredential.remove();
+  }
 }


### PR DESCRIPTION
In the previous implementation HttpDispatcher was running in the same task group as AuthenticationChannelHandler. It generally works until after we receive over 512 packets at once (about 750KB). In this case with we get, say, 700 tasks for AuthenticationChannelHandler that adds 700 more tasks for HttpDispatcher. As soon as group is over 1024 tasks (see `io.cdap.http.internal.NonStickyEventExecutorGroup#NonStickyEventExecutorGroup(io.netty.util.concurrent.EventExecutorGroup)`), the group will be split and tail can be processed by another thread.

With this fix call from AuthenticationChannelHandler do not create new HttpDispatcher tasks for later, but rather run the tasks synchronously. It does not change original HttpService logic as AuthenticationChannelHandler itself uses the original executor  and runs within a proper task.