### PR TITLE
[CDAP-17772] Introduce Internal Access Token Generation and Auth Context Propagation

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
@@ -283,7 +283,7 @@ public class DistributedWorkflowProgramRunnerTest {
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new TwillModule(),
-      new AppFabricServiceRuntimeModule().getDistributedModules(),
+      new AppFabricServiceRuntimeModule(cConf).getDistributedModules(),
       new ProgramRunnerRuntimeModule().getDistributedModules(),
       new SecureStoreServerModule(),
       new OperationalStatsModule(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -149,6 +149,13 @@ import java.util.List;
 public final class AppFabricServiceRuntimeModule extends RuntimeModule {
   public static final String NOAUTH_ARTIFACT_REPO = "noAuthArtifactRepo";
 
+  private final CConfiguration cConf;
+
+  @Inject
+  public AppFabricServiceRuntimeModule(CConfiguration cConf) {
+    this.cConf = cConf;
+  }
+
   @Override
   public Module getInMemoryModules() {
     return Modules.combine(new AppFabricServiceModule(),
@@ -249,7 +256,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new NamespaceAdminModule().getDistributedModules(),
                            new ConfigStoreModule(),
                            new EntityVerifierModule(),
-                           new AuthenticationContextModules().getMasterModule(),
+                           new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
                            new ProvisionerModule(),
                            BootstrapModules.getFileBasedModule(),
                            new AbstractModule() {
@@ -277,6 +284,26 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                servicesNamesBinder.addBinding().toInstance(Constants.Service.SECURE_STORE_SERVICE);
                              }
                            });
+  }
+
+  /**
+   * Returns modules to be used for preview runners.
+   *
+   * @return Module which contains bindings for preview runners
+   */
+  public Module getPreviewRunnerModules() {
+    return Modules.override(getStandaloneModules()).with(new AuthenticationContextModules()
+                                                           .getInternalAuthWorkerModule(cConf));
+  }
+
+  /**
+   * Returns modules to be used for preview master.
+   *
+   * @return Module which contains bindings for preview master
+   */
+  public Module getPreviewMasterModules() {
+    return Modules.override(getStandaloneModules()).with(new AuthenticationContextModules()
+                                                           .getInternalAuthMasterModule(cConf));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
@@ -169,7 +169,7 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
     return Guice.createInjector(
       new ConfigModule(previewCConf, previewHConf, previewSConf),
       new IOModule(),
-      new AuthenticationContextModules().getMasterModule(),
+      new AuthenticationContextModules().getInternalAuthWorkerModule(previewCConf),
       new PreviewSecureStoreModule(secureStore),
       new PreviewDiscoveryRuntimeModule(discoveryService),
       new LocalLocationModule(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -219,7 +219,7 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     modules.add(new PreviewRunnerManagerModule().getDistributedModules());
     modules.add(new DataSetServiceModules().getStandaloneModules());
     modules.add(new DataSetsModules().getStandaloneModules());
-    modules.add(new AppFabricServiceRuntimeModule().getStandaloneModules());
+    modules.add(new AppFabricServiceRuntimeModule(cConf).getPreviewRunnerModules());
     modules.add(new ProgramRunnerRuntimeModule().getStandaloneModules());
     modules.add(new MetricsStoreModule());
     modules.add(new MessagingClientModule());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/RemoteWorkerPluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/RemoteWorkerPluginFinder.java
@@ -16,13 +16,11 @@ package io.cdap.cdap.internal.app.worker;
 
 import com.google.inject.Inject;
 import io.cdap.cdap.common.ArtifactNotFoundException;
-import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.internal.app.runtime.artifact.RemotePluginFinder;
 import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
 import io.cdap.cdap.proto.id.ArtifactId;
-import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -38,12 +36,10 @@ public class RemoteWorkerPluginFinder extends RemotePluginFinder {
   private final ArtifactLocalizerClient artifactLocalizerClient;
 
   @Inject
-  RemoteWorkerPluginFinder(CConfiguration cConf,
-                           AuthenticationContext authenticationContext,
-                           LocationFactory locationFactory,
+  RemoteWorkerPluginFinder(LocationFactory locationFactory,
                            RemoteClientFactory remoteClientFactory,
                            ArtifactLocalizerClient artifactLocalizerClient) {
-    super(cConf, authenticationContext, locationFactory, remoteClientFactory);
+    super(locationFactory, remoteClientFactory);
     this.artifactLocalizerClient = artifactLocalizerClient;
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
@@ -42,6 +42,7 @@ import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.AbstractTwillRunnable;
 import org.apache.twill.api.TwillContext;
@@ -79,6 +80,7 @@ public class TaskWorkerTwillRunnable extends AbstractTwillRunnable {
 
     modules.add(new ConfigModule(cConf, hConf));
     modules.add(new IOModule());
+    modules.add(new AuthenticationContextModules().getInternalAuthWorkerModule(cConf));
 
     // If MasterEnvironment is not available, assuming it is the old hadoop stack with ZK, Kafka
     MasterEnvironment masterEnv = MasterEnvironments.getMasterEnvironment();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
@@ -112,7 +112,7 @@ public class MasterEnvironmentMain {
 
         //TODO: CDAP-17754 Use proper authentication context with internal token from configuration
         RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
-          masterEnv.getDiscoveryServiceClientSupplier().get(), new WorkerAuthenticationContext());
+          masterEnv.getDiscoveryServiceClientSupplier().get(), new WorkerAuthenticationContext(), cConf);
         MasterEnvironmentRunnableContext runnableContext =
           new DefaultMasterEnvironmentRunnableContext(context.getLocationFactory(), remoteClientFactory);
         @SuppressWarnings("unchecked")

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
@@ -30,7 +30,7 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnable;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnableContext;
-import io.cdap.cdap.security.auth.context.MasterAuthenticationContext;
+import io.cdap.cdap.security.auth.context.WorkerAuthenticationContext;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
@@ -110,9 +110,9 @@ public class MasterEnvironmentMain {
                                                + MasterEnvironmentRunnable.class);
         }
 
-        //TODO: CDAP-17754 Use proper authenticaiton context with internal token from configuration
+        //TODO: CDAP-17754 Use proper authentication context with internal token from configuration
         RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
-          masterEnv.getDiscoveryServiceClientSupplier().get(), new MasterAuthenticationContext());
+          masterEnv.getDiscoveryServiceClientSupplier().get(), new WorkerAuthenticationContext());
         MasterEnvironmentRunnableContext runnableContext =
           new DefaultMasterEnvironmentRunnableContext(context.getLocationFactory(), remoteClientFactory);
         @SuppressWarnings("unchecked")

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/AuthorizationHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/AuthorizationHandlerTest.java
@@ -96,7 +96,7 @@ public class AuthorizationHandlerTest {
         @Override
         public void modify(ChannelPipeline pipeline) {
           pipeline.addBefore("dispatcher", "usernamesetter", new TestUserNameSetter());
-          pipeline.addAfter("usernamesetter", "authenticator", new AuthenticationChannelHandler());
+          pipeline.addAfter("usernamesetter", "authenticator", new AuthenticationChannelHandler(false));
         }
       })
       .build();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
@@ -109,7 +109,7 @@ public class RemoteConfiguratorTest {
     namespaceAdmin.create(NamespaceMeta.SYSTEM);
     namespaceAdmin.create(NamespaceMeta.DEFAULT);
 
-    remoteClientFactory = new RemoteClientFactory(discoveryService, new AuthenticationTestContext());
+    remoteClientFactory = new RemoteClientFactory(discoveryService, new AuthenticationTestContext(), cConf);
     httpService = new CommonNettyHttpServiceBuilder(cConf, "test")
       .setHttpHandlers(
         new TaskWorkerHttpHandlerInternal(cConf, className -> { }),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -280,7 +280,7 @@ public abstract class AppFabricTestBase {
     metadataSubscriberService.startAndWait();
     locationFactory = getInjector().getInstance(LocationFactory.class);
     datasetClient = new DatasetClient(getClientConfig(discoveryClient, Constants.Service.DATASET_MANAGER));
-    remoteClientFactory = new RemoteClientFactory(discoveryClient, new AuthenticationTestContext());
+    remoteClientFactory = new RemoteClientFactory(discoveryClient, new AuthenticationTestContext(), cConf);
     metadataClient = new MetadataClient(getClientConfig(discoveryClient, Constants.Service.METADATA_SERVICE));
     metadataServiceClient = new DefaultMetadataServiceClient(remoteClientFactory);
     metricStore = injector.getInstance(MetricStore.class);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
@@ -71,7 +71,7 @@ public class ArtifactLocalizerServiceTest extends AppFabricTestBase {
     String tempFolderPath = tmpFolder.newFolder().getPath();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, tempFolderPath);
     RemoteClientFactory remoteClientFactory = new RemoteClientFactory(discoveryClient,
-                                                                      new AuthenticationTestContext());
+                                                                      new AuthenticationTestContext(), cConf);
     ArtifactLocalizerService artifactLocalizerService =
       new ArtifactLocalizerService(cConf, new ArtifactLocalizer(cConf, remoteClientFactory));
     // start the service

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/AutoInstallTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/AutoInstallTest.java
@@ -69,7 +69,7 @@ public class AutoInstallTest {
     cConf.set(Constants.AppFabric.TEMP_DIR, "appfabric");
     cConf.setInt(Constants.Capability.AUTO_INSTALL_THREADS, 5);
     ArtifactRepository artifactRepository = PowerMockito.mock(ArtifactRepository.class);
-    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(null, null);
+    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(null, null, cConf);
     CapabilityApplier capabilityApplier = new CapabilityApplier(null, null,
                                                                 null, null, null,
                                                                 artifactRepository, cConf, remoteClientFactory);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/guice/AppFabricTestModule.java
@@ -89,7 +89,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new ConfigModule(cConf, hConf, sConf));
     install(new IOModule());
     install(new InMemoryDiscoveryModule());
-    install(new AppFabricServiceRuntimeModule().getInMemoryModules());
+    install(new AppFabricServiceRuntimeModule(cConf).getInMemoryModules());
     install(new MonitorHandlerModule(false));
     install(new ProgramRunnerRuntimeModule().getInMemoryModules());
     install(new NonCustomLocationUnitTestModule());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/master/environment/DefaultMasterEnvironmentRunnableContextTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/master/environment/DefaultMasterEnvironmentRunnableContextTest.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.master.environment;
 
 
+import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.discovery.ResolvingDiscoverable;
 import io.cdap.cdap.common.discovery.URIScheme;
@@ -66,7 +67,7 @@ public class DefaultMasterEnvironmentRunnableContextTest {
     DiscoveryService discoveryService = new InMemoryDiscoveryService();
     LocationFactory locationFactory = new LocalLocationFactory(TMP_FOLDER.newFolder());
     RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
-      (DiscoveryServiceClient) discoveryService, new AuthenticationTestContext());
+      (DiscoveryServiceClient) discoveryService, new AuthenticationTestContext(), CConfiguration.create());
     context = new DefaultMasterEnvironmentRunnableContext(locationFactory, remoteClientFactory);
 
     httpService = NettyHttpService.builder(Constants.Service.APP_FABRIC_HTTP)

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/OAuthMacroEvaluatorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/OAuthMacroEvaluatorTest.java
@@ -21,7 +21,7 @@ import com.google.gson.Gson;
 import io.cdap.cdap.api.ServiceDiscoverer;
 import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.app.services.AbstractServiceDiscoverer;
-import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.service.ServiceDiscoverable;
 import io.cdap.cdap.proto.ProgramType;
@@ -33,7 +33,6 @@ import io.cdap.http.NettyHttpService;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.twill.discovery.Discoverable;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.discovery.InMemoryDiscoveryService;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -74,7 +73,7 @@ public class OAuthMacroEvaluatorTest {
                                                        Constants.STUDIO_SERVICE_NAME);
     discoveryService.register(new Discoverable(discoveryName, httpService.getBindAddress()));
     RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
-      discoveryService, new AuthenticationTestContext());
+      discoveryService, new AuthenticationTestContext(), CConfiguration.create());
     serviceDiscoverer = new AbstractServiceDiscoverer(NamespaceId.DEFAULT.app("testapp").spark("testspark")) {
       @Override
       protected RemoteClientFactory getRemoteClientFactory() {

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1104,6 +1104,9 @@ public final class Constants {
     /** Key to specify the kerberos principal of the entity owner **/
     public static final String PRINCIPAL = "principal";
 
+    /** Requires all intra-cluster communications to be authenticated. */
+    public static final String ENFORCE_INTERNAL_AUTH = "security.internal.enforce.auth";
+
     /**
      * App Fabric
      */

--- a/cdap-common/src/main/java/io/cdap/cdap/common/guice/ZKClientModule.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/guice/ZKClientModule.java
@@ -17,9 +17,11 @@ package io.cdap.cdap.common.guice;
 
 import com.google.common.base.Preconditions;
 import com.google.inject.AbstractModule;
+import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.CConfigurationUtil;
 import io.cdap.cdap.common.conf.Constants;
 import org.apache.twill.zookeeper.RetryStrategies;
 import org.apache.twill.zookeeper.ZKClient;
@@ -61,5 +63,31 @@ public class ZKClientModule extends AbstractModule {
         )
       )
     );
+  }
+
+  /**
+   * Helper function which returns true if ZKClientModule is necessary.
+   * @param cConf The cluster configuration
+   * @return whether to use ZK or not
+   */
+  public static boolean requiresZKClient(CConfiguration cConf) {
+    return !CConfigurationUtil.isOverridden(cConf, Constants.Security.CFG_FILE_BASED_KEYFILE_PATH)
+      || CConfigurationUtil.isOverridden(cConf, Constants.Zookeeper.QUORUM);
+  }
+
+  /**
+   * Returns a ZKClientModule if necessary, otherwise returns an empty module.
+   *
+   * @param cConf The cluster configuration
+   * @return A ZKClientModule if necessary or an empty module otherwise
+   */
+  public static Module getZKClientModuleIfRequired(CConfiguration cConf) {
+    if (requiresZKClient(cConf)) {
+      return new ZKClientModule();
+    }
+    return new AbstractModule() {
+      @Override
+      protected void configure() { }
+    };
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
@@ -45,7 +45,9 @@ public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
           // This is needed before we use a InheritableThreadLocal in SecurityRequestContext
           // to remember the user id.
           EventExecutor executor = pipeline.context("dispatcher").executor();
-          pipeline.addBefore(executor, "dispatcher", "authenticator", new AuthenticationChannelHandler());
+          pipeline.addBefore(executor, "dispatcher", "authenticator",
+                             new AuthenticationChannelHandler(cConf.getBoolean(Constants.Security
+                                                                                 .ENFORCE_INTERNAL_AUTH)));
         }
       };
     }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.common.internal.remote;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.common.http.HttpRequestConfig;
 import org.apache.twill.discovery.DiscoveryServiceClient;
@@ -30,16 +31,19 @@ public class RemoteClientFactory {
 
   private final DiscoveryServiceClient discoveryClient;
   private final AuthenticationContext authenticationContext;
+  private final CConfiguration cConf;
 
   @Inject @VisibleForTesting
-  public RemoteClientFactory(DiscoveryServiceClient discoveryClient, AuthenticationContext authenticationContext) {
+  public RemoteClientFactory(DiscoveryServiceClient discoveryClient, AuthenticationContext authenticationContext,
+                             CConfiguration cConf) {
     this.discoveryClient = discoveryClient;
     this.authenticationContext = authenticationContext;
+    this.cConf = cConf;
   }
 
   public RemoteClient createRemoteClient(String discoverableServiceName,
                                          HttpRequestConfig httpRequestConfig, String basePath) {
-    return new RemoteClient(authenticationContext, discoveryClient, discoverableServiceName, httpRequestConfig,
+    return new RemoteClient(authenticationContext, discoveryClient, cConf, discoverableServiceName, httpRequestConfig,
                             basePath);
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/namespace/RemoteNamespaceQueryClient.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/namespace/RemoteNamespaceQueryClient.java
@@ -17,17 +17,14 @@
 package io.cdap.cdap.common.namespace;
 
 import com.google.inject.Inject;
-import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
-import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpResponse;
 import io.cdap.http.HttpHandler;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.io.IOException;
 import java.net.URL;
@@ -38,30 +35,21 @@ import java.net.URL;
  */
 public class RemoteNamespaceQueryClient extends AbstractNamespaceQueryClient {
   private final RemoteClient remoteClient;
-  private final AuthenticationContext authenticationContext;
 
   @Inject
-  RemoteNamespaceQueryClient(CConfiguration cConf,
-                             AuthenticationContext authenticationContext,
-                             RemoteClientFactory remoteClientFactory) {
+  RemoteNamespaceQueryClient(RemoteClientFactory remoteClientFactory) {
     this.remoteClient = remoteClientFactory.createRemoteClient(
       Constants.Service.APP_FABRIC_HTTP,
       new DefaultHttpRequestConfig(false), Constants.Gateway.API_VERSION_3);
-    this.authenticationContext = authenticationContext;
   }
 
   @Override
   protected HttpResponse execute(HttpRequest request) throws IOException, UnauthorizedException {
-    return remoteClient.execute(addUserIdHeader(request));
+    return remoteClient.execute(request);
   }
 
   @Override
   protected URL resolve(String resource) throws IOException {
     return remoteClient.resolve(resource);
-  }
-
-  private HttpRequest addUserIdHeader(HttpRequest request) throws IOException {
-    return new HttpRequest.Builder(request).addHeader(Constants.Security.Headers.USER_ID,
-                                                      authenticationContext.getPrincipal().getName()).build();
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4157,6 +4157,16 @@
     </description>
   </property>
 
+  <!-- Internal Security -->
+
+  <property>
+    <name>security.internal.enforce.auth</name>
+    <value>false</value>
+    <description>
+      A security-hardening measure which enforces authenticated communication between internal system services.
+    </description>
+  </property>
+
   <!-- UI Configuration -->
 
   <property>

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterMain.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterMain.java
@@ -28,7 +28,8 @@ import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.guice.ZKDiscoveryModule;
 import io.cdap.cdap.common.runtime.DaemonMain;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import org.apache.twill.internal.Services;
 import org.apache.twill.zookeeper.ZKClientService;
@@ -134,7 +135,8 @@ public class RouterMain extends DaemonMain {
       new ZKClientModule(),
       new ZKDiscoveryModule(),
       new RouterModules().getDistributedModules(),
-      new SecurityModules().getDistributedModules(),
+      CoreSecurityModules.getDistributedModule(cConf),
+      new ExternalAuthenticationModule(),
       new IOModule()
     );
   }

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayTestBase.java
@@ -49,7 +49,8 @@ import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.RunRecord;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.spi.authorization.NoOpAccessController;
@@ -160,7 +161,8 @@ public abstract class GatewayTestBase {
                                       ("localhost", 0).getAddress());
           }
         },
-        new SecurityModules().getInMemoryModules(),
+        new CoreSecurityModules().getInMemoryModules(),
+        new ExternalAuthenticationModule(),
         new AppFabricTestModule(conf)
       ).with(new AbstractModule() {
         @Override

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/AuthServerAnnounceTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/AuthServerAnnounceTest.java
@@ -31,7 +31,8 @@ import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.AuthenticationMode;
 import io.cdap.cdap.security.auth.TokenValidator;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.server.GrantAccessToken;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -118,7 +119,8 @@ public class AuthServerAnnounceTest {
     @Override
     protected void startUp() {
       SConfiguration sConfiguration = SConfiguration.create();
-      Injector injector = Guice.createInjector(new SecurityModules().getInMemoryModules(),
+      Injector injector = Guice.createInjector(new CoreSecurityModules().getInMemoryModules(),
+                                               new ExternalAuthenticationModule(),
                                                new InMemoryDiscoveryModule(),
                                                new AppFabricTestModule(cConf));
       DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/NettyRouterHttpTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/NettyRouterHttpTest.java
@@ -25,7 +25,8 @@ import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import org.apache.commons.net.DefaultSocketFactory;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.twill.discovery.DiscoveryService;
@@ -74,7 +75,8 @@ public class NettyRouterHttpTest extends NettyRouterTestBase {
     protected void startUp() {
       CConfiguration cConf = CConfiguration.create();
       SConfiguration sConfiguration = SConfiguration.create();
-      Injector injector = Guice.createInjector(new SecurityModules().getInMemoryModules(),
+      Injector injector = Guice.createInjector(new CoreSecurityModules().getInMemoryModules(),
+                                               new ExternalAuthenticationModule(),
                                                new InMemoryDiscoveryModule(),
                                                new AppFabricTestModule(cConf));
       DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/NettyRouterHttpsTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/NettyRouterHttpsTest.java
@@ -27,7 +27,8 @@ import io.cdap.cdap.common.security.KeyStores;
 import io.cdap.cdap.common.security.KeyStoresTest;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.common.http.HttpRequests;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import org.apache.http.conn.ClientConnectionManager;
@@ -164,7 +165,8 @@ public class NettyRouterHttpsTest extends NettyRouterTestBase {
 
     @Override
     protected void startUp() {
-      Injector injector = Guice.createInjector(new SecurityModules().getInMemoryModules(),
+      Injector injector = Guice.createInjector(new CoreSecurityModules().getInMemoryModules(),
+                                               new ExternalAuthenticationModule(),
                                                new InMemoryDiscoveryModule(),
                                                new AppFabricTestModule(cConf));
       DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterResource.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterResource.java
@@ -26,7 +26,8 @@ import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.TokenValidator;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.junit.rules.ExternalResource;
@@ -55,7 +56,8 @@ class RouterResource extends ExternalResource {
   @Override
   protected void before() {
     CConfiguration cConf = CConfiguration.create();
-    Injector injector = Guice.createInjector(new SecurityModules().getInMemoryModules(),
+    Injector injector = Guice.createInjector(new CoreSecurityModules().getStandaloneModules(),
+                                             new ExternalAuthenticationModule(),
                                              new InMemoryDiscoveryModule(),
                                              new AppFabricTestModule(cConf));
     DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RoutingToDataSetsTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RoutingToDataSetsTest.java
@@ -28,7 +28,8 @@ import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.utils.Networks;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpResponder;
 import io.netty.handler.codec.http.HttpRequest;
@@ -61,7 +62,8 @@ public class RoutingToDataSetsTest {
   @BeforeClass
   public static void before() throws Exception {
     CConfiguration cConf = CConfiguration.create();
-    Injector injector = Guice.createInjector(new SecurityModules().getInMemoryModules(),
+    Injector injector = Guice.createInjector(new CoreSecurityModules().getInMemoryModules(),
+                                             new ExternalAuthenticationModule(),
                                              new InMemoryDiscoveryModule(),
                                              new AppFabricTestModule(cConf));
 

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
@@ -572,7 +572,7 @@ public class MasterServiceMain extends DaemonMain {
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new TwillModule(),
-      new AppFabricServiceRuntimeModule().getDistributedModules(),
+      new AppFabricServiceRuntimeModule(cConf).getDistributedModules(),
       new MonitorHandlerModule(true),
       new ProgramRunnerRuntimeModule().getDistributedModules(),
       new SecureStoreServerModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/tools/JobQueueDebugger.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/tools/JobQueueDebugger.java
@@ -329,7 +329,7 @@ public class JobQueueDebugger extends AbstractIdleService {
       new ExploreClientModule(),
       new DataFabricModules().getDistributedModules(),
       new DataSetsModules().getDistributedModules(),
-      new AppFabricServiceRuntimeModule().getDistributedModules(),
+      new AppFabricServiceRuntimeModule(cConf).getDistributedModules(),
       new ProgramRunnerRuntimeModule().getDistributedModules(),
       new SystemDatasetRuntimeModule().getDistributedModules(),
       new KafkaLogAppenderModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/tools/UpgradeTool.java
@@ -203,7 +203,7 @@ public class UpgradeTool {
       new AuthorizationEnforcementModule().getMasterModule(),
       new SecureStoreServerModule(),
       new DataFabricModules(UpgradeTool.class.getName()).getDistributedModules(),
-      new AppFabricServiceRuntimeModule().getDistributedModules(),
+      new AppFabricServiceRuntimeModule(cConf).getDistributedModules(),
       new KafkaLogAppenderModule(),
       // the DataFabricDistributedModule needs MetricsCollectionService binding
       new AbstractModule() {

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AuthenticationServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AuthenticationServiceMain.java
@@ -31,8 +31,8 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
-import io.cdap.cdap.security.guice.SecurityModule;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.server.ExternalAuthenticationServer;
 import org.apache.twill.zookeeper.ZKClientService;
@@ -60,14 +60,10 @@ public class AuthenticationServiceMain extends AbstractServiceMain<EnvironmentOp
 
     List<Module> modules = new ArrayList<>();
     modules.add(new MessagingClientModule());
-    modules.add(new AuthenticationContextModules().getMasterModule());
-
-    SecurityModule securityModule = SecurityModules.getDistributedModule(cConf);
-    modules.add(securityModule);
-    if (securityModule.requiresZKClient()) {
-      modules.add(new ZKClientModule());
-    }
-
+    modules.add(CoreSecurityModules.getDistributedModule(cConf));
+    modules.add(new AuthenticationContextModules().getInternalAuthMasterModule(cConf));
+    modules.add(new ExternalAuthenticationModule());
+    modules.add(ZKClientModule.getZKClientModuleIfRequired(cConf));
     return modules;
   }
 

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetadataServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetadataServiceMain.java
@@ -20,7 +20,9 @@ import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.AbstractService;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.AbstractModule;
+import com.google.inject.Binding;
 import com.google.inject.Injector;
+import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.cdap.cdap.app.guice.EntityVerifierModule;
@@ -28,6 +30,7 @@ import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
+import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.namespace.guice.NamespaceQueryAdminModule;
@@ -44,8 +47,10 @@ import io.cdap.cdap.metadata.MetadataService;
 import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.metadata.MetadataSubscriberService;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
@@ -53,6 +58,7 @@ import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.spi.authorization.NoOpAccessController;
 import io.cdap.cdap.security.spi.authorization.PermissionManager;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
+import org.apache.twill.zookeeper.ZKClientService;
 
 import java.util.Arrays;
 import java.util.List;
@@ -85,7 +91,9 @@ public class MetadataServiceMain extends AbstractServiceMain<EnvironmentOptions>
       new AuditModule(),
       new EntityVerifierModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
-      new AuthenticationContextModules().getMasterModule(),
+      new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
+      CoreSecurityModules.getDistributedModule(cConf),
+      ZKClientModule.getZKClientModuleIfRequired(cConf),
       new DFSLocationModule(),
       new AbstractModule() {
         @Override
@@ -111,6 +119,11 @@ public class MetadataServiceMain extends AbstractServiceMain<EnvironmentOptions>
                              EnvironmentOptions options) {
     services.add(injector.getInstance(MetadataService.class));
     services.add(injector.getInstance(MetadataSubscriberService.class));
+    Binding<ZKClientService> zkBinding = injector.getExistingBinding(Key.get(ZKClientService.class));
+    if (zkBinding != null) {
+      services.add(zkBinding.getProvider().get());
+    }
+    services.add(injector.getInstance(TokenManager.class));
 
     // Add a service just for closing MetadataStorage to release resource.
     // MetadataStorage is binded as Singleton, so ok to get the instance and close it.

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/StorageMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/StorageMain.java
@@ -25,7 +25,9 @@ import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.DFSLocationModule;
+import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.data.runtime.ConstantTransactionSystemClient;
 import io.cdap.cdap.data.runtime.DataSetsModules;
@@ -33,6 +35,7 @@ import io.cdap.cdap.data.runtime.StorageModule;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import io.cdap.cdap.security.spi.authorization.NoOpAccessController;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
@@ -70,7 +73,10 @@ public class StorageMain {
       new InMemoryDiscoveryModule(),
       new StorageModule(),
       new DFSLocationModule(),
-      new AuthenticationContextModules().getNoOpModule(),
+      new IOModule(),
+      new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
+      CoreSecurityModules.getDistributedModule(cConf),
+      ZKClientModule.getZKClientModuleIfRequired(cConf),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Credential.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Credential.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.security;
+
+/**
+ * Encapsulating class for credentials passing through CDAP.
+ */
+public class Credential {
+  public static final String CREDENTIAL_TYPE_INTERNAL = "CDAP-Internal";
+  public static final String CREDENTIAL_TYPE_EXTERNAL = "CDAP-External";
+  public static final String CREDENTIAL_TYPE_EXTERNAL_ENCRYPTED = "CDAP-External-Encrypted";
+
+  /**
+   * Identifies the type of credential.
+   */
+  public enum CredentialType {
+    /**
+     * Internal credentials will be checked by the internal access enforcer instead of the access enforcer extension.
+     */
+    INTERNAL(CREDENTIAL_TYPE_INTERNAL),
+    /**
+     * External credentials are credentials which should be checked by the access enforcer extension.
+     */
+    EXTERNAL(CREDENTIAL_TYPE_EXTERNAL),
+    /**
+     * External encrypted credentials are credentials which should be decrypted prior to being checked by the
+     * access enforcer extension.
+     */
+    EXTERNAL_ENCRYPTED(CREDENTIAL_TYPE_EXTERNAL_ENCRYPTED);
+
+    private final String qualifiedName;
+
+    CredentialType(String qualifiedName) {
+      this.qualifiedName = qualifiedName;
+    }
+
+    public String getQualifiedName() {
+      return qualifiedName;
+    }
+
+    /**
+     * Returns the {@link CredentialType} from the qualified name.
+     *
+     * @param qualifiedName the qualified name
+     * @return the credential type
+     */
+    public static CredentialType fromQualifiedName(String qualifiedName) {
+      switch (qualifiedName) {
+        case CREDENTIAL_TYPE_INTERNAL:
+          return CredentialType.INTERNAL;
+        case CREDENTIAL_TYPE_EXTERNAL:
+          return CredentialType.EXTERNAL;
+        case CREDENTIAL_TYPE_EXTERNAL_ENCRYPTED:
+          return CredentialType.EXTERNAL_ENCRYPTED;
+        default:
+          throw new IllegalArgumentException("Invalid qualified credential type");
+      }
+    }
+  }
+
+  private final String value;
+  private final CredentialType type;
+
+  public Credential(String value, CredentialType type) {
+    this.value = value;
+    this.type = type;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public CredentialType getType() {
+    return type;
+  }
+
+  @Override
+  public String toString() {
+    return "Credential{" +
+      "type=" + type +
+      ", length=" + value.length() +
+      "}";
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Principal.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Principal.java
@@ -39,7 +39,7 @@ public class Principal {
   private final String name;
   private final PrincipalType type;
   private final String kerberosPrincipal;
-  private final String credential;
+  private final Credential credential;
   // This needs to be transient because we don't want this to be populated during deserialization since that
   // value will not be provided by the client.
   private transient int hashCode;
@@ -48,11 +48,12 @@ public class Principal {
     this(name, type, null, null);
   }
 
-  public Principal(String name, PrincipalType type, @Nullable String credentials) {
+  public Principal(String name, PrincipalType type, @Nullable Credential credentials) {
     this(name, type, null, credentials);
   }
 
-  public Principal(String name, PrincipalType type, @Nullable String kerberosPrincipal, @Nullable String credential) {
+  public Principal(String name, PrincipalType type, @Nullable String kerberosPrincipal,
+                   @Nullable Credential credential) {
     this.name = name;
     this.type = type;
     this.kerberosPrincipal = kerberosPrincipal;
@@ -74,6 +75,14 @@ public class Principal {
 
   @Nullable
   public String getCredential() {
+    if (credential == null) {
+      return null;
+    }
+    return credential.getValue();
+  }
+
+  @Nullable
+  public Credential getFullCredential() {
     return credential;
   }
 
@@ -110,7 +119,7 @@ public class Principal {
       "name='" + name + '\'' +
       ", type=" + type +
       ", kerberosPrincipal=" + kerberosPrincipal +
-      ", credentialLength=" + (credential == null ? "NULL" : String.valueOf(credential.length())) +
+      ", credential=" + credential +
       '}';
   }
 }

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authentication/SecurityRequestContext.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authentication/SecurityRequestContext.java
@@ -15,6 +15,7 @@
  */
 package io.cdap.cdap.security.spi.authentication;
 
+import io.cdap.cdap.proto.security.Credential;
 import io.cdap.cdap.proto.security.Principal;
 
 import javax.annotation.Nullable;
@@ -24,7 +25,7 @@ import javax.annotation.Nullable;
  */
 public final class SecurityRequestContext {
   private static final ThreadLocal<String> userId = new InheritableThreadLocal<>();
-  private static final ThreadLocal<String> userCredential = new InheritableThreadLocal<>();
+  private static final ThreadLocal<Credential> userCredential = new InheritableThreadLocal<>();
   private static final ThreadLocal<String> userIP = new InheritableThreadLocal<>();
 
   private SecurityRequestContext() {
@@ -42,7 +43,7 @@ public final class SecurityRequestContext {
    * @return the user credential set on the current thread or null if user credential is not set
    */
   @Nullable
-  public static String getUserCredential() {
+  public static Credential getUserCredential() {
     return userCredential.get();
   }
 
@@ -68,7 +69,7 @@ public final class SecurityRequestContext {
    *
    * @param userCredentialParam user credential to be set
    */
-  public static void setUserCredential(@Nullable String userCredentialParam) {
+  public static void setUserCredential(@Nullable Credential userCredentialParam) {
     userCredential.set(userCredentialParam);
   }
 

--- a/cdap-security/src/main/java/io/cdap/cdap/security/auth/context/MasterAuthenticationContext.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/auth/context/MasterAuthenticationContext.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.security.auth.context;
 
 import com.google.common.base.Throwables;
+import io.cdap.cdap.proto.security.Credential;
 import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
@@ -37,13 +38,12 @@ import java.io.IOException;
  * @see UserGroupInformation
  */
 public class MasterAuthenticationContext implements AuthenticationContext {
-
   @Override
   public Principal getPrincipal() {
     // When requests come in via rest endpoints, the userId is updated inside SecurityRequestContext, so give that
     // precedence.
     String userId = SecurityRequestContext.getUserId();
-    String userCredential = SecurityRequestContext.getUserCredential();
+    Credential userCredential = SecurityRequestContext.getUserCredential();
     // This userId can be null, when the master itself is asynchoronously updating the policy cache, since
     // during that process the router will not set the SecurityRequestContext. In that case, obtain the userId from
     // the UserGroupInformation, which will be the user that the master is running as.

--- a/cdap-security/src/main/java/io/cdap/cdap/security/auth/context/SystemAuthenticationContext.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/auth/context/SystemAuthenticationContext.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.auth.context;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.proto.security.Credential;
+import io.cdap.cdap.proto.security.Principal;
+import io.cdap.cdap.security.auth.AccessToken;
+import io.cdap.cdap.security.auth.AccessTokenCodec;
+import io.cdap.cdap.security.auth.TokenManager;
+import io.cdap.cdap.security.auth.UserIdentity;
+import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
+import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Collections;
+
+/**
+ * Authentication context for master services which utilize internal authentication.
+ */
+public class SystemAuthenticationContext implements AuthenticationContext {
+  public static final String SYSTEM_IDENTITY = "system";
+  // Default expiration time of 5 minutes.
+  private static final long DEFAULT_EXPIRATION = 300000;
+
+  private final AccessTokenCodec accessTokenCodec;
+  private final TokenManager tokenManager;
+
+  @Inject
+  SystemAuthenticationContext(AccessTokenCodec accessTokenCodec, TokenManager tokenManager) {
+    this.accessTokenCodec = accessTokenCodec;
+    this.tokenManager = tokenManager;
+  }
+
+  @Override
+  public Principal getPrincipal() {
+    // By default, assume the principal comes from a user request and handle accordingly using SecurityRequestContext.
+    String userId = SecurityRequestContext.getUserId();
+    Credential userCredential = SecurityRequestContext.getUserCredential();
+    if (userId != null) {
+      return new Principal(userId, Principal.PrincipalType.USER, userCredential);
+    }
+
+    // Use internal identity if user ID is null.
+    // If user ID is null, the service is not handling a user request, so we assume it is an internal request.
+    long currentTimestamp = System.currentTimeMillis();
+    UserIdentity identity = new UserIdentity(SYSTEM_IDENTITY, Collections.emptyList(), currentTimestamp,
+                                             currentTimestamp + DEFAULT_EXPIRATION);
+    AccessToken accessToken = tokenManager.signIdentifier(identity);
+    String encodedAccessToken;
+    try {
+      encodedAccessToken = Base64.getEncoder().encodeToString(accessTokenCodec.encode(accessToken));
+      Credential credential = new Credential(encodedAccessToken, Credential.CredentialType.INTERNAL);
+      return new Principal(SYSTEM_IDENTITY, Principal.PrincipalType.USER, credential);
+    } catch (IOException e) {
+      throw new RuntimeException("Unexpected failure while creating internal system identity", e);
+    }
+  }
+}

--- a/cdap-security/src/main/java/io/cdap/cdap/security/auth/context/WorkerAuthenticationContext.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/auth/context/WorkerAuthenticationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2016 Cask Data, Inc.
+ * Copyright © 2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,23 +16,25 @@
 
 package io.cdap.cdap.security.auth.context;
 
+import io.cdap.cdap.proto.security.Credential;
 import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
-import org.apache.hadoop.security.UserGroupInformation;
 
 /**
- * An {@link AuthenticationContext} for use in program containers. The authentication details in this context are
- * determined based on the {@link UserGroupInformation} of the user running the program.
+ * Authentication context for workers.
  */
-class ProgramContainerAuthenticationContext implements AuthenticationContext {
-  private final Principal principal;
-
-  ProgramContainerAuthenticationContext(Principal principal) {
-    this.principal = principal;
-  }
-
+public class WorkerAuthenticationContext implements AuthenticationContext {
+  private static final String WORKER_USER_ID = "worker";
+  private static final String PLACEHOLDER_CREDENTIAL = "placeholder";
+  /**
+   * Currently only returns a hardcoded set of user ID and credentials to get around the required auth limitation.
+   * TODO CDAP-17772: Implement proper authentication context for workers.
+   *
+   * @return A placeholder principal for workers.
+   */
   @Override
   public Principal getPrincipal() {
-    return principal;
+    return new Principal(WORKER_USER_ID, Principal.PrincipalType.USER,
+                         new Credential(PLACEHOLDER_CREDENTIAL, Credential.CredentialType.INTERNAL));
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/CoreSecurityModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/CoreSecurityModule.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2014-2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.guice;
+
+import com.google.inject.Binder;
+import com.google.inject.PrivateModule;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import io.cdap.cdap.common.io.Codec;
+import io.cdap.cdap.security.auth.AccessToken;
+import io.cdap.cdap.security.auth.AccessTokenCodec;
+import io.cdap.cdap.security.auth.AccessTokenValidator;
+import io.cdap.cdap.security.auth.KeyIdentifier;
+import io.cdap.cdap.security.auth.KeyIdentifierCodec;
+import io.cdap.cdap.security.auth.TokenManager;
+import io.cdap.cdap.security.auth.TokenValidator;
+import io.cdap.cdap.security.auth.UserIdentity;
+import io.cdap.cdap.security.auth.UserIdentityCodec;
+
+/**
+ * Guice bindings for core security related functionality including token and key management.
+ * This extends {@code PrivateModule} in order to limit which classes are exposed.
+ */
+public abstract class CoreSecurityModule extends PrivateModule {
+  public boolean requiresZKClient() {
+    return false;
+  }
+
+  @Override
+  protected final void configure() {
+    bind(new TypeLiteral<Codec<AccessToken>>() { }).to(AccessTokenCodec.class).in(Scopes.SINGLETON);
+    bind(new TypeLiteral<Codec<UserIdentity>>() { }).to(UserIdentityCodec.class).in(Scopes.SINGLETON);
+    bind(new TypeLiteral<Codec<KeyIdentifier>>() { }).to(KeyIdentifierCodec.class).in(Scopes.SINGLETON);
+
+    bindKeyManager(binder());
+    bind(TokenManager.class).in(Scopes.SINGLETON);
+    bind(TokenValidator.class).to(AccessTokenValidator.class);
+
+    expose(TokenValidator.class);
+    expose(TokenManager.class);
+    expose(new TypeLiteral<Codec<AccessToken>>() { });
+    expose(new TypeLiteral<Codec<KeyIdentifier>>() { });
+  }
+
+  protected abstract void bindKeyManager(Binder binder);
+}

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/CoreSecurityModules.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/CoreSecurityModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,8 +18,7 @@ package io.cdap.cdap.security.guice;
 
 import com.google.inject.Module;
 import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.common.conf.CConfigurationUtil;
-import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.runtime.RuntimeModule;
 import org.apache.twill.zookeeper.ZKClient;
 
@@ -27,16 +26,16 @@ import org.apache.twill.zookeeper.ZKClient;
  * Security guice modules
  */
 //TODO: we need to have separate implementations for inMemoryModule and standaloneModule
-public class SecurityModules extends RuntimeModule {
+public class CoreSecurityModules extends RuntimeModule {
 
   @Override
   public Module getInMemoryModules() {
-    return new InMemorySecurityModule();
+    return new InMemoryCoreSecurityModule();
   }
 
   @Override
   public Module getStandaloneModules() {
-    return new InMemorySecurityModule();
+    return new InMemoryCoreSecurityModule();
   }
 
   /**
@@ -45,20 +44,19 @@ public class SecurityModules extends RuntimeModule {
    */
   @Override
   public Module getDistributedModules() {
-    return new DistributedSecurityModule();
+    return new DistributedCoreSecurityModule();
   }
 
   /**
    * Returns {@code true} if a {@link ZKClient} binding is needed for the distributed module.
    */
-  public static SecurityModule getDistributedModule(CConfiguration cConf) {
+  public static CoreSecurityModule getDistributedModule(CConfiguration cConf) {
     // If the file based path is not set explicitly, use ZK.
     // If ZK is set explicitly, always use ZK.
     // This is the backward compatible behavior.
-    if (!CConfigurationUtil.isOverridden(cConf, Constants.Security.CFG_FILE_BASED_KEYFILE_PATH)
-        || CConfigurationUtil.isOverridden(cConf, Constants.Zookeeper.QUORUM)) {
-      return new DistributedSecurityModule();
+    if (ZKClientModule.requiresZKClient(cConf)) {
+      return new DistributedCoreSecurityModule();
     }
-    return new FileBasedSecurityModule();
+    return new FileBasedCoreSecurityModule();
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/DistributedCoreSecurityModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/DistributedCoreSecurityModule.java
@@ -18,17 +18,22 @@ package io.cdap.cdap.security.guice;
 
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
-import io.cdap.cdap.security.auth.FileBasedKeyManager;
+import io.cdap.cdap.security.auth.DistributedKeyManager;
 import io.cdap.cdap.security.auth.KeyManager;
 
 /**
- * Guice bindings for FileBasedKeyManagers. This extends {@code SecurityModule} to provide
- * an instance of {@code FileBasedKeyManager}.
+ * Configures dependency injection with all security class implementations required to run in a distributed
+ * environment.
  */
-public class FileBasedSecurityModule extends SecurityModule {
+final class DistributedCoreSecurityModule extends CoreSecurityModule {
+
+  @Override
+  public boolean requiresZKClient() {
+    return true;
+  }
 
   @Override
   protected void bindKeyManager(Binder binder) {
-    binder.bind(KeyManager.class).to(FileBasedKeyManager.class).in(Scopes.SINGLETON);
+    binder.bind(KeyManager.class).to(DistributedKeyManager.class).in(Scopes.SINGLETON);
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/ExternalAuthenticationModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/ExternalAuthenticationModule.java
@@ -1,23 +1,20 @@
 /*
- * Copyright © 2014-2021 Cask Data, Inc.
- *
+ * Copyright © 2021 Cask Data, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
  * the License at
- *
  * http://www.apache.org/licenses/LICENSE-2.0
- *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
 
 package io.cdap.cdap.security.guice;
 
 import com.google.common.reflect.TypeToken;
-import com.google.inject.Binder;
 import com.google.inject.Inject;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provider;
@@ -30,16 +27,9 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.common.lang.InstantiatorFactory;
-import io.cdap.cdap.security.auth.AccessToken;
-import io.cdap.cdap.security.auth.AccessTokenCodec;
 import io.cdap.cdap.security.auth.AccessTokenIdentityExtractor;
-import io.cdap.cdap.security.auth.AccessTokenValidator;
 import io.cdap.cdap.security.auth.AuthenticationMode;
-import io.cdap.cdap.security.auth.KeyIdentifier;
-import io.cdap.cdap.security.auth.KeyIdentifierCodec;
 import io.cdap.cdap.security.auth.ProxyUserIdentityExtractor;
-import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.TokenValidator;
 import io.cdap.cdap.security.auth.UserIdentity;
 import io.cdap.cdap.security.auth.UserIdentityCodec;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
@@ -51,51 +41,35 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Guice bindings for security related classes. This extends {@code PrivateModule} in order to limit which classes
- * are exposed.
+ * Guice bindings for classes relating to external authentication including the external authentication server
+ * and identity extractors.
  */
-public abstract class SecurityModule extends PrivateModule {
-
+public class ExternalAuthenticationModule extends PrivateModule {
   private static final Logger EXTERNAL_AUTH_AUDIT_LOG = LoggerFactory.getLogger("external-auth-access");
 
-  public boolean requiresZKClient() {
-    return false;
-  }
-
   @Override
-  protected final void configure() {
-    bind(new TypeLiteral<Codec<AccessToken>>() { }).to(AccessTokenCodec.class).in(Scopes.SINGLETON);
+  protected void configure() {
     bind(new TypeLiteral<Codec<UserIdentity>>() { }).to(UserIdentityCodec.class).in(Scopes.SINGLETON);
-    bind(new TypeLiteral<Codec<KeyIdentifier>>() { }).to(KeyIdentifierCodec.class).in(Scopes.SINGLETON);
-
-    bindKeyManager(binder());
-    bind(TokenManager.class).in(Scopes.SINGLETON);
-
     bind(ExternalAuthenticationServer.class).in(Scopes.SINGLETON);
 
     MapBinder<String, Object> handlerBinder = MapBinder.newMapBinder(binder(), String.class, Object.class,
                                                                      Names.named("security.handlers.map"));
 
-    handlerBinder.addBinding(ExternalAuthenticationServer.HandlerType.AUTHENTICATION_HANDLER)
-                 .toProvider(AuthenticationHandlerProvider.class).in(Scopes.SINGLETON);
-    handlerBinder.addBinding(ExternalAuthenticationServer.HandlerType.GRANT_TOKEN_HANDLER)
-                 .to(GrantAccessToken.class).in(Scopes.SINGLETON);
-
     bind(AuditLogHandler.class)
       .annotatedWith(Names.named(ExternalAuthenticationServer.NAMED_EXTERNAL_AUTH))
       .toInstance(new AuditLogHandler(EXTERNAL_AUTH_AUDIT_LOG));
+    handlerBinder.addBinding(ExternalAuthenticationServer.HandlerType.AUTHENTICATION_HANDLER)
+      .toProvider(AuthenticationHandlerProvider.class).in(Scopes.SINGLETON);
+    handlerBinder.addBinding(ExternalAuthenticationServer.HandlerType.GRANT_TOKEN_HANDLER)
+      .to(GrantAccessToken.class).in(Scopes.SINGLETON);
 
-    bind(TokenValidator.class).to(AccessTokenValidator.class);
     bind(UserIdentityExtractor.class).annotatedWith(Names.named(AccessTokenIdentityExtractor.NAME))
       .to(AccessTokenIdentityExtractor.class);
     bind(UserIdentityExtractor.class).annotatedWith(Names.named(ProxyUserIdentityExtractor.NAME))
       .to(ProxyUserIdentityExtractor.class);
     bind(UserIdentityExtractor.class).toProvider(UserIdentityExtractorProvider.class).in(Scopes.SINGLETON);
     expose(UserIdentityExtractor.class);
-    expose(TokenValidator.class);
-    expose(TokenManager.class);
     expose(ExternalAuthenticationServer.class);
-    expose(new TypeLiteral<Codec<KeyIdentifier>>() { });
   }
 
   private static final class AuthenticationHandlerProvider implements Provider<Handler> {
@@ -145,6 +119,4 @@ public abstract class SecurityModule extends PrivateModule {
       }
     }
   }
-
-  protected abstract void bindKeyManager(Binder binder);
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/FileBasedCoreSecurityModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/FileBasedCoreSecurityModule.java
@@ -18,22 +18,17 @@ package io.cdap.cdap.security.guice;
 
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
-import io.cdap.cdap.security.auth.DistributedKeyManager;
+import io.cdap.cdap.security.auth.FileBasedKeyManager;
 import io.cdap.cdap.security.auth.KeyManager;
 
 /**
- * Configures dependency injection with all security class implementations required to run in a distributed
- * environment.
+ * Guice bindings for FileBasedKeyManagers. This extends {@code SecurityModule} to provide
+ * an instance of {@code FileBasedKeyManager}.
  */
-final class DistributedSecurityModule extends SecurityModule {
-
-  @Override
-  public boolean requiresZKClient() {
-    return true;
-  }
+public class FileBasedCoreSecurityModule extends CoreSecurityModule {
 
   @Override
   protected void bindKeyManager(Binder binder) {
-    binder.bind(KeyManager.class).to(DistributedKeyManager.class).in(Scopes.SINGLETON);
+    binder.bind(KeyManager.class).to(FileBasedKeyManager.class).in(Scopes.SINGLETON);
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/InMemoryCoreSecurityModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/InMemoryCoreSecurityModule.java
@@ -28,7 +28,7 @@ import io.cdap.cdap.security.auth.KeyManager;
  * Guice bindings for InMemoryKeyManagers. This extends {@code SecurityModule} to provide
  * an instance of {@code InMemoryKeyManager}.
  */
-final class InMemorySecurityModule extends SecurityModule {
+final class InMemoryCoreSecurityModule extends CoreSecurityModule {
 
   @Override
   protected void bindKeyManager(Binder binder) {

--- a/cdap-security/src/main/java/io/cdap/cdap/security/runtime/AuthenticationServerMain.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/runtime/AuthenticationServerMain.java
@@ -28,7 +28,8 @@ import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.guice.ZKDiscoveryModule;
 import io.cdap.cdap.common.runtime.DaemonMain;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.server.ExternalAuthenticationServer;
 import org.apache.twill.internal.Services;
@@ -55,7 +56,8 @@ public class AuthenticationServerMain extends DaemonMain {
                                              new IOModule(),
                                              new ZKClientModule(),
                                              new ZKDiscoveryModule(),
-                                             new SecurityModules().getDistributedModules());
+                                             new CoreSecurityModules().getDistributedModules(),
+                                             new ExternalAuthenticationModule());
     configuration = injector.getInstance(CConfiguration.class);
 
     if (SecurityUtil.isManagedSecurity(configuration)) {

--- a/cdap-security/src/main/java/io/cdap/cdap/security/tools/AuthenticationTool.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/tools/AuthenticationTool.java
@@ -29,7 +29,7 @@ import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.security.auth.FileBasedKeyManager;
 import io.cdap.cdap.security.auth.KeyIdentifier;
 import io.cdap.cdap.security.auth.KeyIdentifierCodec;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -82,7 +82,7 @@ public class AuthenticationTool {
         new ConfigModule(cConf),
         new IOModule(),
         new InMemoryDiscoveryModule(),
-        SecurityModules.getDistributedModule(cConf));
+        CoreSecurityModules.getDistributedModule(cConf));
 
       Codec<KeyIdentifier> codec = injector.getInstance(Key.get(new TypeLiteral<Codec<KeyIdentifier>>() { }));
       FileBasedKeyManager keyManager = new FileBasedKeyManager(injector.getInstance(CConfiguration.class),

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/DistributedKeyManagerTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/DistributedKeyManagerTest.java
@@ -31,8 +31,8 @@ import io.cdap.cdap.common.guice.ZKDiscoveryModule;
 import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.common.utils.ImmutablePair;
 import io.cdap.cdap.common.utils.Tasks;
-import io.cdap.cdap.security.guice.SecurityModule;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.zookeeper.MiniZooKeeperCluster;
@@ -79,9 +79,9 @@ public class DistributedKeyManagerTest extends TestTokenManager {
     modules.add(new ConfigModule(cConf1, testUtil.getConfiguration()));
     modules.add(new IOModule());
 
-    SecurityModule securityModule = SecurityModules.getDistributedModule(cConf1);
-    modules.add(securityModule);
-    if (securityModule.requiresZKClient()) {
+    CoreSecurityModule coreSecurityModule = CoreSecurityModules.getDistributedModule(cConf1);
+    modules.add(coreSecurityModule);
+    if (coreSecurityModule.requiresZKClient()) {
       modules.add(new ZKClientModule());
       modules.add(new ZKDiscoveryModule());
     }
@@ -91,9 +91,9 @@ public class DistributedKeyManagerTest extends TestTokenManager {
     modules.add(new ConfigModule(cConf2, testUtil.getConfiguration()));
     modules.add(new IOModule());
 
-    securityModule = SecurityModules.getDistributedModule(cConf2);
-    modules.add(securityModule);
-    if (securityModule.requiresZKClient()) {
+    coreSecurityModule = CoreSecurityModules.getDistributedModule(cConf2);
+    modules.add(coreSecurityModule);
+    if (coreSecurityModule.requiresZKClient()) {
       modules.add(new ZKClientModule());
       modules.add(new ZKDiscoveryModule());
     }

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/FileBasedTokenManagerTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/FileBasedTokenManagerTest.java
@@ -29,7 +29,7 @@ import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.common.utils.ImmutablePair;
 import io.cdap.cdap.common.utils.Tasks;
-import io.cdap.cdap.security.guice.FileBasedSecurityModule;
+import io.cdap.cdap.security.guice.FileBasedCoreSecurityModule;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -58,7 +58,7 @@ public class FileBasedTokenManagerTest extends TestTokenManager {
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
     Injector injector = Guice.createInjector(new IOModule(),
                                              new ConfigModule(cConf),
-                                             new FileBasedSecurityModule(),
+                                             new FileBasedCoreSecurityModule(),
                                              new InMemoryDiscoveryModule());
     TokenManager tokenManager = injector.getInstance(TokenManager.class);
     tokenManager.startAndWait();
@@ -78,14 +78,14 @@ public class FileBasedTokenManagerTest extends TestTokenManager {
     TokenManager tokenManager = Guice.createInjector(
       new IOModule(),
       new ConfigModule(cConf),
-      new FileBasedSecurityModule(),
+      new FileBasedCoreSecurityModule(),
       new InMemoryDiscoveryModule()).getInstance(TokenManager.class);
     tokenManager.startAndWait();
 
     TokenManager tokenManager2 = Guice.createInjector(
       new IOModule(),
       new ConfigModule(cConf),
-      new FileBasedSecurityModule(),
+      new FileBasedCoreSecurityModule(),
       new InMemoryDiscoveryModule()).getInstance(TokenManager.class);
     tokenManager2.startAndWait();
 
@@ -114,7 +114,7 @@ public class FileBasedTokenManagerTest extends TestTokenManager {
     Injector injector = Guice.createInjector(
       new IOModule(),
       new ConfigModule(cConf),
-      new FileBasedSecurityModule(),
+      new FileBasedCoreSecurityModule(),
       new InMemoryDiscoveryModule()
     );
 

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/TestInMemoryTokenManager.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/TestInMemoryTokenManager.java
@@ -23,7 +23,7 @@ import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.common.utils.ImmutablePair;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 
 /**
  * Tests for InMemoryTokenManager that ensure that keys are maintained in memory and can be used to create
@@ -33,7 +33,7 @@ public class TestInMemoryTokenManager extends TestTokenManager {
 
   @Override
   protected ImmutablePair<TokenManager, Codec<AccessToken>> getTokenManagerAndCodec() {
-    Injector injector = Guice.createInjector(new IOModule(), new SecurityModules().getInMemoryModules(),
+    Injector injector = Guice.createInjector(new IOModule(), new CoreSecurityModules().getStandaloneModules(),
                                              new ConfigModule(), new InMemoryDiscoveryModule());
     TokenManager tokenManager = injector.getInstance(TokenManager.class);
     tokenManager.startAndWait();

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/TestKeyIdentifierCodec.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/TestKeyIdentifierCodec.java
@@ -24,7 +24,7 @@ import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.io.Codec;
-import io.cdap.cdap.security.guice.FileBasedSecurityModule;
+import io.cdap.cdap.security.guice.FileBasedCoreSecurityModule;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -45,7 +45,7 @@ public class TestKeyIdentifierCodec {
 
   @BeforeClass
   public static void setup() throws Exception {
-    Injector injector = Guice.createInjector(new IOModule() , new ConfigModule(), new FileBasedSecurityModule(),
+    Injector injector = Guice.createInjector(new IOModule() , new ConfigModule(), new FileBasedCoreSecurityModule(),
                                              new InMemoryDiscoveryModule());
     CConfiguration conf = injector.getInstance(CConfiguration.class);
     keyIdentifierCodec = injector.getInstance(KeyIdentifierCodec.class);

--- a/cdap-security/src/test/java/io/cdap/cdap/security/authorization/DefaultAccessEnforcerTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/authorization/DefaultAccessEnforcerTest.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.security.Authorizable;
+import io.cdap.cdap.proto.security.Credential;
 import io.cdap.cdap.proto.security.Permission;
 import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.proto.security.StandardPermission;
@@ -51,6 +52,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Base64;
 import java.util.Collections;
@@ -210,9 +212,9 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
     SConfiguration sConfCopy = enableCredentialEncryption();
     TinkCipher cipher = new TinkCipher(sConfCopy);
 
-    Principal userWithCredEncrypted = new Principal(
-      "userFoo", Principal.PrincipalType.USER, null,
-      cipher.encryptToBase64("credential".getBytes(), null));
+    String cred = cipher.encryptToBase64("credential".getBytes(StandardCharsets.UTF_8), null);
+    Principal userWithCredEncrypted = new Principal("userFoo", Principal.PrincipalType.USER, null,
+                                                    new Credential(cred, Credential.CredentialType.EXTERNAL_ENCRYPTED));
 
     try (AccessControllerInstantiator accessControllerInstantiator =
            new AccessControllerInstantiator(CCONF, AUTH_CONTEXT_FACTORY)) {
@@ -240,8 +242,9 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
 
     String badCipherCred = Base64.getEncoder().encodeToString("invalid encrypted credential".getBytes());
 
-    Principal userWithCredEncrypted = new Principal("userFoo", Principal.PrincipalType.USER,
-                                                    null, badCipherCred);
+    Principal userWithCredEncrypted = new Principal("userFoo", Principal.PrincipalType.USER, null,
+                                                    new Credential(badCipherCred,
+                                                                   Credential.CredentialType.EXTERNAL_ENCRYPTED));
 
     try (AccessControllerInstantiator accessControllerInstantiator =
            new AccessControllerInstantiator(CCONF, AUTH_CONTEXT_FACTORY)) {
@@ -262,9 +265,9 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
     SConfiguration sConfCopy = enableCredentialEncryption();
     TinkCipher cipher = new TinkCipher(sConfCopy);
 
-    Principal userWithCredEncrypted = new Principal(
-      "userFoo", Principal.PrincipalType.USER, null,
-      cipher.encryptToBase64("credential".getBytes(), null));
+    String cred = cipher.encryptToBase64("credential".getBytes(StandardCharsets.UTF_8), null);
+    Principal userWithCredEncrypted = new Principal("userFoo", Principal.PrincipalType.USER, null,
+                                                    new Credential(cred, Credential.CredentialType.EXTERNAL_ENCRYPTED));
 
     try (AccessControllerInstantiator accessControllerInstantiator =
            new AccessControllerInstantiator(CCONF, AUTH_CONTEXT_FACTORY)) {

--- a/cdap-security/src/test/java/io/cdap/cdap/security/impersonation/UGIProviderTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/impersonation/UGIProviderTest.java
@@ -165,7 +165,7 @@ public class UGIProviderTest {
       discoveryService.register(new Discoverable(Constants.Service.APP_FABRIC_HTTP, httpService.getBindAddress()));
 
       RemoteClientFactory remoteClientFactory = new RemoteClientFactory(discoveryService,
-                                                                        new AuthenticationTestContext());
+                                                                        new AuthenticationTestContext(), cConf);
       RemoteUGIProvider ugiProvider = new RemoteUGIProvider(cConf, locationFactory,
                                                             ownerAdmin,
                                                             remoteClientFactory);

--- a/cdap-security/src/test/java/io/cdap/cdap/security/server/ExternalAuthenticationServerTestBase.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/server/ExternalAuthenticationServerTestBase.java
@@ -35,7 +35,8 @@ import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.security.auth.AccessToken;
 import io.cdap.cdap.security.auth.AccessTokenCodec;
-import io.cdap.cdap.security.guice.SecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.twill.discovery.Discoverable;
@@ -103,8 +104,8 @@ public abstract class ExternalAuthenticationServerTestBase {
     // values verify that they are not used by external authentication server
     configuration.set(Constants.Security.AUTH_SERVER_ANNOUNCE_URLS, "invalid.urls");
 
-    Module securityModule = Modules.override(new SecurityModules().getInMemoryModules()).with(
-      new AbstractModule() {
+    Module externalAuthenticationModule = Modules.override(new ExternalAuthenticationModule())
+      .with(new AbstractModule() {
         @Override
         protected void configure() {
           bind(AuditLogHandler.class)
@@ -112,9 +113,9 @@ public abstract class ExternalAuthenticationServerTestBase {
               ExternalAuthenticationServer.NAMED_EXTERNAL_AUTH))
             .toInstance(new AuditLogHandler(TEST_AUDIT_LOGGER));
         }
-      }
-    );
-    Injector injector = Guice.createInjector(new IOModule(), securityModule,
+      });
+    Injector injector = Guice.createInjector(new IOModule(), externalAuthenticationModule,
+                                             new CoreSecurityModules().getInMemoryModules(),
                                              new ConfigModule(getConfiguration(configuration),
                                                               HBaseConfiguration.create(), sConfiguration),
                                              new InMemoryDiscoveryModule());

--- a/cdap-security/src/test/java/io/cdap/cdap/security/store/client/RemoteSecureStoreTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/store/client/RemoteSecureStoreTest.java
@@ -84,7 +84,7 @@ public class RemoteSecureStoreTest {
                                                          httpService.getBindAddress()));
 
     RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
-      discoveryService, new AuthenticationTestContext());
+      discoveryService, new AuthenticationTestContext(), conf);
     remoteSecureStore = new RemoteSecureStore(remoteClientFactory);
   }
 

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -93,8 +93,9 @@ import io.cdap.cdap.operations.OperationalStatsService;
 import io.cdap.cdap.operations.guice.OperationalStatsModule;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
-import io.cdap.cdap.security.guice.SecurityModules;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.server.ExternalAuthenticationServer;
 import io.cdap.cdap.security.store.SecureStoreService;
@@ -523,7 +524,8 @@ public class StandaloneMain {
       new LocalLogAppenderModule(),
       new LogReaderRuntimeModules().getStandaloneModules(),
       new RouterModules().getStandaloneModules(),
-      new SecurityModules().getStandaloneModules(),
+      new CoreSecurityModules().getStandaloneModules(),
+      new ExternalAuthenticationModule(),
       new SecureStoreServerModule(),
       new ExploreRuntimeModule().getStandaloneModules(),
       new ExploreClientModule(),
@@ -536,7 +538,7 @@ public class StandaloneMain {
       new PreviewManagerModule(false),
       new PreviewRunnerManagerModule().getStandaloneModules(),
       new MessagingServerRuntimeModule().getStandaloneModules(),
-      new AppFabricServiceRuntimeModule().getStandaloneModules(),
+      new AppFabricServiceRuntimeModule(cConf).getStandaloneModules(),
       new MonitorHandlerModule(false),
       new RuntimeServerModule(),
       new OperationalStatsModule(),

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -275,7 +275,7 @@ public class TestBase {
       new IOModule(),
       new LocalLocationModule(),
       new InMemoryDiscoveryModule(),
-      new AppFabricServiceRuntimeModule().getInMemoryModules(),
+      new AppFabricServiceRuntimeModule(cConf).getInMemoryModules(),
       new MonitorHandlerModule(false),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/logbuffer/handler/LogBufferHandlerTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/logbuffer/handler/LogBufferHandlerTest.java
@@ -106,7 +106,7 @@ public class LogBufferHandlerTest {
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     discoveryService.register(new Discoverable(Constants.Service.LOG_BUFFER_SERVICE, httpService.getBindAddress()));
     RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
-      discoveryService, new AuthenticationTestContext());
+      discoveryService, new AuthenticationTestContext(), cConf);
     return new RemoteLogAppender(cConf, remoteClientFactory);
   }
 


### PR DESCRIPTION
This PR adds support for internal access token generation via the new `SystemAuthenticationContext` class.

Additionally, this PR also introduces a new `Credential` class in cdap-proto and adds plumbing logic in the `RemoteClient` class to support propagating the authentication contexts between services.