### PR TITLE
CDAP-18176: Fix high latency issue when deploying pipelines in rbac enabled instances

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandlerInternal.java
@@ -57,10 +57,13 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Type;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.ws.rs.DefaultValue;
@@ -128,13 +131,22 @@ public class ArtifactHttpHandlerInternal extends AbstractHttpHandler {
       .add(HttpHeaderNames.LAST_MODIFIED, newModifiedDate.format(DateTimeFormatter.RFC_1123_DATE_TIME));
 
     String lastModified = request.headers().get(HttpHeaderNames.IF_MODIFIED_SINCE);
-    if (!Strings.isNullOrEmpty(lastModified) &&
-      newModifiedDate.equals(ZonedDateTime.parse(lastModified, DateTimeFormatter.RFC_1123_DATE_TIME))) {
+    if (areDatesEqual(lastModified, newModifiedDate)) {
       responder.sendStatus(HttpResponseStatus.NOT_MODIFIED, headers);
       return;
     }
-
     responder.sendContent(HttpResponseStatus.OK, new LocationBodyProducer(location), headers);
+  }
+
+  private boolean areDatesEqual(String lastModifiedDate, ZonedDateTime newModifiedDate) {
+    if (Strings.isNullOrEmpty(lastModifiedDate) || newModifiedDate == null) {
+      return false;
+    }
+    //We truncate milliseconds from timestamps when comparing them.
+    //Reason: newModifiedDate may contain millisecond while lastModifiedDate may not.
+    Comparator<ZonedDateTime> comparator = Comparator.comparing(zdt -> zdt.truncatedTo(ChronoUnit.SECONDS));
+    return comparator.compare(newModifiedDate, ZonedDateTime
+      .of(LocalDateTime.parse(lastModifiedDate, DateTimeFormatter.RFC_1123_DATE_TIME), ZoneId.of("GMT"))) == 0;
   }
 
   @GET


### PR DESCRIPTION
Why: the root cause of the issue were:
	1.	Time zone was not being set correctly when comparing modified time of cached artifact (in artifact localizer) and new modified time of artifact in app fabric.
	2.	The cached artifact timestamp was being saved with its milliseconds being set to 000. This though was not the case for the new modified time in app fabric.
The above issues resulted in artifact localizer downloading artifacts every time (since timestamps were not equal) even though artifact localizer cached artifact hadn't been changed.
