### PR TITLE
CDAP-18532: Provide a way to declare server error through Configuration file

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1746,10 +1746,5 @@ public final class Constants {
      * The config name to define the status code for the error
      */
     public static final String CFG_STATUS_CODE = "error.declared.status.code";
-
-    /**
-     * The default status code if it is not defined in the config
-     */
-    public static final int DEFAULT_STATUS_CODE = 503;
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1728,23 +1728,23 @@ public final class Constants {
   }
 
   /**
-   * To declare an error through configuration,
-   * Router will start responding with the declared error to every inbound request
+   * To block inbound requests through configuration,
+   * Router will start responding to every inbound request with the response (status and message) declared in config
    */
-  public static final class ConfigDeclaredError {
+  public static final class ConfigBasedRequestBlocking {
     /**
-     * A prefix to add configs related to config-declared error
+     * Property to start/stop blocking requests to the router. Will be blocked if enabled.
      */
-    public static final String CONFIG_DECLARED_ERROR_PROPERTY_PREFIX = "error.declared.custom.";
+    public static final String ROUTER_BLOCK_REQUEST_ENABLED = "router.block.request.enabled";
 
     /**
-     * Property to enable/disable config-declared error
+     * The config name to define the status code for the response
      */
-    public static final String CONFIG_DECLARED_ERROR_ENABLED = "error.declared.enabled";
+    public static final String CFG_STATUS_CODE = "router.block.request.status.code";
 
     /**
-     * The config name to define the status code for the error
+     * The config name to define the response body
      */
-    public static final String CFG_STATUS_CODE = "error.declared.status.code";
+    public static final String CFG_MESSAGE = "router.block.request.message";
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -694,6 +694,8 @@ public final class Constants {
 
     public static final String DONT_ROUTE_SERVICE = "dont-route-to-service";
     public static final String AUDIT_LOGGER_NAME = "http-access";
+
+    public static final String CCONF_RELOAD_INTERVAL_MINUTES = "router.cconf.reload.interval.minutes";
   }
 
   /**
@@ -1723,5 +1725,31 @@ public final class Constants {
        */
       public static final String WORKER_SECRET_DISK_PATH = "twill.security.worker.secret.disk.path";
     }
+  }
+
+  /**
+   * To declare an error through configuration,
+   * Router will start responding with the declared error to every inbound request
+   */
+  public static final class ConfigDeclaredError {
+    /**
+     * A prefix to add configs related to config-declared error
+     */
+    public static final String CONFIG_DECLARED_ERROR_PROPERTY_PREFIX = "error.declared.custom.";
+
+    /**
+     * Property to enable/disable config-declared error
+     */
+    public static final String CONFIG_DECLARED_ERROR_ENABLED = "error.declared.enabled";
+
+    /**
+     * The config name to define the status code for the error
+     */
+    public static final String CFG_STATUS_CODE = "error.declared.status.code";
+
+    /**
+     * The default status code if it is not defined in the config
+     */
+    public static final int DEFAULT_STATUS_CODE = 503;
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -696,7 +696,7 @@ public final class Constants {
     public static final String AUDIT_LOGGER_NAME = "http-access";
 
     /** Interval in minutes at which CDAP Router reloads cconf */
-    public static final String CCONF_RELOAD_INTERVAL_MINUTES = "router.cconf.reload.interval.minutes";
+    public static final String CCONF_RELOAD_INTERVAL_SECONDS = "router.cconf.reload.interval.seconds";
 
     // To block inbound requests through configuration,
     // Router will start responding to every inbound request with the response (status and message) declared in config

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -695,7 +695,17 @@ public final class Constants {
     public static final String DONT_ROUTE_SERVICE = "dont-route-to-service";
     public static final String AUDIT_LOGGER_NAME = "http-access";
 
+    /** Interval in minutes at which CDAP Router reloads cconf */
     public static final String CCONF_RELOAD_INTERVAL_MINUTES = "router.cconf.reload.interval.minutes";
+
+    // To block inbound requests through configuration,
+    // Router will start responding to every inbound request with the response (status and message) declared in config
+    /** Property to start/stop blocking requests to the router. Will be blocked if enabled */
+    public static final String BLOCK_REQUEST_ENABLED = "router.block.request.enabled";
+    /** The config name to define the status code for the response */
+    public static final String BLOCK_REQUEST_STATUS_CODE = "router.block.request.status.code";
+    /** The config name to define the response body */
+    public static final String BLOCK_REQUEST_MESSAGE = "router.block.request.message";
   }
 
   /**
@@ -1725,26 +1735,5 @@ public final class Constants {
        */
       public static final String WORKER_SECRET_DISK_PATH = "twill.security.worker.secret.disk.path";
     }
-  }
-
-  /**
-   * To block inbound requests through configuration,
-   * Router will start responding to every inbound request with the response (status and message) declared in config
-   */
-  public static final class ConfigBasedRequestBlocking {
-    /**
-     * Property to start/stop blocking requests to the router. Will be blocked if enabled.
-     */
-    public static final String ROUTER_BLOCK_REQUEST_ENABLED = "router.block.request.enabled";
-
-    /**
-     * The config name to define the status code for the response
-     */
-    public static final String CFG_STATUS_CODE = "router.block.request.status.code";
-
-    /**
-     * The config name to define the response body
-     */
-    public static final String CFG_MESSAGE = "router.block.request.message";
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4560,21 +4560,21 @@
     </description>
   </property>
 
-  <!-- Default values for Config-declared errors -->
+  <!-- Default values for Config-based request-blocking -->
   <property>
-    <name>error.declared.status.code</name>
-    <value>503</value>
+    <name>router.block.request.enabled</name>
+    <value>false</value>
     <description>
-      The status code if config-declared errors are enabled
+      Determines whether server should start blocking inbound requests. If true, server would start
+      responding to every request (not router health checks) with response declared in cconf.
     </description>
   </property>
 
   <property>
-    <name>error.declared.enabled</name>
-    <value>false</value>
+    <name>router.block.request.status.code</name>
+    <value>503</value>
     <description>
-      Determines whether server should start responding with config-declared errors. If true, server would start
-      responding to every user request (not router health checks) with error declared in cconf.
+      The status code if request-blocking is enabled.
     </description>
   </property>
 </configuration>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4577,4 +4577,12 @@
       The status code if request-blocking is enabled.
     </description>
   </property>
+
+  <property>
+    <name>router.block.request.message</name>
+    <value></value>
+    <description>
+      The response body if request-blocking is enabled.
+    </description>
+  </property>
 </configuration>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3751,10 +3751,11 @@
   </property>
 
   <property>
-    <name>router.cconf.reload.interval.minutes</name>
-    <value>10</value>
+    <name>router.cconf.reload.interval.seconds</name>
+    <value>0</value>
     <description>
-      Interval in minutes at which CDAP Router reloads cconf, defaults to 10 minutes
+      Interval in seconds at which CDAP Router reloads cconf,
+      defaults to 0 which means no reloading should happen
     </description>
   </property>
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4559,4 +4559,22 @@
       The interval (in minutes) that the cleanup service will delete old artifact cache files.
     </description>
   </property>
+
+  <!-- Default values for Config-declared errors -->
+  <property>
+    <name>error.declared.status.code</name>
+    <value>503</value>
+    <description>
+      The status code if config-declared errors are enabled
+    </description>
+  </property>
+
+  <property>
+    <name>error.declared.enabled</name>
+    <value>false</value>
+    <description>
+      Determines whether server should start responding with config-declared errors. If true, server would start
+      responding to every user request (not router health checks) with error declared in cconf.
+    </description>
+  </property>
 </configuration>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3751,6 +3751,14 @@
   </property>
 
   <property>
+    <name>router.cconf.reload.interval.minutes</name>
+    <value>10</value>
+    <description>
+      Interval in minutes at which CDAP Router reloads cconf, defaults to 10 minutes
+    </description>
+  </property>
+
+  <property>
     <name>router.connection.backlog</name>
     <value>20000</value>
     <description>

--- a/cdap-gateway/pom.xml
+++ b/cdap-gateway/pom.xml
@@ -108,6 +108,10 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-client</artifactId>
       <scope>provided</scope>

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/NettyRouter.java
@@ -268,15 +268,17 @@ public class NettyRouter extends AbstractIdleService {
    */
   private void scheduleConfigReloadThread() {
     if (scheduledExecutorService == null || scheduledExecutorService.isShutdown()) {
-      long cConfReloadIntervalMinutes = cConf.getLong(Constants.Router.CCONF_RELOAD_INTERVAL_MINUTES);
-      scheduledExecutorService =
-        Executors.newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("router-config-reload"));
-      LOG.debug("Starting CConfiguration-reload thread with period of {} minutes", cConfReloadIntervalMinutes);
-      scheduledExecutorService.scheduleAtFixedRate(
-        () -> {
-          cConf.reloadConfiguration();
-          LOG.trace("CConfiguration reloaded");
-        }, cConfReloadIntervalMinutes, cConfReloadIntervalMinutes, TimeUnit.MINUTES);
+      long cConfReloadIntervalSeconds = cConf.getLong(Constants.Router.CCONF_RELOAD_INTERVAL_SECONDS);
+      if (cConfReloadIntervalSeconds > 0) { // Schedule only if a positive interval is provided
+        scheduledExecutorService =
+          Executors.newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("router-config-reload"));
+        LOG.debug("Starting CConfiguration-reload thread with period of {} seconds", cConfReloadIntervalSeconds);
+        scheduledExecutorService.scheduleAtFixedRate(
+          () -> {
+            cConf.reloadConfiguration();
+            LOG.trace("CConfiguration reloaded");
+          }, cConfReloadIntervalSeconds, cConfReloadIntervalSeconds, TimeUnit.SECONDS);
+      }
     }
   }
 

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/NettyRouter.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/NettyRouter.java
@@ -271,19 +271,18 @@ public class NettyRouter extends AbstractIdleService {
       long cConfReloadIntervalMinutes = cConf.getLong(Constants.Router.CCONF_RELOAD_INTERVAL_MINUTES);
       scheduledExecutorService =
         Executors.newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("router-config-reload"));
-      LOG.info("Starting CConfiguration-reload thread with period of {} minutes", cConfReloadIntervalMinutes);
+      LOG.debug("Starting CConfiguration-reload thread with period of {} minutes", cConfReloadIntervalMinutes);
       scheduledExecutorService.scheduleAtFixedRate(
         () -> {
           cConf.reloadConfiguration();
-          LOG.info("CConfiguration reloaded");
-        }, cConfReloadIntervalMinutes,
-        cConfReloadIntervalMinutes, TimeUnit.MINUTES);
+          LOG.trace("CConfiguration reloaded");
+        }, cConfReloadIntervalMinutes, cConfReloadIntervalMinutes, TimeUnit.MINUTES);
     }
   }
 
   private void stopConfigReloadThread() {
     if (scheduledExecutorService != null) {
-      LOG.info("Stopping CConfiguration-reload thread");
+      LOG.debug("Stopping CConfiguration-reload thread");
       scheduledExecutorService.shutdownNow();
     }
   }

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/ConfigBasedRequestBlockingHandler.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/ConfigBasedRequestBlockingHandler.java
@@ -48,14 +48,14 @@ public class ConfigBasedRequestBlockingHandler extends ChannelInboundHandlerAdap
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
     if (!(msg instanceof HttpRequest)
-      || !cConf.getBoolean(Constants.ConfigBasedRequestBlocking.ROUTER_BLOCK_REQUEST_ENABLED)) {
+      || !cConf.getBoolean(Constants.Router.BLOCK_REQUEST_ENABLED)) {
       ctx.fireChannelRead(msg);
       return;
     }
 
     try {
-      int statusCode = cConf.getInt(Constants.ConfigBasedRequestBlocking.CFG_STATUS_CODE);
-      String responseMsg = cConf.get(Constants.ConfigBasedRequestBlocking.CFG_MESSAGE, "");
+      int statusCode = cConf.getInt(Constants.Router.BLOCK_REQUEST_STATUS_CODE);
+      String responseMsg = cConf.get(Constants.Router.BLOCK_REQUEST_MESSAGE, "");
 
       ByteBuf content = Unpooled.copiedBuffer(responseMsg, StandardCharsets.UTF_8);
       HttpResponse response = new DefaultFullHttpResponse(

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/ConfigDeclaredErrorHandler.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/ConfigDeclaredErrorHandler.java
@@ -49,14 +49,14 @@ public class ConfigDeclaredErrorHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-    if (!(msg instanceof HttpRequest) || !isConfigDeclaredErrorEnabled()) {
+    if (!(msg instanceof HttpRequest)
+      || !cConf.getBoolean(Constants.ConfigDeclaredError.CONFIG_DECLARED_ERROR_ENABLED)) {
       ctx.fireChannelRead(msg);
       return;
     }
 
     try {
-      int statusCode =
-        cConf.getInt(Constants.ConfigDeclaredError.CFG_STATUS_CODE, Constants.ConfigDeclaredError.DEFAULT_STATUS_CODE);
+      int statusCode = cConf.getInt(Constants.ConfigDeclaredError.CFG_STATUS_CODE);
       JsonObject jsonContent = new JsonObject();
       for (Map.Entry<String, String> cConfEntry : cConf) {
         if (cConfEntry.getKey().startsWith(Constants.ConfigDeclaredError.CONFIG_DECLARED_ERROR_PROPERTY_PREFIX)) {
@@ -77,12 +77,5 @@ public class ConfigDeclaredErrorHandler extends ChannelInboundHandlerAdapter {
     } finally {
       ReferenceCountUtil.release(msg);
     }
-  }
-
-  /**
-   * Returns true if config-declared error is enabled
-   */
-  private boolean isConfigDeclaredErrorEnabled() {
-    return cConf.getBoolean(Constants.ConfigDeclaredError.CONFIG_DECLARED_ERROR_ENABLED, false);
   }
 }

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/ConfigDeclaredErrorHandler.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/ConfigDeclaredErrorHandler.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.router.handlers;
+
+import com.google.gson.JsonObject;
+import io.cdap.cdap.common.conf.Configuration;
+import io.cdap.cdap.common.conf.Constants;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpUtil;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.ReferenceCountUtil;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Handler to block all the inbound requests if config-declared error is enabled in {@link #cConf}
+ */
+public class ConfigDeclaredErrorHandler extends ChannelInboundHandlerAdapter {
+
+  private final Configuration cConf;
+
+  public ConfigDeclaredErrorHandler(Configuration cConf) {
+    this.cConf = cConf;
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+    if (!(msg instanceof HttpRequest) || !isConfigDeclaredErrorEnabled()) {
+      ctx.fireChannelRead(msg);
+      return;
+    }
+
+    try {
+      int statusCode =
+        cConf.getInt(Constants.ConfigDeclaredError.CFG_STATUS_CODE, Constants.ConfigDeclaredError.DEFAULT_STATUS_CODE);
+      JsonObject jsonContent = new JsonObject();
+      for (Map.Entry<String, String> cConfEntry : cConf) {
+        if (cConfEntry.getKey().startsWith(Constants.ConfigDeclaredError.CONFIG_DECLARED_ERROR_PROPERTY_PREFIX)) {
+          jsonContent.addProperty(
+            cConfEntry.getKey().substring(Constants.ConfigDeclaredError.CONFIG_DECLARED_ERROR_PROPERTY_PREFIX.length()),
+            cConfEntry.getValue()
+          );
+        }
+      }
+
+      ByteBuf content = Unpooled.copiedBuffer(jsonContent.toString(), StandardCharsets.UTF_8);
+      HttpResponse response = new DefaultFullHttpResponse(
+        HttpVersion.HTTP_1_1, HttpResponseStatus.valueOf(statusCode), content
+      );
+      HttpUtil.setContentLength(response, content.readableBytes());
+      response.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/json;charset=UTF-8");
+      ctx.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
+    } finally {
+      ReferenceCountUtil.release(msg);
+    }
+  }
+
+  /**
+   * Returns true if config-declared error is enabled
+   */
+  private boolean isConfigDeclaredErrorEnabled() {
+    return cConf.getBoolean(Constants.ConfigDeclaredError.CONFIG_DECLARED_ERROR_ENABLED, false);
+  }
+}

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/ConfigBasedRequestBlockingTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/ConfigBasedRequestBlockingTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.router;
+
+import com.google.common.io.ByteStreams;
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.security.auth.TokenValidator;
+import io.cdap.http.NettyHttpService;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.InMemoryDiscoveryService;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URL;
+
+public class ConfigBasedRequestBlockingTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  private static NettyRouter router;
+  private static NettyHttpService httpService;
+  private static CConfiguration cConf;
+  private static Cancellable cancelDiscovery;
+
+  @BeforeClass
+  public static void init() throws Exception {
+    cConf = CConfiguration.create();
+    cConf.set(Constants.Router.ADDRESS, InetAddress.getLoopbackAddress().getHostAddress());
+    cConf.setInt(Constants.Router.ROUTER_PORT, 0);
+
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
+    TokenValidator successValidator = new SuccessTokenValidator();
+
+    router = new NettyRouter(cConf, SConfiguration.create(), InetAddress.getLoopbackAddress(),
+                             new RouterServiceLookup(cConf, discoveryService, new RouterPathLookup()),
+                             successValidator,
+                             new MockAccessTokenIdentityExtractor(successValidator), discoveryService);
+    router.startAndWait();
+
+    httpService = NettyHttpService.builder("test").setHttpHandlers(new AuditLogTest.TestHandler()).build();
+    httpService.start();
+
+    cancelDiscovery = discoveryService.register(new Discoverable(Constants.Service.APP_FABRIC_HTTP,
+                                                                 httpService.getBindAddress()));
+  }
+
+  @Test
+  public void testStatusCode() throws Exception {
+    // Enable request-blocking
+    cConf.setBoolean(Constants.ConfigBasedRequestBlocking.ROUTER_BLOCK_REQUEST_ENABLED, true);
+
+    testGet(cConf.getInt(Constants.ConfigBasedRequestBlocking.CFG_STATUS_CODE), null, "/get");
+  }
+
+  @Test
+  public void testResponseBody() throws Exception {
+    // Enable request-blocking
+    cConf.setBoolean(Constants.ConfigBasedRequestBlocking.ROUTER_BLOCK_REQUEST_ENABLED, true);
+
+    // When no config is present for message, response should be empty
+    cConf.unset(Constants.ConfigBasedRequestBlocking.CFG_MESSAGE);
+    testGet(cConf.getInt(Constants.ConfigBasedRequestBlocking.CFG_STATUS_CODE), "", "/get");
+
+    // Custom message passed in config
+    cConf.set(Constants.ConfigBasedRequestBlocking.CFG_MESSAGE, "custom message");
+    testGet(cConf.getInt(Constants.ConfigBasedRequestBlocking.CFG_STATUS_CODE),
+            cConf.get(Constants.ConfigBasedRequestBlocking.CFG_MESSAGE), "/get");
+  }
+
+  @Test
+  public void testRequestBlockingDisabled() throws Exception {
+    // Disable request-blocking
+    cConf.setBoolean(Constants.ConfigBasedRequestBlocking.ROUTER_BLOCK_REQUEST_ENABLED, false);
+
+    testGet(HttpResponseStatus.OK.code(), null, "/get");
+  }
+
+  @Test
+  public void testRouterStatus() throws Exception {
+    // Enable request-blocking
+    cConf.setBoolean(Constants.ConfigBasedRequestBlocking.ROUTER_BLOCK_REQUEST_ENABLED, true);
+
+    testGet(HttpResponseStatus.OK.code(), null, Constants.EndPoints.STATUS);
+  }
+
+  @AfterClass
+  public static void finish() throws Exception {
+    cancelDiscovery.cancel();
+    httpService.stop();
+    router.stopAndWait();
+  }
+
+  private void testGet(int expectedStatus, String expectedResponse, String path)
+    throws Exception {
+
+    InetSocketAddress address = router.getBoundAddress().orElseThrow(IllegalStateException::new);
+    URL url = new URL("http", address.getHostName(), address.getPort(), path);
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setRequestMethod("GET");
+    connection.setDoInput(true);
+    connection.connect();
+    try {
+      InputStream inputStream;
+
+      try {
+        inputStream = connection.getInputStream();
+      } catch (IOException e) {
+        // In case of status code >= 400, IOException is thrown and the original response is sent through Error Stream
+        inputStream = connection.getErrorStream();
+      }
+
+      if (expectedResponse != null) {
+        if (expectedResponse.length() == 0) {
+          // Special case when input HttpURLConnection will throw IOException if status code >= 400
+          // but Error Stream won't be populated so rely on content-length header instead
+          Assert.assertEquals("0", connection.getHeaderField("content-length"));
+        } else {
+          Assert.assertEquals(expectedResponse, Bytes.toString(ByteStreams.toByteArray(inputStream)));
+        }
+      }
+      Assert.assertEquals(expectedStatus, connection.getResponseCode());
+    } finally {
+      connection.disconnect();
+    }
+  }
+}

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/ConfigBasedRequestBlockingTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/ConfigBasedRequestBlockingTest.java
@@ -41,6 +41,9 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URL;
 
+/**
+ * Tests config-based request-blocking
+ */
 public class ConfigBasedRequestBlockingTest {
 
   @ClassRule
@@ -76,30 +79,30 @@ public class ConfigBasedRequestBlockingTest {
   @Test
   public void testStatusCode() throws Exception {
     // Enable request-blocking
-    cConf.setBoolean(Constants.ConfigBasedRequestBlocking.ROUTER_BLOCK_REQUEST_ENABLED, true);
+    cConf.setBoolean(Constants.Router.BLOCK_REQUEST_ENABLED, true);
 
-    testGet(cConf.getInt(Constants.ConfigBasedRequestBlocking.CFG_STATUS_CODE), null, "/get");
+    testGet(cConf.getInt(Constants.Router.BLOCK_REQUEST_STATUS_CODE), null, "/get");
   }
 
   @Test
   public void testResponseBody() throws Exception {
     // Enable request-blocking
-    cConf.setBoolean(Constants.ConfigBasedRequestBlocking.ROUTER_BLOCK_REQUEST_ENABLED, true);
+    cConf.setBoolean(Constants.Router.BLOCK_REQUEST_ENABLED, true);
 
     // When no config is present for message, response should be empty
-    cConf.unset(Constants.ConfigBasedRequestBlocking.CFG_MESSAGE);
-    testGet(cConf.getInt(Constants.ConfigBasedRequestBlocking.CFG_STATUS_CODE), "", "/get");
+    cConf.unset(Constants.Router.BLOCK_REQUEST_MESSAGE);
+    testGet(cConf.getInt(Constants.Router.BLOCK_REQUEST_STATUS_CODE), "", "/get");
 
     // Custom message passed in config
-    cConf.set(Constants.ConfigBasedRequestBlocking.CFG_MESSAGE, "custom message");
-    testGet(cConf.getInt(Constants.ConfigBasedRequestBlocking.CFG_STATUS_CODE),
-            cConf.get(Constants.ConfigBasedRequestBlocking.CFG_MESSAGE), "/get");
+    cConf.set(Constants.Router.BLOCK_REQUEST_MESSAGE, "custom message");
+    testGet(cConf.getInt(Constants.Router.BLOCK_REQUEST_STATUS_CODE),
+            cConf.get(Constants.Router.BLOCK_REQUEST_MESSAGE), "/get");
   }
 
   @Test
   public void testRequestBlockingDisabled() throws Exception {
     // Disable request-blocking
-    cConf.setBoolean(Constants.ConfigBasedRequestBlocking.ROUTER_BLOCK_REQUEST_ENABLED, false);
+    cConf.setBoolean(Constants.Router.BLOCK_REQUEST_ENABLED, false);
 
     testGet(HttpResponseStatus.OK.code(), null, "/get");
   }
@@ -107,7 +110,7 @@ public class ConfigBasedRequestBlockingTest {
   @Test
   public void testRouterStatus() throws Exception {
     // Enable request-blocking
-    cConf.setBoolean(Constants.ConfigBasedRequestBlocking.ROUTER_BLOCK_REQUEST_ENABLED, true);
+    cConf.setBoolean(Constants.Router.BLOCK_REQUEST_ENABLED, true);
 
     testGet(HttpResponseStatus.OK.code(), null, Constants.EndPoints.STATUS);
   }


### PR DESCRIPTION
- If a config `error.declared.enabled: true` is present in cconf, the server should respond with an error to every user request, hence blocking all the user requests.
- If a status code is provided using config `error.declared.status.code`, the server should respond with this status code., otherwise default to 503.
- The response's body will be a json object containing all the attributes which are provided in config using prefix `error.declared.custom.`.

To check for new changes in cconf, Router will periodically reload the cconf (every 10 minutes by default).