### PR TITLE
Added a method to create nameless record type in Schema

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/data/schema/Schema.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/data/schema/Schema.java
@@ -38,6 +38,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import javax.annotation.Nullable;
 
 /**
@@ -454,6 +455,37 @@ public final class Schema implements Serializable {
       throw new IllegalArgumentException("Record name cannot be null.");
     }
     return new Schema(Type.RECORD, null, null, null, null, null, name, null, null, 0, 0);
+  }
+
+  /**
+   * Creates a {@link Type#RECORD RECORD} {@link Schema} with a name based its {@link Field Fields}.
+   * The ordering of the fields inside the record would be the same as the one being passed in.
+   *
+   * @param fields All the fields that the record contains.
+   * @return A {@link Schema} of {@link Type#RECORD RECORD} type.
+   */
+  public static Schema recordOf(Field...fields) {
+    return recordOf(Arrays.asList(fields));
+  }
+
+  /**
+   * Creates a {@link Type#RECORD RECORD} {@link Schema} with a name based on its {@link Field Fields}.
+   * The ordering of the fields inside the record would be the same as the {@link Iterable#iterator()} order.
+   *
+   * @param fields All the fields that the record contains.
+   * @return A {@link Schema} of {@link Type#RECORD RECORD} type.
+   */
+  public static Schema recordOf(Iterable<Field> fields) {
+    // We generate a temporary random name for the record.
+    // The name has to be different from all its child schemas, as AVRO does not allow to redefine a record
+    // The name will not be part of the final hash
+    String tempName = UUID.randomUUID().toString().replace("-", "");
+    Schema tempRecord = recordOf(tempName, fields);
+
+    // SchemaHash ignores the record name when receiving false as its second parameter.
+    SchemaHash schemaHash = new SchemaHash(tempRecord, false);
+    String hashName = schemaHash.toString();
+    return recordOf(hashName, fields);
   }
 
   /**

--- a/cdap-api-common/src/test/java/io/cdap/cdap/api/data/schema/SchemaTest.java
+++ b/cdap-api-common/src/test/java/io/cdap/cdap/api/data/schema/SchemaTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.data.schema;
+
+import io.cdap.cdap.api.data.schema.Schema.Field;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Test Schema Class
+ */
+public class SchemaTest {
+
+  private Schema createNamelessRecord1() {
+    Field stringField = Field.of("stringField", Schema.of(Schema.Type.STRING));
+    Field longField = Field.of("numericField", Schema.of(Schema.Type.LONG));
+    Field booleanField = Field.of("booleanField", Schema.of(Schema.Type.BOOLEAN));
+    Field namelessRecordField = Field.of("namelessRecord", Schema.recordOf(booleanField));
+    Field recordField = Field.of("namedRecord", Schema.recordOf("namedRecord", stringField, longField));
+    return Schema.recordOf(recordField, namelessRecordField);
+  }
+
+  private Schema createNamelessRecord2() {
+    Field stringField = Field.of("stringField", Schema.of(Schema.Type.STRING));
+    Field booleanField = Field.of("booleanField", Schema.of(Schema.Type.BOOLEAN));
+    Field namelessRecordField = Field.of("namelessRecord", Schema.recordOf(booleanField));
+    Field recordField = Field.of("namedRecord", Schema.recordOf("namedRecord", stringField));
+    return Schema.recordOf(recordField, namelessRecordField);
+  }
+
+  /**
+   * Checks if two nameless records with the same field have the same hashes and names
+   */
+  @Test
+  public void test_SameHashNamelessRecords() {
+    Schema namelessRecord1 = createNamelessRecord1();
+    Schema namelessRecord2 = createNamelessRecord1();
+    Assert.assertEquals(namelessRecord1.getRecordName(), namelessRecord2.getRecordName());
+    Assert.assertEquals(namelessRecord1, namelessRecord2);
+  }
+
+
+  /**
+   * Checks if two nameless records with different field have different hashes and names
+   */
+  @Test
+  public void test_DifferentHashNamelessRecords() {
+    Schema namelessRecord1 = createNamelessRecord1();
+    Schema namelessRecord2 = createNamelessRecord2();
+    Assert.assertNotEquals(namelessRecord1.getRecordName(), namelessRecord2.getRecordName());
+    Assert.assertNotEquals(namelessRecord1, namelessRecord2);
+  }
+
+}


### PR DESCRIPTION
Added a method to create nameless record type in Schema.  Nameless records are records whose type names are generated based on the record fields