### PR TITLE
CDAP-18340 let service able to create plugin with macro evaluator

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/plugin/PluginConfigurer.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/plugin/PluginConfigurer.java
@@ -128,15 +128,4 @@ public interface PluginConfigurer {
     Map<String, String> properties, MacroEvaluator evaluator, MacroParserOptions options) throws InvalidMacroException {
     throw new UnsupportedOperationException("Evaluating macros is not supported.");
   }
-
-  /**
-   * Creates a new instance of {@link ClassLoader} that contains this program classloader, all the plugins
-   * export-package classloader instantiated by this configurer and system classloader in that loading order.
-   * Currently this method is only supported in services.
-   *
-   * @return a combined classloader
-   */
-  default ClassLoader createClassLoader() {
-    throw new UnsupportedOperationException("Creating classloader for all plugins is not supported.");
-  }
 }

--- a/cdap-api/src/main/java/io/cdap/cdap/api/service/http/HttpServiceContext.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/service/http/HttpServiceContext.java
@@ -63,7 +63,9 @@ public interface HttpServiceContext extends RuntimeContext, DatasetContext, Serv
    * then to be forgotten.
    *
    * @return an dynamic plugin configurer that must be closed
+   * @deprecated use {@link #createServicePluginConfigurer()} instead
    */
+  @Deprecated
   PluginConfigurer createPluginConfigurer();
 
   /**
@@ -79,6 +81,39 @@ public interface HttpServiceContext extends RuntimeContext, DatasetContext, Serv
    *
    * @param namespace the namespace for user scoped plugins
    * @return an dynamic plugin configurer that must be closed
+   * @deprecated use {@link #createServicePluginConfigurer(String)} instead
    */
+  @Deprecated
   PluginConfigurer createPluginConfigurer(String namespace);
+
+  /**
+   * Create a {@link ServicePluginConfigurer} that can be used to instantiate plugins at runtime that
+   * were not registered at configure time. Plugins registered by the dynamic configurer live in their own scope
+   * and will not conflict with any plugins that were registered by the service when it was configured.
+   * Plugins registered by the returned configurer will also not be available through
+   * {@link #newPluginInstance(String)} or {@link #newPluginInstance(String, MacroEvaluator)}.
+   * Plugins with system scope and plugins in the same namespace as the running service will be visible.
+   *
+   * The dynamic configurer is meant to be used to create plugins for the lifetime of a single service call and
+   * then to be forgotten.
+   *
+   * @return an dynamic plugin configurer that must be closed
+   */
+  ServicePluginConfigurer createServicePluginConfigurer();
+
+  /**
+   * Create a {@link ServicePluginConfigurer} that can be used to instantiate plugins at runtime that
+   * were not registered at configure time. Plugins registered by the dynamic configurer live in their own scope
+   * and will not conflict with any plugins that were registered by the service when it was configured.
+   * Plugins registered by the returned configurer will also not be available through
+   * {@link #newPluginInstance(String)} or {@link #newPluginInstance(String, MacroEvaluator)}.
+   * Plugins with system scope and plugins in the same namespace as the running service will be visible.
+   *
+   * The dynamic configurer is meant to be used to create plugins for the lifetime of a single service call and
+   * then to be forgotten.
+   *
+   * @param namespace the namespace for user scoped plugins
+   * @return an dynamic plugin configurer that must be closed
+   */
+  ServicePluginConfigurer createServicePluginConfigurer(String namespace);
 }

