### PR TITLE
CDAP-18073 let system app able to list namespaces

### DIFF
--- a/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/http/SystemHttpServiceContext.java
+++ b/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/http/SystemHttpServiceContext.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.api.service.http;
 
+import io.cdap.cdap.api.NamespaceSummary;
 import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.api.macro.InvalidMacroException;
 import io.cdap.cdap.api.macro.MacroEvaluator;
@@ -25,6 +26,7 @@ import io.cdap.cdap.api.service.worker.RunnableTaskRequest;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -97,4 +99,9 @@ public interface SystemHttpServiceContext extends HttpServiceContext, Transactio
    * @return
    */
   boolean isRemoteTaskEnabled();
+
+  /**
+   * List all the namespaces
+   */
+  List<NamespaceSummary> listNamespaces() throws Exception;
 }


### PR DESCRIPTION
This will allow the upgrade process in system app much easier since: 
1. we can always get the latest namespace information with generation id, so we can ignore the old generations and non-existing namespaces. 
2. most stores supporting listing by namespaces. Adding these can avoid a full scan on the keys to avoid OOM

