### PR TITLE
Support python3 in Spark runtime

### DIFF
--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -504,9 +504,6 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     // as WARN, which pollute the logs a lot if there are concurrent Spark job running (e.g. a fork in Workflow).
     configs.put("spark.ui.port", "0");
 
-    // Force python 2. Spark 3 runs with python 3 by default, but we don't support it yet
-    configs.put("spark.pyspark.python", "python");
-
     // Setup app.id and executor.id for Metric System
     configs.put("spark.app.id", context.getApplicationSpecification().getName());
     configs.put("spark.executor.id", context.getApplicationSpecification().getName());

--- a/cdap-spark-python/src/main/resources/cdap/pyspark/__init__.py
+++ b/cdap-spark-python/src/main/resources/cdap/pyspark/__init__.py
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
-from context import *
+from __future__ import absolute_import
+from .context import *
 
 __all__ = ["SparkExecutionContext", "Metrics", "ServiceDiscoverer"]

--- a/cdap-spark-python/src/main/resources/cdap/pyspark/context.py
+++ b/cdap-spark-python/src/main/resources/cdap/pyspark/context.py
@@ -14,6 +14,9 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import print_function
+from builtins import str
+from builtins import object
 import os
 from py4j.java_gateway import java_import, JavaGateway
 from threading import RLock
@@ -228,5 +231,5 @@ class SparkRuntimeContext(object):
         cls._gateway = gateway
         cls._jvm = gateway.jvm
         cls._runtimeContext = cls._jvm.SparkRuntimeContextProvider.get()
-        print "Java gateway initialized with gateway port ", gatewayPort
+        print("Java gateway initialized with gateway port ", gatewayPort)
 

--- a/cdap-spark-python/src/main/resources/cdap/pyspark/context.py
+++ b/cdap-spark-python/src/main/resources/cdap/pyspark/context.py
@@ -15,8 +15,7 @@
 # the License.
 
 from __future__ import print_function
-from builtins import str
-from builtins import object
+
 import os
 from py4j.java_gateway import java_import, JavaGateway
 from threading import RLock

--- a/cdap-spark-python/src/main/resources/cdap/pyspark/log.py
+++ b/cdap-spark-python/src/main/resources/cdap/pyspark/log.py
@@ -14,6 +14,7 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 
+from __future__ import print_function
 from logging import Handler
 
 __all__ = ["CDAPLogHandler"]
@@ -24,4 +25,4 @@ class CDAPLogHandler(Handler):
     Handler.__init__(self)
 
   def emit(self, event):
-    print("Event", dir(event))
+    print(("Event", dir(event)))


### PR DESCRIPTION
in 6.5.X CDAP now supports execution in Spark3 by default however usage of the Dynamic PySpark plugin is gated on using Python2. We have found that using python2 with Spark3 on Dataproc results in a `pyspark.zip` to be picked up that is not compatible with python 2 (Thanks Vitali) 

Tested by checking that `io.cdap.cdap.spark.Spark2Test` passes in both `cdap-unit-test-spark2_2.11` and `cdap-unit-test-spark3_2.12` modules