### PR TITLE
[Cherry-pick 6.5][CDAP-18117] We should not try to instantiate main classes if they are not Applications

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactInspector.java
@@ -198,14 +198,14 @@ final class DefaultArtifactInspector implements ArtifactInspector {
     }
 
     try {
-      Object appMain = artifactClassLoader.loadClass(mainClassName).newInstance();
-      if (!(appMain instanceof Application)) {
+      Class<?> mainClass = artifactClassLoader.loadClass(mainClassName);
+      if (!(Application.class.isAssignableFrom(mainClass))) {
         // we don't want to error here, just don't record an application class.
         // possible for 3rd party plugin artifacts to have the main class set
         return builder;
       }
 
-      Application app = (Application) appMain;
+      Application app = (Application) mainClass.newInstance();
 
       java.lang.reflect.Type configType;
       // if the user parameterized their application, like 'xyz extends Application<T>',


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/13514
E.g. IBM iSeries JDBC driver has a main class without default constructor. Without this fix we fail to add the driver