### PR TITLE
CDAP-18532: Provide a way to declare server error through Configuration file

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -694,6 +694,8 @@ public final class Constants {
 
     public static final String DONT_ROUTE_SERVICE = "dont-route-to-service";
     public static final String AUDIT_LOGGER_NAME = "http-access";
+
+    public static final String CCONF_RELOAD_INTERVAL_MINUTES = "router.cconf.reload.interval.minutes";
   }
 
   /**
@@ -1723,5 +1725,31 @@ public final class Constants {
        */
       public static final String WORKER_SECRET_DISK_PATH = "twill.security.worker.secret.disk.path";
     }
+  }
+
+  /**
+   * To declare an error through configuration,
+   * Router will start responding with the declared error to every inbound request
+   */
+  public static final class ConfigDeclaredError {
+    /**
+     * A prefix to add configs related to config-declared error
+     */
+    public static final String CONFIG_DECLARED_ERROR_PROPERTY_PREFIX = "error.declared.custom.";
+
+    /**
+     * Property to enable/disable config-declared error
+     */
+    public static final String CONFIG_DECLARED_ERROR_ENABLED = "error.declared.enabled";
+
+    /**
+     * The config name to define the status code for the error
+     */
+    public static final String CFG_STATUS_CODE = "error.declared.status.code";
+
+    /**
+     * The default status code if it is not defined in the config
+     */
+    public static final int DEFAULT_STATUS_CODE = 503;
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3751,6 +3751,14 @@
   </property>
 
   <property>
+    <name>router.cconf.reload.interval.minutes</name>
+    <value>10</value>
+    <description>
+      Interval in minutes at which CDAP Router reloads cconf, defaults to 10 minutes
+    </description>
+  </property>
+
+  <property>
     <name>router.connection.backlog</name>
     <value>20000</value>
     <description>

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/ConfigDeclaredErrorHandler.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/ConfigDeclaredErrorHandler.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.router.handlers;
+
+import com.google.gson.JsonObject;
+import io.cdap.cdap.common.conf.Configuration;
+import io.cdap.cdap.common.conf.Constants;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Handler to block all the inbound requests if config-declared error is enabled in {@link #cConf}
+ */
+public class ConfigDeclaredErrorHandler extends ChannelInboundHandlerAdapter {
+
+  private final Configuration cConf;
+
+  public ConfigDeclaredErrorHandler(Configuration cConf) {
+    this.cConf = cConf;
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+    if (!(msg instanceof HttpRequest) || !isConfigDeclaredErrorEnabled()) {
+      ctx.fireChannelRead(msg);
+      return;
+    }
+
+    try {
+      int statusCode =
+        cConf.getInt(Constants.ConfigDeclaredError.CFG_STATUS_CODE, Constants.ConfigDeclaredError.DEFAULT_STATUS_CODE);
+      JsonObject jsonContent = new JsonObject();
+      for (Map.Entry<String, String> cConfEntry : cConf) {
+        if (cConfEntry.getKey().startsWith(Constants.ConfigDeclaredError.CONFIG_DECLARED_ERROR_PROPERTY_PREFIX)) {
+          jsonContent.addProperty(
+            cConfEntry.getKey().substring(Constants.ConfigDeclaredError.CONFIG_DECLARED_ERROR_PROPERTY_PREFIX.length()),
+            cConfEntry.getValue()
+          );
+        }
+      }
+
+      ByteBuf content = Unpooled.copiedBuffer(jsonContent.toString(), StandardCharsets.UTF_8);
+      HttpResponse response = new DefaultFullHttpResponse(
+        HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(statusCode), content
+      );
+      HttpUtil.setContentLength(response, content.readableBytes());
+      response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json;charset=UTF-8");
+      ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+    } finally {
+      ReferenceCountUtil.release(msg);
+    }
+  }
+
+  /**
+   * Returns true if config-declared error is enabled
+   */
+  private boolean isConfigDeclaredErrorEnabled() {
+    return cConf.getBoolean(Constants.ConfigDeclaredError.CONFIG_DECLARED_ERROR_ENABLED, false);
+  }
+}


### PR DESCRIPTION
- If a config `error.declared.enabled: true` is present in cconf, the server should respond with an error to every user request, hence blocking all the user requests.
- If a status code is provided using config `error.declared.status.code`, the server should respond with this status code., otherwise default to 503.
- The response's body will be a json object containing all the attributes which are provided in config using prefix `error.declared.custom.`.

To check for new changes in cconf, Router will periodically reload the cconf (every 10 minutes by default).