### PR TITLE
CDAP-18337 fix connection macro encode

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineConnectionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineConnectionTest.java
@@ -86,6 +86,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -298,8 +300,8 @@ public class DataPipelineConnectionTest extends HydratorTestBase {
   }
 
   private void testUsingConnections(Engine engine) throws Exception {
-    String sourceConnName = "sourceConn" + engine;
-    String sinkConnName = "sinkConn" + engine;
+    String sourceConnName = "sourceConn " + engine;
+    String sinkConnName = "sinkConn " + engine;
     String srcTableName = "src" + engine;
     String sinkTableName = "sink" + engine;
 
@@ -389,9 +391,10 @@ public class DataPipelineConnectionTest extends HydratorTestBase {
   }
 
   private void addConnection(String connection, ConnectionCreationRequest creationRequest) throws IOException {
-    URL validatePipelineURL =
-      serviceURI.resolve(String.format("v1/contexts/%s/connections/%s", NamespaceId.DEFAULT.getNamespace(),
-                                       connection)).toURL();
+    String url = URLEncoder.encode(
+      String.format("v1/contexts/%s/connections/%s", NamespaceId.DEFAULT.getNamespace(), connection),
+      StandardCharsets.UTF_8.name());
+    URL validatePipelineURL = serviceURI.resolve(url).toURL();
     HttpRequest request = HttpRequest.builder(HttpMethod.PUT, validatePipelineURL)
                             .withBody(GSON.toJson(creationRequest))
                             .build();
@@ -400,18 +403,21 @@ public class DataPipelineConnectionTest extends HydratorTestBase {
   }
 
   private void deleteConnection(String connection) throws IOException {
-    URL validatePipelineURL =
-      serviceURI.resolve(String.format("v1/contexts/%s/connections/%s", NamespaceId.DEFAULT.getNamespace(),
-                                       connection)).toURL();
+    String url = URLEncoder.encode(
+      String.format("v1/contexts/%s/connections/%s", NamespaceId.DEFAULT.getNamespace(),
+                    connection), StandardCharsets.UTF_8.name());
+    URL validatePipelineURL = serviceURI.resolve(url).toURL();
     HttpRequest request = HttpRequest.builder(HttpMethod.DELETE, validatePipelineURL).build();
     HttpResponse response = HttpRequests.execute(request, new DefaultHttpRequestConfig(false));
     Assert.assertEquals(200, response.getResponseCode());
   }
 
   private BrowseDetail browseConnection(String connection, String path, int limit) throws IOException {
+    String url = URLEncoder.encode(
+      String.format("v1/contexts/%s/connections/%s/browse", NamespaceId.DEFAULT.getNamespace(),
+                    connection), StandardCharsets.UTF_8.name());
     URL validatePipelineURL =
-      serviceURI.resolve(String.format("v1/contexts/%s/connections/%s/browse?path=%s&limit=%s",
-                                       NamespaceId.DEFAULT.getNamespace(), connection, path, limit)).toURL();
+      serviceURI.resolve(String.format("%s?path=%s&limit=%s", url, path, limit)).toURL();
     HttpRequest request = HttpRequest.builder(HttpMethod.POST, validatePipelineURL)
                             .withBody(GSON.toJson(BrowseRequest.builder(path).setLimit(limit).build()))
                             .build();
@@ -421,9 +427,11 @@ public class DataPipelineConnectionTest extends HydratorTestBase {
   }
 
   private SampleResponse sampleConnection(String connection, String path, int limit) throws IOException {
+    String url = URLEncoder.encode(
+      String.format("v1/contexts/%s/connections/%s/sample", NamespaceId.DEFAULT.getNamespace(),
+                    connection), StandardCharsets.UTF_8.name());
     URL validatePipelineURL =
-      serviceURI.resolve(String.format("v1/contexts/%s/connections/%s/sample?path=%s&limit=%s",
-                                       NamespaceId.DEFAULT.getNamespace(), connection, path, limit)).toURL();
+      serviceURI.resolve(String.format("%s?path=%s&limit=%s", url, path, limit)).toURL();
     HttpRequest request = HttpRequest.builder(HttpMethod.POST, validatePipelineURL)
                             .withBody(GSON.toJson(SampleRequest.builder(limit).setPath(path).build()))
                             .build();

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ConnectionMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ConnectionMacroEvaluator.java
@@ -27,6 +27,8 @@ import io.cdap.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A {@link MacroEvaluator} for resolving the {@code ${conn(connection-name)}} macro function. It uses
@@ -60,11 +62,11 @@ public class ConnectionMacroEvaluator extends AbstractServiceRetryableMacroEvalu
       throw new InvalidMacroException("Macro '" + FUNCTION_NAME + "' should have exactly 1 arguments");
     }
 
+    String path = URLEncoder.encode(String.format("v1/contexts/%s/connections/%s",
+                                                  namespace, args[0]), StandardCharsets.UTF_8.name());
     HttpURLConnection urlConn = serviceDiscoverer.openConnection(NamespaceId.SYSTEM.getNamespace(),
                                                                  Constants.PIPELINEID,
-                                                                 Constants.STUDIO_SERVICE_NAME,
-                                                                 String.format("v1/contexts/%s/connections/%s",
-                                                                               namespace, args[0]));
+                                                                 Constants.STUDIO_SERVICE_NAME, path);
     Connection connection = gson.fromJson(validateAndRetrieveContent(SERVICE_NAME, urlConn), Connection.class);
     return gson.toJson(connection.getPlugin().getProperties());
   }


### PR DESCRIPTION
Encode the path we use when evaluating connection macro since it is super common a connection name contains a space