### PR TITLE
Fix file compression/decompression based on file name

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -38,7 +38,6 @@ import io.kubernetes.client.openapi.models.V1ContainerBuilder;
 import io.kubernetes.client.openapi.models.V1DownwardAPIVolumeFile;
 import io.kubernetes.client.openapi.models.V1DownwardAPIVolumeSource;
 import io.kubernetes.client.openapi.models.V1EnvVar;
-import io.kubernetes.client.openapi.models.V1KeyToPath;
 import io.kubernetes.client.openapi.models.V1ObjectFieldSelector;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
@@ -401,8 +400,9 @@ public class KubeMasterEnvironment implements MasterEnvironment {
       V1ConfigMapBuilder configMapBuilder = new V1ConfigMapBuilder();
       // create config map with localize resources
       for (Map.Entry<String, SparkLocalizeResource> resource : sparkSubmitContext.getLocalizeResources().entrySet()) {
-        configMapBuilder.addToBinaryData(resource.getKey(), getContents(resource.getValue().getURI(),
-                                                                        !resource.getValue().isArchive()));
+        String fileName = resource.getValue().isArchive() ? resource.getKey() : resource.getKey() + ".zip";
+        configMapBuilder.addToBinaryData(fileName, getContents(resource.getValue().getURI(),
+                                                               !resource.getValue().isArchive()));
       }
 
       String configMapName = CDAP_CONFIG_MAP_PREFIX + UUID.randomUUID();

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/k8s/SparkContainerDriverLauncher.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/k8s/SparkContainerDriverLauncher.java
@@ -109,13 +109,16 @@ public class SparkContainerDriverLauncher {
 
     // Copy all the files from config map
     for (File file : new File(CONFIGMAP_FILES_BASE_PATH).listFiles()) {
-      if (!file.isFile()) {
-        continue;
+      if (file.isFile()) {
+        String fileName = file.getName();
+        boolean shouldDecompress = fileName.endsWith(".zip");
+        if (shouldDecompress) {
+          fileName = fileName.substring(0, fileName.lastIndexOf('.'));
+        }
+        copy(file, new File(new File(WORKING_DIRECTORY), fileName), shouldDecompress);
       }
-      String fileName = file.getName();
-      boolean shouldDecompress = !fileName.endsWith(".jar") && !fileName.endsWith(".zip");
-      copy(file, new File(new File(WORKING_DIRECTORY), file.getName()), shouldDecompress);
     }
+
     // TODO: CDAP-18525: remove below line once this jira is fixed
     FileUtils.copyDirectory(new File(WORKING_DIRECTORY), new File(SPARK_LOCAL_DIR));
 


### PR DESCRIPTION
Fixing compression/decompression where assumption is compressed files should end with `.zip` extension. Upon decompression remove `.zip` extension