### PR TITLE
Fail early and show better message for failed runs

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/AutoJoinerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/AutoJoinerTest.java
@@ -212,7 +212,7 @@ public class AutoJoinerTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     Map<String, String> args = Collections.singletonMap(MockAutoJoiner.PARTITIONS_ARGUMENT, "1");
-    workflowManager.startAndWaitForRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(output);
     List<StructuredRecord> actual = MockSink.readOutput(outputManager);
@@ -554,7 +554,7 @@ public class AutoJoinerTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     Map<String, String> args = Collections.singletonMap(MockAutoJoiner.PARTITIONS_ARGUMENT, "1");
-    workflowManager.startAndWaitForRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(output);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -631,7 +631,7 @@ public class AutoJoinerTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     Map<String, String> args = Collections.singletonMap(MockAutoJoiner.PARTITIONS_ARGUMENT, "1");
-    workflowManager.startAndWaitForRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(output);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -714,7 +714,7 @@ public class AutoJoinerTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     Map<String, String> args = Collections.singletonMap(MockAutoJoiner.PARTITIONS_ARGUMENT, "1");
-    workflowManager.startAndWaitForRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(output);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -1008,7 +1008,7 @@ public class AutoJoinerTest extends HydratorTestBase {
     MockSource.writeInput(inputManager, interestData);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(output);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -1145,7 +1145,7 @@ public class AutoJoinerTest extends HydratorTestBase {
     MockSource.writeInput(inputManager, attributesData);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(output);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -1326,7 +1326,7 @@ public class AutoJoinerTest extends HydratorTestBase {
     MockSource.writeInput(inputManager, records);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(output);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -1416,7 +1416,7 @@ public class AutoJoinerTest extends HydratorTestBase {
     MockSource.writeInput(inputManager, records);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(output);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -1531,7 +1531,7 @@ public class AutoJoinerTest extends HydratorTestBase {
     MockSource.writeInput(inputManager, records);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(output);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
@@ -1620,7 +1620,7 @@ public class AutoJoinerTest extends HydratorTestBase {
     runtimeArgs.put("required", joinerProperties.get(MockAutoJoiner.Conf.REQUIRED));
     runtimeArgs.put("select", joinerProperties.get(MockAutoJoiner.Conf.SELECT));
     runtimeArgs.put("schema", expectedSchema.toString());
-    workflowManager.startAndWaitForRun(runtimeArgs, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(runtimeArgs, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(output);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineConnectionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineConnectionTest.java
@@ -129,7 +129,7 @@ public class DataPipelineConnectionTest extends HydratorTestBase {
     appManager = getApplicationManager(pipeline);
     waitForAppToDeploy(appManager, pipeline);
     serviceManager = appManager.getServiceManager(io.cdap.cdap.etl.common.Constants.STUDIO_SERVICE_NAME);
-    serviceManager.startAndWaitForRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
+    serviceManager.startAndWaitForGoodRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
     serviceURI = serviceManager.getServiceURL(1, TimeUnit.MINUTES).toURI();
   }
 
@@ -326,7 +326,7 @@ public class DataPipelineConnectionTest extends HydratorTestBase {
     MockSource.writeInput(sourceTable, ImmutableList.of(samuel, dwayne));
 
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    manager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 3, TimeUnit.MINUTES);
+    manager.startAndWaitForGoodRun(ProgramRunStatus.COMPLETED, 3, TimeUnit.MINUTES);
 
     DataSetManager<Table> sinkTable = getDataset(sinkTableName);
     List<StructuredRecord> outputRecords = MockSink.readOutput(sinkTable);

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
@@ -111,7 +111,7 @@ public class DataPipelineServiceTest extends HydratorTestBase {
     appManager = getApplicationManager(pipeline);
     waitForAppToDeploy(appManager, pipeline);
     serviceManager = appManager.getServiceManager(io.cdap.cdap.etl.common.Constants.STUDIO_SERVICE_NAME);
-    serviceManager.startAndWaitForRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
+    serviceManager.startAndWaitForGoodRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
     serviceURI = serviceManager.getServiceURL(1, TimeUnit.MINUTES).toURI();
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
@@ -277,7 +277,7 @@ public class DataPipelineTest extends HydratorTestBase {
     ApplicationManager appManager = deployApplication(appId, appRequest);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     FieldLineageAdmin fieldAdmin = getFieldLineageAdmin();
 
@@ -373,7 +373,7 @@ public class DataPipelineTest extends HydratorTestBase {
     runtimeArgs.put("field", "name");
     runtimeArgs.put("value", "samuel");
     WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    manager.startAndWaitForRun(runtimeArgs, ProgramRunStatus.COMPLETED, 3, TimeUnit.MINUTES);
+    manager.startAndWaitForGoodRun(runtimeArgs, ProgramRunStatus.COMPLETED, 3, TimeUnit.MINUTES);
 
     DataSetManager<Table> sinkTable = getDataset(sinkName);
     List<StructuredRecord> outputRecords = MockSink.readOutput(sinkTable);
@@ -772,7 +772,7 @@ public class DataPipelineTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     Map<String, String> args = Collections.singletonMap(io.cdap.cdap.etl.common.Constants.CONSOLIDATE_STAGES, "true");
-    workflowManager.startAndWaitForRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
 
     Schema flattenSchema =
@@ -1958,7 +1958,7 @@ public class DataPipelineTest extends HydratorTestBase {
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
     Map<String, String> args = Collections.singletonMap(io.cdap.cdap.etl.common.Constants.CONSOLIDATE_STAGES, "true");
-    workflowManager.startAndWaitForRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     // sink1 should get records from source1 and source2
     Set<StructuredRecord> expected = ImmutableSet.of(recordSamuel, recordBob);
@@ -2451,7 +2451,7 @@ public class DataPipelineTest extends HydratorTestBase {
 
     Map<String, String> args = Collections.singletonMap(io.cdap.cdap.etl.common.Constants.CONSOLIDATE_STAGES, "true");
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     StructuredRecord joinRecordSamuel = StructuredRecord.builder(outSchema)
       .set("customer_id", "1").set("customer_name", "samuel")
@@ -2867,7 +2867,7 @@ public class DataPipelineTest extends HydratorTestBase {
 
     Map<String, String> args = Collections.singletonMap(io.cdap.cdap.etl.common.Constants.CONSOLIDATE_STAGES, "true");
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
     List<RunRecord> history = workflowManager.getHistory();
     // there should be only one completed run
     Assert.assertEquals(1, history.size());
@@ -3578,7 +3578,7 @@ public class DataPipelineTest extends HydratorTestBase {
     // run pipeline
     Map<String, String> args = Collections.singletonMap(io.cdap.cdap.etl.common.Constants.CONSOLIDATE_STAGES, "true");
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
 
     Schema errorSchema =

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/ReducibleAggregatorTestBase.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/ReducibleAggregatorTestBase.java
@@ -117,7 +117,7 @@ public class ReducibleAggregatorTestBase extends HydratorTestBase {
     MockSource.writeInput(inputManager, userData);
 
     WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
-    workflowManager.startAndWaitForRun(arguments, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    workflowManager.startAndWaitForGoodRun(arguments, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     DataSetManager<Table> outputManager = getDataset(output);
     List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/DataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/DataStreamsTest.java
@@ -1103,7 +1103,7 @@ public class DataStreamsTest extends HydratorTestBase {
 
     Map<String, String> args = Collections.singletonMap(io.cdap.cdap.etl.common.Constants.CONSOLIDATE_STAGES, "true");
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
-    sparkManager.startAndWaitForRun(args, ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
+    sparkManager.startAndWaitForGoodRun(args, ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     Schema flattenSchema =
       Schema.recordOf("erroruser",
@@ -1189,7 +1189,7 @@ public class DataStreamsTest extends HydratorTestBase {
     // run pipeline
     Map<String, String> args = Collections.singletonMap(io.cdap.cdap.etl.common.Constants.CONSOLIDATE_STAGES, "true");
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
-    sparkManager.startAndWaitForRun(args, ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
+    sparkManager.startAndWaitForGoodRun(args, ProgramRunStatus.RUNNING, 10, TimeUnit.SECONDS);
 
     // check output
     // sink1 should only have records where both name and email are null (user0)
@@ -1376,7 +1376,7 @@ public class DataStreamsTest extends HydratorTestBase {
     // run pipeline
     Map<String, String> args = Collections.singletonMap(io.cdap.cdap.etl.common.Constants.CONSOLIDATE_STAGES, "true");
     SparkManager sparkManager = appManager.getSparkManager(DataStreamsSparkLauncher.NAME);
-    sparkManager.startAndWaitForRun(args, ProgramRunStatus.RUNNING, 5, TimeUnit.MINUTES);
+    sparkManager.startAndWaitForGoodRun(args, ProgramRunStatus.RUNNING, 5, TimeUnit.MINUTES);
 
 
     Schema errorSchema =

--- a/cdap-system-app-unit-test/src/test/java/io/cdap/cdap/test/SystemAppTestBaseTest.java
+++ b/cdap-system-app-unit-test/src/test/java/io/cdap/cdap/test/SystemAppTestBaseTest.java
@@ -107,7 +107,7 @@ public class SystemAppTestBaseTest extends SystemAppTestBase {
     ApplicationManager applicationManager = deployApplication(NamespaceId.SYSTEM, SystemTestApp.class);
 
     ServiceManager serviceManager = applicationManager.getServiceManager(SystemTestApp.SERVICE_NAME);
-    serviceManager.startAndWaitForRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
+    serviceManager.startAndWaitForGoodRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
     URI serviceURI = serviceManager.getServiceURL(1, TimeUnit.MINUTES).toURI();
 
     String key = "k0";

--- a/cdap-test/src/main/java/io/cdap/cdap/test/ProgramManager.java
+++ b/cdap-test/src/main/java/io/cdap/cdap/test/ProgramManager.java
@@ -52,6 +52,20 @@ public interface ProgramManager<T extends ProgramManager> {
     throws InterruptedException, ExecutionException, TimeoutException;
 
   /**
+   * Starts the program and waits for one additional run of the specified status. This is essentially a
+   * call to {@link #start()} followed by a call to {@link #waitForRuns(ProgramRunStatus, int, long, TimeUnit)}.
+   * Fails early if run gets into status that's {@link ProgramRunStatus#isUnsuccessful()}.
+   * It should not be used if there is another run in progress.
+   *
+   * @param status the status of the run to wait for
+   * @param timeout amount of time units to wait
+   * @param timeoutUnit time unit type
+   * @return the program manager itself
+   */
+  T startAndWaitForGoodRun(ProgramRunStatus status, long timeout, TimeUnit timeoutUnit)
+    throws InterruptedException, ExecutionException, TimeoutException;
+
+  /**
    * Starts the program with arguments
    * @param arguments the arguments to start the program with
    * @return T the ProgramManager, itself
@@ -71,6 +85,23 @@ public interface ProgramManager<T extends ProgramManager> {
    * @return the program manager itself
    */
   T startAndWaitForRun(Map<String, String> arguments, ProgramRunStatus status, long timeout, TimeUnit timeoutUnit)
+    throws InterruptedException, ExecutionException, TimeoutException;
+
+  /**
+   * Starts the program with arguments and waits for one additional run of the specified status.
+   * Fails early if run gets into status that's {@link ProgramRunStatus#isUnsuccessful()}.
+   * This method assumes another run is not started by another thread. This is essentially a
+   * call to {@link #start(Map)} ()} followed by a call to {@link #waitForRuns(ProgramRunStatus, int, long, TimeUnit)}.
+   * It should not be used if there is another run in progress.
+   *
+   * @param arguments the arguments to start the program with
+   * @param status the status of the run to wait for
+   * @param timeout amount of time units to wait
+   * @param timeoutUnit time unit type
+   * @return the program manager itself
+   */
+  T startAndWaitForGoodRun(Map<String, String> arguments, ProgramRunStatus status, long timeout,
+                           TimeUnit timeoutUnit)
     throws InterruptedException, ExecutionException, TimeoutException;
 
   /**

--- a/cdap-unit-test-base/src/test/java/io/cdap/cdap/spark/Spark2Test.java
+++ b/cdap-unit-test-base/src/test/java/io/cdap/cdap/spark/Spark2Test.java
@@ -289,10 +289,10 @@ public class Spark2Test extends TestBase {
     }
 
     File outputDir = new File(TMP_FOLDER.newFolder(), "output");
-    appManager.getSparkManager(PythonSpark2.class.getSimpleName())
-      .startAndWaitForRun(ImmutableMap.of("input.file", inputFile.getAbsolutePath(),
-                                          "output.path", outputDir.getAbsolutePath()),
-                          ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
+    appManager.getSparkManager(PythonSpark2.class.getSimpleName()).startAndWaitForGoodRun(
+      ImmutableMap.of("input.file", inputFile.getAbsolutePath(),
+                      "output.path", outputDir.getAbsolutePath()),
+      ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
 
     // Verify the result
     File resultFile = DirUtils.listFiles(outputDir).stream()

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/service/DynamicPluginServiceTestRun.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/service/DynamicPluginServiceTestRun.java
@@ -74,7 +74,7 @@ public class DynamicPluginServiceTestRun extends TestFrameworkTestBase {
     AppRequest<Void> appRequest = new AppRequest<>(summary);
     ApplicationManager appManager = deployApplication(appId, appRequest);
     serviceManager = appManager.getServiceManager(DynamicPluginServiceApp.SERVICE_NAME);
-    serviceManager.startAndWaitForRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
+    serviceManager.startAndWaitForGoodRun(ProgramRunStatus.RUNNING, 2, TimeUnit.MINUTES);
 
     baseURI = serviceManager.getServiceURL(1, TimeUnit.MINUTES).toURI();
   }

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/spark/SparkTest.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/spark/SparkTest.java
@@ -136,7 +136,7 @@ public class SparkTest extends TestFrameworkTestBase {
     tableManager.flush();
 
     SparkManager sparkManager = appManager.getSparkManager(DatasetSQLSpark.class.getSimpleName());
-    sparkManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
+    sparkManager.startAndWaitForGoodRun(ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
 
     // The program executes "SELECT * FROM Person WHERE age > 10", hence expected two new entries for Bill and Berry.
     tableManager.flush();
@@ -159,7 +159,7 @@ public class SparkTest extends TestFrameworkTestBase {
 
     for (Class<?> sparkClass : Arrays.asList(TestSparkApp.ClassicSpark.class, TestSparkApp.ScalaClassicSpark.class)) {
       final SparkManager sparkManager = appManager.getSparkManager(sparkClass.getSimpleName());
-      sparkManager.startAndWaitForRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+      sparkManager.startAndWaitForGoodRun(ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
     }
 
     KeyValueTable resultTable = this.<KeyValueTable>getDataset("ResultTable").get();
@@ -181,10 +181,10 @@ public class SparkTest extends TestFrameworkTestBase {
     }
 
     SparkManager sparkManager = appManager.getSparkManager(ScalaDynamicSpark.class.getSimpleName());
-    sparkManager.startAndWaitForRun(ImmutableMap.of("input", inputFile.getAbsolutePath(),
-                                                    "output", "ResultTable",
-                                                    "tmpdir", TMP_FOLDER.newFolder().getAbsolutePath()),
-                                    ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+    sparkManager.startAndWaitForGoodRun(ImmutableMap.of("input", inputFile.getAbsolutePath(),
+                                                        "output", "ResultTable",
+                                                        "tmpdir", TMP_FOLDER.newFolder().getAbsolutePath()),
+                                        ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
 
     // Validate the result written to dataset
     KeyValueTable resultTable = this.<KeyValueTable>getDataset("ResultTable").get();
@@ -210,10 +210,10 @@ public class SparkTest extends TestFrameworkTestBase {
     }
 
     File outputDir = new File(TMP_FOLDER.newFolder(), "output");
-    appManager.getSparkManager(PythonSpark.class.getSimpleName())
-      .startAndWaitForRun(ImmutableMap.of("input.file", inputFile.getAbsolutePath(),
-                                          "output.path", outputDir.getAbsolutePath()),
-                          ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
+    appManager.getSparkManager(PythonSpark.class.getSimpleName()).startAndWaitForGoodRun(
+      ImmutableMap.of("input.file", inputFile.getAbsolutePath(),
+                      "output.path", outputDir.getAbsolutePath()),
+      ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
 
     // Verify the result
     File resultFile = Iterables.find(DirUtils.listFiles(outputDir), input ->
@@ -433,7 +433,7 @@ public class SparkTest extends TestFrameworkTestBase {
     args.put("output", "logStats");
 
     SparkManager sparkManager = applicationManager.getSparkManager(sparkProgram);
-    sparkManager.startAndWaitForRun(args, ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
+    sparkManager.startAndWaitForGoodRun(args, ProgramRunStatus.COMPLETED, 2, TimeUnit.MINUTES);
 
     DataSetManager<KeyValueTable> logStatsManager = getDataset("logStats");
     KeyValueTable logStatsTable = logStatsManager.get();


### PR DESCRIPTION
It will fail fast if run moved to bad status (e.g. FAILED) instead of waiting for timeout and will report the final status