### PR TITLE
[CDAP-18004] Add Support for Setting Worker Security Secrets

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
+import io.cdap.cdap.master.spi.twill.SecretDisk;
 import io.cdap.cdap.master.spi.twill.SecureTwillPreparer;
 import io.cdap.cdap.master.spi.twill.SecurityContext;
 import io.cdap.cdap.master.spi.twill.StatefulDisk;
@@ -186,6 +187,13 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
                 .withIdentity(twillUserIdentity).build();
               twillPreparer = ((SecureTwillPreparer) twillPreparer)
                 .withSecurityContext(PreviewRunnerTwillRunnable.class.getSimpleName(), securityContext);
+            }
+            if (cConf.getBoolean(Constants.Twill.Security.WORKER_MOUNT_SECRET)) {
+              String secretName = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_NAME);
+              String secretPath = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_PATH);
+              twillPreparer = ((SecureTwillPreparer) twillPreparer)
+                .withSecretDisk(PreviewRunnerTwillRunnable.class.getSimpleName(),
+                                new SecretDisk(secretName, secretPath));
             }
           }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -271,8 +271,8 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
                 .withIdentity(twillSystemIdentity).build();
               twillPreparer = ((SecureTwillPreparer) twillPreparer).withSecurityContext(runnable, securityContext);
             }
-            String securityName = cConf.get(Constants.Twill.Security.SECRET_DISK_NAME);
-            String securityPath = cConf.get(Constants.Twill.Security.SECRET_DISK_PATH);
+            String securityName = cConf.get(Constants.Twill.Security.MASTER_SECRET_DISK_NAME);
+            String securityPath = cConf.get(Constants.Twill.Security.MASTER_SECRET_DISK_PATH);
             twillPreparer = ((SecureTwillPreparer) twillPreparer)
               .withSecretDisk(runnable, new SecretDisk(securityName, securityPath));
           }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerTwillRunnable;
 import io.cdap.cdap.master.spi.twill.DependentTwillPreparer;
+import io.cdap.cdap.master.spi.twill.SecretDisk;
 import io.cdap.cdap.master.spi.twill.SecureTwillPreparer;
 import io.cdap.cdap.master.spi.twill.SecurityContext;
 import io.cdap.cdap.master.spi.twill.StatefulDisk;
@@ -183,6 +184,12 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
             SecurityContext securityContext = createSecurityContext();
             twillPreparer = ((SecureTwillPreparer) twillPreparer)
               .withSecurityContext(TaskWorkerTwillRunnable.class.getSimpleName(), securityContext);
+            if (cConf.getBoolean(Constants.Twill.Security.WORKER_MOUNT_SECRET)) {
+              String secretName = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_NAME);
+              String secretPath = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_PATH);
+              twillPreparer = ((SecureTwillPreparer) twillPreparer)
+                .withSecretDisk(TaskWorkerTwillRunnable.class.getSimpleName(), new SecretDisk(secretName, secretPath));
+            }
           }
 
           activeController = twillPreparer.start(5, TimeUnit.MINUTES);

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1632,14 +1632,29 @@ public final class Constants {
       public static final String IDENTITY_SYSTEM = "twill.security.identity.system";
 
       /**
-       * The secret name for the cdap-security.xml disk mount.
+       * The secret name for the cdap-security.xml disk mount for master services.
        */
-      public static final String SECRET_DISK_NAME = "twill.security.secret.disk.name";
+      public static final String MASTER_SECRET_DISK_NAME = "twill.security.master.secret.disk.name";
 
       /**
-       * The secret path for the cdap-security.xml disk mount.
+       * The secret path for the cdap-security.xml disk mount for master services.
        */
-      public static final String SECRET_DISK_PATH = "twill.security.secret.disk.path";
+      public static final String MASTER_SECRET_DISK_PATH = "twill.security.master.secret.disk.path";
+
+      /**
+       * Whether to mount a secret disk for worker runnables
+       */
+      public static final String WORKER_MOUNT_SECRET = "twill.security.worker.mount.secret";
+
+      /**
+       * The secret name for the cdap-security.xml disk mount for worker services including preview and task workers.
+       */
+      public static final String WORKER_SECRET_DISK_NAME = "twill.security.master.secret.disk.name";
+
+      /**
+       * The secret path for the cdap-security.xml disk mount for worker services including preview and task workers.
+       */
+      public static final String WORKER_SECRET_DISK_PATH = "twill.security.master.secret.disk.path";
     }
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -265,18 +265,42 @@
   </property>
 
   <property>
-    <name>twill.security.secret.disk.name</name>
+    <name>twill.security.master.secret.disk.name</name>
     <value>cdap-security</value>
     <description>
-      The name of the Twill security disk mount which contains cdap-security.xml.
+      The name of the Twill security disk mount which contains cdap-security.xml for master services.
     </description>
   </property>
 
   <property>
-    <name>twill.security.secret.disk.path</name>
+    <name>twill.security.master.secret.disk.path</name>
     <value>/etc/cdap/security</value>
     <description>
-      The absolute directory of the Twill security disk mount which contains cdap-security.xml.
+      The absolute directory of the Twill security disk mount which contains cdap-security.xml for master services.
+    </description>
+  </property>
+
+  <property>
+    <name>twill.security.worker.mount.secret</name>
+    <value>false</value>
+    <description>
+      Whether to mount a secret disk in worker runnables.
+    </description>
+  </property>
+
+  <property>
+    <name>twill.security.worker.secret.disk.name</name>
+    <value>cdap-security</value>
+    <description>
+      The name of the Twill security disk mount which contains cdap-security.xml for worker runnables.
+    </description>
+  </property>
+
+  <property>
+    <name>twill.security.worker.secret.disk.path</name>
+    <value>/etc/cdap/security</value>
+    <description>
+      The absolute directory of the Twill security disk mount which contains cdap-security.xml for worker runnables.
     </description>
   </property>
 


### PR DESCRIPTION
Currently, worker pods (e.g. task worker pods, preview runner pods) do not have secure disks mounted. We should allow worker pods to use a separate configured secret from the master pods instead of disallowing secret mounting entirely.

This is useful for specifying the SSL certificate for worker pods.