### PR TITLE
[CDAP-18384] Authorization Metrics

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramRunners.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramRunners.java
@@ -35,7 +35,7 @@ import io.cdap.cdap.app.runtime.ProgramRunner;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.io.Locations;
-import io.cdap.cdap.internal.app.program.ProgramTypeMetricTag;
+import io.cdap.cdap.common.metrics.ProgramTypeMetricTag;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.ProgramRunId;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramRunnableResourceReporter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramRunnableResourceReporter.java
@@ -18,7 +18,7 @@ package io.cdap.cdap.internal.app.runtime.distributed;
 
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.internal.app.program.ProgramTypeMetricTag;
+import io.cdap.cdap.common.metrics.ProgramTypeMetricTag;
 import io.cdap.cdap.internal.app.runtime.AbstractResourceReporter;
 import io.cdap.cdap.proto.id.ProgramId;
 import org.apache.twill.api.TwillContext;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.deploy;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gson.Gson;
+import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import io.cdap.cdap.AllProgramsApp;
@@ -25,6 +26,7 @@ import io.cdap.cdap.ConfigTestApp;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.app.ProgramType;
 import io.cdap.cdap.api.artifact.ApplicationClass;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.deploy.ConfigResponse;
 import io.cdap.cdap.app.deploy.Configurator;
 import io.cdap.cdap.app.runtime.DummyProgramRunnerFactory;
@@ -32,6 +34,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.common.test.AppJarHelper;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppSpecInfo;
@@ -81,7 +84,14 @@ public class ConfiguratorTest {
     Injector injector = Guice.createInjector(new ConfigModule(conf),
                                              new AuthorizationTestModule(),
                                              new AuthorizationEnforcementModule().getInMemoryModules(),
-                                             new AuthenticationContextModules().getNoOpModule());
+                                             new AuthenticationContextModules().getNoOpModule(),
+                                             new AbstractModule() {
+                                               @Override
+                                               protected void configure() {
+                                                 bind(MetricsCollectionService.class)
+                                                   .to(NoOpMetricsCollectionService.class);
+                                               }
+                                             });
     authEnforcer = injector.getInstance(AccessEnforcer.class);
     authenticationContext = injector.getInstance(AuthenticationContext.class);
   }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -768,6 +768,11 @@ public final class Constants {
     public static final String PROGRAM_METRICS_ENABLED = "app.program.metrics.enabled";
     public static final String STRUCTURED_TABLE_TIME_METRICS_ENABLED = "structured.table.time.metrics.enabled";
 
+    /** Whether to enable metrics tracking for authorization */
+    public static final String AUTHORIZATION_METRICS_ENABLED = "security.authorization.metrics.enabled";
+    /** Whether to enable entity tagging for metrics for aggregation purposes. */
+    public static final String AUTHORIZATION_METRICS_TAGS_ENABLED = "security.authorization.metrics.tags.enabled";
+
     /**
      * Metric's dataset related constants.
      */
@@ -931,6 +936,22 @@ public final class Constants {
      */
     public static final class MetadataStorage {
       public static final String METRICS_PREFIX = "metadata.storage.";
+    }
+
+    /**
+     * Authorization metrics
+     */
+    public static final class Authorization {
+      public static final String INTERNAL_CHECK_SUCCESS_COUNT = "authorization.internal.check.success.count";
+      public static final String INTERNAL_CHECK_FAILURE_COUNT = "authorization.internal.check.failure.count";
+      public static final String INTERNAL_VISIBILITY_CHECK_COUNT = "authorization.internal.visibility.check.count";
+      public static final String EXTENSION_CHECK_SUCCESS_COUNT = "authorization.extension.check.success.count";
+      public static final String EXTENSION_CHECK_FAILURE_COUNT = "authorization.extension.check.failure.count";
+      public static final String EXTENSION_CHECK_BYPASS_COUNT = "authorization.extension.check.bypass.count";
+      public static final String NON_INTERNAL_VISIBILITY_CHECK_COUNT =
+        "authorization.non.internal.visibility.check.count";
+      public static final String EXTENSION_CHECK_MILLIS = "authorization.extension.check.millis";
+      public static final String EXTENSION_VISIBILITY_MILLIS = "authorization.extension.visibility.millis";
     }
   }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/metrics/ProgramTypeMetricTag.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/metrics/ProgramTypeMetricTag.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.internal.app.program;
+package io.cdap.cdap.common.metrics;
 
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.proto.ProgramType;

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4210,6 +4210,24 @@
     </description>
   </property>
 
+  <!-- Authorization Metrics -->
+
+  <property>
+    <name>security.authorization.metrics.enabled</name>
+    <value>false</value>
+    <description>
+      Whether to collect metrics for authorization checks.
+    </description>
+  </property>
+
+  <property>
+    <name>security.authorization.metrics.tags.enabled</name>
+    <value>false</value>
+    <description>
+      Whether to enable entity tagging for authorization metrics for metrics aggregations.
+    </description>
+  </property>
+
   <!-- UI Configuration -->
 
   <property>

--- a/cdap-security/src/test/java/io/cdap/cdap/security/authorization/AuthorizationTestBase.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/authorization/AuthorizationTestBase.java
@@ -46,6 +46,8 @@ public class AuthorizationTestBase {
     CCONF.set(Constants.CFG_LOCAL_DATA_DIR, TEMPORARY_FOLDER.newFolder().getAbsolutePath());
     CCONF.setBoolean(Constants.Security.ENABLED, true);
     CCONF.setBoolean(Constants.Security.Authorization.ENABLED, true);
+    CCONF.setBoolean(Constants.Metrics.AUTHORIZATION_METRICS_ENABLED, true);
+    CCONF.setBoolean(Constants.Metrics.AUTHORIZATION_METRICS_TAGS_ENABLED, true);
     locationFactory = new LocalLocationFactory(TEMPORARY_FOLDER.newFolder());
   }
 }

