### PR TITLE
[CDAP-18315] Add ArtifactFetcher service for fetching artifacts bundle from spark driver

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/spark/ArtifactFetcherHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/spark/ArtifactFetcherHttpHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.spark;
+
+
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.LocationBodyProducer;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.filesystem.Location;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * HTTP handler for serving local artifacts to spark executors.
+ */
+@Path(Constants.Gateway.INTERNAL_API_VERSION_3 + "/artifacts")
+public class ArtifactFetcherHttpHandler extends AbstractHttpHandler {
+  private final Location bundleLocation;
+
+  public ArtifactFetcherHttpHandler(Location bundleLocation) {
+    this.bundleLocation = bundleLocation;
+  }
+
+  /**
+   * Bundles and downloads the content of {@link this#bundleLocation}
+   *
+   * @param request   {@link HttpRequest}
+   * @param responder {@link HttpResponse}
+   */
+  @GET
+  @Path("/fetch")
+  public void fetch(HttpRequest request, HttpResponder responder) {
+    if (bundleLocation == null) {
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, "Bundle location was not found.",
+                           EmptyHttpHeaders.INSTANCE);
+      return;
+    }
+    responder.sendContent(HttpResponseStatus.OK, new LocationBodyProducer(bundleLocation),
+                          new DefaultHttpHeaders().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM));
+  }
+
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/spark/ArtifactFetcherService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/spark/ArtifactFetcherService.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.spark;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
+import io.cdap.http.NettyHttpService;
+import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Launches an HTTP server for fetching artifacts.
+ */
+public class ArtifactFetcherService extends AbstractIdleService {
+  private static final Logger LOG = LoggerFactory.getLogger(ArtifactFetcherService.class);
+
+  private final NettyHttpService httpService;
+
+  public ArtifactFetcherService(CConfiguration cConf, Location bundleLocation) {
+    httpService = new CommonNettyHttpServiceBuilder(cConf, "artifact.fetcher")
+      .setHttpHandlers(
+        new ArtifactFetcherHttpHandler(bundleLocation)
+      )
+      .setHost(cConf.get(Constants.Spark.Driver.ADDRESS))
+      .setPort(cConf.getInt(Constants.Spark.Driver.PORT))
+      .setExecThreadPoolSize(cConf.getInt(Constants.Spark.Driver.EXEC_THREADS))
+      .setBossThreadPoolSize(cConf.getInt(Constants.Spark.Driver.BOSS_THREADS))
+      .setWorkerThreadPoolSize(cConf.getInt(Constants.Spark.Driver.WORKER_THREADS))
+      .build();
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting ArtifactFetcherService");
+    httpService.start();
+    LOG.info("ArtifactFetcherService started");
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Stopping ArtifactFetcherService");
+    httpService.stop(1, 2, TimeUnit.SECONDS);
+    LOG.info("ArtifactFetcherService stopped");
+  }
+
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -382,6 +382,19 @@ public final class Constants {
   }
 
   /**
+   * Spark on k8s
+   */
+  public static final class Spark {
+    public static final class Driver {
+      public static final String ADDRESS = "driver.artifact.fetcher.bind.address";
+      public static final String PORT = "driver.artifact.fetcher.bind.port";
+      public static final String EXEC_THREADS = "driver.artifact.fetcher.exec.threads";
+      public static final String BOSS_THREADS = "driver.artifact.fetcher.boss.threads";
+      public static final String WORKER_THREADS = "driver.artifact.fetcher.worker.threads";
+    }
+  }
+
+  /**
    * Task worker.
    */
   public static final class TaskWorker {

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4323,6 +4323,47 @@
     </description>
   </property>
 
+  <!-- Spark on k8s  -->
+  <property>
+    <name>driver.artifact.fetcher.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      The bind address for artifact fetcher service
+    </description>
+  </property>
+
+  <property>
+    <name>driver.artifact.fetcher.bind.port</name>
+    <value>11013</value>
+    <description>
+      The bind port for artifact fetcher service
+    </description>
+  </property>
+
+  <property>
+    <name>driver.artifact.fetcher.worker.threads</name>
+    <value>10</value>
+    <description>
+      The number of worker threads in the artifacts fetcher.
+    </description>
+  </property>
+
+  <property>
+    <name>driver.artifact.fetcher.exec.threads</name>
+    <value>10</value>
+    <description>
+      The number of executor threads for the artifacts fetcher.
+    </description>
+  </property>
+
+  <property>
+    <name>driver.artifact.fetcher.boss.threads</name>
+    <value>1</value>
+    <description>
+      The number of boss threads for the artifacts fetcher.
+    </description>
+  </property>
+
   <!-- Task Worker Configuration  -->
   <property>
     <name>task.worker.pool.enable</name>


### PR DESCRIPTION
ArtifactFetcherService will run on spark driver, and it allows spark executors to fetch artifacts from spark driver.

Note: changes to spark driver/executors will be included in a followup PR. 