### PR TITLE
[CDAP-18095] Mount worker secrets by default for backwards compatibility

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -188,6 +188,8 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
               twillPreparer = ((SecureTwillPreparer) twillPreparer)
                 .withSecurityContext(PreviewRunnerTwillRunnable.class.getSimpleName(), securityContext);
             }
+
+            // TODO CDAP-18095: Refactor to be secure-by-default in the future or fail-fast if it is not mounted.
             if (cConf.getBoolean(Constants.Twill.Security.WORKER_MOUNT_SECRET)) {
               String secretName = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_NAME);
               String secretPath = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_PATH);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
@@ -184,6 +184,7 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
             SecurityContext securityContext = createSecurityContext();
             twillPreparer = ((SecureTwillPreparer) twillPreparer)
               .withSecurityContext(TaskWorkerTwillRunnable.class.getSimpleName(), securityContext);
+            // TODO CDAP-18095: Refactor to be secure-by-default in the future or fail-fast if it is not mounted.
             if (cConf.getBoolean(Constants.Twill.Security.WORKER_MOUNT_SECRET)) {
               String secretName = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_NAME);
               String secretPath = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_PATH);

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -282,7 +282,7 @@
 
   <property>
     <name>twill.security.worker.mount.secret</name>
-    <value>false</value>
+    <value>true</value>
     <description>
       Whether to mount a secret disk in worker runnables.
     </description>


### PR DESCRIPTION
[CDAP-18095] Add TODO for refactoring to be secure-by-default in the future

Cherry-pick of #13502 

[CDAP-18095]: https://cdap.atlassian.net/browse/CDAP-18095