--- a/cdap-security/src/test/java/io/cdap/cdap/security/authorization/DefaultAccessEnforcerTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/authorization/DefaultAccessEnforcerTest.java
@@ -22,16 +22,21 @@ import com.google.crypto.tink.JsonKeysetWriter;
 import com.google.crypto.tink.KeyTemplates;
 import com.google.crypto.tink.KeysetHandle;
 import com.google.crypto.tink.aead.AeadConfig;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.api.metrics.MetricsContext;
 import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.common.metrics.ProgramTypeMetricTag;
 import io.cdap.cdap.common.test.AppJarHelper;
+import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.security.Authorizable;
 import io.cdap.cdap.proto.security.Credential;
 import io.cdap.cdap.proto.security.Permission;
@@ -58,9 +63,18 @@ import java.security.GeneralSecurityException;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link DefaultAccessEnforcer}.
@@ -72,6 +86,19 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
   private static final NamespaceId NS = new NamespaceId("ns");
   private static final ApplicationId APP = NS.app("app");
 
+  private static class ControllerWrapper {
+    private final AccessController accessController;
+    private final DefaultAccessEnforcer defaultAccessEnforcer;
+    private final MetricsContext mockMetricsContext;
+
+    ControllerWrapper(AccessController accessController, DefaultAccessEnforcer defaultAccessEnforcer,
+                      MetricsContext mockMetricsContext) {
+      this.accessController = accessController;
+      this.defaultAccessEnforcer = defaultAccessEnforcer;
+      this.mockMetricsContext = mockMetricsContext;
+    }
+  }
+
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -82,6 +109,19 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
     Location externalAuthJar = AppJarHelper.createDeploymentJar(
       locationFactory, InMemoryAccessController.class, manifest);
     CCONF.set(Constants.Security.Authorization.EXTENSION_JAR_PATH, externalAuthJar.toString());
+  }
+
+  private static ControllerWrapper createControllerWrapper(CConfiguration cConf, SConfiguration sConf,
+                                                           AccessEnforcer internalAccessEnforcer) {
+    MetricsCollectionService mockMetricsCollectionService = mock(MetricsCollectionService.class);
+    MetricsContext mockMetricsContext = mock(MetricsContext.class);
+    when(mockMetricsCollectionService.getContext(any(Map.class))).thenReturn(mockMetricsContext);
+    AccessControllerInstantiator accessControllerInstantiator = new AccessControllerInstantiator(cConf,
+                                                                                                 AUTH_CONTEXT_FACTORY);
+    DefaultAccessEnforcer defaultAccessEnforcer = new DefaultAccessEnforcer(cConf, sConf, accessControllerInstantiator,
+                                                                            internalAccessEnforcer,
+                                                                            mockMetricsCollectionService);
+    return new ControllerWrapper(accessControllerInstantiator.get(), defaultAccessEnforcer, mockMetricsContext);
   }
 
   @Test
