### PR TITLE
Upgrade netty-http library to 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
     <mockftp.version>2.6</mockftp.version>
     <mockito.version>1.9.5</mockito.version>
     <mysql.version>5.1.21</mysql.version>
-    <netty.http.version>1.5.0</netty.http.version>
+    <netty.http.version>1.6.0</netty.http.version>
     <netty.version>4.1.16.Final</netty.version>
     <powermock.version>1.5.6</powermock.version>
     <quartz.version>2.2.0</quartz.version>


### PR DESCRIPTION
- This is to incorporate the executor thread model change to make sure SecurityRequestContext is always set to the correct thread