### PR TITLE
Refacotring related to internal auth and security related bindings (cherry-pick)

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
@@ -63,8 +63,9 @@ import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.Configs;
@@ -281,7 +282,8 @@ public class DistributedWorkflowProgramRunnerTest {
       new MessagingClientModule(),
       new ExploreClientModule(),
       new AuditModule(),
-      new CoreSecurityModules().getDistributedModule(cConf),
+      CoreSecurityRuntimeModule.getDistributedModule(cConf),
+      new AuthenticationContextModules().getNoOpModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new TwillModule(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -118,7 +118,6 @@ import io.cdap.cdap.pipeline.PipelineFactory;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
 import io.cdap.cdap.scheduler.Scheduler;
 import io.cdap.cdap.securestore.spi.SecretStore;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.DefaultUGIProvider;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
@@ -163,7 +162,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new NamespaceAdminModule().getInMemoryModules(),
                            new ConfigStoreModule(),
                            new EntityVerifierModule(),
-                           new AuthenticationContextModules().getMasterModule(),
                            BootstrapModules.getInMemoryModule(),
                            new AbstractModule() {
                              @Override
@@ -203,7 +201,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new NamespaceAdminModule().getStandaloneModules(),
                            new ConfigStoreModule(),
                            new EntityVerifierModule(),
-                           new AuthenticationContextModules().getMasterModule(),
                            new ProvisionerModule(),
                            BootstrapModules.getFileBasedModule(),
                            new AbstractModule() {
@@ -256,7 +253,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new NamespaceAdminModule().getDistributedModules(),
                            new ConfigStoreModule(),
                            new EntityVerifierModule(),
-                           new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
                            new ProvisionerModule(),
                            BootstrapModules.getFileBasedModule(),
                            new AbstractModule() {
@@ -284,26 +280,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                servicesNamesBinder.addBinding().toInstance(Constants.Service.SECURE_STORE_SERVICE);
                              }
                            });
-  }
-
-  /**
-   * Returns modules to be used for preview runners.
-   *
-   * @return Module which contains bindings for preview runners
-   */
-  public Module getPreviewRunnerModules() {
-    return Modules.override(getStandaloneModules()).with(new AuthenticationContextModules()
-                                                           .getInternalAuthWorkerModule(cConf));
-  }
-
-  /**
-   * Returns modules to be used for preview master.
-   *
-   * @return Module which contains bindings for preview master
-   */
-  public Module getPreviewMasterModules() {
-    return Modules.override(getStandaloneModules()).with(new AuthenticationContextModules()
-                                                           .getInternalAuthMasterModule(cConf));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/TwillModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/TwillModule.java
@@ -70,7 +70,7 @@ public class TwillModule extends PrivateModule {
 
     @Override
     public TwillRunnerService get() {
-      String zkConnectStr = cConf.get(Constants.Zookeeper.QUORUM) + cConf.get(Constants.CFG_TWILL_ZK_NAMESPACE);
+      String zkConnectStr = Constants.Zookeeper.getZKQuorum(cConf) + cConf.get(Constants.CFG_TWILL_ZK_NAMESPACE);
 
       // Copy the yarn config and setup twill configs
       YarnConfiguration yarnConfig = new YarnConfiguration(yarnConf);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
@@ -55,7 +55,7 @@ import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.preview.PreviewSecureStoreModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
@@ -170,8 +170,8 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
     return Guice.createInjector(
       new ConfigModule(previewCConf, previewHConf, previewSConf),
       new IOModule(),
-      new CoreSecurityModules().getInMemoryModules(),
-      new AuthenticationContextModules().getInternalAuthWorkerModule(previewCConf),
+      new CoreSecurityRuntimeModule().getInMemoryModules(),
+      new AuthenticationContextModules().getMasterWorkerModule(),
       new PreviewSecureStoreModule(secureStore),
       new PreviewDiscoveryRuntimeModule(discoveryService),
       new LocalLocationModule(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -70,8 +70,9 @@ import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.SecureStoreClientModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
@@ -220,7 +221,7 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     modules.add(new PreviewRunnerManagerModule().getDistributedModules());
     modules.add(new DataSetServiceModules().getStandaloneModules());
     modules.add(new DataSetsModules().getStandaloneModules());
-    modules.add(new AppFabricServiceRuntimeModule(cConf).getPreviewRunnerModules());
+    modules.add(new AppFabricServiceRuntimeModule(cConf).getStandaloneModules());
     modules.add(new ProgramRunnerRuntimeModule().getStandaloneModules());
     modules.add(new MetricsStoreModule());
     modules.add(new MessagingClientModule());
@@ -229,7 +230,8 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     modules.add(new MetadataReaderWriterModules().getStandaloneModules());
     modules.add(new DFSLocationModule());
     modules.add(new MetadataServiceModule());
-    modules.add(new CoreSecurityModules().getInMemoryModules());
+    modules.add(new CoreSecurityRuntimeModule().getInMemoryModules());
+    modules.add(new AuthenticationContextModules().getMasterWorkerModule());
     modules.add(new AuthorizationModule());
     modules.add(new AuthorizationEnforcementModule().getMasterModule());
     modules.add(Modules.override(

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -58,6 +58,7 @@ import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.appender.loader.LogAppenderLoaderService;
 import io.cdap.cdap.logging.context.LoggingContextHelper;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.security.auth.TokenManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.api.Command;
@@ -439,8 +440,8 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
 
   private void addOnPremiseServices(Injector injector, ProgramOptions programOptions,
                                     MetricsCollectionService metricsCollectionService, Collection<Service> services) {
-    for (Class<? extends Service> cls : Arrays.asList(ZKClientService.class,
-                                                      KafkaClientService.class, BrokerService.class)) {
+    for (Class<? extends Service> cls : Arrays.asList(ZKClientService.class, KafkaClientService.class,
+                                                      BrokerService.class, TokenManager.class)) {
       Binding<? extends Service> binding = injector.getExistingBinding(Key.get(cls));
       if (binding != null) {
         services.add(binding.getProvider().get());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerService.java
@@ -43,8 +43,6 @@ public class TaskWorkerService extends AbstractIdleService {
 
   private static final Logger LOG = LoggerFactory.getLogger(TaskWorkerService.class);
 
-  private final CConfiguration cConf;
-  private final SConfiguration sConf;
   private final DiscoveryService discoveryService;
   private final NettyHttpService httpService;
   private Cancellable cancelDiscovery;
@@ -54,8 +52,6 @@ public class TaskWorkerService extends AbstractIdleService {
   TaskWorkerService(CConfiguration cConf,
                     SConfiguration sConf,
                     DiscoveryService discoveryService) {
-    this.cConf = cConf;
-    this.sConf = sConf;
     this.discoveryService = discoveryService;
 
     NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf, Constants.Service.TASK_WORKER)
@@ -64,7 +60,7 @@ public class TaskWorkerService extends AbstractIdleService {
       .setExecThreadPoolSize(cConf.getInt(Constants.TaskWorker.EXEC_THREADS))
       .setBossThreadPoolSize(cConf.getInt(Constants.TaskWorker.BOSS_THREADS))
       .setWorkerThreadPoolSize(cConf.getInt(Constants.TaskWorker.WORKER_THREADS))
-      .setHttpHandlers(new TaskWorkerHttpHandlerInternal(this.cConf, this::stopService));
+      .setHttpHandlers(new TaskWorkerHttpHandlerInternal(cConf, this::stopService));
 
     if (cConf.getBoolean(Constants.Security.SSL.INTERNAL_ENABLED)) {
       new HttpsEnabler().configureKeyStore(cConf, sConf).enable(builder);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/guice/AppFabricTestModule.java
@@ -44,6 +44,7 @@ import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsHandlerModule;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import org.apache.hadoop.conf.Configuration;
@@ -101,6 +102,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new ExploreClientModule());
     install(new ConfigStoreModule());
     install(new MetadataServiceModule());
+    install(new AuthenticationContextModules().getMasterModule());
     install(new AuthorizationModule());
     install(new AuthorizationEnforcementModule().getStandaloneModules());
     install(new SecureStoreServerModule());

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.common.conf;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.BindingAnnotation;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -153,6 +154,19 @@ public final class Constants {
 
     // System property name to control the InMemoryZKServer to bind to localhost only or not
     public static final String TWILL_ZK_SERVER_LOCALHOST = "twill.zk.server.localhost";
+
+    /**
+     * Convenient method to get ZK quorum string from the configuration with proper default value.
+     */
+    public static String getZKQuorum(CConfiguration cConf) {
+      String quorum = cConf.get(QUORUM);
+      if (!Strings.isNullOrEmpty(quorum)) {
+        return quorum;
+      }
+      quorum = "127.0.0.1:2181";
+      String root = cConf.get(ROOT_NAMESPACE);
+      return Strings.isNullOrEmpty(root) ? quorum : quorum + "/" + root;
+    }
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -348,7 +348,7 @@
 
   <property>
     <name>zookeeper.quorum</name>
-    <value>127.0.0.1:2181/${root.namespace}</value>
+    <value/>
     <description>
       ZooKeeper quorum string; specifies the ZooKeeper host:port; substitute
       the quorum (FQDN1:2181,FQDN2:2181,...) for the components shown here

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/NettyRouter.java
@@ -89,9 +89,9 @@ public class NettyRouter extends AbstractIdleService {
   private final TokenValidator tokenValidator;
   private final UserIdentityExtractor userIdentityExtractor;
   private final boolean sslEnabled;
-  private InetSocketAddress boundAddress;
+  private final DiscoveryServiceClient discoveryServiceClient;
 
-  private DiscoveryServiceClient discoveryServiceClient;
+  private InetSocketAddress boundAddress;
   private Cancellable serverCancellable;
 
   @Inject

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterMain.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterMain.java
@@ -28,7 +28,7 @@ import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.guice.ZKDiscoveryModule;
 import io.cdap.cdap.common.runtime.DaemonMain;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import org.apache.twill.internal.Services;
@@ -82,13 +82,6 @@ public class RouterMain extends DaemonMain {
         }
       }
 
-      // Initialize ZK client
-      String zookeeper = cConf.get(Constants.Zookeeper.QUORUM);
-      if (zookeeper == null) {
-        LOG.error("No ZooKeeper quorum provided.");
-        System.exit(1);
-      }
-
       Injector injector = createGuiceInjector(cConf);
       zkClientService = injector.getInstance(ZKClientService.class);
 
@@ -112,7 +105,7 @@ public class RouterMain extends DaemonMain {
                                                                     "ZooKeeper client. Please verify that the " +
                                                                     "ZooKeeper quorum settings are correct in " +
                                                                     "cdap-site.xml. Currently configured as: %s",
-                                                                    cConf.get(Constants.Zookeeper.QUORUM)));
+                                                                    zkClientService.getConnectString()));
     router.startAndWait();
     LOG.info("Router started.");
   }
@@ -135,7 +128,7 @@ public class RouterMain extends DaemonMain {
       new ZKClientModule(),
       new ZKDiscoveryModule(),
       new RouterModules().getDistributedModules(),
-      CoreSecurityModules.getDistributedModule(cConf),
+      CoreSecurityRuntimeModule.getDistributedModule(cConf),
       new ExternalAuthenticationModule(),
       new IOModule()
     );

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayTestBase.java
@@ -49,7 +49,7 @@ import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.RunRecord;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
@@ -161,7 +161,7 @@ public abstract class GatewayTestBase {
                                       ("localhost", 0).getAddress());
           }
         },
-        new CoreSecurityModules().getInMemoryModules(),
+        new CoreSecurityRuntimeModule().getInMemoryModules(),
         new ExternalAuthenticationModule(),
         new AppFabricTestModule(conf)
       ).with(new AbstractModule() {

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/AuthServerAnnounceTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/AuthServerAnnounceTest.java
@@ -31,7 +31,7 @@ import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.AuthenticationMode;
 import io.cdap.cdap.security.auth.TokenValidator;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.server.GrantAccessToken;
 import org.apache.http.HttpResponse;
@@ -119,7 +119,7 @@ public class AuthServerAnnounceTest {
     @Override
     protected void startUp() {
       SConfiguration sConfiguration = SConfiguration.create();
-      Injector injector = Guice.createInjector(new CoreSecurityModules().getInMemoryModules(),
+      Injector injector = Guice.createInjector(new CoreSecurityRuntimeModule().getInMemoryModules(),
                                                new ExternalAuthenticationModule(),
                                                new InMemoryDiscoveryModule(),
                                                new AppFabricTestModule(cConf));

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/NettyRouterHttpTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/NettyRouterHttpTest.java
@@ -25,7 +25,7 @@ import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import org.apache.commons.net.DefaultSocketFactory;
 import org.apache.http.impl.client.DefaultHttpClient;
@@ -75,7 +75,7 @@ public class NettyRouterHttpTest extends NettyRouterTestBase {
     protected void startUp() {
       CConfiguration cConf = CConfiguration.create();
       SConfiguration sConfiguration = SConfiguration.create();
-      Injector injector = Guice.createInjector(new CoreSecurityModules().getInMemoryModules(),
+      Injector injector = Guice.createInjector(new CoreSecurityRuntimeModule().getInMemoryModules(),
                                                new ExternalAuthenticationModule(),
                                                new InMemoryDiscoveryModule(),
                                                new AppFabricTestModule(cConf));

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/NettyRouterHttpsTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/NettyRouterHttpsTest.java
@@ -27,7 +27,7 @@ import io.cdap.cdap.common.security.KeyStores;
 import io.cdap.cdap.common.security.KeyStoresTest;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.common.http.HttpRequests;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -165,7 +165,7 @@ public class NettyRouterHttpsTest extends NettyRouterTestBase {
 
     @Override
     protected void startUp() {
-      Injector injector = Guice.createInjector(new CoreSecurityModules().getInMemoryModules(),
+      Injector injector = Guice.createInjector(new CoreSecurityRuntimeModule().getInMemoryModules(),
                                                new ExternalAuthenticationModule(),
                                                new InMemoryDiscoveryModule(),
                                                new AppFabricTestModule(cConf));

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterResource.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterResource.java
@@ -26,7 +26,7 @@ import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.TokenValidator;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
@@ -56,7 +56,7 @@ class RouterResource extends ExternalResource {
   @Override
   protected void before() {
     CConfiguration cConf = CConfiguration.create();
-    Injector injector = Guice.createInjector(new CoreSecurityModules().getStandaloneModules(),
+    Injector injector = Guice.createInjector(new CoreSecurityRuntimeModule().getStandaloneModules(),
                                              new ExternalAuthenticationModule(),
                                              new InMemoryDiscoveryModule(),
                                              new AppFabricTestModule(cConf));

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RoutingToDataSetsTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RoutingToDataSetsTest.java
@@ -28,7 +28,7 @@ import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.utils.Networks;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpResponder;
@@ -62,7 +62,7 @@ public class RoutingToDataSetsTest {
   @BeforeClass
   public static void before() throws Exception {
     CConfiguration cConf = CConfiguration.create();
-    Injector injector = Guice.createInjector(new CoreSecurityModules().getInMemoryModules(),
+    Injector injector = Guice.createInjector(new CoreSecurityRuntimeModule().getInMemoryModules(),
                                              new ExternalAuthenticationModule(),
                                              new InMemoryDiscoveryModule(),
                                              new AppFabricTestModule(cConf));

--- a/cdap-kafka/src/main/java/io/cdap/cdap/kafka/run/KafkaServerMain.java
+++ b/cdap-kafka/src/main/java/io/cdap/cdap/kafka/run/KafkaServerMain.java
@@ -58,7 +58,7 @@ public class KafkaServerMain extends DaemonMain {
   public void init(String[] args) {
     CConfiguration cConf = CConfiguration.create();
 
-    String zkConnectStr = cConf.get(Constants.Zookeeper.QUORUM);
+    String zkConnectStr = Constants.Zookeeper.getZKQuorum(cConf);
     String zkNamespace = cConf.get(KafkaConstants.ConfigKeys.ZOOKEEPER_NAMESPACE_CONFIG);
 
     if (zkNamespace != null) {
@@ -69,7 +69,7 @@ public class KafkaServerMain extends DaemonMain {
                               String.format("Connection timed out while trying to start ZooKeeper client. Please " +
                                             "verify that the ZooKeeper quorum settings are correct in " +
                                             "cdap-site.xml. Currently configured as: %s",
-                                            cConf.get(Constants.Zookeeper.QUORUM)));
+                                            client.getConnectString()));
 
         String path = "/" + zkNamespace;
         LOG.info(String.format("Creating zookeeper namespace %s", path));

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -149,13 +149,14 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
   private final TwillSpecification twillSpec;
   private final String resourcePrefix;
   private final Map<String, String> extraLabels;
+  private final Map<String, SecretDiskRunnable> secretDiskRunnables;
+  private final Map<String, V1SecurityContext> containerSecurityContexts;
+  private final Map<String, Set<String>> readonlyDisks;
+
   private String schedulerQueue;
   private String mainRunnableName;
   private Set<String> dependentRunnableNames;
   private String serviceAccountName;
-  private final Map<String, SecretDiskRunnable> secretDiskRunnables;
-  private final HashMap<String, V1SecurityContext> containerSecurityContexts;
-  private final Map<String, Set<String>> readonlyDisks;
 
   KubeTwillPreparer(MasterEnvironmentContext masterEnvContext, ApiClient apiClient, String kubeNamespace,
                     PodInfo podInfo, TwillSpecification spec, RunId twillRunId, Location appLocation,

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
@@ -88,9 +88,10 @@ import io.cdap.cdap.operations.OperationalStatsService;
 import io.cdap.cdap.operations.guice.OperationalStatsModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.TokenSecureStoreRenewer;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.store.SecureStoreService;
@@ -266,7 +267,7 @@ public class MasterServiceMain extends DaemonMain {
                           TimeUnit.MILLISECONDS,
                           String.format("Connection timed out while trying to start ZooKeeper client. Please " +
                                           "verify that the ZooKeeper quorum settings are correct in cdap-site.xml. " +
-                                          "Currently configured as: %s", cConf.get(Constants.Zookeeper.QUORUM)));
+                                          "Currently configured as: %s", zkClient.getConnectString()));
     // Tries to create the ZK root node (which can be namespaced through the zk connection string)
     Futures.getUnchecked(ZKOperations.ignoreError(zkClient.create("/", null, CreateMode.PERSISTENT),
                                                   KeeperException.NodeExistsException.class, null));
@@ -570,7 +571,8 @@ public class MasterServiceMain extends DaemonMain {
       new MessagingClientModule(),
       new ExploreClientModule(),
       new AuditModule(),
-      new CoreSecurityModules().getDistributedModule(cConf),
+      CoreSecurityRuntimeModule.getDistributedModule(cConf),
+      new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new TwillModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/tools/JobQueueDebugger.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/tools/JobQueueDebugger.java
@@ -65,8 +65,9 @@ import io.cdap.cdap.messaging.data.MessageId;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
@@ -337,7 +338,8 @@ public class JobQueueDebugger extends AbstractIdleService {
       new MetricsClientRuntimeModule().getDistributedModules(),
       new MetricsStoreModule(),
       new KafkaClientModule(),
-      new CoreSecurityModules().getDistributedModule(cConf),
+      CoreSecurityRuntimeModule.getDistributedModule(cConf),
+      new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new SecureStoreServerModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/tools/UpgradeTool.java
@@ -73,7 +73,7 @@ import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.messaging.store.hbase.HBaseTableFactory;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
@@ -201,7 +201,7 @@ public class UpgradeTool {
       new SystemDatasetRuntimeModule().getDistributedModules(),
       new KafkaClientModule(),
       new IOModule(),
-      new CoreSecurityModules().getDistributedModule(cConf),
+      CoreSecurityRuntimeModule.getDistributedModule(cConf),
       new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
@@ -265,7 +265,7 @@ public class UpgradeTool {
                           TimeUnit.MILLISECONDS,
                           String.format("Connection timed out while trying to start ZooKeeper client. Please " +
                                           "verify that the ZooKeeper quorum settings are correct in cdap-site.xml. " +
-                                          "Currently configured as: %s", cConf.get(Constants.Zookeeper.QUORUM)));
+                                          "Currently configured as: %s", zkClientService.getConnectString()));
     LOG.info("Starting Transaction Service...");
     txService.startAndWait();
     LOG.info("Initializing Dataset Framework...");

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -33,7 +33,6 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.guice.SupplierProviderBridge;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.service.RetryOnStartFailureService;
@@ -62,7 +61,6 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.store.SecureStoreService;
 import org.apache.twill.api.TwillRunner;
@@ -107,8 +105,6 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
           bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
         }
       }),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf),
       new ProgramRunnerRuntimeModule().getDistributedModules(true),
       new MonitorHandlerModule(false),
       new SecureStoreServerModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AuthenticationServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AuthenticationServiceMain.java
@@ -23,15 +23,12 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.server.ExternalAuthenticationServer;
@@ -60,10 +57,7 @@ public class AuthenticationServiceMain extends AbstractServiceMain<EnvironmentOp
 
     List<Module> modules = new ArrayList<>();
     modules.add(new MessagingClientModule());
-    modules.add(CoreSecurityModules.getDistributedModule(cConf));
-    modules.add(new AuthenticationContextModules().getInternalAuthMasterModule(cConf));
     modules.add(new ExternalAuthenticationModule());
-    modules.add(ZKClientModule.getZKClientModuleIfRequired(cConf));
     return modules;
   }
 

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/LogsServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/LogsServiceMain.java
@@ -33,7 +33,6 @@ import io.cdap.cdap.api.logging.AppenderContext;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.LocalLocationModule;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.data.runtime.DataSetsModules;
@@ -53,9 +52,7 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.http.HttpHandler;
@@ -85,9 +82,6 @@ public class LogsServiceMain extends AbstractServiceMain<EnvironmentOptions> {
                                            EnvironmentOptions options, CConfiguration cConf) {
     return Arrays.asList(
       new AuthorizationEnforcementModule().getDistributedModules(),
-      new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf),
       new MessagingClientModule(),
       getDataFabricModule(),
       // Always use local table implementations, which use LevelDB.

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MessagingServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MessagingServiceMain.java
@@ -24,7 +24,6 @@ import com.google.inject.Module;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.namespace.guice.NamespaceQueryAdminModule;
@@ -35,9 +34,7 @@ import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
 import io.cdap.cdap.messaging.server.MessagingHttpService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import org.apache.twill.zookeeper.ZKClientService;
 
 import java.util.Arrays;
@@ -63,9 +60,6 @@ public class MessagingServiceMain extends AbstractServiceMain<EnvironmentOptions
     return Arrays.asList(
       new NamespaceQueryAdminModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
-      new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf),
       new MessagingServerRuntimeModule().getStandaloneModules(),
       new DFSLocationModule()
     );

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetadataServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetadataServiceMain.java
@@ -30,7 +30,6 @@ import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.namespace.guice.NamespaceQueryAdminModule;
@@ -48,9 +47,7 @@ import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.metadata.MetadataSubscriberService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
@@ -91,9 +88,6 @@ public class MetadataServiceMain extends AbstractServiceMain<EnvironmentOptions>
       new AuditModule(),
       new EntityVerifierModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
-      new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf),
       new DFSLocationModule(),
       new AbstractModule() {
         @Override

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMain.java
@@ -27,7 +27,6 @@ import io.cdap.cdap.api.metrics.MetricsContext;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.namespace.guice.NamespaceQueryAdminModule;
@@ -46,9 +45,7 @@ import io.cdap.cdap.metrics.query.MetricsQueryService;
 import io.cdap.cdap.metrics.store.MetricsCleanUpService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import org.apache.twill.zookeeper.ZKClientService;
 
 import java.util.Arrays;
@@ -76,9 +73,6 @@ public class MetricsServiceMain extends AbstractServiceMain<EnvironmentOptions> 
     return Arrays.asList(
       new NamespaceQueryAdminModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
-      new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf),
       new MessagingClientModule(),
       new SystemDatasetRuntimeModule().getStandaloneModules(),
       new MetricsStoreModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMain.java
@@ -36,7 +36,6 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.guice.SupplierProviderBridge;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.data.runtime.DataSetServiceModules;
@@ -52,7 +51,6 @@ import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreClientModule;
 import org.apache.twill.api.Configs;
 import org.apache.twill.api.TwillRunner;
@@ -101,13 +99,10 @@ public class PreviewServiceMain extends AbstractServiceMain<EnvironmentOptions> 
   @Override
   protected List<Module> getServiceModules(MasterEnvironment masterEnv,
                                            EnvironmentOptions options, CConfiguration cConf) {
-    List<Module> modules = new ArrayList<>();
-    modules.addAll(Arrays.asList(
+    List<Module> modules = new ArrayList<>(Arrays.asList(
       new DataSetServiceModules().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
-      new AppFabricServiceRuntimeModule(cConf).getPreviewMasterModules(),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf),
+      new AppFabricServiceRuntimeModule(cConf).getStandaloneModules(),
       new ProgramRunnerRuntimeModule().getStandaloneModules(),
       new MetricsStoreModule(),
       new MessagingClientModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
@@ -24,7 +24,6 @@ import com.google.inject.Module;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.gateway.router.NettyRouter;
@@ -34,8 +33,6 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import org.apache.twill.zookeeper.ZKClientService;
 import org.slf4j.Logger;
@@ -66,17 +63,8 @@ public class RouterServiceMain extends AbstractServiceMain<EnvironmentOptions> {
     modules.add(new MessagingClientModule());
     modules.add(new RouterModules().getDistributedModules());
     modules.add(new DFSLocationModule());
-    modules.addAll(getSecurityModules(cConf));
-
-    return modules;
-  }
-
-  private List<Module> getSecurityModules(CConfiguration cConf) {
-    List<Module> modules = new ArrayList<>();
-    modules.add(new AuthenticationContextModules().getInternalAuthMasterModule(cConf));
-    modules.add(CoreSecurityModules.getDistributedModule(cConf));
     modules.add(new ExternalAuthenticationModule());
-    modules.add(ZKClientModule.getZKClientModuleIfRequired(cConf));
+
     return modules;
   }
 

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
@@ -26,7 +26,6 @@ import io.cdap.cdap.app.guice.RuntimeServerModule;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -37,9 +36,7 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
@@ -71,10 +68,7 @@ public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> 
       new SystemDatasetRuntimeModule().getStandaloneModules(),
       getDataFabricModule(),
       new RuntimeServerModule(),
-      new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
-      new AuthorizationEnforcementModule().getDistributedModules(),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf)
+      new AuthorizationEnforcementModule().getDistributedModules()
     );
   }
 

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
@@ -61,7 +61,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.jar.Manifest;
 
 /**
- * Unit test for {@link AppFabricServiceMain}.
+ * Unit test for {@link PreviewServiceMain}.
  */
 public class PreviewServiceMainTest extends MasterServiceMainTestBase {
   private static final Gson GSON = new Gson();

--- a/cdap-security/src/main/java/io/cdap/cdap/security/auth/InMemoryKeyManager.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/auth/InMemoryKeyManager.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.security.auth;
 
+import com.google.inject.Inject;
 import io.cdap.cdap.common.conf.CConfiguration;
 
 import java.io.IOException;
@@ -27,9 +28,9 @@ public class InMemoryKeyManager extends MapBackedKeyManager {
 
   /**
    * Create an InMemoryKeyManager that stores keys in memory only.
-   * @param conf
    */
-  public InMemoryKeyManager(CConfiguration conf) {
+  @Inject
+  InMemoryKeyManager(CConfiguration conf) {
     super(conf);
   }
 

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/InMemoryCoreSecurityModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/InMemoryCoreSecurityModule.java
@@ -17,10 +17,7 @@
 package io.cdap.cdap.security.guice;
 
 import com.google.inject.Binder;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.google.inject.Scopes;
-import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.security.auth.InMemoryKeyManager;
 import io.cdap.cdap.security.auth.KeyManager;
 
@@ -32,20 +29,6 @@ final class InMemoryCoreSecurityModule extends CoreSecurityModule {
 
   @Override
   protected void bindKeyManager(Binder binder) {
-    binder.bind(KeyManager.class).toProvider(InMemoryKeyManagerProvider.class).in(Scopes.SINGLETON);
-  }
-
-  private static final class InMemoryKeyManagerProvider implements Provider<KeyManager> {
-    private final CConfiguration cConf;
-
-    @Inject
-    InMemoryKeyManagerProvider(CConfiguration conf) {
-      this.cConf = conf;
-    }
-
-    @Override
-    public KeyManager get() {
-      return new InMemoryKeyManager(cConf);
-    }
+    binder.bind(KeyManager.class).to(InMemoryKeyManager.class).in(Scopes.SINGLETON);
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/runtime/AuthenticationServerMain.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/runtime/AuthenticationServerMain.java
@@ -28,7 +28,7 @@ import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.guice.ZKDiscoveryModule;
 import io.cdap.cdap.common.runtime.DaemonMain;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.server.ExternalAuthenticationServer;
@@ -56,7 +56,7 @@ public class AuthenticationServerMain extends DaemonMain {
                                              new IOModule(),
                                              new ZKClientModule(),
                                              new ZKDiscoveryModule(),
-                                             new CoreSecurityModules().getDistributedModules(),
+                                             new CoreSecurityRuntimeModule().getDistributedModules(),
                                              new ExternalAuthenticationModule());
     configuration = injector.getInstance(CConfiguration.class);
 
@@ -83,7 +83,7 @@ public class AuthenticationServerMain extends DaemonMain {
                                                                           "ZooKeeper client. Please verify that the " +
                                                                           "ZooKeeper quorum settings are correct in " +
                                                                           "cdap-site.xml. Currently configured as: %s",
-                                                                        configuration.get(Constants.Zookeeper.QUORUM)));
+                                                                        zkClientService.getConnectString()));
         authServer.startAndWait();
       } catch (Exception e) {
         Throwable rootCause = Throwables.getRootCause(e);

--- a/cdap-security/src/main/java/io/cdap/cdap/security/tools/AuthenticationTool.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/tools/AuthenticationTool.java
@@ -29,7 +29,7 @@ import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.security.auth.FileBasedKeyManager;
 import io.cdap.cdap.security.auth.KeyIdentifier;
 import io.cdap.cdap.security.auth.KeyIdentifierCodec;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -82,7 +82,7 @@ public class AuthenticationTool {
         new ConfigModule(cConf),
         new IOModule(),
         new InMemoryDiscoveryModule(),
-        CoreSecurityModules.getDistributedModule(cConf));
+        CoreSecurityRuntimeModule.getDistributedModule(cConf));
 
       Codec<KeyIdentifier> codec = injector.getInstance(Key.get(new TypeLiteral<Codec<KeyIdentifier>>() { }));
       FileBasedKeyManager keyManager = new FileBasedKeyManager(injector.getInstance(CConfiguration.class),

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/DistributedKeyManagerTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/DistributedKeyManagerTest.java
@@ -32,7 +32,7 @@ import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.common.utils.ImmutablePair;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.security.guice.CoreSecurityModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.zookeeper.MiniZooKeeperCluster;
@@ -70,16 +70,18 @@ public class DistributedKeyManagerTest extends TestTokenManager {
       + zkCluster.getClientPort();
     LOG.info("Running ZK cluster at " + zkConnectString);
     CConfiguration cConf1 = CConfiguration.create();
+    cConf1.setBoolean(Constants.Security.ENABLED, true);
     cConf1.set(Constants.Zookeeper.QUORUM, zkConnectString);
 
     CConfiguration cConf2 = CConfiguration.create();
+    cConf2.setBoolean(Constants.Security.ENABLED, true);
     cConf2.set(Constants.Zookeeper.QUORUM, zkConnectString);
 
     List<Module> modules = new ArrayList<>();
     modules.add(new ConfigModule(cConf1, testUtil.getConfiguration()));
     modules.add(new IOModule());
 
-    CoreSecurityModule coreSecurityModule = CoreSecurityModules.getDistributedModule(cConf1);
+    CoreSecurityModule coreSecurityModule = CoreSecurityRuntimeModule.getDistributedModule(cConf1);
     modules.add(coreSecurityModule);
     if (coreSecurityModule.requiresZKClient()) {
       modules.add(new ZKClientModule());
@@ -91,7 +93,7 @@ public class DistributedKeyManagerTest extends TestTokenManager {
     modules.add(new ConfigModule(cConf2, testUtil.getConfiguration()));
     modules.add(new IOModule());
 
-    coreSecurityModule = CoreSecurityModules.getDistributedModule(cConf2);
+    coreSecurityModule = CoreSecurityRuntimeModule.getDistributedModule(cConf2);
     modules.add(coreSecurityModule);
     if (coreSecurityModule.requiresZKClient()) {
       modules.add(new ZKClientModule());

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/TestInMemoryTokenManager.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/TestInMemoryTokenManager.java
@@ -23,7 +23,7 @@ import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.common.utils.ImmutablePair;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 
 /**
  * Tests for InMemoryTokenManager that ensure that keys are maintained in memory and can be used to create
@@ -33,7 +33,7 @@ public class TestInMemoryTokenManager extends TestTokenManager {
 
   @Override
   protected ImmutablePair<TokenManager, Codec<AccessToken>> getTokenManagerAndCodec() {
-    Injector injector = Guice.createInjector(new IOModule(), new CoreSecurityModules().getStandaloneModules(),
+    Injector injector = Guice.createInjector(new IOModule(), new CoreSecurityRuntimeModule().getStandaloneModules(),
                                              new ConfigModule(), new InMemoryDiscoveryModule());
     TokenManager tokenManager = injector.getInstance(TokenManager.class);
     tokenManager.startAndWait();

--- a/cdap-security/src/test/java/io/cdap/cdap/security/server/ExternalAuthenticationServerTestBase.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/server/ExternalAuthenticationServerTestBase.java
@@ -35,7 +35,7 @@ import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.security.auth.AccessToken;
 import io.cdap.cdap.security.auth.AccessTokenCodec;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -115,7 +115,7 @@ public abstract class ExternalAuthenticationServerTestBase {
         }
       });
     Injector injector = Guice.createInjector(new IOModule(), externalAuthenticationModule,
-                                             new CoreSecurityModules().getInMemoryModules(),
+                                             new CoreSecurityRuntimeModule().getInMemoryModules(),
                                              new ConfigModule(getConfiguration(configuration),
                                                               HBaseConfiguration.create(), sConfiguration),
                                              new InMemoryDiscoveryModule());

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -91,9 +91,10 @@ import io.cdap.cdap.metrics.process.loader.MetricsWriterModule;
 import io.cdap.cdap.metrics.query.MetricsQueryService;
 import io.cdap.cdap.operations.OperationalStatsService;
 import io.cdap.cdap.operations.guice.OperationalStatsModule;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
@@ -524,7 +525,7 @@ public class StandaloneMain {
       new LocalLogAppenderModule(),
       new LogReaderRuntimeModules().getStandaloneModules(),
       new RouterModules().getStandaloneModules(),
-      new CoreSecurityModules().getStandaloneModules(),
+      new CoreSecurityRuntimeModule().getStandaloneModules(),
       new ExternalAuthenticationModule(),
       new SecureStoreServerModule(),
       new ExploreRuntimeModule().getStandaloneModules(),
@@ -532,6 +533,7 @@ public class StandaloneMain {
       new MetadataServiceModule(),
       new MetadataReaderWriterModules().getStandaloneModules(),
       new AuditModule(),
+      new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getStandaloneModules(),
       new PreviewConfigModule(cConf, new Configuration(), SConfiguration.create()),

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -125,6 +125,7 @@ import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.runtime.spi.SparkCompat;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
 import io.cdap.cdap.scheduler.Scheduler;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.authorization.InvalidAccessControllerException;
@@ -279,6 +280,7 @@ public class TestBase {
       new InMemoryDiscoveryModule(),
       new AppFabricServiceRuntimeModule(cConf).getInMemoryModules(),
       new MonitorHandlerModule(false),
+      new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
       new ProgramRunnerRuntimeModule().getInMemoryModules(),


### PR DESCRIPTION
- Simplify InMemoryKeyManager bindings
- Rename CoreSecurityModules to CoreSecurityRuntimeModule
-- Don’t call static method on instance
- Simplify AuthenticationContext injection
- Not requiring distributed security bindings when security feature is not enabled
- Remove zk quorum from the cdap-default.xml
-- Move the default value into code
-- We can now distinguish which KeyManager to use by check if the zk quorum is set
--- The check is the preserve backward compatibility
- Starts the TokenManager in the work twill runnables
- Fix the AbstractProgramTwillRunnable to only start TokenManager if available.