### PR TITLE
[CDAP-18172] Use Proper Authentication Context for System Apps

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
@@ -73,7 +73,6 @@ import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.NoOpOwnerAdmin;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
-import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.spi.metadata.noop.NoopMetadataStorage;
@@ -232,15 +231,8 @@ public class DistributedProgramContainerModule extends AbstractModule {
 
   private void addOnPremiseModules(List<Module> modules) {
     CoreSecurityModule coreSecurityModule = CoreSecurityRuntimeModule.getDistributedModule(cConf);
-
-    // Within k8s when internal authorization is enabled we use a generated token
-    // Otherwise just add a NoOp module to satisfy dependencies
-    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
-      modules.add(new AuthenticationContextModules().getMasterModule());
-      modules.add(coreSecurityModule);
-    } else {
-      modules.add(new AuthenticationContextModules().getNoOpModule());
-    }
+    modules.add(new AuthenticationContextModules().getMasterModule());
+    modules.add(coreSecurityModule);
 
     // If MasterEnvironment is not available, assuming it is the old hadoop stack with ZK, Kafka
     MasterEnvironment masterEnv = MasterEnvironments.getMasterEnvironment();


### PR DESCRIPTION
System apps need to use the master authentication context because they are handling user-facing requests. For additional details, see [CDAP-18172](https://cdap.atlassian.net/browse/CDAP-18172).