### PR TITLE
[6.5 Cherry-pick] Reuse dataproc clusters

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/DefaultProvisionerContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/DefaultProvisionerContext.java
@@ -38,6 +38,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.Nullable;
 
 /**
@@ -57,13 +59,14 @@ public class DefaultProvisionerContext implements ProvisionerContext {
   private final RuntimeMonitorType runtimeMonitorType;
   private final MetricsCollectionService metricsCollectionService;
   private final String provisionerName;
+  private final String profileName;
   private final Executor executor;
 
   DefaultProvisionerContext(ProgramRunId programRunId, String provisionerName, Map<String, String> properties,
                             SparkCompat sparkCompat, @Nullable SSHContext sshContext,
                             @Nullable VersionInfo appCDAPVersion, LocationFactory locationFactory,
                             RuntimeMonitorType runtimeMonitorType, MetricsCollectionService metricsCollectionService,
-                            Executor executor) {
+                            @Nullable String profileName, Executor executor) {
     this.programRun = new ProgramRun(programRunId.getNamespace(), programRunId.getApplication(),
                                      programRunId.getProgram(), programRunId.getRun());
     this.programRunInfo = new ProgramRunInfo.Builder()
@@ -79,6 +82,7 @@ public class DefaultProvisionerContext implements ProvisionerContext {
     this.sparkCompat = sparkCompat;
     this.appCDAPVersion = appCDAPVersion;
     this.locationFactory = locationFactory;
+    this.profileName = profileName;
     this.cdapVersion = ProjectInfo.getVersion();
     this.runtimeMonitorType = runtimeMonitorType;
     this.metricsCollectionService = metricsCollectionService;
@@ -130,6 +134,11 @@ public class DefaultProvisionerContext implements ProvisionerContext {
   @Override
   public RuntimeMonitorType getRuntimeMonitorType() {
     return runtimeMonitorType;
+  }
+
+  @Override
+  public String getProfileName() {
+    return profileName;
   }
 
   @Override

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -28,18 +28,23 @@ import io.cdap.cdap.runtime.spi.provisioner.PollingStrategies;
 import io.cdap.cdap.runtime.spi.provisioner.PollingStrategy;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSpecification;
+import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
 import io.cdap.cdap.runtime.spi.ssh.SSHContext;
 import io.cdap.cdap.runtime.spi.ssh.SSHKeyPair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 
 /**
  * Provisions a cluster using GCP Dataproc.
@@ -60,6 +65,9 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
 
   //First version spark 3 is default one
   private static final String SPARK3_CDAP_DEFAULT = "6.5";
+
+  //A lock to use for cluster reuse
+  private static final String REUSE_LOCK = "reuse";
 
   @SuppressWarnings("WeakerAccess")
   public DataprocProvisioner() {
@@ -111,9 +119,16 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       }
     }
 
-    String clusterName = getClusterName(context);
+    try (DataprocClient client = getClient(conf)) {
+      Cluster reused = tryReuseCluster(client, context, conf);
+      if (reused != null) {
+        DataprocUtils.emitMetric(context, conf.getRegion(),
+                                 "provisioner.createCluster.reuse.count");
+        return reused;
+      }
 
-    try (DataprocClient client = DataprocClient.fromConf(conf)) {
+      String clusterName = getRunKey(context);
+
       // if it already exists, it means this is a retry. We can skip actually making the request
       Optional<Cluster> existing = client.getCluster(clusterName);
       if (existing.isPresent()) {
@@ -129,6 +144,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       // Reload system context properties and get system labels
       Map<String, String> labels = new HashMap<>();
       labels.putAll(getSystemLabels());
+      labels.putAll(getReuseLabels(context, conf));
       labels.putAll(conf.getClusterLabels());
       LOG.info("Creating Dataproc cluster {} in project {}, in region {}, with image {}, with labels {}",
                clusterName, conf.getProjectId(), conf.getRegion(), imageDescription, labels);
@@ -150,6 +166,117 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
                                "provisioner.createCluster.response.count", e);
       throw e;
     }
+  }
+
+  private Map<? extends String, ? extends String> getReuseLabels(ProvisionerContext context, DataprocConf conf) {
+    Map<String, String> reuseLabels = new HashMap<>();
+    String normalProfileName = getNormalizedProfileName(context);
+    if (normalProfileName != null) {
+      reuseLabels.put(LABEL_PROFILE, normalProfileName);
+    }
+    reuseLabels.put(LABEL_REUSE_KEY, conf.getClusterReuseKey());
+    reuseLabels.put(LABEL_RUN_KEY, getRunKey(context));
+    return reuseLabels;
+  }
+
+  /**
+   * If cluster reuse is enabled & possible tries to find a cluster to reuse.
+   * @param client data proc client
+   * @param context provisioner contex
+   * @param conf dataproc configuration
+   * @return a cluster ready to reuse or null if none available.
+   */
+  @Nullable
+  private Cluster tryReuseCluster(DataprocClient client, ProvisionerContext context, DataprocConf conf)
+    throws RetryableProvisionException, IOException {
+    if (!isReuseSupported(conf)) {
+      LOG.debug("Not checking custer reuse, enabled: {}, skip delete: {}, idle ttl: {}, reuse threshold: {}",
+                conf.isClusterReuseEnabled(), conf.isSkipDelete(), conf.getIdleTTLMinutes(),
+                conf.getClusterReuseThresholdMinutes());
+      return null;
+    }
+
+    String clusterKey = getRunKey(context);
+
+    //For idempotency, check if we already have the cluster allocated
+    Optional<Cluster> clusterOptional = findCluster(clusterKey, client);
+    if (clusterOptional.isPresent()) {
+      Cluster cluster = clusterOptional.get();
+      if (cluster.getStatus() == ClusterStatus.CREATING ||
+        cluster.getStatus() == ClusterStatus.RUNNING) {
+        LOG.debug("Found allocated cluster {}", cluster.getName());
+        return cluster;
+      } else {
+        LOG.debug("Preallocated cluster {} expired, will look for new one");
+        //Let's remove the reuse label to ensure new cluster will be picked up by findCluster
+        try {
+          client.updateClusterLabels(cluster.getName(), Collections.emptyMap(), Collections.singleton(LABEL_RUN_KEY));
+        } catch (Exception e) {
+          LOG.trace("Unable to remove reuse label, probably cluster died already", e);
+          if (!LOG.isTraceEnabled()) {
+            LOG.debug("Unable to remove reuse label, probably cluster died already");
+          }
+        }
+      }
+    }
+
+    Lock reuseLock = getSystemContext().getLock(REUSE_LOCK);
+    reuseLock.lock();
+    try {
+      Map<String, String> filter = new HashMap<>();
+      String normalizedProfileName = getNormalizedProfileName(context);
+      if (normalizedProfileName != null) {
+        filter.put(LABEL_PROFILE, normalizedProfileName);
+      }
+      filter.put(LABEL_VERSON, getVersionLabel());
+      filter.put(LABEL_REUSE_KEY, conf.getClusterReuseKey());
+      filter.put(LABEL_REUSE_UNTIL, "*");
+
+      Optional<Cluster> cluster = client.getClusters(ClusterStatus.RUNNING, filter, clientCluster -> {
+        //Verify reuse label
+        long reuseUntil = Long.valueOf(clientCluster.getLabelsOrDefault(LABEL_REUSE_UNTIL, "0"));
+        long now = System.currentTimeMillis();
+        if (reuseUntil < now) {
+          LOG.debug("Skipping expired cluster {}, reuse until {} is before now {}",
+                    clientCluster.getClusterName(), reuseUntil, now);
+          return false;
+        }
+        return true;
+      }).findAny();
+
+      if (cluster.isPresent()) {
+        String clusterName = cluster.get().getName();
+        LOG.info("Found cluster to reuse: {}", clusterName);
+        // Add cdap-reuse-for to find cluster later if needed
+        // And remove reuseUntil to indicate the cluster is taken
+        client.updateClusterLabels(clusterName,
+                                   Collections.singletonMap(LABEL_RUN_KEY, clusterKey),
+                                   Collections.singleton(LABEL_REUSE_UNTIL)
+        );
+      } else {
+        LOG.debug("Could not find any available cluster to reuse.");
+      }
+      return cluster.orElse(null);
+    } catch (Exception e) {
+      LOG.warn("Error retrieving clusters to reuse, will create a new one", e);
+      return null;
+    } finally {
+      reuseLock.unlock();
+    }
+  }
+
+  private boolean isReuseSupported(DataprocConf conf) {
+    return conf.isClusterReuseEnabled() && conf.isSkipDelete() &&
+      conf.getIdleTTLMinutes() > conf.getClusterReuseThresholdMinutes();
+  }
+
+  @Nullable
+  private String getNormalizedProfileName(ProvisionerContext context) {
+    if (context.getProfileName() == null) {
+      return null;
+    }
+    String normalName = context.getProfileName().replaceAll("[^a-zA-Z0-9]", "");
+    return normalName.isEmpty() ? null : normalName;
   }
 
   @VisibleForTesting
