### PR TITLE
CDAP-18374: Add worker pod periodic restart and kill after certain number of user code executions

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
@@ -104,7 +104,7 @@ public class RemoteConfiguratorTest {
   public static void init() throws Exception {
     cConf = CConfiguration.create();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
-    cConf.setBoolean(Constants.TaskWorker.CONTAINER_KILL_AFTER_EXECUTION, false);
+    cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 0);
 
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     MasterEnvironments.setMasterEnvironment(new TestMasterEnvironment(discoveryService));

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -406,7 +406,10 @@ public final class Constants {
     public static final String CONTAINER_MEMORY_MULTIPLIER = "task.worker.container.memory.multiplier";
     public static final String CONTAINER_HEAP_RESERVED_RATIO = "task.worker.container.java.heap.memory.ratio";
     public static final String CONTAINER_PRIORITY_CLASS_NAME = "task.worker.container.priority.class.name";
-    public static final String CONTAINER_KILL_AFTER_EXECUTION = "task.worker.container.kill.after.execution";
+    public static final String CONTAINER_KILL_AFTER_REQUEST_COUNT =
+      "task.worker.container.kill.after.request.count";
+    public static final String CONTAINER_KILL_AFTER_DURATION_SECOND =
+      "task.worker.container.kill.after.duration.second";
     public static final String CONTAINER_RUN_AS_USER = "task.worker.container.run.as.user";
     public static final String CONTAINER_RUN_AS_GROUP = "task.worker.container.run.as.group";
     public static final String CONTAINER_DISK_READONLY = "task.worker.container.disk.readonly";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4389,14 +4389,25 @@
   </property>
 
   <property>
-    <name>task.worker.container.kill.after.execution</name>
-    <value>true</value>
+    <name>task.worker.container.kill.after.request.count</name>
+    <value>100</value>
     <description>
-      If true, kill the task worker container after it executes a request.
+      The number of executions by the task worker before it gets killed.
+      Zero or negative values result in no pod restart.
     </description>
   </property>
 
   <property>
+    <name>task.worker.container.kill.after.duration.second</name>
+    <value>7200</value>
+    <description>
+      Duration (in seconds) to wait before killing the pod after it starts.
+      Actual duration varies randomly within a defined range.
+      Zero or negative values result in no periodic task worker restart.
+    </description>
+  </property>
+
+  <property>CommonDirectiveExecutor
     <name>task.worker.preload.artifacts</name>
     <value></value>
     <description>


### PR DESCRIPTION
This PR introduces the following features:

- Repurposes "task.worker.container.kill.after.request.count" conf which defines number of times a worker pod is allowed to execute user code before being restarted
- Introduces "task.worker.container.kill.after.duration.second" conf which defines the duration after which the worker pod needs to get restarted. 