### PR TITLE
Added support for instance Id logic in k8s environment

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -170,7 +170,8 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     } else {
       pollerInfo = new PreviewRequestPollerInfo(context.getInstanceId(), null);
     }
-    LOG.debug("Initializing preview runner with poller info {}", pollerInfo);
+    LOG.debug("Initializing preview runner with poller info {} in total {} runners",
+              pollerInfo, context.getInstanceCount());
 
     Injector injector = createInjector(cConf, hConf, pollerInfo);
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
@@ -27,7 +27,6 @@ import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
-import io.cdap.cdap.master.spi.twill.TwillConstants;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.security.impersonation.Impersonator;
@@ -37,7 +36,6 @@ import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
 
 import java.io.File;
-import java.util.Collections;
 
 /**
  * Distributed ProgramRunner for Worker.
@@ -82,9 +80,5 @@ public class DistributedWorkerProgramRunner extends DistributedProgramRunner
     launchConfig.addRunnable(workerSpec.getName(), new WorkerTwillRunnable(workerSpec.getName()),
                              Integer.parseInt(instances), options.getUserArguments().asMap(),
                              workerSpec.getResources());
-    if (clusterMode == ClusterMode.ON_PREMISE) {
-      launchConfig.addExtraRuntimeArgs(
-        Collections.singletonMap(TwillConstants.PROGRAM_RUNTIME_ENV_PARALLELISM, instances));
-    }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
@@ -157,12 +157,16 @@ public class TaskWorkerTwillRunnable extends AbstractTwillRunnable {
   @Override
   public void stop() {
     LOG.info("Stopping task worker");
-    taskWorker.stop();
+    if (taskWorker != null) {
+      taskWorker.stop();
+    }
   }
 
   @Override
   public void destroy() {
-    logAppenderInitializer.close();
+    if (logAppenderInitializer != null) {
+      logAppenderInitializer.close();
+    }
   }
 
   private void doInitialize(TwillContext context) throws Exception {

--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -33,7 +33,7 @@
     <!-- Needs to bump the okhttp version for fixing https://github.com/square/okhttp/issues/4029 that hangs on exit -->
     <okhttp.version>4.9.1</okhttp.version>
     <!-- Needs to define the gson and guava versions to override the one from dependency management in cdap pom.xml -->
-    <gson.version>2.6.2</gson.version>
+    <gson.version>2.8.6</gson.version>
     <guava.version>25.1-jre</guava.version>
   </properties>
 

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillLauncher.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillLauncher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Cask Data, Inc.
+ * Copyright © 2020-2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -25,11 +25,8 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnable;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnableContext;
 import io.kubernetes.client.openapi.ApiClient;
-import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1DeleteOptions;
-import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1Preconditions;
 import io.kubernetes.client.util.Config;
 import org.apache.twill.api.RunId;
@@ -43,7 +40,6 @@ import org.apache.twill.internal.utils.Instances;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -53,8 +49,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A {@link MasterEnvironmentRunnable} for running {@link TwillRunnable} in the current process.
@@ -63,7 +57,6 @@ public class KubeTwillLauncher implements MasterEnvironmentRunnable {
 
   private static final Logger LOG = LoggerFactory.getLogger(KubeTwillLauncher.class);
   private static final Gson GSON = new Gson();
-  private static final String JOB_INSTANCES = "job-instances";
 
   private final MasterEnvironmentRunnableContext context;
   private final KubeMasterEnvironment masterEnv;
@@ -116,13 +109,11 @@ public class KubeTwillLauncher implements MasterEnvironmentRunnable {
       }
 
       twillRunnable = (TwillRunnable) Instances.newInstance(runnableClass);
-      InstanceInfo instanceInfo = claimInstanceId(podInfo);
 
       try (KubeTwillContext twillContext = new KubeTwillContext(runtimeSpec, runId,
                                                                 RunIds.fromString(runId.getId() + "-0"),
                                                                 appArgs.toArray(new String[0]),
-                                                                runnableArgs.toArray(new String[0]), masterEnv,
-                                                                instanceInfo.instanceId, instanceInfo.instanceCount)) {
+                                                                runnableArgs.toArray(new String[0]), masterEnv)) {
         twillRunnable.initialize(twillContext);
         if (!stopped) {
           twillRunnable.run();
@@ -155,7 +146,6 @@ public class KubeTwillLauncher implements MasterEnvironmentRunnable {
     }
   }
 
-
   private void deletePod(PodInfo podInfo) {
     try {
       ApiClient apiClient = Config.defaultClient();
@@ -165,85 +155,6 @@ public class KubeTwillLauncher implements MasterEnvironmentRunnable {
                                    null, null, null, null, delOptions, new ApiCallbackAdapter<>());
     } catch (Exception e) {
       LOG.warn("Failed to delete pod {} with uid {}", podInfo.getName(), podInfo.getUid(), e);
-    }
-  }
-
-  /**
-   * Claims instance id from the annotation. When a job is submitted with parallelism > 1, it has job annotation that
-   * is used to claim instance ids.
-   * For example, a job, submitted with parallelism 3, will have annotation "job-instance" -> [false, false, false]
-   * upon startup. Each of the three KubeTwillLauncher containers running on 3 different pods will try to claim an
-   * instance id by generating random number representing index in the boolean array.
-   * In case a given index is already claimed, 409 will be returned by kubernetes. When that happens, we will retry
-   * the attempt to claim the instance id by generating another random number.
-   *
-   * When this process is complete, job will have annotation as "job-instance" -> [true, true, true]
-   */
-  private InstanceInfo claimInstanceId(PodInfo podInfo) throws Exception {
-    int instanceId = 0;
-    int instanceCount = 1;
-
-    if (!podInfo.getOwnerReferences().stream().anyMatch(r -> "Job".equals(r.getKind()))) {
-      return new InstanceInfo(instanceId, instanceCount);
-    }
-
-    String jobName = podInfo.getOwnerReferences().get(0).getName();
-    ApiClient client = Config.defaultClient();
-    BatchV1Api batchApi = new BatchV1Api(client);
-    Random rand = new Random();
-
-    try {
-      V1Job v1Job = batchApi.readNamespacedJob(jobName, podInfo.getNamespace(), null, null, null);
-      Map<String, String> annotations = v1Job.getMetadata().getAnnotations();
-
-      if (!annotations.containsKey(JOB_INSTANCES)) {
-        // this means parallelism is 1. No further processing is needed
-        return new InstanceInfo(instanceId, instanceCount);
-      }
-
-      boolean done = false;
-      int randomNumber = 0;
-      while (!done) {
-        v1Job = batchApi.readNamespacedJob(jobName, podInfo.getNamespace(), null, null, null);
-        annotations = v1Job.getMetadata().getAnnotations();
-        boolean[] jobInstances = GSON.fromJson(annotations.get(JOB_INSTANCES), boolean[].class);
-        do {
-          // make sure we choose index that is still unreserved yet
-          randomNumber = rand.nextInt(jobInstances.length);
-        } while ((jobInstances[randomNumber]));
-
-        // reserve the chosen index
-        jobInstances[randomNumber] = true;
-        annotations.put(JOB_INSTANCES, GSON.toJson(jobInstances));
-        v1Job.getMetadata().setAnnotations(annotations);
-
-        try {
-          batchApi.replaceNamespacedJob(jobName, podInfo.getNamespace(), v1Job, null, null, null);
-          instanceCount = jobInstances.length;
-          done = true;
-        } catch (ApiException e) {
-          if (e.getCode() == 409) {
-
-            LOG.debug("Conflict occurred while updating the job, operation will be be retried.", e);
-          } else {
-            throw e;
-          }
-        }
-      }
-      instanceId = randomNumber;
-    } catch (ApiException e) {
-      throw new IOException(e.getResponseBody(), e);
-    }
-    return new InstanceInfo(instanceId, instanceCount);
-  }
-
-  static class InstanceInfo {
-    int instanceId;
-    int instanceCount;
-
-    InstanceInfo(int instanceId, int instanceCount) {
-      this.instanceId = instanceId;
-      this.instanceCount = instanceCount;
     }
   }
 }

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/TwillConstants.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/TwillConstants.java
@@ -22,5 +22,4 @@ package io.cdap.cdap.master.spi.twill;
 public class TwillConstants {
   // Configuration used to determine whether to use V1Job to launch twill runnables.
   public static final String PROGRAM_RUNTIME_ENV = "program.runtime.env";
-  public static final String PROGRAM_RUNTIME_ENV_PARALLELISM = "program.runtime.env.parallelism";
 }


### PR DESCRIPTION
- Works for all supported resources type (Deployment, StatefulSet, Job)
- Handling of scaling up and down
- Handling of pod restart correctly
  - Old logic can create infinite loop