### PR TITLE
CDAP-18362-CDAP-18357-multiple-fixes-in-url

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
@@ -144,6 +144,9 @@ public class RemotePluginFinder implements PluginFinder {
                                       String pluginType,
                                       String pluginName)
     throws IOException, PluginNotExistsException, UnauthorizedException {
+    // replace the space in the name
+    // TODO: CDAP-18375 improve url encoding the our remote call
+    pluginName = pluginName.replace(" ", "%20");
     HttpRequest.Builder requestBuilder =
       remoteClient.requestBuilder(
         HttpMethod.GET,

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ConnectionMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ConnectionMacroEvaluator.java
@@ -62,11 +62,16 @@ public class ConnectionMacroEvaluator extends AbstractServiceRetryableMacroEvalu
       throw new InvalidMacroException("Macro '" + FUNCTION_NAME + "' should have exactly 1 arguments");
     }
 
-    String path = URLEncoder.encode(String.format("v1/contexts/%s/connections/%s",
-                                                  namespace, args[0]), StandardCharsets.UTF_8.name());
+    // only encode the connection name here since / will get encoded to %2f and some router cannot recognize it
+    // we don't need to worry about space getting converted to plus here since connection lookup is based on id,
+    // space and plus both get converted to _ in the id
+    String connName = URLEncoder.encode(args[0], StandardCharsets.UTF_8.name());
+
     HttpURLConnection urlConn = serviceDiscoverer.openConnection(NamespaceId.SYSTEM.getNamespace(),
                                                                  Constants.PIPELINEID,
-                                                                 Constants.STUDIO_SERVICE_NAME, path);
+                                                                 Constants.STUDIO_SERVICE_NAME,
+                                                                 String.format("v1/contexts/%s/connections/%s",
+                                                                               namespace, connName));
     Connection connection = gson.fromJson(validateAndRetrieveContent(SERVICE_NAME, urlConn), Connection.class);
     return gson.toJson(connection.getPlugin().getProperties());
   }


### PR DESCRIPTION
This pr fixes two url problem: 
1. Since we introduced space in SQL Server plugin in https://github.com/data-integrations/database-plugins/pull/154/files, this resulted in the remote call failure. 
2. On sandbox and unit test, encode the full url works, but on data fusion it didn't because "/" gets converted to "%2F", so only encode the connection name.  
Successful run on data fusion
![image](https://user-images.githubusercontent.com/12615579/129430479-3e2b8fa1-1de3-4cb9-b42e-1712c9f2ef2e.png)
