### PR TITLE
Refactor classLoader logic to accept already unpacked directory

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -34,7 +34,6 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
-import com.google.inject.util.Providers;
 import io.cdap.cdap.app.deploy.Configurator;
 import io.cdap.cdap.app.deploy.Manager;
 import io.cdap.cdap.app.deploy.ManagerFactory;
@@ -107,7 +106,6 @@ import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
 import io.cdap.cdap.internal.app.services.RunRecordCorrectorService;
 import io.cdap.cdap.internal.app.services.ScheduledRunRecordCorrectorService;
 import io.cdap.cdap.internal.app.store.DefaultStore;
-import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
 import io.cdap.cdap.internal.bootstrap.guice.BootstrapModules;
 import io.cdap.cdap.internal.capability.CapabilityModule;
 import io.cdap.cdap.internal.pipeline.SynchronousPipelineFactory;
@@ -294,7 +292,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
     @Override
     protected void configure() {
-      bind(ArtifactLocalizerClient.class).toProvider(Providers.of(null));
       bind(PipelineFactory.class).to(SynchronousPipelineFactory.class);
 
       bind(PluginFinder.class).to(LocalPluginFinder.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTask.java
@@ -29,7 +29,7 @@ import io.cdap.cdap.app.deploy.ConfigResponse;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
-import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.deploy.InMemoryConfigurator;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
@@ -37,6 +37,7 @@ import io.cdap.cdap.internal.app.runtime.artifact.ApplicationClassCodec;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.RequirementsCodec;
+import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import org.apache.twill.filesystem.Location;
@@ -86,24 +87,25 @@ public class ConfiguratorTask implements RunnableTask {
     private final PluginFinder pluginFinder;
     private final ArtifactRepository artifactRepository;
     private final CConfiguration cConf;
+    private final ArtifactLocalizerClient artifactLocalizerClient;
 
     @Inject
     ConfiguratorTaskRunner(Impersonator impersonator, PluginFinder pluginFinder,
-                           ArtifactRepository artifactRepository, CConfiguration cConf) {
+                           ArtifactRepository artifactRepository, CConfiguration cConf,
+                           ArtifactLocalizerClient artifactLocalizerClient) {
       this.impersonator = impersonator;
       this.pluginFinder = pluginFinder;
       this.artifactRepository = artifactRepository;
       this.cConf = cConf;
+      this.artifactLocalizerClient = artifactLocalizerClient;
     }
 
     public ConfigResponse configure(AppDeploymentInfo info) throws Exception {
       // Getting the pipeline app from appfabric
       LOG.debug("Fetching artifact '{}' from app-fabric to create artifact class loader.", info.getArtifactId());
 
-      Location artifactLocation = artifactRepository
-        .getArtifact(Id.Artifact.fromEntityId(info.getArtifactId()))
-        .getDescriptor()
-        .getLocation();
+      Location artifactLocation = Locations
+        .toLocation(artifactLocalizerClient.getUnpackedArtifactLocation(info.getArtifactId()));
 
       // Creates a new deployment info with the newly fetched artifact
       AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(info, artifactLocation);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
@@ -145,7 +145,7 @@ public class ArtifactLocalizer {
       }
       File tempUnpackDir = DirUtils.createTempDir(unpackDir.getParentFile());
       try {
-        BundleJarUtil.unJar(jarLocation, tempUnpackDir);
+        BundleJarUtil.prepareClassLoaderFolder(jarLocation, tempUnpackDir);
         Files.move(tempUnpackDir.toPath(), unpackDir.toPath(), StandardCopyOption.ATOMIC_MOVE,
                    StandardCopyOption.REPLACE_EXISTING);
       } finally {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerHttpHandlerInternal.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.internal.app.worker.sidecar;
 
-import avro.shaded.com.google.common.annotations.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Singleton;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.proto.id.ArtifactId;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
@@ -112,8 +112,7 @@ public class RemoteConfiguratorTest {
     remoteClientFactory = new RemoteClientFactory(discoveryService, new AuthenticationTestContext());
     httpService = new CommonNettyHttpServiceBuilder(cConf, "test")
       .setHttpHandlers(
-        new TaskWorkerHttpHandlerInternal(cConf, className -> {
-        }),
+        new TaskWorkerHttpHandlerInternal(cConf, className -> { }),
         new ArtifactHttpHandlerInternal(new TestArtifactRepository(cConf), namespaceAdmin),
         new ArtifactLocalizerHttpHandlerInternal(new ArtifactLocalizer(cConf, remoteClientFactory))
       )


### PR DESCRIPTION
Currently the logic for creating a class loader will always unpack the source JAR before proceeding. This is causing performance issues when running in the worker pod because we cannot leverage the caching logic that was introduced in #13454 . 

This change allows the BundleJarUtil library to accept an already unpacked directory as the input. If a local directory is passed, it will create hard-links from the input to the temporary destination directory. This avoids the need to unpack and copy any artifacts. And once the classLoader is closed it will delete the hard-links and leave the cache unaffected. 