### PR TITLE
CDAP-18249 Uploading a directive does not close an upload window

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -340,20 +340,19 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     } catch (IOException e) {
       throw new BadRequestException("Unable to read properties from the request.", e);
     }
+    
+    if(properties == null)
+    {
+      throw new BadRequestException("Properties attribute is missing in the json or set as null, " +
+                                      "add properties: {} in json");
+    }
 
     try {
-      if (properties == null) {
-        throw new NullPointerException("Properties attribute is missing in the json or set as null, " +
-                                         "add properties: {} in json");
-      }
       artifactRepository.writeArtifactProperties(Id.Artifact.fromEntityId(artifactId), properties);
       responder.sendStatus(HttpResponseStatus.OK);
     } catch (IOException e) {
       LOG.error("Exception writing properties for artifact {}.", artifactId, e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error adding properties to artifact.");
-    } catch (NullPointerException e) {
-      LOG.error("Exception writing properties for artifact {}.", artifactId, e);
-      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -342,11 +342,18 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
     }
 
     try {
+      if (properties == null) {
+        throw new NullPointerException("Properties attribute is missing in the json or set as null, " +
+                                         "add properties: {} in json");
+      }
       artifactRepository.writeArtifactProperties(Id.Artifact.fromEntityId(artifactId), properties);
       responder.sendStatus(HttpResponseStatus.OK);
     } catch (IOException e) {
       LOG.error("Exception writing properties for artifact {}.", artifactId, e);
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Error adding properties to artifact.");
+    } catch (NullPointerException e) {
+      LOG.error("Exception writing properties for artifact {}.", artifactId, e);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
   }
 


### PR DESCRIPTION
[CDAP-18249](https://cdap.atlassian.net/browse/CDAP-18249)

When the user tries to upload a UDD, if the json had the attribute property missing, then a null pointer exception is raised while updating the artifact properties in the transaction runner which aborts the transaction at that point but the UI freezes at that point because it didn't return a meaningful error message rather the request was terminated with the status code 500 and response undefined.

Tested using this [directive](https://drive.google.com/drive/folders/1X2Scm_RuQBP8CpFsxgLSWIhTWpiKMCyU?resourcekey=0-EZL374Czlfp94LDXzr59fA&usp=sharing)  provided by the reporter.