### PR TITLE
[CDAP-18315] Adding k8s spark submitter changes

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkPreparer.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkPreparer.java
@@ -82,7 +82,10 @@ public class SparkPreparer extends AbstractSparkPreparer {
     throws TransactionFailureException, InstantiationException, IOException {
     stageOperations = new HashMap<>();
     stagePartitions = new HashMap<>();
-    File configFile = File.createTempFile("HydratorSpark", ".config");
+
+    File parentDirectory = new File("/tmp");
+    Files.createDirectories(parentDirectory.toPath());
+    File configFile = File.createTempFile("HydratorSpark", ".config", parentDirectory);
 
     List<Finisher> finishers = super.prepare(phaseSpec);
     finishers.add(new Finisher() {

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/spark/SparkConfig.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/spark/SparkConfig.java
@@ -24,6 +24,7 @@ import java.util.Map;
  * Represents environment specific spark submit configurations.
  */
 public class SparkConfig {
+  public static final String DRIVER_ENV_PREFIX = "spark.kubernetes.driverEnv.";
   private final String master;
   private final Map<String, String> configs;
 

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -499,11 +499,6 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     // Setup configs from the default spark conf
     Map<String, String> configs = new HashMap<>(Maps.fromProperties(SparkPackageUtils.getSparkDefaultConf()));
 
-    // Make Spark UI runs on random port. By default, Spark UI runs on port 4040 and it will do a sequential search
-    // of the next port if 4040 is already occupied. However, during the process, it unnecessarily logs big stacktrace
-    // as WARN, which pollute the logs a lot if there are concurrent Spark job running (e.g. a fork in Workflow).
-    configs.put("spark.ui.port", "0");
-
     // Setup app.id and executor.id for Metric System
     configs.put("spark.app.id", context.getApplicationSpecification().getName());
     configs.put("spark.executor.id", context.getApplicationSpecification().getName());

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/DistributedSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/DistributedSparkSubmitter.java
@@ -81,6 +81,11 @@ public class DistributedSparkSubmitter extends AbstractSparkSubmitter {
     config.put("spark.yarn.security.tokens.hbase.enabled", "false");
     config.put("spark.yarn.security.tokens.hive.enabled", "false");
 
+    // Make Spark UI runs on random port. By default, Spark UI runs on port 4040 and it will do a sequential search
+    // of the next port if 4040 is already occupied. However, during the process, it unnecessarily logs big stacktrace
+    // as WARN, which pollute the logs a lot if there are concurrent Spark job running (e.g. a fork in Workflow).
+    config.put("spark.ui.port", "0");
+
     return config;
   }
 

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.runtime.spark.submit;
+
+import com.google.common.collect.ImmutableList;
+import io.cdap.cdap.app.runtime.spark.SparkRuntimeContext;
+import io.cdap.cdap.app.runtime.spark.SparkRuntimeEnv;
+import io.cdap.cdap.app.runtime.spark.SparkRuntimeUtils;
+import io.cdap.cdap.app.runtime.spark.distributed.SparkExecutionService;
+import io.cdap.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
+import io.cdap.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
+import io.cdap.cdap.master.spi.environment.spark.SparkConfig;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.twill.filesystem.LocationFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Master environment spark submitter.
+ */
+public class MasterEnvironmentSparkSubmitter extends AbstractSparkSubmitter {
+  private final SparkExecutionService sparkExecutionService;
+  private final SparkConfig sparkConfig;
+
+  /**
+   * Master environment spark submitter constructor.
+   */
+  public MasterEnvironmentSparkSubmitter(LocationFactory locationFactory, String hostname,
+                                         SparkRuntimeContext runtimeContext, SparkConfig sparkConfig) {
+    ProgramRunId programRunId = runtimeContext.getProgram().getId().run(runtimeContext.getRunId().getId());
+    WorkflowProgramInfo workflowInfo = runtimeContext.getWorkflowInfo();
+    BasicWorkflowToken workflowToken = workflowInfo == null ? null : workflowInfo.getWorkflowToken();
+    this.sparkExecutionService = new SparkExecutionService(locationFactory, hostname, programRunId, workflowToken);
+    this.sparkConfig = sparkConfig;
+  }
+
+  @Override
+  protected Map<String, String> getSubmitConf() {
+    Map<String, String> config = new HashMap<>();
+    config.put(SparkConfig.DRIVER_ENV_PREFIX + "CDAP_LOG_DIR", ApplicationConstants.LOG_DIR_EXPANSION_VAR);
+    config.put("spark.executorEnv.CDAP_LOG_DIR", ApplicationConstants.LOG_DIR_EXPANSION_VAR);
+    config.putAll(sparkConfig.getConfigs());
+    return config;
+  }
+
+  @Override
+  protected void addMaster(Map<String, String> configs, ImmutableList.Builder<String> argBuilder) {
+    argBuilder.add("--master").add(sparkConfig.getMaster()).add("--deploy-mode").add("cluster");
+  }
+
+  @Override
+  protected List<String> beforeSubmit() {
+    sparkExecutionService.startAndWait();
+    SparkRuntimeEnv.setProperty(SparkConfig.DRIVER_ENV_PREFIX + SparkRuntimeUtils.CDAP_SPARK_EXECUTION_SERVICE_URI,
+                                sparkExecutionService.getBaseURI().toString());
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected void triggerShutdown() {
+    // Just stop the execution service and block on that.
+    // It will wait until the "completed" call from the Spark driver.
+    sparkExecutionService.stopAndWait();
+  }
+
+  @Override
+  protected void onCompleted(boolean succeeded) {
+    if (succeeded) {
+      sparkExecutionService.stopAndWait();
+    } else {
+      sparkExecutionService.shutdownNow();
+    }
+  }
+}


### PR DESCRIPTION
Owner reference:
![image](https://user-images.githubusercontent.com/14131070/131739737-3d9b45a7-e6ae-4227-893b-4f262c69a83b.png)


```
kubectl describe pod/phase-1-25123f7b529d5118-driver
Name:         phase-1-25123f7b529d5118-driver
Namespace:    default
Priority:     0
Node:         gke-<k8s-cluster>-default-pool-adba3fd5-7c0s/10.138.0.73
Start Time:   Mon, 16 Aug 2021 22:37:31 -0700
Labels:       spark-app-selector=spark-ea48fb4578a142279bbdf7daaa81c33a
              spark-role=driver
Annotations:  <none>
Status:       Failed
IP:           10.4.5.200
IPs:
  IP:  10.4.5.200
Containers:
  spark-kubernetes-driver:
    Container ID:  containerd://3465ac477aadc6fa8f57647b25184289c30a0530c80617e3402e383de66be125
    Image:        us.gcr.io/<gcr_path>
    Image ID:      us.gcr.io/<gcr_path>
    Ports:         7078/TCP, 7079/TCP, 4040/TCP
    Host Ports:    0/TCP, 0/TCP, 0/TCP
    Args:
      driver
      --properties-file
      /opt/spark/conf/spark.properties
      --class
      io.cdap.cdap.app.runtime.spark.SparkMainWrapper
      spark-internal
      --cdap.spark.program=program_run:default.sparkpipeline_v14.-SNAPSHOT.spark.phase-1.2fccfdb1-ff1d-11eb-aa2e-ba69492271c6
      --cdap.user.main.class=io.cdap.cdap.etl.spark.batch.BatchSparkPipelineDriver
    State:          Terminated
      Reason:       Error
      Exit Code:    1
      Started:      Mon, 16 Aug 2021 22:37:39 -0700
      Finished:     Mon, 16 Aug 2021 22:37:39 -0700
    Ready:          False
    Restart Count:  0
    Limits:
      memory:  2432Mi
    Requests:
      cpu:     1
      memory:  2432Mi
    Environment:
      SPARK_USER:                 root
      SPARK_APPLICATION_ID:       spark-ea48fb4578a142279bbdf7daaa81c33a
      CDAP_LOG_DIR:               <LOG_DIR>
      SPARK_DRIVER_BIND_ADDRESS:   (v1:status.podIP)
      SPARK_LOCAL_DIRS:           /workDir-f4cb616f-ac19-4f5d-b96e-2ae93bc8eb88/data/tmp/1629178638906-0
      SPARK_CONF_DIR:             /opt/spark/conf
    Mounts:
      /etc/cdap/conf from cdap-cconf (rw)
      /opt/spark/conf from spark-conf-volume-driver (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kubespark-token-<> (ro)
      /workDir-f4cb616f-ac19-4f5d-b96e-2ae93bc8eb88/data/tmp/1629178638906-0 from spark-local-dir-1 (rw)
Conditions:
  Type              Status
  Initialized       True
  Ready             False
  ContainersReady   False
  PodScheduled      True
Volumes:
  cdap-cconf:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      cdap-cdap-cconf
    Optional:  false
  spark-local-dir-1:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:
    SizeLimit:  <unset>
  spark-conf-volume-driver:
    Type:      ConfigMap (a volume populated by a ConfigMap)
    Name:      spark-drv-dace837b529d6151-conf-map
    Optional:  false
  kubespark-token-<>:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  kubespark-token-<>
    Optional:    false
QoS Class:       Burstable
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                 node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:          <none>