### PR TITLE
Add config allowing to enable/disable killing taskworker pod after an execution completes

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -388,6 +388,7 @@ public final class Constants {
     public static final String CONTAINER_MEMORY_MULTIPLIER = "task.worker.container.memory.multiplier";
     public static final String CONTAINER_HEAP_RESERVED_RATIO = "task.worker.container.java.heap.memory.ratio";
     public static final String CONTAINER_PRIORITY_CLASS_NAME = "task.worker.container.priority.class.name";
+    public static final String CONTAINER_KILL_AFTER_EXECUTION = "task.worker.container.kill.after.execution";
 
     /**
      * Task worker http handler configuration

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4304,6 +4304,14 @@
   </property>
 
   <property>
+    <name>task.worker.container.kill.after.execution</name>
+    <value>true</value>
+    <description>
+      If true, kill the task worker container after it executes a request.
+    </description>
+  </property>
+
+  <property>
     <name>task.worker.bind.address</name>
     <value>0.0.0.0</value>
     <description>


### PR DESCRIPTION
Also, fixes the issue in which a pod is getting killed, but before it terminates, it accepts a new request.