### PR TITLE
CDAP-18162 let preview discover external services

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
@@ -60,7 +60,7 @@ import io.cdap.cdap.security.guice.preview.PreviewSecureStoreModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.twill.common.Threads;
-import org.apache.twill.discovery.DiscoveryService;
+import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.internal.ServiceListenerAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,7 +80,7 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
   private final Configuration previewHConf;
   private final SConfiguration previewSConf;
   private final int maxConcurrentPreviews;
-  private final DiscoveryService discoveryService;
+  private final DiscoveryServiceClient discoveryServiceClient;
   private final DatasetFramework datasetFramework;
   private final SecureStore secureStore;
   private final TransactionSystemClient transactionSystemClient;
@@ -94,7 +94,8 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
   DefaultPreviewRunnerManager(@Named(PreviewConfigModule.PREVIEW_CCONF) CConfiguration previewCConf,
                               @Named(PreviewConfigModule.PREVIEW_HCONF) Configuration previewHConf,
                               @Named(PreviewConfigModule.PREVIEW_SCONF) SConfiguration previewSConf,
-                              SecureStore secureStore, DiscoveryService discoveryService,
+                              SecureStore secureStore,
+                              DiscoveryServiceClient discoveryServiceClient,
                               @Named(DataSetsModules.BASE_DATASET_FRAMEWORK) DatasetFramework datasetFramework,
                               TransactionSystemClient transactionSystemClient,
                               PreviewRunnerModule previewRunnerModule,
@@ -105,7 +106,7 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
     this.previewSConf = previewSConf;
     this.datasetFramework = datasetFramework;
     this.secureStore = secureStore;
-    this.discoveryService = discoveryService;
+    this.discoveryServiceClient = discoveryServiceClient;
     this.transactionSystemClient = transactionSystemClient;
     this.maxConcurrentPreviews = previewCConf.getInt(Constants.Preview.POLLER_COUNT);
     this.previewRunnerServices = ConcurrentHashMap.newKeySet();
@@ -173,7 +174,7 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
       new CoreSecurityRuntimeModule().getInMemoryModules(),
       new AuthenticationContextModules().getMasterWorkerModule(),
       new PreviewSecureStoreModule(secureStore),
-      new PreviewDiscoveryRuntimeModule(discoveryService),
+      new PreviewDiscoveryRuntimeModule(discoveryServiceClient),
       new LocalLocationModule(),
       new ConfigStoreModule(),
       previewRunnerModule,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -105,7 +105,7 @@ import io.cdap.cdap.store.DefaultOwnerStore;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
-import org.apache.twill.discovery.DiscoveryService;
+import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,7 +129,7 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
   private final CConfiguration previewCConf;
   private final Configuration previewHConf;
   private final SConfiguration previewSConf;
-  private final DiscoveryService discoveryService;
+  private final DiscoveryServiceClient discoveryServiceClient;
   private final DatasetFramework datasetFramework;
   private final TransactionSystemClient transactionSystemClient;
   private final LevelDBTableService previewLevelDBTableService;
@@ -145,7 +145,7 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
   private LogAppender logAppender;
 
   @Inject
-  DefaultPreviewManager(DiscoveryService discoveryService,
+  DefaultPreviewManager(DiscoveryServiceClient discoveryServiceClient,
                         @Named(DataSetsModules.BASE_DATASET_FRAMEWORK) DatasetFramework datasetFramework,
                         TransactionSystemClient transactionSystemClient,
                         AccessControllerInstantiator accessControllerInstantiator,
@@ -164,7 +164,7 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
     this.previewHConf = previewHConf;
     this.previewSConf = previewSConf;
     this.datasetFramework = datasetFramework;
-    this.discoveryService = discoveryService;
+    this.discoveryServiceClient = discoveryServiceClient;
     this.transactionSystemClient = transactionSystemClient;
     this.accessEnforcer = accessEnforcer;
     this.accessControllerInstantiator = accessControllerInstantiator;
@@ -296,7 +296,7 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
       new PreviewDataModules().getDataSetsModule(datasetFramework),
       new AuthenticationContextModules().getMasterModule(),
       new LocalLocationModule(),
-      new PreviewDiscoveryRuntimeModule(discoveryService),
+      new PreviewDiscoveryRuntimeModule(discoveryServiceClient),
       new MetricsClientRuntimeModule().getInMemoryModules(),
       new DataSetServiceModules().getStandaloneModules(),
       new MessagingServerRuntimeModule().getInMemoryModules(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -46,7 +46,7 @@ import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillPreparer;
 import org.apache.twill.api.TwillRunner;
 import org.apache.twill.common.Threads;
-import org.apache.twill.discovery.DiscoveryService;
+import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +75,8 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
   private TwillController controller;
 
   @Inject
-  DistributedPreviewManager(CConfiguration cConf, Configuration hConf, DiscoveryService discoveryService,
+  DistributedPreviewManager(CConfiguration cConf, Configuration hConf,
+                            DiscoveryServiceClient discoveryServiceClient,
                             @Named(DataSetsModules.BASE_DATASET_FRAMEWORK) DatasetFramework datasetFramework,
                             TransactionSystemClient transactionSystemClient,
                             AccessControllerInstantiator accessControllerInstantiator,
@@ -90,10 +91,10 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
                             MetricsCollectionService metricsCollectionService,
                             PreviewDataCleanupService previewDataCleanupService,
                             TwillRunner twillRunner) {
-    super(discoveryService, datasetFramework, transactionSystemClient, accessControllerInstantiator,
-          accessEnforcer, authenticationContext, previewLevelDBTableService, previewCConf, previewHConf, previewSConf,
-          previewRequestQueue, previewStore, previewRunStopper, messagingService, previewDataCleanupService,
-          metricsCollectionService);
+    super(discoveryServiceClient, datasetFramework, transactionSystemClient,
+          accessControllerInstantiator, accessEnforcer, authenticationContext, previewLevelDBTableService,
+          previewCConf, previewHConf, previewSConf, previewRequestQueue, previewStore, previewRunStopper,
+          messagingService, previewDataCleanupService, metricsCollectionService);
 
     this.cConf = cConf;
     this.hConf = hConf;

--- a/cdap-common/src/main/java/io/cdap/cdap/common/discovery/preview/PreviewDiscoveryService.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/discovery/preview/PreviewDiscoveryService.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.common.discovery.preview;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.cdap.cdap.common.guice.preview.PreviewDiscoveryRuntimeModule;
+import io.netty.util.internal.ConcurrentSet;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryService;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.discovery.InMemoryDiscoveryService;
+import org.apache.twill.discovery.ServiceDiscovered;
+
+import java.util.Set;
+
+/**
+ * Discovery service that delegates either to in memory discovery service(local) or shared (actual) discovery service.
+ */
+public class PreviewDiscoveryService implements DiscoveryService, DiscoveryServiceClient {
+  private final DiscoveryServiceClient actual;
+  private final InMemoryDiscoveryService local;
+  private final Set<String> registeredLocalServices;
+
+  @Inject
+  PreviewDiscoveryService(
+    @Named(PreviewDiscoveryRuntimeModule.ACTUAL_DISCOVERY_CLIENT) DiscoveryServiceClient actual) {
+    this.actual = actual;
+    this.local = new InMemoryDiscoveryService();
+    this.registeredLocalServices = new ConcurrentSet<>();
+  }
+
+  // we only allow register using local discovery service as preview should not affect actual environment
+  @Override
+  public Cancellable register(Discoverable discoverable) {
+    Cancellable cancellable = local.register(discoverable);
+    registeredLocalServices.add(discoverable.getName());
+    return () -> {
+      cancellable.cancel();
+      registeredLocalServices.remove(discoverable.getName());
+    };
+  }
+
+  @Override
+  public ServiceDiscovered discover(String name) {
+    // if this service is registered in local, discover it using local discovery service
+    if (registeredLocalServices.contains(name)) {
+      return local.discover(name);
+    }
+    return actual.discover(name);
+  }
+}


### PR DESCRIPTION
Without this change, preview is not able to discover any external services, so the connection macro is not able to get evaluated.