### PR TITLE
[CDAP-18606] Add Declarative Language interfaces

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngine.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngine.java
@@ -28,6 +28,11 @@ import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinDefinition;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPullRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPushRequest;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLRelationDefinition;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLTransformDefinition;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLTransformRequest;
+import io.cdap.cdap.etl.api.relational.Engine;
+import io.cdap.cdap.etl.api.relational.Relation;
 
 /**
  * A SQL Engine can be used to pushdown certain dataset operations.
@@ -89,6 +94,24 @@ public interface SQLEngine<KEY_IN, VALUE_IN, KEY_OUT, VALUE_OUT>
   boolean canJoin(SQLJoinDefinition joinDefinition);
 
   /**
+   *
+   * @return if engine supports relational plugins
+   * @see io.cdap.cdap.etl.api.relational.RelationalTransform
+   */
+  default boolean supportsRelationalTranform() {
+    return false;
+  };
+
+  /**
+   * Final check if the requested transformations can be executed in the SQL Engine.
+   * @param transformDefinition SQL transformation to validate
+   * @return if transformations can be executed in the SQL Egine
+   */
+  default boolean canTransform(SQLTransformDefinition transformDefinition) {
+    return false;
+  }
+
+  /**
    * Executes the join operation defined by the supplied join request.
    * <p>
    * All datasets involved in this joinRequest must be pushed to the SQL engine by calling the
@@ -107,4 +130,34 @@ public interface SQLEngine<KEY_IN, VALUE_IN, KEY_OUT, VALUE_OUT>
    * @param datasetName boolean specifying if all running tasks should be stopped at this time (if any are running).
    */
   void cleanup(String datasetName) throws SQLEngineException;