@@ -101,110 +141,117 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
   @Test
   public void testPropagationDisabled() throws IOException, AccessException {
     CConfiguration cConfCopy = CConfiguration.copy(CCONF);
-    try (AccessControllerInstantiator accessControllerInstantiator =
-           new AccessControllerInstantiator(cConfCopy, AUTH_CONTEXT_FACTORY)) {
-      DefaultAccessEnforcer accessEnforcer =
-        new DefaultAccessEnforcer(cConfCopy, SCONF, accessControllerInstantiator, null);
-      accessControllerInstantiator.get().grant(Authorizable.fromEntityId(NS), ALICE,
-                                               ImmutableSet.of(StandardPermission.UPDATE));
-      accessEnforcer.enforce(NS, ALICE, StandardPermission.UPDATE);
-      try {
-        accessEnforcer.enforce(APP, ALICE, StandardPermission.UPDATE);
-        Assert.fail("Alice should not have ADMIN privilege on the APP.");
-      } catch (UnauthorizedException ignored) {
-        // expected
-      }
+    ControllerWrapper controllerWrapper = createControllerWrapper(cConfCopy, SCONF, null);
+    controllerWrapper.accessController.grant(Authorizable.fromEntityId(NS), ALICE,
+                                                  ImmutableSet.of(StandardPermission.UPDATE));
+    DefaultAccessEnforcer accessEnforcer = controllerWrapper.defaultAccessEnforcer;
+    accessEnforcer.enforce(NS, ALICE, StandardPermission.UPDATE);
+    try {
+      accessEnforcer.enforce(APP, ALICE, StandardPermission.UPDATE);
+      Assert.fail("Alice should not have ADMIN privilege on the APP.");
+    } catch (UnauthorizedException ignored) {
+      // expected
     }
+    // Verify the metrics context was called with correct metrics
+    verify(controllerWrapper.mockMetricsContext, times(1))
+      .increment(Constants.Metrics.Authorization.EXTENSION_CHECK_SUCCESS_COUNT, 1);
+    verify(controllerWrapper.mockMetricsContext, times(1))
+      .increment(Constants.Metrics.Authorization.EXTENSION_CHECK_FAILURE_COUNT, 1);
+    verify(controllerWrapper.mockMetricsContext, times(2))
+      .gauge(eq(Constants.Metrics.Authorization.EXTENSION_CHECK_MILLIS), any(Long.class));
   }
 
   @Test
   public void testAuthEnforce() throws IOException, AccessException {
-    try (AccessControllerInstantiator accessControllerInstantiator =
-           new AccessControllerInstantiator(CCONF, AUTH_CONTEXT_FACTORY)) {
-      AccessController accessController = accessControllerInstantiator.get();
-      DefaultAccessEnforcer authEnforcementService =
-        new DefaultAccessEnforcer(CCONF, SCONF, accessControllerInstantiator, null);
-      // update privileges for alice. Currently alice has not been granted any privileges.
-      assertAuthorizationFailure(authEnforcementService, NS, ALICE, StandardPermission.UPDATE);
+    ControllerWrapper controllerWrapper = createControllerWrapper(CCONF, SCONF, null);
+    AccessController accessController = controllerWrapper.accessController;
+    DefaultAccessEnforcer authEnforcementService = controllerWrapper.defaultAccessEnforcer;
+    // update privileges for alice. Currently alice has not been granted any privileges.
+    assertAuthorizationFailure(authEnforcementService, NS, ALICE, StandardPermission.UPDATE);
 
-      // grant some test privileges
-      DatasetId ds = NS.dataset("ds");
-      accessController.grant(Authorizable.fromEntityId(NS), ALICE, ImmutableSet.of(StandardPermission.GET,
-                                                                                   StandardPermission.UPDATE));
-      accessController.grant(Authorizable.fromEntityId(ds), BOB, ImmutableSet.of(StandardPermission.UPDATE));
-      accessController.grant(Authorizable.fromEntityId(NS, EntityType.DATASET), ALICE,
-                             ImmutableSet.of(StandardPermission.LIST));
+    // grant some test privileges
+    DatasetId ds = NS.dataset("ds");
+    accessController.grant(Authorizable.fromEntityId(NS), ALICE, ImmutableSet.of(StandardPermission.GET,
+                                                                                 StandardPermission.UPDATE));
+    accessController.grant(Authorizable.fromEntityId(ds), BOB, ImmutableSet.of(StandardPermission.UPDATE));
+    accessController.grant(Authorizable.fromEntityId(NS, EntityType.DATASET), ALICE,
+                           ImmutableSet.of(StandardPermission.LIST));
 
-      // auth enforcement for alice should succeed on ns for actions read, write and list datasets
-      authEnforcementService.enforce(NS, ALICE, ImmutableSet.of(StandardPermission.GET, StandardPermission.UPDATE));
-      authEnforcementService.enforceOnParent(EntityType.DATASET, NS, ALICE, StandardPermission.LIST);
-      assertAuthorizationFailure(authEnforcementService, NS, ALICE, EnumSet.allOf(StandardPermission.class));
-      // alice do not have CREATE, READ or WRITE on the dataset, so authorization should fail
-      assertAuthorizationFailure(authEnforcementService, ds, ALICE, StandardPermission.GET);
-      assertAuthorizationFailure(authEnforcementService, ds, ALICE, StandardPermission.UPDATE);
-      assertAuthorizationFailure(authEnforcementService, EntityType.DATASET, NS, ALICE, StandardPermission.CREATE);
+    // auth enforcement for alice should succeed on ns for actions read, write and list datasets
+    authEnforcementService.enforce(NS, ALICE, ImmutableSet.of(StandardPermission.GET, StandardPermission.UPDATE));
+    authEnforcementService.enforceOnParent(EntityType.DATASET, NS, ALICE, StandardPermission.LIST);
+    assertAuthorizationFailure(authEnforcementService, NS, ALICE, EnumSet.allOf(StandardPermission.class));
+    // alice do not have CREATE, READ or WRITE on the dataset, so authorization should fail
+    assertAuthorizationFailure(authEnforcementService, ds, ALICE, StandardPermission.GET);
+    assertAuthorizationFailure(authEnforcementService, ds, ALICE, StandardPermission.UPDATE);
+    assertAuthorizationFailure(authEnforcementService, EntityType.DATASET, NS, ALICE, StandardPermission.CREATE);
 
-      // Alice doesn't have Delete right on NS, hence should fail.
-      assertAuthorizationFailure(authEnforcementService, NS, ALICE, StandardPermission.DELETE);
-      // bob enforcement should succeed since we grant him admin privilege
-      authEnforcementService.enforce(ds, BOB, StandardPermission.UPDATE);
-      // revoke all of alice's privileges
-      accessController.revoke(Authorizable.fromEntityId(NS), ALICE, ImmutableSet.of(StandardPermission.GET));
-      try {
-        authEnforcementService.enforce(NS, ALICE, StandardPermission.GET);
-        Assert.fail(String.format("Expected %s to not have '%s' privilege on %s but it does.",
-                                  ALICE, StandardPermission.GET, NS));
-      } catch (UnauthorizedException ignored) {
-        // expected
-      }
-      accessController.revoke(Authorizable.fromEntityId(NS));
+    // Alice doesn't have Delete right on NS, hence should fail.
+    assertAuthorizationFailure(authEnforcementService, NS, ALICE, StandardPermission.DELETE);
+    // bob enforcement should succeed since we grant him admin privilege
+    authEnforcementService.enforce(ds, BOB, StandardPermission.UPDATE);
+    // revoke all of alice's privileges
+    accessController.revoke(Authorizable.fromEntityId(NS), ALICE, ImmutableSet.of(StandardPermission.GET));
+    assertAuthorizationFailure(authEnforcementService, NS, ALICE, StandardPermission.GET);
 
-      assertAuthorizationFailure(authEnforcementService, NS, ALICE, StandardPermission.GET);
-      assertAuthorizationFailure(authEnforcementService, NS, ALICE, StandardPermission.UPDATE);
-      authEnforcementService.enforce(ds, BOB, StandardPermission.UPDATE);
-    }
+    accessController.revoke(Authorizable.fromEntityId(NS));
+
+    assertAuthorizationFailure(authEnforcementService, NS, ALICE, StandardPermission.GET);
+    assertAuthorizationFailure(authEnforcementService, NS, ALICE, StandardPermission.UPDATE);
+    authEnforcementService.enforce(ds, BOB, StandardPermission.UPDATE);
+    // Verify the metrics context was called with correct metrics
+    verify(controllerWrapper.mockMetricsContext, times(4))
+      .increment(Constants.Metrics.Authorization.EXTENSION_CHECK_SUCCESS_COUNT, 1);
+    verify(controllerWrapper.mockMetricsContext, times(9))
+      .increment(Constants.Metrics.Authorization.EXTENSION_CHECK_FAILURE_COUNT, 1);
+    verify(controllerWrapper.mockMetricsContext, times(13))
+      .gauge(eq(Constants.Metrics.Authorization.EXTENSION_CHECK_MILLIS), any(Long.class));
   }
 
   @Test
   public void testIsVisible() throws IOException, AccessException {
-    try (AccessControllerInstantiator accessControllerInstantiator =
-           new AccessControllerInstantiator(CCONF, AUTH_CONTEXT_FACTORY)) {
-      AccessController accessController = accessControllerInstantiator.get();
-      NamespaceId ns1 = new NamespaceId("ns1");
-      NamespaceId ns2 = new NamespaceId("ns2");
-      DatasetId ds11 = ns1.dataset("ds11");
-      DatasetId ds12 = ns1.dataset("ds12");
-      DatasetId ds21 = ns2.dataset("ds21");
-      DatasetId ds22 = ns2.dataset("ds22");
-      DatasetId ds23 = ns2.dataset("ds33");
-      Set<NamespaceId> namespaces = ImmutableSet.of(ns1, ns2);
-      // Alice has access on ns1, ns2, ds11, ds21, ds23, Bob has access on ds11, ds12, ds22
-      accessController.grant(Authorizable.fromEntityId(ns1), ALICE, Collections.singleton(StandardPermission.UPDATE));
-      accessController.grant(Authorizable.fromEntityId(ns2), ALICE, Collections.singleton(StandardPermission.UPDATE));
-      accessController.grant(Authorizable.fromEntityId(ds11), ALICE, Collections.singleton(StandardPermission.GET));
-      accessController.grant(Authorizable.fromEntityId(ds11), BOB, Collections.singleton(StandardPermission.UPDATE));
-      accessController.grant(Authorizable.fromEntityId(ds21), ALICE, Collections.singleton(StandardPermission.UPDATE));
-      accessController.grant(Authorizable.fromEntityId(ds12), BOB, Collections.singleton(StandardPermission.UPDATE));
-      accessController.grant(Authorizable.fromEntityId(ds12), BOB, EnumSet.allOf(StandardPermission.class));
-      accessController.grant(Authorizable.fromEntityId(ds21), ALICE, Collections.singleton(StandardPermission.UPDATE));
-      accessController.grant(Authorizable.fromEntityId(ds23), ALICE, Collections.singleton(StandardPermission.UPDATE));
-      accessController.grant(Authorizable.fromEntityId(ds22), BOB, Collections.singleton(StandardPermission.UPDATE));
-      DefaultAccessEnforcer authEnforcementService =
-        new DefaultAccessEnforcer(CCONF, SCONF, accessControllerInstantiator, null);
-      Assert.assertEquals(namespaces.size(), authEnforcementService.isVisible(namespaces, ALICE).size());
-      // bob should also be able to list two namespaces since he has privileges on the dataset in both namespaces
-      Assert.assertEquals(namespaces.size(), authEnforcementService.isVisible(namespaces, BOB).size());
-      Set<DatasetId> expectedDatasetIds = ImmutableSet.of(ds11, ds21, ds23);
-      Assert.assertEquals(expectedDatasetIds.size(), authEnforcementService.isVisible(expectedDatasetIds,
-                                                                                      ALICE).size());
-      expectedDatasetIds = ImmutableSet.of(ds12, ds22);
-      // this will be empty since now isVisible will not check the hierarchy privilege for the parent of the entity
-      Assert.assertEquals(Collections.EMPTY_SET, authEnforcementService.isVisible(expectedDatasetIds, ALICE));
-      expectedDatasetIds = ImmutableSet.of(ds11, ds12, ds22);
-      Assert.assertEquals(expectedDatasetIds.size(), authEnforcementService.isVisible(expectedDatasetIds, BOB).size());
-      expectedDatasetIds = ImmutableSet.of(ds21, ds23);
-      Assert.assertTrue(authEnforcementService.isVisible(expectedDatasetIds, BOB).isEmpty());
-    }
+    ControllerWrapper controllerWrapper = createControllerWrapper(CCONF, SCONF, null);
+    AccessController accessController = controllerWrapper.accessController;
+    DefaultAccessEnforcer authEnforcementService = controllerWrapper.defaultAccessEnforcer;
+
+    NamespaceId ns1 = new NamespaceId("ns1");
+    NamespaceId ns2 = new NamespaceId("ns2");
+    DatasetId ds11 = ns1.dataset("ds11");
+    DatasetId ds12 = ns1.dataset("ds12");
+    DatasetId ds21 = ns2.dataset("ds21");
+    DatasetId ds22 = ns2.dataset("ds22");
+    DatasetId ds23 = ns2.dataset("ds33");
+    Set<NamespaceId> namespaces = ImmutableSet.of(ns1, ns2);
+    // Alice has access on ns1, ns2, ds11, ds21, ds23, Bob has access on ds11, ds12, ds22
+    accessController.grant(Authorizable.fromEntityId(ns1), ALICE, Collections.singleton(StandardPermission.UPDATE));
+    accessController.grant(Authorizable.fromEntityId(ns2), ALICE, Collections.singleton(StandardPermission.UPDATE));
+    accessController.grant(Authorizable.fromEntityId(ds11), ALICE, Collections.singleton(StandardPermission.GET));
+    accessController.grant(Authorizable.fromEntityId(ds11), BOB, Collections.singleton(StandardPermission.UPDATE));
+    accessController.grant(Authorizable.fromEntityId(ds21), ALICE, Collections.singleton(StandardPermission.UPDATE));
+    accessController.grant(Authorizable.fromEntityId(ds12), BOB, Collections.singleton(StandardPermission.UPDATE));
+    accessController.grant(Authorizable.fromEntityId(ds12), BOB, EnumSet.allOf(StandardPermission.class));
+    accessController.grant(Authorizable.fromEntityId(ds21), ALICE, Collections.singleton(StandardPermission.UPDATE));
+    accessController.grant(Authorizable.fromEntityId(ds23), ALICE, Collections.singleton(StandardPermission.UPDATE));
+    accessController.grant(Authorizable.fromEntityId(ds22), BOB, Collections.singleton(StandardPermission.UPDATE));
+
+    Assert.assertEquals(namespaces.size(), authEnforcementService.isVisible(namespaces, ALICE).size());
+    // bob should also be able to list two namespaces since he has privileges on the dataset in both namespaces
+    Assert.assertEquals(namespaces.size(), authEnforcementService.isVisible(namespaces, BOB).size());
+    Set<DatasetId> expectedDatasetIds = ImmutableSet.of(ds11, ds21, ds23);
+    Assert.assertEquals(expectedDatasetIds.size(), authEnforcementService.isVisible(expectedDatasetIds,
+                                                                                    ALICE).size());
+    expectedDatasetIds = ImmutableSet.of(ds12, ds22);
+    // this will be empty since now isVisible will not check the hierarchy privilege for the parent of the entity
+    Assert.assertEquals(Collections.EMPTY_SET, authEnforcementService.isVisible(expectedDatasetIds, ALICE));
+    expectedDatasetIds = ImmutableSet.of(ds11, ds12, ds22);
+    Assert.assertEquals(expectedDatasetIds.size(), authEnforcementService.isVisible(expectedDatasetIds, BOB).size());
+    expectedDatasetIds = ImmutableSet.of(ds21, ds23);
+    Assert.assertTrue(authEnforcementService.isVisible(expectedDatasetIds, BOB).isEmpty());
+    // Verify the metrics context was called with correct metrics
+    verify(controllerWrapper.mockMetricsContext, times(6))
+      .increment(Constants.Metrics.Authorization.NON_INTERNAL_VISIBILITY_CHECK_COUNT, 1);
+    verify(controllerWrapper.mockMetricsContext, times(6))
+      .gauge(eq(Constants.Metrics.Authorization.EXTENSION_VISIBILITY_MILLIS), any(Long.class));
   }
 
   @Test
@@ -217,20 +264,24 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
     Principal userWithCredEncrypted = new Principal("userFoo", Principal.PrincipalType.USER, null,
                                                     new Credential(cred, Credential.CredentialType.EXTERNAL_ENCRYPTED));
 
-    try (AccessControllerInstantiator accessControllerInstantiator =
-           new AccessControllerInstantiator(CCONF, AUTH_CONTEXT_FACTORY)) {
-      AccessController accessController = accessControllerInstantiator.get();
-      DefaultAccessEnforcer accessEnforcer = new DefaultAccessEnforcer(CCONF, sConfCopy, accessControllerInstantiator,
-                                                                       null);
+    ControllerWrapper controllerWrapper = createControllerWrapper(CCONF, sConfCopy, null);
+    AccessController accessController = controllerWrapper.accessController;
+    DefaultAccessEnforcer accessEnforcer = controllerWrapper.defaultAccessEnforcer;
 
-      assertAuthorizationFailure(accessEnforcer, NS, userWithCredEncrypted, StandardPermission.UPDATE);
+    assertAuthorizationFailure(accessEnforcer, NS, userWithCredEncrypted, StandardPermission.UPDATE);
 
-      accessController.grant(Authorizable.fromEntityId(NS), userWithCredEncrypted,
-                             ImmutableSet.of(StandardPermission.GET, StandardPermission.UPDATE));
+    accessController.grant(Authorizable.fromEntityId(NS), userWithCredEncrypted,
+                           ImmutableSet.of(StandardPermission.GET, StandardPermission.UPDATE));
 
-      accessEnforcer.enforce(NS, userWithCredEncrypted, StandardPermission.GET);
-      accessEnforcer.enforce(NS, userWithCredEncrypted, StandardPermission.UPDATE);
-    }
+    accessEnforcer.enforce(NS, userWithCredEncrypted, StandardPermission.GET);
+    accessEnforcer.enforce(NS, userWithCredEncrypted, StandardPermission.UPDATE);
+    // Verify the metrics context was called with correct metrics
+    verify(controllerWrapper.mockMetricsContext, times(2))
+      .increment(Constants.Metrics.Authorization.EXTENSION_CHECK_SUCCESS_COUNT, 1);
+    verify(controllerWrapper.mockMetricsContext, times(1))
+      .increment(Constants.Metrics.Authorization.EXTENSION_CHECK_FAILURE_COUNT, 1);
+    verify(controllerWrapper.mockMetricsContext, times(3))
+      .gauge(eq(Constants.Metrics.Authorization.EXTENSION_CHECK_MILLIS), any(Long.class));
   }
 
   @Test
