### PR TITLE
[CDAP-18273] Runtime Identity Propagation

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1128,6 +1128,10 @@ public final class Constants {
     /** Requires all intra-cluster communications to be authenticated. */
     public static final String INTERNAL_AUTH_ENABLED = "security.internal.auth.enabled";
 
+    /** This is a backwards compatibility measure which disables the usage of the RuntimeIdentityHandler. */
+    public static final String RUNTIME_IDENTITY_COMPATIBILITY_ENABLED =
+      "security.runtime.identity.compatibility.enabled";
+
     /**
      * App Fabric
      */

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4201,6 +4201,15 @@
     </description>
   </property>
 
+  <property>
+    <name>security.runtime.identity.compatibility.enabled</name>
+    <value>true</value>
+    <description>
+      A backwards-compatibility setting which does not add the runtime identity handler to the runtime service. This
+      setting is enabled by default for backwards compatibility but should not be used for new secure deployments.
+    </description>
+  </property>
+
   <!-- UI Configuration -->
 
   <property>


### PR DESCRIPTION
Only propagate runtime identity if internal auth is enabled.

For additional details, see [CDAP-18273](https://cdap.atlassian.net/browse/CDAP-18273).