--- a/cdap-api/src/main/java/io/cdap/cdap/api/service/http/ServicePluginConfigurer.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/service/http/ServicePluginConfigurer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.api.service.http;
+
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
+import io.cdap.cdap.api.plugin.InvalidPluginConfigException;
+import io.cdap.cdap.api.plugin.PluginConfigurer;
+import io.cdap.cdap.api.plugin.PluginContext;
+import io.cdap.cdap.api.plugin.PluginProperties;
+import io.cdap.cdap.api.plugin.PluginSelector;
+
+import javax.annotation.Nullable;
+
+/**
+ * Plugin configurer specifically for service. It provides additional functionality such as instantiate the plugin
+ * with provided macro evaluator.
+ */
+public interface ServicePluginConfigurer extends PluginConfigurer {
+  /**
+   * Adds a Plugin usage to the Application and create a new instance.
+   * The Plugin will be accessible at execution time via the {@link PluginContext}.
+   *
+   * @param pluginType plugin type name
+   * @param pluginName plugin name
+   * @param pluginId an unique identifier for this usage. The same id is used to get the plugin at execution time.
+   * @param properties properties for the plugin. The same set of properties will be used to instantiate the plugin
+   *                   instance at execution time
+   * @param selector for selecting which plugin to use
+   * @param macroEvaluator macro evaluator to be used to evaluate macros
+   * @param options macro parsing options
+   * @param <T> type of the plugin class
+   * @return A new instance of the plugin class or {@code null} if no plugin was found
+   * @throws InvalidPluginConfigException if the plugin config could not be created from the given properties
+   */
+  @Nullable
+  <T> T usePlugin(String pluginType, String pluginName, String pluginId, PluginProperties properties,
+                  PluginSelector selector, MacroEvaluator macroEvaluator, MacroParserOptions options);
+
+  /**
+   * Creates a new instance of {@link ClassLoader} that contains this program classloader, all the plugins
+   * export-package classloader instantiated by this configurer and system classloader in that loading order.
+   * Currently this method is only supported in services.
+   *
+   * @return a combined classloader
+   */
+  default ClassLoader createClassLoader() {
+    throw new UnsupportedOperationException("Creating classloader for all plugins is not supported.");
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultPluginConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultPluginConfigurer.java
@@ -51,9 +51,9 @@ import javax.annotation.Nullable;
  */
 public class DefaultPluginConfigurer implements PluginConfigurer {
 
+  protected final PluginInstantiator pluginInstantiator;
   private final ArtifactId artifactId;
   private final NamespaceId pluginNamespaceId;
-  private final PluginInstantiator pluginInstantiator;
   private final PluginFinder pluginFinder;
   private final Map<String, PluginWithLocation> plugins;
 
@@ -113,8 +113,8 @@ public class DefaultPluginConfigurer implements PluginConfigurer {
     return evaluated;
   }
 
-  private Plugin addPlugin(String pluginType, String pluginName, String pluginId,
-                           PluginProperties properties, PluginSelector selector) throws PluginNotExistsException {
+  Plugin addPlugin(String pluginType, String pluginName, String pluginId,
+                   PluginProperties properties, PluginSelector selector) throws PluginNotExistsException {
     PluginWithLocation existing = plugins.get(pluginId);
     if (existing != null) {
       throw new IllegalArgumentException(String.format("Plugin of type %s, name %s was already added as id %s.",

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultServicePluginConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultServicePluginConfigurer.java
@@ -17,21 +17,30 @@
 
 package io.cdap.cdap.internal.app;
 
+import com.google.common.base.Throwables;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.Plugin;
+import io.cdap.cdap.api.plugin.PluginProperties;
+import io.cdap.cdap.api.plugin.PluginSelector;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
 import io.cdap.cdap.common.lang.CombineClassLoader;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginClassLoaders;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
+import io.cdap.cdap.internal.app.runtime.plugin.PluginNotExistsException;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Default service plugin configurer which supports creating a combined class loader for all the plugins used.
  */
-public class DefaultServicePluginConfigurer extends DefaultPluginConfigurer {
+public class DefaultServicePluginConfigurer extends DefaultPluginConfigurer implements ServicePluginConfigurer {
   private final ClassLoader programClassLoader;
 
   public DefaultServicePluginConfigurer(ArtifactId artifactId, NamespaceId pluginNamespaceId,
@@ -49,5 +58,20 @@ public class DefaultServicePluginConfigurer extends DefaultPluginConfigurer {
     ClassLoader pluginsClassLoader =
       PluginClassLoaders.createFilteredPluginsClassLoader(plugins, getPluginInstantiator());
     return new CombineClassLoader(null, programClassLoader, pluginsClassLoader, getClass().getClassLoader());
+  }
+
+  @Nullable
+  @Override
+  public <T> T usePlugin(String pluginType, String pluginName, String pluginId, PluginProperties properties,
+                         PluginSelector selector, MacroEvaluator macroEvaluator, MacroParserOptions options) {
+    try {
+      Plugin plugin = addPlugin(pluginType, pluginName, pluginId, properties, selector);
+      return pluginInstantiator.newInstance(plugin, macroEvaluator, options);
+    } catch (PluginNotExistsException | IOException e) {
+      return null;
+    } catch (ClassNotFoundException e) {
+      // Shouldn't happen
+      throw Throwables.propagate(e);
+    }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/DefaultPluginContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/DefaultPluginContext.java
@@ -58,7 +58,7 @@ public class DefaultPluginContext implements PluginContext {
     if (pluginInstantiator == null) {
       throw new UnsupportedOperationException("Plugin is not supported");
     }
-    return pluginInstantiator.substituteMacros(plugin, evaluator);
+    return pluginInstantiator.substituteMacros(plugin, evaluator, null);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.api.security.store.SecureStore;
 import io.cdap.cdap.api.security.store.SecureStoreManager;
 import io.cdap.cdap.api.service.http.HttpServiceContext;
 import io.cdap.cdap.api.service.http.HttpServiceHandlerSpecification;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
 import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -163,11 +164,21 @@ public class BasicHttpServiceContext extends AbstractContext implements HttpServ
 
   @Override
   public PluginConfigurer createPluginConfigurer() {
-    return createPluginConfigurer(getNamespace());
+    return createServicePluginConfigurer(getNamespace());
   }
 
   @Override
   public PluginConfigurer createPluginConfigurer(String namespace) {
+    return createServicePluginConfigurer(namespace);
+  }
+
+  @Override
+  public ServicePluginConfigurer createServicePluginConfigurer() {
+    return createServicePluginConfigurer(getNamespace());
+  }
+
+  @Override
+  public ServicePluginConfigurer createServicePluginConfigurer(String namespace) {
     File tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
     try {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/service/http/HttpHandlerGeneratorTest.java
@@ -59,6 +59,7 @@ import io.cdap.cdap.api.service.http.HttpServiceHandler;
 import io.cdap.cdap.api.service.http.HttpServiceHandlerSpecification;
 import io.cdap.cdap.api.service.http.HttpServiceRequest;
 import io.cdap.cdap.api.service.http.HttpServiceResponder;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.test.NoopAdmin;
 import io.cdap.cdap.internal.app.preview.NoopDataTracerFactory;
@@ -675,6 +676,16 @@ public class HttpHandlerGeneratorTest {
 
     @Override
     public PluginConfigurer createPluginConfigurer(String namespace) {
+      return null;
+    }
+
+    @Override
+    public ServicePluginConfigurer createServicePluginConfigurer() {
+      return null;
+    }
+
+    @Override
+    public ServicePluginConfigurer createServicePluginConfigurer(String namespace) {
       return null;
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/connection/DefaultConnectorConfigurer.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/connection/DefaultConnectorConfigurer.java
@@ -76,9 +76,4 @@ public class DefaultConnectorConfigurer implements ConnectorConfigurer {
                                             MacroParserOptions options) throws InvalidMacroException {
     return delegate.evaluateMacros(properties, evaluator, options);
   }
-
-  @Override
-  public ClassLoader createClassLoader() {
-    return delegate.createClassLoader();
-  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/connection/LimitingConnector.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/connection/LimitingConnector.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.datapipeline.connection;
 
 import io.cdap.cdap.api.data.batch.InputFormatProvider;
 import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
 import io.cdap.cdap.etl.api.batch.BatchConnector;
 import io.cdap.cdap.etl.api.connector.BrowseDetail;
 import io.cdap.cdap.etl.api.connector.BrowseRequest;
@@ -52,20 +53,21 @@ import java.util.Map;
  */
 public class LimitingConnector implements DirectConnector {
   private final BatchConnector batchConnector;
+  private final ServicePluginConfigurer pluginConfigurer;
 
-  public LimitingConnector(BatchConnector batchConnector) {
+  public LimitingConnector(BatchConnector batchConnector, ServicePluginConfigurer pluginConfigurer) {
     this.batchConnector = batchConnector;
+    this.pluginConfigurer = pluginConfigurer;
   }
 
   @Override
   public List<StructuredRecord> sample(ConnectorContext context, SampleRequest request) throws IOException {
     InputFormatProvider inputFormatProvider = batchConnector.getInputFormatProvider(context, request);
-
     // use limiting format to read from the input format
     Map<String, String> configs =
       LimitingInputFormatProvider.getConfiguration(inputFormatProvider, request.getLimit());
     Configuration hConf = new Configuration();
-    hConf.setClassLoader(context.getPluginConfigurer().createClassLoader());
+    hConf.setClassLoader(pluginConfigurer.createClassLoader());
     configs.forEach(hConf::set);
 
     Job job = Job.getInstance(hConf);

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ValidationHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ValidationHandler.java
@@ -172,9 +172,8 @@ public class ValidationHandler extends AbstractSystemHttpServiceHandler {
       .build();
     Function<Map<String, String>, Map<String, String>> macroFn =
       macroProperties -> getContext().evaluateMacros(namespace, macroProperties, macroEvaluator, macroParserOptions);
-    String validationResponse = GSON.toJson(ValidationUtils.validate(validationRequest,
-                                                                     getContext().createPluginConfigurer(namespace),
-                                                                     macroFn));
+    String validationResponse = GSON.toJson(ValidationUtils.validate(
+      validationRequest, getContext().createServicePluginConfigurer(namespace), macroFn));
     responder.sendString(validationResponse);
   }
 

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/service/DefaultSparkHttpServicePluginContext.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/service/DefaultSparkHttpServicePluginContext.java
@@ -182,7 +182,7 @@ public class DefaultSparkHttpServicePluginContext implements SparkHttpServicePlu
     } catch (IllegalArgumentException | UnsupportedOperationException e) {
       // Expected if the plugin is not in the runtime context. Keep going.
     }
-    return pluginInstantiator.substituteMacros(getExtraPlugin(pluginId), evaluator);
+    return pluginInstantiator.substituteMacros(getExtraPlugin(pluginId), evaluator, null);
   }
 
   @Override

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/service/DynamicPluginServiceApp.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/service/DynamicPluginServiceApp.java
@@ -21,19 +21,24 @@ import com.google.gson.Gson;
 import io.cdap.cdap.api.Transactional;
 import io.cdap.cdap.api.app.AbstractApplication;
 import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.api.plugin.PluginProperties;
+import io.cdap.cdap.api.plugin.PluginSelector;
 import io.cdap.cdap.api.service.AbstractService;
 import io.cdap.cdap.api.service.http.AbstractHttpServiceHandler;
 import io.cdap.cdap.api.service.http.HttpContentConsumer;
 import io.cdap.cdap.api.service.http.HttpContentProducer;
 import io.cdap.cdap.api.service.http.HttpServiceRequest;
 import io.cdap.cdap.api.service.http.HttpServiceResponder;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.internal.app.runtime.plugin.TestMacroEvaluator;
 import io.cdap.cdap.internal.guava.reflect.TypeToken;
 
 import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
@@ -85,9 +90,36 @@ public class DynamicPluginServiceApp extends AbstractApplication {
         .addAll(properties)
         .build();
 
-      PluginConfigurer pluginConfigurer = getContext().createPluginConfigurer(getNamespace(request));
+      PluginConfigurer pluginConfigurer = getContext().createServicePluginConfigurer(getNamespace(request));
       Function<PluginConfigurer, String> plugin =
         pluginConfigurer.usePlugin(PLUGIN_TYPE, name, UUID.randomUUID().toString(), pluginProperties);
+      if (plugin == null) {
+        responder.sendError(404, "Plugin " + name + " not found.");
+        return;
+      }
+
+      responder.sendString(plugin.apply(pluginConfigurer));
+    }
+
+    @POST
+    @Path("plugins/{name}/macro")
+    public void callPluginFunctionWithMacro(HttpServiceRequest request, HttpServiceResponder responder,
+                                            @PathParam("name") String name) {
+      MacroPluginRequest pluginRequest = GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(),
+                                                       MacroPluginRequest.class);
+      PluginProperties pluginProperties = PluginProperties.builder()
+                                            .addAll(pluginRequest.rawProperties)
+                                            .build();
+
+      TestMacroEvaluator macroEvaluator = new TestMacroEvaluator(pluginRequest.macroProperties, Collections.emptyMap());
+      MacroParserOptions options = MacroParserOptions.builder()
+                                     .skipInvalidMacros()
+                                     .setEscaping(false)
+                                     .build();
+      ServicePluginConfigurer pluginConfigurer = getContext().createServicePluginConfigurer(getNamespace(request));
+      Function<PluginConfigurer, String> plugin =
+        pluginConfigurer.usePlugin(PLUGIN_TYPE, name, UUID.randomUUID().toString(), pluginProperties,
+                                   new PluginSelector(), macroEvaluator, options);
       if (plugin == null) {
         responder.sendError(404, "Plugin " + name + " not found.");
         return;
@@ -102,7 +134,7 @@ public class DynamicPluginServiceApp extends AbstractApplication {
     public void producePluginFunction(HttpServiceRequest request, HttpServiceResponder responder) {
       PluginRequest pluginRequest = GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(),
                                                   PluginRequest.class);
-      PluginConfigurer pluginConfigurer = getContext().createPluginConfigurer(getNamespace(request));
+      PluginConfigurer pluginConfigurer = getContext().createServicePluginConfigurer(getNamespace(request));
 
       HttpContentProducer producer = new HttpContentProducer() {
         private boolean done = false;
@@ -161,7 +193,7 @@ public class DynamicPluginServiceApp extends AbstractApplication {
     @POST
     @Path("consumer")
     public HttpContentConsumer callWithConsumer(HttpServiceRequest request, HttpServiceResponder responder) {
-      PluginConfigurer pluginConfigurer = getContext().createPluginConfigurer(getNamespace(request));
+      PluginConfigurer pluginConfigurer = getContext().createServicePluginConfigurer(getNamespace(request));
       return new HttpContentConsumer() {
         private byte[] body = new byte[0];
         private PluginRequest pluginRequest;
@@ -225,6 +257,19 @@ public class DynamicPluginServiceApp extends AbstractApplication {
       this.errorName = errorName;
       this.goodProperties = goodProperties;
       this.errorProperties = errorProperties;
+    }
+  }
+
+  /**
+   * Request body of the 'macro' endpoint
+   */
+  public static class MacroPluginRequest {
+    private final Map<String, String> rawProperties;
+    private final Map<String, String> macroProperties;
+
+    public MacroPluginRequest(Map<String, String> rawProperties, Map<String, String> macroProperties) {
+      this.rawProperties = rawProperties;
+      this.macroProperties = macroProperties;
     }
   }
 }

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/service/DynamicPluginServiceTestRun.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/service/DynamicPluginServiceTestRun.java
@@ -29,13 +29,13 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.service.function.ConstantFunction;
 import io.cdap.cdap.service.function.DelegatingFunction;
+import io.cdap.cdap.service.function.MacroFunction;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.ServiceManager;
 import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.base.TestFrameworkTestBase;
 import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
-import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
 import org.junit.After;
 import org.junit.Assert;
@@ -68,7 +68,8 @@ public class DynamicPluginServiceTestRun extends TestFrameworkTestBase {
     addAppArtifact(appArtifactId, DynamicPluginServiceApp.class);
 
     ArtifactId pluginArtifactId = NamespaceId.DEFAULT.artifact("plugins", "1.0.0");
-    addPluginArtifact(pluginArtifactId, appArtifactId, ConstantFunction.class, DelegatingFunction.class);
+    addPluginArtifact(pluginArtifactId, appArtifactId, ConstantFunction.class, DelegatingFunction.class,
+                      MacroFunction.class);
     ApplicationId appId = NamespaceId.DEFAULT.app("dynamicPluginService");
     ArtifactSummary summary = new ArtifactSummary(appArtifactId.getArtifact(), appArtifactId.getVersion());
     AppRequest<Void> appRequest = new AppRequest<>(summary);
@@ -125,6 +126,30 @@ public class DynamicPluginServiceTestRun extends TestFrameworkTestBase {
     response = executeHttp(request);
     Assert.assertEquals(200, response.getResponseCode());
     Assert.assertEquals("y", response.getResponseBodyAsString());
+  }
+
+  @Test
+  public void testServiceMacroEvaluator() throws Exception {
+    // properties with macro
+    Map<String, String> rawProperties = new HashMap<>();
+    rawProperties.put("key1", "${macro1}");
+    rawProperties.put("key2", "${macro2}");
+    Map<String, String> macroProperties = new HashMap<>();
+    macroProperties.put("macro1", "value1");
+    macroProperties.put("macro2", "value2");
+    URL url = baseURI.resolve(String.format("plugins/%s/macro", MacroFunction.NAME)).toURL();
+    HttpRequest request = HttpRequest.builder(HttpMethod.POST, url)
+                            .withBody(GSON.toJson(new DynamicPluginServiceApp.MacroPluginRequest(rawProperties,
+                                                                                                 macroProperties)))
+                            .build();
+    HttpResponse response = executeHttp(request);
+    Assert.assertEquals(200, response.getResponseCode());
+
+    MacroFunction.MacroFunctionResult result = GSON.fromJson(response.getResponseBodyAsString(),
+                                                             MacroFunction.MacroFunctionResult.class);
+    Assert.assertEquals(rawProperties, result.getRawProperties());
+    Assert.assertEquals("value1", result.getConf().getKey1());
+    Assert.assertEquals("value2", result.getConf().getKey2());
   }
 
   @Test

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/service/function/MacroFunction.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/service/function/MacroFunction.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.service.function;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.plugin.PluginConfig;
+import io.cdap.cdap.api.plugin.PluginConfigurer;
+import io.cdap.cdap.service.DynamicPluginServiceApp;
+
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Plugin Function that returns raw properties and conf as response
+ */
+@Plugin(type = DynamicPluginServiceApp.PLUGIN_TYPE)
+@Name(MacroFunction.NAME)
+public class MacroFunction implements Function<PluginConfigurer, String> {
+  public static final String NAME = "macro";
+  private static final Gson GSON = new Gson();
+  private final Conf conf;
+
+  public MacroFunction(Conf conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public String apply(PluginConfigurer pluginConfigurer) {
+    return GSON.toJson(new MacroFunctionResult(conf.getRawProperties().getProperties(), conf));
+  }
+
+  /**
+   * Config for the supplier
+   */
+  public static class Conf extends PluginConfig {
+    @Macro
+    private String key1;
+
+    @Macro
+    private String key2;
+
+    public String getKey1() {
+      return key1;
+    }
+
+    public String getKey2() {
+      return key2;
+    }
+  }
+
+  public static class MacroFunctionResult {
+    private final Map<String, String> rawProperties;
+    private final Conf conf;
+
+    public MacroFunctionResult(Map<String, String> rawProperties, Conf conf) {
+      this.rawProperties = rawProperties;
+      this.conf = conf;
+    }
+
+    public Map<String, String> getRawProperties() {
+      return rawProperties;
+    }
+
+    public Conf getConf() {
+      return conf;
+    }
+  }
+}


### PR DESCRIPTION
This change is needed because the plugin instantiated by the service does not have the correct raw properties, some use cases require the plugin to return back raw properties, for example, when generating spec for a database plugin