### PR TITLE
CDAP-18053: Fix hanging issue of testConcurrentRequests in TaskWorkerServiceTest

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerService.java
@@ -95,7 +95,7 @@ public class TaskWorkerService extends AbstractIdleService {
      * based on number of requests per particular class,
      * the service gets stopped.
      */
-    stopAndWait();
+    stop();
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Fixes the issue of testConcurrentRequests in TaskWorkerServiceTest hanging. 

The issue is that by calling stopAndWait, httpService cannot be closed (thus hanging) since the stopAndWait itself is being called by a netty executor thread.