### PR TITLE
CDAP-17772: Introduce a way to pass around internal authorization token.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/services/AbstractServiceDiscoverer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/services/AbstractServiceDiscoverer.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.ServiceDiscoverer;
 import io.cdap.cdap.common.ServiceUnavailableException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.service.ServiceDiscoverable;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramId;
@@ -86,9 +87,9 @@ public abstract class AbstractServiceDiscoverer implements ServiceDiscoverer {
   }
 
   /**
-   * @return the {@link DiscoveryServiceClient} for Service Discovery
+   * @return the {@link RemoteClientFactory}
    */
-  protected abstract DiscoveryServiceClient getDiscoveryServiceClient();
+  protected abstract RemoteClientFactory getRemoteClientFactory();
 
   /**
    * Creates a {@link RemoteClient} for connecting to the given service endpoint.
@@ -102,6 +103,6 @@ public abstract class AbstractServiceDiscoverer implements ServiceDiscoverer {
     String discoveryName = ServiceDiscoverable.getName(namespaceId, applicationId, ProgramType.SERVICE, serviceId);
     String basePath = String.format("%s/namespaces/%s/apps/%s/services/%s/methods/",
                                     Constants.Gateway.API_VERSION_3_TOKEN, namespaceId, applicationId, serviceId);
-    return new RemoteClient(getDiscoveryServiceClient(), discoveryName, HttpRequestConfig.DEFAULT, basePath);
+    return getRemoteClientFactory().createRemoteClient(discoveryName, HttpRequestConfig.DEFAULT, basePath);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/RemoteTaskExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/RemoteTaskExecutor.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.service.Retries;
 import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.common.service.RetryStrategy;
@@ -48,10 +49,10 @@ public class RemoteTaskExecutor {
   private final RemoteClient remoteClient;
   private final RetryStrategy retryStrategy;
 
-  public RemoteTaskExecutor(CConfiguration cConf, DiscoveryServiceClient discoveryServiceClient) {
-    this.remoteClient = new RemoteClient(discoveryServiceClient, Constants.Service.TASK_WORKER,
-                                         new DefaultHttpRequestConfig(false),
-                                         Constants.Gateway.INTERNAL_API_VERSION_3);
+  public RemoteTaskExecutor(CConfiguration cConf, RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(Constants.Service.TASK_WORKER,
+                                                               new DefaultHttpRequestConfig(false),
+                                                               Constants.Gateway.INTERNAL_API_VERSION_3);
     this.retryStrategy = RetryStrategies.fromConfiguration(cConf, Constants.Service.TASK_WORKER + ".");
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteConfigurator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteConfigurator.java
@@ -27,13 +27,13 @@ import io.cdap.cdap.api.service.worker.RunnableTaskRequest;
 import io.cdap.cdap.app.deploy.ConfigResponse;
 import io.cdap.cdap.app.deploy.Configurator;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.app.RemoteTaskExecutor;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import io.cdap.cdap.internal.app.runtime.artifact.ApplicationClassCodec;
 import io.cdap.cdap.internal.app.runtime.artifact.RequirementsCodec;
 import io.cdap.cdap.internal.app.worker.ConfiguratorTask;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.nio.charset.StandardCharsets;
 
@@ -52,10 +52,11 @@ public class RemoteConfigurator implements Configurator {
   private final RemoteTaskExecutor remoteTaskExecutor;
 
   @Inject
-  public RemoteConfigurator(CConfiguration cConf, DiscoveryServiceClient discoveryServiceClient,
-                            @Assisted AppDeploymentInfo deploymentInfo) {
+  public RemoteConfigurator(CConfiguration cConf,
+                            @Assisted AppDeploymentInfo deploymentInfo,
+                            RemoteClientFactory remoteClientFactory) {
     this.deploymentInfo = deploymentInfo;
-    this.remoteTaskExecutor = new RemoteTaskExecutor(cConf, discoveryServiceClient);
+    this.remoteTaskExecutor = new RemoteTaskExecutor(cConf, remoteClientFactory);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/RemotePreviewRequestFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/RemotePreviewRequestFetcher.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.app.preview.PreviewRequest;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
@@ -43,11 +44,12 @@ public class RemotePreviewRequestFetcher implements PreviewRequestFetcher {
   private final PreviewRequestPollerInfoProvider pollerInfoProvider;
 
   @Inject
-  RemotePreviewRequestFetcher(DiscoveryServiceClient discoveryServiceClient,
-                              PreviewRequestPollerInfoProvider pollerInfoProvider) {
-    this.remoteClientInternal = new RemoteClient(discoveryServiceClient, Constants.Service.PREVIEW_HTTP,
-                                                 new DefaultHttpRequestConfig(false),
-                                                 Constants.Gateway.INTERNAL_API_VERSION_3 + "/previews");
+  RemotePreviewRequestFetcher(PreviewRequestPollerInfoProvider pollerInfoProvider,
+                              RemoteClientFactory remoteClientFactory) {
+    this.remoteClientInternal = remoteClientFactory.createRemoteClient(
+      Constants.Service.PREVIEW_HTTP,
+      new DefaultHttpRequestConfig(false),
+      Constants.Gateway.INTERNAL_API_VERSION_3 + "/previews");
     this.pollerInfoProvider = pollerInfoProvider;
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepositoryReader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepositoryReader.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.gateway.handlers.AppLifecycleHttpHandler;
 import io.cdap.cdap.gateway.handlers.ArtifactHttpHandlerInternal;
@@ -67,10 +68,10 @@ public class RemoteArtifactRepositoryReader implements ArtifactRepositoryReader 
   private final LocationFactory locationFactory;
 
   @Inject
-  public RemoteArtifactRepositoryReader(DiscoveryServiceClient discoveryClient,
-                                        LocationFactory locationFactory) {
-    this.remoteClient = new RemoteClient(
-      discoveryClient, Constants.Service.APP_FABRIC_HTTP,
+  public RemoteArtifactRepositoryReader(LocationFactory locationFactory,
+                                        RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.APP_FABRIC_HTTP,
       new DefaultHttpRequestConfig(false), Constants.Gateway.INTERNAL_API_VERSION_3);
     this.locationFactory = locationFactory;
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.api.security.store.SecureStoreManager;
 import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.lang.WeakReferenceDelegatorClassLoader;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
@@ -103,11 +104,11 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
                         MessagingService messagingService, MetadataReader metadataReader,
                         MetadataPublisher metadataPublisher,
                         NamespaceQueryAdmin namespaceQueryAdmin,
-                        FieldLineageWriter fieldLineageWriter) {
-    super(program, programOptions, cConf, spec.getDataSets(), dsFramework, txClient, discoveryServiceClient, false,
+                        FieldLineageWriter fieldLineageWriter, RemoteClientFactory remoteClientFactory) {
+    super(program, programOptions, cConf, spec.getDataSets(), dsFramework, txClient, false,
           metricsCollectionService, createMetricsTags(workflowProgramInfo), secureStore, secureStoreManager,
           messagingService, pluginInstantiator, metadataReader, metadataPublisher, namespaceQueryAdmin,
-          fieldLineageWriter);
+          fieldLineageWriter, remoteClientFactory);
 
     this.workflowProgramInfo = workflowProgramInfo;
     this.spec = spec;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -48,6 +48,7 @@ import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.lang.WeakReferenceDelegatorClassLoader;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
@@ -142,12 +143,13 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
                             AuthenticationContext authenticationContext,
                             MessagingService messagingService, MapReduceClassLoader mapReduceClassLoader,
                             MetadataReader metadataReader, MetadataPublisher metadataPublisher,
-                            NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter) {
-    super(program, programOptions, cConf, ImmutableSet.of(), dsFramework, txClient, discoveryServiceClient,
+                            NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter,
+                            RemoteClientFactory remoteClientFactory) {
+    super(program, programOptions, cConf, ImmutableSet.of(), dsFramework, txClient,
           true, metricsCollectionService, createMetricsTags(programOptions,
                                                             taskId, type, workflowProgramInfo), secureStore,
           secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin, fieldLineageWriter);
+          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
     this.cConf = cConf;
     this.workflowProgramInfo = workflowProgramInfo;
     this.transaction = transaction;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -36,6 +36,7 @@ import io.cdap.cdap.app.runtime.ProgramController;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.lang.InstantiatorFactory;
 import io.cdap.cdap.common.lang.PropertyFieldSetter;
 import io.cdap.cdap.common.logging.LoggingContextAccessor;
@@ -95,6 +96,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final FieldLineageWriter fieldLineageWriter;
   private final MetadataPublisher metadataPublisher;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final RemoteClientFactory remoteClientFactory;
 
   @Inject
   public MapReduceProgramRunner(Injector injector, CConfiguration cConf, Configuration hConf,
@@ -106,7 +108,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                 SecureStore secureStore, SecureStoreManager secureStoreManager,
                                 MessagingService messagingService, MetadataReader metadataReader,
                                 MetadataPublisher metadataPublisher, FieldLineageWriter fieldLineageWriter,
-                                NamespaceQueryAdmin namespaceQueryAdmin) {
+                                NamespaceQueryAdmin namespaceQueryAdmin, RemoteClientFactory remoteClientFactory) {
     super(cConf);
     this.injector = injector;
     this.cConf = cConf;
@@ -123,6 +125,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.metadataPublisher = metadataPublisher;
     this.fieldLineageWriter = fieldLineageWriter;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.remoteClientFactory = remoteClientFactory;
   }
 
   @Override
@@ -173,7 +176,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                   metricsCollectionService, txSystemClient, programDatasetFramework,
                                   getPluginArchive(options), pluginInstantiator, secureStore, secureStoreManager,
                                   messagingService, metadataReader, metadataPublisher, namespaceQueryAdmin,
-                                  fieldLineageWriter);
+                                  fieldLineageWriter, remoteClientFactory);
       closeables.add(context);
 
       Reflections.visit(mapReduce, mapReduce.getClass(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data.ProgramContextAware;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
@@ -179,6 +180,7 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
     MetadataReader metadataReader = injector.getInstance(MetadataReader.class);
     MetadataPublisher metadataPublisher = injector.getInstance(MetadataPublisher.class);
     FieldLineageWriter fieldLineageWriter = injector.getInstance(FieldLineageWriter.class);
+    RemoteClientFactory remoteClientFactory = injector.getInstance(RemoteClientFactory.class);
 
     return new CacheLoader<ContextCacheKey, BasicMapReduceTaskContext>() {
       @Override
@@ -251,8 +253,8 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
           transaction, programDatasetFramework, classLoader.getPluginInstantiator(),
           contextConfig.getLocalizedResources(), secureStore, secureStoreManager,
           accessEnforcer, authenticationContext, messagingService, mapReduceClassLoader, metadataReader,
-          metadataPublisher, namespaceQueryAdmin, fieldLineageWriter
-        );
+          metadataPublisher, namespaceQueryAdmin, fieldLineageWriter,
+          remoteClientFactory);
       }
     };
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.api.workflow.WorkflowToken;
 import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
@@ -60,13 +61,13 @@ public class BasicCustomActionContext extends AbstractContext implements CustomA
                                   SecureStore secureStore, SecureStoreManager secureStoreManager,
                                   MessagingService messagingService, MetadataReader metadataReader,
                                   MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin,
-                                  FieldLineageWriter fieldLineageWriter) {
+                                  FieldLineageWriter fieldLineageWriter, RemoteClientFactory remoteClientFactory) {
 
     super(workflow, programOptions, cConf, customActionSpecification.getDatasets(),
-          datasetFramework, txClient, discoveryServiceClient, false,
+          datasetFramework, txClient, false,
           metricsCollectionService, workflowProgramInfo.updateMetricsTags(new HashMap<>()), secureStore,
           secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin, fieldLineageWriter);
+          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
 
     this.customActionSpecification = customActionSpecification;
     this.workflowProgramInfo = workflowProgramInfo;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClient.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClient.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.TopicId;
@@ -60,11 +61,12 @@ public class RuntimeClient {
   private final RemoteClient remoteClient;
 
   @Inject
-  public RuntimeClient(CConfiguration cConf, DiscoveryServiceClient discoveryClient) {
+  public RuntimeClient(CConfiguration cConf, RemoteClientFactory remoteClientFactory) {
     this.compression = cConf.getBoolean(Constants.RuntimeMonitor.COMPRESSION_ENABLED);
-    this.remoteClient = new RemoteClient(discoveryClient, Constants.Service.RUNTIME,
-                                         new DefaultHttpRequestConfig(false),
-                                         Constants.Gateway.INTERNAL_API_VERSION_3 + "/runtime/namespaces/");
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.RUNTIME,
+      new DefaultHttpRequestConfig(false),
+      Constants.Gateway.INTERNAL_API_VERSION_3 + "/runtime/namespaces/");
 
     // Validate the schema is what as expected by the logic of this client.
     // This is to make sure unit test will fail if schema is changed without changing the logic in this class.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.app.runtime.ProgramController;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.app.runtime.ProgramRunner;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.common.service.RetryStrategy;
 import io.cdap.cdap.data.ProgramContextAware;
@@ -83,6 +84,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final FieldLineageWriter fieldLineageWriter;
   private final TransactionRunner transactionRunner;
   private final PreferencesFetcher preferencesFetcher;
+  private final RemoteClientFactory remoteClientFactory;
   private final ContextAccessEnforcer contextAccessEnforcer;
 
   @Inject
@@ -95,7 +97,8 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                               MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                               NamespaceQueryAdmin namespaceQueryAdmin, PluginFinder pluginFinder,
                               FieldLineageWriter fieldLineageWriter, TransactionRunner transactionRunner,
-                              PreferencesFetcher preferencesFetcher, ContextAccessEnforcer contextAccessEnforcer) {
+                              PreferencesFetcher preferencesFetcher, RemoteClientFactory remoteClientFactory,
+                              ContextAccessEnforcer contextAccessEnforcer) {
     super(cConf);
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
@@ -113,6 +116,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.fieldLineageWriter = fieldLineageWriter;
     this.transactionRunner = transactionRunner;
     this.preferencesFetcher = preferencesFetcher;
+    this.remoteClientFactory = remoteClientFactory;
     this.contextAccessEnforcer = contextAccessEnforcer;
   }
 
@@ -157,7 +161,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           messagingService, artifactManager, metadataReader,
                                                           metadataPublisher, namespaceQueryAdmin, pluginFinder,
                                                           fieldLineageWriter, transactionRunner, preferencesFetcher,
-                                                          contextAccessEnforcer);
+                                                          remoteClientFactory, contextAccessEnforcer);
 
       // Add a service listener to make sure the plugin instantiator is closed when the http server is finished.
       component.addListener(createRuntimeServiceListener(Collections.singleton(pluginInstantiator)),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -31,12 +31,12 @@ import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
-import io.cdap.cdap.internal.app.DefaultPluginConfigurer;
 import io.cdap.cdap.internal.app.DefaultServicePluginConfigurer;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
 import io.cdap.cdap.internal.app.runtime.ProgramRunners;
@@ -85,7 +85,7 @@ public class BasicHttpServiceContext extends AbstractContext implements HttpServ
    * @param programOptions program options for the program execution context
    * @param cConf the CDAP configuration
    * @param spec spec of the service handler of this context. If {@code null} is provided, this context
-   *             is not associated with any service handler (e.g. for the http server itself).
+*             is not associated with any service handler (e.g. for the http server itself).
    * @param instanceId instanceId of the component.
    * @param instanceCount total number of instances of the component.
    * @param metricsCollectionService metricsCollectionService to use for emitting metrics.
@@ -102,6 +102,7 @@ public class BasicHttpServiceContext extends AbstractContext implements HttpServ
    * @param namespaceQueryAdmin the {@link NamespaceQueryAdmin} for querying namespace information
    * @param pluginFinder the {@link PluginFinder} for plugin discovery
    * @param fieldLineageWriter the {@link FieldLineageWriter} for writing out field level lineage
+   * @param remoteClientFactory
    */
   public BasicHttpServiceContext(Program program, ProgramOptions programOptions, CConfiguration cConf,
                                  @Nullable HttpServiceHandlerSpecification spec,
@@ -115,12 +116,12 @@ public class BasicHttpServiceContext extends AbstractContext implements HttpServ
                                  MetadataPublisher metadataPublisher,
                                  NamespaceQueryAdmin namespaceQueryAdmin,
                                  PluginFinder pluginFinder,
-                                 FieldLineageWriter fieldLineageWriter) {
+                                 FieldLineageWriter fieldLineageWriter, RemoteClientFactory remoteClientFactory) {
     super(program, programOptions, cConf, spec == null ? Collections.emptySet() : spec.getDatasets(),
-          dsFramework, txClient, discoveryServiceClient, false,
+          dsFramework, txClient, false,
           metricsCollectionService, createMetricsTags(spec, instanceId),
           secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin, fieldLineageWriter);
+          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
     this.cConf = cConf;
     this.artifactId = ProgramRunners.getArtifactId(programOptions);
     this.spec = spec;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicSystemHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicSystemHttpServiceContext.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.common.service.Retries;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
@@ -97,18 +98,19 @@ public class BasicSystemHttpServiceContext extends BasicHttpServiceContext imple
                                        MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                                        NamespaceQueryAdmin namespaceQueryAdmin, PluginFinder pluginFinder,
                                        FieldLineageWriter fieldLineageWriter, TransactionRunner transactionRunner,
-                                       PreferencesFetcher preferencesFetcher,
+                                       PreferencesFetcher preferencesFetcher, RemoteClientFactory remoteClientFactory,
                                        ContextAccessEnforcer contextAccessEnforcer) {
     super(program, programOptions, cConf, spec, instanceId, instanceCount, metricsCollectionService, dsFramework,
           discoveryServiceClient, txClient, pluginInstantiator, secureStore, secureStoreManager, messagingService,
-          artifactManager, metadataReader, metadataPublisher, namespaceQueryAdmin, pluginFinder, fieldLineageWriter);
+          artifactManager, metadataReader, metadataPublisher, namespaceQueryAdmin, pluginFinder, fieldLineageWriter,
+          remoteClientFactory);
 
     this.namespaceId = program.getId().getNamespaceId();
     this.transactionRunner = transactionRunner;
     this.preferencesFetcher = preferencesFetcher;
     this.cConf = cConf;
     this.contextAccessEnforcer = contextAccessEnforcer;