@@ -177,7 +304,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
   @Override
   public ClusterStatus getClusterStatus(ProvisionerContext context, Cluster cluster) throws Exception {
     DataprocConf conf = DataprocConf.create(createContextProperties(context));
-    String clusterName = getClusterName(context);
+    String clusterName = cluster.getName();
 
     ClusterStatus status = cluster.getStatus();
     // if we are skipping the delete, need to avoid checking the real cluster status and pretend like it is deleted.
@@ -185,7 +312,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       return ClusterStatus.NOT_EXISTS;
     }
 
-    try (DataprocClient client = DataprocClient.fromConf(conf)) {
+    try (DataprocClient client = getClient(conf)) {
       status = client.getClusterStatus(clusterName);
       DataprocUtils.emitMetric(context, conf.getRegion(),
                                "provisioner.clusterStatus.response.count");
@@ -200,8 +327,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
   @Override
   public Cluster getClusterDetail(ProvisionerContext context, Cluster cluster) throws Exception {
     DataprocConf conf = DataprocConf.create(createContextProperties(context));
-    String clusterName = getClusterName(context);
-    try (DataprocClient client = DataprocClient.fromConf(conf)) {
+    String clusterName = cluster.getName();
+    try (DataprocClient client = getClient(conf)) {
       Optional<Cluster> existing = client.getCluster(clusterName);
       DataprocUtils.emitMetric(context, conf.getRegion(),
                                "provisioner.clusterDetail.response.count");
@@ -215,12 +342,25 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
 
   @Override
   protected void doDeleteCluster(ProvisionerContext context, Cluster cluster, DataprocConf conf) throws Exception {
-    if (conf.isSkipDelete()) {
+    if (!isReuseSupported(conf) && conf.isSkipDelete()) {
       return;
     }
-    String clusterName = getClusterName(context);
-    try (DataprocClient client = DataprocClient.fromConf(conf)) {
-      client.deleteCluster(clusterName);
+    String clusterName = cluster.getName();
+    try (DataprocClient client = getClient(conf)) {
+      if (isReuseSupported(conf)) {
+        long reuseUntil = System.currentTimeMillis() +
+          TimeUnit.MINUTES.toMillis(conf.getIdleTTLMinutes() - conf.getClusterReuseThresholdMinutes());
+        LOG.debug("Marking cluster {} reusable for {} minutes",
+                  clusterName,
+                  conf.getIdleTTLMinutes() - conf.getClusterReuseThresholdMinutes());
+        client.updateClusterLabels(clusterName,
+                                   //Add reuse until
+                                   Collections.singletonMap(LABEL_REUSE_UNTIL, Long.toString(reuseUntil)),
+                                   //Drop allocation
+                                   Collections.singleton(LABEL_RUN_KEY));
+      } else {
+        client.deleteCluster(clusterName);
+      }
       DataprocUtils.emitMetric(context, conf.getRegion(),
                                "provisioner.deleteCluster.response.count");
     } catch (Exception e) {
@@ -228,6 +368,29 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
                                "provisioner.deleteCluster.response.count", e);
       throw e;
     }
+  }
+
+  @Override
+  protected String getClusterName(ProvisionerContext context) throws Exception {
+    DataprocConf conf = DataprocConf.create(createContextProperties(context));
+    String clusterKey = getRunKey(context);
+    if (isReuseSupported(conf)) {
+      try (DataprocClient client = getClient(conf)) {
+        Optional<Cluster> allocatedCluster = findCluster(clusterKey, client);
+        return allocatedCluster.map(Cluster::getName).orElse(clusterKey);
+      }
+    }
+    return clusterKey;
+  }
+
+  @VisibleForTesting
+  protected DataprocClient getClient(DataprocConf conf) throws IOException, GeneralSecurityException {
+    return DataprocClient.fromConf(conf);
+  }
+
+  private Optional<Cluster> findCluster(String clusterKey, DataprocClient client)
+    throws RetryableProvisionException {
+    return client.getClusters(null, Collections.singletonMap(LABEL_RUN_KEY, clusterKey)).findAny();
   }
 
   @Override
@@ -258,7 +421,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       DataprocConf.STACKDRIVER_MONITORING_ENABLED,
       DataprocConf.COMPONENT_GATEWAY_ENABLED,
       DataprocConf.IMAGE_VERSION,
-      DataprocConf.CLUSTER_MEATA_DATA,
+      DataprocConf.CLUSTER_META_DATA,
       DataprocConf.SERVICE_ACCOUNT
     ).contains(property);
   }
@@ -287,7 +450,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
   }
 
   /**
-   * Gets the cluster name for the given context.
+   * Gets the identifier to locate cluster for the given context.
+   * It's used as a cluster name when reuse is disabled and put into {@link #LABEL_RUN_KEY} when reuse is enabled.
    * Name must start with a lowercase letter followed by up to 51 lowercase letters,
    * numbers, or hyphens, and cannot end with a hyphen
    * We'll use app-runid, where app is truncated to fit, lowercased, and stripped of invalid characters.
@@ -295,8 +459,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
    * @param context the provisioner context
    * @return a string that is a valid cluster name
    */
-  @Override
-  protected String getClusterName(ProvisionerContext context) {
+  @VisibleForTesting
+  String getRunKey(ProvisionerContext context) {
     ProgramRunInfo programRunInfo = context.getProgramRunInfo();
 
     String cleanedAppName = programRunInfo.getApplication().replaceAll("[^A-Za-z0-9\\-]", "").toLowerCase();

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerContext.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerContext.java
@@ -37,7 +37,11 @@ import javax.annotation.Nullable;
 public class MockProvisionerContext implements ProvisionerContext {
 
   private final Map<String, String> properties;
-  private final ProgramRunInfo programRunInfo;
+  private ProgramRunInfo programRunInfo;
+  private SparkCompat sparkCompat;
+  private VersionInfo appCDAPVersionInfo;
+  private String cdapVersion;
+  private String profileName;
 
   public MockProvisionerContext() {
     this(null);
@@ -56,6 +60,10 @@ public class MockProvisionerContext implements ProvisionerContext {
   @Override
   public ProgramRunInfo getProgramRunInfo() {
     return programRunInfo;
+  }
+
+  public void setProgramRunInfo(ProgramRunInfo programRunInfo) {
+    this.programRunInfo = programRunInfo;
   }
 
   @Override
@@ -79,12 +87,20 @@ public class MockProvisionerContext implements ProvisionerContext {
 
   @Override
   public SparkCompat getSparkCompat() {
-    return null;
+    return sparkCompat;
+  }
+
+  public void setSparkCompat(SparkCompat sparkCompat) {
+    this.sparkCompat = sparkCompat;
   }
 
   @Override
   public String getCDAPVersion() {
-    return null;
+    return cdapVersion;
+  }
+
+  public void setCdapVersion(String cdapVersion) {
+    this.cdapVersion = cdapVersion;
   }
 
   @Override
@@ -94,7 +110,11 @@ public class MockProvisionerContext implements ProvisionerContext {
 
   @Override @Nullable
   public VersionInfo getAppCDAPVersionInfo() {
-    return null;
+    return appCDAPVersionInfo;
+  }
+
+  public void setAppCDAPVersionInfo(VersionInfo appCDAPVersionInfo) {
+    this.appCDAPVersionInfo = appCDAPVersionInfo;
   }
 
   @Override
@@ -105,6 +125,15 @@ public class MockProvisionerContext implements ProvisionerContext {
   @Override
   public RuntimeMonitorType getRuntimeMonitorType() {
     return null;
+  }
+
+  @Override
+  public String getProfileName() {
+    return profileName;
+  }
+
+  public void setProfileName(String profileName) {
+    this.profileName = profileName;
   }
 
   @Override

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerSystemContext.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerSystemContext.java
@@ -20,12 +20,18 @@ import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSystemContext;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class MockProvisionerSystemContext implements ProvisionerSystemContext {
   Map<String, String> properties;
+  private final Map<String, Lock> locks;
+  private String cdapVersion;
 
   public MockProvisionerSystemContext() {
     properties = new HashMap<>();
+    locks = new ConcurrentHashMap<>();
   }
 
   @Override
@@ -46,7 +52,16 @@ public class MockProvisionerSystemContext implements ProvisionerSystemContext {
   }
 
   @Override
+  public Lock getLock(String name) {
+    return locks.computeIfAbsent(name, n -> new ReentrantLock());
+  }
+
+  @Override
   public String getCDAPVersion() {
-    return null;
+    return cdapVersion;
+  }
+
+  public void setCDAPVersion(String cdapVersion) {
+    this.cdapVersion = cdapVersion;
   }
 }

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerContext.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerContext.java
@@ -26,6 +26,7 @@ import org.apache.twill.filesystem.LocationFactory;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.locks.Lock;
 import javax.annotation.Nullable;
 
 /**
@@ -113,4 +114,10 @@ public interface ProvisionerContext {
    * @return a {@link CompletionStage} that carries result of the task execution
    */
   <T> CompletionStage<T> execute(Callable<T> callable);
+
+  /**
+   * @return provisioner profile name.
+   */
+  @Nullable
+  String getProfileName();
 }

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerSystemContext.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerSystemContext.java
@@ -18,6 +18,7 @@
 package io.cdap.cdap.runtime.spi.provisioner;
 
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Context for system level provisioner information. System level information cannot be seen or modified by end
@@ -46,4 +47,12 @@ public interface ProvisionerSystemContext {
    * Returns the CDAP version
    */
   String getCDAPVersion();
+
+  /**
+   * Creates or retrieves a lock specific to this provisioner. Multiple locks can be created by passing
+   * different names.
+   * @param name lock name used as a key to identify lock requested
+   * @return a new or existing lock instance that can be used to coordinate multiple instances of same provisioner
+   */
+  Lock getLock(String name);
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/13505
This PR allows to reuse ephemeral dataproc clusters if:

Cluster is not deleted on job finish
There is a TTL set
`clusterReuseEnabled` is set to true for the profile (E.g. by setting `system.profile.properties.clusterReuseEnabled=true` on a pipeline)