@@ -248,18 +299,19 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
                                                     new Credential(badCipherCred,
                                                                    Credential.CredentialType.EXTERNAL_ENCRYPTED));
 
-    try (AccessControllerInstantiator accessControllerInstantiator =
-           new AccessControllerInstantiator(CCONF, AUTH_CONTEXT_FACTORY)) {
-      AccessController accessController = accessControllerInstantiator.get();
+    ControllerWrapper controllerWrapper = createControllerWrapper(CCONF, sConfCopy, null);
+    AccessController accessController = controllerWrapper.accessController;
+    DefaultAccessEnforcer accessEnforcer = controllerWrapper.defaultAccessEnforcer;
 
-      accessController.grant(Authorizable.fromEntityId(NS), userWithCredEncrypted,
-                             ImmutableSet.of(StandardPermission.GET, StandardPermission.GET));
+    accessController.grant(Authorizable.fromEntityId(NS), userWithCredEncrypted,
+                           ImmutableSet.of(StandardPermission.GET, StandardPermission.GET));
 
-      DefaultAccessEnforcer accessEnforcer = new DefaultAccessEnforcer(CCONF, sConfCopy, accessControllerInstantiator,
-                                                                       null);
-
-      accessEnforcer.enforce(NS, userWithCredEncrypted, StandardPermission.GET);
-    }
+    accessEnforcer.enforce(NS, userWithCredEncrypted, StandardPermission.GET);
+    // Verify the metrics context was not called
+    verify(controllerWrapper.mockMetricsContext, times(0))
+      .increment(any(String.class), any(Long.class));
+    verify(controllerWrapper.mockMetricsContext, times(0))
+      .gauge(any(String.class), any(Long.class));
   }
 
   @Test
