### PR TITLE
[CDAP-18540] Allow levelDB compression to be enabled/disabled.

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1436,6 +1436,7 @@ public final class Constants {
   /** defines which persistence engine to use when running all in one JVM. **/
   public static final String CFG_DATA_INMEMORY_PERSISTENCE = "data.local.inmemory.persistence.type";
   public static final String CFG_DATA_LEVELDB_DIR = "data.local.storage";
+  public static final String CFG_DATA_LEVELDB_COMPRESSION_ENABLED = "data.local.storage.compression.enabled";
   public static final String CFG_DATA_LEVELDB_BLOCKSIZE = "data.local.storage.blocksize";
   public static final String CFG_DATA_LEVELDB_CACHESIZE = "data.local.storage.cachesize";
   public static final String CFG_DATA_LEVELDB_FSYNC = "data.local.storage.fsync";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -802,6 +802,14 @@
   </property>
 
   <property>
+    <name>data.local.storage.compression.enabled</name>
+    <value>true</value>
+    <description>
+      Whether compression is enabled for data fabric when in CDAP Local Sandbox
+    </description>
+  </property>
+
+  <property>
     <name>data.local.storage.blocksize</name>
     <value>1024</value>
     <description>

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
@@ -28,6 +28,7 @@ import com.google.inject.Singleton;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.data2.util.TableId;
+import org.iq80.leveldb.CompressionType;
 import org.iq80.leveldb.DB;
 import org.iq80.leveldb.DBComparator;
 import org.iq80.leveldb.Options;
@@ -54,6 +55,7 @@ public class LevelDBTableService implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(LevelDBTableService.class);
 
+  private boolean compressionEnabled;
   private int blockSize;
   private long cacheSize;
   private String basePath;
@@ -85,7 +87,7 @@ public class LevelDBTableService implements AutoCloseable {
   public void setConfiguration(CConfiguration config) {
     basePath = config.get(Constants.CFG_DATA_LEVELDB_DIR);
     Preconditions.checkNotNull(basePath, "No base directory configured for LevelDB.");
-
+    compressionEnabled = config.getBoolean(Constants.CFG_DATA_LEVELDB_COMPRESSION_ENABLED);
     blockSize = config.getInt(Constants.CFG_DATA_LEVELDB_BLOCKSIZE, Constants.DEFAULT_DATA_LEVELDB_BLOCKSIZE);
     cacheSize = config.getLong(Constants.CFG_DATA_LEVELDB_CACHESIZE, Constants.DEFAULT_DATA_LEVELDB_CACHESIZE);
     writeOptions = new WriteOptions().sync(
@@ -206,6 +208,7 @@ public class LevelDBTableService implements AutoCloseable {
     options.createIfMissing(false);
     options.errorIfExists(false);
     options.comparator(new KeyValueDBComparator());
+    options.compressionType(compressionEnabled ? CompressionType.SNAPPY : CompressionType.NONE);
     options.blockSize(blockSize);
     options.cacheSize(cacheSize);
 
@@ -229,6 +232,7 @@ public class LevelDBTableService implements AutoCloseable {
     options.createIfMissing(true);
     options.errorIfExists(false);
     options.comparator(new KeyValueDBComparator());
+    options.compressionType(compressionEnabled ? CompressionType.SNAPPY : CompressionType.NONE);
     options.blockSize(blockSize);
     options.cacheSize(cacheSize);
 


### PR DESCRIPTION
Why:
When levelDB compression is enabled, LevelDB internal global serialization
could cause read performance to degrade substantially when there are high
concurrent reads/scans on the same levelDB. In such use cases, it would be
preferrable to disable compression given the suboptimal implementation
in java-version of levelDB