### PR TITLE
Changes for BQ Pushdown behaviors

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/AutoJoinerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/AutoJoinerTest.java
@@ -673,6 +673,7 @@ public class AutoJoinerTest extends HydratorTestBase {
     String output = UUID.randomUUID().toString();
     String sqlEnginePlugin = UUID.randomUUID().toString();
     ETLBatchConfig config = ETLBatchConfig.builder()
+      .setPushdownEnabled(true)
       .setTransformationPushdown(
         new ETLTransformationPushdown(MockSQLEngine.getPlugin(sqlEnginePlugin,
                                                               joinInputDir.getAbsolutePath(),

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/BatchPipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/BatchPipelineSpecGenerator.java
@@ -67,7 +67,8 @@ public class BatchPipelineSpecGenerator extends PipelineSpecGenerator<ETLBatchCo
   }
 
   private StageSpec configureSqlEngine(ETLBatchConfig config) throws ValidationException {
-    if (config.getTransformationPushdown() == null || config.getTransformationPushdown().getPlugin() == null) {
+    if (!config.isPushdownEnabled() || config.getTransformationPushdown() == null
+      || config.getTransformationPushdown().getPlugin() == null) {
       return null;
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
@@ -874,6 +874,7 @@ public class PipelineSpecGeneratorTest {
     ETLBatchConfig config = ETLBatchConfig.builder()
       .setTimeSchedule("* * * * *")
       .addStage(new ETLStage("action", MOCK_ACTION))
+      .setPushdownEnabled(true)
       .setTransformationPushdown(new ETLTransformationPushdown(MOCK_SQL_ENGINE))
       .build();
     PipelineSpec actual = specGenerator.generateSpec(config);
@@ -889,6 +890,54 @@ public class PipelineSpecGeneratorTest {
       .setSqlEngineStageSpec(
         StageSpec.builder("sqlengine_mocksqlengine",
                           new PluginSpec(BatchSQLEngine.PLUGIN_TYPE, "mocksqlengine", emptyMap, ARTIFACT_ID)).build())
+      .build();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSQLEngineNotEnabled() throws ValidationException {
+    ETLBatchConfig config = ETLBatchConfig.builder()
+      .setTimeSchedule("* * * * *")
+      .addStage(new ETLStage("action", MOCK_ACTION))
+      .setPushdownEnabled(false)
+      .setTransformationPushdown(new ETLTransformationPushdown(MOCK_SQL_ENGINE))
+      .build();
+    PipelineSpec actual = specGenerator.generateSpec(config);
+
+    Map<String, String> emptyMap = ImmutableMap.of();
+    PipelineSpec expected = BatchPipelineSpec.builder()
+      .addStage(
+        StageSpec.builder("action", new PluginSpec(Action.PLUGIN_TYPE, "mockaction", emptyMap, ARTIFACT_ID)).build())
+      .setResources(config.getResources())
+      .setDriverResources(config.getDriverResources())
+      .setClientResources(config.getClientResources())
+      .setStageLoggingEnabled(config.isStageLoggingEnabled())
+      .setSqlEngineStageSpec(null)
+      .build();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSQLEngineEnabledButNotConfigured() throws ValidationException {
+    ETLBatchConfig config = ETLBatchConfig.builder()
+      .setTimeSchedule("* * * * *")
+      .addStage(new ETLStage("action", MOCK_ACTION))
+      .setPushdownEnabled(true)
+      .setTransformationPushdown(null)
+      .build();
+    PipelineSpec actual = specGenerator.generateSpec(config);
+
+    Map<String, String> emptyMap = ImmutableMap.of();
+    PipelineSpec expected = BatchPipelineSpec.builder()
+      .addStage(
+        StageSpec.builder("action", new PluginSpec(Action.PLUGIN_TYPE, "mockaction", emptyMap, ARTIFACT_ID)).build())
+      .setResources(config.getResources())
+      .setDriverResources(config.getDriverResources())
+      .setClientResources(config.getClientResources())
+      .setStageLoggingEnabled(config.isStageLoggingEnabled())
+      .setSqlEngineStageSpec(null)
       .build();
 
     Assert.assertEquals(expected, actual);

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLBatchConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLBatchConfig.java
@@ -46,6 +46,7 @@ public final class ETLBatchConfig extends ETLConfig {
   private final List<ETLStage> actions;
   private final Boolean service;
   // support for SQL Engines
+  private final Boolean pushdownEnabled;
   private final ETLTransformationPushdown transformationPushdown;
 
   private ETLBatchConfig(Set<ETLStage> stages,
@@ -63,6 +64,7 @@ public final class ETLBatchConfig extends ETLConfig {
                          Map<String, String> engineProperties,
                          Boolean service,
                          List<Object> comments,
+                         @Nullable Boolean pushdownEnabled,
                          @Nullable ETLTransformationPushdown transformationPushdown) {
     super(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled, processTimingEnabled,
           numOfRecordsPreview, engineProperties, comments);
@@ -74,6 +76,7 @@ public final class ETLBatchConfig extends ETLConfig {
     this.actions = null;
     this.service = service;
     // fields related to SQL Engines
+    this.pushdownEnabled = pushdownEnabled;
     this.transformationPushdown = transformationPushdown;
   }
 
@@ -121,6 +124,10 @@ public final class ETLBatchConfig extends ETLConfig {
     return maxConcurrentRuns;
   }
 
+  public boolean isPushdownEnabled() {
+    return pushdownEnabled != null ? pushdownEnabled : false;
+  }
+
   @Nullable
   public ETLTransformationPushdown getTransformationPushdown() {
     return transformationPushdown;
@@ -143,7 +150,7 @@ public final class ETLBatchConfig extends ETLConfig {
     return new ETLBatchConfig(upgradedStages, connections, postActions, resources, stageLoggingEnabled,
                               processTimingEnabled, engine, schedule, driverResources, clientResources,
                               numOfRecordsPreview, maxConcurrentRuns, properties, service, comments,
-                              transformationPushdown);
+                              pushdownEnabled, transformationPushdown);
   }
 
   @Override
@@ -209,7 +216,7 @@ public final class ETLBatchConfig extends ETLConfig {
   public static ETLBatchConfig forSystemService() {
     return new ETLBatchConfig(Collections.emptySet(), Collections.emptySet(), Collections.emptyList(),
                               null, false, false, null, null, null, null, 0, null, Collections.emptyMap(), true,
-                              Collections.emptyList(), null);
+                              Collections.emptyList(), false, null);
   }
 
   /**
@@ -220,6 +227,7 @@ public final class ETLBatchConfig extends ETLConfig {
     private Engine engine;
     private List<ETLStage> endingActions;
     private Integer maxConcurrentRuns;
+    private Boolean pushdownEnabled;
     private ETLTransformationPushdown transformationPushdown;
     // Only used for upgrade purpose.
     private List<Object> comments;
@@ -271,6 +279,11 @@ public final class ETLBatchConfig extends ETLConfig {
       return this;
     }
 
+    public Builder setPushdownEnabled(Boolean pushdownEnabled) {
+      this.pushdownEnabled = pushdownEnabled;
+      return this;
+    }
+
     public Builder setTransformationPushdown(ETLTransformationPushdown transformationPushdown) {
       this.transformationPushdown = transformationPushdown;
       return this;
@@ -280,7 +293,7 @@ public final class ETLBatchConfig extends ETLConfig {
       return new ETLBatchConfig(stages, connections, endingActions, resources, stageLoggingEnabled,
                                 processTimingEnabled, engine, schedule, driverResources, clientResources,
                                 numOfRecordsPreview, maxConcurrentRuns, properties, false, comments,
-                                transformationPushdown);
+                                pushdownEnabled, transformationPushdown);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/io/cdap/cdap/etl/tool/config/Upgrader.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/io/cdap/cdap/etl/tool/config/Upgrader.java
@@ -159,6 +159,7 @@ public class Upgrader {
         .setResources(batchConfig.getResources())
         .setDriverResources(batchConfig.getDriverResources())
         .setEngine(batchConfig.getEngine())
+        .setPushdownEnabled(batchConfig.isPushdownEnabled())
         .setTransformationPushdown(batchConfig.getTransformationPushdown());
       // upgrade any of the plugin artifact versions if needed
       for (ETLStage postAction : batchConfig.getPostActions()) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
@@ -191,9 +191,12 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
         sec.getRuntimeArguments().getOrDefault(Constants.CONSOLIDATE_STAGES, Boolean.TRUE.toString()));
       boolean shouldCacheFunctions = Boolean.parseBoolean(
         sec.getRuntimeArguments().getOrDefault(Constants.CACHE_FUNCTIONS, Boolean.TRUE.toString()));
+      boolean isPreviewEnabled =
+        phaseSpec.getPhase().size() == 0
+          || sec.getDataTracer(phaseSpec.getPhase().iterator().next().getName()).isEnabled();
 
       // Initialize SQL engine instance if needed.
-      if (phaseSpec.getSQLEngineStageSpec() != null) {
+      if (!isPreviewEnabled && phaseSpec.getSQLEngineStageSpec() != null) {
         String sqlEngineStage = SQLEngineUtils.buildStageName(phaseSpec.getSQLEngineStageSpec().getPlugin().getName());
 
         // Instantiate SQL engine and prepare run.


### PR DESCRIPTION
Added setting to allow users to enable/disable pushdown behavior without deleting pushdown settings.

Added check to ensure the pushdown engine is not used when running pipeline previews.