### PR TITLE
Add a new TaskWorker temp directory property

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
@@ -156,6 +156,9 @@ public class TaskWorkerTwillRunnable extends AbstractTwillRunnable {
   private void doInitialize(TwillContext context) throws Exception {
     CConfiguration cConf = CConfiguration.create(new File(getArgument("cConf")).toURI().toURL());
 
+    // Overwrite the app fabric temp directory with the task worker temp directory
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, cConf.get(Constants.TaskWorker.LOCAL_DATA_DIR));
+
     Configuration hConf = new Configuration();
     hConf.clear();
     hConf.addResource(new File(getArgument("hConf")).toURI().toURL());

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -382,6 +382,7 @@ public final class Constants {
     /**
      * Task worker container configurations
      */
+    public static final String LOCAL_DATA_DIR = "task.worker.local.data.dir";
     public static final String CONTAINER_DISK_SIZE_GB = "task.worker.container.disk.size.gb";
     public static final String CONTAINER_MEMORY_MB = "task.worker.container.memory.mb";
     public static final String CONTAINER_CORES = "task.worker.container.num.cores";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4406,4 +4406,12 @@
       The number of boss threads for the artifact localizer.
     </description>
   </property>
+
+  <property>
+    <name>task.worker.local.data.dir</name>
+    <value>/tmp</value>
+    <description>
+      The local data directory for the task worker container.
+    </description>
+  </property>
 </configuration>


### PR DESCRIPTION
This PR introduces a new property for setting the temp directory path in the task worker container. This can be used to ensure we dont run into permission issues with the readonly data directory in the task worker. 

Most classes uses DATA_DIR + TEMP_DIR to construct the path for the temporary directory. But in the task worker container, the tasks don't have write access to DATA_DIR. We can get around this issue but using a relative path for the TEMP_DIR to ensure we dont write in the DATA_DIR.