### PR TITLE
Skip schema deserialization and hash computation if it's already in cache

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/data/format/StructuredRecord.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/data/format/StructuredRecord.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.data.schema.Schema.LogicalType;
+import io.cdap.cdap.api.data.schema.SchemaCache;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -52,7 +53,6 @@ import javax.annotation.Nullable;
 @Beta
 public class StructuredRecord implements Serializable {
   private static final SimpleDateFormat DEFAULT_FORMAT = new SimpleDateFormat("YYYY-MM-DD'T'HH:mm:ss z");
-  private static final LRUCache<String, Schema> SCHEMA_CACHE = new LRUCache<>(100);
 
   private final Schema schema;
   private final Map<String, Object> fields;
@@ -64,7 +64,7 @@ public class StructuredRecord implements Serializable {
   }
 
   private StructuredRecord(Schema schema, Map<String, Object> fields) {
-    this.schema = SCHEMA_CACHE.putIfAbsent(schema.getSchemaHash().toString(), schema);
+    this.schema = SchemaCache.intern(schema);
     this.fields = fields;
   }
 

--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/data/schema/SchemaCache.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/data/schema/SchemaCache.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.data.schema;
+
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+
+import java.io.IOException;
+
+/**
+ * Class that provides a JVM-singleton schema cache. There are two ways to use it:
+ * <ul>
+ *   <li>If you already has a schema object, you can deduplicate it using {@link #intern(Schema) method}</li>
+ *   <li>If you have a schema hash string and schema JSON representation, use {@link #fromJson(String, String)}
+ *   method. This would allow you to skip schema deserialization if schema is already in the cache.
+ *   </li>
+ *   <li>If you have a top schema JSON previously produced by {@link Schema#toString()} you can use
+ *   {@link #parseJson(String)} that will compute a hash out of json. Note that you should not use any modified
+ *   (e.g. indented) json as a different hash would be computed and cache slot will be wasted. Also you should use it
+ *   only for top level schemas for not to pollute cache.
+ *   </li>
+ * </ul>
+ */
+public class SchemaCache {
+  private static final LRUCache<String, Schema> SCHEMA_CACHE = new LRUCache<>(100);
+  private static final SchemaTypeAdapter SCHEMA_TYPE_ADAPTER = new SchemaTypeAdapter();
+
+  public static final Schema intern(Schema schema) {
+    return SCHEMA_CACHE.putIfAbsent(schema.getSchemaHash().toString(), schema);
+  }
+
+  public static final Schema fromJson(String schemaHashStr, String json) {
+    return SCHEMA_CACHE.computeIfAbsent(schemaHashStr, () -> {
+      try {
+        return SCHEMA_TYPE_ADAPTER.fromJson(json);
+      } catch (IOException e) {
+        throw new IllegalArgumentException("Can't parse schema", e);
+      }
+    });
+  }
+}

--- a/cdap-api-common/src/test/java/io/cdap/cdap/api/data/schema/LRUCacheTest.java
+++ b/cdap-api-common/src/test/java/io/cdap/cdap/api/data/schema/LRUCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Cask Data, Inc.
+ * Copyright © 2020-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.api.data.format;
+package io.cdap.cdap.api.data.schema;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -29,6 +29,16 @@ public class LRUCacheTest {
     LRUCache<String, Integer> cache = new LRUCache<>(1);
     Assert.assertEquals(Integer.valueOf(1), cache.putIfAbsent("key1", 1));
     Assert.assertEquals(Integer.valueOf(2), cache.putIfAbsent("key2", 2));
+
+    Assert.assertNull(cache.get("key1"));
+    Assert.assertEquals(Integer.valueOf(2), cache.get("key2"));
+  }
+
+  @Test
+  public void testCacheCompute() {
+    LRUCache<String, Integer> cache = new LRUCache<>(1);
+    Assert.assertEquals(Integer.valueOf(1), cache.computeIfAbsent("key1", () -> 1));
+    Assert.assertEquals(Integer.valueOf(2), cache.computeIfAbsent("key2", () -> 2));
 
     Assert.assertNull(cache.get("key1"));
     Assert.assertEquals(Integer.valueOf(2), cache.get("key2"));

--- a/cdap-common/src/test/java/io/cdap/cdap/io/SchemaTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/io/SchemaTest.java
@@ -22,11 +22,13 @@ import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.data.schema.SchemaCache;
 import io.cdap.cdap.api.data.schema.UnsupportedTypeException;
 import io.cdap.cdap.internal.io.ReflectionSchemaGenerator;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
+import org.apache.commons.lang.SerializationUtils;
 import org.codehaus.jackson.node.IntNode;
 import org.codehaus.jackson.node.TextNode;
 import org.junit.Assert;
@@ -658,6 +660,12 @@ public class SchemaTest {
 
   private org.apache.avro.Schema convertSchema(Schema cdapSchema) {
     return new org.apache.avro.Schema.Parser().parse(cdapSchema.toString());
+  }
+
+  @Test
+  public void testCachedJavaSerialization() throws UnsupportedTypeException {
+    Schema s1 = SchemaCache.intern(new ReflectionSchemaGenerator().generate(Node.class));
+    Assert.assertSame(s1, SerializationUtils.clone(s1));
   }
 
   private void verifyThrowsException(String toParse) {

--- a/cdap-spark-core-base/src/test/java/io/cdap/cdap/app/runtime/spark/serializer/KryoSerializerTest.java
+++ b/cdap-spark-core-base/src/test/java/io/cdap/cdap/app/runtime/spark/serializer/KryoSerializerTest.java
@@ -246,6 +246,11 @@ public class KryoSerializerTest {
     // The StructuredRecord.equals is broken, Json it and compare for now
     Assert.assertEquals(StructuredRecordStringConverter.toJsonString(record),
                         StructuredRecordStringConverter.toJsonString(newRecord));
+
+    // Verify that schema is deserialized only once and then cached
+    input = new Input(bos.toByteArray());
+    StructuredRecord newRecord2 = kryo.readObject(input, StructuredRecord.class);
+    Assert.assertSame(newRecord.getSchema(), newRecord2.getSchema());
   }
 
   @Test


### PR DESCRIPTION
To achieve this:

 * Serialize hash separately, so that we don't need to compute it once again for each record on deserialization
 * Serialize schema as json string to be able to skip deserialization efficiently. String is still read, but as soon as schema hash is in cache string is not parsed, but cached Schema is returned