### PR TITLE
CDAP-18010: Code refactoring to move parentClassloader creation into DefaultArtifactInspector

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactInspector.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.common.id.Id;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -34,16 +35,15 @@ interface ArtifactInspector {
    *
    * @param artifactId the id of the artifact to inspect
    * @param artifactFile the artifact file
-   * @param parentClassLoader the parent classloader to use when inspecting plugins contained in the artifact.
-   * For example, a ProgramClassLoader created from the artifact the input artifact extends
+   * @param parentDescriptors {@link ArtifactDescriptor} of parent and grandparent (if any) artifacts.
    * @param additionalPlugins Additional plugin classes
    * @return metadata about the classes contained in the artifact
-   * @throws IOException if there was an exception opening the jar file
+   * @throws IOException              if there was an exception opening the jar file
    * @throws InvalidArtifactException if the artifact is invalid. For example, if the application main class is not
-   * actually an Application.
+   *                                  actually an Application.
    */
   ArtifactClassesWithMetadata inspectArtifact(Id.Artifact artifactId, File artifactFile,
-                                              @Nullable ClassLoader parentClassLoader,
+                                              List<ArtifactDescriptor> parentDescriptors,
                                               Set<PluginClass> additionalPlugins)
     throws IOException, InvalidArtifactException;
 }


### PR DESCRIPTION

This is part 2 of isolating artifact inspection.

Why:
Currently artifact inspection caller creates parent classloader and
then pass to inspector. This requires duplicating the logic of
parent classloader for local and remote execution.

Moving the parent classloader creation into DefaultArtifactInspector
avoids such duplication.

BEFORE
- artifact inspection
  CreateParentClassLoader()
    DefaultArtifactInspector(ArtifactId, parentClassLoader)
      // Inspect artifact

AFTER
- artifact inspection
  getParentArtifactDescriptor()
  DefaultArtifactInspector (ArtifactId, parent ArtifactDescriptor)
    CreateParentClassLoader(parent ArtifactDescriptor)
    // Inspect artifact

FUTURE
- local artifact inspection
    getParentArtifactDescriptor()
      DefaultArtifactInspector (ArtifactId, parent ArtifactDescriptor)
        CreateParentClassLoader(parent ArtifactDescriptor)
        // Inpsect artifact
- remote artifact inspection:
  getParentArtifactDescriptor()
    CallRemote(parent ArtifactDescriptor)
      DefaultArtifactInspector (ArtifactId, parent ArtifactDescriptor)
        CreateParentClassLoader(parent ArtifactDescriptor)
        // Inspect artifact