-    this.remoteTaskExecutor = new RemoteTaskExecutor(cConf, discoveryServiceClient);
+    this.remoteTaskExecutor = new RemoteTaskExecutor(cConf, remoteClientFactory);
     this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
@@ -59,12 +60,13 @@ final class BasicWorkerContext extends AbstractContext implements WorkerContext 
                      SecureStoreManager secureStoreManager,
                      MessagingService messagingService, MetadataReader metadataReader,
                      MetadataPublisher metadataPublisher,
-                     NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter) {
+                     NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter,
+                     RemoteClientFactory remoteClientFactory) {
     super(program, programOptions, cConf, spec.getDatasets(),
-          datasetFramework, transactionSystemClient, discoveryServiceClient, true,
+          datasetFramework, transactionSystemClient, true,
           metricsCollectionService, ImmutableMap.of(Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId)),
           secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin, fieldLineageWriter);
+          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
 
     this.specification = spec;
     this.instanceId = instanceId;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.app.runtime.ProgramController;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.app.runtime.ProgramRunner;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data.ProgramContextAware;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
@@ -70,6 +71,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final MetadataPublisher metadataPublisher;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final FieldLineageWriter fieldLineageWriter;
+  private final RemoteClientFactory remoteClientFactory;
 
   @Inject
   public WorkerProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
