### PR TITLE
CDAP-18076: Unset certificate path in CConfiguration when launching TaskWorkerTwillApplication

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
@@ -125,9 +125,13 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
 
         Path runDir = Files.createTempDirectory(tmpDir, "task.worker.launcher");
         try {
+          // Unset the internal certificate path since certificate is stored cdap-security which
+          // is not exposed (i.e. mounted in k8s) to TaskWorkerService.
+          CConfiguration cConfCopy = CConfiguration.copy(cConf);
+          cConfCopy.unset(Constants.Security.SSL.INTERNAL_CERT_PATH);
           Path cConfPath = runDir.resolve("cConf.xml");
           try (Writer writer = Files.newBufferedWriter(cConfPath, StandardCharsets.UTF_8)) {
-            cConf.writeXml(writer);
+            cConfCopy.writeXml(writer);
           }
           Path hConfPath = runDir.resolve("hConf.xml");
           try (Writer writer = Files.newBufferedWriter(hConfPath, StandardCharsets.UTF_8)) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
@@ -154,9 +154,7 @@ public class TaskWorkerTwillRunnable extends AbstractTwillRunnable {
   }
 
   private void doInitialize(TwillContext context) throws Exception {
-    CConfiguration cConf = CConfiguration.create();
-    cConf.clear();
-    cConf.addResource(new File(getArgument("cConf")).toURI().toURL());
+    CConfiguration cConf = CConfiguration.create(new File(getArgument("cConf")).toURI().toURL());
 
     Configuration hConf = new Configuration();
     hConf.clear();


### PR DESCRIPTION
Why:
TaskWorkerService is currently used to run user code in isolation and
cdap-security is not exposed to it. So it has no access to certificate.
Unset the path in the cConf for TaskWorkerService, so it will generate
a certifacte itself if SSL is enabled. This is fine for now as currently
there is no code path verify the certificate (e.g. always trust servers)