@@ -272,21 +324,23 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
     Principal userWithCredEncrypted = new Principal("userFoo", Principal.PrincipalType.USER, null,
                                                     new Credential(cred, Credential.CredentialType.EXTERNAL_ENCRYPTED));
 
-    try (AccessControllerInstantiator accessControllerInstantiator =
-           new AccessControllerInstantiator(CCONF, AUTH_CONTEXT_FACTORY)) {
-      AccessController accessController = accessControllerInstantiator.get();
-      DefaultAccessEnforcer accessEnforcer = new DefaultAccessEnforcer(CCONF, sConfCopy, accessControllerInstantiator,
-                                                                       null);
+    ControllerWrapper controllerWrapper = createControllerWrapper(CCONF, sConfCopy, null);
+    AccessController accessController = controllerWrapper.accessController;
+    DefaultAccessEnforcer accessEnforcer = controllerWrapper.defaultAccessEnforcer;
 
-      Set<NamespaceId> namespaces = ImmutableSet.of(NS);
+    Set<NamespaceId> namespaces = ImmutableSet.of(NS);
 
-      Assert.assertEquals(0, accessEnforcer.isVisible(namespaces, userWithCredEncrypted).size());
+    Assert.assertEquals(0, accessEnforcer.isVisible(namespaces, userWithCredEncrypted).size());
 
-      accessController.grant(Authorizable.fromEntityId(NS), userWithCredEncrypted,
-                             ImmutableSet.of(StandardPermission.GET, StandardPermission.UPDATE));
+    accessController.grant(Authorizable.fromEntityId(NS), userWithCredEncrypted,
+                           ImmutableSet.of(StandardPermission.GET, StandardPermission.UPDATE));
 
-      Assert.assertEquals(1, accessEnforcer.isVisible(namespaces, userWithCredEncrypted).size());
-    }
+    Assert.assertEquals(1, accessEnforcer.isVisible(namespaces, userWithCredEncrypted).size());
+    // Verify the metrics context was called with correct metrics
+    verify(controllerWrapper.mockMetricsContext, times(2))
+      .increment(Constants.Metrics.Authorization.NON_INTERNAL_VISIBILITY_CHECK_COUNT, 1);
+    verify(controllerWrapper.mockMetricsContext, times(2))
+      .gauge(eq(Constants.Metrics.Authorization.EXTENSION_VISIBILITY_MILLIS), any(Long.class));
   }
 
   @Test
