### PR TITLE
Change NamespaceConfig to store configurations in a map

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/remote/RemoteNamespaceQueryTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/remote/RemoteNamespaceQueryTest.java
@@ -85,8 +85,7 @@ public class RemoteNamespaceQueryTest {
     AppFabricTestHelper.shutdown();
   }
 
-  private static void waitForService(DiscoveryServiceClient discoveryService, String discoverableName)
-    throws InterruptedException {
+  private static void waitForService(DiscoveryServiceClient discoveryService, String discoverableName) {
     EndpointStrategy endpointStrategy = new RandomEndpointStrategy(() -> discoveryService.discover(discoverableName));
     Preconditions.checkNotNull(endpointStrategy.pick(5, TimeUnit.SECONDS),
                                "%s service is not up after 5 seconds", discoverableName);
@@ -120,6 +119,6 @@ public class RemoteNamespaceQueryTest {
     Assert.assertEquals(namespaceConfig, resultMeta.getConfig());
 
     namespaceAdmin.delete(namespaceId);
-    Assert.assertTrue(!queryClient.exists(namespaceId));
+    Assert.assertFalse(queryClient.exists(namespaceId));
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/NamespaceTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/NamespaceTable.java
@@ -30,12 +30,14 @@ import io.cdap.cdap.spi.data.table.field.Fields;
 import io.cdap.cdap.spi.data.table.field.Range;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 
 /**
@@ -45,7 +47,7 @@ import javax.annotation.Nullable;
 public final class NamespaceTable {
   private static final Gson GSON = new Gson();
 
-  private StructuredTable table;
+  private final StructuredTable table;
 
   public NamespaceTable(StructuredTableContext context) throws TableNotFoundException {
     this.table = context.getTable(StoreDefinition.NamespaceStore.NAMESPACES);
@@ -72,14 +74,10 @@ public final class NamespaceTable {
    */
   @Nullable
   public NamespaceMeta get(NamespaceId id) throws IOException {
-    Optional<StructuredRow> row =
-      table.read(
-        ImmutableList.of(Fields.stringField(StoreDefinition.NamespaceStore.NAMESPACE_FIELD, id.getEntityName())));
-    if (!row.isPresent()) {
-      return null;
-    }
-    return GSON.fromJson(
-      row.get().getString(StoreDefinition.NamespaceStore.NAMESPACE_METADATA_FIELD), NamespaceMeta.class);
+    return table.read(Collections.singleton(Fields.stringField(StoreDefinition.NamespaceStore.NAMESPACE_FIELD,
+                                                               id.getEntityName())))
+      .map(this::getNamespaceMeta)
+      .orElse(null);
   }
 
   /**
@@ -98,15 +96,11 @@ public final class NamespaceTable {
    * @return list of all namespace metas
    */
   public List<NamespaceMeta> list() throws IOException {
-    List<NamespaceMeta> result = new ArrayList<>();
     try (CloseableIterator<StructuredRow> iterator = table.scan(Range.all(), Integer.MAX_VALUE)) {
-      while (iterator.hasNext()) {
-        result.add(
-          GSON.fromJson(
-            iterator.next().getString(StoreDefinition.NamespaceStore.NAMESPACE_METADATA_FIELD), NamespaceMeta.class));
-      }
+      return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
+        .map(this::getNamespaceMeta)
+        .collect(Collectors.toList());
     }
-    return result;
   }
 
   /**
@@ -126,5 +120,12 @@ public final class NamespaceTable {
    */
   public long getNamespaceCount(Collection<Range> ranges) throws IOException {
     return table.count(ranges);
+  }
+
+  @Nullable
+  private NamespaceMeta getNamespaceMeta(StructuredRow row) {
+    return Optional.ofNullable(row.getString(StoreDefinition.NamespaceStore.NAMESPACE_METADATA_FIELD))
+      .map(field -> GSON.fromJson(field, NamespaceMeta.class))
+      .orElse(null);
   }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/NamespaceConfig.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/NamespaceConfig.java
@@ -16,9 +16,12 @@
 
 package io.cdap.cdap.proto;
 
-import com.google.gson.annotations.SerializedName;
+import com.google.gson.annotations.JsonAdapter;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -26,6 +29,7 @@ import javax.annotation.Nullable;
 /**
  * Represents the configuration of a namespace. This class needs to be GSON serializable.
  */
+@JsonAdapter(NamespaceConfigCodec.class)
 public class NamespaceConfig {
 
   public static final String SCHEDULER_QUEUE_NAME = "scheduler.queue.name";
@@ -33,25 +37,11 @@ public class NamespaceConfig {
   public static final String HBASE_NAMESPACE = "hbase.namespace";
   public static final String HIVE_DATABASE = "hive.database";
   public static final String EXPLORE_AS_PRINCIPAL = "explore.as.principal";
+  public static final String PRINCIPAL = "principal";
+  public static final String GROUP_NAME = "groupName";
+  public static final String KEYTAB_URI = "keytabURI";
 
-  @SerializedName(SCHEDULER_QUEUE_NAME)
-  private final String schedulerQueueName;
-
-  @SerializedName(ROOT_DIRECTORY)
-  private final String rootDirectory;
-
-  @SerializedName(HBASE_NAMESPACE)
-  private final String hbaseNamespace;
-
-  @SerializedName(HIVE_DATABASE)
-  private final String hiveDatabase;
-
-  @SerializedName(EXPLORE_AS_PRINCIPAL)
-  private final Boolean exploreAsPrincipal;
-
-  private final String principal;
-  private final String groupName;
-  private final String keytabURI;
+  private final Map<String, String> configs;
 
   // scheduler queue name is kept non nullable unlike others like root directory, hbase namespace etc for backward
   // compatibility
@@ -65,47 +55,76 @@ public class NamespaceConfig {
                          @Nullable String hbaseNamespace, @Nullable String hiveDatabase,
                          @Nullable String principal, @Nullable String groupName, @Nullable String keytabURI,
                          boolean exploreAsPrincipal) {
-    this.schedulerQueueName = schedulerQueueName;
-    this.rootDirectory = rootDirectory;
-    this.hbaseNamespace = hbaseNamespace;
-    this.hiveDatabase = hiveDatabase;
-    this.principal = principal;
-    this.groupName = groupName;
-    this.keytabURI = keytabURI;
-    this.exploreAsPrincipal = exploreAsPrincipal;
+    Map<String, String> configs = new HashMap<>();
+    configs.put(SCHEDULER_QUEUE_NAME, schedulerQueueName);
+
+    if (rootDirectory != null) {
+      configs.put(ROOT_DIRECTORY, rootDirectory);
+    }
+
+    if (hbaseNamespace != null) {
+      configs.put(HBASE_NAMESPACE, hbaseNamespace);
+    }
+
+    if (hiveDatabase != null) {
+      configs.put(HIVE_DATABASE, hiveDatabase);
+    }
+
+    if (principal != null) {
+      configs.put(PRINCIPAL, principal);
+    }
+
+    if (groupName != null) {
+      configs.put(GROUP_NAME, groupName);
+    }
+
+    if (keytabURI != null) {
+      configs.put(KEYTAB_URI, keytabURI);
+    }
+
+    configs.put(EXPLORE_AS_PRINCIPAL, Boolean.toString(exploreAsPrincipal));
+
+    this.configs = Collections.unmodifiableMap(configs);
+  }
+
+  /**
+   * Creates a new instance with the given set of configurations.
+   */
+  public NamespaceConfig(Map<String, String> configs) {
+    this.configs = Collections.unmodifiableMap(new HashMap<>(configs));
   }
 
   public String getSchedulerQueueName() {
-    return schedulerQueueName;
+    return getConfig(SCHEDULER_QUEUE_NAME);
   }
 
   @Nullable
   public String getRootDirectory() {
-    return rootDirectory;
+    return getConfig(ROOT_DIRECTORY);
   }
 
   @Nullable
   public String getHbaseNamespace() {
-    return hbaseNamespace;
+    return getConfig(HBASE_NAMESPACE);
   }
 
   @Nullable
   public String getHiveDatabase() {
-    return hiveDatabase;
+    return getConfig(HIVE_DATABASE);
   }
 
   @Nullable
   public String getPrincipal() {
-    return principal;
+    return getConfig(PRINCIPAL);
   }
 
   public String getGroupName() {
-    return groupName;
+    return getConfig(GROUP_NAME);
   }
 
   @Nullable
   public String getKeytabURI() {
-    return keytabURI;
+    return getConfig(KEYTAB_URI);
   }
 
   /**
@@ -114,6 +133,7 @@ public class NamespaceConfig {
   @Nullable
   public String getKeytabURIWithoutVersion() {
     // try to get the keytab URI version if the keytab URI is not null
+    String keytabURI = getKeytabURI();
     if (keytabURI != null) {
       // find the position of the fragment containing the version in the keytab URI
       int versionIdx = keytabURI.lastIndexOf("#");
@@ -127,6 +147,7 @@ public class NamespaceConfig {
    */
   public int getKeytabURIVersion() {
     // try to get the keytab URI version if the keytab URI is not null
+    String keytabURI = getKeytabURI();
     if (keytabURI != null) {
       // find the position where the fragment containing the version in the keytab URI
       int versionIdx = keytabURI.lastIndexOf("#");
@@ -137,36 +158,49 @@ public class NamespaceConfig {
   }
 
   public Boolean isExploreAsPrincipal() {
-    return exploreAsPrincipal == null || exploreAsPrincipal;
+    String value = configs.get(EXPLORE_AS_PRINCIPAL);
+    return value == null || Boolean.parseBoolean(value);
   }
 
   public Set<String> getDifference(@Nullable NamespaceConfig other) {
-    Set<String> difference = new HashSet<>();
     if (other == null) {
       // nothing to validate
-      return difference;
+      return Collections.emptySet();
     }
 
-    if (!Objects.equals(this.rootDirectory, other.rootDirectory)) {
+    Set<String> difference = new HashSet<>();
+
+    if (!Objects.equals(this.getRootDirectory(), other.getRootDirectory())) {
       difference.add(ROOT_DIRECTORY);
     }
 
-    if (!Objects.equals(this.hbaseNamespace, other.hbaseNamespace)) {
+    if (!Objects.equals(this.getHbaseNamespace(), other.getHbaseNamespace())) {
       difference.add(HBASE_NAMESPACE);
     }
 
-    if (!Objects.equals(this.hiveDatabase, other.hiveDatabase)) {
+    if (!Objects.equals(this.getHiveDatabase(), other.getHiveDatabase())) {
       difference.add(HIVE_DATABASE);
     }
 
-    if (!Objects.equals(this.principal, other.principal)) {
-      difference.add("principal");
+    if (!Objects.equals(this.getPrincipal(), other.getPrincipal())) {
+      difference.add(PRINCIPAL);
     }
 
-    if (!Objects.equals(this.groupName, other.groupName)) {
-      difference.add("groupName");
+    if (!Objects.equals(this.getGroupName(), other.getGroupName())) {
+      difference.add(GROUP_NAME);
     }
     return difference;
+  }
+
+  /**
+   * Returns the config value of the given name.
+   *
+   * @param name name of the config
+   * @return the value of the config or {@code null} if the config doesn't exist.
+   */
+  @Nullable
+  public String getConfig(String name) {
+    return configs.get(name);
   }
 
   @Override
@@ -177,35 +211,26 @@ public class NamespaceConfig {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    NamespaceConfig other = (NamespaceConfig) o;
-    return Objects.equals(schedulerQueueName, other.schedulerQueueName) &&
-      Objects.equals(rootDirectory, other.rootDirectory) &&
-      Objects.equals(hbaseNamespace, other.hbaseNamespace) &&
-      Objects.equals(hiveDatabase, other.hiveDatabase) &&
-      Objects.equals(principal, other.principal) &&
-      Objects.equals(groupName, other.groupName) &&
-      Objects.equals(keytabURI, other.keytabURI) &&
-      Objects.equals(exploreAsPrincipal, other.exploreAsPrincipal);
+    NamespaceConfig that = (NamespaceConfig) o;
+    return Objects.equals(configs, that.configs);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(
-      schedulerQueueName, rootDirectory, hbaseNamespace, hiveDatabase, principal, groupName, keytabURI,
-      exploreAsPrincipal);
+    return Objects.hash(configs);
   }
 
   @Override
   public String toString() {
     return "NamespaceConfig{" +
-      "schedulerQueueName='" + schedulerQueueName + '\'' +
-      ", rootDirectory='" + rootDirectory + '\'' +
-      ", hbaseNamespace='" + hbaseNamespace + '\'' +
-      ", hiveDatabase='" + hiveDatabase + '\'' +
-      ", principal='" + principal + '\'' +
-      ", groupName='" + groupName + '\'' +
-      ", keytabURI='" + keytabURI + '\'' +
-      ", exploreAsPrincipal='" + exploreAsPrincipal + '\'' +
+      "configs=" + configs +
       '}';
+  }
+
+  /**
+   * Returns the raw full config map. This is for the {@link NamespaceConfigCodec} to use.
+   */
+  Map<String, String> getConfigs() {
+    return configs;
   }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/NamespaceConfigCodec.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/NamespaceConfigCodec.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * A {@link TypeAdapterFactory} to serialize and deserialize {@link NamespaceConfig} as map.
+ */
+public class NamespaceConfigCodec implements TypeAdapterFactory {
+
+  public static final TypeToken<Map<String, String>> MAP_TYPE_TOKEN = new TypeToken<Map<String, String>>() { };
+
+  @Override
+  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+    if (!NamespaceConfig.class.equals(type.getRawType())) {
+      return null;
+    }
+
+    TypeAdapter<Map<String, String>> mapTypeAdapter = gson.getAdapter(MAP_TYPE_TOKEN);
+
+    return new TypeAdapter<T>() {
+      @Override
+      public void write(JsonWriter out, T value) throws IOException {
+        if (value == null) {
+          out.nullValue();
+        } else {
+          mapTypeAdapter.write(out, ((NamespaceConfig) value).getConfigs());
+        }
+      }
+
+      @Override
+      public T read(JsonReader in) throws IOException {
+        Map<String, String> configs = mapTypeAdapter.read(in);
+        if (configs == null) {
+          return null;
+        }
+        //noinspection unchecked
+        return (T) new NamespaceConfig(configs);
+      }
+    };
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
     <findbugs.jsr305.version>2.0.1</findbugs.jsr305.version>
     <geronimo.version>2.0.0</geronimo.version>
     <grok.version>0.1.0</grok.version>
-    <gson.version>2.2.4</gson.version>
+    <gson.version>2.3.1</gson.version>
     <guava.version>13.0.1</guava.version>
     <guice.version>4.0</guice.version>
     <hadoop.version>2.6.0</hadoop.version>


### PR DESCRIPTION
- Updated GSON version to 2.3.1 to use JsonAdapter. This is a minimal bump to maintain backward compatibility of the GSON library.
- Use a custom codec for NamespaceConfig to ser/de it as a Map. This is backward compatible to existing serialized data.