### PR TITLE
CDAP-18502 - Enable request count, latency metrics for task worker

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/retry/RetryCountProvider.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/retry/RetryCountProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.retry;
+
+/**
+ * Retry count provider interface
+ */
+public interface RetryCountProvider {
+  /**
+   * Return the retry count
+   * @return
+   */
+  int getRetries();
+}

--- a/cdap-api/src/main/java/io/cdap/cdap/api/retry/RetryFailedException.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/retry/RetryFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017 Cask Data, Inc.
+ * Copyright © 2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,38 +17,24 @@
 package io.cdap.cdap.api.retry;
 
 /**
- * An exception that indicates an operation failed after it was retried.
+ * Exception for retry failure. Provides the number of retries.
  */
-public class RetriesExhaustedException extends RuntimeException implements RetryCountProvider {
+public class RetryFailedException extends RuntimeException implements RetryCountProvider {
+  private final int retries;
 
-  /**
-   * Number of retries
-   */
-  private int retries;
-
-  public RetriesExhaustedException(String message, int retries) {
+  public RetryFailedException(String message, int retries) {
     super(message);
     this.retries = retries;
   }
 
-  public RetriesExhaustedException(String message) {
-    super(message);
-  }
-
-  public RetriesExhaustedException(Throwable cause) {
-    super(cause);
-  }
-
-  public RetriesExhaustedException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
   /**
-   * Return the retry count set
+   * Return the retry count
+   *
    * @return int for retry count
    */
   @Override
   public int getRetries() {
     return retries;
   }
+
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteConfigurator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteConfigurator.java
@@ -22,6 +22,7 @@ import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.api.plugin.Requirements;
 import io.cdap.cdap.api.service.worker.RunnableTaskRequest;
 import io.cdap.cdap.app.deploy.ConfigResponse;
@@ -53,11 +54,11 @@ public class RemoteConfigurator implements Configurator {
   private final RemoteTaskExecutor remoteTaskExecutor;
 
   @Inject
-  public RemoteConfigurator(CConfiguration cConf,
+  public RemoteConfigurator(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
                             @Assisted AppDeploymentInfo deploymentInfo,
                             RemoteClientFactory remoteClientFactory) {
     this.deploymentInfo = deploymentInfo;
-    this.remoteTaskExecutor = new RemoteTaskExecutor(cConf, remoteClientFactory);
+    this.remoteTaskExecutor = new RemoteTaskExecutor(cConf, metricsCollectionService, remoteClientFactory);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicSystemHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicSystemHttpServiceContext.java
@@ -108,7 +108,7 @@ public class BasicSystemHttpServiceContext extends BasicHttpServiceContext imple
     this.preferencesFetcher = preferencesFetcher;
     this.cConf = cConf;
     this.contextAccessEnforcer = contextAccessEnforcer;
-    this.remoteTaskExecutor = new RemoteTaskExecutor(cConf, remoteClientFactory);
+    this.remoteTaskExecutor = new RemoteTaskExecutor(cConf, metricsCollectionService, remoteClientFactory);
     this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
@@ -174,11 +174,10 @@ public class BasicSystemHttpServiceContext extends BasicHttpServiceContext imple
       throw new RuntimeException("Remote task worker is not enabled. Task cannot be executed.");
     }
     String systemAppClassName = SystemAppTask.class.getName();
-    String systemAppParam = GSON.toJson(runnableTaskRequest);
     RunnableTaskRequest taskRequest = RunnableTaskRequest.getBuilder(systemAppClassName)
-      .withParam(systemAppParam)
       .withNamespace(getNamespace())
       .withArtifact(getArtifactId().toApiArtifactId())
+      .withEmbeddedTaskRequest(runnableTaskRequest)
       .build();
     return remoteTaskExecutor.runTask(taskRequest);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/RunnableTaskLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/RunnableTaskLauncher.java
@@ -23,8 +23,6 @@ import io.cdap.cdap.api.service.worker.RunnableTaskContext;
 import io.cdap.cdap.api.service.worker.RunnableTaskRequest;
 import io.cdap.cdap.common.conf.CConfiguration;
 
-import java.nio.ByteBuffer;
-
 /**
  * RunnableTaskLauncher launches a {@link RunnableTask} by loading its class and calling its run method.
  */

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppTask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppTask.java
@@ -104,7 +104,7 @@ public class SystemAppTask implements RunnableTask {
          SystemAppTaskContext systemAppTaskContext = buildTaskSystemAppContext(injector, systemAppNamespace,
                                                                                systemAppArtifactId,
                                                                                artifactClassLoader)) {
-      RunnableTaskRequest taskRequest = GSON.fromJson(context.getParam(), RunnableTaskRequest.class);
+      RunnableTaskRequest taskRequest = context.getEmbeddedRequest();
       String taskClassName = taskRequest.getClassName();
       if (taskClassName == null) {
         LOG.debug("No system app task to execute");
@@ -119,8 +119,8 @@ public class SystemAppTask implements RunnableTask {
 
       LOG.debug("Launching system app task {}", taskClassName);
       RunnableTask runnableTask = (RunnableTask) injector.getInstance(clazz);
-      RunnableTaskContext runnableTaskContext = new RunnableTaskContext(taskRequest.getParam(), null, null,
-                                                                        systemAppTaskContext) {
+      RunnableTaskContext runnableTaskContext = new RunnableTaskContext(taskRequest.getParam().getSimpleParam(), null,
+                                                                        null, null, systemAppTaskContext) {
         @Override
         public void writeResult(byte[] data) throws IOException {
           context.writeResult(data);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskDetails.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskDetails.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.worker;
+
+/**
+ * Class for holding details of a task
+ */
+public class TaskDetails {
+  private final boolean success;
+  private final String className;
+  private final long startTime;
+
+  public TaskDetails(boolean success, String className, long startTime) {
+    this.success = success;
+    this.className = className;
+    this.startTime = startTime;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
@@ -25,6 +25,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
@@ -43,6 +44,7 @@ import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.guice.CoreSecurityModule;
@@ -61,6 +63,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -73,6 +76,7 @@ public class TaskWorkerTwillRunnable extends AbstractTwillRunnable {
 
   private TaskWorkerService taskWorker;
   private LogAppenderInitializer logAppenderInitializer;
+  private MetricsCollectionService metricsCollectionService;
 
   public TaskWorkerTwillRunnable(String cConfFileName, String hConfFileName) {
     super(ImmutableMap.of("cConf", cConfFileName, "hConf", hConfFileName));
@@ -91,6 +95,7 @@ public class TaskWorkerTwillRunnable extends AbstractTwillRunnable {
     modules.add(coreSecurityModule);
     modules.add(new MessagingClientModule());
     modules.add(new SystemAppModule());
+    modules.add(new MetricsClientRuntimeModule().getDistributedModules());
 
     // If MasterEnvironment is not available, assuming it is the old hadoop stack with ZK, Kafka
     MasterEnvironment masterEnv = MasterEnvironments.getMasterEnvironment();
@@ -162,6 +167,7 @@ public class TaskWorkerTwillRunnable extends AbstractTwillRunnable {
   @Override
   public void stop() {
     LOG.info("Stopping task worker");
+    Optional.ofNullable(metricsCollectionService).map(MetricsCollectionService::stop);
     if (taskWorker != null) {
       taskWorker.stop();
     }
@@ -189,6 +195,9 @@ public class TaskWorkerTwillRunnable extends AbstractTwillRunnable {
     // Initialize logging context
     logAppenderInitializer = injector.getInstance(LogAppenderInitializer.class);
     logAppenderInitializer.initialize();
+
+    metricsCollectionService = injector.getInstance(MetricsCollectionService.class);
+    metricsCollectionService.startAndWait();
 
     LoggingContext loggingContext = new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
                                                               Constants.Logging.COMPONENT_NAME,

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/RemoteTaskExecutorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/RemoteTaskExecutorTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app;
+
+import com.google.common.collect.Iterators;
+import io.cdap.cdap.api.metrics.MetricValue;
+import io.cdap.cdap.api.metrics.MetricValues;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.RunnableTaskContext;
+import io.cdap.cdap.api.service.worker.RunnableTaskRequest;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.discovery.URIScheme;
+import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
+import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.internal.app.worker.TaskWorkerHttpHandlerInternal;
+import io.cdap.cdap.metrics.collect.AggregatedMetricsCollectionService;
+import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
+import io.cdap.http.ChannelPipelineModifier;
+import io.cdap.http.NettyHttpService;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpContentDecompressor;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.discovery.InMemoryDiscoveryService;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Tests for RemoteTaskExecutor
+ */
+public class RemoteTaskExecutorTest {
+
+  private static RemoteClientFactory remoteClientFactory;
+  private static CConfiguration cConf;
+  private static NettyHttpService httpService;
+  private static InMemoryDiscoveryService discoveryService;
+
+  private List<MetricValues> published;
+  private AggregatedMetricsCollectionService mockMetricsCollector;
+  private Cancellable registered;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    cConf = CConfiguration.create();
+    discoveryService = new InMemoryDiscoveryService();
+    remoteClientFactory = new RemoteClientFactory(discoveryService,
+                                                  new DefaultInternalAuthenticator(new AuthenticationTestContext()));
+    httpService = new CommonNettyHttpServiceBuilder(cConf, "test")
+      .setHttpHandlers(
+        new TaskWorkerHttpHandlerInternal(cConf, className -> {
+        }, new NoOpMetricsCollectionService())
+      )
+      .setPort(cConf.getInt(Constants.ArtifactLocalizer.PORT))
+      .setChannelPipelineModifier(new ChannelPipelineModifier() {
+        @Override
+        public void modify(ChannelPipeline pipeline) {
+          pipeline.addAfter("compressor", "decompressor", new HttpContentDecompressor());
+        }
+      })
+      .build();
+    httpService.start();
+  }
+
+  @Before
+  public void beforeTest() {
+    published = new ArrayList<>();
+    mockMetricsCollector = new AggregatedMetricsCollectionService(1000L) {
+      @Override
+      protected void publish(Iterator<MetricValues> metrics) {
+        Iterators.addAll(published, metrics);
+      }
+    };
+    mockMetricsCollector.startAndWait();
+    registered = discoveryService
+      .register(URIScheme.createDiscoverable(Constants.Service.TASK_WORKER, httpService));
+  }
+
+  @After
+  public void afterTest() {
+    registered.cancel();
+  }
+
+  @AfterClass
+  public static void cleanup() throws Exception {
+    httpService.stop();
+  }
+
+  @Test
+  public void testFailedMetrics() throws Exception {
+    RemoteTaskExecutor remoteTaskExecutor = new RemoteTaskExecutor(cConf, mockMetricsCollector, remoteClientFactory);
+    RunnableTaskRequest runnableTaskRequest = RunnableTaskRequest.getBuilder(InValidRunnableClass.class.getName()).
+      withParam("param").build();
+    try {
+      remoteTaskExecutor.runTask(runnableTaskRequest);
+    } catch (Exception e) {
+
+    }
+    mockMetricsCollector.stopAndWait();
+    Assert.assertSame(1, published.size());
+
+    //check the metrics are present
+    MetricValues metricValues = published.get(0);
+    Assert.assertTrue(hasMetric(metricValues, Constants.Metrics.TaskWorker.CLIENT_REQUEST_LATENCY_MS));
+    Assert.assertTrue(hasMetric(metricValues, Constants.Metrics.TaskWorker.CLIENT_REQUEST_COUNT));
+    //check the clz tag is set correctly
+    Assert.assertEquals(InValidRunnableClass.class.getName(), metricValues.getTags().get("clz"));
+  }
+
+  @Test
+  public void testSuccessMetrics() throws Exception {
+    RemoteTaskExecutor remoteTaskExecutor = new RemoteTaskExecutor(cConf, mockMetricsCollector, remoteClientFactory);
+    RunnableTaskRequest runnableTaskRequest = RunnableTaskRequest.getBuilder(ValidRunnableClass.class.getName()).
+      withParam("param").build();
+    remoteTaskExecutor.runTask(runnableTaskRequest);
+    mockMetricsCollector.stopAndWait();
+    Assert.assertSame(1, published.size());
+
+    //check the metrics are present
+    MetricValues metricValues = published.get(0);
+    Assert.assertTrue(hasMetric(metricValues, Constants.Metrics.TaskWorker.CLIENT_REQUEST_LATENCY_MS));
+    Assert.assertTrue(hasMetric(metricValues, Constants.Metrics.TaskWorker.CLIENT_REQUEST_COUNT));
+    //check the clz tag is set correctly
+    Assert.assertEquals(ValidRunnableClass.class.getName(), metricValues.getTags().get("clz"));
+  }
+
+  @Test
+  public void testRetryMetrics() throws Exception {
+    // Remove the service registration
+    registered.cancel();
+    RemoteTaskExecutor remoteTaskExecutor = new RemoteTaskExecutor(cConf, mockMetricsCollector, remoteClientFactory);
+    RunnableTaskRequest runnableTaskRequest = RunnableTaskRequest.getBuilder(ValidRunnableClass.class.getName()).
+      withParam("param").build();
+    try {
+      remoteTaskExecutor.runTask(runnableTaskRequest);
+    } catch (Exception e) {
+
+    }
+    mockMetricsCollector.stopAndWait();
+    Assert.assertSame(1, published.size());
+
+    //check the metrics are present
+    MetricValues metricValues = published.get(0);
+    Assert.assertTrue(hasMetric(metricValues, Constants.Metrics.TaskWorker.CLIENT_REQUEST_COUNT));
+    Assert.assertTrue(hasMetric(metricValues, Constants.Metrics.TaskWorker.CLIENT_REQUEST_LATENCY_MS));
+    Assert.assertEquals("failure", metricValues.getTags().get(Constants.Metrics.Tag.STATUS));
+    int retryCount = Integer.parseInt(metricValues.getTags().get(Constants.Metrics.Tag.TRIES));
+    Assert.assertTrue(retryCount > 1);
+  }
+
+  private boolean hasMetric(MetricValues metricValues, String metricName) {
+    for (MetricValue metricValue : metricValues.getMetrics()) {
+      if (metricValue.getName().equals(metricName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static class ValidRunnableClass implements RunnableTask {
+    @Override
+    public void run(RunnableTaskContext context) throws Exception {
+      context.writeResult("success".getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+  static class InValidRunnableClass implements RunnableTask {
+    @Override
+    public void run(RunnableTaskContext context) throws Exception {
+      throw new RuntimeException("Invalid");
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerMetricsTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerMetricsTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.worker;
+
+import com.google.common.collect.Iterators;
+import com.google.common.util.concurrent.Service;
+import com.google.gson.Gson;
+import io.cdap.cdap.api.metrics.MetricValue;
+import io.cdap.cdap.api.metrics.MetricValues;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.RunnableTaskContext;
+import io.cdap.cdap.api.service.worker.RunnableTaskRequest;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.metrics.collect.AggregatedMetricsCollectionService;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import org.apache.twill.discovery.InMemoryDiscoveryService;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Tests for TaskWorker Metrics
+ */
+public class TaskWorkerMetricsTest {
+
+  private static final Gson GSON = new Gson();
+
+  private TaskWorkerService taskWorkerService;
+  private List<MetricValues> published;
+  private URI uri;
+  private CompletableFuture<Service.State> taskWorkerStateFuture;
+
+  private CConfiguration createCConf() {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.TaskWorker.ADDRESS, "localhost");
+    cConf.setInt(Constants.TaskWorker.PORT, 0);
+    cConf.setBoolean(Constants.Security.SSL.INTERNAL_ENABLED, false);
+    cConf.set(Constants.TaskWorker.PRELOAD_ARTIFACTS, "");
+    cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 1);
+    return cConf;
+  }
+
+  @Before
+  public void beforeTest() {
+    CConfiguration cConf = createCConf();
+    SConfiguration sConf = SConfiguration.create();
+    published = new ArrayList<>();
+
+    AggregatedMetricsCollectionService mockMetricsCollector = new AggregatedMetricsCollectionService(1000L) {
+      @Override
+      protected void publish(Iterator<MetricValues> metrics) {
+        Iterators.addAll(published, metrics);
+      }
+    };
+    mockMetricsCollector.startAndWait();
+    taskWorkerService = new TaskWorkerService(cConf, sConf, new InMemoryDiscoveryService(),
+                                                                (namespaceId, retryStrategy) -> null,
+                                                                mockMetricsCollector);
+    taskWorkerStateFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);
+    // start the service
+    taskWorkerService.startAndWait();
+    InetSocketAddress addr = taskWorkerService.getBindAddress();
+    this.uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
+  }
+
+  @After
+  public void afterTest() {
+    if (taskWorkerService != null) {
+      taskWorkerService.stopAndWait();
+    }
+  }
+
+  @Test
+  public void testSimpleRequest() throws IOException {
+    String taskClassName = TaskWorkerServiceTest.TestRunnableClass.class.getName();
+    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(taskClassName)
+      .withParam("100")
+      .build();
+    String reqBody = GSON.toJson(req);
+    HttpResponse response = HttpRequests.execute(
+      HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
+        .withBody(reqBody).build(),
+      new DefaultHttpRequestConfig(false));
+    TaskWorkerTestUtil.waitForServiceCompletion(taskWorkerStateFuture);
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    Assert.assertSame(1, published.size());
+
+    //check the metrics are present
+    MetricValues metricValues = published.get(0);
+    Assert.assertTrue(hasMetric(metricValues, Constants.Metrics.TaskWorker.REQUEST_LATENCY_MS));
+    Assert.assertTrue(hasMetric(metricValues, Constants.Metrics.TaskWorker.REQUEST_COUNT));
+    //check the clz tag is set correctly
+    Assert.assertEquals(taskClassName, metricValues.getTags().get("clz"));
+  }
+
+  @Test
+  public void testWrappedRequest() throws IOException {
+    String taskClassName = TaskWorkerServiceTest.TestRunnableClass.class.getName();
+    String wrappedClassName = "testClassName";
+    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(
+      taskClassName).withParam("100")
+      .withEmbeddedTaskRequest(RunnableTaskRequest.getBuilder(wrappedClassName).build()).build();
+    String reqBody = GSON.toJson(req);
+    HttpResponse response = HttpRequests.execute(
+      HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
+        .withBody(reqBody).build(),
+      new DefaultHttpRequestConfig(false));
+    TaskWorkerTestUtil.waitForServiceCompletion(taskWorkerStateFuture);
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    Assert.assertSame(1, published.size());
+
+    //check the metrics are present
+    MetricValues metricValues = published.get(0);
+    Assert.assertTrue(hasMetric(metricValues, Constants.Metrics.TaskWorker.REQUEST_COUNT));
+    Assert.assertTrue(hasMetric(metricValues, Constants.Metrics.TaskWorker.REQUEST_LATENCY_MS));
+    //check the clz tag is set correctly
+    Assert.assertEquals(wrappedClassName, metricValues.getTags().get(Constants.Metrics.Tag.CLASS));
+  }
+
+  private boolean hasMetric(MetricValues metricValues, String metricName) {
+    for (MetricValue metricValue : metricValues.getMetrics()) {
+      if (metricValue.getName().equals(metricName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static class TestFailingRunnableClass implements RunnableTask {
+    @Override
+    public void run(RunnableTaskContext context) throws Exception {
+      throw new RuntimeException("unexpected error");
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerTestUtil.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerTestUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.worker;
+
+import com.google.common.util.concurrent.Service;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.twill.common.Threads;
+import org.apache.twill.internal.ServiceListenerAdapter;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Common TaskWorker test utility functions
+ */
+public final class TaskWorkerTestUtil {
+
+  private TaskWorkerTestUtil() {
+
+  }
+
+  /**
+   * Creates a listener for the task worker service that updates a {@link CompletableFuture<Service.State>}
+   *
+   * @param taskWorker {@link TaskWorkerService}
+   */
+  static CompletableFuture<Service.State> getServiceCompletionFuture(TaskWorkerService taskWorker) {
+    CompletableFuture<Service.State> future = new CompletableFuture<>();
+    taskWorker.addListener(new ServiceListenerAdapter() {
+      @Override
+      public void terminated(Service.State from) {
+        future.complete(from);
+      }
+
+      @Override
+      public void failed(Service.State from, Throwable failure) {
+        future.completeExceptionally(failure);
+      }
+    }, Threads.SAME_THREAD_EXECUTOR);
+    return future;
+  }
+
+  /**
+   * Waits for the future to be completed
+   *
+   * @param future {@link CompletableFuture<Service.State>}
+   */
+  static void waitForServiceCompletion(CompletableFuture<Service.State> future) {
+    try {
+      Uninterruptibles.getUninterruptibly(future);
+    } catch (Exception e) {
+      //ignore
+    }
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -436,6 +436,7 @@ public final class Constants {
     public static final String BOSS_THREADS = "task.worker.boss.threads";
     public static final String WORKER_THREADS = "task.worker.worker.threads";
     public static final String METADATA_SERVICE_END_POINT = "task.worker.metadata.service.endpoint";
+    public static final String METRIC_PREFIX = "task.worker.";
   }
 
   /**
@@ -832,6 +833,10 @@ public final class Constants {
       public static final String PROGRAM = "prg";
       public static final String PROGRAM_TYPE = "prt";
       public static final String PROGRAM_ENTITY = "ent";
+
+      //For task worker
+      public static final String CLASS = "clz";
+      public static final String TRIES = "try";
     }
 
     /**
@@ -897,6 +902,15 @@ public final class Constants {
      */
     public static final class Preview {
       public static final String RUN_TIME_SECONDS = "preview.run.seconds";
+    }
+
+    public static final class TaskWorker {
+      public static final String REQUEST_COUNT = Constants.TaskWorker.METRIC_PREFIX + "request.count";
+      public static final String REQUEST_LATENCY_MS = Constants.TaskWorker.METRIC_PREFIX + "request.latency.millis";
+      public static final String CLIENT_REQUEST_COUNT =
+        "client." + Constants.TaskWorker.METRIC_PREFIX + "request.count";
+      public static final String CLIENT_REQUEST_LATENCY_MS =
+        "client." + Constants.TaskWorker.METRIC_PREFIX + "request.latency.millis";
     }
 
     /**

--- a/cdap-common/src/main/java/io/cdap/cdap/common/service/RetryContext.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/service/RetryContext.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.service;
+
+/**
+ * Can be used to provide any required context to the {@link Retries.CallableWithContext}
+ */
+public class RetryContext {
+
+  private final int retryAttempt;
+
+  private RetryContext(int retryAttempt) {
+    this.retryAttempt = retryAttempt;
+  }
+
+  /**
+   * Returns retry attempt
+   *
+   * @return integer indicating the attempt
+   */
+  public int getRetryAttempt() {
+    return retryAttempt;
+  }
+
+  /**
+   * Builder for {@link RetryContext}
+   */
+  public static class Builder {
+    private int retryAttempt;
+
+    /**
+     * @param retryAttempt integer indicating the attempt
+     * @return {@link Builder}
+     */
+    public Builder withRetryAttempt(int retryAttempt) {
+      this.retryAttempt = retryAttempt;
+      return this;
+    }
+
+    /**
+     * @return {@link RetryContext}
+     */
+    public RetryContext build() {
+      return new RetryContext(retryAttempt);
+    }
+  }
+}

--- a/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/worker/RunnableTaskContext.java
+++ b/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/worker/RunnableTaskContext.java
@@ -29,7 +29,10 @@ import javax.annotation.Nullable;
  */
 public class RunnableTaskContext {
   private final ExposedByteArrayOutputStream outputStream;
+  @Nullable
   private final String param;
+  @Nullable
+  private final RunnableTaskRequest embeddedRequest;
   @Nullable
   private final String namespace;
   @Nullable
@@ -39,9 +42,11 @@ public class RunnableTaskContext {
 
   private boolean terminateOnComplete;
 
-  public RunnableTaskContext(String param, @Nullable String namespace,
-                             @Nullable ArtifactId artifactId, @Nullable SystemAppTaskContext systemAppTaskContext) {
+  public RunnableTaskContext(@Nullable String param, @Nullable RunnableTaskRequest embeddedRequest,
+                             @Nullable String namespace, @Nullable ArtifactId artifactId,
+                             @Nullable SystemAppTaskContext systemAppTaskContext) {
     this.param = param;
+    this.embeddedRequest = embeddedRequest;
     this.namespace = namespace;
     this.artifactId = artifactId;
     this.systemAppTaskContext = systemAppTaskContext;
@@ -76,8 +81,14 @@ public class RunnableTaskContext {
     return outputStream.toByteBuffer();
   }
 
+  @Nullable
   public String getParam() {
     return param;
+  }
+
+  @Nullable
+  public RunnableTaskRequest getEmbeddedRequest() {
+    return embeddedRequest;
   }
 
   @Nullable
@@ -103,7 +114,7 @@ public class RunnableTaskContext {
    * Builder for RunnableTaskContext
    */
   public static class Builder {
-    private String param;
+    private RunnableTaskParam param;
     @Nullable
     private String namespace;
     @Nullable
@@ -115,7 +126,7 @@ public class RunnableTaskContext {
 
     }
 
-    public Builder withParam(String param) {
+    public Builder withParam(RunnableTaskParam param) {
       this.param = param;
       return this;
     }
@@ -137,7 +148,8 @@ public class RunnableTaskContext {
     }
 
     public RunnableTaskContext build() {
-      return new RunnableTaskContext(param, namespace, artifactId, systemAppTaskContext);
+      return new RunnableTaskContext(param.getSimpleParam(), param.getEmbeddedTaskRequest(), namespace, artifactId,
+                                     systemAppTaskContext);
     }
   }
 }

--- a/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/worker/RunnableTaskParam.java
+++ b/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/worker/RunnableTaskParam.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.service.worker;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Class for the parameter of {@link RunnableTaskRequest}
+ */
+public class RunnableTaskParam {
+
+  /**
+   * Param string value
+   */
+  private final String simpleParam;
+  /**
+   * Param class name
+   */
+  private final RunnableTaskRequest embeddedTaskRequest;
+
+  public RunnableTaskParam(@Nullable String simpleParam, @Nullable RunnableTaskRequest embeddedTaskRequest) {
+    this.simpleParam = simpleParam;
+    this.embeddedTaskRequest = embeddedTaskRequest;
+  }
+
+  @Nullable
+  public RunnableTaskRequest getEmbeddedTaskRequest() {
+    return embeddedTaskRequest;
+  }
+
+  @Nullable
+  public String getSimpleParam() {
+    return simpleParam;
+  }
+
+  @Override
+  public String toString() {
+    String format = "RunnableTaskParam{simpleParam='%s' , embeddedTaskRequest='%s'}";
+    return String.format(format, simpleParam, embeddedTaskRequest);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RunnableTaskParam)) {
+      return false;
+    }
+    RunnableTaskParam that = (RunnableTaskParam) o;
+    return Objects.equals(simpleParam, that.simpleParam) && Objects
+      .equals(embeddedTaskRequest, that.embeddedTaskRequest);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(simpleParam, embeddedTaskRequest);
+  }
+}

--- a/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/worker/RunnableTaskRequest.java
+++ b/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/worker/RunnableTaskRequest.java
@@ -26,16 +26,18 @@ import javax.annotation.Nullable;
 public class RunnableTaskRequest {
   private final String className;
   @Nullable
-  private final String param;
+  private final RunnableTaskParam param;
   @Nullable
   private final ArtifactId artifactId;
   @Nullable
   private final String namespace;
+  @Nullable
 
   private RunnableTaskRequest(String className, @Nullable String param,
-                              @Nullable ArtifactId artifactId, @Nullable String namespace) {
+                              @Nullable ArtifactId artifactId, @Nullable String namespace,
+                              @Nullable RunnableTaskRequest embeddedTaskRequest) {
     this.className = className;
-    this.param = param;
+    this.param = new RunnableTaskParam(param, embeddedTaskRequest);
     this.artifactId = artifactId;
     this.namespace = namespace;
   }
@@ -45,7 +47,7 @@ public class RunnableTaskRequest {
   }
 
   @Nullable
-  public String getParam() {
+  public RunnableTaskParam getParam() {
     return param;
   }
 
@@ -61,9 +63,11 @@ public class RunnableTaskRequest {
 
   @Override
   public String toString() {
-    String requestString = "RunnableTaskRequest{className=%s, param=%s, artifactId=%s, namespace=%s}";
-    return String.format(requestString, className,
-                         param == null ? null : param.length() > 500 ? param.substring(500) : param,
+    String requestString =
+      "RunnableTaskRequest{className=%s, param=%s, artifactId=%s, namespace=%s}";
+    return String.format(requestString, className, param == null ? null :
+                           param.getSimpleParam().length() > 500 ?
+                             param.getSimpleParam().substring(500) : param.getSimpleParam(),
                          artifactId, namespace);
   }
 
@@ -77,18 +81,20 @@ public class RunnableTaskRequest {
   public static class Builder {
     private final String className;
     @Nullable
-    private String param;
+    private String simpleParam;
     @Nullable
     private ArtifactId artifactId;
     @Nullable
     private String namespace;
+    @Nullable
+    private RunnableTaskRequest embeddedTaskRequest;
 
     private Builder(String className) {
       this.className = className;
     }
 
     public Builder withParam(String param) {
-      this.param = param;
+      this.simpleParam = param;
       return this;
     }
 
@@ -102,8 +108,13 @@ public class RunnableTaskRequest {
       return this;
     }
 
+    public Builder withEmbeddedTaskRequest(RunnableTaskRequest embeddedTaskRequest) {
+      this.embeddedTaskRequest = embeddedTaskRequest;
+      return this;
+    }
+
     public RunnableTaskRequest build() {
-      return new RunnableTaskRequest(className, param, artifactId, namespace);
+      return new RunnableTaskRequest(className, simpleParam, artifactId, namespace, embeddedTaskRequest);
     }
   }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsQueryHelper.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsQueryHelper.java
@@ -119,6 +119,8 @@ public class MetricsQueryHelper {
       // put profile related tag
       .put(Constants.Metrics.Tag.PROFILE, "profile")
       .put(Constants.Metrics.Tag.PROFILE_SCOPE, "profilescope")
+      .put(Constants.Metrics.Tag.CLASS, "class")
+      .put(Constants.Metrics.Tag.TRIES, "retry")
       .build();
 
     tagNameToHuman = mapping;


### PR DESCRIPTION
CDAP-18502
- Enable request count, latency metrics for task worker
- Tagged with task class, status of request and number of attempt.
- Modified Retries.java to capture retry count