@@ -294,39 +348,39 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
     CConfiguration cConfCopy = CConfiguration.copy(CCONF);
     Principal systemUser =
       new Principal(UserGroupInformation.getCurrentUser().getShortUserName(), Principal.PrincipalType.USER);
-    try (AccessControllerInstantiator accessControllerInstantiator =
-           new AccessControllerInstantiator(cConfCopy, AUTH_CONTEXT_FACTORY)) {
-      DefaultAccessEnforcer accessEnforcer =
-        new DefaultAccessEnforcer(cConfCopy, SCONF, accessControllerInstantiator, null);
-      NamespaceId ns1 = new NamespaceId("ns1");
-      accessEnforcer.enforce(NamespaceId.SYSTEM, systemUser, EnumSet.allOf(StandardPermission.class));
-      accessEnforcer.enforce(NamespaceId.SYSTEM, systemUser, StandardPermission.GET);
-      Assert.assertEquals(ImmutableSet.of(NamespaceId.SYSTEM),
-                          accessEnforcer.isVisible(ImmutableSet.of(ns1, NamespaceId.SYSTEM),
-                                                   systemUser));
-    }
+    ControllerWrapper controllerWrapper = createControllerWrapper(cConfCopy, SCONF, null);
+    DefaultAccessEnforcer accessEnforcer = controllerWrapper.defaultAccessEnforcer;
+    NamespaceId ns1 = new NamespaceId("ns1");
+    accessEnforcer.enforce(NamespaceId.SYSTEM, systemUser, EnumSet.allOf(StandardPermission.class));
+    accessEnforcer.enforce(NamespaceId.SYSTEM, systemUser, StandardPermission.GET);
+    Assert.assertEquals(ImmutableSet.of(NamespaceId.SYSTEM),
+                        accessEnforcer.isVisible(ImmutableSet.of(ns1, NamespaceId.SYSTEM),
+                                                 systemUser));
+    // Verify the metrics context was called with correct metrics
+    verify(controllerWrapper.mockMetricsContext, times(2))
+      .increment(Constants.Metrics.Authorization.EXTENSION_CHECK_BYPASS_COUNT, 1);
   }
 
   @Test
   public void testInternalAuthEnforce() throws IOException, AccessException {
     Principal userWithInternalCred = new Principal("system", Principal.PrincipalType.USER, null,
-                                                    new Credential("credential",
-                                                                   Credential.CredentialType.INTERNAL));
+                                                   new Credential("credential",
+                                                                  Credential.CredentialType.INTERNAL));
     CConfiguration cConfCopy = CConfiguration.copy(CCONF);
     cConfCopy.setBoolean(Constants.Security.INTERNAL_AUTH_ENABLED, true);
