### PR TITLE
[CDAP-18208] Disable Runtime Token Generation if Internal Auth is Disabled

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
@@ -64,6 +64,7 @@ import io.cdap.cdap.security.auth.AccessToken;
 import io.cdap.cdap.security.auth.AccessTokenCodec;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.auth.UserIdentity;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import org.apache.hadoop.conf.Configuration;
@@ -341,8 +342,10 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
       secretFiles.put(Constants.RuntimeMonitor.SERVICE_PROXY_PASSWORD_FILE,
                       generateAndSaveServiceProxySecret(programRunId, keysDirLocation));
     }
-    secretFiles.put(Constants.Security.Authentication.RUNTIME_TOKEN_FILE,
-                    generateAndSaveRuntimeToken(programRunId, keysDirLocation));
+    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
+      secretFiles.put(Constants.Security.Authentication.RUNTIME_TOKEN_FILE,
+                      generateAndSaveRuntimeToken(programRunId, keysDirLocation));
+    }
 
     RuntimeJobManager jobManager = provisioningService.getRuntimeJobManager(programRunId, programOpts).orElse(null);
     // Use RuntimeJobManager to launch the remote process if it is supported


### PR DESCRIPTION
Otherwise the token manager will not be initialized and can throw all kinds of errors.

For additional details, see [CDAP-18208](https://cdap.atlassian.net/browse/CDAP-18208).