### PR TITLE
CDAP-18176: Fix high latency issue when deploying pipelines in rbac enabled instances

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,4 +16,4 @@
 [submodule "cdap-ui"]
   path = cdap-ui
   url = ../cdap-ui
-  branch = develop
+  branch = release/6.5

--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
@@ -63,8 +63,9 @@ import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.Configs;
@@ -281,7 +282,8 @@ public class DistributedWorkflowProgramRunnerTest {
       new MessagingClientModule(),
       new ExploreClientModule(),
       new AuditModule(),
-      new CoreSecurityModules().getDistributedModule(cConf),
+      CoreSecurityRuntimeModule.getDistributedModule(cConf),
+      new AuthenticationContextModules().getNoOpModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new TwillModule(),

--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
@@ -64,6 +64,7 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.Configs;
@@ -280,6 +281,7 @@ public class DistributedWorkflowProgramRunnerTest {
       new MessagingClientModule(),
       new ExploreClientModule(),
       new AuditModule(),
+      new CoreSecurityModules().getDistributedModule(cConf),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new TwillModule(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -118,7 +118,6 @@ import io.cdap.cdap.pipeline.PipelineFactory;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
 import io.cdap.cdap.scheduler.Scheduler;
 import io.cdap.cdap.securestore.spi.SecretStore;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.DefaultUGIProvider;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
@@ -163,7 +162,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new NamespaceAdminModule().getInMemoryModules(),
                            new ConfigStoreModule(),
                            new EntityVerifierModule(),
-                           new AuthenticationContextModules().getMasterModule(),
                            BootstrapModules.getInMemoryModule(),
                            new AbstractModule() {
                              @Override
@@ -203,7 +201,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new NamespaceAdminModule().getStandaloneModules(),
                            new ConfigStoreModule(),
                            new EntityVerifierModule(),
-                           new AuthenticationContextModules().getMasterModule(),
                            new ProvisionerModule(),
                            BootstrapModules.getFileBasedModule(),
                            new AbstractModule() {
@@ -256,7 +253,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new NamespaceAdminModule().getDistributedModules(),
                            new ConfigStoreModule(),
                            new EntityVerifierModule(),
-                           new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
                            new ProvisionerModule(),
                            BootstrapModules.getFileBasedModule(),
                            new AbstractModule() {
@@ -284,26 +280,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                servicesNamesBinder.addBinding().toInstance(Constants.Service.SECURE_STORE_SERVICE);
                              }
                            });
-  }
-
-  /**
-   * Returns modules to be used for preview runners.
-   *
-   * @return Module which contains bindings for preview runners
-   */
-  public Module getPreviewRunnerModules() {
-    return Modules.override(getStandaloneModules()).with(new AuthenticationContextModules()
-                                                           .getInternalAuthWorkerModule(cConf));
-  }
-
-  /**
-   * Returns modules to be used for preview master.
-   *
-   * @return Module which contains bindings for preview master
-   */
-  public Module getPreviewMasterModules() {
-    return Modules.override(getStandaloneModules()).with(new AuthenticationContextModules()
-                                                           .getInternalAuthMasterModule(cConf));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedArtifactManagerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedArtifactManagerModule.java
@@ -18,12 +18,15 @@ package io.cdap.cdap.app.guice;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.multibindings.OptionalBinder;
+import com.google.inject.util.Providers;
 import io.cdap.cdap.api.artifact.ArtifactManager;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactManagerFactory;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactManager;
 import io.cdap.cdap.internal.app.runtime.artifact.RemotePluginFinder;
+import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
 
 /**
  * Guice module for bindings for artifacts and plugins supports for program API.
@@ -35,6 +38,9 @@ public class DistributedArtifactManagerModule extends AbstractModule {
     // Bind the PluginFinder implementation
     bind(PluginFinder.class).to(RemotePluginFinder.class);
     bind(ArtifactFinder.class).to(RemotePluginFinder.class);
+    // ArtifactLocalizerClient is only used for task worker
+    OptionalBinder.newOptionalBinder(binder(), ArtifactLocalizerClient.class)
+      .setBinding().toProvider(Providers.of(null));
 
     // Bind the ArtifactManager implementation
     install(new FactoryModuleBuilder()

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/TwillModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/TwillModule.java
@@ -70,7 +70,7 @@ public class TwillModule extends PrivateModule {
 
     @Override
     public TwillRunnerService get() {
-      String zkConnectStr = cConf.get(Constants.Zookeeper.QUORUM) + cConf.get(Constants.CFG_TWILL_ZK_NAMESPACE);
+      String zkConnectStr = Constants.Zookeeper.getZKQuorum(cConf) + cConf.get(Constants.CFG_TWILL_ZK_NAMESPACE);
 
       // Copy the yarn config and setup twill configs
       YarnConfiguration yarnConfig = new YarnConfiguration(yarnConf);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
@@ -55,7 +55,7 @@ import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.preview.PreviewSecureStoreModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
@@ -170,8 +170,8 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
     return Guice.createInjector(
       new ConfigModule(previewCConf, previewHConf, previewSConf),
       new IOModule(),
-      new CoreSecurityModules().getInMemoryModules(),
-      new AuthenticationContextModules().getInternalAuthWorkerModule(previewCConf),
+      new CoreSecurityRuntimeModule().getInMemoryModules(),
+      new AuthenticationContextModules().getMasterWorkerModule(),
       new PreviewSecureStoreModule(secureStore),
       new PreviewDiscoveryRuntimeModule(discoveryService),
       new LocalLocationModule(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
@@ -55,6 +55,7 @@ import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.preview.PreviewSecureStoreModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
@@ -169,6 +170,7 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
     return Guice.createInjector(
       new ConfigModule(previewCConf, previewHConf, previewSConf),
       new IOModule(),
+      new CoreSecurityModules().getInMemoryModules(),
       new AuthenticationContextModules().getInternalAuthWorkerModule(previewCConf),
       new PreviewSecureStoreModule(secureStore),
       new PreviewDiscoveryRuntimeModule(discoveryService),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/common/twill/TwillAppLifecycleEventHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/common/twill/TwillAppLifecycleEventHandler.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.runtime.spi.RuntimeMonitorType;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.EventHandler;
 import org.apache.twill.api.EventHandlerContext;
@@ -146,6 +147,7 @@ public class TwillAppLifecycleEventHandler extends AbortOnTimeoutEventHandler {
           modules.add(new KafkaClientModule());
           break;
         case ISOLATED:
+          modules.add(new AuthenticationContextModules().getProgramContainerModule(cConf));
           modules.add(new RemoteExecutionDiscoveryModule());
           modules.add(new AbstractModule() {
             @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
+import io.cdap.cdap.master.spi.twill.SecretDisk;
 import io.cdap.cdap.master.spi.twill.SecureTwillPreparer;
 import io.cdap.cdap.master.spi.twill.SecurityContext;
 import io.cdap.cdap.master.spi.twill.StatefulDisk;
@@ -186,6 +187,13 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
                 .withIdentity(twillUserIdentity).build();
               twillPreparer = ((SecureTwillPreparer) twillPreparer)
                 .withSecurityContext(PreviewRunnerTwillRunnable.class.getSimpleName(), securityContext);
+            }
+            if (cConf.getBoolean(Constants.Twill.Security.WORKER_MOUNT_SECRET)) {
+              String secretName = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_NAME);
+              String secretPath = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_PATH);
+              twillPreparer = ((SecureTwillPreparer) twillPreparer)
+                .withSecretDisk(PreviewRunnerTwillRunnable.class.getSimpleName(),
+                                new SecretDisk(secretName, secretPath));
             }
           }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -188,6 +188,8 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
               twillPreparer = ((SecureTwillPreparer) twillPreparer)
                 .withSecurityContext(PreviewRunnerTwillRunnable.class.getSimpleName(), securityContext);
             }
+
+            // TODO CDAP-18095: Refactor to be secure-by-default in the future or fail-fast if it is not mounted.
             if (cConf.getBoolean(Constants.Twill.Security.WORKER_MOUNT_SECRET)) {
               String secretName = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_NAME);
               String secretPath = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_PATH);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -71,6 +71,7 @@ import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreClientModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
@@ -228,6 +229,7 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     modules.add(new MetadataReaderWriterModules().getStandaloneModules());
     modules.add(new DFSLocationModule());
     modules.add(new MetadataServiceModule());
+    modules.add(new CoreSecurityModules().getInMemoryModules());
     modules.add(new AuthorizationModule());
     modules.add(new AuthorizationEnforcementModule().getMasterModule());
     modules.add(Modules.override(

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -70,8 +70,9 @@ import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.SecureStoreClientModule;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
@@ -220,7 +221,7 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     modules.add(new PreviewRunnerManagerModule().getDistributedModules());
     modules.add(new DataSetServiceModules().getStandaloneModules());
     modules.add(new DataSetsModules().getStandaloneModules());
-    modules.add(new AppFabricServiceRuntimeModule(cConf).getPreviewRunnerModules());
+    modules.add(new AppFabricServiceRuntimeModule(cConf).getStandaloneModules());
     modules.add(new ProgramRunnerRuntimeModule().getStandaloneModules());
     modules.add(new MetricsStoreModule());
     modules.add(new MessagingClientModule());
@@ -229,7 +230,8 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     modules.add(new MetadataReaderWriterModules().getStandaloneModules());
     modules.add(new DFSLocationModule());
     modules.add(new MetadataServiceModule());
-    modules.add(new CoreSecurityModules().getInMemoryModules());
+    modules.add(new CoreSecurityRuntimeModule().getInMemoryModules());
+    modules.add(new AuthenticationContextModules().getMasterWorkerModule());
     modules.add(new AuthorizationModule());
     modules.add(new AuthorizationEnforcementModule().getMasterModule());
     modules.add(Modules.override(

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactInspector.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactInspector.java
@@ -198,14 +198,14 @@ final class DefaultArtifactInspector implements ArtifactInspector {
     }
 
     try {
-      Object appMain = artifactClassLoader.loadClass(mainClassName).newInstance();
-      if (!(appMain instanceof Application)) {
+      Class<?> mainClass = artifactClassLoader.loadClass(mainClassName);
+      if (!(Application.class.isAssignableFrom(mainClass))) {
         // we don't want to error here, just don't record an application class.
         // possible for 3rd party plugin artifacts to have the main class set
         return builder;
       }
 
-      Application app = (Application) appMain;
+      Application app = (Application) mainClass.newInstance();
 
       java.lang.reflect.Type configType;
       // if the user parameterized their application, like 'xyz extends Application<T>',

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractProgramTwillRunnable.java
@@ -58,6 +58,7 @@ import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.appender.loader.LogAppenderLoaderService;
 import io.cdap.cdap.logging.context.LoggingContextHelper;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.security.auth.TokenManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.twill.api.Command;
@@ -439,8 +440,8 @@ public abstract class AbstractProgramTwillRunnable<T extends ProgramRunner> impl
 
   private void addOnPremiseServices(Injector injector, ProgramOptions programOptions,
                                     MetricsCollectionService metricsCollectionService, Collection<Service> services) {
-    for (Class<? extends Service> cls : Arrays.asList(ZKClientService.class,
-                                                      KafkaClientService.class, BrokerService.class)) {
+    for (Class<? extends Service> cls : Arrays.asList(ZKClientService.class, KafkaClientService.class,
+                                                      BrokerService.class, TokenManager.class)) {
       Binding<? extends Service> binding = injector.getExistingBinding(Key.get(cls));
       if (binding != null) {
         services.add(binding.getProvider().get());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -271,8 +271,8 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
                 .withIdentity(twillSystemIdentity).build();
               twillPreparer = ((SecureTwillPreparer) twillPreparer).withSecurityContext(runnable, securityContext);
             }
-            String securityName = cConf.get(Constants.Twill.Security.SECRET_DISK_NAME);
-            String securityPath = cConf.get(Constants.Twill.Security.SECRET_DISK_PATH);
+            String securityName = cConf.get(Constants.Twill.Security.MASTER_SECRET_DISK_NAME);
+            String securityPath = cConf.get(Constants.Twill.Security.MASTER_SECRET_DISK_PATH);
             twillPreparer = ((SecureTwillPreparer) twillPreparer)
               .withSecretDisk(runnable, new SecretDisk(securityName, securityPath));
           }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionJobMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionJobMain.java
@@ -139,7 +139,7 @@ public class RemoteExecutionJobMain {
       new DFSLocationModule(),
       new InMemoryDiscoveryModule(),
       new TwillModule(),
-      new AuthenticationContextModules().getProgramContainerModule(),
+      new AuthenticationContextModules().getProgramContainerModule(cConf),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
@@ -16,6 +16,10 @@
 
 package io.cdap.cdap.internal.app.runtime.distributed.remote;
 
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.Service;
@@ -60,6 +64,10 @@ import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.Node;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobManager;
 import io.cdap.cdap.runtime.spi.ssh.SSHKeyPair;
+import io.cdap.cdap.security.auth.AccessToken;
+import io.cdap.cdap.security.auth.AccessTokenCodec;
+import io.cdap.cdap.security.auth.TokenManager;
+import io.cdap.cdap.security.auth.UserIdentity;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import org.apache.hadoop.conf.Configuration;
@@ -95,8 +103,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -104,6 +114,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
@@ -125,6 +136,8 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
 
   private static final Logger LOG = LoggerFactory.getLogger(RemoteExecutionTwillRunnerService.class);
   private static final Gson GSON = new Gson();
+  //We can have really long jobs, so the tokens would be long-lived
+  private static final long DEFAULT_EXPIRATION = TimeUnit.DAYS.toMillis(365);
 
   private final CConfiguration cConf;
   private final Configuration hConf;
@@ -136,6 +149,8 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
   private final RuntimeServiceSocksProxyAuthenticator serviceSocksProxyAuthenticator;
   private final Map<ProgramRunId, RemoteExecutionTwillController> controllers;
   private final Lock controllersLock;
+  private final AccessTokenCodec accessTokenCodec;
+  private final TokenManager tokenManager;
 
   private LocationCache locationCache;
   private Path cachePath;
@@ -147,13 +162,17 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
                                     LocationFactory locationFactory,
                                     ProvisioningService provisioningService,
                                     ProgramStateWriter programStateWriter,
-                                    TransactionRunner transactionRunner) {
+                                    TransactionRunner transactionRunner,
+                                    AccessTokenCodec accessTokenCodec,
+                                    TokenManager tokenManager) {
     this.cConf = cConf;
     this.hConf = hConf;
     this.locationFactory = locationFactory;
     this.provisioningService = provisioningService;
     this.programStateWriter = programStateWriter;
     this.txRunner = transactionRunner;
+    this.accessTokenCodec = accessTokenCodec;
+    this.tokenManager = tokenManager;
     this.controllers = new ConcurrentHashMap<>();
     this.controllersLock = new ReentrantLock();
     this.serviceSocksProxyAuthenticator = new RuntimeServiceSocksProxyAuthenticator();
@@ -321,17 +340,20 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
                                        ProgramOptions programOpts, TwillSpecification twillSpec,
                                        LocationCache locationCache, TwillControllerFactory controllerFactory) {
 
-    Location serviceProxySecretLocation = null;
+    Location keysDirLocation = getKeysDirLocation(programOpts, locationFactory);
+    Map<String, Location> secretFiles = new HashMap<>();
     if (SystemArguments.getRuntimeMonitorType(cConf, programOpts) == RuntimeMonitorType.SSH) {
-      serviceProxySecretLocation = generateAndSaveServiceProxySecret(programRunId,
-                                                                     getKeysDirLocation(programOpts, locationFactory));
+      secretFiles.put(Constants.RuntimeMonitor.SERVICE_PROXY_PASSWORD_FILE,
+                      generateAndSaveServiceProxySecret(programRunId, keysDirLocation));
     }
+    secretFiles.put(Constants.Security.Authentication.RUNTIME_TOKEN_FILE,
+                    generateAndSaveRuntimeToken(programRunId, keysDirLocation));
 
     RuntimeJobManager jobManager = provisioningService.getRuntimeJobManager(programRunId, programOpts).orElse(null);
     // Use RuntimeJobManager to launch the remote process if it is supported
     if (jobManager != null) {
       return new RuntimeJobTwillPreparer(cConf, hConf, twillSpec, programRunId, programOpts,
-                                         serviceProxySecretLocation,
+                                         secretFiles,
                                          locationCache, locationFactory,
                                          controllerFactory,
                                          () -> provisioningService.getRuntimeJobManager(programRunId, programOpts)
@@ -341,7 +363,7 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
     // Use SSH if there is no RuntimeJobManager
     ClusterKeyInfo clusterKeyInfo = new ClusterKeyInfo(cConf, programOpts, locationFactory);
     return new RemoteExecutionTwillPreparer(cConf, hConf, clusterKeyInfo.getCluster(), clusterKeyInfo.getSSHConfig(),
-                                            serviceProxySecretLocation,
+                                            secretFiles,
                                             twillSpec, programRunId, programOpts,
                                             locationCache, locationFactory, controllerFactory);
   }
@@ -355,6 +377,28 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
       serviceSocksProxy.startAndWait();
     }
     return serviceSocksProxy.getBindAddress().getPort();
+  }
+
+  /**
+   * Generates a runtime token to talk back from the execution cluster to CDAP instance.
+   */
+  private Location generateAndSaveRuntimeToken(ProgramRunId programRunId, Location keysDir) {
+    try {
+      long currentTimestamp = System.currentTimeMillis();
+      //TODO: Use a better identity & expiration
+      UserIdentity identity = new UserIdentity(Constants.Security.Authentication.RUNTIME_IDENTITY,
+                                               Collections.emptyList(), currentTimestamp,
+                                               currentTimestamp + DEFAULT_EXPIRATION);
+      AccessToken accessToken = tokenManager.signIdentifier(identity);
+      byte[] encodedAccessToken = Base64.getEncoder().encode(accessTokenCodec.encode(accessToken));
+      Location location = keysDir.append(Constants.Security.Authentication.RUNTIME_TOKEN_FILE);
+      try (OutputStream os = location.getOutputStream()) {
+        os.write(encodedAccessToken);
+      }
+      return location;
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to generate runtime token for " + programRunId, e);
+    }
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
@@ -153,7 +153,7 @@ public class DefaultRuntimeJob implements RuntimeJob {
 
     // Get Program Options
     ProgramOptions programOpts = readJsonFile(new File(DistributedProgramRunner.PROGRAM_OPTIONS_FILE_NAME),
-                                                 ProgramOptions.class);
+                                              ProgramOptions.class);
     ProgramRunId programRunId = programOpts.getProgramId().run(ProgramRunners.getRunId(programOpts));
     ProgramId programId = programRunId.getParent();
 
@@ -296,6 +296,13 @@ public class DefaultRuntimeJob implements RuntimeJob {
       }
     }
 
+    // Pass runtime token to distributed jobs
+    Path tokenFile = Paths.get(Constants.Security.Authentication.RUNTIME_TOKEN_FILE);
+    if (Files.exists(tokenFile)) {
+      cConf.set(Constants.Security.Authentication.RUNTIME_TOKEN,
+                new String(Files.readAllBytes(tokenFile), StandardCharsets.UTF_8));
+    }
+
     return cConf;
   }
 
@@ -345,7 +352,7 @@ public class DefaultRuntimeJob implements RuntimeJob {
     modules.add(new IOModule());
     modules.add(new TMSLogAppenderModule());
     modules.add(new RemoteExecutionDiscoveryModule());
-    modules.add(new AuthenticationContextModules().getProgramContainerModule());
+    modules.add(new AuthenticationContextModules().getProgramContainerModule(cConf));
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
     modules.add(new MessagingServerRuntimeModule().getStandaloneModules());
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeIdentityHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeIdentityHandler.java
@@ -16,19 +16,38 @@
 
 package io.cdap.cdap.internal.app.runtime.monitor;
 
+import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.logging.AuditLogEntry;
 import io.cdap.cdap.common.utils.Networks;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.HttpURLConnection;
+
+import static io.cdap.cdap.proto.security.Credential.CREDENTIAL_TYPE_INTERNAL;
 
 /**
  * A {@link ChannelInboundHandler} for properly propagating runtime identity to calls to other system services.
  */
 public class RuntimeIdentityHandler extends ChannelInboundHandlerAdapter {
-  private static final String RUNTIME_IDENTITY = "runtime";
+  private static final Logger AUDIT_LOGGER = LoggerFactory
+    .getLogger(Constants.RuntimeMonitor.MONITOR_AUDIT_LOGGER_NAME);
+
+  private final boolean enforceAuthenticatedRequests;
+  private final boolean auditLogEnabled;
+
+  public RuntimeIdentityHandler(CConfiguration cConf) {
+    this.enforceAuthenticatedRequests = cConf.getBoolean(Constants.Security.ENFORCE_INTERNAL_AUTH);
+    this.auditLogEnabled = cConf.getBoolean(Constants.RuntimeMonitor.MONITOR_AUDIT_LOG_ENABLED);
+  }
 
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) {
@@ -38,14 +57,31 @@ public class RuntimeIdentityHandler extends ChannelInboundHandlerAdapter {
     }
 
     HttpRequest request = (HttpRequest) msg;
-    // TODO(CDAP-17754): This is a placeholder for proper runtime identity propagation.
-    // For now, only support propagating the system-level root principal.
+
     request.headers().remove(HttpHeaderNames.AUTHORIZATION);
-    request.headers().set(Constants.Security.Headers.USER_ID, RUNTIME_IDENTITY);
+    request.headers().set(Constants.Security.Headers.USER_ID, Constants.Security.Authentication.RUNTIME_IDENTITY);
     String clientIP = Networks.getIP(ctx.channel().remoteAddress());
     if (clientIP != null) {
       request.headers().set(Constants.Security.Headers.USER_IP, clientIP);
+    } else {
+      request.headers().remove(Constants.Security.Headers.USER_IP);
+    }
+    if (enforceAuthenticatedRequests &&
+      !request.headers().contains(Constants.Security.Headers.RUNTIME_TOKEN)) {
+      auditLogIfNeeded(request, ctx.channel(), HttpURLConnection.HTTP_FORBIDDEN);
+      throw new UnauthorizedException("Runtime token not found");
     }
     ctx.fireChannelRead(msg);
+  }
+
+  private void auditLogIfNeeded(HttpRequest request, Channel channel, int code) {
+    if (!auditLogEnabled) {
+      return;
+    }
+
+    AuditLogEntry logEntry = new AuditLogEntry(request, Networks.getIP(channel.remoteAddress()));
+    logEntry.setResponse(code, -1);
+
+    AUDIT_LOGGER.trace(logEntry.toString());
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/spark/SparkCompatReader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/spark/SparkCompatReader.java
@@ -53,12 +53,7 @@ public class SparkCompatReader {
     compatStr = compatStr == null ? cConf.get(Constants.AppFabric.SPARK_COMPAT) : compatStr;
 
     if (compatStr == null) {
-      try {
-        return getCurrentSparkCompat();
-      } catch (Throwable e) {
-        LOG.info("Can't detect spark version({}), using default {}", e, SparkCompat.SPARK2_2_11);
-        return SparkCompat.SPARK2_2_11;
-      }
+      return SparkCompat.SPARK2_2_11;
     }
 
     for (SparkCompat sparkCompat : SparkCompat.values()) {
@@ -74,18 +69,5 @@ public class SparkCompatReader {
 
     throw new IllegalArgumentException(
       String.format("Invalid SparkCompat version '%s'. Must be one of %s", compatStr, allowedCompatStrings));
-  }
-
-  @VisibleForTesting
-  public static SparkCompat getCurrentSparkCompat() {
-    String sparkVersion = package$.MODULE$.SPARK_VERSION();
-    switch (sparkVersion.charAt(0)) {
-      case '3':
-        return SparkCompat.SPARK3_2_12;
-      case '2':
-        return SparkCompat.SPARK2_2_11;
-      default:
-        throw new IllegalStateException("Spark version " + sparkVersion + " is not known");
-    }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/DefaultSystemAppTaskContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/DefaultSystemAppTaskContext.java
@@ -73,10 +73,9 @@ public class DefaultSystemAppTaskContext extends AbstractServiceDiscoverer imple
   private final RemoteClientFactory remoteClientFactory;
 
   DefaultSystemAppTaskContext(CConfiguration cConf, PreferencesFetcher preferencesFetcher, PluginFinder pluginFinder,
-                              SecureStore secureStore,
-                              String artifactNameSpace, ArtifactId artifactId, ClassLoader artifactClassLoader,
-                              ArtifactManagerFactory artifactManagerFactory, String serviceName,
-                              RemoteClientFactory remoteClientFactory) {
+                              SecureStore secureStore, String artifactNameSpace, ArtifactId artifactId,
+                              ClassLoader artifactClassLoader, ArtifactManagerFactory artifactManagerFactory,
+                              String serviceName, RemoteClientFactory remoteClientFactory) {
     super(artifactNameSpace);
     this.cConf = cConf;
     this.serviceName = serviceName;
@@ -87,7 +86,7 @@ public class DefaultSystemAppTaskContext extends AbstractServiceDiscoverer imple
     this.remoteClientFactory = remoteClientFactory;
     this.artifactManager = artifactManagerFactory.create(new NamespaceId(artifactNameSpace), retryStrategy);
     this.pluginsDir = createTempFolder();
-    this.instantiator = new PluginInstantiator(cConf, artifactClassLoader, pluginsDir);
+    this.instantiator = new PluginInstantiator(cConf, artifactClassLoader, pluginsDir, true);
     this.protoArtifactId = Artifacts.toProtoArtifactId(new NamespaceId(artifactNameSpace), artifactId);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppModule.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.internal.app.worker;
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.MapBinder;
+import com.google.inject.multibindings.OptionalBinder;
 import io.cdap.cdap.app.guice.DefaultProgramRunnerFactory;
 import io.cdap.cdap.app.runtime.ProgramRunner;
 import io.cdap.cdap.app.runtime.ProgramRunnerFactory;
@@ -28,8 +29,10 @@ import io.cdap.cdap.common.guice.SupplierProviderBridge;
 import io.cdap.cdap.internal.app.program.MessagingProgramStateWriter;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepositoryReader;
+import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.metadata.PreferencesFetcher;
@@ -67,5 +70,7 @@ public class SystemAppModule extends AbstractModule {
     bind(ArtifactRepositoryReader.class).to(RemoteArtifactRepositoryReader.class).in(Scopes.SINGLETON);
     bind(ArtifactRepository.class).to(RemoteArtifactRepository.class);
     bind(PreferencesFetcher.class).to(RemotePreferencesFetcherInternal.class).in(Scopes.SINGLETON);
+    bind(PluginFinder.class).to(RemoteWorkerPluginFinder.class);
+    OptionalBinder.newOptionalBinder(binder(), ArtifactLocalizerClient.class);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerService.java
@@ -43,8 +43,6 @@ public class TaskWorkerService extends AbstractIdleService {
 
   private static final Logger LOG = LoggerFactory.getLogger(TaskWorkerService.class);
 
-  private final CConfiguration cConf;
-  private final SConfiguration sConf;
   private final DiscoveryService discoveryService;
   private final NettyHttpService httpService;
   private Cancellable cancelDiscovery;
@@ -54,8 +52,6 @@ public class TaskWorkerService extends AbstractIdleService {
   TaskWorkerService(CConfiguration cConf,
                     SConfiguration sConf,
                     DiscoveryService discoveryService) {
-    this.cConf = cConf;
-    this.sConf = sConf;
     this.discoveryService = discoveryService;
 
     NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf, Constants.Service.TASK_WORKER)
@@ -64,7 +60,7 @@ public class TaskWorkerService extends AbstractIdleService {
       .setExecThreadPoolSize(cConf.getInt(Constants.TaskWorker.EXEC_THREADS))
       .setBossThreadPoolSize(cConf.getInt(Constants.TaskWorker.BOSS_THREADS))
       .setWorkerThreadPoolSize(cConf.getInt(Constants.TaskWorker.WORKER_THREADS))
-      .setHttpHandlers(new TaskWorkerHttpHandlerInternal(this.cConf, this::stopService));
+      .setHttpHandlers(new TaskWorkerHttpHandlerInternal(cConf, this::stopService));
 
     if (cConf.getBoolean(Constants.Security.SSL.INTERNAL_ENABLED)) {
       new HttpsEnabler().configureKeyStore(cConf, sConf).enable(builder);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerTwillRunnable;
 import io.cdap.cdap.master.spi.twill.DependentTwillPreparer;
+import io.cdap.cdap.master.spi.twill.SecretDisk;
 import io.cdap.cdap.master.spi.twill.SecureTwillPreparer;
 import io.cdap.cdap.master.spi.twill.SecurityContext;
 import io.cdap.cdap.master.spi.twill.StatefulDisk;
@@ -183,6 +184,12 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
             SecurityContext securityContext = createSecurityContext();
             twillPreparer = ((SecureTwillPreparer) twillPreparer)
               .withSecurityContext(TaskWorkerTwillRunnable.class.getSimpleName(), securityContext);
+            if (cConf.getBoolean(Constants.Twill.Security.WORKER_MOUNT_SECRET)) {
+              String secretName = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_NAME);
+              String secretPath = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_PATH);
+              twillPreparer = ((SecureTwillPreparer) twillPreparer)
+                .withSecretDisk(TaskWorkerTwillRunnable.class.getSimpleName(), new SecretDisk(secretName, secretPath));
+            }
           }
 
           activeController = twillPreparer.start(5, TimeUnit.MINUTES);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
@@ -184,6 +184,7 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
             SecurityContext securityContext = createSecurityContext();
             twillPreparer = ((SecureTwillPreparer) twillPreparer)
               .withSecurityContext(TaskWorkerTwillRunnable.class.getSimpleName(), securityContext);
+            // TODO CDAP-18095: Refactor to be secure-by-default in the future or fail-fast if it is not mounted.
             if (cConf.getBoolean(Constants.Twill.Security.WORKER_MOUNT_SECRET)) {
               String secretName = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_NAME);
               String secretPath = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_PATH);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
@@ -160,6 +160,9 @@ public class TaskWorkerTwillRunnable extends AbstractTwillRunnable {
   private void doInitialize(TwillContext context) throws Exception {
     CConfiguration cConf = CConfiguration.create(new File(getArgument("cConf")).toURI().toURL());
 
+    // Overwrite the app fabric temp directory with the task worker temp directory
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, cConf.get(Constants.TaskWorker.LOCAL_DATA_DIR));
+
     Configuration hConf = new Configuration();
     hConf.clear();
     hConf.addResource(new File(getArgument("hConf")).toURI().toURL());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
@@ -98,9 +98,10 @@ public class ArtifactLocalizer {
 
   @Inject
   public ArtifactLocalizer(CConfiguration cConf, RemoteClientFactory remoteClientFactory) {
+  // TODO (CDAP-18047) verify SSL cert should be enabled.
     this.remoteClient = remoteClientFactory.createRemoteClient(Constants.Service.APP_FABRIC_HTTP,
-                                         HttpRequestConfig.DEFAULT,
-                                         Constants.Gateway.INTERNAL_API_VERSION_3);
+                                                               RemoteClientFactory.NO_VERIFY_HTTP_REQUEST_CONFIG,
+                                                               Constants.Gateway.INTERNAL_API_VERSION_3);
     this.retryStrategy = RetryStrategies.fromConfiguration(cConf, Constants.Service.TASK_WORKER + ".");
     this.dataDir = cConf.get(Constants.CFG_LOCAL_DATA_DIR);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/DefaultProvisionerContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/DefaultProvisionerContext.java
@@ -38,6 +38,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.Nullable;
 
 /**
@@ -57,13 +59,14 @@ public class DefaultProvisionerContext implements ProvisionerContext {
   private final RuntimeMonitorType runtimeMonitorType;
   private final MetricsCollectionService metricsCollectionService;
   private final String provisionerName;
+  private final String profileName;
   private final Executor executor;
 
   DefaultProvisionerContext(ProgramRunId programRunId, String provisionerName, Map<String, String> properties,
                             SparkCompat sparkCompat, @Nullable SSHContext sshContext,
                             @Nullable VersionInfo appCDAPVersion, LocationFactory locationFactory,
                             RuntimeMonitorType runtimeMonitorType, MetricsCollectionService metricsCollectionService,
-                            Executor executor) {
+                            @Nullable String profileName, Executor executor) {
     this.programRun = new ProgramRun(programRunId.getNamespace(), programRunId.getApplication(),
                                      programRunId.getProgram(), programRunId.getRun());
     this.programRunInfo = new ProgramRunInfo.Builder()
@@ -79,6 +82,7 @@ public class DefaultProvisionerContext implements ProvisionerContext {
     this.sparkCompat = sparkCompat;
     this.appCDAPVersion = appCDAPVersion;
     this.locationFactory = locationFactory;
+    this.profileName = profileName;
     this.cdapVersion = ProjectInfo.getVersion();
     this.runtimeMonitorType = runtimeMonitorType;
     this.metricsCollectionService = metricsCollectionService;
@@ -130,6 +134,11 @@ public class DefaultProvisionerContext implements ProvisionerContext {
   @Override
   public RuntimeMonitorType getRuntimeMonitorType() {
     return runtimeMonitorType;
+  }
+
+  @Override
+  public String getProfileName() {
+    return profileName;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
@@ -110,7 +110,6 @@ public class MasterEnvironmentMain {
                                                + MasterEnvironmentRunnable.class);
         }
 
-        //TODO: CDAP-17754 Use proper authentication context with internal token from configuration
         RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
           masterEnv.getDiscoveryServiceClientSupplier().get(), new WorkerAuthenticationContext(), cConf);
         MasterEnvironmentRunnableContext runnableContext =

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/AuthorizationHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/AuthorizationHandlerTest.java
@@ -96,7 +96,6 @@ public class AuthorizationHandlerTest {
         @Override
         public void modify(ChannelPipeline pipeline) {
           pipeline.addBefore("dispatcher", "usernamesetter", new TestUserNameSetter());
-          pipeline.addAfter("usernamesetter", "authenticator", new AuthenticationChannelHandler(false));
         }
       })
       .build();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServerTest.java
@@ -71,6 +71,9 @@ import java.util.stream.IntStream;
 @RunWith(Parameterized.class)
 public class RuntimeClientServerTest {
 
+  public static final String TEST_TOPIC_KEY = "topic.key";
+  public static final String TEST_TOPIC = "topic";
+
   @Parameterized.Parameters(name = "{index}: compression = {0}")
   public static Collection<Object[]> parameters() {
     return Arrays.asList(new Object[][]{
@@ -100,6 +103,8 @@ public class RuntimeClientServerTest {
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
     cConf.setBoolean(Constants.RuntimeMonitor.COMPRESSION_ENABLED, compression);
     cConf.setBoolean(Constants.AppFabric.SPARK_EVENT_LOGS_ENABLED, true);
+    cConf.set(TEST_TOPIC_KEY, TEST_TOPIC);
+    cConf.set(Constants.RuntimeMonitor.TOPICS_CONFIGS, Constants.Logging.TMS_TOPIC_PREFIX + ":1," + TEST_TOPIC_KEY);
 
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
@@ -166,7 +171,7 @@ public class RuntimeClientServerTest {
   @Test
   public void testLargeMessage() throws Exception {
     ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").workflow("workflow").run(RunIds.generate());
-    TopicId topicId = NamespaceId.SYSTEM.topic("topic");
+    TopicId topicId = NamespaceId.SYSTEM.topic(TEST_TOPIC);
 
     List<Message> messages = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
@@ -199,7 +204,7 @@ public class RuntimeClientServerTest {
   @Test
   public void testLogMessage() throws Exception {
     ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").workflow("workflow").run(RunIds.generate());
-    TopicId topicId = NamespaceId.SYSTEM.topic(cConf.get(Constants.Logging.TMS_TOPIC_PREFIX) + "-1");
+    TopicId topicId = NamespaceId.SYSTEM.topic(cConf.get(Constants.Logging.TMS_TOPIC_PREFIX) + "0");
 
     List<Message> messages = IntStream.range(0, 100).mapToObj(this::createMessage).collect(Collectors.toList());
     runtimeClient.sendMessages(programRunId, topicId, messages.iterator());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/guice/AppFabricTestModule.java
@@ -44,6 +44,7 @@ import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsHandlerModule;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import org.apache.hadoop.conf.Configuration;
@@ -101,6 +102,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new ExploreClientModule());
     install(new ConfigStoreModule());
     install(new MetadataServiceModule());
+    install(new AuthenticationContextModules().getMasterModule());
     install(new AuthorizationModule());
     install(new AuthorizationEnforcementModule().getStandaloneModules());
     install(new SecureStoreServerModule());

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineConnectionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineConnectionTest.java
@@ -165,7 +165,9 @@ public class DataPipelineConnectionTest extends HydratorTestBase {
       conn, new ConnectionCreationRequest(
         "", new PluginInfo(
         FileConnector.NAME, Connector.PLUGIN_TYPE, null, Collections.emptyMap(),
-        new ArtifactSelectorConfig("system", APP_ARTIFACT_ID.getArtifact(), APP_ARTIFACT_ID.getVersion()))));
+        // in set up we add "-mocks" as the suffix for the artifact id
+        new ArtifactSelectorConfig("system", APP_ARTIFACT_ID.getArtifact() + "-mocks",
+                                   APP_ARTIFACT_ID.getVersion()))));
 
     // get all 10 results back
     BrowseDetail browseDetail = browseConnection(conn, directory.getCanonicalPath(), 10);
@@ -196,7 +198,7 @@ public class DataPipelineConnectionTest extends HydratorTestBase {
       records.add(StructuredRecord.builder(schema).set("offset", i * 2L).set("body", "1").build());
     }
     ArtifactSelectorConfig artifact = new ArtifactSelectorConfig(APP_ARTIFACT_ID.getNamespace(),
-                                                                 APP_ARTIFACT_ID.getArtifact(),
+                                                                 APP_ARTIFACT_ID.getArtifact() + "-mocks",
                                                                  APP_ARTIFACT_ID.getVersion());
     Map<String, String> properties = ImmutableMap.of("path", entities.get(1).getPath(),
                                                      "useConnection", "true",

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -382,6 +382,7 @@ public final class Constants {
     /**
      * Task worker container configurations
      */
+    public static final String LOCAL_DATA_DIR = "task.worker.local.data.dir";
     public static final String CONTAINER_DISK_SIZE_GB = "task.worker.container.disk.size.gb";
     public static final String CONTAINER_MEMORY_MB = "task.worker.container.memory.mb";
     public static final String CONTAINER_CORES = "task.worker.container.num.cores";

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1632,14 +1632,29 @@ public final class Constants {
       public static final String IDENTITY_SYSTEM = "twill.security.identity.system";
 
       /**
-       * The secret name for the cdap-security.xml disk mount.
+       * The secret name for the cdap-security.xml disk mount for master services.
        */
-      public static final String SECRET_DISK_NAME = "twill.security.secret.disk.name";
+      public static final String MASTER_SECRET_DISK_NAME = "twill.security.master.secret.disk.name";
 
       /**
-       * The secret path for the cdap-security.xml disk mount.
+       * The secret path for the cdap-security.xml disk mount for master services.
        */
-      public static final String SECRET_DISK_PATH = "twill.security.secret.disk.path";
+      public static final String MASTER_SECRET_DISK_PATH = "twill.security.master.secret.disk.path";
+
+      /**
+       * Whether to mount a secret disk for worker runnables
+       */
+      public static final String WORKER_MOUNT_SECRET = "twill.security.worker.mount.secret";
+
+      /**
+       * The secret name for the cdap-security.xml disk mount for worker services including preview and task workers.
+       */
+      public static final String WORKER_SECRET_DISK_NAME = "twill.security.master.secret.disk.name";
+
+      /**
+       * The secret path for the cdap-security.xml disk mount for worker services including preview and task workers.
+       */
+      public static final String WORKER_SECRET_DISK_PATH = "twill.security.master.secret.disk.path";
     }
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -972,6 +972,8 @@ public final class Constants {
     public static final String MONITOR_TYPE_PREFIX = "app.program.runtime.monitor.type.";
     public static final String MONITOR_URL_AUTHENTICATOR_CLASS_PREFIX =
       "app.program.runtime.monitor.url.authenticator.class.";
+    public static final String MONITOR_AUDIT_LOG_ENABLED = "app.program.runtime.monitor.audit.log.enabled";
+    public static final String MONITOR_AUDIT_LOGGER_NAME = "http-access";
 
     // Prefix for that configuration key for storing discovery endpoint in the format of "host:port"
     public static final String DISCOVERY_SERVICE_PREFIX = "app.program.runtime.discovery.service.";
@@ -1142,6 +1144,13 @@ public final class Constants {
       /** Keyset used for user credential encryption. Set in cdap-security.xml */
       public static final String USER_CREDENTIAL_ENCRYPTION_KEYSET =
         "security.authentication.user.credentials.encryption.keyset";
+      /** {@link CConfiguration} property to pass runtime token from driver to distributed jobs */
+      public static final String RUNTIME_TOKEN =
+        "security.authentication.runtime.token";
+      /** File name to use to pass {@link Constants.Security.Headers#RUNTIME_TOKEN} to execution job */
+      public static final String RUNTIME_TOKEN_FILE = "cdap.runtime.token";
+      /** Identity used for runtime monitor */
+      public static final String RUNTIME_IDENTITY = "runtime";
     }
 
     /**

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.common.conf;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.BindingAnnotation;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -153,6 +154,19 @@ public final class Constants {
 
     // System property name to control the InMemoryZKServer to bind to localhost only or not
     public static final String TWILL_ZK_SERVER_LOCALHOST = "twill.zk.server.localhost";
+
+    /**
+     * Convenient method to get ZK quorum string from the configuration with proper default value.
+     */
+    public static String getZKQuorum(CConfiguration cConf) {
+      String quorum = cConf.get(QUORUM);
+      if (!Strings.isNullOrEmpty(quorum)) {
+        return quorum;
+      }
+      quorum = "127.0.0.1:2181";
+      String root = cConf.get(ROOT_NAMESPACE);
+      return Strings.isNullOrEmpty(root) ? quorum : quorum + "/" + root;
+    }
   }
 
   /**

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
@@ -30,6 +30,8 @@ import javax.annotation.Nullable;
  */
 public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
 
+  public static final String AUTHENTICATOR_NAME = "authenticator";
+
   private ChannelPipelineModifier pipelineModifier;
   private ChannelPipelineModifier additionalModifier;
 
@@ -45,7 +47,7 @@ public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
           // This is needed before we use a InheritableThreadLocal in SecurityRequestContext
           // to remember the user id.
           EventExecutor executor = pipeline.context("dispatcher").executor();
-          pipeline.addBefore(executor, "dispatcher", "authenticator",
+          pipeline.addBefore(executor, "dispatcher", AUTHENTICATOR_NAME,
                              new AuthenticationChannelHandler(cConf.getBoolean(Constants.Security
                                                                                  .ENFORCE_INTERNAL_AUTH)));
         }
@@ -54,8 +56,21 @@ public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
     this.setExceptionHandler(new HttpExceptionHandler());
   }
 
+  /**
+   * Sets pipeline modifier, preserving the security one installed in constructor.
+   */
   @Override
-  public NettyHttpService.Builder setChannelPipelineModifier(ChannelPipelineModifier channelPipelineModifier) {
+  public NettyHttpService.Builder setChannelPipelineModifier(ChannelPipelineModifier additionalPipelineModifier) {
+    additionalModifier = additionalPipelineModifier;
+    return this;
+  }
+
+  /**
+   * Sets a pipeline modifier replacing the security one installed in constructor.
+   */
+  public NettyHttpService.Builder replaceDefaultChannelPipelineModifier(
+    ChannelPipelineModifier channelPipelineModifier) {
+
     pipelineModifier = channelPipelineModifier;
     return this;
   }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
@@ -29,6 +29,9 @@ import javax.inject.Inject;
  */
 public class RemoteClientFactory {
 
+  public static final HttpRequestConfig NO_VERIFY_HTTP_REQUEST_CONFIG = new HttpRequestConfig(15000,
+                                                                                              15000,
+                                                                                              false);
   private final DiscoveryServiceClient discoveryClient;
   private final AuthenticationContext authenticationContext;
   private final CConfiguration cConf;

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -282,7 +282,7 @@
 
   <property>
     <name>twill.security.worker.mount.secret</name>
-    <value>false</value>
+    <value>true</value>
     <description>
       Whether to mount a secret disk in worker runnables.
     </description>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4447,4 +4447,12 @@
       The number of boss threads for the artifact localizer.
     </description>
   </property>
+
+  <property>
+    <name>task.worker.local.data.dir</name>
+    <value>/tmp</value>
+    <description>
+      The local data directory for the task worker container.
+    </description>
+  </property>
 </configuration>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2773,7 +2773,6 @@
     <description>
       A comma-separated list of topic config to be monitored by runtime monitor
     </description>
-    <final>true</final>
   </property>
 
   <property>
@@ -2850,6 +2849,14 @@
     <value>20</value>
     <description>
       Maximum number of threads being used by runtime monitor for runtime monitoring
+    </description>
+  </property>
+
+  <property>
+    <name>app.program.runtime.monitor.audit.log.enabled</name>
+    <value>${security.enabled}</value>
+    <description>
+      Determine if access audit log is enabled
     </description>
   </property>
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -265,18 +265,42 @@
   </property>
 
   <property>
-    <name>twill.security.secret.disk.name</name>
+    <name>twill.security.master.secret.disk.name</name>
     <value>cdap-security</value>
     <description>
-      The name of the Twill security disk mount which contains cdap-security.xml.
+      The name of the Twill security disk mount which contains cdap-security.xml for master services.
     </description>
   </property>
 
   <property>
-    <name>twill.security.secret.disk.path</name>
+    <name>twill.security.master.secret.disk.path</name>
     <value>/etc/cdap/security</value>
     <description>
-      The absolute directory of the Twill security disk mount which contains cdap-security.xml.
+      The absolute directory of the Twill security disk mount which contains cdap-security.xml for master services.
+    </description>
+  </property>
+
+  <property>
+    <name>twill.security.worker.mount.secret</name>
+    <value>false</value>
+    <description>
+      Whether to mount a secret disk in worker runnables.
+    </description>
+  </property>
+
+  <property>
+    <name>twill.security.worker.secret.disk.name</name>
+    <value>cdap-security</value>
+    <description>
+      The name of the Twill security disk mount which contains cdap-security.xml for worker runnables.
+    </description>
+  </property>
+
+  <property>
+    <name>twill.security.worker.secret.disk.path</name>
+    <value>/etc/cdap/security</value>
+    <description>
+      The absolute directory of the Twill security disk mount which contains cdap-security.xml for worker runnables.
     </description>
   </property>
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -348,7 +348,7 @@
 
   <property>
     <name>zookeeper.quorum</name>
-    <value>127.0.0.1:2181/${root.namespace}</value>
+    <value/>
     <description>
       ZooKeeper quorum string; specifies the ZooKeeper host:port; substitute
       the quorum (FQDN1:2181,FQDN2:2181,...) for the components shown here

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3672,33 +3672,28 @@
   </property>
 
   <!-- Retry configuration for task worker -->
+  <!-- small delay helps when there are free worker pods available -->
   <property>
     <name>task.worker.retry.policy.base.delay.ms</name>
-    <value>500</value>
+    <value>1</value>
     <description>
       The base delay between retries in milliseconds
     </description>
   </property>
 
-  <property>
-    <name>task.worker.retry.policy.max.delay.ms</name>
-    <value>3000</value>
-    <description>
-      The maximum delay between retries in milliseconds
-    </description>
-  </property>
-
+  <!-- Set to Integer max value, so the retry attempts end based on task.worker.retry.policy.max.time.secs -->
   <property>
     <name>task.worker.retry.policy.max.retries</name>
-    <value>10</value>
+    <value>2147483647</value>
     <description>
       The maximum number of retries to attempt before aborting
     </description>
   </property>
 
+  <!-- Set to 60s to match the default http request timeout -->
   <property>
     <name>task.worker.retry.policy.max.time.secs</name>
-    <value>600</value>
+    <value>60</value>
     <description>
       The maximum elapsed time in seconds before retries are aborted
     </description>

--- a/cdap-data-fabric-tests/pom.xml
+++ b/cdap-data-fabric-tests/pom.xml
@@ -121,6 +121,13 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <!-- explicitly get protobuf 2.5.0 for testing since it has been excluded from regular dependencies -->
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>2.5.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/NettyRouter.java
@@ -89,9 +89,9 @@ public class NettyRouter extends AbstractIdleService {
   private final TokenValidator tokenValidator;
   private final UserIdentityExtractor userIdentityExtractor;
   private final boolean sslEnabled;
-  private InetSocketAddress boundAddress;
+  private final DiscoveryServiceClient discoveryServiceClient;
 
-  private DiscoveryServiceClient discoveryServiceClient;
+  private InetSocketAddress boundAddress;
   private Cancellable serverCancellable;
 
   @Inject

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterMain.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterMain.java
@@ -28,7 +28,7 @@ import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.guice.ZKDiscoveryModule;
 import io.cdap.cdap.common.runtime.DaemonMain;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import org.apache.twill.internal.Services;
@@ -82,13 +82,6 @@ public class RouterMain extends DaemonMain {
         }
       }
 
-      // Initialize ZK client
-      String zookeeper = cConf.get(Constants.Zookeeper.QUORUM);
-      if (zookeeper == null) {
-        LOG.error("No ZooKeeper quorum provided.");
-        System.exit(1);
-      }
-
       Injector injector = createGuiceInjector(cConf);
       zkClientService = injector.getInstance(ZKClientService.class);
 
@@ -112,7 +105,7 @@ public class RouterMain extends DaemonMain {
                                                                     "ZooKeeper client. Please verify that the " +
                                                                     "ZooKeeper quorum settings are correct in " +
                                                                     "cdap-site.xml. Currently configured as: %s",
-                                                                    cConf.get(Constants.Zookeeper.QUORUM)));
+                                                                    zkClientService.getConnectString()));
     router.startAndWait();
     LOG.info("Router started.");
   }
@@ -135,7 +128,7 @@ public class RouterMain extends DaemonMain {
       new ZKClientModule(),
       new ZKDiscoveryModule(),
       new RouterModules().getDistributedModules(),
-      CoreSecurityModules.getDistributedModule(cConf),
+      CoreSecurityRuntimeModule.getDistributedModule(cConf),
       new ExternalAuthenticationModule(),
       new IOModule()
     );

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayTestBase.java
@@ -49,7 +49,7 @@ import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.RunRecord;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
@@ -161,7 +161,7 @@ public abstract class GatewayTestBase {
                                       ("localhost", 0).getAddress());
           }
         },
-        new CoreSecurityModules().getInMemoryModules(),
+        new CoreSecurityRuntimeModule().getInMemoryModules(),
         new ExternalAuthenticationModule(),
         new AppFabricTestModule(conf)
       ).with(new AbstractModule() {

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/AuthServerAnnounceTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/AuthServerAnnounceTest.java
@@ -31,7 +31,7 @@ import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.AuthenticationMode;
 import io.cdap.cdap.security.auth.TokenValidator;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.server.GrantAccessToken;
 import org.apache.http.HttpResponse;
@@ -119,7 +119,7 @@ public class AuthServerAnnounceTest {
     @Override
     protected void startUp() {
       SConfiguration sConfiguration = SConfiguration.create();
-      Injector injector = Guice.createInjector(new CoreSecurityModules().getInMemoryModules(),
+      Injector injector = Guice.createInjector(new CoreSecurityRuntimeModule().getInMemoryModules(),
                                                new ExternalAuthenticationModule(),
                                                new InMemoryDiscoveryModule(),
                                                new AppFabricTestModule(cConf));

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/NettyRouterHttpTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/NettyRouterHttpTest.java
@@ -25,7 +25,7 @@ import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import org.apache.commons.net.DefaultSocketFactory;
 import org.apache.http.impl.client.DefaultHttpClient;
@@ -75,7 +75,7 @@ public class NettyRouterHttpTest extends NettyRouterTestBase {
     protected void startUp() {
       CConfiguration cConf = CConfiguration.create();
       SConfiguration sConfiguration = SConfiguration.create();
-      Injector injector = Guice.createInjector(new CoreSecurityModules().getInMemoryModules(),
+      Injector injector = Guice.createInjector(new CoreSecurityRuntimeModule().getInMemoryModules(),
                                                new ExternalAuthenticationModule(),
                                                new InMemoryDiscoveryModule(),
                                                new AppFabricTestModule(cConf));

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/NettyRouterHttpsTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/NettyRouterHttpsTest.java
@@ -27,7 +27,7 @@ import io.cdap.cdap.common.security.KeyStores;
 import io.cdap.cdap.common.security.KeyStoresTest;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.common.http.HttpRequests;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
@@ -165,7 +165,7 @@ public class NettyRouterHttpsTest extends NettyRouterTestBase {
 
     @Override
     protected void startUp() {
-      Injector injector = Guice.createInjector(new CoreSecurityModules().getInMemoryModules(),
+      Injector injector = Guice.createInjector(new CoreSecurityRuntimeModule().getInMemoryModules(),
                                                new ExternalAuthenticationModule(),
                                                new InMemoryDiscoveryModule(),
                                                new AppFabricTestModule(cConf));

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterResource.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterResource.java
@@ -26,7 +26,7 @@ import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.TokenValidator;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
@@ -56,7 +56,7 @@ class RouterResource extends ExternalResource {
   @Override
   protected void before() {
     CConfiguration cConf = CConfiguration.create();
-    Injector injector = Guice.createInjector(new CoreSecurityModules().getStandaloneModules(),
+    Injector injector = Guice.createInjector(new CoreSecurityRuntimeModule().getStandaloneModules(),
                                              new ExternalAuthenticationModule(),
                                              new InMemoryDiscoveryModule(),
                                              new AppFabricTestModule(cConf));

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RoutingToDataSetsTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RoutingToDataSetsTest.java
@@ -28,7 +28,7 @@ import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.utils.Networks;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.security.auth.UserIdentityExtractor;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpResponder;
@@ -62,7 +62,7 @@ public class RoutingToDataSetsTest {
   @BeforeClass
   public static void before() throws Exception {
     CConfiguration cConf = CConfiguration.create();
-    Injector injector = Guice.createInjector(new CoreSecurityModules().getInMemoryModules(),
+    Injector injector = Guice.createInjector(new CoreSecurityRuntimeModule().getInMemoryModules(),
                                              new ExternalAuthenticationModule(),
                                              new InMemoryDiscoveryModule(),
                                              new AppFabricTestModule(cConf));

--- a/cdap-kafka/src/main/java/io/cdap/cdap/kafka/run/KafkaServerMain.java
+++ b/cdap-kafka/src/main/java/io/cdap/cdap/kafka/run/KafkaServerMain.java
@@ -58,7 +58,7 @@ public class KafkaServerMain extends DaemonMain {
   public void init(String[] args) {
     CConfiguration cConf = CConfiguration.create();
 
-    String zkConnectStr = cConf.get(Constants.Zookeeper.QUORUM);
+    String zkConnectStr = Constants.Zookeeper.getZKQuorum(cConf);
     String zkNamespace = cConf.get(KafkaConstants.ConfigKeys.ZOOKEEPER_NAMESPACE_CONFIG);
 
     if (zkNamespace != null) {
@@ -69,7 +69,7 @@ public class KafkaServerMain extends DaemonMain {
                               String.format("Connection timed out while trying to start ZooKeeper client. Please " +
                                             "verify that the ZooKeeper quorum settings are correct in " +
                                             "cdap-site.xml. Currently configured as: %s",
-                                            cConf.get(Constants.Zookeeper.QUORUM)));
+                                            client.getConnectString()));
 
         String path = "/" + zkNamespace;
         LOG.info(String.format("Creating zookeeper namespace %s", path));

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -149,13 +149,14 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
   private final TwillSpecification twillSpec;
   private final String resourcePrefix;
   private final Map<String, String> extraLabels;
+  private final Map<String, SecretDiskRunnable> secretDiskRunnables;
+  private final Map<String, V1SecurityContext> containerSecurityContexts;
+  private final Map<String, Set<String>> readonlyDisks;
+
   private String schedulerQueue;
   private String mainRunnableName;
   private Set<String> dependentRunnableNames;
   private String serviceAccountName;
-  private final Map<String, SecretDiskRunnable> secretDiskRunnables;
-  private final HashMap<String, V1SecurityContext> containerSecurityContexts;
-  private final Map<String, Set<String>> readonlyDisks;
 
   KubeTwillPreparer(MasterEnvironmentContext masterEnvContext, ApiClient apiClient, String kubeNamespace,
                     PodInfo podInfo, TwillSpecification spec, RunId twillRunId, Location appLocation,

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
@@ -90,6 +90,7 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.TokenSecureStoreRenewer;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.store.SecureStoreService;
@@ -569,6 +570,7 @@ public class MasterServiceMain extends DaemonMain {
       new MessagingClientModule(),
       new ExploreClientModule(),
       new AuditModule(),
+      new CoreSecurityModules().getDistributedModule(cConf),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new TwillModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
@@ -88,9 +88,10 @@ import io.cdap.cdap.operations.OperationalStatsService;
 import io.cdap.cdap.operations.guice.OperationalStatsModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.TokenSecureStoreRenewer;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.store.SecureStoreService;
@@ -266,7 +267,7 @@ public class MasterServiceMain extends DaemonMain {
                           TimeUnit.MILLISECONDS,
                           String.format("Connection timed out while trying to start ZooKeeper client. Please " +
                                           "verify that the ZooKeeper quorum settings are correct in cdap-site.xml. " +
-                                          "Currently configured as: %s", cConf.get(Constants.Zookeeper.QUORUM)));
+                                          "Currently configured as: %s", zkClient.getConnectString()));
     // Tries to create the ZK root node (which can be namespaced through the zk connection string)
     Futures.getUnchecked(ZKOperations.ignoreError(zkClient.create("/", null, CreateMode.PERSISTENT),
                                                   KeeperException.NodeExistsException.class, null));
@@ -570,7 +571,8 @@ public class MasterServiceMain extends DaemonMain {
       new MessagingClientModule(),
       new ExploreClientModule(),
       new AuditModule(),
-      new CoreSecurityModules().getDistributedModule(cConf),
+      CoreSecurityRuntimeModule.getDistributedModule(cConf),
+      new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new TwillModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/tools/JobQueueDebugger.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/tools/JobQueueDebugger.java
@@ -66,6 +66,7 @@ import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
@@ -336,6 +337,7 @@ public class JobQueueDebugger extends AbstractIdleService {
       new MetricsClientRuntimeModule().getDistributedModules(),
       new MetricsStoreModule(),
       new KafkaClientModule(),
+      new CoreSecurityModules().getDistributedModule(cConf),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new SecureStoreServerModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/tools/JobQueueDebugger.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/tools/JobQueueDebugger.java
@@ -65,8 +65,9 @@ import io.cdap.cdap.messaging.data.MessageId;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
@@ -337,7 +338,8 @@ public class JobQueueDebugger extends AbstractIdleService {
       new MetricsClientRuntimeModule().getDistributedModules(),
       new MetricsStoreModule(),
       new KafkaClientModule(),
-      new CoreSecurityModules().getDistributedModule(cConf),
+      CoreSecurityRuntimeModule.getDistributedModule(cConf),
+      new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
       new SecureStoreServerModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/tools/UpgradeTool.java
@@ -40,6 +40,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.DFSLocationModule;
+import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.KafkaClientModule;
 import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.guice.ZKDiscoveryModule;
@@ -72,6 +73,7 @@ import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.messaging.store.hbase.HBaseTableFactory;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
@@ -198,6 +200,8 @@ public class UpgradeTool {
       new ProgramRunnerRuntimeModule().getDistributedModules(),
       new SystemDatasetRuntimeModule().getDistributedModules(),
       new KafkaClientModule(),
+      new IOModule(),
+      new CoreSecurityModules().getDistributedModule(cConf),
       new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/tools/UpgradeTool.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/tools/UpgradeTool.java
@@ -73,7 +73,7 @@ import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.messaging.store.hbase.HBaseTableFactory;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
@@ -201,7 +201,7 @@ public class UpgradeTool {
       new SystemDatasetRuntimeModule().getDistributedModules(),
       new KafkaClientModule(),
       new IOModule(),
-      new CoreSecurityModules().getDistributedModule(cConf),
+      CoreSecurityRuntimeModule.getDistributedModule(cConf),
       new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getMasterModule(),
@@ -265,7 +265,7 @@ public class UpgradeTool {
                           TimeUnit.MILLISECONDS,
                           String.format("Connection timed out while trying to start ZooKeeper client. Please " +
                                           "verify that the ZooKeeper quorum settings are correct in cdap-site.xml. " +
-                                          "Currently configured as: %s", cConf.get(Constants.Zookeeper.QUORUM)));
+                                          "Currently configured as: %s", zkClientService.getConnectString()));
     LOG.info("Starting Transaction Service...");
     txService.startAndWait();
     LOG.info("Initializing Dataset Framework...");

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -33,7 +33,6 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.guice.SupplierProviderBridge;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.service.RetryOnStartFailureService;
@@ -62,7 +61,6 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.store.SecureStoreService;
 import org.apache.twill.api.TwillRunner;
@@ -107,8 +105,6 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
           bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
         }
       }),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf),
       new ProgramRunnerRuntimeModule().getDistributedModules(true),
       new MonitorHandlerModule(false),
       new SecureStoreServerModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AuthenticationServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AuthenticationServiceMain.java
@@ -23,15 +23,12 @@ import com.google.inject.Key;
 import com.google.inject.Module;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.server.ExternalAuthenticationServer;
@@ -60,10 +57,7 @@ public class AuthenticationServiceMain extends AbstractServiceMain<EnvironmentOp
 
     List<Module> modules = new ArrayList<>();
     modules.add(new MessagingClientModule());
-    modules.add(CoreSecurityModules.getDistributedModule(cConf));
-    modules.add(new AuthenticationContextModules().getInternalAuthMasterModule(cConf));
     modules.add(new ExternalAuthenticationModule());
-    modules.add(ZKClientModule.getZKClientModuleIfRequired(cConf));
     return modules;
   }
 

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/LogsServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/LogsServiceMain.java
@@ -33,7 +33,6 @@ import io.cdap.cdap.api.logging.AppenderContext;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.LocalLocationModule;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.data.runtime.DataSetsModules;
@@ -53,9 +52,7 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.http.HttpHandler;
@@ -85,9 +82,6 @@ public class LogsServiceMain extends AbstractServiceMain<EnvironmentOptions> {
                                            EnvironmentOptions options, CConfiguration cConf) {
     return Arrays.asList(
       new AuthorizationEnforcementModule().getDistributedModules(),
-      new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf),
       new MessagingClientModule(),
       getDataFabricModule(),
       // Always use local table implementations, which use LevelDB.

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MessagingServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MessagingServiceMain.java
@@ -24,7 +24,6 @@ import com.google.inject.Module;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.namespace.guice.NamespaceQueryAdminModule;
@@ -35,9 +34,7 @@ import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
 import io.cdap.cdap.messaging.server.MessagingHttpService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import org.apache.twill.zookeeper.ZKClientService;
 
 import java.util.Arrays;
@@ -63,9 +60,6 @@ public class MessagingServiceMain extends AbstractServiceMain<EnvironmentOptions
     return Arrays.asList(
       new NamespaceQueryAdminModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
-      new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf),
       new MessagingServerRuntimeModule().getStandaloneModules(),
       new DFSLocationModule()
     );

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetadataServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetadataServiceMain.java
@@ -30,7 +30,6 @@ import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.namespace.guice.NamespaceQueryAdminModule;
@@ -48,9 +47,7 @@ import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.metadata.MetadataSubscriberService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
@@ -91,9 +88,6 @@ public class MetadataServiceMain extends AbstractServiceMain<EnvironmentOptions>
       new AuditModule(),
       new EntityVerifierModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
-      new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf),
       new DFSLocationModule(),
       new AbstractModule() {
         @Override

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMain.java
@@ -27,7 +27,6 @@ import io.cdap.cdap.api.metrics.MetricsContext;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.namespace.guice.NamespaceQueryAdminModule;
@@ -46,9 +45,7 @@ import io.cdap.cdap.metrics.query.MetricsQueryService;
 import io.cdap.cdap.metrics.store.MetricsCleanUpService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import org.apache.twill.zookeeper.ZKClientService;
 
 import java.util.Arrays;
@@ -76,9 +73,6 @@ public class MetricsServiceMain extends AbstractServiceMain<EnvironmentOptions> 
     return Arrays.asList(
       new NamespaceQueryAdminModule(),
       new AuthorizationEnforcementModule().getDistributedModules(),
-      new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf),
       new MessagingClientModule(),
       new SystemDatasetRuntimeModule().getStandaloneModules(),
       new MetricsStoreModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMain.java
@@ -36,7 +36,6 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.guice.SupplierProviderBridge;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.data.runtime.DataSetServiceModules;
@@ -52,7 +51,6 @@ import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.SecureStoreClientModule;
 import org.apache.twill.api.Configs;
 import org.apache.twill.api.TwillRunner;
@@ -101,13 +99,10 @@ public class PreviewServiceMain extends AbstractServiceMain<EnvironmentOptions> 
   @Override
   protected List<Module> getServiceModules(MasterEnvironment masterEnv,
                                            EnvironmentOptions options, CConfiguration cConf) {
-    List<Module> modules = new ArrayList<>();
-    modules.addAll(Arrays.asList(
+    List<Module> modules = new ArrayList<>(Arrays.asList(
       new DataSetServiceModules().getStandaloneModules(),
       new DataSetsModules().getStandaloneModules(),
-      new AppFabricServiceRuntimeModule(cConf).getPreviewMasterModules(),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf),
+      new AppFabricServiceRuntimeModule(cConf).getStandaloneModules(),
       new ProgramRunnerRuntimeModule().getStandaloneModules(),
       new MetricsStoreModule(),
       new MessagingClientModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
@@ -24,7 +24,6 @@ import com.google.inject.Module;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.gateway.router.NettyRouter;
@@ -34,8 +33,6 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import org.apache.twill.zookeeper.ZKClientService;
 import org.slf4j.Logger;
@@ -66,17 +63,8 @@ public class RouterServiceMain extends AbstractServiceMain<EnvironmentOptions> {
     modules.add(new MessagingClientModule());
     modules.add(new RouterModules().getDistributedModules());
     modules.add(new DFSLocationModule());
-    modules.addAll(getSecurityModules(cConf));
-
-    return modules;
-  }
-
-  private List<Module> getSecurityModules(CConfiguration cConf) {
-    List<Module> modules = new ArrayList<>();
-    modules.add(new AuthenticationContextModules().getInternalAuthMasterModule(cConf));
-    modules.add(CoreSecurityModules.getDistributedModule(cConf));
     modules.add(new ExternalAuthenticationModule());
-    modules.add(ZKClientModule.getZKClientModuleIfRequired(cConf));
+
     return modules;
   }
 

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
@@ -26,7 +26,6 @@ import io.cdap.cdap.app.guice.RuntimeServerModule;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.DFSLocationModule;
-import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -37,9 +36,7 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
@@ -71,10 +68,7 @@ public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> 
       new SystemDatasetRuntimeModule().getStandaloneModules(),
       getDataFabricModule(),
       new RuntimeServerModule(),
-      new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
-      new AuthorizationEnforcementModule().getDistributedModules(),
-      CoreSecurityModules.getDistributedModule(cConf),
-      ZKClientModule.getZKClientModuleIfRequired(cConf)
+      new AuthorizationEnforcementModule().getDistributedModules()
     );
   }
 

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
@@ -38,6 +38,7 @@ import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
+import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.guice.CoreSecurityModules;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
@@ -71,6 +72,7 @@ public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> 
       getDataFabricModule(),
       new RuntimeServerModule(),
       new AuthenticationContextModules().getInternalAuthMasterModule(cConf),
+      new AuthorizationEnforcementModule().getDistributedModules(),
       CoreSecurityModules.getDistributedModule(cConf),
       ZKClientModule.getZKClientModuleIfRequired(cConf)
     );

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMainTest.java
@@ -61,7 +61,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.jar.Manifest;
 
 /**
- * Unit test for {@link AppFabricServiceMain}.
+ * Unit test for {@link PreviewServiceMain}.
  */
 public class PreviewServiceMainTest extends MasterServiceMainTestBase {
   private static final Gson GSON = new Gson();

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMainTest.java
@@ -52,6 +52,7 @@ import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.TopicId;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -66,6 +67,15 @@ import java.util.concurrent.TimeUnit;
 public class RuntimeServiceMainTest extends MasterServiceMainTestBase {
 
   private static final Gson GSON = new Gson();
+
+  @BeforeClass
+  public static void init() throws Exception {
+    //We write through runtime client to this topic in this test, so add it to the allow list
+    cConf.set(Constants.RuntimeMonitor.TOPICS_CONFIGS,
+              cConf.get(Constants.RuntimeMonitor.TOPICS_CONFIGS, "") + ","
+                + Constants.AppFabric.PROGRAM_STATUS_RECORD_EVENT_TOPIC);
+    MasterServiceMainTestBase.init();
+  }
 
   @Test
   public void testRuntimeService() throws Exception {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -169,6 +169,9 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
   }
 
   private Map<? extends String, ? extends String> getReuseLabels(ProvisionerContext context, DataprocConf conf) {
+    if (!isReuseSupported(conf)) {
+      return Collections.emptyMap();
+    }
     Map<String, String> reuseLabels = new HashMap<>();
     String normalProfileName = getNormalizedProfileName(context);
     if (normalProfileName != null) {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -28,18 +28,23 @@ import io.cdap.cdap.runtime.spi.provisioner.PollingStrategies;
 import io.cdap.cdap.runtime.spi.provisioner.PollingStrategy;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSpecification;
+import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
 import io.cdap.cdap.runtime.spi.ssh.SSHContext;
 import io.cdap.cdap.runtime.spi.ssh.SSHKeyPair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 
 /**
  * Provisions a cluster using GCP Dataproc.
@@ -60,6 +65,9 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
 
   //First version spark 3 is default one
   private static final String SPARK3_CDAP_DEFAULT = "6.5";
+
+  //A lock to use for cluster reuse
+  private static final String REUSE_LOCK = "reuse";
 
   @SuppressWarnings("WeakerAccess")
   public DataprocProvisioner() {
@@ -111,9 +119,16 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       }
     }
 
-    String clusterName = getClusterName(context);
+    try (DataprocClient client = getClient(conf)) {
+      Cluster reused = tryReuseCluster(client, context, conf);
+      if (reused != null) {
+        DataprocUtils.emitMetric(context, conf.getRegion(),
+                                 "provisioner.createCluster.reuse.count");
+        return reused;
+      }
 
-    try (DataprocClient client = DataprocClient.fromConf(conf)) {
+      String clusterName = getRunKey(context);
+
       // if it already exists, it means this is a retry. We can skip actually making the request
       Optional<Cluster> existing = client.getCluster(clusterName);
       if (existing.isPresent()) {
@@ -129,6 +144,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       // Reload system context properties and get system labels
       Map<String, String> labels = new HashMap<>();
       labels.putAll(getSystemLabels());
+      labels.putAll(getReuseLabels(context, conf));
       labels.putAll(conf.getClusterLabels());
       LOG.info("Creating Dataproc cluster {} in project {}, in region {}, with image {}, with labels {}",
                clusterName, conf.getProjectId(), conf.getRegion(), imageDescription, labels);
@@ -150,6 +166,117 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
                                "provisioner.createCluster.response.count", e);
       throw e;
     }
+  }
+
+  private Map<? extends String, ? extends String> getReuseLabels(ProvisionerContext context, DataprocConf conf) {
+    Map<String, String> reuseLabels = new HashMap<>();
+    String normalProfileName = getNormalizedProfileName(context);
+    if (normalProfileName != null) {
+      reuseLabels.put(LABEL_PROFILE, normalProfileName);
+    }
+    reuseLabels.put(LABEL_REUSE_KEY, conf.getClusterReuseKey());
+    reuseLabels.put(LABEL_RUN_KEY, getRunKey(context));
+    return reuseLabels;
+  }
+
+  /**
+   * If cluster reuse is enabled & possible tries to find a cluster to reuse.
+   * @param client data proc client
+   * @param context provisioner contex
+   * @param conf dataproc configuration
+   * @return a cluster ready to reuse or null if none available.
+   */
+  @Nullable
+  private Cluster tryReuseCluster(DataprocClient client, ProvisionerContext context, DataprocConf conf)
+    throws RetryableProvisionException, IOException {
+    if (!isReuseSupported(conf)) {
+      LOG.debug("Not checking custer reuse, enabled: {}, skip delete: {}, idle ttl: {}, reuse threshold: {}",
+                conf.isClusterReuseEnabled(), conf.isSkipDelete(), conf.getIdleTTLMinutes(),
+                conf.getClusterReuseThresholdMinutes());
+      return null;
+    }
+
+    String clusterKey = getRunKey(context);
+
+    //For idempotency, check if we already have the cluster allocated
+    Optional<Cluster> clusterOptional = findCluster(clusterKey, client);
+    if (clusterOptional.isPresent()) {
+      Cluster cluster = clusterOptional.get();
+      if (cluster.getStatus() == ClusterStatus.CREATING ||
+        cluster.getStatus() == ClusterStatus.RUNNING) {
+        LOG.debug("Found allocated cluster {}", cluster.getName());
+        return cluster;
+      } else {
+        LOG.debug("Preallocated cluster {} expired, will look for new one");
+        //Let's remove the reuse label to ensure new cluster will be picked up by findCluster
+        try {
+          client.updateClusterLabels(cluster.getName(), Collections.emptyMap(), Collections.singleton(LABEL_RUN_KEY));
+        } catch (Exception e) {
+          LOG.trace("Unable to remove reuse label, probably cluster died already", e);
+          if (!LOG.isTraceEnabled()) {
+            LOG.debug("Unable to remove reuse label, probably cluster died already");
+          }
+        }
+      }
+    }
+
+    Lock reuseLock = getSystemContext().getLock(REUSE_LOCK);
+    reuseLock.lock();
+    try {
+      Map<String, String> filter = new HashMap<>();
+      String normalizedProfileName = getNormalizedProfileName(context);
+      if (normalizedProfileName != null) {
+        filter.put(LABEL_PROFILE, normalizedProfileName);
+      }
+      filter.put(LABEL_VERSON, getVersionLabel());
+      filter.put(LABEL_REUSE_KEY, conf.getClusterReuseKey());
+      filter.put(LABEL_REUSE_UNTIL, "*");
+
+      Optional<Cluster> cluster = client.getClusters(ClusterStatus.RUNNING, filter, clientCluster -> {
+        //Verify reuse label
+        long reuseUntil = Long.valueOf(clientCluster.getLabelsOrDefault(LABEL_REUSE_UNTIL, "0"));
+        long now = System.currentTimeMillis();
+        if (reuseUntil < now) {
+          LOG.debug("Skipping expired cluster {}, reuse until {} is before now {}",
+                    clientCluster.getClusterName(), reuseUntil, now);
+          return false;
+        }
+        return true;
+      }).findAny();
+
+      if (cluster.isPresent()) {
+        String clusterName = cluster.get().getName();
+        LOG.info("Found cluster to reuse: {}", clusterName);
+        // Add cdap-reuse-for to find cluster later if needed
+        // And remove reuseUntil to indicate the cluster is taken
+        client.updateClusterLabels(clusterName,
+                                   Collections.singletonMap(LABEL_RUN_KEY, clusterKey),
+                                   Collections.singleton(LABEL_REUSE_UNTIL)
+        );
+      } else {
+        LOG.debug("Could not find any available cluster to reuse.");
+      }
+      return cluster.orElse(null);
+    } catch (Exception e) {
+      LOG.warn("Error retrieving clusters to reuse, will create a new one", e);
+      return null;
+    } finally {
+      reuseLock.unlock();
+    }
+  }
+
+  private boolean isReuseSupported(DataprocConf conf) {
+    return conf.isClusterReuseEnabled() && conf.isSkipDelete() &&
+      conf.getIdleTTLMinutes() > conf.getClusterReuseThresholdMinutes();
+  }
+
+  @Nullable
+  private String getNormalizedProfileName(ProvisionerContext context) {
+    if (context.getProfileName() == null) {
+      return null;
+    }
+    String normalName = context.getProfileName().replaceAll("[^a-zA-Z0-9]", "");
+    return normalName.isEmpty() ? null : normalName;
   }
 
   @VisibleForTesting
@@ -177,7 +304,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
   @Override
   public ClusterStatus getClusterStatus(ProvisionerContext context, Cluster cluster) throws Exception {
     DataprocConf conf = DataprocConf.create(createContextProperties(context));
-    String clusterName = getClusterName(context);
+    String clusterName = cluster.getName();
 
     ClusterStatus status = cluster.getStatus();
     // if we are skipping the delete, need to avoid checking the real cluster status and pretend like it is deleted.
@@ -185,7 +312,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       return ClusterStatus.NOT_EXISTS;
     }
 
-    try (DataprocClient client = DataprocClient.fromConf(conf)) {
+    try (DataprocClient client = getClient(conf)) {
       status = client.getClusterStatus(clusterName);
       DataprocUtils.emitMetric(context, conf.getRegion(),
                                "provisioner.clusterStatus.response.count");
@@ -200,8 +327,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
   @Override
   public Cluster getClusterDetail(ProvisionerContext context, Cluster cluster) throws Exception {
     DataprocConf conf = DataprocConf.create(createContextProperties(context));
-    String clusterName = getClusterName(context);
-    try (DataprocClient client = DataprocClient.fromConf(conf)) {
+    String clusterName = cluster.getName();
+    try (DataprocClient client = getClient(conf)) {
       Optional<Cluster> existing = client.getCluster(clusterName);
       DataprocUtils.emitMetric(context, conf.getRegion(),
                                "provisioner.clusterDetail.response.count");
@@ -215,12 +342,25 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
 
   @Override
   protected void doDeleteCluster(ProvisionerContext context, Cluster cluster, DataprocConf conf) throws Exception {
-    if (conf.isSkipDelete()) {
+    if (!isReuseSupported(conf) && conf.isSkipDelete()) {
       return;
     }
-    String clusterName = getClusterName(context);
-    try (DataprocClient client = DataprocClient.fromConf(conf)) {
-      client.deleteCluster(clusterName);
+    String clusterName = cluster.getName();
+    try (DataprocClient client = getClient(conf)) {
+      if (isReuseSupported(conf)) {
+        long reuseUntil = System.currentTimeMillis() +
+          TimeUnit.MINUTES.toMillis(conf.getIdleTTLMinutes() - conf.getClusterReuseThresholdMinutes());
+        LOG.debug("Marking cluster {} reusable for {} minutes",
+                  clusterName,
+                  conf.getIdleTTLMinutes() - conf.getClusterReuseThresholdMinutes());
+        client.updateClusterLabels(clusterName,
+                                   //Add reuse until
+                                   Collections.singletonMap(LABEL_REUSE_UNTIL, Long.toString(reuseUntil)),
+                                   //Drop allocation
+                                   Collections.singleton(LABEL_RUN_KEY));
+      } else {
+        client.deleteCluster(clusterName);
+      }
       DataprocUtils.emitMetric(context, conf.getRegion(),
                                "provisioner.deleteCluster.response.count");
     } catch (Exception e) {
@@ -228,6 +368,29 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
                                "provisioner.deleteCluster.response.count", e);
       throw e;
     }
+  }
+
+  @Override
+  protected String getClusterName(ProvisionerContext context) throws Exception {
+    DataprocConf conf = DataprocConf.create(createContextProperties(context));
+    String clusterKey = getRunKey(context);
+    if (isReuseSupported(conf)) {
+      try (DataprocClient client = getClient(conf)) {
+        Optional<Cluster> allocatedCluster = findCluster(clusterKey, client);
+        return allocatedCluster.map(Cluster::getName).orElse(clusterKey);
+      }
+    }
+    return clusterKey;
+  }
+
+  @VisibleForTesting
+  protected DataprocClient getClient(DataprocConf conf) throws IOException, GeneralSecurityException {
+    return DataprocClient.fromConf(conf);
+  }
+
+  private Optional<Cluster> findCluster(String clusterKey, DataprocClient client)
+    throws RetryableProvisionException {
+    return client.getClusters(null, Collections.singletonMap(LABEL_RUN_KEY, clusterKey)).findAny();
   }
 
   @Override
@@ -258,7 +421,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       DataprocConf.STACKDRIVER_MONITORING_ENABLED,
       DataprocConf.COMPONENT_GATEWAY_ENABLED,
       DataprocConf.IMAGE_VERSION,
-      DataprocConf.CLUSTER_MEATA_DATA,
+      DataprocConf.CLUSTER_META_DATA,
       DataprocConf.SERVICE_ACCOUNT
     ).contains(property);
   }
@@ -287,7 +450,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
   }
 
   /**
-   * Gets the cluster name for the given context.
+   * Gets the identifier to locate cluster for the given context.
+   * It's used as a cluster name when reuse is disabled and put into {@link #LABEL_RUN_KEY} when reuse is enabled.
    * Name must start with a lowercase letter followed by up to 51 lowercase letters,
    * numbers, or hyphens, and cannot end with a hyphen
    * We'll use app-runid, where app is truncated to fit, lowercased, and stripped of invalid characters.
@@ -295,8 +459,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
    * @param context the provisioner context
    * @return a string that is a valid cluster name
    */
-  @Override
-  protected String getClusterName(ProvisionerContext context) {
+  @VisibleForTesting
+  String getRunKey(ProvisionerContext context) {
     ProgramRunInfo programRunInfo = context.getProgramRunInfo();
 
     String cleanedAppName = programRunInfo.getApplication().replaceAll("[^A-Za-z0-9\\-]", "").toLowerCase();

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerContext.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerContext.java
@@ -37,7 +37,11 @@ import javax.annotation.Nullable;
 public class MockProvisionerContext implements ProvisionerContext {
 
   private final Map<String, String> properties;
-  private final ProgramRunInfo programRunInfo;
+  private ProgramRunInfo programRunInfo;
+  private SparkCompat sparkCompat;
+  private VersionInfo appCDAPVersionInfo;
+  private String cdapVersion;
+  private String profileName;
 
   public MockProvisionerContext() {
     this(null);
@@ -56,6 +60,10 @@ public class MockProvisionerContext implements ProvisionerContext {
   @Override
   public ProgramRunInfo getProgramRunInfo() {
     return programRunInfo;
+  }
+
+  public void setProgramRunInfo(ProgramRunInfo programRunInfo) {
+    this.programRunInfo = programRunInfo;
   }
 
   @Override
@@ -79,12 +87,20 @@ public class MockProvisionerContext implements ProvisionerContext {
 
   @Override
   public SparkCompat getSparkCompat() {
-    return null;
+    return sparkCompat;
+  }
+
+  public void setSparkCompat(SparkCompat sparkCompat) {
+    this.sparkCompat = sparkCompat;
   }
 
   @Override
   public String getCDAPVersion() {
-    return null;
+    return cdapVersion;
+  }
+
+  public void setCdapVersion(String cdapVersion) {
+    this.cdapVersion = cdapVersion;
   }
 
   @Override
@@ -94,7 +110,11 @@ public class MockProvisionerContext implements ProvisionerContext {
 
   @Override @Nullable
   public VersionInfo getAppCDAPVersionInfo() {
-    return null;
+    return appCDAPVersionInfo;
+  }
+
+  public void setAppCDAPVersionInfo(VersionInfo appCDAPVersionInfo) {
+    this.appCDAPVersionInfo = appCDAPVersionInfo;
   }
 
   @Override
@@ -105,6 +125,15 @@ public class MockProvisionerContext implements ProvisionerContext {
   @Override
   public RuntimeMonitorType getRuntimeMonitorType() {
     return null;
+  }
+
+  @Override
+  public String getProfileName() {
+    return profileName;
+  }
+
+  public void setProfileName(String profileName) {
+    this.profileName = profileName;
   }
 
   @Override

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerSystemContext.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerSystemContext.java
@@ -20,12 +20,18 @@ import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSystemContext;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class MockProvisionerSystemContext implements ProvisionerSystemContext {
   Map<String, String> properties;
+  private final Map<String, Lock> locks;
+  private String cdapVersion;
 
   public MockProvisionerSystemContext() {
     properties = new HashMap<>();
+    locks = new ConcurrentHashMap<>();
   }
 
   @Override
@@ -46,7 +52,16 @@ public class MockProvisionerSystemContext implements ProvisionerSystemContext {
   }
 
   @Override
+  public Lock getLock(String name) {
+    return locks.computeIfAbsent(name, n -> new ReentrantLock());
+  }
+
+  @Override
   public String getCDAPVersion() {
-    return null;
+    return cdapVersion;
+  }
+
+  public void setCDAPVersion(String cdapVersion) {
+    this.cdapVersion = cdapVersion;
   }
 }

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/Cluster.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/Cluster.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.runtime.spi.provisioner;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -33,7 +34,8 @@ public class Cluster {
   public Cluster(String name, ClusterStatus status, Collection<Node> nodes, Map<String, String> properties) {
     this.name = name;
     this.status = status;
-    this.nodes = Collections.unmodifiableCollection(nodes);
+    this.nodes = nodes instanceof List ? Collections.unmodifiableList((List<Node>) nodes) :
+      Collections.unmodifiableCollection(nodes);
     this.properties = properties;
   }
 

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerContext.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerContext.java
@@ -26,6 +26,7 @@ import org.apache.twill.filesystem.LocationFactory;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.locks.Lock;
 import javax.annotation.Nullable;
 
 /**
@@ -113,4 +114,10 @@ public interface ProvisionerContext {
    * @return a {@link CompletionStage} that carries result of the task execution
    */
   <T> CompletionStage<T> execute(Callable<T> callable);
+
+  /**
+   * @return provisioner profile name.
+   */
+  @Nullable
+  String getProfileName();
 }

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerSystemContext.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerSystemContext.java
@@ -18,6 +18,7 @@
 package io.cdap.cdap.runtime.spi.provisioner;
 
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
 
 /**
  * Context for system level provisioner information. System level information cannot be seen or modified by end
@@ -46,4 +47,12 @@ public interface ProvisionerSystemContext {
    * Returns the CDAP version
    */
   String getCDAPVersion();
+
+  /**
+   * Creates or retrieves a lock specific to this provisioner. Multiple locks can be created by passing
+   * different names.
+   * @param name lock name used as a key to identify lock requested
+   * @return a new or existing lock instance that can be used to coordinate multiple instances of same provisioner
+   */
+  Lock getLock(String name);
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/auth/InMemoryKeyManager.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/auth/InMemoryKeyManager.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.security.auth;
 
+import com.google.inject.Inject;
 import io.cdap.cdap.common.conf.CConfiguration;
 
 import java.io.IOException;
@@ -27,9 +28,9 @@ public class InMemoryKeyManager extends MapBackedKeyManager {
 
   /**
    * Create an InMemoryKeyManager that stores keys in memory only.
-   * @param conf
    */
-  public InMemoryKeyManager(CConfiguration conf) {
+  @Inject
+  InMemoryKeyManager(CConfiguration conf) {
     super(conf);
   }
 

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/InMemoryCoreSecurityModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/InMemoryCoreSecurityModule.java
@@ -17,10 +17,7 @@
 package io.cdap.cdap.security.guice;
 
 import com.google.inject.Binder;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
 import com.google.inject.Scopes;
-import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.security.auth.InMemoryKeyManager;
 import io.cdap.cdap.security.auth.KeyManager;
 
@@ -32,20 +29,6 @@ final class InMemoryCoreSecurityModule extends CoreSecurityModule {
 
   @Override
   protected void bindKeyManager(Binder binder) {
-    binder.bind(KeyManager.class).toProvider(InMemoryKeyManagerProvider.class).in(Scopes.SINGLETON);
-  }
-
-  private static final class InMemoryKeyManagerProvider implements Provider<KeyManager> {
-    private final CConfiguration cConf;
-
-    @Inject
-    InMemoryKeyManagerProvider(CConfiguration conf) {
-      this.cConf = conf;
-    }
-
-    @Override
-    public KeyManager get() {
-      return new InMemoryKeyManager(cConf);
-    }
+    binder.bind(KeyManager.class).to(InMemoryKeyManager.class).in(Scopes.SINGLETON);
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/runtime/AuthenticationServerMain.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/runtime/AuthenticationServerMain.java
@@ -28,7 +28,7 @@ import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.ZKClientModule;
 import io.cdap.cdap.common.guice.ZKDiscoveryModule;
 import io.cdap.cdap.common.runtime.DaemonMain;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.server.ExternalAuthenticationServer;
@@ -56,7 +56,7 @@ public class AuthenticationServerMain extends DaemonMain {
                                              new IOModule(),
                                              new ZKClientModule(),
                                              new ZKDiscoveryModule(),
-                                             new CoreSecurityModules().getDistributedModules(),
+                                             new CoreSecurityRuntimeModule().getDistributedModules(),
                                              new ExternalAuthenticationModule());
     configuration = injector.getInstance(CConfiguration.class);
 
@@ -83,7 +83,7 @@ public class AuthenticationServerMain extends DaemonMain {
                                                                           "ZooKeeper client. Please verify that the " +
                                                                           "ZooKeeper quorum settings are correct in " +
                                                                           "cdap-site.xml. Currently configured as: %s",
-                                                                        configuration.get(Constants.Zookeeper.QUORUM)));
+                                                                        zkClientService.getConnectString()));
         authServer.startAndWait();
       } catch (Exception e) {
         Throwable rootCause = Throwables.getRootCause(e);

--- a/cdap-security/src/main/java/io/cdap/cdap/security/tools/AuthenticationTool.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/tools/AuthenticationTool.java
@@ -29,7 +29,7 @@ import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.security.auth.FileBasedKeyManager;
 import io.cdap.cdap.security.auth.KeyIdentifier;
 import io.cdap.cdap.security.auth.KeyIdentifierCodec;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -82,7 +82,7 @@ public class AuthenticationTool {
         new ConfigModule(cConf),
         new IOModule(),
         new InMemoryDiscoveryModule(),
-        CoreSecurityModules.getDistributedModule(cConf));
+        CoreSecurityRuntimeModule.getDistributedModule(cConf));
 
       Codec<KeyIdentifier> codec = injector.getInstance(Key.get(new TypeLiteral<Codec<KeyIdentifier>>() { }));
       FileBasedKeyManager keyManager = new FileBasedKeyManager(injector.getInstance(CConfiguration.class),

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/DistributedKeyManagerTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/DistributedKeyManagerTest.java
@@ -32,7 +32,7 @@ import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.common.utils.ImmutablePair;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.security.guice.CoreSecurityModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.zookeeper.MiniZooKeeperCluster;
@@ -70,16 +70,18 @@ public class DistributedKeyManagerTest extends TestTokenManager {
       + zkCluster.getClientPort();
     LOG.info("Running ZK cluster at " + zkConnectString);
     CConfiguration cConf1 = CConfiguration.create();
+    cConf1.setBoolean(Constants.Security.ENABLED, true);
     cConf1.set(Constants.Zookeeper.QUORUM, zkConnectString);
 
     CConfiguration cConf2 = CConfiguration.create();
+    cConf2.setBoolean(Constants.Security.ENABLED, true);
     cConf2.set(Constants.Zookeeper.QUORUM, zkConnectString);
 
     List<Module> modules = new ArrayList<>();
     modules.add(new ConfigModule(cConf1, testUtil.getConfiguration()));
     modules.add(new IOModule());
 
-    CoreSecurityModule coreSecurityModule = CoreSecurityModules.getDistributedModule(cConf1);
+    CoreSecurityModule coreSecurityModule = CoreSecurityRuntimeModule.getDistributedModule(cConf1);
     modules.add(coreSecurityModule);
     if (coreSecurityModule.requiresZKClient()) {
       modules.add(new ZKClientModule());
@@ -91,7 +93,7 @@ public class DistributedKeyManagerTest extends TestTokenManager {
     modules.add(new ConfigModule(cConf2, testUtil.getConfiguration()));
     modules.add(new IOModule());
 
-    coreSecurityModule = CoreSecurityModules.getDistributedModule(cConf2);
+    coreSecurityModule = CoreSecurityRuntimeModule.getDistributedModule(cConf2);
     modules.add(coreSecurityModule);
     if (coreSecurityModule.requiresZKClient()) {
       modules.add(new ZKClientModule());

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/TestInMemoryTokenManager.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/TestInMemoryTokenManager.java
@@ -23,7 +23,7 @@ import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.common.utils.ImmutablePair;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 
 /**
  * Tests for InMemoryTokenManager that ensure that keys are maintained in memory and can be used to create
@@ -33,7 +33,7 @@ public class TestInMemoryTokenManager extends TestTokenManager {
 
   @Override
   protected ImmutablePair<TokenManager, Codec<AccessToken>> getTokenManagerAndCodec() {
-    Injector injector = Guice.createInjector(new IOModule(), new CoreSecurityModules().getStandaloneModules(),
+    Injector injector = Guice.createInjector(new IOModule(), new CoreSecurityRuntimeModule().getStandaloneModules(),
                                              new ConfigModule(), new InMemoryDiscoveryModule());
     TokenManager tokenManager = injector.getInstance(TokenManager.class);
     tokenManager.startAndWait();

--- a/cdap-security/src/test/java/io/cdap/cdap/security/server/ExternalAuthenticationServerTestBase.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/server/ExternalAuthenticationServerTestBase.java
@@ -35,7 +35,7 @@ import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.io.Codec;
 import io.cdap.cdap.security.auth.AccessToken;
 import io.cdap.cdap.security.auth.AccessTokenCodec;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -115,7 +115,7 @@ public abstract class ExternalAuthenticationServerTestBase {
         }
       });
     Injector injector = Guice.createInjector(new IOModule(), externalAuthenticationModule,
-                                             new CoreSecurityModules().getInMemoryModules(),
+                                             new CoreSecurityRuntimeModule().getInMemoryModules(),
                                              new ConfigModule(getConfiguration(configuration),
                                                               HBaseConfiguration.create(), sConfiguration),
                                              new InMemoryDiscoveryModule());

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -91,9 +91,10 @@ import io.cdap.cdap.metrics.process.loader.MetricsWriterModule;
 import io.cdap.cdap.metrics.query.MetricsQueryService;
 import io.cdap.cdap.operations.OperationalStatsService;
 import io.cdap.cdap.operations.guice.OperationalStatsModule;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityModules;
+import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
@@ -524,7 +525,7 @@ public class StandaloneMain {
       new LocalLogAppenderModule(),
       new LogReaderRuntimeModules().getStandaloneModules(),
       new RouterModules().getStandaloneModules(),
-      new CoreSecurityModules().getStandaloneModules(),
+      new CoreSecurityRuntimeModule().getStandaloneModules(),
       new ExternalAuthenticationModule(),
       new SecureStoreServerModule(),
       new ExploreRuntimeModule().getStandaloneModules(),
@@ -532,6 +533,7 @@ public class StandaloneMain {
       new MetadataServiceModule(),
       new MetadataReaderWriterModules().getStandaloneModules(),
       new AuditModule(),
+      new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getStandaloneModules(),
       new PreviewConfigModule(cConf, new Configuration(), SConfiguration.create()),

--- a/cdap-unit-test-base/src/test/java/io/cdap/cdap/spark/Spark2Test.java
+++ b/cdap-unit-test-base/src/test/java/io/cdap/cdap/spark/Spark2Test.java
@@ -271,12 +271,6 @@ public class Spark2Test extends TestBase {
 
   @Test
   public void testPySpark() throws Exception {
-    if (SparkCompatReader.getCurrentSparkCompat() == SparkCompat.SPARK3_2_12) {
-      //For spark 3 we need python 2.7 or higher
-      ComparableVersion pythonVersion = getPythonVersion();
-      assumeTrue("Wrong python2 version " + pythonVersion + ", need 2.7 or up",
-                 pythonVersion.compareTo(new ComparableVersion("2.7")) >= 0);
-    }
     ApplicationManager appManager = deploy(NamespaceId.DEFAULT, Spark2TestApp.class);
 
     // Write some data to a local file

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -122,6 +122,7 @@ import io.cdap.cdap.proto.profile.Profile;
 import io.cdap.cdap.proto.security.Authorizable;
 import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.runtime.spi.SparkCompat;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
 import io.cdap.cdap.scheduler.Scheduler;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
@@ -142,6 +143,7 @@ import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.package$;
 import org.apache.tephra.TransactionManager;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.tephra.inmemory.InMemoryTxSystemClient;
@@ -543,6 +545,9 @@ public class TestBase {
     // Speed up test
     cConf.setLong(Constants.Scheduler.EVENT_POLL_DELAY_MILLIS, 100L);
     cConf.setLong(Constants.AppFabric.STATUS_EVENT_POLL_DELAY_MILLIS, 100L);
+
+    // Set spark compat
+    cConf.set(Constants.AppFabric.SPARK_COMPAT, getCurrentSparkCompat().getCompat());
 
     return cConf;
   }
@@ -1134,5 +1139,17 @@ public class TestBase {
     previewCConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
 
     return previewCConf;
+  }
+
+  public static SparkCompat getCurrentSparkCompat() {
+    String sparkVersion = package$.MODULE$.SPARK_VERSION();
+    switch (sparkVersion.charAt(0)) {
+      case '3':
+        return SparkCompat.SPARK3_2_12;
+      case '2':
+        return SparkCompat.SPARK2_2_11;
+      default:
+        throw new IllegalStateException("Spark version " + sparkVersion + " is not known");
+    }
   }
 }

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -125,6 +125,7 @@ import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.runtime.spi.SparkCompat;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
 import io.cdap.cdap.scheduler.Scheduler;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.authorization.InvalidAccessControllerException;
@@ -279,6 +280,7 @@ public class TestBase {
       new InMemoryDiscoveryModule(),
       new AppFabricServiceRuntimeModule(cConf).getInMemoryModules(),
       new MonitorHandlerModule(false),
+      new AuthenticationContextModules().getMasterModule(),
       new AuthorizationModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
       new ProgramRunnerRuntimeModule().getInMemoryModules(),

--- a/pom.xml
+++ b/pom.xml
@@ -534,6 +534,10 @@
         <version>${twill.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>asm</groupId>
             <artifactId>asm</artifactId>
           </exclusion>
@@ -619,6 +623,10 @@
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -694,6 +702,10 @@
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
           </exclusion>
@@ -713,6 +725,10 @@
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -723,6 +739,10 @@
         <artifactId>hadoop-yarn-client</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
@@ -738,6 +758,10 @@
         <artifactId>hadoop-yarn-common</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
@@ -778,6 +802,10 @@
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -796,6 +824,10 @@
         <artifactId>hadoop-mapreduce-client-app</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
@@ -819,6 +851,10 @@
         <artifactId>hadoop-mapreduce-client-core</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
@@ -859,6 +895,10 @@
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -889,6 +929,10 @@
         <version>${hbase10.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>jdk.tools</groupId>
             <artifactId>jdk.tools</artifactId>
           </exclusion>
@@ -903,6 +947,10 @@
         <artifactId>hbase-client</artifactId>
         <version>${hbase10.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>jdk.tools</groupId>
             <artifactId>jdk.tools</artifactId>
@@ -927,6 +975,10 @@
         <version>${hbase10.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -937,6 +989,10 @@
         <artifactId>hbase-server</artifactId>
         <version>${hbase10.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
@@ -1511,6 +1567,10 @@
         <version>${spark3.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
           </exclusion>
@@ -1521,6 +1581,10 @@
         <artifactId>spark-sql_2.11</artifactId>
         <version>${spark2.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-compiler</artifactId>
@@ -1584,6 +1648,10 @@
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -1613,6 +1681,10 @@
         <version>${tez.version}</version>
         <scope>provided</scope>
         <exclusions>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>jdk.tools</groupId>
             <artifactId>jdk.tools</artifactId>
@@ -2088,7 +2160,7 @@
         <package.rpm.arch>all</package.rpm.arch>
         <package.dirs>opt etc</package.dirs>
         <package.config.dirs>--config-files etc/cdap --config-files etc/logrotate.d --config-files etc/security</package.config.dirs>
-        <dependency.groupId.exclusions>org.apache.hadoop,org.apache.hbase,org.apache.hive,com.google.protobuf,\
+        <dependency.groupId.exclusions>org.apache.hadoop,org.apache.hbase,org.apache.hive,\
           org.datanucleus,asm,org.apache.spark,slf4j-log4j12,commons-logging</dependency.groupId.exclusions>
       </properties>
       <build>


### PR DESCRIPTION
Why: the root cause of the issue were:

1. Time zone was not being set correctly when comparing modified time of cached artifact (in artifact localizer) and new modified time of artifact in app fabric.
2. The cached artifact timestamp was being saved with its milliseconds being set to 000. This though was not the case for the new modified time in app fabric. 

The above issues resulted in artifact localizer downloading artifacts every time (since timestamps were not equal) even though artifact localizer cached artifact hadn't been changed.  