@@ -78,7 +80,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
                              SecureStore secureStore, SecureStoreManager secureStoreManager,
                              MessagingService messagingService, MetadataReader metadataReader,
                              MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin,
-                             FieldLineageWriter fieldLineageWriter) {
+                             FieldLineageWriter fieldLineageWriter, RemoteClientFactory remoteClientFactory) {
     super(cConf);
     this.cConf = cConf;
     this.metricsCollectionService = metricsCollectionService;
@@ -92,6 +94,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.metadataPublisher = metadataPublisher;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.fieldLineageWriter = fieldLineageWriter;
+    this.remoteClientFactory = remoteClientFactory;
   }
 
   @Override
@@ -135,7 +138,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           discoveryServiceClient,
                                                           pluginInstantiator, secureStore, secureStoreManager,
                                                           messagingService, metadataReader, metadataPublisher,
-                                                          namespaceQueryAdmin, fieldLineageWriter);
+                                                          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
 
       WorkerDriver worker = new WorkerDriver(program, newWorkerSpec, context);
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
@@ -68,13 +69,14 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
                        SecureStore secureStore, SecureStoreManager secureStoreManager,
                        MessagingService messagingService, @Nullable ConditionSpecification conditionSpecification,
                        MetadataReader metadataReader, MetadataPublisher metadataPublisher,
-                       NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter) {
+                       NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter,
+                       RemoteClientFactory remoteClientFactory) {
     super(program, programOptions, cConf, new HashSet<>(),
-          datasetFramework, txClient, discoveryServiceClient, false,
+          datasetFramework, txClient, false,
           metricsCollectionService, Collections.singletonMap(Constants.Metrics.Tag.WORKFLOW_RUN_ID,
                                                              ProgramRunners.getRunId(programOptions).getId()),
           secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin, fieldLineageWriter);
+          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
     this.workflowSpec = workflowSpec;
     this.conditionSpecification = conditionSpecification;
     this.token = token;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -57,6 +57,7 @@ import io.cdap.cdap.app.runtime.ProgramRunnerFactory;
 import io.cdap.cdap.app.runtime.ProgramStateWriter;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.lang.Exceptions;
 import io.cdap.cdap.common.lang.InstantiatorFactory;
 import io.cdap.cdap.common.lang.PropertyFieldSetter;
@@ -145,6 +146,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
   private final MetadataPublisher metadataPublisher;
   private final FieldLineageWriter fieldLineageWriter;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final RemoteClientFactory remoteClientFactory;
 
   private volatile Thread runningThread;
   private boolean suspended;
@@ -159,7 +161,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                  SecureStoreManager secureStoreManager, MessagingService messagingService,
                  ProgramStateWriter programStateWriter, MetadataReader metadataReader,
                  MetadataPublisher metadataPublisher, FieldLineageWriter fieldLineageWriter,
-                 NamespaceQueryAdmin namespaceQueryAdmin) {
+                 NamespaceQueryAdmin namespaceQueryAdmin, RemoteClientFactory remoteClientFactory) {
     this.program = program;
     this.programOptions = options;
     this.workflowSpec = workflowSpec;
@@ -184,7 +186,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                                                     discoveryServiceClient, nodeStates, pluginInstantiator,
                                                     secureStore, secureStoreManager, messagingService, null,
                                                     metadataReader, metadataPublisher, namespaceQueryAdmin,
-                                                    fieldLineageWriter);
+                                                    fieldLineageWriter, remoteClientFactory);
     this.pluginInstantiator = pluginInstantiator;
     this.secureStore = secureStore;
     this.secureStoreManager = secureStoreManager;
@@ -193,6 +195,7 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
     this.metadataPublisher = metadataPublisher;
     this.fieldLineageWriter = fieldLineageWriter;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.remoteClientFactory = remoteClientFactory;
   }
 
   @Override
@@ -422,7 +425,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                                                                     pluginInstantiator, secureStore,
                                                                     secureStoreManager, messagingService,
                                                                     metadataReader, metadataPublisher,
-                                                                    namespaceQueryAdmin, fieldLineageWriter);
+                                                                    namespaceQueryAdmin, fieldLineageWriter,
+                                                                    remoteClientFactory);
     customActionExecutor = new CustomActionExecutor(context, instantiator, classLoader);
     status.put(node.getNodeId(), node);
     workflowStateWriter.addWorkflowNodeState(workflowRunId,
@@ -493,7 +497,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
                                                                   pluginInstantiator, secureStore, secureStoreManager,
                                                                   messagingService, node.getConditionSpecification(),
                                                                   metadataReader, metadataPublisher,
-                                                                  namespaceQueryAdmin, fieldLineageWriter);
+                                                                  namespaceQueryAdmin, fieldLineageWriter,
+                                                                  remoteClientFactory);
     final Iterator<WorkflowNode> iterator;
     Class<?> clz = classLoader.loadClass(node.getPredicateClassName());
     Predicate<WorkflowContext> predicate = instantiator.get(

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.app.runtime.ProgramRunner;
 import io.cdap.cdap.app.runtime.ProgramRunnerFactory;
 import io.cdap.cdap.app.runtime.ProgramStateWriter;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data.ProgramContextAware;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
@@ -73,6 +74,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final MetadataPublisher metadataPublisher;
   private final FieldLineageWriter fieldLineageWriter;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final RemoteClientFactory remoteClientFactory;
 
   @Inject
   public WorkflowProgramRunner(ProgramRunnerFactory programRunnerFactory,
@@ -82,7 +84,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
                                SecureStoreManager secureStoreManager, MessagingService messagingService,
                                ProgramStateWriter programStateWriter, MetadataReader metadataReader,
                                MetadataPublisher metadataPublisher, FieldLineageWriter fieldLineageWriter,
-                               NamespaceQueryAdmin namespaceQueryAdmin) {
+                               NamespaceQueryAdmin namespaceQueryAdmin, RemoteClientFactory remoteClientFactory) {
     super(cConf);
     this.programRunnerFactory = programRunnerFactory;
     this.metricsCollectionService = metricsCollectionService;
@@ -99,6 +101,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.metadataPublisher = metadataPublisher;
     this.fieldLineageWriter = fieldLineageWriter;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.remoteClientFactory = remoteClientFactory;
   }
 
   @Override
@@ -135,7 +138,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                  txClient, workflowStateWriter, cConf, pluginInstantiator,
                                                  secureStore, secureStoreManager, messagingService,
                                                  programStateWriter, metadataReader, metadataPublisher,
-                                                 fieldLineageWriter, namespaceQueryAdmin);
+                                                 fieldLineageWriter, namespaceQueryAdmin, remoteClientFactory);
 
       // Controller needs to be created before starting the driver so that the state change of the driver
       // service can be fully captured by the controller.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ServiceHttpServer.java
@@ -38,6 +38,7 @@ import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.http.AuthenticationChannelHandler;
 import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.lang.InstantiatorFactory;
 import io.cdap.cdap.common.lang.PropertyFieldSetter;
 import io.cdap.cdap.common.logging.LoggingContext;
@@ -96,7 +97,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                            MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin,
                            PluginFinder pluginFinder, FieldLineageWriter fieldLineageWriter,
                            TransactionRunner transactionRunner, PreferencesFetcher preferencesFetcher,
-                           ContextAccessEnforcer contextAccessEnforcer) {
+                           RemoteClientFactory remoteClientFactory, ContextAccessEnforcer contextAccessEnforcer) {
     super(host, program, programOptions, instanceId, serviceAnnouncer, TransactionControl.IMPLICIT);
 
     this.cConf = cConf;
@@ -107,7 +108,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
                                                messagingService, artifactManager, metadataReader, metadataPublisher,
                                                pluginFinder, fieldLineageWriter, transactionRunner,
-                                               preferencesFetcher, contextAccessEnforcer);
+                                               preferencesFetcher, remoteClientFactory, contextAccessEnforcer);
     this.context = contextFactory.create(null, null);
     this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
@@ -169,6 +170,7 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                               FieldLineageWriter fieldLineageWriter,
                                                               TransactionRunner transactionRunner,
                                                               PreferencesFetcher preferencesFetcher,
