### PR TITLE
[CDAP-18554] Fix preview to use local submitter

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewConfigModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewConfigModule.java
@@ -86,6 +86,9 @@ public class PreviewConfigModule extends AbstractModule {
     // Don't upload event logs for preview execution
     previewCConf.setBoolean(Constants.AppFabric.SPARK_EVENT_LOGS_ENABLED, false);
 
+    // Set this property for preview runs
+    previewCConf.setBoolean(Constants.Environment.PROGRAM_SUBMISSION_MASTER_ENV_ENABLED, false);
+
     // Setup Hadoop configuration
     previewHConf = new Configuration(hConf);
     previewHConf.set(MRConfig.FRAMEWORK_NAME, MRConfig.LOCAL_FRAMEWORK_NAME);

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -395,6 +395,16 @@ public final class Constants {
   }
 
   /**
+   * Environment configurations.
+   */
+  public static final class Environment {
+    /**
+     * Configuration to decide if the master environment should be used for programs or not.
+     */
+    public static final String PROGRAM_SUBMISSION_MASTER_ENV_ENABLED = "program.submission.master.environment.enabled";
+  }
+
+  /**
    * Task worker.
    */
   public static final class TaskWorker {

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -211,7 +211,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
       SparkSubmitter submitter;
       // If MasterEnvironment is not available, use non-master env spark submitters
       MasterEnvironment masterEnv = MasterEnvironments.getMasterEnvironment();
-      if (masterEnv != null) {
+      if (masterEnv != null && cConf.getBoolean(Constants.Environment.PROGRAM_SUBMISSION_MASTER_ENV_ENABLED, true)) {
         submitter = new MasterEnvironmentSparkSubmitter(cConf, locationFactory, host, runtimeContext, masterEnv);
       } else {
         submitter = isLocal


### PR DESCRIPTION
Fix: In preview mode, we were choosing to use MasterEnvironmentSparkSubmitter instead of LocalSubmitter. Adding a config property only set by preview manager in conf to determine which submitter should be used when. 

![image](https://user-images.githubusercontent.com/14131070/137415806-49df7c29-94ba-4468-99b4-fa303ec38d34.png)

![image](https://user-images.githubusercontent.com/14131070/137415816-46fa747d-e665-45ea-b746-a2bd6c14ee9d.png)

![image](https://user-images.githubusercontent.com/14131070/137416213-4fbf0bc3-09f7-4a2f-af78-750d252f94a6.png)

