### PR TITLE
[CDAP-18555] Create Kubernetes namespaces

### DIFF
--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -102,6 +102,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <profiles>

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1NamespaceList;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link KubeMasterEnvironment}
+ */
+public class KubeMasterEnvironmentTest {
+
+  private static final String CDAP_NAMESPACE = "TEST_CDAP_Namespace";
+  private static final String KUBE_NAMESPACE = "test-kube-namespace";
+
+  private CoreV1Api coreV1Api;
+  private KubeMasterEnvironment kubeMasterEnvironment;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void init() {
+    coreV1Api = mock(CoreV1Api.class);
+    kubeMasterEnvironment = new KubeMasterEnvironment();
+    kubeMasterEnvironment.setCoreV1Api(coreV1Api);
+    kubeMasterEnvironment.setNamespaceCreationEnabled();
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithNoNamespace() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    thrown.expect(IOException.class);
+    thrown.expectMessage(String.format("Cannot create Kubernetes namespace for %s because no name was provided",
+            CDAP_NAMESPACE));
+    kubeMasterEnvironment.onNamespaceCreation(CDAP_NAMESPACE, properties);
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithExistingNamespace() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+
+    V1NamespaceList returnedNamespaceList = new V1NamespaceList();
+    V1Namespace returnedNamespace = new V1Namespace().metadata(new V1ObjectMeta().name(KUBE_NAMESPACE));
+    returnedNamespaceList.setItems(Collections.singletonList(returnedNamespace));
+    when(coreV1Api.listNamespace(any(), any(), any(), eq(String.format("metadata.name=%s", KUBE_NAMESPACE)), any(),
+            any(), any(), any(), any(), any()))
+            .thenReturn(returnedNamespaceList);
+
+    thrown.expect(IOException.class);
+    thrown.expectMessage(String.format("Kubernetes namespace %s already exists", KUBE_NAMESPACE));
+    kubeMasterEnvironment.onNamespaceCreation(CDAP_NAMESPACE, properties);
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithKubernetesError() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+
+    when(coreV1Api.listNamespace(any(), any(), any(), eq(String.format("metadata.name=%s", KUBE_NAMESPACE)), any(),
+            any(), any(), any(), any(), any()))
+            .thenReturn(new V1NamespaceList());
+    when(coreV1Api.createNamespace(any(), any(), any(), any()))
+            .thenThrow(new ApiException());
+    when(coreV1Api.deleteNamespace(eq(KUBE_NAMESPACE), any(), any(), any(), any(), any(), any()))
+            .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "message"));
+
+    thrown.expect(IOException.class);
+    thrown.expectMessage("Error occurred while creating Kubernetes namespace.");
+    kubeMasterEnvironment.onNamespaceCreation(CDAP_NAMESPACE, properties);
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithSuppressedDeletionError() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+
+    when(coreV1Api.listNamespace(any(), any(), any(), eq(String.format("metadata.name=%s", KUBE_NAMESPACE)), any(),
+            any(), any(), any(), any(), any()))
+            .thenReturn(new V1NamespaceList());
+    when(coreV1Api.createNamespace(any(), any(), any(), any()))
+            .thenThrow(new ApiException());
+    when(coreV1Api.deleteNamespace(eq(KUBE_NAMESPACE), any(), any(), any(), any(), any(), any()))
+            .thenThrow(new ApiException(HttpURLConnection.HTTP_INTERNAL_ERROR, "internal error message"));
+
+    try {
+      kubeMasterEnvironment.onNamespaceCreation(CDAP_NAMESPACE, properties);
+    } catch (IOException e) {
+      Assert.assertThat(e.getMessage(),
+                 CoreMatchers.containsString("Error occurred while creating Kubernetes namespace"));
+      Assert.assertEquals(1, e.getCause().getSuppressed().length);
+      Assert.assertThat(e.getCause().getSuppressed()[0].getMessage(),
+                 CoreMatchers.containsString("Error occurred while deleting Kubernetes namespace."));
+    }
+  }
+
+  @Test
+  public void testOnNamespaceDeletionWithKubernetesNotFoundError() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    when(coreV1Api.deleteNamespace(eq(KUBE_NAMESPACE), any(), any(), any(), any(), any(), any()))
+            .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "message"));
+    try {
+      kubeMasterEnvironment.onNamespaceDeletion(CDAP_NAMESPACE, properties);
+    } catch (Exception e) {
+      Assert.fail("Kubernetes deletion should not error if namespace does not exist. Exception: " + e);
+    }
+  }
+}

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/MasterEnvironment.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/MasterEnvironment.java
@@ -22,6 +22,7 @@ import org.apache.twill.api.TwillRunnerService;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -96,5 +97,19 @@ public interface MasterEnvironment {
    */
   default SparkConfig generateSparkSubmitConfig(SparkSubmitContext sparkSubmitContext) throws Exception {
     throw new UnsupportedOperationException("Method not implemented");
+  }
+
+  /**
+   * Called during namespace creation
+   */
+  default void onNamespaceCreation(String namespace, Map<String, String> properties) throws Exception {
+    // no-op by default
+  }
+
+  /**
+   * Called during namespace deletion
+   */
+  default void onNamespaceDeletion(String namespace, Map<String, String> properties) throws Exception {
+    // no-op by default
   }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/NamespaceConfig.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/NamespaceConfig.java
@@ -55,7 +55,15 @@ public class NamespaceConfig {
                          @Nullable String hbaseNamespace, @Nullable String hiveDatabase,
                          @Nullable String principal, @Nullable String groupName, @Nullable String keytabURI,
                          boolean exploreAsPrincipal) {
-    Map<String, String> configs = new HashMap<>();
+    this(schedulerQueueName, rootDirectory, hbaseNamespace, hiveDatabase, principal, groupName, keytabURI,
+            exploreAsPrincipal, new HashMap<>());
+  }
+
+  public NamespaceConfig(String schedulerQueueName, @Nullable String rootDirectory,
+                         @Nullable String hbaseNamespace, @Nullable String hiveDatabase,
+                         @Nullable String principal, @Nullable String groupName, @Nullable String keytabURI,
+                         boolean exploreAsPrincipal, Map<String, String> existingConfigs) {
+    Map<String, String> configs = new HashMap<>(existingConfigs);
     configs.put(SCHEDULER_QUEUE_NAME, schedulerQueueName);
 
     if (rootDirectory != null) {
@@ -230,7 +238,7 @@ public class NamespaceConfig {
   /**
    * Returns the raw full config map. This is for the {@link NamespaceConfigCodec} to use.
    */
-  Map<String, String> getConfigs() {
+  public Map<String, String> getConfigs() {
     return configs;
   }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/NamespaceMeta.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/NamespaceMeta.java
@@ -18,6 +18,8 @@ package io.cdap.cdap.proto;
 
 import io.cdap.cdap.proto.id.NamespaceId;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 
@@ -88,6 +90,7 @@ public final class NamespaceMeta {
     private int keytabURIVersion;
     private long generation = 0;
     private boolean exploreAsPrincipal = true;
+    private Map<String, String> configMap = new HashMap<>();
 
     public Builder() {
       // No-Op
@@ -99,6 +102,7 @@ public final class NamespaceMeta {
       this.generation = meta.getGeneration();
       NamespaceConfig config = meta.getConfig();
       if (config != null) {
+        this.configMap = config.getConfigs();
         this.schedulerQueueName = config.getSchedulerQueueName();
         this.rootDirectory = config.getRootDirectory();
         this.hbaseNamespace = config.getHbaseNamespace();
@@ -214,7 +218,7 @@ public final class NamespaceMeta {
                                new NamespaceConfig(schedulerQueueName, rootDirectory,
                                                    hbaseNamespace, hiveDatabase,
                                                    principal, groupName, keytabURI,
-                                                   exploreAsPrincipal));
+                                                   exploreAsPrincipal, configMap));
     }
   }
 


### PR DESCRIPTION
When running in a Kubernetes environment, have namespace admin create/delete a corresponding k8 namespace. If CPU/memory limits are passed in the `NamespaceMeta`, create a k8 namespace resource quota as well.

JIRA: CDAP-18555

Testing:
Used HTTP calls to create (and later delete) a namespace named `Kubernetes_TEST` with k8s namespace `kube-test`, k8s namespace memory limit 1Gi, and k8s namespace CPU limit 1. Corresponding k8 namespace and resource quota were created
```
$ kubectl get namespaces --show-labels
NAME              STATUS   AGE     LABELS
cdap-system       Active   4d9h    control-plane=cdap-operator,name=cdap-system
default           Active   4d10h   <none>
elastic-system    Active   4d9h    app.kubernetes.io/version=1.3.1,control-plane=elastic-operator,name=elastic-system
kube-node-lease   Active   4d10h   <none>
kube-public       Active   4d10h   <none>
kube-system       Active   4d10h   <none>
kube-test         Active   4s      cdap.namespace=Kubernetes_TEST

$ kubectl get resourcequotas --namespace=kube-test --show-labels
NAME                  AGE   REQUEST                                                                                                                            LIMIT                                   LABELS
cdap-resource-quota   7s                                                                                                                                       limits.cpu: 0/1, limits.memory: 0/1Gi   cdap.namespace=Kubernetes_TEST
gke-resource-quotas   7s    count/ingresses.extensions: 0/5k, count/ingresses.networking.k8s.io: 0/5k, count/jobs.batch: 0/10k, pods: 0/5k, services: 0/1500                                           <none>
```