+                                                              RemoteClientFactory remoteClientFactory,
                                                               ContextAccessEnforcer contextAccessEnforcer) {
     return (spec, handlerClass) -> {
       if (handlerClass != null && AbstractSystemHttpServiceHandler.class.isAssignableFrom(handlerClass)) {
@@ -177,13 +179,14 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                  txClient, pluginInstantiator, secureStore, secureStoreManager,
                                                  messagingService, artifactManager, metadataReader, metadataPublisher,
                                                  namespaceQueryAdmin, pluginFinder, fieldLineageWriter,
-                                                 transactionRunner, preferencesFetcher, contextAccessEnforcer);
+                                                 transactionRunner, preferencesFetcher, remoteClientFactory,
+                                                 contextAccessEnforcer);
       }
       return new BasicHttpServiceContext(program, programOptions, cConf, spec, instanceId, instanceCount,
                                          metricsCollectionService, datasetFramework, discoveryServiceClient,
                                          txClient, pluginInstantiator, secureStore, secureStoreManager,
                                          messagingService, artifactManager, metadataReader, metadataPublisher,
-                                         namespaceQueryAdmin, pluginFinder, fieldLineageWriter);
+                                         namespaceQueryAdmin, pluginFinder, fieldLineageWriter, remoteClientFactory);
     };
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/DefaultSystemAppTaskContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/DefaultSystemAppTaskContext.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.app.services.AbstractServiceDiscoverer;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.service.Retries;
 import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.common.service.RetryStrategy;
@@ -42,7 +43,6 @@ import io.cdap.cdap.internal.app.runtime.plugin.MacroParser;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.proto.id.NamespaceId;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +63,6 @@ public class DefaultSystemAppTaskContext extends AbstractServiceDiscoverer imple
   private final PreferencesFetcher preferencesFetcher;
   private final CConfiguration cConf;
   private final PluginFinder pluginFinder;
-  private final DiscoveryServiceClient discoveryServiceClient;
   private final SecureStore secureStore;
   private final String serviceName;
   private final RetryStrategy retryStrategy;
@@ -71,19 +70,21 @@ public class DefaultSystemAppTaskContext extends AbstractServiceDiscoverer imple
   private final PluginInstantiator instantiator;
   private final File pluginsDir;
   private final io.cdap.cdap.proto.id.ArtifactId protoArtifactId;
+  private final RemoteClientFactory remoteClientFactory;
 
   DefaultSystemAppTaskContext(CConfiguration cConf, PreferencesFetcher preferencesFetcher, PluginFinder pluginFinder,
-                              DiscoveryServiceClient discoveryServiceClient, SecureStore secureStore,
+                              SecureStore secureStore,
                               String artifactNameSpace, ArtifactId artifactId, ClassLoader artifactClassLoader,
-                              ArtifactManagerFactory artifactManagerFactory, String serviceName) {
+                              ArtifactManagerFactory artifactManagerFactory, String serviceName,
+                              RemoteClientFactory remoteClientFactory) {
     super(artifactNameSpace);
     this.cConf = cConf;
     this.serviceName = serviceName;
     this.retryStrategy = RetryStrategies.fromConfiguration(cConf, Constants.Retry.SERVICE_PREFIX);
     this.preferencesFetcher = preferencesFetcher;
     this.pluginFinder = pluginFinder;
-    this.discoveryServiceClient = discoveryServiceClient;
     this.secureStore = secureStore;
+    this.remoteClientFactory = remoteClientFactory;
     this.artifactManager = artifactManagerFactory.create(new NamespaceId(artifactNameSpace), retryStrategy);
     this.pluginsDir = createTempFolder();
     this.instantiator = new PluginInstantiator(cConf, artifactClassLoader, pluginsDir);
@@ -140,8 +141,8 @@ public class DefaultSystemAppTaskContext extends AbstractServiceDiscoverer imple
   }
 
   @Override
