### PR TITLE
CDAP-18063 support creating a single classloader for all plugins created

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/plugin/PluginConfigurer.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/plugin/PluginConfigurer.java
@@ -126,4 +126,15 @@ public interface PluginConfigurer {
    */
   Map<String, String> evaluateMacros(Map<String, String> properties,
                                      MacroEvaluator evaluator, MacroParserOptions options) throws InvalidMacroException;
+
+  /**
+   * Creates a new instance of {@link ClassLoader} that contains this program classloader, all the plugins
+   * export-package classloader instantiated by this configurer and system classloader in that loading order.
+   * Currently this method is only supported in services.
+   *
+   * @return a combined classloader
+   */
+  default ClassLoader createClassLoader() {
+    throw new UnsupportedOperationException("Creating classloader for all plugins is not supported.");
+  }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultServicePluginConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultServicePluginConfigurer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.internal.app;
+
+import io.cdap.cdap.api.plugin.Plugin;
+import io.cdap.cdap.common.lang.CombineClassLoader;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
+import io.cdap.cdap.internal.app.runtime.plugin.PluginClassLoaders;
+import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.cdap.proto.id.NamespaceId;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Default service plugin configurer which supports creating a combined class loader for all the plugins used.
+ */
+public class DefaultServicePluginConfigurer extends DefaultPluginConfigurer {
+  private final ClassLoader programClassLoader;
+
+  public DefaultServicePluginConfigurer(ArtifactId artifactId, NamespaceId pluginNamespaceId,
+                                        PluginInstantiator pluginInstantiator, PluginFinder pluginFinder,
+                                        ClassLoader programClassLoader) {
+    super(artifactId, pluginNamespaceId, pluginInstantiator, pluginFinder);
+    this.programClassLoader = programClassLoader;
+  }
+
+  @Override
+  public ClassLoader createClassLoader() {
+    Map<String, Plugin> plugins = getPlugins().entrySet().stream()
+                                    .collect(Collectors.toMap(Map.Entry::getKey, v -> v.getValue().getPlugin()));
+
+    ClassLoader pluginsClassLoader =
+      PluginClassLoaders.createFilteredPluginsClassLoader(plugins, getPluginInstantiator());
+    return new CombineClassLoader(null, programClassLoader, pluginsClassLoader, getClass().getClassLoader());
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.DefaultPluginConfigurer;
+import io.cdap.cdap.internal.app.DefaultServicePluginConfigurer;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
 import io.cdap.cdap.internal.app.runtime.ProgramRunners;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
@@ -171,6 +172,7 @@ public class BasicHttpServiceContext extends AbstractContext implements HttpServ
     try {
       File pluginsDir = Files.createTempDirectory(tmpDir.toPath(), "plugins").toFile();
       PluginInstantiator instantiator = new PluginInstantiator(cConf, getProgram().getClassLoader(), pluginsDir);
+      // this closeables will be closed after each execution of a handler event
       closeables.add(() -> {
         try {
           instantiator.close();
@@ -178,7 +180,8 @@ public class BasicHttpServiceContext extends AbstractContext implements HttpServ
           DirUtils.deleteDirectoryContents(pluginsDir, true);
         }
       });
-      return new DefaultPluginConfigurer(artifactId, new NamespaceId(namespace), instantiator, pluginFinder);
+      return new DefaultServicePluginConfigurer(artifactId, new NamespaceId(namespace), instantiator, pluginFinder,
+                                                getProgram().getClassLoader());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/connection/DefaultConnectorConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/connection/DefaultConnectorConfigurer.java
@@ -76,4 +76,9 @@ public class DefaultConnectorConfigurer implements ConnectorConfigurer {
                                             MacroParserOptions options) throws InvalidMacroException {
     return delegate.evaluateMacros(properties, evaluator, options);
   }
+
+  @Override
+  public ClassLoader createClassLoader() {
+    return delegate.createClassLoader();
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/connection/LimitingConnector.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/connection/LimitingConnector.java
@@ -65,6 +65,7 @@ public class LimitingConnector implements DirectConnector {
     Map<String, String> configs =
       LimitingInputFormatProvider.getConfiguration(inputFormatProvider, request.getLimit());
     Configuration hConf = new Configuration();
+    hConf.setClassLoader(context.getPluginConfigurer().createClassLoader());
     configs.forEach(hConf::set);
 
     Job job = Job.getInstance(hConf);


### PR DESCRIPTION
This is a blocker for `BatchConnector` to work, without this change the `LimitingInputFormat` is not able to instantiate the correct format class because of missing PluginClassLoader. Like we do for other programs, we need to have a single classloader which contains the program classloader + all the plugins getting used in the configurer.

Cannot find a way to just add this function for service without breaking backward compatibility since `HttpServiceContext`'s `createPluginConfigurer` returns a `PluginConfigurer`, so can only add the method to it, and only supports it for service