-    try (AccessControllerInstantiator accessControllerInstantiator =
-           new AccessControllerInstantiator(cConfCopy, AUTH_CONTEXT_FACTORY)) {
-      AccessController accessController = accessControllerInstantiator.get();
-      DefaultAccessEnforcer accessEnforcer = new DefaultAccessEnforcer(cConfCopy, SCONF, accessControllerInstantiator,
-                                                                       new NoOpAccessController());
-      // Make sure that the actual access controller does not have access.
-      assertAuthorizationFailure(accessController, NS, userWithInternalCred, StandardPermission.GET);
-      assertAuthorizationFailure(accessController, NS, userWithInternalCred, StandardPermission.UPDATE);
-      // The no-op access enforcer allows all requests through, so this should succeed if it is using the right
-      // access controller.
-      accessEnforcer.enforce(NS, userWithInternalCred, StandardPermission.GET);
-      accessEnforcer.enforce(NS, userWithInternalCred, StandardPermission.UPDATE);
-    }
+    ControllerWrapper controllerWrapper = createControllerWrapper(cConfCopy, SCONF, new NoOpAccessController());
+    AccessController accessController = controllerWrapper.accessController;
+    DefaultAccessEnforcer accessEnforcer = controllerWrapper.defaultAccessEnforcer;
+    // Make sure that the actual access controller does not have access.
+    assertAuthorizationFailure(accessController, NS, userWithInternalCred, StandardPermission.GET);
+    assertAuthorizationFailure(accessController, NS, userWithInternalCred, StandardPermission.UPDATE);
+    // The no-op access enforcer allows all requests through, so this should succeed if it is using the right
+    // access controller.
+    accessEnforcer.enforce(NS, userWithInternalCred, StandardPermission.GET);
+    accessEnforcer.enforce(NS, userWithInternalCred, StandardPermission.UPDATE);
+    // Verify the metrics context was called with correct metrics
+    verify(controllerWrapper.mockMetricsContext, times(2))
+      .increment(Constants.Metrics.Authorization.INTERNAL_CHECK_SUCCESS_COUNT, 1);
   }
 
   @Test
@@ -336,36 +390,56 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
                                                                   Credential.CredentialType.INTERNAL));
     CConfiguration cConfCopy = CConfiguration.copy(CCONF);
     cConfCopy.setBoolean(Constants.Security.INTERNAL_AUTH_ENABLED, true);
-    try (AccessControllerInstantiator accessControllerInstantiator =
-           new AccessControllerInstantiator(cConfCopy, AUTH_CONTEXT_FACTORY)) {
-      AccessController accessController = accessControllerInstantiator.get();
-      DefaultAccessEnforcer accessEnforcer = new DefaultAccessEnforcer(cConfCopy, SCONF, accessControllerInstantiator,
-                                                                       new NoOpAccessController());
+    ControllerWrapper controllerWrapper = createControllerWrapper(cConfCopy, SCONF, new NoOpAccessController());
+    AccessController accessController = controllerWrapper.accessController;
+    DefaultAccessEnforcer accessEnforcer = controllerWrapper.defaultAccessEnforcer;
+    Set<EntityId> namespaces = ImmutableSet.of(NS);
+    // Make sure that the actual access controller does not have access.
+    Assert.assertEquals(Collections.emptySet(), accessController.isVisible(namespaces, userWithInternalCred));
+    // The no-op access enforcer allows all requests through, so this should succeed if it is using the right
+    // access controller.
+    Assert.assertEquals(namespaces, accessEnforcer.isVisible(namespaces, userWithInternalCred));
+    // Verify the metrics context was called with correct metrics
+    verify(controllerWrapper.mockMetricsContext, times(1))
+      .increment(Constants.Metrics.Authorization.INTERNAL_VISIBILITY_CHECK_COUNT, 1);
+  }
 
