### PR TITLE
[CDAP-17858] Fix Upgrade and Post Upgrade Jobs to Work with Proxy Auth Mode

### DIFF
--- a/cdap-client/src/main/java/io/cdap/cdap/client/config/ClientConfig.java
+++ b/cdap-client/src/main/java/io/cdap/cdap/client/config/ClientConfig.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.client.config;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.client.exception.DisconnectedException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -26,6 +27,8 @@ import io.cdap.common.http.HttpRequestConfig;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -56,12 +59,14 @@ public class ClientConfig {
   private int unavailableRetryLimit;
   private String apiVersion;
   private Supplier<AccessToken> accessToken;
+  private Map<String, String> additionalHeaders;
 
   private ClientConfig(@Nullable ConnectionConfig connectionConfig,
                        boolean verifySSLCert, int unavailableRetryLimit,
                        String apiVersion, Supplier<AccessToken> accessToken,
                        int defaultReadTimeout, int defaultConnectTimeout,
-                       int uploadReadTimeout, int uploadConnectTimeout) {
+                       int uploadReadTimeout, int uploadConnectTimeout,
+                       Map<String, String> additionalHeaders) {
     this.connectionConfig = connectionConfig;
     this.verifySSLCert = verifySSLCert;
     this.apiVersion = apiVersion;
@@ -71,6 +76,7 @@ public class ClientConfig {
     this.defaultConnectTimeout = defaultConnectTimeout;
     this.uploadReadTimeout = uploadReadTimeout;
     this.uploadConnectTimeout = uploadConnectTimeout;
+    this.additionalHeaders = additionalHeaders;
   }
 
   public static ClientConfig getDefault() {
@@ -158,6 +164,10 @@ public class ClientConfig {
 
   public int getUploadConnectTimeout() {
     return uploadConnectTimeout;
+  }
+
+  public Map<String, String> getAdditionalHeaders() {
+    return additionalHeaders;
   }
 
   public void setConnectionConfig(@Nullable ConnectionConfig connectionConfig) {
@@ -255,6 +265,7 @@ public class ClientConfig {
     private int defaultConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
 
     private int unavailableRetryLimit = DEFAULT_SERVICE_UNAVAILABLE_RETRY_LIMIT;
+    private Map<String, String> additionalHeaders = new HashMap<>();
 
     public Builder() { }
 
@@ -320,11 +331,16 @@ public class ClientConfig {
       return this;
     }
 
+    public Builder addAdditionalHeader(String header, String value) {
+      this.additionalHeaders.put(header, value);
+      return this;
+    }
+
     public ClientConfig build() {
       return new ClientConfig(connectionConfig, verifySSLCert,
                               unavailableRetryLimit, apiVersion, accessToken,
                               defaultReadTimeout, defaultConnectTimeout,
-                              uploadReadTimeout, uploadConnectTimeout);
+                              uploadReadTimeout, uploadConnectTimeout, ImmutableMap.copyOf(additionalHeaders));
     }
   }
 

--- a/cdap-client/src/main/java/io/cdap/cdap/client/util/RESTClient.java
+++ b/cdap-client/src/main/java/io/cdap/cdap/client/util/RESTClient.java
@@ -167,9 +167,12 @@ public class RESTClient {
   }
 
   private Map<String, String> getAuthHeaders(AccessToken accessToken) {
-    Map<String, String> headers = ImmutableMap.of();
+    Map<String, String> headers = clientConfig.getAdditionalHeaders();
     if (accessToken != null) {
-      headers = ImmutableMap.of(HttpHeaders.AUTHORIZATION, accessToken.getTokenType() + " " + accessToken.getValue());
+      ImmutableMap.Builder<String, String> headersBuilder = ImmutableMap.builder();
+      headersBuilder.putAll(headers);
+      headersBuilder.put(HttpHeaders.AUTHORIZATION, accessToken.getTokenType() + " " + accessToken.getValue());
+      headers = headersBuilder.build();
     }
     return headers;
   }

--- a/cdap-master/src/main/java/io/cdap/cdap/master/upgrade/UpgradeUserIDProvider.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/upgrade/UpgradeUserIDProvider.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.cdap.master.upgrade;
+
+import com.google.common.base.Throwables;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.io.IOException;
+
+/**
+ * Provides a user ID to use for upgrade and post-upgrade jobs based on the {@link UserGroupInformation}.
+ */
+public class UpgradeUserIDProvider {
+
+  /**
+   * @return The user ID obtained from the UGI.
+   */
+  public static String getUserID() {
+    // For backwards compatibility, the upgrade job should assume the same local identity as other pods.
+    // This may not work if Kerberos is enabled in the cluster.
+    String userId;
+    try {
+      userId = UserGroupInformation.getCurrentUser().getShortUserName();
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    return userId;
+  }
+}

--- a/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/SecurityUtil.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/SecurityUtil.java
@@ -149,6 +149,19 @@ public final class SecurityUtil {
   }
 
   /**
+   * Checks if perimeter security is enabled in proxy mode.
+   *
+   * @return {@code true} if security enabled in proxy mode
+   * @see Constants.Security#ENABLED
+   * @see Constants.Security.Authentication#MODE
+   */
+  public static boolean isProxySecurity(CConfiguration cConf) {
+    return cConf.getBoolean(Constants.Security.ENABLED)
+      && cConf.getEnum(Constants.Security.Authentication.MODE,
+                       AuthenticationMode.MANAGED).equals(AuthenticationMode.PROXY);
+  }
+
+  /**
    * Checks if internal authenticated communication should be enforced.
    *
    * @return {@code true} if internal auth is enabled.


### PR DESCRIPTION
For info, see the [Proxy Authentication Mode](https://cdap.atlassian.net/wiki/spaces/DOCS/pages/1162641409/Configuring+Proxy+Authentication+Mode) documentation.

This bug occurs because, in proxy authentication mode, the CDAP router expects the header key defined by the `security.authentication.proxy.user.identity.header` configuration to be set in all cases; otherwise it returns unauthenticated. As such, the upgrade and post-upgrade jobs will fail in proxy auth mode since they don't set the header, and they make requests through the CDAP router.

This PR adds a configuration option in ClientConfig to support adding extra headers for all requests, and, during upgrade jobs, the extra header is parsed from the `security.authentication.proxy.user.identity.header` configuration.

See [CDAP-17858](https://cdap.atlassian.net/browse/cdap-17858) for details.