### PR TITLE
[CDAP-18303] Fix Compute Credentials Bug

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -36,6 +36,7 @@ import com.google.api.services.compute.model.Instance;
 import com.google.api.services.compute.model.Network;
 import com.google.api.services.compute.model.NetworkList;
 import com.google.api.services.compute.model.NetworkPeering;
+import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.cloud.dataproc.v1.AutoscalingConfig;
 import com.google.cloud.dataproc.v1.Cluster;
 import com.google.cloud.dataproc.v1.ClusterConfig;
@@ -330,7 +331,8 @@ class DataprocClient implements AutoCloseable {
    */
   private static Compute getCompute(DataprocConf conf) throws GeneralSecurityException, IOException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-    return new Compute.Builder(httpTransport, JacksonFactory.getDefaultInstance(), conf.getComputeCredential())
+    return new Compute.Builder(httpTransport, JacksonFactory.getDefaultInstance(),
+                               new HttpCredentialsAdapter(conf.getComputeCredential()))
       .setApplicationName("cdap")
       .build();
   }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Strings;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
@@ -434,17 +433,16 @@ final class DataprocConf {
   }
 
   /**
-   * @return GoogleCredential for use with Compute
+   * @return GoogleCredentials for use with Compute
    * @throws IOException if there was an error reading the account key
    */
-  GoogleCredential getComputeCredential() throws IOException {
+  GoogleCredentials getComputeCredential() throws IOException {
     if (accountKey == null) {
-      return GoogleCredential.getApplicationDefault();
+      return ComputeEngineCredentials.getOrCreate(tokenEndpoint);
     }
 
     try (InputStream is = new ByteArrayInputStream(accountKey.getBytes(StandardCharsets.UTF_8))) {
-      return GoogleCredential.fromStream(is)
-        .createScoped(Collections.singleton(CLOUD_PLATFORM_SCOPE));
+      return GoogleCredentials.fromStream(is).createScoped(Collections.singleton(CLOUD_PLATFORM_SCOPE));
     }
   }
 


### PR DESCRIPTION
The [`getComputeCredential()` method](https://github.com/cdapio/cdap/blob/391ddeb49769cc68293c3d05cd8a4b650882291c/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java#L440) is using the local application default credentials when it should be using the same credentials as the worker pod to launch Dataproc jobs.