-      Set<EntityId> namespaces = ImmutableSet.of(NS);
-      // Make sure that the actual access controller does not have access.
-      Assert.assertEquals(Collections.emptySet(), accessController.isVisible(namespaces, userWithInternalCred));
-      // The no-op access enforcer allows all requests through, so this should succeed if it is using the right
-      // access controller.
-      Assert.assertEquals(namespaces, accessEnforcer.isVisible(namespaces, userWithInternalCred));
-    }
+  @Test
+  public void testMetricsContextNotCalledIfDisabled() throws IOException, AccessException {
+    CConfiguration cConfCopy = CConfiguration.copy(CCONF);
+    cConfCopy.setBoolean(Constants.Metrics.AUTHORIZATION_METRICS_ENABLED, false);
+    ControllerWrapper controllerWrapper = createControllerWrapper(cConfCopy, SCONF, null);
+    AccessController accessController = controllerWrapper.accessController;
+    DefaultAccessEnforcer accessEnforcer = controllerWrapper.defaultAccessEnforcer;
+    DatasetId ds = NS.dataset("ds");
+    accessController.grant(Authorizable.fromEntityId(NS), ALICE, ImmutableSet.of(StandardPermission.GET,
+                                                                                 StandardPermission.UPDATE));
+    accessEnforcer.enforce(NS, ALICE, ImmutableSet.of(StandardPermission.GET, StandardPermission.UPDATE));
+    // Verify the metrics context was not called
+    verify(controllerWrapper.mockMetricsContext, times(0))
+      .increment(any(String.class), any(Long.class));
+    verify(controllerWrapper.mockMetricsContext, times(0))
+      .gauge(any(String.class), any(Long.class));
   }
 
   private void verifyDisabled(CConfiguration cConf) throws IOException, AccessException {
-    try (AccessControllerInstantiator accessControllerInstantiator =
-           new AccessControllerInstantiator(cConf, AUTH_CONTEXT_FACTORY)) {
-      DefaultAccessEnforcer authEnforcementService =
-        new DefaultAccessEnforcer(cConf, SCONF, accessControllerInstantiator, null);
-      DatasetId ds = NS.dataset("ds");
-      // All enforcement operations should succeed, since authorization is disabled
-      accessControllerInstantiator.get().grant(Authorizable.fromEntityId(ds), BOB,
-                                               ImmutableSet.of(StandardPermission.UPDATE));
-      authEnforcementService.enforce(NS, ALICE, StandardPermission.UPDATE);
-      authEnforcementService.enforce(ds, BOB, StandardPermission.UPDATE);
-      authEnforcementService.enforce(NS, BOB, StandardPermission.GET);
-      authEnforcementService.enforce(ds, BOB, StandardPermission.GET);
-      Assert.assertEquals(2, authEnforcementService.isVisible(ImmutableSet.<EntityId>of(NS, ds), BOB).size());
-    }
+    ControllerWrapper controllerWrapper = createControllerWrapper(cConf, SCONF, null);
+    AccessController accessController = controllerWrapper.accessController;
+    DefaultAccessEnforcer authEnforcementService = controllerWrapper.defaultAccessEnforcer;
+    DatasetId ds = NS.dataset("ds");
+    // All enforcement operations should succeed, since authorization is disabled
+    accessController.grant(Authorizable.fromEntityId(ds), BOB,
+                                             ImmutableSet.of(StandardPermission.UPDATE));
+    authEnforcementService.enforce(NS, ALICE, StandardPermission.UPDATE);
+    authEnforcementService.enforce(ds, BOB, StandardPermission.UPDATE);
+    authEnforcementService.enforce(NS, BOB, StandardPermission.GET);
+    authEnforcementService.enforce(ds, BOB, StandardPermission.GET);
+    Assert.assertEquals(2, authEnforcementService.isVisible(ImmutableSet.<EntityId>of(NS, ds), BOB).size());
+    // Verify the metrics context was not called
+    verify(controllerWrapper.mockMetricsContext, times(0))
+      .increment(any(String.class), any(Long.class));
+    verify(controllerWrapper.mockMetricsContext, times(0))
+      .gauge(any(String.class), any(Long.class));
   }
 
   private void assertAuthorizationFailure(AccessEnforcer authEnforcementService,
@@ -418,5 +492,32 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     CleartextKeysetHandle.write(keysetHandle, JsonKeysetWriter.withOutputStream(outputStream));
     return outputStream.toString();
+  }
+
+  @Test
+  public void testExpectedMetricsTagsForEntityId() {
+    String namespaceName = "namespace";
+    NamespaceId namespaceId = new NamespaceId(namespaceName);
+    Map<String, String> expectedTags = new HashMap<>();
+    expectedTags.put(Constants.Metrics.Tag.NAMESPACE, namespaceName);
+    Map<String, String> tags = DefaultAccessEnforcer.createEntityIdMetricsTags(namespaceId);
+    Assert.assertEquals(expectedTags, tags);
+  }
+
+  @Test
+  public void testExpectedMetricsTagsForChildEntityId() {
+    String namespaceName = "namespace";
+    NamespaceId namespaceId = new NamespaceId(namespaceName);
+    String appName = "app";
+    ApplicationId applicationId = namespaceId.app(appName);
+    String programName = "program";
+    ProgramId programId = applicationId.program(ProgramType.SPARK, programName);
+    Map<String, String> expectedTags = new HashMap<>();
+    expectedTags.put(Constants.Metrics.Tag.NAMESPACE, namespaceName);
+    expectedTags.put(Constants.Metrics.Tag.APP, appName);
+    expectedTags.put(Constants.Metrics.Tag.PROGRAM, programName);
+    expectedTags.put(Constants.Metrics.Tag.PROGRAM_TYPE, ProgramTypeMetricTag.getTagName(programId.getType()));
+    Map<String, String> tags = DefaultAccessEnforcer.createEntityIdMetricsTags(programId);
+    Assert.assertEquals(expectedTags, tags);
   }
 }


### PR DESCRIPTION
Added the following metrics for authorization:
 - `authorization.internal.check.success.count` - Successful internal auth checks (counter)
 - `authorization.internal.check.failure.count` - Failed internal auth checks (counter)
 - `authorization.internal.visibility.check.count` - Internal visibility checks (counter)
 - `authorization.extension.check.success.count` - Successful extension checks (counter)
 - `authorization.extension.check.failure.count` - Failed extension checks (counter)
 - `authorization.extension.check.bypass.count` - Bypassed extension checks (due to master principal) (counter)
 - `authorization.non.internal.visibility.check.count` - Non-internal visibility checks (counter)
 - `authorization.extension.check.millis` - Milliseconds taken per authorization extension check (gauge)
 - `authorization.extension.visibility.millis` - Milliseconds taken per authorization extension visibility check (gauge)