### PR TITLE
[CDAP-18044] Don't detect spark version in production code.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/spark/SparkCompatReader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/spark/SparkCompatReader.java
@@ -53,12 +53,7 @@ public class SparkCompatReader {
     compatStr = compatStr == null ? cConf.get(Constants.AppFabric.SPARK_COMPAT) : compatStr;
 
     if (compatStr == null) {
-      try {
-        return getCurrentSparkCompat();
-      } catch (Throwable e) {
-        LOG.info("Can't detect spark version({}), using default {}", e, SparkCompat.SPARK2_2_11);
-        return SparkCompat.SPARK2_2_11;
-      }
+      return SparkCompat.SPARK2_2_11;
     }
 
     for (SparkCompat sparkCompat : SparkCompat.values()) {
@@ -74,18 +69,5 @@ public class SparkCompatReader {
 
     throw new IllegalArgumentException(
       String.format("Invalid SparkCompat version '%s'. Must be one of %s", compatStr, allowedCompatStrings));
-  }
-
-  @VisibleForTesting
-  public static SparkCompat getCurrentSparkCompat() {
-    String sparkVersion = package$.MODULE$.SPARK_VERSION();
-    switch (sparkVersion.charAt(0)) {
-      case '3':
-        return SparkCompat.SPARK3_2_12;
-      case '2':
-        return SparkCompat.SPARK2_2_11;
-      default:
-        throw new IllegalStateException("Spark version " + sparkVersion + " is not known");
-    }
   }
 }

--- a/cdap-unit-test-base/src/test/java/io/cdap/cdap/spark/Spark2Test.java
+++ b/cdap-unit-test-base/src/test/java/io/cdap/cdap/spark/Spark2Test.java
@@ -271,12 +271,6 @@ public class Spark2Test extends TestBase {
 
   @Test
   public void testPySpark() throws Exception {
-    if (SparkCompatReader.getCurrentSparkCompat() == SparkCompat.SPARK3_2_12) {
-      //For spark 3 we need python 2.7 or higher
-      ComparableVersion pythonVersion = getPythonVersion();
-      assumeTrue("Wrong python2 version " + pythonVersion + ", need 2.7 or up",
-                 pythonVersion.compareTo(new ComparableVersion("2.7")) >= 0);
-    }
     ApplicationManager appManager = deploy(NamespaceId.DEFAULT, Spark2TestApp.class);
 
     // Write some data to a local file

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -122,6 +122,7 @@ import io.cdap.cdap.proto.profile.Profile;
 import io.cdap.cdap.proto.security.Authorizable;
 import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.runtime.spi.SparkCompat;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
 import io.cdap.cdap.scheduler.Scheduler;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
@@ -142,6 +143,7 @@ import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.package$;
 import org.apache.tephra.TransactionManager;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.tephra.inmemory.InMemoryTxSystemClient;
@@ -543,6 +545,9 @@ public class TestBase {
     // Speed up test
     cConf.setLong(Constants.Scheduler.EVENT_POLL_DELAY_MILLIS, 100L);
     cConf.setLong(Constants.AppFabric.STATUS_EVENT_POLL_DELAY_MILLIS, 100L);
+
+    // Set spark compat
+    cConf.set(Constants.AppFabric.SPARK_COMPAT, getCurrentSparkCompat().getCompat());
 
     return cConf;
   }
@@ -1134,5 +1139,17 @@ public class TestBase {
     previewCConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
 
     return previewCConf;
+  }
+
+  public static SparkCompat getCurrentSparkCompat() {
+    String sparkVersion = package$.MODULE$.SPARK_VERSION();
+    switch (sparkVersion.charAt(0)) {
+      case '3':
+        return SparkCompat.SPARK3_2_12;
+      case '2':
+        return SparkCompat.SPARK2_2_11;
+      default:
+        throw new IllegalStateException("Spark version " + sparkVersion + " is not known");
+    }
   }
 }


### PR DESCRIPTION
 It does not bring much benefits as we still don't deploy selectively in runtime, so we need spark 2 artifacts to be sent even to spark3 cluster