### PR TITLE
[CDAP-15768] Empty macros should fail pipeline deployment

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParser.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParser.java
@@ -131,6 +131,8 @@ public class MacroParser {
     if (endIndex < 0) {
       throw new InvalidMacroException(String.format("Could not find enclosing '}' for macro '%s'.",
                                                     str.substring(startIndex)));
+    } else if (endIndex == startIndex + 2) {
+      throw new InvalidMacroException("Macro expression can not be empty");
     }
 
     // macroStr = 'macroFunction(macroArguments)' or just 'property' for ${property}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParserTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParserTest.java
@@ -81,9 +81,14 @@ public class MacroParserTest {
     assertContainsMacroParsing("${badFormatting", false);
   }
 
-  @Test
+  @Test(expected = InvalidMacroException.class)
   public void containsEmptyMacro() throws InvalidMacroException {
     assertContainsMacroParsing("${}", true);
+  }
+
+  @Test(expected = InvalidMacroException.class)
+  public void containsEmptyMacroInsideNestedMacro() throws InvalidMacroException {
+    assertContainsMacroParsing("${abc${}}", true);
   }
 
   @Test
@@ -102,22 +107,6 @@ public class MacroParserTest {
   @Test(expected = InvalidMacroException.class)
   public void testUndefinedMacro() throws InvalidMacroException {
     assertSubstitution("${undefined}", "", Collections.emptyMap(), Collections.emptyMap());
-  }
-
-  /**
-   * Tests if the empty string can be passed macro-substituted.
-   * Expands the following macro tree of depth 1:
-   *
-   *             ${}
-   *              |
-   *           emptyMacro
-   */
-  @Test
-  public void testEmptyMacro() throws InvalidMacroException {
-    Map<String, String> properties = ImmutableMap.<String, String>builder()
-      .put("", "emptyMacro")
-      .build();
-    assertSubstitution("${}", "emptyMacro", properties, Collections.emptyMap());
   }
 
   /**


### PR DESCRIPTION
- Adding check for Empty Macro.
- Empty macro can be inside nested macro.
- Removing unit test which allows support for empty macro.

Author:    ameya-111 <12438767+ameya-111@users.noreply.github.com>
Date:      Thu Oct 14 12:16:41 2021 -0700