### PR TITLE
CDAP-18265  - Remove unnecessary log message to prevent flooding the logs.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
@@ -287,7 +287,7 @@ class CapabilityApplier {
 
   private void deployAllSystemApps(String capability, List<SystemApplication> applications)  {
     if (applications.isEmpty()) {
-      LOG.debug("Capability {} do not have apps associated with it", capability);
+      //skip logging here to prevent flooding the logs
       return;
     }
     try {


### PR DESCRIPTION
CDAP-18265  - Remove unnecessary log message to prevent flooding the logs.