### PR TITLE
CDAP-18504 use ip instead hostname for spark execution service

### DIFF
--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkExecutionService.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkExecutionService.java
@@ -106,11 +106,19 @@ public final class SparkExecutionService extends AbstractIdleService {
    * Returns the base {@link URI} for talking to this service remotely through HTTP.
    */
   public URI getBaseURI() {
+    InetSocketAddress bindAddress = getBindAddress();
+    return URI.create(String.format("http://%s:%d", bindAddress.getHostName(), bindAddress.getPort()));
+  }
+
+  /**
+   * Returns the socket address that the service is bound to.
+   */
+  public InetSocketAddress getBindAddress() {
     InetSocketAddress bindAddress = httpServer.getBindAddress();
     if (bindAddress == null) {
       throw new IllegalStateException("SparkExecutionService hasn't been started");
     }
-    return URI.create(String.format("http://%s:%d", bindAddress.getHostName(), bindAddress.getPort()));
+    return bindAddress;
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.twill.filesystem.LocationFactory;
 
+import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -69,8 +70,11 @@ public class MasterEnvironmentSparkSubmitter extends AbstractSparkSubmitter {
   @Override
   protected List<String> beforeSubmit() {
     sparkExecutionService.startAndWait();
+    InetSocketAddress socketAddress = sparkExecutionService.getBindAddress();
+    // use ip instead of hostname, as some environments (like kubernetes) don't work properly with hostname
+    String uri = String.format("http://%s:%d", socketAddress.getAddress().getHostAddress(), socketAddress.getPort());
     SparkRuntimeEnv.setProperty(SparkConfig.DRIVER_ENV_PREFIX + SparkRuntimeUtils.CDAP_SPARK_EXECUTION_SERVICE_URI,
-                                sparkExecutionService.getBaseURI().toString());
+                                uri);
     return Collections.emptyList();
   }
 


### PR DESCRIPTION
In kubernetes env, the hostname for the SparkExecutionService
is not accessible, though the IP is.