### PR TITLE
Add TwillRunnable security context and readonly volumes

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -182,8 +182,7 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
           if (twillPreparer instanceof SecureTwillPreparer) {
             String twillUserIdentity = cConf.get(Constants.Twill.Security.IDENTITY_USER);
             if (twillUserIdentity != null) {
-              SecurityContext securityContext = new SecurityContext
-                .SecurityContextBuilder()
+              SecurityContext securityContext = new SecurityContext.Builder()
                 .withIdentity(twillUserIdentity).build();
               twillPreparer = ((SecureTwillPreparer) twillPreparer)
                 .withSecurityContext(PreviewRunnerTwillRunnable.class.getSimpleName(), securityContext);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
 import io.cdap.cdap.master.spi.twill.SecureTwillPreparer;
+import io.cdap.cdap.master.spi.twill.SecurityContext;
 import io.cdap.cdap.master.spi.twill.StatefulDisk;
 import io.cdap.cdap.master.spi.twill.StatefulTwillPreparer;
 import io.cdap.cdap.messaging.MessagingService;
@@ -181,8 +182,11 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
           if (twillPreparer instanceof SecureTwillPreparer) {
             String twillUserIdentity = cConf.get(Constants.Twill.Security.IDENTITY_USER);
             if (twillUserIdentity != null) {
+              SecurityContext securityContext = new SecurityContext
+                .SecurityContextBuilder()
+                .withIdentity(twillUserIdentity).build();
               twillPreparer = ((SecureTwillPreparer) twillPreparer)
-                .withIdentity(PreviewRunnerTwillRunnable.class.getSimpleName(), twillUserIdentity);
+                .withSecurityContext(PreviewRunnerTwillRunnable.class.getSimpleName(), securityContext);
             }
           }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -267,8 +267,7 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
           if (twillPreparer instanceof SecureTwillPreparer) {
             String twillSystemIdentity = cConf.get(Constants.Twill.Security.IDENTITY_SYSTEM);
             if (twillSystemIdentity != null) {
-              SecurityContext securityContext = new SecurityContext
-                .SecurityContextBuilder()
+              SecurityContext securityContext = new SecurityContext.Builder()
                 .withIdentity(twillSystemIdentity).build();
               twillPreparer = ((SecureTwillPreparer) twillPreparer).withSecurityContext(runnable, securityContext);
             }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -56,6 +56,7 @@ import io.cdap.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import io.cdap.cdap.logging.context.LoggingContextHelper;
 import io.cdap.cdap.master.spi.twill.SecretDisk;
 import io.cdap.cdap.master.spi.twill.SecureTwillPreparer;
+import io.cdap.cdap.master.spi.twill.SecurityContext;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import io.cdap.cdap.security.store.SecureStoreUtils;
@@ -266,7 +267,10 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
           if (twillPreparer instanceof SecureTwillPreparer) {
             String twillSystemIdentity = cConf.get(Constants.Twill.Security.IDENTITY_SYSTEM);
             if (twillSystemIdentity != null) {
-              twillPreparer = ((SecureTwillPreparer) twillPreparer).withIdentity(runnable, twillSystemIdentity);
+              SecurityContext securityContext = new SecurityContext
+                .SecurityContextBuilder()
+                .withIdentity(twillSystemIdentity).build();
+              twillPreparer = ((SecureTwillPreparer) twillPreparer).withSecurityContext(runnable, securityContext);
             }
             String securityName = cConf.get(Constants.Twill.Security.SECRET_DISK_NAME);
             String securityPath = cConf.get(Constants.Twill.Security.SECRET_DISK_PATH);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
@@ -51,6 +51,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class TaskWorkerServiceLauncher extends AbstractScheduledService {
   private static final Logger LOG = LoggerFactory.getLogger(TaskWorkerServiceLauncher.class);
+  private static final String STATEFUL_DISK_NAME = "task-worker-data";
 
   private final CConfiguration cConf;
   private final Configuration hConf;
@@ -169,8 +170,9 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
             int diskSize = cConf.getInt(Constants.TaskWorker.CONTAINER_DISK_SIZE_GB);
             twillPreparer = ((StatefulTwillPreparer) twillPreparer)
               .withStatefulRunnable(TaskWorkerTwillRunnable.class.getSimpleName(), false,
-                                    new StatefulDisk("task-worker-data", diskSize,
-                                                     cConf.get(Constants.CFG_LOCAL_DATA_DIR)));
+                                    new StatefulDisk(STATEFUL_DISK_NAME, diskSize,
+                                                     cConf.get(Constants.CFG_LOCAL_DATA_DIR)))
+              .withReadonlyDisk(TaskWorkerTwillRunnable.class.getSimpleName(), STATEFUL_DISK_NAME);
           }
 
           if (twillPreparer instanceof SecureTwillPreparer) {
@@ -195,7 +197,7 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
   }
 
   private SecurityContext createSecurityContext() {
-    SecurityContext.SecurityContextBuilder builder = new SecurityContext.SecurityContextBuilder();
+    SecurityContext.Builder builder = new SecurityContext.Builder();
     String twillUserIdentity = cConf.get(Constants.Twill.Security.IDENTITY_USER);
     if (twillUserIdentity != null) {
       builder.withIdentity(twillUserIdentity);

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -390,7 +390,8 @@ public final class Constants {
     public static final String CONTAINER_HEAP_RESERVED_RATIO = "task.worker.container.java.heap.memory.ratio";
     public static final String CONTAINER_PRIORITY_CLASS_NAME = "task.worker.container.priority.class.name";
     public static final String CONTAINER_KILL_AFTER_EXECUTION = "task.worker.container.kill.after.execution";
-
+    public static final String CONTAINER_RUN_AS_USER = "task.worker.container.run.as.user";
+    public static final String CONTAINER_RUN_AS_GROUP = "task.worker.container.run.as.group";
     /**
      * Task worker http handler configuration
      */

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/SecureTwillPreparer.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/SecureTwillPreparer.java
@@ -25,16 +25,6 @@ import org.apache.twill.api.TwillRunnable;
  */
 public interface SecureTwillPreparer extends TwillPreparer {
   /**
-   * Runs the given runnable as a certain identity.
-   * In this case, the concept of identity is up to the preparer to define.
-   *
-   * @param runnableName name of the {@link TwillRunnable}
-   * @param identity the identity to run as
-   * @return this {@link TwillPreparer}
-   */
-  SecureTwillPreparer withIdentity(String runnableName, String identity);
-
-  /**
    * Runs the given runnable with the specified secret disks.
    *
    * @param runnableName name of the {@link TwillRunnable}
@@ -42,4 +32,14 @@ public interface SecureTwillPreparer extends TwillPreparer {
    * @return this {@link TwillPreparer}
    */
   SecureTwillPreparer withSecretDisk(String runnableName, SecretDisk... secretDisks);
+
+  /**
+   * Runs the given runnable with provided {@link SecurityContext}
+   * @param runnableName name of the {@link TwillRunnable}
+   * @param securityContext the security context to be used
+   * @return this {@link TwillPreparer}
+   */
+  SecureTwillPreparer withSecurityContext(String runnableName,
+                                          SecurityContext securityContext);
+
 }

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/SecurityContext.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/SecurityContext.java
@@ -52,23 +52,23 @@ public class SecurityContext {
   /**
    * Builds and returns an instance of {@link SecurityContext}.
    */
-  public static class SecurityContextBuilder {
+  public static class Builder {
 
     private Long userId;
     private Long groupId;
     private String identity;
 
-    public SecurityContextBuilder withUserId(long userId) {
+    public Builder withUserId(Long userId) {
       this.userId = userId;
       return this;
     }
 
-    public SecurityContextBuilder withGroupId(long groupId) {
+    public Builder withGroupId(Long groupId) {
       this.groupId = groupId;
       return this;
     }
 
-    public SecurityContextBuilder withIdentity(String identity) {
+    public Builder withIdentity(String identity) {
       this.identity = identity;
       return this;
     }

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/SecurityContext.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/SecurityContext.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.spi.twill;
+
+import javax.annotation.Nullable;
+
+/**
+ * Specifies security context of a {@link org.apache.twill.api.TwillRunnable}.
+ * This includes its identity, along with userId and groupId.
+ */
+public class SecurityContext {
+
+  private final Long userId;
+  private final Long groupId;
+  private final String identity;
+
+  private SecurityContext(@Nullable Long userId, @Nullable Long groupId, @Nullable String identity) {
+    this.identity = identity;
+    this.userId = userId;
+    this.groupId = groupId;
+  }
+
+  @Nullable
+  public Long getUserId() {
+    return userId;
+  }
+
+  @Nullable
+  public Long getGroupId() {
+    return groupId;
+  }
+
+  @Nullable
+  public String getIdentity() {
+    return identity;
+  }
+
+  /**
+   * Builds and returns an instance of {@link SecurityContext}.
+   */
+  public static class SecurityContextBuilder {
+
+    private Long userId;
+    private Long groupId;
+    private String identity;
+
+    public SecurityContextBuilder withUserId(long userId) {
+      this.userId = userId;
+      return this;
+    }
+
+    public SecurityContextBuilder withGroupId(long groupId) {
+      this.groupId = groupId;
+      return this;
+    }
+
+    public SecurityContextBuilder withIdentity(String identity) {
+      this.identity = identity;
+      return this;
+    }
+
+    public SecurityContext build() {
+      return new SecurityContext(this.userId, this.groupId, this.identity);
+    }
+  }
+}

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/StatefulTwillPreparer.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/StatefulTwillPreparer.java
@@ -35,4 +35,12 @@ public interface StatefulTwillPreparer extends DependentTwillPreparer {
    */
   StatefulTwillPreparer withStatefulRunnable(String runnableName, boolean orderedStart,
                                              StatefulDisk... statefulDisk);
+
+  /**
+   * Mount the provided disk name for the given runnable name as readonly volume.
+   * @param runnableName name of the {@link TwillRunnable}
+   * @param diskName name of the {@link StatefulDisk}
+   * @return @return this {@link TwillPreparer}
+   */
+  StatefulTwillPreparer withReadonlyDisk(String runnableName, String diskName);
 }


### PR DESCRIPTION
Security context contains identity, userId and groupId which can be set for a TwillRunnable.

This allows us to run task worker containers with a different userId/groupId.

This PR also allows to mount a volume as readonly. This allows us to mount a volume as readonly in one container, and as read-write for another container inside a pod. Taskworker pod leverages this feature to mount the PD as readonly in taskworker container and as readwrite in the sidecar artifact localizer container.