### PR TITLE
CDAP-17981: Make FileLocalizer to download files via AppFab instead of from HDFS

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/FileLocalizer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/FileLocalizer.java
@@ -21,7 +21,6 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnable;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnableContext;
 import org.apache.twill.api.LocalFile;
 import org.apache.twill.filesystem.LocalLocationFactory;
-import org.apache.twill.filesystem.Location;
 import org.apache.twill.internal.Constants;
 import org.apache.twill.internal.TwillRuntimeSpecification;
 import org.apache.twill.internal.json.TwillRuntimeSpecificationAdapter;
@@ -29,9 +28,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -63,16 +65,21 @@ public class FileLocalizer implements MasterEnvironmentRunnable {
       throw new IllegalArgumentException("Expected to have two arguments: runtime config uri and the runnable name.");
     }
 
+    LocalLocationFactory localLocationFactory = new LocalLocationFactory();
+
     // Localize the runtime config jar
     URI uri = URI.create(args[0]);
-    Location runtimeConfigLocation;
-    if (context.getLocationFactory().getHomeLocation().toURI().getScheme().equals(uri.getScheme())) {
-      runtimeConfigLocation = context.getLocationFactory().create(uri);
-    } else {
-      runtimeConfigLocation = new LocalLocationFactory().create(new File(uri).toURI());
-    }
 
-    Path runtimeConfigDir = expand(runtimeConfigLocation, Paths.get(Constants.Files.RUNTIME_CONFIG_JAR));
+    Path runtimeConfigDir;
+    if (localLocationFactory.getHomeLocation().toURI().getScheme().equals(uri.getScheme())) {
+      try (FileInputStream is = new FileInputStream(new File(uri))) {
+        runtimeConfigDir = expand(uri, is, Paths.get(Constants.Files.RUNTIME_CONFIG_JAR));
+      }
+    } else {
+      try (InputStream is = getHttpURLConnectionInputStream(fileDownloadURLPath(uri))) {
+        runtimeConfigDir = expand(uri, is, Paths.get(Constants.Files.RUNTIME_CONFIG_JAR));
+      }
+    }
 
     try (Reader reader = Files.newBufferedReader(runtimeConfigDir.resolve(Constants.Files.TWILL_SPEC),
                                                  StandardCharsets.UTF_8)) {
@@ -87,13 +94,14 @@ public class FileLocalizer implements MasterEnvironmentRunnable {
           break;
         }
 
-        Location location = context.getLocationFactory().create(localFile.getURI());
         Path targetPath = targetDir.resolve(localFile.getName());
 
-        if (localFile.isArchive()) {
-          expand(location, targetPath);
-        } else {
-          copy(location, targetPath);
+        try (InputStream is = getHttpURLConnectionInputStream(fileDownloadURLPath(localFile.getURI()))) {
+          if (localFile.isArchive()) {
+            expand(localFile.getURI(), is, targetPath);
+          } else {
+            copy(localFile.getURI(), is, targetPath);
+          }
         }
       }
     }
@@ -104,23 +112,42 @@ public class FileLocalizer implements MasterEnvironmentRunnable {
     stopped = true;
   }
 
-  private void copy(Location location, Path target) throws IOException {
-    LOG.debug("Localize {} to {}", location, target);
-
-    try (InputStream is = location.getInputStream()) {
-      Files.copy(is, target, StandardCopyOption.REPLACE_EXISTING);
-    }
+  /**
+   * Return an {@link InputStream} for the given {@link HttpURLConnection} URL path that
+   * auto disconnects upon closing the {@link InputStream}
+   */
+  private InputStream getHttpURLConnectionInputStream(String urlPath) throws IOException {
+    HttpURLConnection conn = context.openHttpURLConnection(urlPath);
+    return new FilterInputStream(conn.getInputStream()) {
+      @Override
+      public void close() throws IOException {
+        try {
+          super.close();
+        } finally {
+          conn.disconnect();
+        }
+      }
+    };
   }
 
-  private Path expand(Location location, Path targetDir) throws IOException {
-    LOG.debug("Localize and expand {} to {}", location, targetDir);
+  private String fileDownloadURLPath(URI uri) {
+    return String.format("%s/%s", "v3Internal/location", uri.getPath());
+  }
 
-    try (ZipInputStream is = new ZipInputStream(location.getInputStream())) {
+  private void copy(URI uri, InputStream inputStream, Path target) throws IOException {
+    LOG.debug("Localize {} to {}", uri, target);
+
+    Files.copy(inputStream, target, StandardCopyOption.REPLACE_EXISTING);
+  }
+
+  private Path expand(URI uri, InputStream inputStream, Path targetDir) throws IOException {
+    LOG.debug("Localize and expand {} to {}", uri.toString(), targetDir);
+
+    try (ZipInputStream is = new ZipInputStream(inputStream)) {
       Path targetPath = Files.createDirectories(targetDir);
       ZipEntry entry;
       while ((entry = is.getNextEntry()) != null && !stopped) {
         Path outputPath = targetPath.resolve(entry.getName());
-
         if (entry.isDirectory()) {
           Files.createDirectories(outputPath);
         } else {


### PR DESCRIPTION
Why:
FileLocalizer is used to localizing files needed to run twill application in k8s env.
The file is most likely in an external distributed file system (e.g. GCS in GCP)
The pod to run twill application may or may not have permission to access distributed
file system. So this change switches the localization to downloading from AppFab
(essentially make AppFab proxy the file content to twill application pod)