### PR TITLE
Added Spark Source interface

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/DataPipelineApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/DataPipelineApp.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.api.batch.SparkSource;
 import io.cdap.cdap.etl.api.condition.Condition;
 import io.cdap.cdap.etl.common.Constants;
 import io.cdap.cdap.etl.proto.v2.ETLBatchConfig;
@@ -49,9 +50,9 @@ public class DataPipelineApp extends AbstractApplication<ETLBatchConfig> {
   public static final String DEFAULT_DESCRIPTION = "Data Pipeline Application";
   private static final Set<String> supportedPluginTypes = ImmutableSet.of(
     BatchSource.PLUGIN_TYPE, BatchSink.PLUGIN_TYPE, Transform.PLUGIN_TYPE, BatchJoiner.PLUGIN_TYPE,
-    Constants.Connector.PLUGIN_TYPE, BatchAggregator.PLUGIN_TYPE, SparkCompute.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE,
-    Action.PLUGIN_TYPE, ErrorTransform.PLUGIN_TYPE, Constants.SPARK_PROGRAM_PLUGIN_TYPE, SplitterTransform.PLUGIN_TYPE,
-    Condition.PLUGIN_TYPE, AlertPublisher.PLUGIN_TYPE);
+    Constants.Connector.PLUGIN_TYPE, BatchAggregator.PLUGIN_TYPE, SparkSource.PLUGIN_TYPE, SparkCompute.PLUGIN_TYPE,
+    SparkSink.PLUGIN_TYPE, Action.PLUGIN_TYPE, ErrorTransform.PLUGIN_TYPE, Constants.SPARK_PROGRAM_PLUGIN_TYPE,
+    SplitterTransform.PLUGIN_TYPE, Condition.PLUGIN_TYPE, AlertPublisher.PLUGIN_TYPE);
 
   @Override
   public void configure() {

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/batch/SparkSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/batch/SparkSource.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.batch;
+
+import io.cdap.cdap.api.annotation.Beta;
+import org.apache.spark.api.java.JavaRDD;
+
+import java.io.Serializable;
+
+
+/**
+ * SparkSource defines an initial stage of a Batch ETL Pipeline. In addition to configuring the Batch run, it
+ * will create a new RDD for the rest of the pipeline to consume.
+ *
+ * {@link SparkSource#create} method is called inside the Batch Run while {@link SparkSource#prepareRun} and
+ * {@link SparkSource#onRunFinish} methods are called on the client side, which launches the Batch run, before the
+ * Batch run starts and after it finishes respectively.
+ *
+ * @param <OUT> The type of output record to the SparkSink.
+ */
+@Beta
+public abstract class SparkSource<OUT> extends BatchConfigurable<SparkPluginContext> implements Serializable {
+
+  public static final String PLUGIN_TYPE = "sparksource";
+
+  private static final long serialVersionUID = 4829903051232692690L;
+
+  /**
+   * User Spark job which will be executed and is responsible for generating a new RDD for the resf of the pipeline
+   * to consume
+   *
+   * @param context {@link SparkExecutionPluginContext} for this job
+   */
+  public abstract JavaRDD<OUT> create(SparkExecutionPluginContext context) throws Exception;
+
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -42,6 +42,7 @@ import io.cdap.cdap.etl.api.batch.BatchReducibleAggregator;
 import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.api.batch.SparkSource;
 import io.cdap.cdap.etl.api.join.AutoJoiner;
 import io.cdap.cdap.etl.api.join.AutoJoinerContext;
 import io.cdap.cdap.etl.api.join.JoinCondition;
@@ -107,7 +108,7 @@ public abstract class SparkPipelineRunner {
   private static final Logger LOG = LoggerFactory.getLogger(SparkPipelineRunner.class);
   private static final Set<String> UNCOMBINABLE_PLUGIN_TYPES = ImmutableSet.of(
     BatchJoiner.PLUGIN_TYPE, BatchAggregator.PLUGIN_TYPE, Constants.Connector.PLUGIN_TYPE,
-    SparkCompute.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE, AlertPublisher.PLUGIN_TYPE);
+    SparkSource.PLUGIN_TYPE, SparkCompute.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE, AlertPublisher.PLUGIN_TYPE);
 
   protected abstract SparkCollection<RecordInfo<Object>> getSource(StageSpec stageSpec,
                                                                    FunctionCache.Factory functionCacheFactory,

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/plugin/SparkPipelinePluginContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/plugin/SparkPipelinePluginContext.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.spark.JavaSparkMain;
 import io.cdap.cdap.api.spark.SparkMain;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.api.batch.SparkSource;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
 import io.cdap.cdap.etl.api.streaming.Windower;
 import io.cdap.cdap.etl.common.plugin.Caller;
@@ -42,6 +43,8 @@ public class SparkPipelinePluginContext extends PipelinePluginContext {
   protected Object wrapUnknownPlugin(String pluginId, Object plugin, Caller caller) {
     if (plugin instanceof Windower) {
       return new WrappedWindower((Windower) plugin, caller);
+    } else if (plugin instanceof SparkSource) {
+      return new WrappedSparkSource<>((SparkSource) plugin, caller);
     } else if (plugin instanceof SparkCompute) {
       return new WrappedSparkCompute<>((SparkCompute) plugin, caller);
     } else if (plugin instanceof SparkSink) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/plugin/WrappedSparkSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/plugin/WrappedSparkSource.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.plugin;
+
+import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.batch.SparkExecutionPluginContext;
+import io.cdap.cdap.etl.api.batch.SparkPluginContext;
+import io.cdap.cdap.etl.api.batch.SparkSource;
+import io.cdap.cdap.etl.common.plugin.Caller;
+import org.apache.spark.api.java.JavaRDD;
+
+import java.util.concurrent.Callable;
+
+public class WrappedSparkSource<OUT> extends SparkSource<OUT> {
+  private final SparkSource<OUT> source;
+  private final Caller caller;
+
+  public WrappedSparkSource(SparkSource<OUT> source, Caller caller) {
+    this.source = source;
+    this.caller = caller;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    caller.callUnchecked(new Callable<Void>() {
+      @Override
+      public Void call() {
+        source.configurePipeline(pipelineConfigurer);
+        return null;
+      }
+    });
+  }
+
+
+  @Override
+  public void prepareRun(SparkPluginContext context) throws Exception {
+    caller.call(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        source.prepareRun(context);
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public void onRunFinish(boolean succeeded, SparkPluginContext context) {
+    caller.callUnchecked(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        source.onRunFinish(succeeded, context);
+        return null;
+      }
+    });
+  }
+
+  @Override
+  public JavaRDD<OUT> create(SparkExecutionPluginContext context) throws Exception {
+    return caller.call(new Callable<JavaRDD<OUT>>() {
+      @Override
+      public JavaRDD<OUT> call() throws Exception {
+        return source.create(context);
+      }
+    });
+  }
+}


### PR DESCRIPTION
This interface will be used to create Spark RDDs and RDDCollection entities from Spark programs.

This will be useful when integrating the Spark BigQuery Connector for BQ Pushdown execution https://github.com/GoogleCloudDataproc/spark-bigquery-connector