### PR TITLE
[CDAP-17754] Identity propagation for Execution Clusters

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
@@ -64,6 +64,7 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.Configs;
@@ -280,6 +281,7 @@ public class DistributedWorkflowProgramRunnerTest {
       new MessagingClientModule(),
       new ExploreClientModule(),
       new AuditModule(),
+      new CoreSecurityModules().getDistributedModule(cConf),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new TwillModule(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
@@ -55,6 +55,7 @@ import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.preview.PreviewSecureStoreModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
@@ -169,6 +170,7 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
     return Guice.createInjector(
       new ConfigModule(previewCConf, previewHConf, previewSConf),
       new IOModule(),
+      new CoreSecurityModules().getInMemoryModules(),
       new AuthenticationContextModules().getInternalAuthWorkerModule(previewCConf),
       new PreviewSecureStoreModule(secureStore),
       new PreviewDiscoveryRuntimeModule(discoveryService),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/common/twill/TwillAppLifecycleEventHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/common/twill/TwillAppLifecycleEventHandler.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.runtime.spi.RuntimeMonitorType;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.EventHandler;
 import org.apache.twill.api.EventHandlerContext;
@@ -146,6 +147,7 @@ public class TwillAppLifecycleEventHandler extends AbortOnTimeoutEventHandler {
           modules.add(new KafkaClientModule());
           break;
         case ISOLATED:
+          modules.add(new AuthenticationContextModules().getProgramContainerModule(cConf));
           modules.add(new RemoteExecutionDiscoveryModule());
           modules.add(new AbstractModule() {
             @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -71,6 +71,7 @@ import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreClientModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
@@ -228,6 +229,7 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     modules.add(new MetadataReaderWriterModules().getStandaloneModules());
     modules.add(new DFSLocationModule());
     modules.add(new MetadataServiceModule());
+    modules.add(new CoreSecurityModules().getInMemoryModules());
     modules.add(new AuthorizationModule());
     modules.add(new AuthorizationEnforcementModule().getMasterModule());
     modules.add(Modules.override(

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionJobMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionJobMain.java
@@ -139,7 +139,7 @@ public class RemoteExecutionJobMain {
       new DFSLocationModule(),
       new InMemoryDiscoveryModule(),
       new TwillModule(),
-      new AuthenticationContextModules().getProgramContainerModule(),
+      new AuthenticationContextModules().getProgramContainerModule(cConf),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
@@ -16,6 +16,10 @@
 
 package io.cdap.cdap.internal.app.runtime.distributed.remote;
 
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.Service;
@@ -60,6 +64,10 @@ import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.Node;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobManager;
 import io.cdap.cdap.runtime.spi.ssh.SSHKeyPair;
+import io.cdap.cdap.security.auth.AccessToken;
+import io.cdap.cdap.security.auth.AccessTokenCodec;
+import io.cdap.cdap.security.auth.TokenManager;
+import io.cdap.cdap.security.auth.UserIdentity;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import org.apache.hadoop.conf.Configuration;
@@ -95,8 +103,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -104,6 +114,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -125,6 +136,8 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
 
   private static final Logger LOG = LoggerFactory.getLogger(RemoteExecutionTwillRunnerService.class);
   private static final Gson GSON = new Gson();
+  //We can have really long jobs, so the tokens would be long-lived
+  private static final long DEFAULT_EXPIRATION = TimeUnit.DAYS.toMillis(365);
 
   private final CConfiguration cConf;
   private final Configuration hConf;
@@ -136,6 +149,8 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
   private final RuntimeServiceSocksProxyAuthenticator serviceSocksProxyAuthenticator;
   private final Map<ProgramRunId, RemoteExecutionTwillController> controllers;
   private final Lock controllersLock;
+  private final AccessTokenCodec accessTokenCodec;
+  private final TokenManager tokenManager;
 
   private LocationCache locationCache;
   private Path cachePath;
@@ -147,13 +162,17 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
                                     LocationFactory locationFactory,
                                     ProvisioningService provisioningService,
                                     ProgramStateWriter programStateWriter,
-                                    TransactionRunner transactionRunner) {
+                                    TransactionRunner transactionRunner,
+                                    AccessTokenCodec accessTokenCodec,
+                                    TokenManager tokenManager) {
     this.cConf = cConf;
     this.hConf = hConf;
     this.locationFactory = locationFactory;
     this.provisioningService = provisioningService;
     this.programStateWriter = programStateWriter;
     this.txRunner = transactionRunner;
+    this.accessTokenCodec = accessTokenCodec;
+    this.tokenManager = tokenManager;
     this.controllers = new ConcurrentHashMap<>();
     this.controllersLock = new ReentrantLock();
     this.serviceSocksProxyAuthenticator = new RuntimeServiceSocksProxyAuthenticator();
@@ -321,17 +340,20 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
                                        ProgramOptions programOpts, TwillSpecification twillSpec,
                                        LocationCache locationCache, TwillControllerFactory controllerFactory) {
 
-    Location serviceProxySecretLocation = null;
+    Location keysDirLocation = getKeysDirLocation(programOpts, locationFactory);
+    Map<String, Location> secretFiles = new HashMap<>();
     if (SystemArguments.getRuntimeMonitorType(cConf, programOpts) == RuntimeMonitorType.SSH) {
-      serviceProxySecretLocation = generateAndSaveServiceProxySecret(programRunId,
-                                                                     getKeysDirLocation(programOpts, locationFactory));
+      secretFiles.put(Constants.RuntimeMonitor.SERVICE_PROXY_PASSWORD_FILE,
+                      generateAndSaveServiceProxySecret(programRunId, keysDirLocation));
     }
+    secretFiles.put(Constants.Security.Authentication.RUNTIME_TOKEN_FILE,
+                    generateAndSaveRuntimeToken(programRunId, keysDirLocation));
 
     RuntimeJobManager jobManager = provisioningService.getRuntimeJobManager(programRunId, programOpts).orElse(null);
     // Use RuntimeJobManager to launch the remote process if it is supported
     if (jobManager != null) {
       return new RuntimeJobTwillPreparer(cConf, hConf, twillSpec, programRunId, programOpts,
-                                         serviceProxySecretLocation,
+                                         secretFiles,
                                          locationCache, locationFactory,
                                          controllerFactory,
                                          () -> provisioningService.getRuntimeJobManager(programRunId, programOpts)
@@ -341,7 +363,7 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
     // Use SSH if there is no RuntimeJobManager
     ClusterKeyInfo clusterKeyInfo = new ClusterKeyInfo(cConf, programOpts, locationFactory);
     return new RemoteExecutionTwillPreparer(cConf, hConf, clusterKeyInfo.getCluster(), clusterKeyInfo.getSSHConfig(),
-                                            serviceProxySecretLocation,
+                                            secretFiles,
                                             twillSpec, programRunId, programOpts,
                                             locationCache, locationFactory, controllerFactory);
   }
@@ -355,6 +377,28 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
       serviceSocksProxy.startAndWait();
     }
     return serviceSocksProxy.getBindAddress().getPort();
+  }
+
+  /**
+   * Generates a runtime token to talk back from the execution cluster to CDAP instance.
+   */
+  private Location generateAndSaveRuntimeToken(ProgramRunId programRunId, Location keysDir) {
+    try {
+      long currentTimestamp = System.currentTimeMillis();
+      //TODO: Use a better identity & expiration
+      UserIdentity identity = new UserIdentity(Constants.Security.Authentication.RUNTIME_IDENTITY,
+                                               Collections.emptyList(), currentTimestamp,
+                                               currentTimestamp + DEFAULT_EXPIRATION);
+      AccessToken accessToken = tokenManager.signIdentifier(identity);
+      byte[] encodedAccessToken = Base64.getEncoder().encode(accessTokenCodec.encode(accessToken));
+      Location location = keysDir.append(Constants.Security.Authentication.RUNTIME_TOKEN_FILE);
+      try (OutputStream os = location.getOutputStream()) {
+        os.write(encodedAccessToken);
+      }
+      return location;
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to generate runtime token for " + programRunId, e);
+    }
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
@@ -153,7 +153,7 @@ public class DefaultRuntimeJob implements RuntimeJob {
 
     // Get Program Options
     ProgramOptions programOpts = readJsonFile(new File(DistributedProgramRunner.PROGRAM_OPTIONS_FILE_NAME),
-                                                 ProgramOptions.class);
+                                              ProgramOptions.class);
     ProgramRunId programRunId = programOpts.getProgramId().run(ProgramRunners.getRunId(programOpts));
     ProgramId programId = programRunId.getParent();
 
@@ -296,6 +296,13 @@ public class DefaultRuntimeJob implements RuntimeJob {
       }
     }
 
+    // Pass runtime token to distributed jobs
+    Path tokenFile = Paths.get(Constants.Security.Authentication.RUNTIME_TOKEN_FILE);
+    if (Files.exists(tokenFile)) {
+      cConf.set(Constants.Security.Authentication.RUNTIME_TOKEN,
+                new String(Files.readAllBytes(tokenFile), StandardCharsets.UTF_8));
+    }
+
     return cConf;
   }
 
@@ -345,7 +352,7 @@ public class DefaultRuntimeJob implements RuntimeJob {
     modules.add(new IOModule());
     modules.add(new TMSLogAppenderModule());
     modules.add(new RemoteExecutionDiscoveryModule());
-    modules.add(new AuthenticationContextModules().getProgramContainerModule());
+    modules.add(new AuthenticationContextModules().getProgramContainerModule(cConf));
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
     modules.add(new MessagingServerRuntimeModule().getStandaloneModules());
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeIdentityHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeIdentityHandler.java
@@ -16,19 +16,38 @@
 
 package io.cdap.cdap.internal.app.runtime.monitor;
 
+import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.logging.AuditLogEntry;
 import io.cdap.cdap.common.utils.Networks;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.HttpURLConnection;
+
+import static io.cdap.cdap.proto.security.Credential.CREDENTIAL_TYPE_INTERNAL;
 
 /**
  * A {@link ChannelInboundHandler} for properly propagating runtime identity to calls to other system services.
  */
 public class RuntimeIdentityHandler extends ChannelInboundHandlerAdapter {
-  private static final String RUNTIME_IDENTITY = "runtime";
+  private static final Logger AUDIT_LOGGER = LoggerFactory
+    .getLogger(Constants.RuntimeMonitor.MONITOR_AUDIT_LOGGER_NAME);
+
+  private final boolean enforceAuthenticatedRequests;
+  private final boolean auditLogEnabled;
+
+  public RuntimeIdentityHandler(CConfiguration cConf) {
+    this.enforceAuthenticatedRequests = cConf.getBoolean(Constants.Security.ENFORCE_INTERNAL_AUTH);
+    this.auditLogEnabled = cConf.getBoolean(Constants.RuntimeMonitor.MONITOR_AUDIT_LOG_ENABLED);
+  }
 
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) {
@@ -38,14 +57,31 @@ public class RuntimeIdentityHandler extends ChannelInboundHandlerAdapter {
     }
 
     HttpRequest request = (HttpRequest) msg;
-    // TODO(CDAP-17754): This is a placeholder for proper runtime identity propagation.
-    // For now, only support propagating the system-level root principal.
+
     request.headers().remove(HttpHeaderNames.AUTHORIZATION);
-    request.headers().set(Constants.Security.Headers.USER_ID, RUNTIME_IDENTITY);
+    request.headers().set(Constants.Security.Headers.USER_ID, Constants.Security.Authentication.RUNTIME_IDENTITY);
     String clientIP = Networks.getIP(ctx.channel().remoteAddress());
     if (clientIP != null) {
       request.headers().set(Constants.Security.Headers.USER_IP, clientIP);
+    } else {
+      request.headers().remove(Constants.Security.Headers.USER_IP);
+    }
+    if (enforceAuthenticatedRequests &&
+      !request.headers().contains(Constants.Security.Headers.RUNTIME_TOKEN)) {
+      auditLogIfNeeded(request, ctx.channel(), HttpURLConnection.HTTP_FORBIDDEN);
+      throw new UnauthorizedException("Runtime token not found");
     }
     ctx.fireChannelRead(msg);
+  }
+
+  private void auditLogIfNeeded(HttpRequest request, Channel channel, int code) {
+    if (!auditLogEnabled) {
+      return;
+    }
+
+    AuditLogEntry logEntry = new AuditLogEntry(request, Networks.getIP(channel.remoteAddress()));
+    logEntry.setResponse(code, -1);
+
+    AUDIT_LOGGER.trace(logEntry.toString());
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
@@ -110,7 +110,6 @@ public class MasterEnvironmentMain {
                                                + MasterEnvironmentRunnable.class);
         }
 
-        //TODO: CDAP-17754 Use proper authentication context with internal token from configuration
         RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
           masterEnv.getDiscoveryServiceClientSupplier().get(), new WorkerAuthenticationContext(), cConf);
         MasterEnvironmentRunnableContext runnableContext =

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/AuthorizationHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/AuthorizationHandlerTest.java
@@ -96,7 +96,6 @@ public class AuthorizationHandlerTest {
         @Override
         public void modify(ChannelPipeline pipeline) {
           pipeline.addBefore("dispatcher", "usernamesetter", new TestUserNameSetter());
-          pipeline.addAfter("usernamesetter", "authenticator", new AuthenticationChannelHandler(false));
         }
       })
       .build();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServerTest.java
@@ -71,6 +71,9 @@ import java.util.stream.IntStream;
 @RunWith(Parameterized.class)
 public class RuntimeClientServerTest {
 
+  public static final String TEST_TOPIC_KEY = "topic.key";
+  public static final String TEST_TOPIC = "topic";
+
   @Parameterized.Parameters(name = "{index}: compression = {0}")
   public static Collection<Object[]> parameters() {
     return Arrays.asList(new Object[][]{
@@ -100,6 +103,8 @@ public class RuntimeClientServerTest {
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
     cConf.setBoolean(Constants.RuntimeMonitor.COMPRESSION_ENABLED, compression);
     cConf.setBoolean(Constants.AppFabric.SPARK_EVENT_LOGS_ENABLED, true);
+    cConf.set(TEST_TOPIC_KEY, TEST_TOPIC);
+    cConf.set(Constants.RuntimeMonitor.TOPICS_CONFIGS, Constants.Logging.TMS_TOPIC_PREFIX + ":1," + TEST_TOPIC_KEY);
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
@@ -166,7 +171,7 @@ public class RuntimeClientServerTest {
   @Test
   public void testLargeMessage() throws Exception {
     ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").workflow("workflow").run(RunIds.generate());
-    TopicId topicId = NamespaceId.SYSTEM.topic("topic");
+    TopicId topicId = NamespaceId.SYSTEM.topic(TEST_TOPIC);
 
     List<Message> messages = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
@@ -199,7 +204,7 @@ public class RuntimeClientServerTest {
   @Test
   public void testLogMessage() throws Exception {
     ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").workflow("workflow").run(RunIds.generate());
-    TopicId topicId = NamespaceId.SYSTEM.topic(cConf.get(Constants.Logging.TMS_TOPIC_PREFIX) + "-1");
+    TopicId topicId = NamespaceId.SYSTEM.topic(cConf.get(Constants.Logging.TMS_TOPIC_PREFIX) + "0");
 
     List<Message> messages = IntStream.range(0, 100).mapToObj(this::createMessage).collect(Collectors.toList());
     runtimeClient.sendMessages(programRunId, topicId, messages.iterator());

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -972,6 +972,8 @@ public final class Constants {
     public static final String MONITOR_TYPE_PREFIX = "app.program.runtime.monitor.type.";
     public static final String MONITOR_URL_AUTHENTICATOR_CLASS_PREFIX =
       "app.program.runtime.monitor.url.authenticator.class.";
+    public static final String MONITOR_AUDIT_LOG_ENABLED = "app.program.runtime.monitor.audit.log.enabled";
+    public static final String MONITOR_AUDIT_LOGGER_NAME = "http-access";
 
     // Prefix for that configuration key for storing discovery endpoint in the format of "host:port"
     public static final String DISCOVERY_SERVICE_PREFIX = "app.program.runtime.discovery.service.";
@@ -1142,6 +1144,13 @@ public final class Constants {
       /** Keyset used for user credential encryption. Set in cdap-security.xml */
       public static final String USER_CREDENTIAL_ENCRYPTION_KEYSET =
         "security.authentication.user.credentials.encryption.keyset";
+      /** {@link CConfiguration} property to pass runtime token from driver to distributed jobs */
+      public static final String RUNTIME_TOKEN =
+        "security.authentication.runtime.token";
+      /** File name to use to pass {@link Constants.Security.Headers#RUNTIME_TOKEN} to execution job */
+      public static final String RUNTIME_TOKEN_FILE = "cdap.runtime.token";
+      /** Identity used for runtime monitor */
+      public static final String RUNTIME_IDENTITY = "runtime";
     }
 
     /**

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
@@ -30,6 +30,8 @@ import javax.annotation.Nullable;
  */
 public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
 
+  public static final String AUTHENTICATOR_NAME = "authenticator";
+
   private ChannelPipelineModifier pipelineModifier;
   private ChannelPipelineModifier additionalModifier;
 
@@ -45,7 +47,7 @@ public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
           // This is needed before we use a InheritableThreadLocal in SecurityRequestContext
           // to remember the user id.
           EventExecutor executor = pipeline.context("dispatcher").executor();
-          pipeline.addBefore(executor, "dispatcher", "authenticator",
+          pipeline.addBefore(executor, "dispatcher", AUTHENTICATOR_NAME,
                              new AuthenticationChannelHandler(cConf.getBoolean(Constants.Security
                                                                                  .ENFORCE_INTERNAL_AUTH)));
         }
@@ -54,8 +56,21 @@ public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
     this.setExceptionHandler(new HttpExceptionHandler());
   }
 
+  /**
+   * Sets pipeline modifier, preserving the security one installed in constructor.
+   */
   @Override
-  public NettyHttpService.Builder setChannelPipelineModifier(ChannelPipelineModifier channelPipelineModifier) {
+  public NettyHttpService.Builder setChannelPipelineModifier(ChannelPipelineModifier additionalPipelineModifier) {
+    additionalModifier = additionalPipelineModifier;
+    return this;
+  }
+
+  /**
+   * Sets a pipeline modifier replacing the security one installed in constructor.
+   */
+  public NettyHttpService.Builder replaceDefaultChannelPipelineModifier(
+    ChannelPipelineModifier channelPipelineModifier) {
+
     pipelineModifier = channelPipelineModifier;
     return this;
   }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2773,7 +2773,6 @@
     <description>
       A comma-separated list of topic config to be monitored by runtime monitor
     </description>
-    <final>true</final>
   </property>
 
   <property>
@@ -2850,6 +2849,14 @@
     <value>20</value>
     <description>
       Maximum number of threads being used by runtime monitor for runtime monitoring
+    </description>
+  </property>
+
+  <property>
+    <name>app.program.runtime.monitor.audit.log.enabled</name>
+    <value>${security.enabled}</value>
+    <description>
+      Determine if access audit log is enabled
     </description>
   </property>
 

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
@@ -90,6 +90,7 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.TokenSecureStoreRenewer;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.store.SecureStoreService;
@@ -569,6 +570,7 @@ public class MasterServiceMain extends DaemonMain {
       new MessagingClientModule(),
       new ExploreClientModule(),
       new AuditModule(),
+      new CoreSecurityModules().getDistributedModule(cConf),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new TwillModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/tools/JobQueueDebugger.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/tools/JobQueueDebugger.java
@@ -66,6 +66,7 @@ import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
@@ -336,6 +337,7 @@ public class JobQueueDebugger extends AbstractIdleService {
       new MetricsClientRuntimeModule().getDistributedModules(),
       new MetricsStoreModule(),
       new KafkaClientModule(),
+      new CoreSecurityModules().getDistributedModule(cConf),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new SecureStoreServerModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/tools/UpgradeTool.java
@@ -40,6 +40,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.DFSLocationModule;
+import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.KafkaClientModule;
 import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.guice.ZKDiscoveryModule;
@@ -72,6 +73,7 @@ import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.messaging.store.hbase.HBaseTableFactory;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
@@ -198,6 +200,8 @@ public class UpgradeTool {
       new ProgramRunnerRuntimeModule().getDistributedModules(),
       new SystemDatasetRuntimeModule().getDistributedModules(),
       new KafkaClientModule(),
+      new IOModule(),
+      new CoreSecurityModules().getDistributedModule(cConf),
       new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
@@ -38,6 +38,7 @@ import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
+import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
@@ -71,6 +72,7 @@ public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> 
       getDataFabricModule(),
       new RuntimeServerModule(),
       new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
+      new AuthorizationEnforcementModule().getDistributedModules(),
       CoreSecurityModules.getDistributedModule(cConf),
       ZKClientModule.getZKClientModuleIfRequired(cConf)
     );

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMainTest.java
@@ -52,6 +52,7 @@ import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.TopicId;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -66,6 +67,15 @@ import java.util.concurrent.TimeUnit;
 public class RuntimeServiceMainTest extends MasterServiceMainTestBase {
 
   private static final Gson GSON = new Gson();
+
+  @BeforeClass
+  public static void init() throws Exception {
+    //We write through runtime client to this topic in this test, so add it to the allow list
+    cConf.set(Constants.RuntimeMonitor.TOPICS_CONFIGS,
+              cConf.get(Constants.RuntimeMonitor.TOPICS_CONFIGS, "") + ","
+                + Constants.AppFabric.PROGRAM_STATUS_RECORD_EVENT_TOPIC);
+    MasterServiceMainTestBase.init();
+  }
 
   @Test
   public void testRuntimeService() throws Exception {


### PR DESCRIPTION
In this PR:
 * Identity itself is a pretty basic token. Proper scoping will be done in a following PR
 * Identity is propagated as a token in a way similar to proxy password:
 * (a) Using a file to the main job
 * (b) Using CConfiguration to distributed program jobs
 * From DataProc to Runtime service it's propagated using `X-CDAP-Runtime-Token` header
 * In Runtime server both `RuntimeIdentityHandler` and `AuthenticationChannelHandler` are used. First verifies runtime token, second loads it into `SecurityRequestContext`
 * In the runtime services security request context is used to enforce on the run id passed
 * Also it's used when forwarding to other services
 * For TMS access only access to a fixed configured set of system topics is checked. 
 * https://cdap.atlassian.net/browse/CDAP-18085 is filled to perform more fine-grained enforcement on TMS.