+
+  /**
+   *
+   * @return engine to use for relational tranform. Will be called only if {@link #supportsRelationalTranform()}
+   * is true
+   * @throws SQLEngineException
+   */
+  default Engine getRelationalEngine() {
+    throw new UnsupportedOperationException("Relational transform is not supported by the engine");
+  }
+
+  /**
+   * Prepares Relational plugin input based on provided descripton and dataset supplier.
+   * @param relationDefinition dataset name and schema
+   * @return a relation for the dataset definition
+   */
+  default Relation getRelation(SQLRelationDefinition relationDefinition) {
+    throw new UnsupportedOperationException("Relational transform is not supported by the engine");
+  }
+
+  /**
+   * Performs transformation of a single relation.
+   * @param context transformation context with transformation definition, input datasets and setter for output
+   * @return output datasets for the transform requested
+   * @throws SQLEngineException
+   */
+  default SQLDataset transform(SQLTransformRequest context)
+    throws SQLEngineException {
+    throw new UnsupportedOperationException("Relational transform is not supported by the engine");
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/StandardSQLCapabilities.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/StandardSQLCapabilities.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.engine.sql;
+
+import io.cdap.cdap.etl.api.relational.Capability;
+
+/**
+ * Defines capabilities for SQL Engine factories
+ */
+public enum StandardSQLCapabilities implements Capability {
+  /**
+   * Defines that factory implements SQL92 language
+   */
+  SQL92
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLRelationDefinition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLRelationDefinition.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.engine.sql.request;
+
+import io.cdap.cdap.api.data.schema.Schema;
+
+import java.io.Serializable;
+
+/**
+ * This class defines a SQL Engine relation during relationalial transform calls
+ */
+public class SQLRelationDefinition implements Serializable {
+  private static final long serialVersionUID = 2528081290251538913L;
+  protected final String datasetName;
+  protected final Schema datasetSchema;
+
+  public SQLRelationDefinition(String datasetName, Schema datasetSchema) {
+    this.datasetName = datasetName;
+    this.datasetSchema = datasetSchema;
+  }
+
+  /**
+   *
+   * @return SQL Engine dataset name for a relation
+   */
+  public String getDatasetName() {
+    return datasetName;
+  }
+
+  /**
+   *
+   * @return schema for the relation
+   */
+  public Schema getDatasetSchema() {
+    return datasetSchema;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLTransformDefinition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLTransformDefinition.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.engine.sql.request;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.relational.Relation;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * Defines resulting relational transform that is requested by the plugin
+ */
+public class SQLTransformDefinition implements Serializable {
+  private final String outputDatasetName;
+  private final Relation outputRelation;
+  private final Schema outputSchema;
+  private final Map<String, Relation> outputRelations;
+  private final Map<String, Schema> outputSchemas;
+
+  public SQLTransformDefinition(String outputDatasetName, Relation outputRelation, Schema outputSchema,
+                                Map<String, Relation> outputRelations,
+                                Map<String, Schema> outputSchemas) {
+    this.outputDatasetName = outputDatasetName;
+    this.outputRelation = outputRelation;
+    this.outputSchema = outputSchema;
+    this.outputRelations = outputRelations;
+    this.outputSchemas = outputSchemas;
+  }
+
+  /**
+   *
+   * @return primary output dataset name
+   */
+  public String getOutputDatasetName() {
+    return outputDatasetName;
+  }
+
+  /**
+   *
+   * @return primary output relation
+   */
+  public Relation getOutputRelation() {
+    return outputRelation;
+  }
+
+  /**
+   *
+   * @return primary output dataset schema
+   */
+  public Schema getOutputSchema() {
+    return outputSchema;
+  }
+
+  /**
+   *
+   * @return map of output dataset name to the relation that defines it
+   */
+  public Map<String, Relation> getOutputRelations() {
+    return outputRelations;
+  }
+
+  /**
+   *
+   * @return map of output dataset name to it's schema
+   */
+  public Map<String, Schema> getOutputSchemas() {
+    return outputSchemas;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLTransformRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLTransformRequest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.engine.sql.request;
+
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.etl.api.engine.sql.dataset.SQLDataset;
+import io.cdap.cdap.etl.api.relational.Relation;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * Defines a request to perform relational transformation by SQL engine
+ */
+public class SQLTransformRequest implements Serializable {
+  private final Map<String, SQLDataset> inputDataSets;
+
+  private final String outputDatasetName;
+  private final Relation outputRelation;
+  private final Schema outputSchema;
+
+  public SQLTransformRequest(Map<String, SQLDataset> inputDataSets, String outputDatasetName,
+                             Relation outputRelation, Schema outputDataSetSchema) {
+    this.inputDataSets = inputDataSets;
+    this.outputDatasetName = outputDatasetName;
+    this.outputRelation = outputRelation;
+    this.outputSchema = outputDataSetSchema;
+  }
+
+  /**
+   * @return map of input datasets used for the output relation
+   */
+  public Map<String, SQLDataset> getInputDataSets() {
+    return inputDataSets;
+  }
+
+  /**
+   *
+   * @return primary output dataset name
+   */
+  public String getOutputDatasetName() {
+    return outputDatasetName;
+  }
+
+  /**
+   *
+   * @return output dataset to transform
+   */
+  public Relation getOutputRelation() {
+    return outputRelation;
+  }
+
+  /**
+   *
+   * @return output SQLDataset schema
+   */
+  public Schema getOutputSchema() {
+    return outputSchema;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/Capability.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/Capability.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+/**
+ * Marker interface that defines various capabilities of the relational engines / expression factories.
+ * This interface is implemented by various enum classes, each enum class defines a group of capabilities.
+ * Plugins can use capabilities to see if passed engine can do a transform and which expression factory to use.
+ */
+public interface Capability {
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/CoreExpressionCapabilities.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/CoreExpressionCapabilities.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+/**
+ * This enum defines core expression factory capabilities
+ */
+public enum CoreExpressionCapabilities implements Capability {
+  /**
+   * Set if {@link ExpressionFactory#setDataSetAlias(Relation, String)} is supported
+   */
+  CAN_SET_DATASET_ALIAS,
+  /**
+   * Set if {@link ExpressionFactory#getQualifiedDataSetName(Relation)} is supported
+   */
+  CAN_GET_QUALIFIED_DATASET_NAME,
+  /**
+   * Set if {@link ExpressionFactory#getQualifiedColumnName(Relation, String)} is supported
+   */
+  CAN_GET_QUALIFIED_COLUMN_NAME,
+  /**
+   * Set if expression factory automatically calculates lineage for it's expressions.
+   * As soon as transformations are done using factory that implements this capability, plugin does not
+   * need to provide lineage information by itself.
+   * Note: TODO CDAP-18609: currently no factories have this capability
+   */
+  CALCULATES_LINEAGE
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/Engine.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/Engine.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Engine interface provides access to functions common to all relations used in the tranformation request.
+ * E.g. it provides expression factories and engine capabilities.
+ */
+public interface Engine {
+  /**
+   *
+   * @return capabilities provided by the engine and it's expression factories
+   */
+  Set<Capability> getCapabilities();
+
+  /**
+   *
+   * @return all expression factories provided by the engine
+   */
+  List<ExpressionFactory<?>> getExpressionFactories();
+
+  /**
+   * Returns expression factory of specified type with required capabilities
+   * Example: getExpressionFactory(StringExpressionFactory.SQL)
+   * @param type expression factory type
+   * @param neededCapabilities capabilities that factory should implement
+   * @return a factory or empty optional if engine does not provide such factory
+   */
+  default <T> Optional<ExpressionFactory<T>> getExpressionFactory(
+    ExpressionFactoryType<T> type,
+    Capability... neededCapabilities) {
+    return getExpressionFactory(type, Arrays.asList(neededCapabilities));
+  }
+
+  /**
+   * Returns expression factory of specified type with required capabilities
+   * Example: getExpressionFactory(StringExpressionFactory.SQL)
+   * @param type expression factory type
+   * @param neededCapabilities capabilities that factory should implement
+   * @return a factory or empty optional if engine does not provide such factory
+   */
+  default <T> Optional<ExpressionFactory<T>> getExpressionFactory(
+    ExpressionFactoryType<T> type,
+    Collection<Capability> neededCapabilities) {
+
+    return getExpressionFactories().stream()
+      .filter(f -> f.getType() == type && f.getCapabilities().containsAll(neededCapabilities))
+      .map(f -> (ExpressionFactory<T>) f)
+      .findFirst();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/Expression.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/Expression.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+/**
+ * Compiled scalar expression produced by {@link ExpressionFactory#compile} that can be
+ * passed to various relational algebra calls of {@link Relation} objects.
+ * Note that relations, engine and expression factories must come from the same {@link RelationalTranformContext}
+ * and are valid only for the time of the {@link RelationalTransform#transform} call.
+ */
+public interface Expression {
+  /**
+   *
+   * @return if this expression is valid. If during expression generation, it's found to be unsupported or invalid,
+   * generation will return an invalid Expression. Any {@link Relation} operation with invalid expression will
+   * result in an invalid {@link Relation}
+   * @see #getValidationError() on operation problem details
+   */
+  boolean isValid();
+
+  /**
+   * @return validation error if expression is not valid
+   * @see #isValid()
+   */
+  String getValidationError();
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/ExpressionFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/ExpressionFactory.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+import java.util.Set;
+
+/**
+ * An expression factory for the specific language that can compile expressions into language-independent form
+ * to be used in {@link Relation} calls.
+ * @param <T> java type of expressions accepted. Can be {@link String} in simple cases or structured objects for
+ *           complex expressions
+ */
+public interface ExpressionFactory<T> {
+  /**
+   *
+   * @return factory type that define both expression language and source expression java type
+   */
+  ExpressionFactoryType<T> getType();
+
+  /**
+   *
+   * @return set of capabilities. At the very least contains {@link #getType()} capability
+   */
+  Set<Capability> getCapabilities();
+
+  /**
+   * Compiles expression into language-independent form
+   * @param expression expression to compile with
+   * @return language-independent expression object that can be used in {@link Relation} calls.
+   * Check {@link Expression#isValid()} for any validation errors
+   */
+  Expression compile(T expression);
+
+  /**
+   * Provides fully qualified name to be used in expressions for a given dataset.
+   * Available with {@link CoreExpressionCapabilities#CAN_GET_QUALIFIED_DATASET_NAME}
+   */
+  default String getQualifiedDataSetName(Relation dataSet) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Provides fully qualified column name to be used in expressions for a given dataset column.
+   * Available with {@link CoreExpressionCapabilities#CAN_GET_QUALIFIED_COLUMN_NAME}
+   */
+  default String getQualifiedColumnName(Relation dataSet, String column) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Allows to set an alias for dataset that can be used for unqualified dataset and column references.
+   * Depending on language alias can be case-sensitive or case-insensitive.
+   * Available with {@link CoreExpressionCapabilities#CAN_SET_DATASET_ALIAS}
+   */
+  default Relation setDataSetAlias(Relation dataSet, String alias) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/ExpressionFactoryType.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/ExpressionFactoryType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+/**
+ * Marker interface for expression factory types denoting expression type. Any expression facotry
+ * type is also a capability.
+ * @param <T> expression type for a factory of this type
+ */
+public interface ExpressionFactoryType<T> extends Capability {
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/LinearRelationalTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/LinearRelationalTransform.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+import java.util.Set;
+
+/**
+ * Linear variant of {@link RelationalTransform} for plugins that has 1 input and produce 1 output relation.
+ */
+public interface LinearRelationalTransform extends RelationalTransform {
+  /**
+   * Implementation of full interface that delegates to {@link #transform(RelationalTranformContext, Relation)}.
+   * @param context tranformation context with engine, input and output parameters
+   * @return true
+   */
+  default boolean transform(RelationalTranformContext context) {
+    Set<String> names = context.getInputRelationNames();
+    if (names.size() != 1) {
+      throw new IllegalArgumentException("Plugin " + getClass().getName() + " supports only single input and got "
+                                           + names.size() + ": " + names);
+    }
+    context.setOutputRelation(transform(context, context.getInputRelation(names.iterator().next())));
+    return true;
+  }
+
+  /**
+   * <p>This call will be done for every suitable engine until after supported tranformation is declared or
+   * there is no more engines left.</p>
+   * <p>A transformation is supported if plugin returned true, all registered output relations are valid and
+   * engine can perform the transformation requested.</p>
+   * <p>If no engine can perform a transformation, a fall back to regular by-row transformation is performed.
+   * @param context tranformation context with engine, input and output parameters
+   * @param input input relation, the only one available from the context
+   * @return output relation. Plugin may return invalid relation to indicate unsupported transformation.
+   * Even if plugin returned a valid relation, engine may deny performing a transformation.
+   * @see {@link LinearRelationalTransform} for simpler interface for plugins that take 1 input and produce 1 output.
+   */
+  Relation transform(RelationalTranformContext context, Relation input);
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/Relation.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/Relation.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+import java.util.Map;
+
+/**
+ * This class defines a relation that can be transformed in a declarative way using
+ * relational algebra calls and expressions. It does not provide row-by-row access, but
+ * rather a set of transformation calls that will be delegated to the underlying engine.
+ */
+public interface Relation {
+  /**
+   *
+   * @return if this relation is valid. If any operation requested is not supported,
+   * it will return an invalid relation.
+   * @see #getValidationError() on operation problem details
+   */
+  boolean isValid();
+
+  /**
+   * @return validation error if relation is not valid
+   * @see #isValid()
+   */
+  String getValidationError();
+
+  /**
+   * Allows to add or replace column for a relation. This operation does not
+   * change number of rows.
+   * @param column name of the column to add / replace
+   * @param value value to set to the column
+   * @return a new relation with a column added or replaced
+   */
+  Relation setColumn(String column, Expression value);
+
+  /**
+   * Allows to drop existing column on a relation. This operation does not
+   * change number of rows.
+   * @param column name of the column to drop
+   * @return a new relation that does not have the column
+   */
+  Relation dropColumn(String column);
+
+  /**
+   * Allows to completely replace set of column with a new one. This operation does not
+   * change number of rows.
+   * @param columns map of column names to value expressions to form new column set
+   * @return a new relation with required columns
+   */
+  Relation select(Map<String, Expression> columns);
+
+  /**
+   * Allows to filter relation rows based on a boolean expression
+   * @param filter boolean expression to use as a filter
+   * @return a new relation with same set of columns, but only rows where filter value is true
+   */
+  Relation filter(Expression filter);
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/RelationalTranformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/RelationalTranformContext.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+import io.cdap.cdap.etl.api.TransformContext;
+
+import java.util.Set;
+
+/**
+ * This interface provides sql engine, input relation(s) and a way to set tranformation results to
+ * a {@link RelationalTransform#transform(RelationalTranformContext)} call
+ */
+public interface RelationalTranformContext {
+  /**
+   *
+   * @return relational engine to be used for tranformation
+   */
+  Engine getEngine();
+
+  /**
+   *
+   * @param inputStage input name
+   * @return relation corresponding to the given input
+   */
+  Relation getInputRelation(String inputStage);
+
+  /**
+   *
+   * @return set of all input relation names
+   */
+  Set<String> getInputRelationNames();
+
+  /**
+   * sets the primary output relation for the transform
+   * @param outputRelation
+   */
+  void setOutputRelation(Relation outputRelation);
+
+  /**
+   *
+   * @param portName
+   * @param outputDataSet
+   */
+  void setOutputRelation(String portName, Relation outputDataSet);
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/RelationalTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/RelationalTransform.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+/**
+ * An analytical or transformation plugin can implement this interface to provide an alternative
+ * declarative way of doing transformations. If relational transform call is successfull, the transform
+ * will be passed to the underlying engine and plugin will not be called to transform each row.
+ * If relational transform is not successful (no engines are available, engines don't have capabilities
+ * or can't perform the requested transformation), fall back to per-row transformation will be performed.
+ */
+public interface RelationalTransform {
+  /**
+   * This call allows to prefilter engines before doing {@link #transform}.
+   * @param engine engine to check
+   * @return if this engine can be used for transform requested
+   */
+  default boolean canUseEngine(Engine engine) {
+    return true;
+  }
+
+  /**
+   * <p>This call will be done for every suitable engine until after supported tranformation is declared or
+   * there is no more engines left.</p>
+   * <p>A transformation is supported if plugin returned true, all registered output relations are valid and
+   * engine can perform the transformation requested.</p>
+   * <p>If no engine can perform a transformation, a fall back to regular by-row transformation is performed.
+   * @param context tranformation context with engine, input and output parameters
+   * @return if plugin could perform a transformation. If true is returned, plugin must set all outputs to
+   * relations. Plugin may still set any output to invalid relation and return true. In this case transformation
+   * would be considered unsupported. Even if plugin returned true and set all outputs to valid relations,
+   * engine may deny performing a transformation.
+   * @see {@link LinearRelationalTransform} for simpler interface for plugins that take 1 input and produce 1 output.
+   */
+  boolean transform(RelationalTranformContext context);
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/StringExpressionFactory.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/StringExpressionFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+/**
+ * This enum lists expression factory types that compile expressions from {@link String}
+ */
+public enum StringExpressionFactory implements ExpressionFactoryType<String> {
+  /**
+   * Expression factories of this type will take SQL String expressions
+   */
+  SQL;
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
@@ -16,11 +16,9 @@
 
 package io.cdap.cdap.etl.spark;
 
-import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.cdap.api.dataset.lib.KeyValue;
-import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.api.relational.RelationalTransform;
 import io.cdap.cdap.etl.api.streaming.Windower;
 import io.cdap.cdap.etl.common.PhaseSpec;
 import io.cdap.cdap.etl.common.RecordInfo;
@@ -33,6 +31,7 @@ import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -57,6 +56,11 @@ public interface SparkCollection<T> {
   SparkCollection<RecordInfo<Object>> transform(StageSpec stageSpec, StageStatisticsCollector collector);
 
   SparkCollection<RecordInfo<Object>> multiOutputTransform(StageSpec stageSpec, StageStatisticsCollector collector);
+
+  default <U> Optional<SparkCollection<U>> tryRelationalTransform(StageSpec stageSpec,
+                                                                  RelationalTransform transform) {
+    return Optional.empty();
+  }
 
   <U> SparkCollection<U> map(Function<T, U> function);
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollectionRelationalEngine.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollectionRelationalEngine.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark;
+
+import io.cdap.cdap.etl.api.relational.Engine;
+import io.cdap.cdap.etl.api.relational.RelationalTransform;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * This interface defines an entity that can do relational tranform on {@link SparkCollection} with
+ * {@link io.cdap.cdap.etl.api.relational.RelationalTransform}.
+ */
+public interface SparkCollectionRelationalEngine {
+  /**
+   * @return underlying relational engine
+   */
+  Engine getRelationalEngine();
+
+  /**
+   * Tries to perform a relational tranform for the stage with given transform plugin
+   * @param stageSpec stage
+   * @param transform transform plugin
+   * @param input map of input collections
+   * @param <T> type of elements in the output spark collection
+   * @return tranformed output {@link SparkCollection} or empty {@link Optional} if relational tranform is not
+   * possible for this engine with the passed plugin
+   */
+  <T> Optional<SparkCollection<T>> tryRelationalTransform(StageSpec stageSpec,
+                                                          RelationalTransform transform,
+                                                          Map<String, SparkCollection<Object>> input);
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BaseRDDCollection.java
@@ -123,7 +123,7 @@ public abstract class BaseRDDCollection<T> implements SparkCollection<T> {
   public SparkCollection<T> cache() {
     SparkConf sparkConf = jsc.getConf();
     if (sparkConf.getBoolean(Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG, true)) {
-      String cacheStorageLevelString = sparkConf.get(Constants.SPARK_PIPELINE_CACHING_STORAGE_LEVEL, 
+      String cacheStorageLevelString = sparkConf.get(Constants.SPARK_PIPELINE_CACHING_STORAGE_LEVEL,
                                                      Constants.DEFAULT_CACHING_STORAGE_LEVEL);
       StorageLevel cacheStorageLevel = StorageLevel.fromString(cacheStorageLevelString);
       return wrap(rdd.persist(cacheStorageLevel));

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BasicRelationalTransformContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BasicRelationalTransformContext.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.etl.api.relational.Engine;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Basic implementation of the {@link RelationalTranformContext} with single output port
+ */
+public class BasicRelationalTransformContext implements RelationalTranformContext {
+  private final Engine engine;
+  private final Map<String, Relation> inputMap;
+  private Relation outputRelation;
+
+
+  public BasicRelationalTransformContext(Engine engine, Map<String, Relation> inputMap) {
+    this.engine = engine;
+    this.inputMap = inputMap;
+  }
+
+  @Override
+  public Engine getEngine() {
+    return engine;
+  }
+
+  @Override
+  public Relation getInputRelation(String inputStage) {
+    return inputMap.get(inputStage);
+  }
+
+  @Override
+  public Set<String> getInputRelationNames() {
+    return Collections.unmodifiableSet(inputMap.keySet());
+  }
+
+  @Override
+  public void setOutputRelation(Relation outputRelation) {
+    this.outputRelation = outputRelation;
+  }
+
+  @Override
+  public void setOutputRelation(String portName, Relation outputDataSet) {
+    throw new UnsupportedOperationException("Only single output is supported");
+  }
+
+  public Relation getOutputRelation() {
+    return outputRelation;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSQLEngineAdapter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSQLEngineAdapter.java
@@ -31,14 +31,21 @@ import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinDefinition;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPullRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPushRequest;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLRelationDefinition;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLTransformDefinition;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLTransformRequest;
 import io.cdap.cdap.etl.api.join.JoinDefinition;
 import io.cdap.cdap.etl.api.join.JoinStage;
+import io.cdap.cdap.etl.api.relational.Engine;
+import io.cdap.cdap.etl.api.relational.Relation;
+import io.cdap.cdap.etl.api.relational.RelationalTransform;
 import io.cdap.cdap.etl.common.Constants;
 import io.cdap.cdap.etl.common.DefaultStageMetrics;
 import io.cdap.cdap.etl.common.StageStatisticsCollector;
 import io.cdap.cdap.etl.engine.SQLEngineJob;
 import io.cdap.cdap.etl.engine.SQLEngineJobKey;
 import io.cdap.cdap.etl.engine.SQLEngineJobType;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 import io.cdap.cdap.etl.spark.SparkCollection;
 import io.cdap.cdap.etl.spark.function.TransformFromPairFunction;
 import io.cdap.cdap.etl.spark.function.TransformToPairFunction;
@@ -52,24 +59,27 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
  * Adapter used to orchestrate interaction between the Pipeline Runner and the SQL Engine.
- *
- * @param <T> type for records supported by this BatchSQLEngineAdapter.
  */
-public class BatchSQLEngineAdapter<T> implements Closeable {
+public class BatchSQLEngineAdapter implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(BatchSQLEngineAdapter.class);
 
   private final JavaSparkExecutionContext sec;
@@ -178,7 +188,7 @@ public class BatchSQLEngineAdapter<T> implements Closeable {
    * @return Job representing this pull operation.
    */
   @SuppressWarnings("unchecked,raw")
-  public SQLEngineJob<JavaRDD<T>> pull(SQLEngineJob<SQLDataset> job,
+  public <T> SQLEngineJob<JavaRDD<T>> pull(SQLEngineJob<SQLDataset> job,
                                        JavaSparkContext jsc) {
     //If this job already exists, return the existing instance.
     SQLEngineJobKey jobKey = new SQLEngineJobKey(job.getDatasetName(), SQLEngineJobType.PULL);
@@ -217,7 +227,7 @@ public class BatchSQLEngineAdapter<T> implements Closeable {
    * @throws SQLEngineException if the pull process fails.
    */
   @SuppressWarnings("unchecked,raw")
-  private JavaRDD<T> pullInternal(SQLDataset dataset,
+  private <T> JavaRDD<T> pullInternal(SQLDataset dataset,
                                   JavaSparkContext jsc) throws SQLEngineException {
     // Create pull operation for this dataset and wait until completion
     SQLPullRequest pullRequest = new SQLPullRequest(dataset);
@@ -270,6 +280,24 @@ public class BatchSQLEngineAdapter<T> implements Closeable {
   }
 
   /**
+   *
+   * @return if underlying engine support relational transform
+   * @see SQLEngine#supportsRelationalTranform
+   */
+  public boolean supportsRelationalTranform() {
+    return sqlEngine.supportsRelationalTranform();
+  }
+
+  /**
+   *
+   * @return relational engine provided by SQL Engine
+   * @see SQLEngine#getRelationalEngine()
+   */
+  public Engine getSQLRelationalEngine() {
+    return sqlEngine.getRelationalEngine();
+  }
+
+  /**
    * Executes a Join operation in the SQL engine
    *
    * @param datasetName    the dataset name to use to store the result of the join operation
@@ -279,17 +307,7 @@ public class BatchSQLEngineAdapter<T> implements Closeable {
   @SuppressWarnings("unchecked,raw")
   public SQLEngineJob<SQLDataset> join(String datasetName,
                                        JoinDefinition joinDefinition) {
-    //If this job already exists, return the existing instance.
-    SQLEngineJobKey jobKey = new SQLEngineJobKey(datasetName, SQLEngineJobType.EXECUTE);
-    if (jobs.containsKey(jobKey)) {
-      return (SQLEngineJob<SQLDataset>) jobs.get(jobKey);
-    }
-
-    CompletableFuture<SQLDataset> future = new CompletableFuture<>();
-
-    Runnable joinTask = () -> {
-      try {
-        LOG.debug("Starting join for dataset '{}'", datasetName);
+    return runJob(datasetName, () -> {
         Collection<SQLDataset> inputDatasets = getJoinInputDatasets(joinDefinition);
         SQLJoinRequest joinRequest = new SQLJoinRequest(datasetName, joinDefinition, inputDatasets);
 
@@ -297,8 +315,31 @@ public class BatchSQLEngineAdapter<T> implements Closeable {
           throw new IllegalArgumentException("Unable to execute this join in the SQL engine");
         }
 
-        joinInternal(future, joinRequest);
-        LOG.debug("Completed join for dataset '{}'", datasetName);
+        return joinInternal(joinRequest);
+      });
+  }
+
+  /**
+   * Kicks off a {@link SQLEngineJobType.EXECUTE} job trat will produce a dataset
+   * @param datasetName dataset name
+   * @param jobFunction actual runnable that will do the work
+   * @param <T> type of result
+   * @return job that produces jobFunction result when finished
+   */
+  private <T> SQLEngineJob<T> runJob(String datasetName, Supplier<T> jobFunction) {
+    //If this job already exists, return the existing instance.
+    SQLEngineJobKey jobKey = new SQLEngineJobKey(datasetName, SQLEngineJobType.EXECUTE);
+    if (jobs.containsKey(jobKey)) {
+      return (SQLEngineJob<T>) jobs.get(jobKey);
+    }
+
+    CompletableFuture<T> future = new CompletableFuture<>();
+
+    Runnable joinTask = () -> {
+      try {
+        LOG.debug("Starting job for dataset '{}'", datasetName);
+        future.complete(jobFunction.get());
+        LOG.debug("Completed job for dataset '{}'", datasetName);
       } catch (Throwable t) {
         future.completeExceptionally(t);
       }
@@ -306,7 +347,7 @@ public class BatchSQLEngineAdapter<T> implements Closeable {
 
     executorService.submit(joinTask);
 
-    SQLEngineJob<SQLDataset> job = new SQLEngineJob<>(jobKey, future);
+    SQLEngineJob<T> job = new SQLEngineJob<>(jobKey, future);
     jobs.put(jobKey, job);
 
     return job;
@@ -323,35 +364,38 @@ public class BatchSQLEngineAdapter<T> implements Closeable {
     List<SQLDataset> datasets = new ArrayList<>(joinDefinition.getStages().size());
 
     for (JoinStage stage : joinDefinition.getStages()) {
-      // Wait for the previous push or execute jobs to complete
-      SQLEngineJobKey pushJobKey = new SQLEngineJobKey(stage.getStageName(), SQLEngineJobType.PUSH);
-      SQLEngineJobKey execJobKey = new SQLEngineJobKey(stage.getStageName(), SQLEngineJobType.EXECUTE);
-
-      if (jobs.containsKey(pushJobKey)) {
-        SQLEngineJob<SQLDataset> job = (SQLEngineJob<SQLDataset>) jobs.get(pushJobKey);
-        waitForJobAndHandleExceptionInternal(job);
-        datasets.add(job.waitFor());
-      } else if (jobs.containsKey(execJobKey)) {
-        SQLEngineJob<SQLDataset> job = (SQLEngineJob<SQLDataset>) jobs.get(execJobKey);
-        waitForJobAndHandleExceptionInternal(job);
-        datasets.add(job.waitFor());
-      } else {
-        throw new IllegalArgumentException("No SQL Engine job exists for stage " + stage.getStageName());
-      }
+      datasets.add(getDatasetForStage(stage.getStageName()));
     }
 
     return datasets;
   }
 
+  private SQLDataset getDatasetForStage(String stageName) {
+    // Wait for the previous push or execute jobs to complete
+    SQLEngineJobKey pushJobKey = new SQLEngineJobKey(stageName, SQLEngineJobType.PUSH);
+    SQLEngineJobKey execJobKey = new SQLEngineJobKey(stageName, SQLEngineJobType.EXECUTE);
+
+    if (jobs.containsKey(pushJobKey)) {
+      SQLEngineJob<SQLDataset> job = (SQLEngineJob<SQLDataset>) jobs.get(pushJobKey);
+      waitForJobAndHandleExceptionInternal(job);
+      return job.waitFor();
+    } else if (jobs.containsKey(execJobKey)) {
+      SQLEngineJob<SQLDataset> job = (SQLEngineJob<SQLDataset>) jobs.get(execJobKey);
+      waitForJobAndHandleExceptionInternal(job);
+      return job.waitFor();
+    } else {
+      throw new IllegalArgumentException("No SQL Engine job exists for stage " + stageName);
+    }
+  }
+
   /**
    * Join implementation. This method has blocking calls and should be executed in a separate thread.
    *
-   * @param future the future instance to use to return results.
    * @param joinRequest the Join Request
    * @throws SQLEngineException   if any of the preceding jobs fails.
+   * @return
    */
-  private void joinInternal(CompletableFuture<SQLDataset> future,
-                            SQLJoinRequest joinRequest)
+  private SQLDataset joinInternal(SQLJoinRequest joinRequest)
     throws SQLEngineException {
 
     String datasetName = joinRequest.getDatasetName();
@@ -368,7 +412,7 @@ public class BatchSQLEngineAdapter<T> implements Closeable {
 
     // Count output rows and complete future.
     countRecordsOut(joinDataset, statisticsCollector, stageMetrics);
-    future.complete(joinDataset);
+    return joinDataset;
   }
 
   /**
@@ -523,5 +567,56 @@ public class BatchSQLEngineAdapter<T> implements Closeable {
                                           String metricName,
                                           long numRecords) {
     stageMetrics.countLong(metricName, numRecords);
+  }
+
+  /**
+   * This method is called when engine is present and is willing to try performing a relational transform.
+   * @param stageSpec stage specification
+   * @param transform transform plugin
+   * @param input input collections
+   * @return resulting collection or empty optional if tranform can't be done with this engine
+   */
+  public Optional<SQLEngineJob<SQLDataset>> tryRelationalTransform(StageSpec stageSpec,
+                                                          RelationalTransform transform,
+                                                          Map<String, SparkCollection<Object>> input) {
+    Map<String, Relation> inputRelations = input.entrySet().stream().collect(Collectors.toMap(
+      Map.Entry::getKey,
+      e -> sqlEngine.getRelation(new SQLRelationDefinition(e.getKey(), stageSpec.getInputSchemas().get(e.getKey())))
+    ));
+    BasicRelationalTransformContext pluginContext = new BasicRelationalTransformContext(
+      getSQLRelationalEngine(),
+      inputRelations);
+    if (!transform.transform(pluginContext)) {
+      //Plugin was not able to do relational tranform with this engine
+      return Optional.empty();
+    }
+    if (pluginContext.getOutputRelation() == null) {
+      //Plugin said that tranformation was success but failed to set output
+      throw new IllegalStateException("Plugin " + transform + " did not produce a relational output");
+    }
+    if (!pluginContext.getOutputRelation().isValid()) {
+      //An output is set to invalid relation, probably some of transforms are not supported by an engine
+      return Optional.empty();
+    }
+    //Validate with engine
+    SQLTransformDefinition transformDefinition = new SQLTransformDefinition(
+      stageSpec.getName(), pluginContext.getOutputRelation(),
+      stageSpec.getOutputSchema(),
+      Collections.emptyMap(),
+      Collections.emptyMap()
+    );
+    if (!sqlEngine.canTransform(transformDefinition)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(runJob(stageSpec.getName(), () -> {
+      Map<String, SQLDataset> inputDatasets = input.keySet().stream().collect(Collectors.toMap(
+        Function.identity(),
+        name -> getDatasetForStage(name)
+      ));
+      SQLTransformRequest sqlContext = new SQLTransformRequest(
+        inputDatasets, stageSpec.getName(), pluginContext.getOutputRelation(), stageSpec.getOutputSchema());
+      return sqlEngine.transform(sqlContext);
+    }));
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.etl.spark.batch;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.SetMultimap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -49,6 +50,7 @@ import io.cdap.cdap.etl.engine.SQLEngineJob;
 import io.cdap.cdap.etl.engine.SQLEngineUtils;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 import io.cdap.cdap.etl.spark.SparkCollection;
+import io.cdap.cdap.etl.spark.SparkCollectionRelationalEngine;
 import io.cdap.cdap.etl.spark.SparkPairCollection;
 import io.cdap.cdap.etl.spark.SparkPipelineRunner;
 import io.cdap.cdap.etl.spark.SparkStageStatisticsCollector;
@@ -69,6 +71,7 @@ import java.io.BufferedReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -211,9 +214,9 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
                                                                     sec.getNamespace());
           Object instance = pluginInstantiator.newPluginInstance(sqlEngineStage,
                                                                  macroEvaluator);
-          sqlEngineAdapter = new BatchSQLEngineAdapter<Object>((SQLEngine<?, ?, ?, ?>) instance,
+          sqlEngineAdapter = new BatchSQLEngineAdapter((SQLEngine<?, ?, ?, ?>) instance,
                                                                sec,
-                                                               collectors);
+                                                       collectors);
           sqlEngineAdapter.prepareRun();
         } catch (InstantiationException ie) {
           LOG.error("Could not create plugin instance for SQLEngine class", ie);
@@ -328,5 +331,26 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
 
     // Execute in the SQL engine if there are no broadcast stages for this join.
     return !containsBroadcastStage;
+  }
+
+  /**
+   * If SQL Engine is present, supports relational transform and current stage data is already
+   * provided by SQL engine, adds SQL Engine implementation of relational engine
+   * @param stageData
+   * @return
+   */
+  @Override
+  protected Iterable<SparkCollectionRelationalEngine> getRelationalEngines(SparkCollection<Object> stageData) {
+    if (sqlEngineAdapter == null || !sqlEngineAdapter.supportsRelationalTranform()
+      || !(stageData instanceof SQLBackedCollection)) {
+      //Relational transform on SQL engine is not supported
+      return super.getRelationalEngines(stageData);
+    }
+    SQLEngineRelationalEngine relationalEngine = new SQLEngineRelationalEngine(
+      sec, functionCacheFactory, jsc, new SQLContext(jsc), datasetContext, sinkFactory, sqlEngineAdapter);
+    return Iterables.concat(
+      Collections.singletonList(relationalEngine),
+      super.getRelationalEngines(stageData)
+    );
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -234,7 +234,7 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
         // as intermediate joins will already be partitioned on the key
         if (joined == left) {
           joined = partitionOnKey(joined, leftKeys, joinRequest.isNullSafe(),
-            leftSparkSchema, joinPartitions);
+                                  leftSparkSchema, joinPartitions);
         }
       }
       joined = joined.join(right, joinOn, joinType);
@@ -387,9 +387,9 @@ public class RDDCollection<T> extends BaseRDDCollection<T> {
 
     // Add a column that uses the 'numbers' array as the value for every row
     Dataset explodedData = data.withColumn(saltColumnName,
-      functions.array(
-        Arrays.stream(numbers).map(functions::lit).toArray(Column[]::new)
-      ));
+                                           functions.array(
+                                             Arrays.stream(numbers).map(functions::lit).toArray(Column[]::new)
+                                           ));
     explodedData = explodedData.withColumn(saltColumnName, functions.explode(explodedData.col(saltColumnName)));
     return explodedData;
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineCollection.java
@@ -57,7 +57,7 @@ public class SQLEngineCollection<T> implements SQLBackedCollection<T> {
   private final SparkBatchSinkFactory sinkFactory;
   private final FunctionCache.Factory functionCacheFactory;
   private final String datasetName;
-  private final BatchSQLEngineAdapter<T> adapter;
+  private final BatchSQLEngineAdapter adapter;
   private final SQLEngineJob<SQLDataset> job;
   private SparkCollection<T> localCollection;
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineRelationalEngine.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineRelationalEngine.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.api.data.DatasetContext;
+import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.etl.api.relational.Engine;
+import io.cdap.cdap.etl.api.relational.RelationalTransform;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.SparkCollection;
+import io.cdap.cdap.etl.spark.SparkCollectionRelationalEngine;
+import io.cdap.cdap.etl.spark.function.FunctionCache;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.SQLContext;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Spark Collection relational engine wrapper that tries to tranform with SQL Engine
+ */
+public class SQLEngineRelationalEngine implements SparkCollectionRelationalEngine {
+  private final JavaSparkExecutionContext sec;
+  private final FunctionCache.Factory functionCacheFactory;
+  private final JavaSparkContext jsc;
+  private final SQLContext sqlContext;
+  private final DatasetContext datasetContext;
+  private final SparkBatchSinkFactory sinkFactory;
+  private final BatchSQLEngineAdapter adapter;
+
+  public SQLEngineRelationalEngine(JavaSparkExecutionContext sec,
+                                   FunctionCache.Factory functionCacheFactory,
+                                   JavaSparkContext jsc,
+                                   SQLContext sqlContext,
+                                   DatasetContext datasetContext,
+                                   SparkBatchSinkFactory sinkFactory,
+                                   BatchSQLEngineAdapter adapter) {
+    this.sec = sec;
+    this.functionCacheFactory = functionCacheFactory;
+    this.jsc = jsc;
+    this.sqlContext = sqlContext;
+    this.datasetContext = datasetContext;
+    this.sinkFactory = sinkFactory;
+    this.adapter = adapter;
+  }
+
+  @Override
+  public Engine getRelationalEngine() {
+    return adapter.getSQLRelationalEngine();
+  }
+
+  @Override
+  public <T> Optional<SparkCollection<T>> tryRelationalTransform(
+    StageSpec stageSpec, RelationalTransform transform, Map<String, SparkCollection<Object>> input) {
+
+    return adapter.tryRelationalTransform(stageSpec, transform, input).map(job ->
+      new SQLEngineCollection<T>(sec, functionCacheFactory, jsc, sqlContext,
+                                 datasetContext, sinkFactory, stageSpec.getName(), adapter, job));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/WrappedSQLEngineCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/WrappedSQLEngineCollection.java
@@ -53,7 +53,7 @@ public class WrappedSQLEngineCollection<T, U> implements SQLBackedCollection<U> 
     this.wrapped = wrapped;
     this.mapper = mapper;
   }
-  
+
   private SparkCollection<U> unwrap() {
     if (unwrapped == null) {
       unwrapped = mapper.apply(wrapped);
@@ -167,7 +167,7 @@ public class WrappedSQLEngineCollection<T, U> implements SQLBackedCollection<U> 
 
   @Override
   public SparkCollection<U> window(StageSpec stageSpec,
-                                               Windower windower) {
+                                   Windower windower) {
     return unwrap().window(stageSpec, windower);
   }
 


### PR DESCRIPTION
This PR provides a new API that can be used by SQL Engines and plugins to provide transformations in a declarative way.
For 6.6 we plan to implement this API for SparkSQL (by platform) and BQ plugin