### PR TITLE
[CDAP-18455] Pass artifact fetcher port to spark executors 

### DIFF
--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -212,7 +212,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
       // If MasterEnvironment is not available, use non-master env spark submitters
       MasterEnvironment masterEnv = MasterEnvironments.getMasterEnvironment();
       if (masterEnv != null) {
-        submitter = new MasterEnvironmentSparkSubmitter(locationFactory, host, runtimeContext, masterEnv);
+        submitter = new MasterEnvironmentSparkSubmitter(cConf, locationFactory, host, runtimeContext, masterEnv);
       } else {
         submitter = isLocal
           ? new LocalSparkSubmitter()

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/k8s/SparkContainerExecutorLauncher.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/k8s/SparkContainerExecutorLauncher.java
@@ -37,19 +37,23 @@ import java.util.List;
 public class SparkContainerExecutorLauncher {
   private static final String DRIVER_URL_FLAG = "--driver-url";
   private static final String DELEGATE_CLASS_FLAG = "--delegate-class";
+  private static final String ARTIFACT_FETCHER_PORT_FLAG = "--artifact-fetcher-port";
   private static final String ARTIFACT_FETCHER_ENDPOINT = Constants.Gateway.INTERNAL_API_VERSION_3 + "/artifacts/fetch";
-
-  //TODO: Needs to be passed/read from args
-  private static final int ARTIFACT_FETCHER_PORT = 11013;
   private static final String WORKING_DIRECTORY = "/opt/spark/work-dir/";
 
   public static void main(String[] args) throws Exception {
+    int artifactFetcherPort = -1;
+
     String delegateClass = "org.apache.spark.deploy.SparkSubmit";
     List<String> delegateArgs = new ArrayList<>();
     String driverHost = null;
     for (int i = 0; i < args.length; i++) {
       if (args[i].equals(DRIVER_URL_FLAG)) {
         driverHost = new URI(args[i + 1]).getHost();
+      } else if (args[i].equals(ARTIFACT_FETCHER_PORT_FLAG)) {
+        artifactFetcherPort = Integer.parseInt(args[i + 1]);
+        i++;
+        continue;
       } else if (args[i].equals(DELEGATE_CLASS_FLAG)) {
         delegateClass = args[i + 1];
         i++;
@@ -61,9 +65,12 @@ public class SparkContainerExecutorLauncher {
     if (driverHost == null || driverHost.length() == 0) {
       throw new IllegalArgumentException("Spark driver url is not set.");
     }
+    if (artifactFetcherPort == -1) {
+      throw new IllegalArgumentException("Spark driver artifact fetcher port is not set.");
+    }
 
     URL fetchArtifactURL =
-      new URL(String.format("http://%s:%s%s", driverHost, ARTIFACT_FETCHER_PORT, ARTIFACT_FETCHER_ENDPOINT));
+      new URL(String.format("http://%s:%s%s", driverHost, artifactFetcherPort, ARTIFACT_FETCHER_ENDPOINT));
     HttpURLConnection connection = (HttpURLConnection) fetchArtifactURL.openConnection();
     connection.connect();
 

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
@@ -21,6 +21,8 @@ import io.cdap.cdap.app.runtime.spark.SparkRuntimeContext;
 import io.cdap.cdap.app.runtime.spark.SparkRuntimeEnv;
 import io.cdap.cdap.app.runtime.spark.SparkRuntimeUtils;
 import io.cdap.cdap.app.runtime.spark.distributed.SparkExecutionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.internal.app.runtime.distributed.LocalizeResource;
 import io.cdap.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
 import io.cdap.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
@@ -50,17 +52,19 @@ public class MasterEnvironmentSparkSubmitter extends AbstractSparkSubmitter {
   private final MasterEnvironment masterEnv;
   private SparkConfig sparkConfig;
   private List<LocalizeResource> resources;
+  private final CConfiguration cConf;
 
   /**
    * Master environment spark submitter constructor.
    */
-  public MasterEnvironmentSparkSubmitter(LocationFactory locationFactory, String hostname,
+  public MasterEnvironmentSparkSubmitter(CConfiguration cConf, LocationFactory locationFactory, String hostname,
                                          SparkRuntimeContext runtimeContext, MasterEnvironment masterEnv) {
     ProgramRunId programRunId = runtimeContext.getProgram().getId().run(runtimeContext.getRunId().getId());
     WorkflowProgramInfo workflowInfo = runtimeContext.getWorkflowInfo();
     BasicWorkflowToken workflowToken = workflowInfo == null ? null : workflowInfo.getWorkflowToken();
     this.sparkExecutionService = new SparkExecutionService(locationFactory, hostname, programRunId, workflowToken);
     this.masterEnv = masterEnv;
+    this.cConf = cConf;
   }
 
   @Override
@@ -79,6 +83,7 @@ public class MasterEnvironmentSparkSubmitter extends AbstractSparkSubmitter {
     Map<String, String> config = new HashMap<>();
     config.put(SparkConfig.DRIVER_ENV_PREFIX + "CDAP_LOG_DIR", ApplicationConstants.LOG_DIR_EXPANSION_VAR);
     config.put("spark.executorEnv.CDAP_LOG_DIR", ApplicationConstants.LOG_DIR_EXPANSION_VAR);
+    config.put("spark.executorEnv.ARTIFACT_FECTHER_PORT", cConf.get(Constants.Spark.Driver.PORT));
     config.putAll(generateOrGetSparkConfig().getConfigs());
     return config;
   }

--- a/cdap-spark-core3_2.12/src/k8s/entrypoint.sh
+++ b/cdap-spark-core3_2.12/src/k8s/entrypoint.sh
@@ -116,6 +116,7 @@ case "$1" in
       --app-id $SPARK_APPLICATION_ID
       --hostname $SPARK_EXECUTOR_POD_IP
       --resourceProfileId $SPARK_RESOURCE_PROFILE_ID
+      --artifact-fetcher-port $ARTIFACT_FECTHER_PORT
     )
     ;;
 


### PR DESCRIPTION
This PR passes the spark driver artifact fetcher service port to spark executors. This in turn allows spark executors to fetch artifacts from spark driver artifact fetcher service.