### PR TITLE
[cherry-pick] CDAP-18374: Add worker pod periodic restart and kill after certain number of user code executions

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerHttpHandlerInternal.java
@@ -38,12 +38,17 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -60,6 +65,10 @@ import javax.ws.rs.core.MediaType;
 @Singleton
 @Path(Constants.Gateway.INTERNAL_API_VERSION_3 + "/worker")
 public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
+  /**
+   * Fraction of duration which will be used for calculating a range.
+   */
+  private static final double DURATION_FRACTION = 0.1;
   private static final Logger LOG = LoggerFactory.getLogger(TaskWorkerHttpHandlerInternal.class);
   private static final Gson GSON = new GsonBuilder().registerTypeAdapter(BasicThrowable.class,
                                                                          new BasicThrowableCodec()).create();
@@ -74,30 +83,82 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
 
   private final RunnableTaskLauncher runnableTaskLauncher;
   private final BiConsumer<Boolean, String> stopper;
-  private final AtomicInteger inflightRequests = new AtomicInteger(0);
+
+  private final AtomicBoolean anyInflightRequest = new AtomicBoolean(false);
+
+  /**
+   * Holds the total number of requests that have been executed by this handler that should count toward max allowed.
+   */
+  private AtomicInteger requestProcessedCount = new AtomicInteger(0);
+
   private final String metadataServiceEndpoint;
 
+  /**
+   * If true, pod will restart once an operation finish its execution.
+   */
+  private AtomicBoolean mustRestart = new AtomicBoolean(false);
+
   public TaskWorkerHttpHandlerInternal(CConfiguration cConf, Consumer<String> stopper) {
+    int killAfterRequestCount = cConf.getInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 0);
     this.runnableTaskLauncher = new RunnableTaskLauncher(cConf);
     this.metadataServiceEndpoint = cConf.get(Constants.TaskWorker.METADATA_SERVICE_END_POINT);
     this.stopper = (terminate, className) -> {
-      if (cConf.getBoolean(Constants.TaskWorker.CONTAINER_KILL_AFTER_EXECUTION) && terminate) {
-        if (className != null) {
-          stopper.accept(className);
-        }
+      if (mustRestart.get()) {
+        stopper.accept(className);
+      }
+
+      if (!terminate || className == null || killAfterRequestCount <= 0) {
+        // No need to restart.
+        requestProcessedCount.decrementAndGet();
+        anyInflightRequest.set(false);
+        return;
+      }
+
+      if (requestProcessedCount.get() >= killAfterRequestCount) {
+        stopper.accept(className);
       } else {
-        inflightRequests.set(0);
+        anyInflightRequest.set(false);
       }
     };
+
+    enablePeriodicRestart(cConf, stopper);
+  }
+
+  /**
+   * If there is no ongoing request, worker pod gets restarted after a random duration is selected from the following
+   * range. Otherwise, worker pod can only get restarted once the ongoing request finishes.
+   * range = [Duration - DURATION_FRACTION * Duration, Duration + DURATION_FRACTION * Duration]
+   * Reason: by randomizing the duration, it is guaranteed that pods do not get restarted at the same time.
+   */
+  private void enablePeriodicRestart(CConfiguration cConf, Consumer<String> stopper) {
+    int duration = cConf.getInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 0);
+    int lowerBound = (int) (duration - duration * DURATION_FRACTION);
+    int upperBound = (int) (duration + duration * DURATION_FRACTION);
+    if (lowerBound > 0) {
+      int waitTime = (new Random()).nextInt(upperBound - lowerBound) + lowerBound;
+      Executors.newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("task-worker-restart"))
+        .schedule(
+          () -> {
+            if (anyInflightRequest.compareAndSet(false, true)) {
+              // there is no ongoing request. pod gets restarted.
+              stopper.accept("");
+            }
+            // we restart once a request finishes.
+            // TODO: this might delay the pod restart to after executing a new request if the
+            // ongoing request is already in the stopper.
+            mustRestart.set(true);
+          }, waitTime, TimeUnit.SECONDS);
+    }
   }
 
   @POST
   @Path("/run")
   public void run(FullHttpRequest request, HttpResponder responder) {
-    if (inflightRequests.incrementAndGet() > 1) {
+    if (!anyInflightRequest.compareAndSet(false, true)) {
       responder.sendStatus(HttpResponseStatus.TOO_MANY_REQUESTS);
       return;
     }
+    requestProcessedCount.incrementAndGet();
 
     String className = null;
     try {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
@@ -104,7 +104,7 @@ public class RemoteConfiguratorTest {
   public static void init() throws Exception {
     cConf = CConfiguration.create();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
-    cConf.setBoolean(Constants.TaskWorker.CONTAINER_KILL_AFTER_EXECUTION, false);
+    cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 0);
 
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     MasterEnvironments.setMasterEnvironment(new TestMasterEnvironment(discoveryService));

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -406,7 +406,10 @@ public final class Constants {
     public static final String CONTAINER_MEMORY_MULTIPLIER = "task.worker.container.memory.multiplier";
     public static final String CONTAINER_HEAP_RESERVED_RATIO = "task.worker.container.java.heap.memory.ratio";
     public static final String CONTAINER_PRIORITY_CLASS_NAME = "task.worker.container.priority.class.name";
-    public static final String CONTAINER_KILL_AFTER_EXECUTION = "task.worker.container.kill.after.execution";
+    public static final String CONTAINER_KILL_AFTER_REQUEST_COUNT =
+      "task.worker.container.kill.after.request.count";
+    public static final String CONTAINER_KILL_AFTER_DURATION_SECOND =
+      "task.worker.container.kill.after.duration.second";
     public static final String CONTAINER_RUN_AS_USER = "task.worker.container.run.as.user";
     public static final String CONTAINER_RUN_AS_GROUP = "task.worker.container.run.as.group";
     public static final String CONTAINER_DISK_READONLY = "task.worker.container.disk.readonly";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4389,14 +4389,25 @@
   </property>
 
   <property>
-    <name>task.worker.container.kill.after.execution</name>
-    <value>true</value>
+    <name>task.worker.container.kill.after.request.count</name>
+    <value>100</value>
     <description>
-      If true, kill the task worker container after it executes a request.
+      The number of executions by the task worker before it gets killed.
+      Zero or negative values result in no pod restart.
     </description>
   </property>
 
   <property>
+    <name>task.worker.container.kill.after.duration.second</name>
+    <value>7200</value>
+    <description>
+      Duration (in seconds) to wait before killing the pod after it starts.
+      Actual duration varies randomly within a defined range.
+      Zero or negative values result in no periodic task worker restart.
+    </description>
+  </property>
+
+  <property>CommonDirectiveExecutor
     <name>task.worker.preload.artifacts</name>
     <value></value>
     <description>


### PR DESCRIPTION
This PR introduces the following features:

- Repurposes "task.worker.container.kill.after.request.count" conf which defines number of times a worker pod is allowed to execute user code before being restarted
- Introduces "task.worker.container.kill.after.duration.second" conf which defines the duration after which the worker pod needs to get restarted. 