-  protected DiscoveryServiceClient getDiscoveryServiceClient() {
-    return discoveryServiceClient;
+  protected RemoteClientFactory getRemoteClientFactory() {
+    return remoteClientFactory;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppTask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppTask.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDetail;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactManagerFactory;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
@@ -119,12 +120,12 @@ public class SystemAppTask implements RunnableTask {
                                                          ArtifactId artifactId, ClassLoader artifactClassLoader) {
     PreferencesFetcher preferencesFetcher = injector.getInstance(PreferencesFetcher.class);
     PluginFinder pluginFinder = injector.getInstance(PluginFinder.class);
-    DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
     SecureStore secureStore = injector.getInstance(SecureStore.class);
     ArtifactManagerFactory artifactManagerFactory = injector.getInstance(ArtifactManagerFactory.class);
-    return new DefaultSystemAppTaskContext(cConf, preferencesFetcher, pluginFinder, discoveryServiceClient,
+    RemoteClientFactory remoteClientFactory = injector.getInstance(RemoteClientFactory.class);
+    return new DefaultSystemAppTaskContext(cConf, preferencesFetcher, pluginFinder,
                                            secureStore, systemAppNamespace, artifactId, artifactClassLoader,
-                                           artifactManagerFactory, Constants.Service.TASK_WORKER);
+                                           artifactManagerFactory, Constants.Service.TASK_WORKER, remoteClientFactory);
   }
 
   private void streamArtifactIfRequired(Id.Artifact artifactId, Location artifactLocation,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.common.InvalidArtifactException;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.common.service.Retries;
 import io.cdap.cdap.common.service.RetryStrategies;
@@ -58,7 +59,6 @@ import io.cdap.cdap.proto.metadata.MetadataSearchResultRecord;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.cdap.spi.metadata.SearchRequest;
 import org.apache.twill.common.Threads;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,14 +113,14 @@ class CapabilityApplier {
   CapabilityApplier(SystemProgramManagementService systemProgramManagementService,
                     ApplicationLifecycleService applicationLifecycleService, NamespaceAdmin namespaceAdmin,
                     ProgramLifecycleService programLifecycleService, CapabilityStatusStore capabilityStatusStore,
-                    ArtifactRepository artifactRepository, DiscoveryServiceClient discoveryClient,
-                    CConfiguration cConf) {
+                    ArtifactRepository artifactRepository,
+                    CConfiguration cConf, RemoteClientFactory remoteClientFactory) {
     this.systemProgramManagementService = systemProgramManagementService;
     this.applicationLifecycleService = applicationLifecycleService;
     this.programLifecycleService = programLifecycleService;
     this.capabilityStatusStore = capabilityStatusStore;
     this.namespaceAdmin = namespaceAdmin;
-    this.metadataSearchClient = new MetadataSearchClient(discoveryClient);
+    this.metadataSearchClient = new MetadataSearchClient(remoteClientFactory);
     this.artifactRepository = artifactRepository;
     this.tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/MetadataSearchClient.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/MetadataSearchClient.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.proto.metadata.MetadataSearchResponse;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.cdap.spi.metadata.SearchRequest;
@@ -49,9 +50,10 @@ public class MetadataSearchClient {
   private static final Gson GSON = new Gson();
   private final RemoteClient remoteClient;
 
-  MetadataSearchClient(DiscoveryServiceClient discoveryClient) {
-    this.remoteClient = new RemoteClient(discoveryClient, Constants.Service.METADATA_SERVICE,
-                                         new DefaultHttpRequestConfig(false), Constants.Gateway.API_VERSION_3);
+  MetadataSearchClient(RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.METADATA_SERVICE,
+      new DefaultHttpRequestConfig(false), Constants.Gateway.API_VERSION_3);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/DefaultMasterEnvironmentRunnableContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/DefaultMasterEnvironmentRunnableContext.java
@@ -19,8 +19,8 @@ package io.cdap.cdap.master.environment;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnableContext;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.IOException;
@@ -30,16 +30,15 @@ import java.net.HttpURLConnection;
  * Default implementation of {@link MasterEnvironmentRunnableContext}.
  */
 public class DefaultMasterEnvironmentRunnableContext implements MasterEnvironmentRunnableContext {
-  private final DiscoveryServiceClient discoveryServiceClient;
   private final LocationFactory locationFactory;
   private final RemoteClient remoteClient;
 
-  public DefaultMasterEnvironmentRunnableContext(DiscoveryServiceClient discoveryServiceClient,
-                                                 LocationFactory locationFactory) {
-    this.discoveryServiceClient = discoveryServiceClient;
+  public DefaultMasterEnvironmentRunnableContext(LocationFactory locationFactory,
+                                                 RemoteClientFactory remoteClientFactory) {
     this.locationFactory = locationFactory;
-    this.remoteClient = new RemoteClient(discoveryServiceClient, Constants.Service.APP_FABRIC_HTTP,
-                                         new DefaultHttpRequestConfig(false), "");
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.APP_FABRIC_HTTP,
+      new DefaultHttpRequestConfig(false), "");
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/AbstractServiceMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/AbstractServiceMain.java
@@ -52,6 +52,7 @@ import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import io.cdap.cdap.common.app.MainClassLoader;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.logging.common.UncaughtExceptionHandler;
 import io.cdap.cdap.common.options.OptionsParser;
 import io.cdap.cdap.common.utils.ProjectInfo;
@@ -29,6 +30,7 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnable;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnableContext;
+import io.cdap.cdap.security.auth.context.MasterAuthenticationContext;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
@@ -108,9 +110,11 @@ public class MasterEnvironmentMain {
                                                + MasterEnvironmentRunnable.class);
         }
 
+        //TODO: CDAP-17754 Use proper authenticaiton context with internal token from configuration
+        RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
+          masterEnv.getDiscoveryServiceClientSupplier().get(), new MasterAuthenticationContext());
         MasterEnvironmentRunnableContext runnableContext =
-          new DefaultMasterEnvironmentRunnableContext(masterEnv.getDiscoveryServiceClientSupplier().get(),
-                                                      context.getLocationFactory());
+          new DefaultMasterEnvironmentRunnableContext(context.getLocationFactory(), remoteClientFactory);
         @SuppressWarnings("unchecked")
         MasterEnvironmentRunnable runnable = masterEnv.createRunnable(runnableContext,
                                                                       (Class<? extends MasterEnvironmentRunnable>) cls);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteApplicationDetailFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteApplicationDetailFetcher.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
@@ -51,11 +52,11 @@ public class RemoteApplicationDetailFetcher implements ApplicationDetailFetcher 
   private final RemoteClient remoteClient;
 
   @Inject
-  public RemoteApplicationDetailFetcher(DiscoveryServiceClient discoveryClient) {
-    this.remoteClient = new RemoteClient(discoveryClient,
-                                         Constants.Service.APP_FABRIC_HTTP,
-                                         new DefaultHttpRequestConfig(false),
-                                         Constants.Gateway.INTERNAL_API_VERSION_3);
+  public RemoteApplicationDetailFetcher(RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.APP_FABRIC_HTTP,
+      new DefaultHttpRequestConfig(false),
+      Constants.Gateway.INTERNAL_API_VERSION_3);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteMetadataClient.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteMetadataClient.java
@@ -20,6 +20,7 @@ import com.google.inject.Inject;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.metadata.AbstractMetadataClient;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
@@ -44,10 +45,10 @@ public class RemoteMetadataClient extends AbstractMetadataClient {
   private final AuthenticationContext authenticationContext;
 
   @Inject
-  RemoteMetadataClient(final DiscoveryServiceClient discoveryClient,
-                       AuthenticationContext authenticationContext) {
-    this.remoteClient = new RemoteClient(discoveryClient, Constants.Service.METADATA_SERVICE,
-                                         new DefaultHttpRequestConfig(false), Constants.Gateway.API_VERSION_3);
+  RemoteMetadataClient(AuthenticationContext authenticationContext, RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.METADATA_SERVICE,
+      new DefaultHttpRequestConfig(false), Constants.Gateway.API_VERSION_3);
     this.authenticationContext = authenticationContext;
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemotePreferencesFetcherInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemotePreferencesFetcherInternal.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.proto.PreferencesDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.EntityId;
@@ -48,9 +49,9 @@ public class RemotePreferencesFetcherInternal implements PreferencesFetcher {
   private final RemoteClient remoteClient;
 
   @Inject
-  public RemotePreferencesFetcherInternal(DiscoveryServiceClient discoveryClient) {
-    this.remoteClient = new RemoteClient(
-      discoveryClient, Constants.Service.APP_FABRIC_HTTP,
+  public RemotePreferencesFetcherInternal(RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.APP_FABRIC_HTTP,
       new DefaultHttpRequestConfig(false), Constants.Gateway.INTERNAL_API_VERSION_3);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteScheduleFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteScheduleFetcher.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.common.ProgramNotFoundException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.app.runtime.schedule.ScheduleNotFoundException;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
@@ -58,9 +59,9 @@ public class RemoteScheduleFetcher implements ScheduleFetcher {
   private final RemoteClient remoteClient;
 
   @Inject
-  public RemoteScheduleFetcher(DiscoveryServiceClient discoveryClient) {
-    this.remoteClient = new RemoteClient(
-      discoveryClient, Constants.Service.APP_FABRIC_HTTP,
+  public RemoteScheduleFetcher(RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.APP_FABRIC_HTTP,
       new DefaultHttpRequestConfig(false), Constants.Gateway.API_VERSION_3);
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServerTest.java
@@ -41,6 +41,7 @@ import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.TopicId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
 import org.junit.After;
@@ -105,6 +106,7 @@ public class RuntimeClientServerTest {
       new InMemoryDiscoveryModule(),
       new LocalLocationModule(),
       new MessagingServerRuntimeModule().getInMemoryModules(),
+      new AuthenticationContextModules().getNoOpModule(),
       new RuntimeServerModule() {
         @Override
         protected void bindRequestValidator() {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
@@ -47,6 +47,7 @@ import io.cdap.cdap.proto.Notification;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.discovery.InMemoryDiscoveryService;
@@ -116,6 +117,7 @@ public class RuntimeClientServiceTest {
       new ConfigModule(cConf),
       new LocalLocationModule(),
       new MessagingServerRuntimeModule().getInMemoryModules(),
+      new AuthenticationContextModules().getNoOpModule(),
       new RuntimeServerModule() {
         @Override
         protected void bindRequestValidator() {
@@ -159,6 +161,7 @@ public class RuntimeClientServiceTest {
     injector = Guice.createInjector(
       new ConfigModule(clientCConf),
       new MessagingServerRuntimeModule().getInMemoryModules(),
+      new AuthenticationContextModules().getNoOpModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -57,6 +57,7 @@ import io.cdap.cdap.common.discovery.EndpointStrategy;
 import io.cdap.cdap.common.discovery.RandomEndpointStrategy;
 import io.cdap.cdap.common.discovery.URIScheme;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.lang.jar.BundleJarUtil;
@@ -105,6 +106,7 @@ import io.cdap.cdap.proto.profile.Profile;
 import io.cdap.cdap.runtime.spi.profile.ProfileStatus;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
 import io.cdap.cdap.scheduler.Scheduler;
+import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
@@ -212,6 +214,7 @@ public abstract class AppFabricTestBase {
   private static DatasetClient datasetClient;
   private static MetadataClient metadataClient;
   private static MetricStore metricStore;
+  private static RemoteClientFactory remoteClientFactory;
 
   private static HttpRequestConfig httpRequestConfig;
 
@@ -277,8 +280,9 @@ public abstract class AppFabricTestBase {
     metadataSubscriberService.startAndWait();
     locationFactory = getInjector().getInstance(LocationFactory.class);
     datasetClient = new DatasetClient(getClientConfig(discoveryClient, Constants.Service.DATASET_MANAGER));
+    remoteClientFactory = new RemoteClientFactory(discoveryClient, new AuthenticationTestContext());
     metadataClient = new MetadataClient(getClientConfig(discoveryClient, Constants.Service.METADATA_SERVICE));
-    metadataServiceClient = new DefaultMetadataServiceClient(discoveryClient);
+    metadataServiceClient = new DefaultMetadataServiceClient(remoteClientFactory);
     metricStore = injector.getInstance(MetricStore.class);
 
     Scheduler programScheduler = injector.getInstance(Scheduler.class);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerInternalTest.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.services.http.handlers;
 
 import io.cdap.cdap.SleepingWorkflowApp;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.gateway.handlers.ProgramLifecycleHttpHandlerInternal;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
@@ -49,7 +50,7 @@ public class ProgramLifecycleHttpHandlerInternalTest extends AppFabricTestBase {
   @BeforeClass
   public static void init() {
     programRunRecordFetcher = new RemoteProgramRunRecordFetcher(
-      getInjector().getInstance(DiscoveryServiceClient.class));
+      getInjector().getInstance(RemoteClientFactory.class));
   }
 
   @Test

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/AutoInstallTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/AutoInstallTest.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.api.artifact.ArtifactRange;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.capability.autoinstall.HubPackage;
 import io.cdap.cdap.internal.capability.autoinstall.Spec;
@@ -68,9 +69,10 @@ public class AutoInstallTest {
     cConf.set(Constants.AppFabric.TEMP_DIR, "appfabric");
     cConf.setInt(Constants.Capability.AUTO_INSTALL_THREADS, 5);
     ArtifactRepository artifactRepository = PowerMockito.mock(ArtifactRepository.class);
+    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(null, null);
     CapabilityApplier capabilityApplier = new CapabilityApplier(null, null,
                                                                 null, null, null,
-                                                                artifactRepository, null, cConf);
+                                                                artifactRepository, cConf, remoteClientFactory);
     CapabilityApplier ca = Mockito.spy(capabilityApplier);
     PowerMockito.mockStatic(HttpClients.class);
     PowerMockito.mockStatic(Files.class);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityApplierTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityApplierTest.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.WorkflowAppWithFork;
 import io.cdap.cdap.api.annotation.Requirements;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.test.AppJarHelper;
 import io.cdap.cdap.internal.AppFabricTestHelper;
@@ -66,9 +67,10 @@ import java.util.UUID;
     artifactRepository = getInjector().getInstance(ArtifactRepository.class);
     CConfiguration cConfiguration = getInjector().getInstance(CConfiguration.class);
     DiscoveryServiceClient client = getInjector().getInstance(DiscoveryServiceClient.class);
+    RemoteClientFactory remoteClientFactory = getInjector().getInstance(RemoteClientFactory.class);
     capabilityApplier = new CapabilityApplier(null, null,
                                               null, null, null,
-                                              null, client, cConfiguration);
+                                              null, cConfiguration, remoteClientFactory);
   }
 
   @AfterClass

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/master/environment/DefaultMasterEnvironmentRunnableContextTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/master/environment/DefaultMasterEnvironmentRunnableContextTest.java
@@ -20,6 +20,8 @@ package io.cdap.cdap.master.environment;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.discovery.ResolvingDiscoverable;
 import io.cdap.cdap.common.discovery.URIScheme;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
 import io.cdap.common.http.HttpMethod;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpResponder;
@@ -63,7 +65,9 @@ public class DefaultMasterEnvironmentRunnableContextTest {
   public static void setup() throws Exception {
     DiscoveryService discoveryService = new InMemoryDiscoveryService();
     LocationFactory locationFactory = new LocalLocationFactory(TMP_FOLDER.newFolder());
-    context = new DefaultMasterEnvironmentRunnableContext((DiscoveryServiceClient) discoveryService, locationFactory);
+    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
+      (DiscoveryServiceClient) discoveryService, new AuthenticationTestContext());
+    context = new DefaultMasterEnvironmentRunnableContext(locationFactory, remoteClientFactory);
 
     httpService = NettyHttpService.builder(Constants.Service.APP_FABRIC_HTTP)
       .setHttpHandlers(new MockHttpHandler())

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/OAuthMacroEvaluatorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/OAuthMacroEvaluatorTest.java
@@ -21,9 +21,12 @@ import com.google.gson.Gson;
 import io.cdap.cdap.api.ServiceDiscoverer;
 import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.app.services.AbstractServiceDiscoverer;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.service.ServiceDiscoverable;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpResponder;
 import io.cdap.http.NettyHttpService;
@@ -70,11 +73,12 @@ public class OAuthMacroEvaluatorTest {
                                                        Constants.PIPELINEID, ProgramType.SERVICE,
                                                        Constants.STUDIO_SERVICE_NAME);
     discoveryService.register(new Discoverable(discoveryName, httpService.getBindAddress()));
+    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
+      discoveryService, new AuthenticationTestContext());
     serviceDiscoverer = new AbstractServiceDiscoverer(NamespaceId.DEFAULT.app("testapp").spark("testspark")) {
-
       @Override
-      protected DiscoveryServiceClient getDiscoveryServiceClient() {
-        return discoveryService;
+      protected RemoteClientFactory getRemoteClientFactory() {
+        return remoteClientFactory;
       }
     };
   }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1194,6 +1194,8 @@ public final class Constants {
       public static final String USER_PRINCIPAL = "CDAP-User-Principal";
       /** program id passed from program container to cdap service containers */
       public static final String PROGRAM_ID = "CDAP-Program-Id";
+      /** token to authorize runtime service calls */
+      public static final String RUNTIME_TOKEN = "X-CDAP-Runtime-Token";
     }
 
     /**

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.internal.remote;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
+import io.cdap.common.http.HttpRequestConfig;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+import javax.inject.Inject;
+
+/**
+ * A factory to create {@link RemoteClient}.
+ */
+public class RemoteClientFactory {
+
+  private final DiscoveryServiceClient discoveryClient;
+  private final AuthenticationContext authenticationContext;
+
+  @Inject @VisibleForTesting
+  public RemoteClientFactory(DiscoveryServiceClient discoveryClient, AuthenticationContext authenticationContext) {
+    this.discoveryClient = discoveryClient;
+    this.authenticationContext = authenticationContext;
+  }
+
+  public RemoteClient createRemoteClient(String discoverableServiceName,
+                                         HttpRequestConfig httpRequestConfig, String basePath) {
+    return new RemoteClient(authenticationContext, discoveryClient, discoverableServiceName, httpRequestConfig,
+                            basePath);
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteOpsClient.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteOpsClient.java
@@ -50,10 +50,10 @@ public class RemoteOpsClient {
 
   private final RemoteClient remoteClient;
 
-  protected RemoteOpsClient(final DiscoveryServiceClient discoveryClient,
-                            final String discoverableServiceName) {
-    this.remoteClient = new RemoteClient(discoveryClient, discoverableServiceName,
-                                         new DefaultHttpRequestConfig(false), "/v1/execute/");
+  protected RemoteOpsClient(RemoteClientFactory remoteClientFactory, final String discoverableServiceName) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(discoverableServiceName,
+                                                               new DefaultHttpRequestConfig(false),
+                                                               "/v1/execute/");
   }
 
   protected HttpResponse executeRequest(String methodName, Object... arguments) throws UnauthorizedException {

--- a/cdap-common/src/main/java/io/cdap/cdap/common/namespace/RemoteNamespaceQueryClient.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/namespace/RemoteNamespaceQueryClient.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.common.http.HttpRequest;
@@ -40,10 +41,12 @@ public class RemoteNamespaceQueryClient extends AbstractNamespaceQueryClient {
   private final AuthenticationContext authenticationContext;
 
   @Inject
-  RemoteNamespaceQueryClient(final DiscoveryServiceClient discoveryClient, CConfiguration cConf,
-                             AuthenticationContext authenticationContext) {
-    this.remoteClient = new RemoteClient(discoveryClient, Constants.Service.APP_FABRIC_HTTP,
-                                         new DefaultHttpRequestConfig(false), Constants.Gateway.API_VERSION_3);
+  RemoteNamespaceQueryClient(CConfiguration cConf,
+                             AuthenticationContext authenticationContext,
+                             RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.APP_FABRIC_HTTP,
+      new DefaultHttpRequestConfig(false), Constants.Gateway.API_VERSION_3);
     this.authenticationContext = authenticationContext;
   }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.data2.dataset2.ModuleConflictException;
 import io.cdap.cdap.proto.DatasetInstanceConfiguration;
 import io.cdap.cdap.proto.DatasetMeta;
@@ -80,10 +81,12 @@ public class DatasetServiceClient {
   private final AuthenticationContext authenticationContext;
   private final String masterShortUserName;
 
-  DatasetServiceClient(final DiscoveryServiceClient discoveryClient, NamespaceId namespaceId,
-                       CConfiguration cConf, AuthenticationContext authenticationContext) {
-    this.remoteClient = new RemoteClient(
-      discoveryClient, Constants.Service.DATASET_MANAGER, new DefaultHttpRequestConfig(false),
+  DatasetServiceClient(NamespaceId namespaceId,
+                       CConfiguration cConf,
+                       AuthenticationContext authenticationContext,
+                       RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.DATASET_MANAGER, new DefaultHttpRequestConfig(false),
       String.format("%s/namespaces/%s/data", Constants.Gateway.API_VERSION_3, namespaceId.getNamespace()));
     this.namespaceId = namespaceId;
     this.securityEnabled = cConf.getBoolean(Constants.Security.ENABLED);

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import io.cdap.cdap.api.dataset.module.DatasetModule;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.lang.ClassLoaders;
 import io.cdap.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
@@ -55,7 +56,6 @@ import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.internal.ApplicationBundler;
 import org.slf4j.Logger;
@@ -85,14 +85,15 @@ public class RemoteDatasetFramework implements DatasetFramework {
   private final DatasetDefinitionRegistryFactory registryFactory;
 
   @Inject
-  public RemoteDatasetFramework(final CConfiguration cConf, final DiscoveryServiceClient discoveryClient,
+  public RemoteDatasetFramework(final CConfiguration cConf,
                                 DatasetDefinitionRegistryFactory registryFactory,
-                                final AuthenticationContext authenticationContext) {
+                                final AuthenticationContext authenticationContext,
+                                RemoteClientFactory remoteClientFactory) {
     this.cConf = cConf;
     this.clientCache = CacheBuilder.newBuilder().build(new CacheLoader<NamespaceId, DatasetServiceClient>() {
       @Override
       public DatasetServiceClient load(NamespaceId namespace) throws Exception {
-        return new DatasetServiceClient(discoveryClient, namespace, cConf, authenticationContext);
+        return new DatasetServiceClient(namespace, cConf, authenticationContext, remoteClientFactory);
       }
     });
     this.registryFactory = registryFactory;

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/executor/RemoteDatasetOpExecutor.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/executor/RemoteDatasetOpExecutor.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.common.HandlerException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.proto.DatasetTypeMeta;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
@@ -55,10 +56,11 @@ public class RemoteDatasetOpExecutor implements DatasetOpExecutor {
   private final AuthenticationContext authenticationContext;
 
   @Inject
-  public RemoteDatasetOpExecutor(DiscoveryServiceClient discoveryClient, AuthenticationContext authenticationContext) {
+  public RemoteDatasetOpExecutor(AuthenticationContext authenticationContext, RemoteClientFactory remoteClientFactory) {
     this.authenticationContext = authenticationContext;
-    this.remoteClient = new RemoteClient(discoveryClient, Constants.Service.DATASET_EXECUTOR,
-                                         new DefaultHttpRequestConfig(false), Constants.Gateway.API_VERSION_3);
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.DATASET_EXECUTOR,
+      new DefaultHttpRequestConfig(false), Constants.Gateway.API_VERSION_3);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/writer/DefaultMetadataServiceClient.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/writer/DefaultMetadataServiceClient.java
@@ -21,6 +21,7 @@ import com.google.gson.GsonBuilder;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.metadata.elastic.ScopedNameOfKindTypeAdapter;
 import io.cdap.cdap.metadata.elastic.ScopedNameTypeAdapter;
 import io.cdap.cdap.proto.codec.NamespacedEntityIdCodec;
@@ -57,10 +58,10 @@ public class DefaultMetadataServiceClient implements MetadataServiceClient {
   private final RemoteClient remoteClient;
 
   @Inject
-  public DefaultMetadataServiceClient(final DiscoveryServiceClient discoveryClient) {
-    this.remoteClient = new RemoteClient(discoveryClient, Constants.Service.METADATA_SERVICE,
-                                         new DefaultHttpRequestConfig(false),
-                                         Constants.Gateway.API_VERSION_3);
+  public DefaultMetadataServiceClient(RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(Constants.Service.METADATA_SERVICE,
+                                                               new DefaultHttpRequestConfig(false),
+                                                               Constants.Gateway.API_VERSION_3);
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.common.discovery.EndpointStrategy;
 import io.cdap.cdap.common.discovery.RandomEndpointStrategy;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.data.dataset.SystemDatasetInstantiatorFactory;
 import io.cdap.cdap.data.runtime.StorageModule;
@@ -144,8 +145,9 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
     MetricsCollectionService metricsCollectionService = injector.getInstance(MetricsCollectionService.class);
     AuthenticationContext authenticationContext = injector.getInstance(AuthenticationContext.class);
+    RemoteClientFactory remoteClientFactory = injector.getInstance(RemoteClientFactory.class);
 
-    framework = new RemoteDatasetFramework(cConf, discoveryServiceClient, registryFactory, authenticationContext);
+    framework = new RemoteDatasetFramework(cConf, registryFactory, authenticationContext, remoteClientFactory);
     SystemDatasetInstantiatorFactory datasetInstantiatorFactory =
       new SystemDatasetInstantiatorFactory(locationFactory, framework, cConf);
 
@@ -171,7 +173,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                                                          authenticationContext);
 
 
-    DatasetOpExecutor opExecutor = new RemoteDatasetOpExecutor(discoveryServiceClient, authenticationContext);
+    DatasetOpExecutor opExecutor = new RemoteDatasetOpExecutor(authenticationContext, remoteClientFactory);
     DatasetInstanceService instanceService = new DatasetInstanceService(typeService, noAuthTypeService,
                                                                         instanceManager, opExecutor,
                                                                         exploreFacade, namespaceQueryAdmin, ownerAdmin,

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AuthenticationServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AuthenticationServiceMain.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.guice.SecurityModule;
 import io.cdap.cdap.security.guice.SecurityModules;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
@@ -59,6 +60,7 @@ public class AuthenticationServiceMain extends AbstractServiceMain<EnvironmentOp
 
     List<Module> modules = new ArrayList<>();
     modules.add(new MessagingClientModule());
+    modules.add(new AuthenticationContextModules().getMasterModule());
 
     SecurityModule securityModule = SecurityModules.getDistributedModule(cConf);
     modules.add(securityModule);

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.guice.SecurityModule;
 import io.cdap.cdap.security.guice.SecurityModules;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
@@ -59,6 +60,8 @@ public class RouterServiceMain extends AbstractServiceMain<EnvironmentOptions> {
   protected List<Module> getServiceModules(MasterEnvironment masterEnv,
                                            EnvironmentOptions options, CConfiguration cConf) {
     List<Module> modules = new ArrayList<>();
+
+    modules.add(new AuthenticationContextModules().getMasterModule());
     modules.add(new MessagingClientModule());
     modules.add(new RouterModules().getDistributedModules());
     modules.add(new DFSLocationModule());

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
@@ -58,6 +59,7 @@ public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> 
   protected List<Module> getServiceModules(MasterEnvironment masterEnv,
                                            EnvironmentOptions options, CConfiguration cConf) {
     return Arrays.asList(
+      new AuthenticationContextModules().getMasterModule(),
       new DFSLocationModule(),
       new MessagingClientModule(),
       new SystemDatasetRuntimeModule().getStandaloneModules(),

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MessagingServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MessagingServiceMainTest.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.master.environment.k8s;
 
 import com.google.inject.Injector;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.TopicMetadata;
 import io.cdap.cdap.messaging.client.ClientMessagingService;
@@ -46,11 +47,11 @@ public class MessagingServiceMainTest extends MasterServiceMainTestBase {
   public void testMessagingService() throws Exception {
     // Discover the TMS endpoint
     Injector injector = getServiceMainInstance(MessagingServiceMain.class).getInjector();
-    DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
+    RemoteClientFactory remoteClientFactory = injector.getInstance(RemoteClientFactory.class);
 
     // Use a separate TMS client to create topic, then publish and then poll some messages
     TopicId topicId = NamespaceId.SYSTEM.topic("test");
-    MessagingService messagingService = new ClientMessagingService(discoveryServiceClient, true);
+    MessagingService messagingService = new ClientMessagingService(remoteClientFactory, true);
     messagingService.createTopic(new TopicMetadata(topicId));
 
     // Publish 10 messages

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/RemoteAccessEnforcer.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/RemoteAccessEnforcer.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.security.AuthEnforceUtil;
 import io.cdap.cdap.proto.codec.EntityIdTypeAdapter;
 import io.cdap.cdap.proto.element.EntityType;
@@ -130,10 +131,11 @@ public class RemoteAccessEnforcer extends AbstractAccessEnforcer {
   private final LoadingCache<VisibilityKey, Boolean> visibilityCache;
 
   @Inject
-  public RemoteAccessEnforcer(CConfiguration cConf, final DiscoveryServiceClient discoveryClient) {
+  public RemoteAccessEnforcer(CConfiguration cConf, RemoteClientFactory remoteClientFactory) {
     super(cConf);
-    this.remoteClient = new RemoteClient(discoveryClient, Constants.Service.APP_FABRIC_HTTP,
-                                         new DefaultHttpRequestConfig(false), "/v1/execute/");
+    this.remoteClient = remoteClientFactory.createRemoteClient(Constants.Service.APP_FABRIC_HTTP,
+                                                               new DefaultHttpRequestConfig(false),
+                                                               "/v1/execute/");
     int cacheTTLSecs = cConf.getInt(Constants.Security.Authorization.CACHE_TTL_SECS);
     int cacheMaxEntries = cConf.getInt(Constants.Security.Authorization.CACHE_MAX_ENTRIES);
     // Cache can be disabled by setting the number of entries to <= 0

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/RemotePermissionManager.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/RemotePermissionManager.java
@@ -20,6 +20,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.internal.remote.RemoteOpsClient;
 import io.cdap.cdap.internal.guava.reflect.TypeToken;
 import io.cdap.cdap.proto.codec.EntityIdTypeAdapter;
@@ -53,8 +54,8 @@ public class RemotePermissionManager extends RemoteOpsClient implements Permissi
   private static final Type SET_GRANTED_PERMISSIONS_TYPE = new TypeToken<Set<GrantedPermission>>() { }.getType();
 
   @Inject
-  RemotePermissionManager(DiscoveryServiceClient discoveryClient) {
-    super(discoveryClient, Constants.Service.APP_FABRIC_HTTP);
+  RemotePermissionManager(RemoteClientFactory remoteClientFactory) {
+    super(remoteClientFactory, Constants.Service.APP_FABRIC_HTTP);
   }
 
   @Override

--- a/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/RemoteUGIProvider.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/RemoteUGIProvider.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.security.AuthEnforceUtil;
 import io.cdap.cdap.proto.codec.EntityIdTypeAdapter;
 import io.cdap.cdap.proto.element.EntityType;
@@ -62,11 +63,11 @@ public class RemoteUGIProvider extends AbstractCachedUGIProvider {
   private final LocationFactory locationFactory;
 
   @Inject
-  RemoteUGIProvider(CConfiguration cConf, final DiscoveryServiceClient discoveryClient,
-                    LocationFactory locationFactory, OwnerAdmin ownerAdmin) {
+  RemoteUGIProvider(CConfiguration cConf,
+                    LocationFactory locationFactory, OwnerAdmin ownerAdmin, RemoteClientFactory remoteClientFactory) {
     super(cConf, ownerAdmin);
-    this.remoteClient = new RemoteClient(discoveryClient, Constants.Service.APP_FABRIC_HTTP,
-                                         new DefaultHttpRequestConfig(false), "/v1/");
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.APP_FABRIC_HTTP, new DefaultHttpRequestConfig(false), "/v1/");
     this.locationFactory = locationFactory;
   }
 

--- a/cdap-security/src/main/java/io/cdap/cdap/security/store/client/RemoteSecureStore.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/store/client/RemoteSecureStore.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.common.SecureKeyNotFoundException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.proto.id.SecureKeyId;
 import io.cdap.cdap.proto.security.SecureKeyCreateRequest;
 import io.cdap.common.http.HttpMethod;
@@ -54,9 +55,9 @@ public class RemoteSecureStore implements SecureStoreManager, SecureStore {
 
   @VisibleForTesting
   @Inject
-  RemoteSecureStore(DiscoveryServiceClient discoveryServiceClient) {
-    this.remoteClient = new RemoteClient(discoveryServiceClient, Constants.Service.SECURE_STORE_SERVICE,
-                                         new DefaultHttpRequestConfig(false), "/v3/namespaces/");
+  RemoteSecureStore(RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.SECURE_STORE_SERVICE, new DefaultHttpRequestConfig(false), "/v3/namespaces/");
   }
 
   @Override

--- a/cdap-security/src/test/java/io/cdap/cdap/security/impersonation/UGIProviderTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/impersonation/UGIProviderTest.java
@@ -22,12 +22,14 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.InMemoryNamespaceAdmin;
 import io.cdap.cdap.proto.codec.EntityIdTypeAdapter;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.NamespacedEntityId;
+import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpResponder;
 import io.cdap.http.NettyHttpService;
@@ -162,8 +164,11 @@ public class UGIProviderTest {
       InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
       discoveryService.register(new Discoverable(Constants.Service.APP_FABRIC_HTTP, httpService.getBindAddress()));
 
-      RemoteUGIProvider ugiProvider = new RemoteUGIProvider(cConf, discoveryService, locationFactory,
-                                                            ownerAdmin);
+      RemoteClientFactory remoteClientFactory = new RemoteClientFactory(discoveryService,
+                                                                        new AuthenticationTestContext());
+      RemoteUGIProvider ugiProvider = new RemoteUGIProvider(cConf, locationFactory,
+                                                            ownerAdmin,
+                                                            remoteClientFactory);
 
       ImpersonationRequest aliceImpRequest = new ImpersonationRequest(aliceEntity, ImpersonatedOpType.OTHER);
       UGIWithPrincipal aliceUGIWithPrincipal = ugiProvider.getConfiguredUGI(aliceImpRequest);

--- a/cdap-security/src/test/java/io/cdap/cdap/security/store/client/RemoteSecureStoreTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/store/client/RemoteSecureStoreTest.java
@@ -25,9 +25,11 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.discovery.URIScheme;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.InMemoryNamespaceAdmin;
 import io.cdap.cdap.common.security.HttpsEnabler;
 import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
 import io.cdap.cdap.security.store.FileSecureStoreService;
 import io.cdap.cdap.security.store.SecureStoreHandler;
 import io.cdap.http.NettyHttpService;
@@ -81,7 +83,9 @@ public class RemoteSecureStoreTest {
     discoveryService.register(URIScheme.HTTPS.createDiscoverable(Constants.Service.SECURE_STORE_SERVICE,
                                                          httpService.getBindAddress()));
 
-    remoteSecureStore = new RemoteSecureStore(discoveryService);
+    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
+      discoveryService, new AuthenticationTestContext());
+    remoteSecureStore = new RemoteSecureStore(remoteClientFactory);
   }
 
   @AfterClass

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.lang.WeakReferenceDelegatorClassLoader;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
@@ -79,7 +80,6 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
   SparkRuntimeContext(Configuration hConf, Program program, ProgramOptions programOptions,
                       CConfiguration cConf, String hostname, TransactionSystemClient txClient,
                       DatasetFramework datasetFramework,
-                      DiscoveryServiceClient discoveryServiceClient,
                       MetricsCollectionService metricsCollectionService,
                       @Nullable WorkflowProgramInfo workflowProgramInfo,
                       @Nullable PluginInstantiator pluginInstantiator,
@@ -91,11 +91,11 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
                       PluginFinder pluginFinder, LocationFactory locationFactory,
                       MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                       NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter,
-                      Closeable closeable) {
+                      RemoteClientFactory remoteClientFactory, Closeable closeable) {
     super(program, programOptions, cConf, getSparkSpecification(program).getDatasets(), datasetFramework, txClient,
-          discoveryServiceClient, true, metricsCollectionService, createMetricsTags(workflowProgramInfo),
+          true, metricsCollectionService, createMetricsTags(workflowProgramInfo),
           secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin, fieldLineageWriter);
+          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
     this.cConf = cConf;
     this.hConf = hConf;
     this.hostname = hostname;

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -42,6 +42,7 @@ import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.lang.ClassLoaders;
 import io.cdap.cdap.common.lang.FilterClassLoader;
@@ -260,7 +261,6 @@ public final class SparkRuntimeContextProvider {
         getHostname(),
         injector.getInstance(TransactionSystemClient.class),
         programDatasetFramework,
-        injector.getInstance(DiscoveryServiceClient.class),
         metricsCollectionService,
         contextConfig.getWorkflowProgramInfo(),
         pluginInstantiator,
@@ -276,8 +276,8 @@ public final class SparkRuntimeContextProvider {
         injector.getInstance(MetadataPublisher.class),
         injector.getInstance(NamespaceQueryAdmin.class),
         injector.getInstance(FieldLineageWriter.class),
-        closeable
-      );
+        injector.getInstance(RemoteClientFactory.class),
+        closeable);
       LoggingContextAccessor.setLoggingContext(sparkRuntimeContext.getLoggingContext());
       return sparkRuntimeContext;
     } catch (Exception e) {

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeUtils.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeUtils.java
@@ -383,7 +383,7 @@ public final class SparkRuntimeUtils {
     }
 
     RuntimeClient runtimeClient = new RuntimeClient(runtimeContext.getCConfiguration(),
-                                                    runtimeContext.getDiscoveryServiceClient());
+                                                    runtimeContext.getRemoteClientFactory());
     Retries.runWithRetries(() -> runtimeClient.uploadSparkEventLogs(programRunId, eventFile),
                            RetryStrategies.fromConfiguration(runtimeContext.getCConfiguration(), "spark."));
     LOG.debug("Uploaded event logs file {} for program run {}", eventFile, programRunId);

--- a/cdap-tms/pom.xml
+++ b/cdap-tms/pom.xml
@@ -163,8 +163,14 @@
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-storage-spi</artifactId>
-      <version>6.5.0-SNAPSHOT</version>
+      <version>${project.version}</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-security</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/ClientMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/ClientMessagingService.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.messaging.MessageFetcher;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.RollbackDetail;
@@ -62,7 +63,6 @@ import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.tephra.TransactionCodec;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -105,14 +105,14 @@ public final class ClientMessagingService implements MessagingService {
   private final boolean compressPayload;
 
   @Inject
-  ClientMessagingService(CConfiguration cConf, DiscoveryServiceClient discoveryServiceClient) {
-    this(discoveryServiceClient, cConf.getBoolean(Constants.MessagingSystem.HTTP_COMPRESS_PAYLOAD));
+  ClientMessagingService(CConfiguration cConf, RemoteClientFactory remoteClientFactory) {
+    this(remoteClientFactory, cConf.getBoolean(Constants.MessagingSystem.HTTP_COMPRESS_PAYLOAD));
   }
 
   @VisibleForTesting
-  public ClientMessagingService(DiscoveryServiceClient discoveryServiceClient, boolean compressPayload) {
-    this.remoteClient = new RemoteClient(discoveryServiceClient, Constants.Service.MESSAGING_SERVICE,
-                                         HTTP_REQUEST_CONFIG, "/v1/namespaces/");
+  public ClientMessagingService(RemoteClientFactory remoteClientFactory, boolean compressPayload) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.MESSAGING_SERVICE, HTTP_REQUEST_CONFIG, "/v1/namespaces/");
     this.compressPayload = compressPayload;
   }
 

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/server/MessagingHttpServiceTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/server/MessagingHttpServiceTest.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.RollbackDetail;
@@ -42,10 +43,10 @@ import io.cdap.cdap.messaging.data.RawMessage;
 import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.TopicId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import org.apache.tephra.Transaction;
 import org.apache.tephra.TxConstants;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -107,6 +108,7 @@ public class MessagingHttpServiceTest {
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
       new InMemoryDiscoveryModule(),
+      new AuthenticationContextModules().getNoOpModule(),
       new MessagingServerRuntimeModule().getInMemoryModules(),
       new AbstractModule() {
         @Override
@@ -118,7 +120,7 @@ public class MessagingHttpServiceTest {
 
     httpService = injector.getInstance(MessagingHttpService.class);
     httpService.startAndWait();
-    client = new ClientMessagingService(injector.getInstance(DiscoveryServiceClient.class), compressPayload);
+    client = new ClientMessagingService(injector.getInstance(RemoteClientFactory.class), compressPayload);
   }
 
   @After

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteProgramRunRecordFetcher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteProgramRunRecordFetcher.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
@@ -42,11 +43,11 @@ public class RemoteProgramRunRecordFetcher implements ProgramRunRecordFetcher {
   private final RemoteClient remoteClient;
 
   @Inject
-  public RemoteProgramRunRecordFetcher(DiscoveryServiceClient discoveryClient) {
-    this.remoteClient = new RemoteClient(discoveryClient,
-                                         Constants.Service.APP_FABRIC_HTTP,
-                                         new DefaultHttpRequestConfig(false),
-                                         Constants.Gateway.INTERNAL_API_VERSION_3);
+  public RemoteProgramRunRecordFetcher(RemoteClientFactory remoteClientFactory) {
+    this.remoteClient = remoteClientFactory.createRemoteClient(
+      Constants.Service.APP_FABRIC_HTTP,
+      new DefaultHttpRequestConfig(false),
+      Constants.Gateway.INTERNAL_API_VERSION_3);
   }
 
   /**

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/logbuffer/handler/LogBufferHandlerTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/logbuffer/handler/LogBufferHandlerTest.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.api.metrics.NoopMetricsContext;
 import io.cdap.cdap.common.HttpExceptionHandler;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.logging.appender.LogMessage;
 import io.cdap.cdap.logging.appender.remote.RemoteLogAppender;
@@ -38,6 +39,7 @@ import io.cdap.cdap.logging.pipeline.LogProcessorPipelineContext;
 import io.cdap.cdap.logging.pipeline.MockAppender;
 import io.cdap.cdap.logging.pipeline.logbuffer.LogBufferPipelineConfig;
 import io.cdap.cdap.logging.pipeline.logbuffer.LogBufferProcessorPipeline;
+import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
 import io.cdap.http.NettyHttpService;
 import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.InMemoryDiscoveryService;
@@ -103,7 +105,9 @@ public class LogBufferHandlerTest {
   private RemoteLogAppender getRemoteAppender(CConfiguration cConf, NettyHttpService httpService) {
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     discoveryService.register(new Discoverable(Constants.Service.LOG_BUFFER_SERVICE, httpService.getBindAddress()));
-    return new RemoteLogAppender(cConf, discoveryService);
+    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
+      discoveryService, new AuthenticationTestContext());
+    return new RemoteLogAppender(cConf, remoteClientFactory);
   }
 
   private LogBufferProcessorPipeline getLogPipeline(LoggerContext loggerContext) {


### PR DESCRIPTION
Uses a separate header for use cases when communication is done through additional proxy (e.g. DataProc to CDAP instance communication).

It's a big refactoring since I introduce a `RemoteClientFactory` to inject `RemoteClient` dependencies in one place only.
Note: I does not fix CDAP-17772 fully, but it's one of the pieces needed.