### PR TITLE
CDAP-18293  - Retry for 503 error while creating dataproc client

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -18,6 +18,8 @@ package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.gax.core.CredentialsProvider;
@@ -123,7 +125,8 @@ class DataprocClient implements AutoCloseable {
    * @throws IOException if failed to connect to GCP api during the client creation
    * @throws GeneralSecurityException if the client is failed to authenticate
    */
-  static DataprocClient fromConf(DataprocConf conf) throws IOException, GeneralSecurityException {
+  static DataprocClient fromConf(DataprocConf conf) throws IOException, GeneralSecurityException,
+    RetryableProvisionException {
     return fromConf(conf, true);
   }
 
@@ -140,7 +143,20 @@ class DataprocClient implements AutoCloseable {
    * @throws GeneralSecurityException if the client is failed to authenticate
    */
   static DataprocClient fromConf(DataprocConf conf,
-                                 boolean requireNetwork) throws IOException, GeneralSecurityException {
+                                 boolean requireNetwork) throws IOException, GeneralSecurityException,
+    RetryableProvisionException {
+    try {
+      return getDataprocClient(conf, requireNetwork);
+    } catch (HttpResponseException e) {
+      if (e.getStatusCode() == HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE) {
+        throw new RetryableProvisionException(e);
+      }
+      throw e;
+    }
+  }
+
+  private static DataprocClient getDataprocClient(DataprocConf conf,
+                                                  boolean requireNetwork) throws IOException, GeneralSecurityException {
     ClusterControllerClient client = getClusterControllerClient(conf);
     Compute compute = getCompute(conf);
 

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -387,7 +387,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
   }
 
   @VisibleForTesting
-  protected DataprocClient getClient(DataprocConf conf) throws IOException, GeneralSecurityException {
+  protected DataprocClient getClient(DataprocConf conf) throws IOException, GeneralSecurityException,
+    RetryableProvisionException {
     return DataprocClient.fromConf(conf);
   }
 

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.SparkCompat;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
+import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -67,7 +68,7 @@ public class DataprocProvisionerTest {
   MockProvisionerContext context = new MockProvisionerContext();
 
   @Before
-  public void init() throws IOException, GeneralSecurityException {
+  public void init() throws IOException, GeneralSecurityException, RetryableProvisionException {
     Mockito.doReturn(dataprocClient).when(provisioner).getClient(Mockito.any());
     MockProvisionerSystemContext provisionerSystemContext = new MockProvisionerSystemContext();
 


### PR DESCRIPTION
Fix for CDAP-18293  - Retry for 503 error while creating dataproc client