### PR TITLE
[CDAP-18323] Add exception propagation for artifact localizer

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerHttpHandlerInternal.java
@@ -17,8 +17,13 @@
 package io.cdap.cdap.internal.app.worker.sidecar;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.inject.Singleton;
+import io.cdap.cdap.api.common.HttpErrorStatusProvider;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.proto.BasicThrowable;
+import io.cdap.cdap.proto.codec.BasicThrowableCodec;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpHandler;
@@ -37,6 +42,8 @@ import javax.ws.rs.PathParam;
 @Singleton
 @Path(Constants.Gateway.INTERNAL_API_VERSION_3 + "/worker")
 public class ArtifactLocalizerHttpHandlerInternal extends AbstractHttpHandler {
+  private static final Gson GSON = new GsonBuilder().registerTypeAdapter(BasicThrowable.class,
+                                                                         new BasicThrowableCodec()).create();
   private final ArtifactLocalizer artifactLocalizer;
 
   @VisibleForTesting
@@ -49,10 +56,28 @@ public class ArtifactLocalizerHttpHandlerInternal extends AbstractHttpHandler {
   public void artifact(HttpRequest request, HttpResponder responder,
                        @PathParam("namespace-id") String namespaceId,
                        @PathParam("artifact-name") String artifactName,
-                       @PathParam("artifact-version") String artifactVersion) throws Exception {
+                       @PathParam("artifact-version") String artifactVersion) {
 
     ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersion);
-    File artifactPath = artifactLocalizer.getAndUnpackArtifact(artifactId);
-    responder.sendString(HttpResponseStatus.OK, artifactPath.toString());
+    try {
+      File artifactPath = artifactLocalizer.getAndUnpackArtifact(artifactId);
+      responder.sendString(HttpResponseStatus.OK, artifactPath.toString());
+    } catch (Exception ex) {
+      if (ex instanceof HttpErrorStatusProvider) {
+        HttpResponseStatus status = HttpResponseStatus.valueOf(((HttpErrorStatusProvider) ex).getStatusCode());
+        responder.sendString(status, exceptionToJson(ex));
+      } else {
+        responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, exceptionToJson(ex));
+      }
+    }
+  }
+
+  /**
+   * Return json representation of an exception.
+   * Used to propagate exception across network for better surfacing errors and debuggability.
+   */
+  private String exceptionToJson(Exception ex) {
+    BasicThrowable basicThrowable = new BasicThrowable(ex);
+    return GSON.toJson(basicThrowable);
   }
 }

--- a/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/worker/RemoteExecutionException.java
+++ b/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/worker/RemoteExecutionException.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.api.service.worker;
 
+import io.cdap.cdap.proto.BasicThrowable;
+
 /**
  * A exception class for wrapping an {@link Exception} coming from remote task execution.
  * The main purpose of this class is to retain the local stacktrace while using the remote exception message as its
@@ -32,5 +34,21 @@ public class RemoteExecutionException extends Exception {
 
   public RemoteTaskException getCause() {
     return cause;
+  }
+
+  /**
+   * Converts a {@link BasicThrowable} to a RemoteExecutionException.
+   *
+   * @return An exception which retains the local stacktrace.
+   */
+  public static RemoteExecutionException fromBasicThrowable(BasicThrowable basicThrowable) {
+    BasicThrowable cause = basicThrowable.getCause();
+    Exception causeException = cause == null ? null : fromBasicThrowable(cause);
+    RemoteTaskException remoteTaskException = new RemoteTaskException(basicThrowable.getClassName(),
+                                                                      basicThrowable.getMessage(), causeException);
+    remoteTaskException.setStackTrace(basicThrowable.getStackTraces());
+
+    // Wrap the remote exception as the cause so that we retain the local stacktrace of the exception.
+    return new RemoteExecutionException(remoteTaskException);
   }
 }


### PR DESCRIPTION
Although task worker runnable propagates exceptions back to app fabric, the artifact localizer does not propagate exceptions back to the task worker runnable.

See [CDAP-18323](https://cdap.atlassian.net/browse/CDAP-18323) for details.