### PR TITLE
CDAP-18272: Fix missing binding for InternalAuthenticator

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppTask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppTask.java
@@ -46,6 +46,7 @@ import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.guice.SecureStoreClientModule;
 import io.cdap.cdap.security.impersonation.EntityImpersonator;
 import io.cdap.cdap.security.impersonation.Impersonator;
@@ -114,6 +115,7 @@ public class SystemAppTask implements RunnableTask {
       new MessagingClientModule(),
       new LocalLocationModule(),
       new SecureStoreClientModule(),
+      new AuthenticationContextModules().getMasterModule(),
       new SystemAppModule());
   }
 


### PR DESCRIPTION
Otherwise wrangler fails to load data with the following error

1) No implementation for io.cdap.cdap.common.internal.remote.InternalAuthenticator was bound.
   while locating io.cdap.cdap.common.internal.remote.InternalAuthenticator
    for parameter 1 at io.cdap.cdap.common.internal.remote.RemoteClientFactory.<init>(RemoteClientFactory.java:36)
   while locating io.cdap.cdap.common.internal.remote.RemoteClientFactory
     for parameter 0 at io.cdap.cdap.security.store.client.RemoteSecureStore.<init>(RemoteSecureStore.java:58)
   at io.cdap.cdap.security.guice.SecureStoreClientModule.configure(SecureStoreClientModule.java:33)

...

6) No implementation for io.cdap.cdap.common.internal.remote.InternalAuthenticator was bound.
  while locating io.cdap.cdap.common.internal.remote.InternalAuthenticator
    for parameter 1 at io.cdap.cdap.common.internal.remote.RemoteClientFactory.<init>(RemoteClientFactory.java:36)
  while locating io.cdap.cdap.common.internal.remote.RemoteClientFactory
    for parameter 1 at io.cdap.cdap.internal.app.worker.RemoteWorkerPluginFinder.<init>(RemoteWorkerPluginFinder.java:42)
  at io.cdap.cdap.internal.app.worker.SystemAppModule.configure(SystemAppModule.java:70)