### PR TITLE
[CDAP-17772] Enforcement 6.5 Cherry-Pick

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/data/schema/Schema.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/data/schema/Schema.java
@@ -386,7 +386,7 @@ public final class Schema implements Serializable {
    * @param enumClass Enum values.
    * @return A {@link Schema} of {@link Type#ENUM ENUM} type.
    */
-  public static Schema enumWith(Class<Enum<?>> enumClass) {
+  public static Schema enumWith(Class<? extends Enum<?>> enumClass) {
     Enum<?>[] enumConstants = enumClass.getEnumConstants();
     String[] names = new String[enumConstants.length];
     for (int i = 0; i < enumConstants.length; i++) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
@@ -73,6 +73,7 @@ import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.NoOpOwnerAdmin;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.spi.metadata.noop.NoopMetadataStorage;
@@ -232,7 +233,7 @@ public class DistributedProgramContainerModule extends AbstractModule {
   private void addOnPremiseModules(List<Module> modules) {
     CoreSecurityModule coreSecurityModule = CoreSecurityRuntimeModule.getDistributedModule(cConf);
 
-    if (cConf.getBoolean(Constants.Security.ENFORCE_INTERNAL_AUTH)) {
+    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
       modules.add(new AuthenticationContextModules().getMasterModule());
       modules.add(coreSecurityModule);
     } else {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
@@ -16,10 +16,6 @@
 
 package io.cdap.cdap.internal.app.runtime.distributed.remote;
 
-import com.google.common.base.Throwables;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.Service;
@@ -114,7 +110,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -387,8 +382,8 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
       long currentTimestamp = System.currentTimeMillis();
       //TODO: Use a better identity & expiration
       UserIdentity identity = new UserIdentity(Constants.Security.Authentication.RUNTIME_IDENTITY,
-                                               Collections.emptyList(), currentTimestamp,
-                                               currentTimestamp + DEFAULT_EXPIRATION);
+                                               UserIdentity.IdentifierType.INTERNAL, Collections.emptyList(),
+                                               currentTimestamp, currentTimestamp + DEFAULT_EXPIRATION);
       AccessToken accessToken = tokenManager.signIdentifier(identity);
       byte[] encodedAccessToken = Base64.getEncoder().encode(accessTokenCodec.encode(accessToken));
       Location location = keysDir.append(Constants.Security.Authentication.RUNTIME_TOKEN_FILE);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeIdentityHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeIdentityHandler.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.logging.AuditLogEntry;
 import io.cdap.cdap.common.utils.Networks;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -32,8 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.HttpURLConnection;
 
-import static io.cdap.cdap.proto.security.Credential.CREDENTIAL_TYPE_INTERNAL;
-
 /**
  * A {@link ChannelInboundHandler} for properly propagating runtime identity to calls to other system services.
  */
@@ -45,7 +44,7 @@ public class RuntimeIdentityHandler extends ChannelInboundHandlerAdapter {
   private final boolean auditLogEnabled;
 
   public RuntimeIdentityHandler(CConfiguration cConf) {
-    this.enforceAuthenticatedRequests = cConf.getBoolean(Constants.Security.ENFORCE_INTERNAL_AUTH);
+    this.enforceAuthenticatedRequests = SecurityUtil.isInternalAuthEnabled(cConf);
     this.auditLogEnabled = cConf.getBoolean(Constants.RuntimeMonitor.MONITOR_AUDIT_LOG_ENABLED);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTask.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.RequirementsCodec;
 import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import org.apache.twill.filesystem.Location;
 import org.slf4j.Logger;
@@ -73,7 +74,8 @@ public class ConfiguratorTask implements RunnableTask {
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
       new LocalLocationModule(),
-      new ConfiguratorTaskModule()
+      new ConfiguratorTaskModule(),
+      new AuthenticationContextModules().getMasterWorkerModule()
     );
     ConfigResponse result = injector.getInstance(ConfiguratorTaskRunner.class).configure(deploymentInfo);
     context.writeResult(GSON.toJson(result).getBytes(StandardCharsets.UTF_8));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTaskModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTaskModule.java
@@ -33,14 +33,11 @@ import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepositoryReader;
-import io.cdap.cdap.internal.app.runtime.artifact.RemotePluginFinder;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.proto.ProgramType;
-import io.cdap.cdap.security.auth.context.MasterAuthenticationContext;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.UGIProvider;
-import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -65,7 +62,6 @@ public class ConfiguratorTaskModule extends AbstractModule {
     bind(ProgramRunnerFactory.class).to(DefaultProgramRunnerFactory.class).in(Scopes.SINGLETON);
 
     bind(PluginFinder.class).to(RemoteWorkerPluginFinder.class);
-    bind(AuthenticationContext.class).to(MasterAuthenticationContext.class);
     bind(UGIProvider.class).to(CurrentUGIProvider.class);
 
     bind(ArtifactRepositoryReader.class).to(RemoteArtifactRepositoryReader.class).in(Scopes.SINGLETON);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppModule.java
@@ -38,10 +38,8 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.metadata.RemotePreferencesFetcherInternal;
 import io.cdap.cdap.proto.ProgramType;
-import io.cdap.cdap.security.auth.context.MasterAuthenticationContext;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.UGIProvider;
-import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -65,7 +63,6 @@ public class SystemAppModule extends AbstractModule {
     bind(ProgramRunnerFactory.class).to(DefaultProgramRunnerFactory.class).in(Scopes.SINGLETON);
 
     bind(UGIProvider.class).to(CurrentUGIProvider.class).in(Scopes.SINGLETON);
-    bind(AuthenticationContext.class).to(MasterAuthenticationContext.class);
 
     bind(ArtifactRepositoryReader.class).to(RemoteArtifactRepositoryReader.class).in(Scopes.SINGLETON);
     bind(ArtifactRepository.class).to(RemoteArtifactRepository.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
@@ -20,6 +20,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import io.cdap.cdap.common.app.MainClassLoader;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.logging.common.UncaughtExceptionHandler;
 import io.cdap.cdap.common.options.OptionsParser;
@@ -111,7 +112,8 @@ public class MasterEnvironmentMain {
         }
 
         RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
-          masterEnv.getDiscoveryServiceClientSupplier().get(), new WorkerAuthenticationContext(), cConf);
+          masterEnv.getDiscoveryServiceClientSupplier().get(),
+          new DefaultInternalAuthenticator(new WorkerAuthenticationContext()));
         MasterEnvironmentRunnableContext runnableContext =
           new DefaultMasterEnvironmentRunnableContext(context.getLocationFactory(), remoteClientFactory);
         @SuppressWarnings("unchecked")

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.discovery.URIScheme;
 import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.InMemoryNamespaceAdmin;
 import io.cdap.cdap.common.namespace.NamespaceAdmin;
@@ -109,7 +110,8 @@ public class RemoteConfiguratorTest {
     namespaceAdmin.create(NamespaceMeta.SYSTEM);
     namespaceAdmin.create(NamespaceMeta.DEFAULT);
 
-    remoteClientFactory = new RemoteClientFactory(discoveryService, new AuthenticationTestContext(), cConf);
+    remoteClientFactory = new RemoteClientFactory(discoveryService,
+                                                  new DefaultInternalAuthenticator(new AuthenticationTestContext()));
     httpService = new CommonNettyHttpServiceBuilder(cConf, "test")
       .setHttpHandlers(
         new TaskWorkerHttpHandlerInternal(cConf, className -> { }),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -57,6 +57,7 @@ import io.cdap.cdap.common.discovery.EndpointStrategy;
 import io.cdap.cdap.common.discovery.RandomEndpointStrategy;
 import io.cdap.cdap.common.discovery.URIScheme;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
 import io.cdap.cdap.common.io.Locations;
@@ -280,7 +281,8 @@ public abstract class AppFabricTestBase {
     metadataSubscriberService.startAndWait();
     locationFactory = getInjector().getInstance(LocationFactory.class);
     datasetClient = new DatasetClient(getClientConfig(discoveryClient, Constants.Service.DATASET_MANAGER));
-    remoteClientFactory = new RemoteClientFactory(discoveryClient, new AuthenticationTestContext(), cConf);
+    remoteClientFactory = new RemoteClientFactory(discoveryClient,
+                                                  new DefaultInternalAuthenticator(new AuthenticationTestContext()));
     metadataClient = new MetadataClient(getClientConfig(discoveryClient, Constants.Service.METADATA_SERVICE));
     metadataServiceClient = new DefaultMetadataServiceClient(remoteClientFactory);
     metricStore = injector.getInstance(MetricStore.class);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/SystemAppModuleTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/SystemAppModuleTest.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactManager;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.guice.SecureStoreClientModule;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import org.apache.hadoop.conf.Configuration;
@@ -57,6 +58,7 @@ public class SystemAppModuleTest {
         .build(ArtifactManagerFactory.class),
       new LocalLocationModule(),
       new SecureStoreClientModule(),
+      new AuthenticationContextModules().getNoOpModule(),
       new SystemAppModule());
     injector.getInstance(ArtifactRepositoryReader.class);
     injector.getInstance(ArtifactRepository.class);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
@@ -20,6 +20,7 @@ import com.google.common.io.Files;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.service.RetryStrategyType;
@@ -70,8 +71,8 @@ public class ArtifactLocalizerServiceTest extends AppFabricTestBase {
 
     String tempFolderPath = tmpFolder.newFolder().getPath();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, tempFolderPath);
-    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(discoveryClient,
-                                                                      new AuthenticationTestContext(), cConf);
+    RemoteClientFactory remoteClientFactory =
+      new RemoteClientFactory(discoveryClient, new DefaultInternalAuthenticator(new AuthenticationTestContext()));
     ArtifactLocalizerService artifactLocalizerService =
       new ArtifactLocalizerService(cConf, new ArtifactLocalizer(cConf, remoteClientFactory));
     // start the service

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/AutoInstallTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/AutoInstallTest.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.api.artifact.ArtifactRange;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.internal.remote.NoOpInternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.capability.autoinstall.HubPackage;
@@ -69,7 +70,8 @@ public class AutoInstallTest {
     cConf.set(Constants.AppFabric.TEMP_DIR, "appfabric");
     cConf.setInt(Constants.Capability.AUTO_INSTALL_THREADS, 5);
     ArtifactRepository artifactRepository = PowerMockito.mock(ArtifactRepository.class);
-    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(null, null, cConf);
+    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(null,
+                                                                      new NoOpInternalAuthenticator());
     CapabilityApplier capabilityApplier = new CapabilityApplier(null, null,
                                                                 null, null, null,
                                                                 artifactRepository, cConf, remoteClientFactory);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/master/environment/DefaultMasterEnvironmentRunnableContextTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/master/environment/DefaultMasterEnvironmentRunnableContextTest.java
@@ -17,10 +17,10 @@
 package io.cdap.cdap.master.environment;
 
 
-import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.discovery.ResolvingDiscoverable;
 import io.cdap.cdap.common.discovery.URIScheme;
+import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
 import io.cdap.common.http.HttpMethod;
@@ -67,7 +67,7 @@ public class DefaultMasterEnvironmentRunnableContextTest {
     DiscoveryService discoveryService = new InMemoryDiscoveryService();
     LocationFactory locationFactory = new LocalLocationFactory(TMP_FOLDER.newFolder());
     RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
-      (DiscoveryServiceClient) discoveryService, new AuthenticationTestContext(), CConfiguration.create());
+      (DiscoveryServiceClient) discoveryService, new DefaultInternalAuthenticator(new AuthenticationTestContext()));
     context = new DefaultMasterEnvironmentRunnableContext(locationFactory, remoteClientFactory);
 
     httpService = NettyHttpService.builder(Constants.Service.APP_FABRIC_HTTP)

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/OAuthMacroEvaluatorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/common/OAuthMacroEvaluatorTest.java
@@ -21,7 +21,7 @@ import com.google.gson.Gson;
 import io.cdap.cdap.api.ServiceDiscoverer;
 import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.app.services.AbstractServiceDiscoverer;
-import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.service.ServiceDiscoverable;
 import io.cdap.cdap.proto.ProgramType;
@@ -73,7 +73,7 @@ public class OAuthMacroEvaluatorTest {
                                                        Constants.STUDIO_SERVICE_NAME);
     discoveryService.register(new Discoverable(discoveryName, httpService.getBindAddress()));
     RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
-      discoveryService, new AuthenticationTestContext(), CConfiguration.create());
+      discoveryService, new DefaultInternalAuthenticator(new AuthenticationTestContext()));
     serviceDiscoverer = new AbstractServiceDiscoverer(NamespaceId.DEFAULT.app("testapp").spark("testspark")) {
       @Override
       protected RemoteClientFactory getRemoteClientFactory() {

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1122,7 +1122,7 @@ public final class Constants {
     public static final String PRINCIPAL = "principal";
 
     /** Requires all intra-cluster communications to be authenticated. */
-    public static final String ENFORCE_INTERNAL_AUTH = "security.internal.enforce.auth";
+    public static final String INTERNAL_AUTH_ENABLED = "security.internal.auth.enabled";
 
     /**
      * App Fabric
@@ -1673,12 +1673,12 @@ public final class Constants {
       /**
        * The secret name for the cdap-security.xml disk mount for worker services including preview and task workers.
        */
-      public static final String WORKER_SECRET_DISK_NAME = "twill.security.master.secret.disk.name";
+      public static final String WORKER_SECRET_DISK_NAME = "twill.security.worker.secret.disk.name";
 
       /**
        * The secret path for the cdap-security.xml disk mount for worker services including preview and task workers.
        */
-      public static final String WORKER_SECRET_DISK_PATH = "twill.security.master.secret.disk.path";
+      public static final String WORKER_SECRET_DISK_PATH = "twill.security.worker.secret.disk.path";
     }
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
@@ -49,7 +49,7 @@ public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
           EventExecutor executor = pipeline.context("dispatcher").executor();
           pipeline.addBefore(executor, "dispatcher", AUTHENTICATOR_NAME,
                              new AuthenticationChannelHandler(cConf.getBoolean(Constants.Security
-                                                                                 .ENFORCE_INTERNAL_AUTH)));
+                                                                                 .INTERNAL_AUTH_ENABLED)));
         }
       };
     }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/DefaultInternalAuthenticator.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/DefaultInternalAuthenticator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.internal.remote;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.proto.security.Credential;
+import io.cdap.cdap.proto.security.Principal;
+import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
+
+import java.util.function.BiConsumer;
+
+/**
+ * A class which sets internal authenticated headers for the remote client using an {@link AuthenticationContext} as
+ * the source.
+ */
+public class DefaultInternalAuthenticator implements InternalAuthenticator {
+  private final AuthenticationContext authenticationContext;
+
+  @Inject
+  public DefaultInternalAuthenticator(AuthenticationContext authenticationContext) {
+    this.authenticationContext = authenticationContext;
+  }
+
+  @Override
+  public void applyInternalAuthenticationHeaders(BiConsumer<String, String> headerSetter) {
+    Principal principal = authenticationContext.getPrincipal();
+    String userID = null;
+    Credential internalCredentials = null;
+    if (principal != null) {
+      userID = principal.getName();
+      internalCredentials = principal.getFullCredential();
+    }
+    if (internalCredentials != null) {
+      headerSetter.accept(Constants.Security.Headers.RUNTIME_TOKEN,
+                          String.format("%s %s", internalCredentials.getType().getQualifiedName(),
+                                        internalCredentials.getValue()));
+    }
+    if (userID != null) {
+      headerSetter.accept(Constants.Security.Headers.USER_ID, userID);
+    }
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/InternalAuthenticator.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/InternalAuthenticator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.internal.remote;
+
+import java.util.function.BiConsumer;
+
+/**
+ * An interface which uses a provided {@link java.util.function.BiConsumer} function to set headers on requests to
+ * propagate internal identity.
+ */
+public interface InternalAuthenticator {
+  /**
+   * Sets internal authentication headers using a provided header setting function.
+   *
+   * @param headerSetter A BiConsumer header setting function used to set header values for a request.
+   */
+  void applyInternalAuthenticationHeaders(BiConsumer<String, String> headerSetter);
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/NoOpInternalAuthenticator.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/NoOpInternalAuthenticator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.internal.remote;
+
+import java.util.function.BiConsumer;
+
+/**
+ * A class which does not set internal authentication headers.
+ */
+public class NoOpInternalAuthenticator implements InternalAuthenticator {
+  @Override
+  public void applyInternalAuthenticationHeaders(BiConsumer<String, String> headerSetter) {
+    return;
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
@@ -17,8 +17,6 @@
 package io.cdap.cdap.common.internal.remote;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.common.http.HttpRequestConfig;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -28,25 +26,21 @@ import javax.inject.Inject;
  * A factory to create {@link RemoteClient}.
  */
 public class RemoteClientFactory {
-
   public static final HttpRequestConfig NO_VERIFY_HTTP_REQUEST_CONFIG = new HttpRequestConfig(15000,
                                                                                               15000,
                                                                                               false);
   private final DiscoveryServiceClient discoveryClient;
-  private final AuthenticationContext authenticationContext;
-  private final CConfiguration cConf;
+  private final InternalAuthenticator internalAuthenticator;
 
   @Inject @VisibleForTesting
-  public RemoteClientFactory(DiscoveryServiceClient discoveryClient, AuthenticationContext authenticationContext,
-                             CConfiguration cConf) {
+  public RemoteClientFactory(DiscoveryServiceClient discoveryClient, InternalAuthenticator internalAuthenticator) {
     this.discoveryClient = discoveryClient;
-    this.authenticationContext = authenticationContext;
-    this.cConf = cConf;
+    this.internalAuthenticator = internalAuthenticator;
   }
 
-  public RemoteClient createRemoteClient(String discoverableServiceName,
-                                         HttpRequestConfig httpRequestConfig, String basePath) {
-    return new RemoteClient(authenticationContext, discoveryClient, cConf, discoverableServiceName, httpRequestConfig,
-                            basePath);
+  public RemoteClient createRemoteClient(String discoverableServiceName, HttpRequestConfig httpRequestConfig,
+                                         String basePath) {
+    return new RemoteClient(internalAuthenticator, discoveryClient, discoverableServiceName,
+                            httpRequestConfig, basePath);
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4186,7 +4186,7 @@
   <!-- Internal Security -->
 
   <property>
-    <name>security.internal.enforce.auth</name>
+    <name>security.internal.auth.enabled</name>
     <value>false</value>
     <description>
       A security-hardening measure which enforces authenticated communication between internal system services.

--- a/cdap-common/src/test/java/io/cdap/cdap/common/internal/remote/DefaultInternalAuthenticatorTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/internal/remote/DefaultInternalAuthenticatorTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.internal.remote;
+
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.proto.security.Credential;
+import io.cdap.cdap.proto.security.Principal;
+import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests for the {@link DefaultInternalAuthenticator}.
+ */
+public class DefaultInternalAuthenticatorTest {
+  @Test
+  public void testProperHeadersSet() {
+    Map<String, String> stringMap = new HashMap<>();
+
+    // Set authentication context principal.
+    String expectedName = "somebody";
+    String expectedCredValue = "credential";
+    Credential.CredentialType expectedCredType = Credential.CredentialType.EXTERNAL;
+    Credential credential = new Credential(expectedCredValue, expectedCredType);
+    Principal expectedPrincipal = new Principal(expectedName, Principal.PrincipalType.USER, credential);
+
+    DefaultInternalAuthenticator defaultInternalAuthenticator =
+      new DefaultInternalAuthenticator(new TestAuthenticationContext(expectedPrincipal));
+
+    defaultInternalAuthenticator.applyInternalAuthenticationHeaders(stringMap::put);
+
+    // Verify return values
+    Assert.assertEquals(expectedName, stringMap.get(Constants.Security.Headers.USER_ID));
+    Assert.assertEquals(String.format("%s %s", expectedCredType.getQualifiedName(), expectedCredValue),
+                        stringMap.get(Constants.Security.Headers.RUNTIME_TOKEN));
+  }
+
+  private static class TestAuthenticationContext implements AuthenticationContext {
+    private final Principal principal;
+
+    private TestAuthenticationContext(Principal principal) {
+      this.principal = principal;
+    }
+
+    @Override
+    public Principal getPrincipal() {
+      return principal;
+    }
+  }
+}

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/NettyRouter.java
@@ -126,7 +126,8 @@ public class NettyRouter extends AbstractIdleService {
 
   @Override
   protected void startUp() throws Exception {
-    if (SecurityUtil.isManagedSecurity(cConf)) {
+    // If internal authorization enforcement is enabled, we avoid re-initialization of the token manager.
+    if (SecurityUtil.isManagedSecurity(cConf) && !SecurityUtil.isInternalAuthEnabled(cConf)) {
       tokenValidator.startAndWait();
     }
     ChannelGroup channelGroup = new DefaultChannelGroup(ImmediateEventExecutor.INSTANCE);
@@ -139,7 +140,8 @@ public class NettyRouter extends AbstractIdleService {
     LOG.info("Stopping Netty Router...");
 
     serverCancellable.cancel();
-    if (SecurityUtil.isManagedSecurity(cConf)) {
+    // If internal authorization enforcement is enabled, we avoid duplicate cleanup of the token manager.
+    if (SecurityUtil.isManagedSecurity(cConf) && !SecurityUtil.isInternalAuthEnabled(cConf)) {
       tokenValidator.stopAndWait();
     }
 

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/MockAccessTokenIdentityExtractor.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/MockAccessTokenIdentityExtractor.java
@@ -60,8 +60,8 @@ public class MockAccessTokenIdentityExtractor implements UserIdentityExtractor {
                                             String.format("Failed to validate access token with reason: %s", state));
     }
     UserIdentityPair pair = new UserIdentityPair(accessToken,
-                                                 new UserIdentity("dummy", new LinkedHashSet<String>(),
-                                                                  System.currentTimeMillis(),
+                                                 new UserIdentity("dummy", UserIdentity.IdentifierType.EXTERNAL,
+                                                                  new LinkedHashSet<>(), System.currentTimeMillis(),
                                                                   System.currentTimeMillis() + 100000));
     return new UserIdentityExtractionResponse(pair);
   }

--- a/cdap-master/src/main/java/io/cdap/cdap/data/tools/HBaseTableExporter.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/tools/HBaseTableExporter.java
@@ -120,7 +120,7 @@ public class HBaseTableExporter {
       new KafkaLogAppenderModule(),
       new ExploreClientModule(),
       new AuthorizationModule(),
-      new AuthorizationEnforcementModule().getMasterModule(),
+      new AuthorizationEnforcementModule().getStandaloneModules(),
       new AuthenticationContextModules().getMasterModule(),
       new NamespaceQueryAdminModule(),
       new SecureStoreServerModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -62,6 +62,7 @@ import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.store.SecureStoreService;
 import org.apache.twill.api.TwillRunner;
 import org.apache.twill.api.TwillRunnerService;
@@ -140,7 +141,7 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
     if (zkBinding != null) {
       services.add(zkBinding.getProvider().get());
     }
-    services.add(injector.getInstance(TokenManager.class));
+
 
     // Start both the remote TwillRunnerService and regular TwillRunnerService
     TwillRunnerService remoteTwillRunner = injector.getInstance(Key.get(TwillRunnerService.class,
@@ -154,7 +155,10 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
     CConfiguration cConf = injector.getInstance(CConfiguration.class);
     if (cConf.getBoolean(Constants.TaskWorker.POOL_ENABLE)) {
       services.add(injector.getInstance(TaskWorkerServiceLauncher.class));
-    } 
+    }
+    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
+      services.add(injector.getInstance(TokenManager.class));
+    }
 
     // Optionally adds the master environment task
     masterEnv.getTask().ifPresent(task -> services.add(new MasterTaskExecutorService(task, masterEnvContext)));

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/LogsServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/LogsServiceMain.java
@@ -54,6 +54,7 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.http.HttpHandler;
 import org.apache.twill.zookeeper.ZKClientService;
@@ -135,7 +136,10 @@ public class LogsServiceMain extends AbstractServiceMain<EnvironmentOptions> {
       services.add(zkBinding.getProvider().get());
     }
     // internal identity generation
-    services.add(injector.getInstance(TokenManager.class));
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
+      services.add(injector.getInstance(TokenManager.class));
+    }
   }
 
   @Nullable

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MessagingServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MessagingServiceMain.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.messaging.server.MessagingHttpService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import org.apache.twill.zookeeper.ZKClientService;
 
 import java.util.Arrays;
@@ -79,7 +80,10 @@ public class MessagingServiceMain extends AbstractServiceMain<EnvironmentOptions
     if (zkBinding != null) {
       services.add(zkBinding.getProvider().get());
     }
-    services.add(injector.getInstance(TokenManager.class));
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
+      services.add(injector.getInstance(TokenManager.class));
+    }
   }
 
   @Nullable

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetadataServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetadataServiceMain.java
@@ -51,6 +51,7 @@ import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.spi.authorization.NoOpAccessController;
 import io.cdap.cdap.security.spi.authorization.PermissionManager;
@@ -117,7 +118,10 @@ public class MetadataServiceMain extends AbstractServiceMain<EnvironmentOptions>
     if (zkBinding != null) {
       services.add(zkBinding.getProvider().get());
     }
-    services.add(injector.getInstance(TokenManager.class));
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
+      services.add(injector.getInstance(TokenManager.class));
+    }
 
     // Add a service just for closing MetadataStorage to release resource.
     // MetadataStorage is binded as Singleton, so ok to get the instance and close it.

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMain.java
@@ -46,6 +46,7 @@ import io.cdap.cdap.metrics.store.MetricsCleanUpService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import org.apache.twill.zookeeper.ZKClientService;
 
 import java.util.Arrays;
@@ -107,7 +108,9 @@ public class MetricsServiceMain extends AbstractServiceMain<EnvironmentOptions> 
     if (zkBinding != null) {
       services.add(zkBinding.getProvider().get());
     }
-    services.add(injector.getInstance(TokenManager.class));
+    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
+      services.add(injector.getInstance(TokenManager.class));
+    }
   }
 
   @Nullable

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMain.java
@@ -52,6 +52,7 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.guice.SecureStoreClientModule;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import org.apache.twill.api.Configs;
 import org.apache.twill.api.TwillRunner;
 import org.apache.twill.api.TwillRunnerService;
@@ -146,11 +147,13 @@ public class PreviewServiceMain extends AbstractServiceMain<EnvironmentOptions> 
     if (zkBinding != null) {
       services.add(zkBinding.getProvider().get());
     }
-    services.add(injector.getInstance(TokenManager.class));
 
     CConfiguration cConf = injector.getInstance(CConfiguration.class);
     if (cConf.getInt(Constants.Preview.CONTAINER_COUNT) <= 0) {
       services.add(injector.getInstance(PreviewRunnerManager.class));
+    }
+    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
+      services.add(injector.getInstance(TokenManager.class));
     }
   }
 

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import org.apache.twill.zookeeper.ZKClientService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,7 +79,10 @@ public class RouterServiceMain extends AbstractServiceMain<EnvironmentOptions> {
       services.add(zkBinding.getProvider().get());
     }
     services.add(injector.getInstance(NettyRouter.class));
-    services.add(injector.getInstance(TokenManager.class));
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
+      services.add(injector.getInstance(TokenManager.class));
+    }
   }
 
   @Nullable

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
@@ -106,7 +107,10 @@ public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> 
     if (zkBinding != null) {
       services.add(zkBinding.getProvider().get());
     }
-    services.add(injector.getInstance(TokenManager.class));
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
+      services.add(injector.getInstance(TokenManager.class));
+    }
   }
 
   @Nullable

--- a/cdap-security/src/main/java/io/cdap/cdap/security/auth/AccessToken.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/auth/AccessToken.java
@@ -40,14 +40,19 @@ import java.util.Map;
  */
 public class AccessToken implements Signed<UserIdentity> {
   static final class Schemas {
-    private static final int VERSION = 1;
+    private static final int VERSION = 2;
     private static final Map<Integer, Schema> schemas = Maps.newHashMap();
     static {
       schemas.put(1,
-          Schema.recordOf("AccessToken",
-              Schema.Field.of("identifier", UserIdentity.Schemas.getSchemaVersion(1)),
-              Schema.Field.of("keyId", Schema.of(Schema.Type.INT)),
-              Schema.Field.of("digest", Schema.of(Schema.Type.BYTES))));
+                  Schema.recordOf("AccessToken",
+                                  Schema.Field.of("identifier", UserIdentity.Schemas.getSchemaVersion(1)),
+                                  Schema.Field.of("keyId", Schema.of(Schema.Type.INT)),
+                                  Schema.Field.of("digest", Schema.of(Schema.Type.BYTES))));
+      schemas.put(2,
+                  Schema.recordOf("AccessToken",
+                                  Schema.Field.of("identifier", UserIdentity.Schemas.getSchemaVersion(2)),
+                                  Schema.Field.of("keyId", Schema.of(Schema.Type.INT)),
+                                  Schema.Field.of("digest", Schema.of(Schema.Type.BYTES))));
     }
 
 

--- a/cdap-security/src/main/java/io/cdap/cdap/security/auth/KeyIdentifier.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/auth/KeyIdentifier.java
@@ -29,7 +29,7 @@ import javax.crypto.spec.SecretKeySpec;
  * Represents a secret key to use for message signing, plus a unique random number identifying it.
  */
 public final class KeyIdentifier {
-  private SecretKey key;
+  private transient SecretKey key;
   private final byte[] encodedKey;
   private final String algorithm;
   private final int keyId;
@@ -78,6 +78,9 @@ public final class KeyIdentifier {
     return keyId;
   }
 
+  /**
+   * Returns the expiration timestamp in milliseconds.
+   */
   public long getExpiration() {
     return expiration;
   }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/auth/ProxyUserIdentityExtractor.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/auth/ProxyUserIdentityExtractor.java
@@ -64,8 +64,8 @@ public class ProxyUserIdentityExtractor implements UserIdentityExtractor {
                                                 "No user identity found");
     }
 
-    UserIdentity userIdentityObj = new UserIdentity(userIdentity, new LinkedHashSet<>(),
-                                                    now, now + EXPIRATION_SECS);
+    UserIdentity identity = new UserIdentity(userIdentity, UserIdentity.IdentifierType.EXTERNAL,
+                                               new LinkedHashSet<>(), now, now + EXPIRATION_SECS);
 
     // Parse the access token from authorization header. The header will be in "Bearer" form.
     String auth = request.headers().get(HttpHeaderNames.AUTHORIZATION);
@@ -75,10 +75,10 @@ public class ProxyUserIdentityExtractor implements UserIdentityExtractor {
     if (auth != null) {
       int idx = auth.trim().indexOf(' ');
       if (idx < 0) {
-        return new UserIdentityExtractionResponse(new UserIdentityPair(null, userIdentityObj));
+        return new UserIdentityExtractionResponse(new UserIdentityPair(null, identity));
       }
       userCredential = auth.substring(idx + 1).trim();
     }
-    return new UserIdentityExtractionResponse(new UserIdentityPair(userCredential, userIdentityObj));
+    return new UserIdentityExtractionResponse(new UserIdentityPair(userCredential, identity));
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/auth/context/AuthenticationTestContext.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/auth/context/AuthenticationTestContext.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.security.auth.context;
 
+import io.cdap.cdap.proto.security.Credential;
 import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 
@@ -25,6 +26,15 @@ import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 public class AuthenticationTestContext implements AuthenticationContext {
   @Override
   public Principal getPrincipal() {
-    return new Principal(System.getProperty("user.name"), Principal.PrincipalType.USER);
+    Credential credential = null;
+    try {
+      String credentialValue = System.getProperty("user.credential.value");
+      Credential.CredentialType credentialType = Credential.CredentialType
+        .valueOf(System.getProperty("user.credential.type"));
+      credential = new Credential(credentialValue, credentialType);
+    } catch (NullPointerException e) {
+      // Skip creating a credential if properties were not set.
+    }
+    return new Principal(System.getProperty("user.name"), Principal.PrincipalType.USER, credential);
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizationEnforcementModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizationEnforcementModule.java
@@ -19,9 +19,11 @@ package io.cdap.cdap.security.authorization;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
+import com.google.inject.name.Names;
 import io.cdap.cdap.common.runtime.RuntimeModule;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
+import io.cdap.cdap.security.spi.authorization.NoOpAccessController;
 
 /**
  * A module that contains bindings for {@link AccessEnforcer}.
@@ -34,6 +36,8 @@ public class AuthorizationEnforcementModule extends RuntimeModule {
       @Override
       protected void configure() {
         bind(AccessEnforcer.class).to(DefaultAccessEnforcer.class).in(Scopes.SINGLETON);
+        bind(AccessEnforcer.class).annotatedWith(Names.named(DefaultAccessEnforcer.INTERNAL_ACCESS_ENFORCER))
+          .to(NoOpAccessController.class).in(Scopes.SINGLETON);
         bind(ContextAccessEnforcer.class).to(DefaultContextAccessEnforcer.class).in(Scopes.SINGLETON);
       }
     };
@@ -45,6 +49,8 @@ public class AuthorizationEnforcementModule extends RuntimeModule {
       @Override
       protected void configure() {
         bind(AccessEnforcer.class).to(DefaultAccessEnforcer.class).in(Scopes.SINGLETON);
+        bind(AccessEnforcer.class).annotatedWith(Names.named(DefaultAccessEnforcer.INTERNAL_ACCESS_ENFORCER))
+          .to(NoOpAccessController.class).in(Scopes.SINGLETON);
         bind(ContextAccessEnforcer.class).to(DefaultContextAccessEnforcer.class).in(Scopes.SINGLETON);
       }
     };
@@ -73,6 +79,8 @@ public class AuthorizationEnforcementModule extends RuntimeModule {
       @Override
       protected void configure() {
         bind(AccessEnforcer.class).to(DefaultAccessEnforcer.class).in(Scopes.SINGLETON);
+        bind(AccessEnforcer.class).annotatedWith(Names.named(DefaultAccessEnforcer.INTERNAL_ACCESS_ENFORCER))
+          .to(InternalAccessEnforcer.class).in(Scopes.SINGLETON);
         bind(ContextAccessEnforcer.class).to(DefaultContextAccessEnforcer.class).in(Scopes.SINGLETON);
       }
     };

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/InternalAccessEnforcer.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/InternalAccessEnforcer.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.authorization;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.api.security.AccessException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.io.Codec;
+import io.cdap.cdap.proto.element.EntityType;
+import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.security.Credential;
+import io.cdap.cdap.proto.security.Permission;
+import io.cdap.cdap.proto.security.Principal;
+import io.cdap.cdap.security.auth.AccessToken;
+import io.cdap.cdap.security.auth.InvalidTokenException;
+import io.cdap.cdap.security.auth.TokenManager;
+import io.cdap.cdap.security.auth.UserIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Set;
+
+public class InternalAccessEnforcer extends AbstractAccessEnforcer {
+  private static final Logger LOG = LoggerFactory.getLogger(InternalAccessEnforcer.class);
+
+  private final TokenManager tokenManager;
+  private final Codec<AccessToken> accessTokenCodec;
+
+  @Inject
+  InternalAccessEnforcer(CConfiguration cConf, TokenManager tokenManager, Codec<AccessToken> accessTokenCodec) {
+    super(cConf);
+    this.tokenManager = tokenManager;
+    this.accessTokenCodec = accessTokenCodec;
+  }
+
+  @Override
+  public void enforce(EntityId entity, Principal principal,
+                      Set<? extends Permission> permissions) throws AccessException {
+    validateAccessTokenAndIdentity(principal.getName(), principal.getFullCredential());
+  }
+
+  @Override
+  public void enforceOnParent(EntityType entityType, EntityId parentId, Principal principal,
+                              Permission permission) throws AccessException {
+    validateAccessTokenAndIdentity(principal.getName(), principal.getFullCredential());
+  }
+
+  @Override
+  public Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds,
+                                           Principal principal) throws AccessException {
+    try {
+      validateAccessTokenAndIdentity(principal.getName(), principal.getFullCredential());
+      return entityIds;
+    } catch (AccessException e) {
+      return Collections.emptySet();
+    }
+  }
+
+  private void validateAccessTokenAndIdentity(String principalName, Credential credential) throws AccessException {
+    if (credential == null) {
+      throw new IllegalStateException("Attempted to internally enforce access on null credential");
+    }
+    if (!credential.getType().equals(Credential.CredentialType.INTERNAL)) {
+      throw new IllegalStateException("Attempted to internally enforce access on non-internal credential type");
+    }
+    AccessToken accessToken;
+    try {
+      accessToken = accessTokenCodec.decode(Base64.getDecoder().decode(credential.getValue()));
+    } catch (IOException e) {
+      throw new AccessException("Failed to deserialize access token", e);
+    }
+    try {
+      tokenManager.validateSecret(accessToken);
+    } catch (InvalidTokenException e) {
+      throw new AccessException("Failed to validate access token", e);
+    }
+    UserIdentity userIdentity = accessToken.getIdentifier();
+    if (!userIdentity.getUsername().equals(principalName)) {
+      LOG.debug(String.format("Internal access token username differs from principal name; got token " +
+                                                "name '%s', expected principal name '%s'",
+                                              userIdentity.getUsername(), principalName));
+    }
+    if (userIdentity.getIdentifierType() == null || !userIdentity.getIdentifierType()
+      .equals(UserIdentity.IdentifierType.INTERNAL)) {
+      throw new AccessException(String.format("Invalid internal access token type; got '%s', want '%s'",
+                                              userIdentity.getIdentifierType(), UserIdentity.IdentifierType.INTERNAL));
+    }
+  }
+}

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/CoreSecurityRuntimeModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/CoreSecurityRuntimeModule.java
@@ -20,6 +20,7 @@ import com.google.inject.Module;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.runtime.RuntimeModule;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import joptsimple.internal.Strings;
 import org.apache.twill.zookeeper.ZKClient;
 
@@ -54,7 +55,7 @@ public class CoreSecurityRuntimeModule extends RuntimeModule {
   public static CoreSecurityModule getDistributedModule(CConfiguration cConf) {
     // If security is not needed, we don't need a distributed security module.
     // It is merely for satisfying the binding dependencies only.
-    if (!cConf.getBoolean(Constants.Security.ENABLED) && !cConf.getBoolean(Constants.Security.ENFORCE_INTERNAL_AUTH)) {
+    if (!cConf.getBoolean(Constants.Security.ENABLED) && !SecurityUtil.isInternalAuthEnabled(cConf)) {
       return new InMemoryCoreSecurityModule();
     }
 

--- a/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/SecurityUtil.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/SecurityUtil.java
@@ -148,6 +148,15 @@ public final class SecurityUtil {
                        AuthenticationMode.MANAGED).equals(AuthenticationMode.MANAGED);
   }
 
+  /**
+   * Checks if internal authenticated communication should be enforced.
+   *
+   * @return {@code true} if internal auth is enabled.
+   */
+  public static boolean isInternalAuthEnabled(CConfiguration cConf) {
+    return cConf.getBoolean(Constants.Security.INTERNAL_AUTH_ENABLED);
+  }
+
   public static String getMasterPrincipal(CConfiguration cConf) {
     String principal = cConf.get(Constants.Security.CFG_CDAP_MASTER_KRB_PRINCIPAL);
     if (principal == null) {

--- a/cdap-security/src/main/java/io/cdap/cdap/security/server/GrantAccessToken.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/server/GrantAccessToken.java
@@ -122,7 +122,8 @@ public class GrantAccessToken {
     long issueTime = System.currentTimeMillis();
     long expireTime = issueTime + tokenValidity;
     // Create and sign a new AccessTokenIdentifier to generate the AccessToken.
-    UserIdentity tokenIdentifier = new UserIdentity(username, userGroups, issueTime, expireTime);
+    UserIdentity tokenIdentifier = new UserIdentity(username, UserIdentity.IdentifierType.EXTERNAL, userGroups,
+                                                    issueTime, expireTime);
     AccessToken token = tokenManager.signIdentifier(tokenIdentifier);
     LOG.debug("Issued token for user {}", username);
 

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/DistributedKeyManagerTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/DistributedKeyManagerTest.java
@@ -122,8 +122,9 @@ public class DistributedKeyManagerTest extends TestTokenManager {
     tokenManager2.startAndWait();
 
     long now = System.currentTimeMillis();
-    UserIdentity ident1 = new UserIdentity("testuser", Lists.newArrayList("users", "admins"),
-                                           now, now + 60 * 60 * 1000);
+    UserIdentity ident1 = new UserIdentity("testuser", UserIdentity.IdentifierType.EXTERNAL,
+                                           Lists.newArrayList("users", "admins"), now,
+                                           now + 60 * 60 * 1000);
     AccessToken token1 = tokenManager1.signIdentifier(ident1);
     // make sure the second token manager has the secret key required to validate the signature
     tokenManager2.waitForKey(tokenManager1.getCurrentKey().getKeyId(), 2000, TimeUnit.MILLISECONDS);

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/FileBasedTokenManagerTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/FileBasedTokenManagerTest.java
@@ -94,7 +94,8 @@ public class FileBasedTokenManagerTest extends TestTokenManager {
     String user = "testuser";
     long now = System.currentTimeMillis();
     List<String> groups = Lists.newArrayList("users", "admins");
-    UserIdentity identifier = new UserIdentity(user, groups, now, now + TOKEN_DURATION);
+    UserIdentity identifier = new UserIdentity(user, UserIdentity.IdentifierType.EXTERNAL, groups, now,
+                                               now + TOKEN_DURATION);
 
     AccessToken token = tokenManager.signIdentifier(identifier);
 

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/TestTokenManager.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/TestTokenManager.java
@@ -49,7 +49,7 @@ public abstract class TestTokenManager {
     long now = System.currentTimeMillis();
     String user = "testuser";
     List<String> groups = Lists.newArrayList("users", "admins");
-    UserIdentity ident1 = new UserIdentity(user, groups,
+    UserIdentity ident1 = new UserIdentity(user, UserIdentity.IdentifierType.EXTERNAL, groups,
                                            now, now + TOKEN_DURATION);
     AccessToken token1 = tokenManager.signIdentifier(ident1);
     LOG.info("Signed token is: " + Bytes.toStringBinary(tokenCodec.encode(token1)));
@@ -57,7 +57,8 @@ public abstract class TestTokenManager {
     tokenManager.validateSecret(token1);
 
     // test token expiration
-    UserIdentity expiredIdent = new UserIdentity(user, groups, now - 1000, now - 1);
+    UserIdentity expiredIdent = new UserIdentity(user, UserIdentity.IdentifierType.EXTERNAL, groups, now - 1000,
+                                                 now - 1);
     AccessToken expiredToken = tokenManager.signIdentifier(expiredIdent);
     try {
       tokenManager.validateSecret(expiredToken);
@@ -98,7 +99,7 @@ public abstract class TestTokenManager {
     long now = System.currentTimeMillis();
     String user = "testuser";
     List<String> groups = Lists.newArrayList("users", "admins");
-    UserIdentity ident1 = new UserIdentity(user, groups,
+    UserIdentity ident1 = new UserIdentity(user, UserIdentity.IdentifierType.EXTERNAL, groups,
                                            now, now + TOKEN_DURATION);
     AccessToken token1 = tokenManager.signIdentifier(ident1);
     byte[] tokenBytes = tokenCodec.encode(token1);

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/context/RemoteClientInternalAuthenticatorTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/context/RemoteClientInternalAuthenticatorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.auth.context;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.proto.security.Credential;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequestConfig;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpResponder;
+import io.cdap.http.NettyHttpService;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryService;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.net.HttpURLConnection;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+/**
+ * Tests for verifying internal authentication for the {@link io.cdap.cdap.common.internal.remote.RemoteClient}.
+ */
+public class RemoteClientInternalAuthenticatorTest {
+  private static final String TEST_SERVICE = "test";
+
+  private static TestHttpHandler testHttpHandler;
+  private static NettyHttpService httpService;
+  private static Injector injector;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    // Setup Guice injector.
+    injector = Guice.createInjector(new ConfigModule(), new InMemoryDiscoveryModule(),
+                                    new AuthenticationContextModules().getNoOpModule());
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    DiscoveryService discoveryService = injector.getInstance(DiscoveryService.class);
+
+    // Setup test HTTP handler and register the service.
+    testHttpHandler = new TestHttpHandler();
+    httpService = new CommonNettyHttpServiceBuilder(cConf, TEST_SERVICE)
+      .setHttpHandlers(testHttpHandler).build();
+    httpService.start();
+    discoveryService.register(new Discoverable(TEST_SERVICE, httpService.getBindAddress()));
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    httpService.stop();
+  }
+
+  @Test
+  public void testRemoteClientWithoutInternalAuthInjectsNoAuthenticationContext() throws Exception {
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    cConf.setBoolean(Constants.Security.INTERNAL_AUTH_ENABLED, false);
+    RemoteClientFactory remoteClientFactory = injector.getInstance(RemoteClientFactory.class);
+    RemoteClient remoteClient = remoteClientFactory
+      .createRemoteClient(TEST_SERVICE, new HttpRequestConfig(15000, 15000, false), "/");
+    HttpURLConnection conn = remoteClient.openConnection(HttpMethod.GET, "");
+    int responseCode = conn.getResponseCode();
+
+    // Verify that the request received the expected headers.
+    HttpHeaders headers = testHttpHandler.getRequest().headers();
+
+    Assert.assertEquals(HttpResponseStatus.OK.code(), responseCode);
+    Assert.assertFalse(headers.contains(Constants.Security.Headers.USER_ID));
+    Assert.assertFalse(headers.contains(Constants.Security.Headers.RUNTIME_TOKEN));
+  }
+
+  @Test
+  public void testRemoteClientWithInternalAuthInjectsAuthenticationContext() throws Exception {
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    cConf.setBoolean(Constants.Security.INTERNAL_AUTH_ENABLED, true);
+    RemoteClientFactory remoteClientFactory = injector.getInstance(RemoteClientFactory.class);
+    RemoteClient remoteClient = remoteClientFactory
+      .createRemoteClient(TEST_SERVICE, new HttpRequestConfig(15000, 15000, false), "/");
+
+    // Set authentication context principal.
+    String expectedName = "somebody";
+    String expectedCredValue = "credential";
+    Credential.CredentialType expectedCredType = Credential.CredentialType.EXTERNAL;
+    System.setProperty("user.name", expectedName);
+    System.setProperty("user.credential.value", expectedCredValue);
+    System.setProperty("user.credential.type", expectedCredType.name());
+
+    HttpURLConnection conn = remoteClient.openConnection(HttpMethod.GET, "");
+    int responseCode = conn.getResponseCode();
+
+    // Verify that the request received the expected headers.
+    HttpHeaders headers = testHttpHandler.getRequest().headers();
+
+    Assert.assertEquals(HttpResponseStatus.OK.code(), responseCode);
+    Assert.assertEquals(expectedName, headers.get(Constants.Security.Headers.USER_ID));
+    Assert.assertEquals(String.format("%s %s", expectedCredType.getQualifiedName(), expectedCredValue),
+                        headers.get(Constants.Security.Headers.RUNTIME_TOKEN));
+  }
+
+  /**
+   * HTTP handler for testing.
+   */
+  public static class TestHttpHandler extends AbstractHttpHandler {
+    private HttpRequest request;
+
+    @GET
+    @Path("/")
+    public void get(HttpRequest request, HttpResponder responder) {
+      this.request = request;
+      responder.sendStatus(HttpResponseStatus.OK);
+    }
+
+    public HttpRequest getRequest() {
+      return request;
+    }
+  }
+}

--- a/cdap-security/src/test/java/io/cdap/cdap/security/authorization/InternalAccessEnforcerTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/authorization/InternalAccessEnforcerTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.authorization;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import io.cdap.cdap.api.security.AccessException;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.IOModule;
+import io.cdap.cdap.common.io.Codec;
+import io.cdap.cdap.proto.element.EntityType;
+import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.security.Credential;
+import io.cdap.cdap.proto.security.Principal;
+import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.security.auth.AccessToken;
+import io.cdap.cdap.security.auth.TokenManager;
+import io.cdap.cdap.security.auth.UserIdentity;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Tests for the {@link InternalAccessEnforcer}.
+ */
+public class InternalAccessEnforcerTest {
+  private static final long MINUTE_MILLIS = 60 * 1000;
+  private static final String SYSTEM_PRINCIPAL = "system";
+
+  private Injector injector;
+  private TokenManager tokenManager;
+  private InternalAccessEnforcer internalAccessEnforcer;
+  private Codec<AccessToken> accessTokenCodec;
+
+  @Before
+  public void setupInternalAccessEnforcer() {
+    this.injector = Guice.createInjector(new IOModule(), new ConfigModule(),
+                                         new CoreSecurityRuntimeModule().getInMemoryModules());
+    this.tokenManager = injector.getInstance(TokenManager.class);
+    this.accessTokenCodec = injector.getInstance(Key.get(new TypeLiteral<Codec<AccessToken>>() { }));
+    this.tokenManager.startUp();
+    this.internalAccessEnforcer = injector.getInstance(InternalAccessEnforcer.class);
+  }
+
+  @After
+  public void teardownInternalAccessEnforcer() {
+    tokenManager.shutDown();
+  }
+
+  @Test
+  public void testInternalAccessEnforceSuccess() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    long currentTime = System.currentTimeMillis();
+    UserIdentity userIdentity = new UserIdentity(SYSTEM_PRINCIPAL, UserIdentity.IdentifierType.INTERNAL,
+                                                 Collections.emptyList(), currentTime,
+                                                 currentTime + 5 * MINUTE_MILLIS);
+    String encodedIdentity = Base64.getEncoder()
+      .encodeToString(accessTokenCodec.encode(tokenManager.signIdentifier(userIdentity)));
+    Credential credential = new Credential(encodedIdentity, Credential.CredentialType.INTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    internalAccessEnforcer.enforce(ns, principal, StandardPermission.GET);
+  }
+
+  @Test
+  public void testInternalAccessEnforceOnParentSuccess() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    long currentTime = System.currentTimeMillis();
+    UserIdentity userIdentity = new UserIdentity(SYSTEM_PRINCIPAL, UserIdentity.IdentifierType.INTERNAL,
+                                                 Collections.emptyList(), currentTime,
+                                                 currentTime + 5 * MINUTE_MILLIS);
+    String encodedIdentity = Base64.getEncoder()
+      .encodeToString(accessTokenCodec.encode(tokenManager.signIdentifier(userIdentity)));
+    Credential credential = new Credential(encodedIdentity, Credential.CredentialType.INTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    internalAccessEnforcer.enforceOnParent(EntityType.APPLICATION, ns, principal, StandardPermission.GET);
+  }
+
+  @Test
+  public void testInternalAccessIsVisibleSuccess() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    Set<EntityId> entities = Collections.singleton(ns);
+    long currentTime = System.currentTimeMillis();
+    UserIdentity userIdentity = new UserIdentity(SYSTEM_PRINCIPAL, UserIdentity.IdentifierType.INTERNAL,
+                                                 Collections.emptyList(), currentTime,
+                                                 currentTime + 5 * MINUTE_MILLIS);
+    String encodedIdentity = Base64.getEncoder()
+      .encodeToString(accessTokenCodec.encode(tokenManager.signIdentifier(userIdentity)));
+    Credential credential = new Credential(encodedIdentity, Credential.CredentialType.INTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    Assert.assertEquals(entities, internalAccessEnforcer.isVisible(entities, principal));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testInternalAccessEnforceNonInternalCredentialType() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    long currentTime = System.currentTimeMillis();
+    UserIdentity userIdentity = new UserIdentity(SYSTEM_PRINCIPAL, UserIdentity.IdentifierType.INTERNAL,
+                                                 Collections.emptyList(), currentTime,
+                                                 currentTime + 5 * MINUTE_MILLIS);
+    String encodedIdentity = Base64.getEncoder()
+      .encodeToString(accessTokenCodec.encode(tokenManager.signIdentifier(userIdentity)));
+    Credential credential = new Credential(encodedIdentity, Credential.CredentialType.EXTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    internalAccessEnforcer.enforce(ns, principal, StandardPermission.GET);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testInternalAccessEnforceOnParentNonInternalCredentialType() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    long currentTime = System.currentTimeMillis();
+    UserIdentity userIdentity = new UserIdentity(SYSTEM_PRINCIPAL, UserIdentity.IdentifierType.INTERNAL,
+                                                 Collections.emptyList(), currentTime,
+                                                 currentTime + 5 * MINUTE_MILLIS);
+    String encodedIdentity = Base64.getEncoder()
+      .encodeToString(accessTokenCodec.encode(tokenManager.signIdentifier(userIdentity)));
+    Credential credential = new Credential(encodedIdentity, Credential.CredentialType.EXTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    internalAccessEnforcer.enforceOnParent(EntityType.APPLICATION, ns, principal, StandardPermission.GET);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testInternalAccessIsVisibleNonInternalCredentialType() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    Set<EntityId> entities = Collections.singleton(ns);
+    long currentTime = System.currentTimeMillis();
+    UserIdentity userIdentity = new UserIdentity(SYSTEM_PRINCIPAL, UserIdentity.IdentifierType.INTERNAL,
+                                                 Collections.emptyList(), currentTime,
+                                                 currentTime + 5 * MINUTE_MILLIS);
+    String encodedIdentity = Base64.getEncoder()
+      .encodeToString(accessTokenCodec.encode(tokenManager.signIdentifier(userIdentity)));
+    Credential credential = new Credential(encodedIdentity, Credential.CredentialType.EXTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    internalAccessEnforcer.isVisible(entities, principal);
+  }
+
+  @Test(expected = AccessException.class)
+  public void testInternalAccessEnforceNonInternalTokenType() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    long currentTime = System.currentTimeMillis();
+    UserIdentity userIdentity = new UserIdentity(SYSTEM_PRINCIPAL, UserIdentity.IdentifierType.EXTERNAL,
+                                                 Collections.emptyList(), currentTime,
+                                                 currentTime + 5 * MINUTE_MILLIS);
+    String encodedIdentity = Base64.getEncoder()
+      .encodeToString(accessTokenCodec.encode(tokenManager.signIdentifier(userIdentity)));
+    Credential credential = new Credential(encodedIdentity, Credential.CredentialType.INTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    internalAccessEnforcer.enforce(ns, principal, StandardPermission.GET);
+  }
+
+  @Test(expected = AccessException.class)
+  public void testInternalAccessEnforceOnParentNonInternalTokenType() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    long currentTime = System.currentTimeMillis();
+    UserIdentity userIdentity = new UserIdentity(SYSTEM_PRINCIPAL, UserIdentity.IdentifierType.EXTERNAL,
+                                                 Collections.emptyList(), currentTime,
+                                                 currentTime + 5 * MINUTE_MILLIS);
+    String encodedIdentity = Base64.getEncoder()
+      .encodeToString(accessTokenCodec.encode(tokenManager.signIdentifier(userIdentity)));
+    Credential credential = new Credential(encodedIdentity, Credential.CredentialType.INTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    internalAccessEnforcer.enforceOnParent(EntityType.APPLICATION, ns, principal, StandardPermission.GET);
+  }
+
+  @Test
+  public void testInternalAccessIsVisibleNonInternalTokenType() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    Set<EntityId> entities = Collections.singleton(ns);
+    long currentTime = System.currentTimeMillis();
+    UserIdentity userIdentity = new UserIdentity(SYSTEM_PRINCIPAL, UserIdentity.IdentifierType.EXTERNAL,
+                                                 Collections.emptyList(), currentTime,
+                                                 currentTime + 5 * MINUTE_MILLIS);
+    String encodedIdentity = Base64.getEncoder()
+      .encodeToString(accessTokenCodec.encode(tokenManager.signIdentifier(userIdentity)));
+    Credential credential = new Credential(encodedIdentity, Credential.CredentialType.INTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    Assert.assertEquals(Collections.emptySet(), internalAccessEnforcer.isVisible(entities, principal));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testInternalAccessEnforceNullCredential() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, null);
+    internalAccessEnforcer.enforce(ns, principal, StandardPermission.GET);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testInternalAccessEnforceOnParentNullCredential() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, null);
+    internalAccessEnforcer.enforceOnParent(EntityType.APPLICATION, ns, principal, StandardPermission.GET);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testInternalAccessIsVisibleNullCredential() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    Set<EntityId> entities = Collections.singleton(ns);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, null);
+    Assert.assertEquals(Collections.emptySet(), internalAccessEnforcer.isVisible(entities, principal));
+  }
+
+  @Test(expected = AccessException.class)
+  public void testInternalAccessEnforceInvalidCredential() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    Credential credential = new Credential("invalid", Credential.CredentialType.INTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    internalAccessEnforcer.enforce(ns, principal, StandardPermission.GET);
+  }
+
+  @Test(expected = AccessException.class)
+  public void testInternalAccessEnforceOnParentInvalidCredential() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    Credential credential = new Credential("invalid", Credential.CredentialType.INTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    internalAccessEnforcer.enforceOnParent(EntityType.APPLICATION, ns, principal, StandardPermission.GET);
+  }
+
+  @Test
+  public void testInternalAccessIsVisibleInvalidCredential() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    Set<EntityId> entities = Collections.singleton(ns);
+    Credential credential = new Credential("invalid", Credential.CredentialType.INTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    Assert.assertEquals(Collections.emptySet(), internalAccessEnforcer.isVisible(entities, principal));
+  }
+
+  @Test(expected = AccessException.class)
+  public void testInternalAccessEnforceExpiredCredential() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    long currentTime = System.currentTimeMillis();
+    UserIdentity userIdentity = new UserIdentity(SYSTEM_PRINCIPAL, UserIdentity.IdentifierType.INTERNAL,
+                                                 Collections.emptyList(), currentTime - 10 * MINUTE_MILLIS,
+                                                 currentTime - 5 * MINUTE_MILLIS);
+    String encodedIdentity = Base64.getEncoder()
+      .encodeToString(accessTokenCodec.encode(tokenManager.signIdentifier(userIdentity)));
+    Credential credential = new Credential(encodedIdentity, Credential.CredentialType.INTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    internalAccessEnforcer.enforce(ns, principal, StandardPermission.GET);
+  }
+
+  @Test(expected = AccessException.class)
+  public void testInternalAccessEnforceOnParentExpiredCredential() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    long currentTime = System.currentTimeMillis();
+    UserIdentity userIdentity = new UserIdentity(SYSTEM_PRINCIPAL, UserIdentity.IdentifierType.INTERNAL,
+                                                 Collections.emptyList(), currentTime - 10 * MINUTE_MILLIS,
+                                                 currentTime - 5 * MINUTE_MILLIS);
+    String encodedIdentity = Base64.getEncoder()
+      .encodeToString(accessTokenCodec.encode(tokenManager.signIdentifier(userIdentity)));
+    Credential credential = new Credential(encodedIdentity, Credential.CredentialType.INTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    internalAccessEnforcer.enforceOnParent(EntityType.APPLICATION, ns, principal, StandardPermission.GET);
+  }
+
+  @Test
+  public void testInternalAccessIsVisibleExpiredCredential() throws IOException {
+    NamespaceId ns = new NamespaceId("namespace");
+    Set<EntityId> entities = Collections.singleton(ns);
+    long currentTime = System.currentTimeMillis();
+    UserIdentity userIdentity = new UserIdentity(SYSTEM_PRINCIPAL, UserIdentity.IdentifierType.INTERNAL,
+                                                 Collections.emptyList(), currentTime - 10 * MINUTE_MILLIS,
+                                                 currentTime - 5 * MINUTE_MILLIS);
+    String encodedIdentity = Base64.getEncoder()
+      .encodeToString(accessTokenCodec.encode(tokenManager.signIdentifier(userIdentity)));
+    Credential credential = new Credential(encodedIdentity, Credential.CredentialType.INTERNAL);
+    Principal principal = new Principal(SYSTEM_PRINCIPAL, Principal.PrincipalType.USER, null, credential);
+    Assert.assertEquals(Collections.emptySet(), internalAccessEnforcer.isVisible(entities, principal));
+  }
+}

--- a/cdap-security/src/test/java/io/cdap/cdap/security/impersonation/UGIProviderTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/impersonation/UGIProviderTest.java
@@ -22,6 +22,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.InMemoryNamespaceAdmin;
 import io.cdap.cdap.proto.codec.EntityIdTypeAdapter;
@@ -164,8 +165,8 @@ public class UGIProviderTest {
       InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
       discoveryService.register(new Discoverable(Constants.Service.APP_FABRIC_HTTP, httpService.getBindAddress()));
 
-      RemoteClientFactory remoteClientFactory = new RemoteClientFactory(discoveryService,
-                                                                        new AuthenticationTestContext(), cConf);
+      RemoteClientFactory remoteClientFactory =
+        new RemoteClientFactory(discoveryService, new DefaultInternalAuthenticator(new AuthenticationTestContext()));
       RemoteUGIProvider ugiProvider = new RemoteUGIProvider(cConf, locationFactory,
                                                             ownerAdmin,
                                                             remoteClientFactory);

--- a/cdap-security/src/test/java/io/cdap/cdap/security/store/client/RemoteSecureStoreTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/store/client/RemoteSecureStoreTest.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.discovery.URIScheme;
+import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.namespace.InMemoryNamespaceAdmin;
 import io.cdap.cdap.common.security.HttpsEnabler;
@@ -83,8 +84,8 @@ public class RemoteSecureStoreTest {
     discoveryService.register(URIScheme.HTTPS.createDiscoverable(Constants.Service.SECURE_STORE_SERVICE,
                                                          httpService.getBindAddress()));
 
-    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
-      discoveryService, new AuthenticationTestContext(), conf);
+    RemoteClientFactory remoteClientFactory =
+      new RemoteClientFactory(discoveryService, new DefaultInternalAuthenticator(new AuthenticationTestContext()));
     remoteSecureStore = new RemoteSecureStore(remoteClientFactory);
   }
 

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/logbuffer/handler/LogBufferHandlerTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/logbuffer/handler/LogBufferHandlerTest.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.api.metrics.NoopMetricsContext;
 import io.cdap.cdap.common.HttpExceptionHandler;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.logging.appender.LogMessage;
@@ -105,8 +106,8 @@ public class LogBufferHandlerTest {
   private RemoteLogAppender getRemoteAppender(CConfiguration cConf, NettyHttpService httpService) {
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     discoveryService.register(new Discoverable(Constants.Service.LOG_BUFFER_SERVICE, httpService.getBindAddress()));
-    RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
-      discoveryService, new AuthenticationTestContext(), cConf);
+    RemoteClientFactory remoteClientFactory =
+      new RemoteClientFactory(discoveryService, new DefaultInternalAuthenticator(new AuthenticationTestContext()));
     return new RemoteLogAppender(cConf, remoteClientFactory);
   }
 


### PR DESCRIPTION
[CDAP-17772] Introduce internal identity enforcement

[CDAP-17772] Refactor logic for starting and stopping the TokenManager service and refactor internal auth enabled flag

[CDAP-18095 CDAP-18004] Fix worker secret config key constant

Cherry-pick of #13504 

[CDAP-17772]: https://cdap.atlassian.net/browse/CDAP-17772
[CDAP-17772]: https://cdap.atlassian.net/browse/CDAP-17772