### PR TITLE
CDAP-17981: Introduce FileFetcherInternalHttpHandler in AppFabric 

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -56,6 +56,7 @@ import io.cdap.cdap.gateway.handlers.BootstrapHttpHandler;
 import io.cdap.cdap.gateway.handlers.CommonHandlers;
 import io.cdap.cdap.gateway.handlers.ConfigHandler;
 import io.cdap.cdap.gateway.handlers.ConsoleSettingsHttpHandler;
+import io.cdap.cdap.gateway.handlers.FileFetcherHttpHandlerInternal;
 import io.cdap.cdap.gateway.handlers.ImpersonationHandler;
 import io.cdap.cdap.gateway.handlers.InstanceOperationHttpHandler;
 import io.cdap.cdap.gateway.handlers.NamespaceHttpHandler;
@@ -380,6 +381,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(ProfileHttpHandler.class);
       handlerBinder.addBinding().to(ProvisionerHttpHandler.class);
       handlerBinder.addBinding().to(BootstrapHttpHandler.class);
+      handlerBinder.addBinding().to(FileFetcherHttpHandlerInternal.class);
 
       for (Class<? extends HttpHandler> handlerClass : handlerClasses) {
         handlerBinder.addBinding().to(handlerClass);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/FileFetcherHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/FileFetcherHttpHandlerInternal.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.LocationBodyProducer;
+import io.cdap.cdap.common.io.Locations;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Internal {@link HttpHandler} for fetching file from {@link LocationFactory}
+ */
+@Singleton
+@Path(Constants.Gateway.INTERNAL_API_VERSION_3)
+public class FileFetcherHttpHandlerInternal extends AbstractHttpHandler {
+
+  private final LocationFactory locationFactory;
+
+  @Inject
+  FileFetcherHttpHandlerInternal(LocationFactory locationFactory) {
+    this.locationFactory = locationFactory;
+  }
+
+  /**
+   * Download the file specified by the given path in the URL.
+   *
+   * @param request {@link HttpRequest}
+   * @param responder {@link HttpResponse}
+   */
+  @GET
+  @Path("/location/**")
+  public void download(HttpRequest request, HttpResponder responder) throws Exception {
+    String prefix = String.format("%s/location/", Constants.Gateway.INTERNAL_API_VERSION_3);
+    String path = request.uri().substring(prefix.length());
+    Location location = Locations.getLocationFromAbsolutePath(locationFactory, path);
+
+    if (!location.exists()) {
+      throw new NotFoundException(String.format("Path %s not found", path));
+    }
+    responder.sendContent(HttpResponseStatus.OK, new LocationBodyProducer(location),
+                          new DefaultHttpHeaders().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM));
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/FileFetcherHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/FileFetcherHttpHandlerInternalTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services.http.handlers;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.cdap.cdap.common.HttpExceptionHandler;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.gateway.handlers.FileFetcherHttpHandlerInternal;
+import io.cdap.common.http.HttpContentConsumer;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import io.cdap.http.NettyHttpService;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.filesystem.Location;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.Random;
+
+/**
+ * Test for {@link FileFetcherHttpHandlerInternal}.
+ */
+public class FileFetcherHttpHandlerInternalTest {
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+  private static final Logger LOG = LoggerFactory.getLogger(FileFetcherHttpHandlerInternalTest.class);
+  private static NettyHttpService httpService;
+  private static URL baseURL;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new LocalLocationModule());
+
+    FileFetcherHttpHandlerInternal handler = injector.getInstance(FileFetcherHttpHandlerInternal.class);
+
+    httpService = NettyHttpService.builder("FileFetcherHttpHandlerInternalTest")
+      .setHttpHandlers(handler)
+      .setExceptionHandler(new HttpExceptionHandler())
+      .build();
+
+    httpService.start();
+
+    InetSocketAddress addr = httpService.getBindAddress();
+    baseURL = new URL(String.format("http://%s:%d", addr.getHostName(), addr.getPort()));
+  }
+
+  @AfterClass
+  public static void stop() throws Exception {
+    httpService.stop();
+  }
+
+  @Test
+  public void testSuccess() throws Exception {
+    // Create a file.
+    File srcFile = TEMP_FOLDER.newFile("src_file");
+    try (FileOutputStream out = new FileOutputStream(srcFile)) {
+      byte[] bytes = new byte[256 * 1024 + 7];
+      new Random().nextBytes(bytes);
+      out.write(bytes);
+    }
+
+    // Download the file.
+    File targetFile = new File(TEMP_FOLDER.newFolder(), "dst_file");
+    Location dst = Locations.toLocation(targetFile);
+    HttpResponse httpResponse = download(srcFile, dst);
+    Assert.assertEquals(HttpResponseStatus.OK.code(), httpResponse.getResponseCode());
+
+    // Verify the source and destination files are identical.
+    byte[] orgFileContent = Files.readAllBytes(srcFile.toPath());
+    byte[] downloadedFileContent = Files.readAllBytes(targetFile.toPath());
+    Assert.assertArrayEquals(orgFileContent, downloadedFileContent);
+  }
+
+  @Test
+  public void testFileNotFound() throws Exception {
+    // A non-existent file
+    File srcFile = new File(TEMP_FOLDER.getRoot(), "file_dont_exist");
+
+    // Download the file.
+    File targetFile = new File(TEMP_FOLDER.newFolder(), "dst_file");
+    Location dst = Locations.toLocation(targetFile);
+
+    HttpResponse httpResponse = download(srcFile, dst);
+    Assert.assertEquals(httpResponse.getResponseCode(), HttpResponseStatus.NOT_FOUND.code());
+  }
+
+  private HttpResponse download(File src, Location dst) throws IOException {
+    // Make a request to download the source file.
+    URL url = new URL(String.format("%s/v3Internal/location/%s", baseURL, src.toURI().getPath()));
+    OutputStream outputStream = dst.getOutputStream();
+    HttpRequest request = HttpRequest.builder(
+      HttpMethod.GET, url).withContentConsumer(
+      new HttpContentConsumer() {
+        @Override
+        public boolean onReceived(ByteBuffer chunk) {
+          try {
+            byte[] bytes = new byte[chunk.remaining()];
+            chunk.get(bytes, 0, bytes.length);
+            outputStream.write(bytes);
+          } catch (IOException e) {
+            LOG.error("Failed to write to {}", dst.toURI());
+            return false;
+          }
+          return true;
+        }
+
+        @Override
+        public void onFinished() {
+          try {
+            outputStream.close();
+          } catch (Exception e) {
+            LOG.error("Failed to close {}", dst.toURI());
+          }
+        }
+      }).build();
+    HttpResponse httpResponse = HttpRequests.execute(request, new DefaultHttpRequestConfig(false));
+    httpResponse.consumeContent();
+    return httpResponse;
+  }
+
+}


### PR DESCRIPTION
* FileFetcherInternalHttpHandler will be used to stream file content from appfab to other services. 
* This will be used in the next PR for file localizer to download files from appfab