### PR TITLE
Revamp the storage SPI to support new storage engine as an extension

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/config/PreferencesTable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/config/PreferencesTable.java
@@ -277,14 +277,14 @@ public class PreferencesTable {
       }
     }
     throw new ConflictException(String.format("Expected sequence id >= %d for %s %s in namespace %s, but found %s",
-                                              seq, type, name, namespace, String.valueOf(currentSeq)));
+                                              seq, type, name, namespace, currentSeq));
   }
 
   private PreferencesDetail get(String namespace, String type, String name) throws IOException {
     List<Field<?>> primaryKey = getPrimaryKey(namespace, type, name);
     Optional<StructuredRow> row = table.read(primaryKey);
     Map<String, String> properties = Collections.emptyMap();
-    Long seqId = new Long(0);
+    Long seqId = null;
     if (row.isPresent()) {
       String string = row.get().getString(StoreDefinition.PreferencesStore.PROPERTIES_FIELD);
       seqId = row.get().getLong(StoreDefinition.PreferencesStore.SEQUENCE_ID_FIELD);
@@ -292,7 +292,7 @@ public class PreferencesTable {
         properties = GSON.fromJson(string, MAP_TYPE);
       }
     }
-    return new PreferencesDetail(properties, seqId, false);
+    return new PreferencesDetail(properties, seqId == null ? 0L : seqId, false);
   }
 
   private List<Field<?>> toFields(String namespace, String type, Config config, long seqId) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -100,7 +100,6 @@ import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.DefaultOwnerStore;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.conf.Configuration;
@@ -180,8 +179,7 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
   @Override
   protected void startUp() throws Exception {
     previewInjector = createPreviewInjector();
-    StoreDefinition.createAllTables(previewInjector.getInstance(StructuredTableAdmin.class),
-                                    previewInjector.getInstance(StructuredTableRegistry.class), false);
+    StoreDefinition.createAllTables(previewInjector.getInstance(StructuredTableAdmin.class));
     metricsCollectionService.start();
     logAppender = previewInjector.getInstance(LogAppender.class);
     logAppender.start();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
@@ -58,7 +58,6 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
@@ -109,7 +108,6 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
   private final ProgramNotificationSubscriberService programNotificationSubscriberService;
   private final LevelDBTableService levelDBTableService;
   private final StructuredTableAdmin structuredTableAdmin;
-  private final StructuredTableRegistry structuredTableRegistry;
   private final Path previewIdDirPath;
 
   @Inject
@@ -127,7 +125,6 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
                        ProgramNotificationSubscriberService programNotificationSubscriberService,
                        LevelDBTableService levelDBTableService,
                        StructuredTableAdmin structuredTableAdmin,
-                       StructuredTableRegistry structuredTableRegistry,
                        CConfiguration cConf) {
     this.messagingService = messagingService;
     this.dsOpExecService = dsOpExecService;
@@ -143,7 +140,6 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
     this.programNotificationSubscriberService = programNotificationSubscriberService;
     this.levelDBTableService = levelDBTableService;
     this.structuredTableAdmin = structuredTableAdmin;
-    this.structuredTableRegistry = structuredTableRegistry;
     this.previewIdDirPath = Paths.get(cConf.get(Constants.CFG_LOCAL_DATA_DIR), "previewid").toAbsolutePath();
   }
 
@@ -295,7 +291,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
   @Override
   protected void startUp() throws Exception {
     LOG.debug("Starting preview runner service");
-    StoreDefinition.createAllTables(structuredTableAdmin, structuredTableRegistry, false);
+    StoreDefinition.createAllTables(structuredTableAdmin);
     if (messagingService instanceof Service) {
       ((Service) messagingService).startAndWait();
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepositoryReaderProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepositoryReaderProvider.java
@@ -24,8 +24,8 @@ import io.cdap.cdap.common.conf.Constants;
 
 /**
  * Provider for {@link ArtifactRepositoryReader}.
- * Use {@link LocalArtifactRepositoryReader} if storage implementation is {@link Constants.Dataset#DATA_STORAGE_SQL}.
- * Use {@link RemoteArtifactRepositoryReader} if storage implementation is {@link Constants.Dataset#DATA_STORAGE_NOSQL}.
+ * Use {@link RemoteArtifactRepositoryReader} if storage implementation is {@link Constants.Dataset#DATA_STORAGE_NOSQL},
+ * otherwise use {@link LocalArtifactRepositoryReader}.
  */
 public final class ArtifactRepositoryReaderProvider implements Provider<ArtifactRepositoryReader> {
 
@@ -50,12 +50,6 @@ public final class ArtifactRepositoryReaderProvider implements Provider<Artifact
     if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
       return injector.getInstance(RemoteArtifactRepositoryReader.class);
     }
-    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
-      return injector.getInstance(LocalArtifactRepositoryReader.class);
-    }
-    throw new UnsupportedOperationException(
-      String.format(
-        "%s is not a supported storage implementation, the supported ones are %s and %s",
-        storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+    return injector.getInstance(LocalArtifactRepositoryReader.class);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/PluginFinderProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/PluginFinderProvider.java
@@ -24,8 +24,8 @@ import io.cdap.cdap.common.conf.Constants;
 
 /**
  * Provider for {@link PluginFinder}.
- * Use {@link LocalPluginFinder} if storage implication is {@link Constants.Dataset#DATA_STORAGE_SQL}.
- * Use {@link RemotePluginFinder} if storage implication is {@link Constants.Dataset#DATA_STORAGE_NOSQL}.
+ * Use {@link RemotePluginFinder} if storage implication is {@link Constants.Dataset#DATA_STORAGE_NOSQL},
+ * otherwise use {@link LocalPluginFinder}.
  */
 public class PluginFinderProvider implements Provider<PluginFinder> {
 
@@ -50,12 +50,7 @@ public class PluginFinderProvider implements Provider<PluginFinder> {
     if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
       return injector.getInstance(RemotePluginFinder.class);
     }
-    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
-      return injector.getInstance(LocalPluginFinder.class);
-    }
-    throw new UnsupportedOperationException(
-      String.format(
-        "%s is not a supported storage implementation, the supported ones are %s and %s",
-        storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+
+    return injector.getInstance(LocalPluginFinder.class);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -93,7 +93,7 @@ public class DefaultStore implements Store {
   private static final DatasetId WORKFLOW_STATS_INSTANCE_ID = NamespaceId.SYSTEM.dataset("workflow.stats");
   private static final Map<String, String> EMPTY_STRING_MAP = Collections.emptyMap();
 
-  private TransactionRunner transactionRunner;
+  private final TransactionRunner transactionRunner;
 
   @Inject
   public DefaultStore(TransactionRunner transactionRunner) {
@@ -617,8 +617,8 @@ public class DefaultStore implements Store {
   }
 
   private static class ApplicationSpecificationWithChangedServices extends ForwardingApplicationSpecification {
-    private String serviceName;
-    private ServiceSpecification serviceSpecification;
+    private final String serviceName;
+    private final ServiceSpecification serviceSpecification;
 
     private ApplicationSpecificationWithChangedServices(ApplicationSpecification delegate,
                                                         String serviceName, ServiceSpecification serviceSpecification) {
@@ -677,8 +677,8 @@ public class DefaultStore implements Store {
   }
 
   private static class ApplicationSpecificationWithChangedWorkers extends ForwardingApplicationSpecification {
-    private String workerId;
-    private WorkerSpecification workerSpecification;
+    private final String workerId;
+    private final WorkerSpecification workerSpecification;
 
     private ApplicationSpecificationWithChangedWorkers(ApplicationSpecification delegate, String workerId,
                                                        WorkerSpecification workerSpec) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/MasterEnvironmentExtensionLoader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/MasterEnvironmentExtensionLoader.java
@@ -25,7 +25,6 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -101,16 +100,7 @@ public class MasterEnvironmentExtensionLoader extends AbstractExtensionLoader<St
         return packages;
       }
 
-      packages = new HashSet<>();
-      Set<String> allowResources = getAllowedResources();
-      for (String resource : allowResources) {
-        if (resource.endsWith(".class")) {
-          int idx = resource.lastIndexOf("/");
-          if (idx >= 0) {
-            packages.add(resource.substring(0, idx));
-          }
-        }
-      }
+      packages = createPackageSets(getAllowedResources());
 
       this.allowedPackages = packages;
       return packages;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/AbstractServiceMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/AbstractServiceMain.java
@@ -30,7 +30,6 @@ import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.preview.PreviewConfigModule;
 import io.cdap.cdap.common.app.MainClassLoader;
 import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.IOModule;
@@ -57,6 +56,7 @@ import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.guice.CoreSecurityModule;
 import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
+import io.cdap.cdap.spi.data.StorageProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.twill.discovery.DiscoveryService;
@@ -67,13 +67,10 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.io.File;
 import java.lang.reflect.Method;
-import java.sql.Connection;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
-import javax.sql.DataSource;
 
 /**
  * The abstract base class for writing various service main classes.
@@ -87,6 +84,7 @@ public abstract class AbstractServiceMain<T extends EnvironmentOptions> extends 
   private final List<Service> services = new ArrayList<>();
   private final List<AutoCloseable> closeableResources = new ArrayList<>();
   private MasterEnvironment masterEnv;
+  private StorageProvider storageProvider;
   private Injector injector;
 
   /**
@@ -194,7 +192,12 @@ public abstract class AbstractServiceMain<T extends EnvironmentOptions> extends 
     // Add Services
     services.add(injector.getInstance(MetricsCollectionService.class));
     addServices(injector, services, closeableResources, masterEnv, masterEnvContext, options);
-    initializeDataSourceConnection(cConf);
+
+    // Optionally get the storage provider. It is for destroy() method to close it on shutdown.
+    Binding<StorageProvider> storageBinding = injector.getExistingBinding(Key.get(StorageProvider.class));
+    if (storageBinding != null) {
+      storageProvider = storageBinding.getProvider().get();
+    }
 
     LOG.info("Service {} initialized", getClass().getName());
   }
@@ -235,6 +238,13 @@ public abstract class AbstractServiceMain<T extends EnvironmentOptions> extends 
 
   @Override
   public final void destroy() {
+    if (storageProvider != null) {
+      try {
+        storageProvider.close();
+      } catch (Exception e) {
+        LOG.warn("Exception raised when closing storage provider", e);
+      }
+    }
     if (masterEnv != null) {
       masterEnv.destroy();
     }
@@ -262,22 +272,6 @@ public abstract class AbstractServiceMain<T extends EnvironmentOptions> extends 
         bind(TransactionSystemClient.class).to(ConstantTransactionSystemClient.class);
       }
     };
-  }
-
-  protected void initializeDataSourceConnection(CConfiguration cConf) throws SQLException {
-    if (cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION).equals(Constants.Dataset.DATA_STORAGE_SQL)) {
-      Binding<DataSource> binding = injector.getExistingBinding(Key.get(DataSource.class));
-      if (binding == null) {
-        return;
-      }
-
-      // instantiate the data source and create a connection
-      DataSource dataSource = binding.getProvider().get();
-      try (Connection connection = dataSource.getConnection()) {
-        // Just to ping the connection and close it to populate the connection pool.
-        connection.isValid(5);
-      }
-    }
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcherProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcherProvider.java
@@ -24,8 +24,8 @@ import io.cdap.cdap.common.conf.Constants;
 
 /**
  * Provider for {@link PreferencesFetcher}.
- * Use {@link LocalPreferencesFetcherInternal} if storage implication is {@link Constants.Dataset#DATA_STORAGE_SQL}
- * Use {@link RemotePreferencesFetcherInternal} if storage implication is {@link Constants.Dataset#DATA_STORAGE_NOSQL}
+ * Use {@link RemotePreferencesFetcherInternal} if storage implication is {@link Constants.Dataset#DATA_STORAGE_NOSQL},
+ * otherwise use {@link LocalPreferencesFetcherInternal}.
  */
 public class ApplicationDetailFetcherProvider implements Provider<ApplicationDetailFetcher> {
   private final CConfiguration cConf;
@@ -48,11 +48,6 @@ public class ApplicationDetailFetcherProvider implements Provider<ApplicationDet
     if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
       return injector.getInstance(RemoteApplicationDetailFetcher.class);
     }
-    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
-      return injector.getInstance(LocalApplicationDetailFetcher.class);
-    }
-    throw new UnsupportedOperationException(
-      String.format("%s is not a supported storage implementation, the supported implementations are %s and %s",
-                    storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+    return injector.getInstance(LocalApplicationDetailFetcher.class);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/PreferencesFetcherProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/PreferencesFetcherProvider.java
@@ -24,8 +24,8 @@ import io.cdap.cdap.common.conf.Constants;
 
 /**
  * Provider for {@link PreferencesFetcher}.
- * Use {@link LocalPreferencesFetcherInternal} if storage implication is {@link Constants.Dataset#DATA_STORAGE_SQL}.
- * Use {@link RemotePreferencesFetcherInternal} if storage implication is {@link Constants.Dataset#DATA_STORAGE_NOSQL}
+ * Use {@link RemotePreferencesFetcherInternal} if storage implication is {@link Constants.Dataset#DATA_STORAGE_NOSQL},
+ * otherwise use {@link LocalPreferencesFetcherInternal}.
  */
 public class PreferencesFetcherProvider implements Provider<PreferencesFetcher> {
 
@@ -50,13 +50,7 @@ public class PreferencesFetcherProvider implements Provider<PreferencesFetcher> 
     if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
       return injector.getInstance(RemotePreferencesFetcherInternal.class);
     }
-    if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
-      return injector.getInstance(LocalPreferencesFetcherInternal.class);
-    }
-    throw new UnsupportedOperationException(
-      String.format(
-        "%s is not a supported storage implementation, the supported ones are %s and %s",
-        storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+    return injector.getInstance(LocalPreferencesFetcherInternal.class);
   }
 }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/app/mapreduce/LocalMRJobInfoFetcherTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/app/mapreduce/LocalMRJobInfoFetcherTest.java
@@ -33,7 +33,6 @@ import io.cdap.cdap.proto.MRJobInfo;
 import io.cdap.cdap.proto.MRTaskInfo;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.mapreduce.TaskCounter;
 import org.apache.tephra.TransactionManager;
@@ -60,9 +59,7 @@ public class LocalMRJobInfoFetcherTest {
   public static Injector startMetricsService(CConfiguration conf) throws Exception {
     Injector injector = Guice.createInjector(new AppFabricTestModule(conf));
     injector.getInstance(TransactionManager.class).startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
     injector.getInstance(DatasetOpExecutorService.class).startAndWait();
     injector.getInstance(DatasetService.class).startAndWait();
     return injector;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/config/SqlUserConfigStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/config/SqlUserConfigStoreTest.java
@@ -17,15 +17,23 @@
 package io.cdap.cdap.config;
 
 import com.google.common.base.Joiner;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
 import io.cdap.cdap.api.dataset.lib.KeyValueTable;
 import io.cdap.cdap.api.dataset.table.Table;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
+import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.sql.PostgresInstantiator;
-import io.cdap.cdap.spi.data.sql.PostgresSqlStructuredTableAdmin;
-import io.cdap.cdap.spi.data.sql.SqlStructuredTableRegistry;
-import io.cdap.cdap.spi.data.sql.SqlTransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -33,7 +41,6 @@ import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import javax.sql.DataSource;
 
 public class SqlUserConfigStoreTest extends UserConfigStoreTest {
 
@@ -49,11 +56,21 @@ public class SqlUserConfigStoreTest extends UserConfigStoreTest {
     cConf.set(Constants.REQUIREMENTS_DATASET_TYPE_EXCLUDE, Joiner.on(",").join(Table.TYPE, KeyValueTable.TYPE));
 
     pg = PostgresInstantiator.createAndStart(cConf, TEMP_FOLDER.newFolder());
-    DataSource dataSource = pg.getPostgresDatabase();
-    SqlStructuredTableRegistry registry = new SqlStructuredTableRegistry(dataSource);
-    registry.initialize();
-    admin = new PostgresSqlStructuredTableAdmin(registry, dataSource);
-    TransactionRunner transactionRunner = new SqlTransactionRunner(admin, dataSource);
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new LocalLocationModule(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new StorageModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+        }
+      }
+    );
+
+    admin = injector.getInstance(StructuredTableAdmin.class);
+    TransactionRunner transactionRunner = injector.getInstance(TransactionRunner.class);
     configStore = new DefaultConfigStore(transactionRunner);
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/config/UserConfigStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/config/UserConfigStoreTest.java
@@ -40,7 +40,7 @@ public abstract class UserConfigStoreTest {
 
   @Before
   public void setupTest() throws Exception {
-    if (admin.getSpecification(StoreDefinition.ConfigStore.CONFIGS) == null) {
+    if (!admin.exists(StoreDefinition.ConfigStore.CONFIGS)) {
       admin.create(StoreDefinition.ConfigStore.CONFIG_TABLE_SPEC);
     }
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
@@ -83,7 +83,6 @@ import io.cdap.cdap.scheduler.Scheduler;
 import io.cdap.cdap.security.authorization.InMemoryAccessController;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -172,16 +171,9 @@ public class AppFabricTestHelper {
       startService(injector, MetadataService.class);
 
       // Register the tables before services will need to use them
-      StructuredTableAdmin tableAdmin = injector.getInstance(StructuredTableAdmin.class);
-      StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
       try {
-        structuredTableRegistry.initialize();
+        StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
       } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-      try {
-        StoreDefinition.createAllTables(tableAdmin, structuredTableRegistry);
-      } catch (IOException | TableAlreadyExistsException e) {
         throw new RuntimeException("Failed to create the system tables", e);
       }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/namespace/StorageProviderNamespaceAdminTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/namespace/StorageProviderNamespaceAdminTest.java
@@ -29,7 +29,6 @@ import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.NamespaceStore;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.tephra.TransactionManager;
@@ -80,8 +79,7 @@ public class StorageProviderNamespaceAdminTest {
     transactionManager = injector.getInstance(TransactionManager.class);
     transactionManager.startAndWait();
     // Define all StructuredTable before starting any services that need StructuredTable
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class),
-                                    injector.getInstance(StructuredTableRegistry.class));
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
 
     datasetService = injector.getInstance(DatasetService.class);
     datasetService.startAndWait();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidatorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidatorTest.java
@@ -57,7 +57,6 @@ import io.cdap.cdap.security.spi.authorization.NoOpAccessController;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.store.StoreDefinition;
@@ -124,8 +123,7 @@ public class DirectRuntimeRequestValidatorTest {
     );
 
     // Create store definition
-    injector.getInstance(StructuredTableRegistry.class).initialize();
-    StoreDefinition.AppMetadataStore.createTables(injector.getInstance(StructuredTableAdmin.class), true);
+    StoreDefinition.AppMetadataStore.create(injector.getInstance(StructuredTableAdmin.class));
 
     txRunner = injector.getInstance(TransactionRunner.class);
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/queue/NoSqlJobQueueTableTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/queue/NoSqlJobQueueTableTest.java
@@ -36,7 +36,6 @@ import io.cdap.cdap.data2.dataset2.DefaultDatasetDefinitionRegistryFactory;
 import io.cdap.cdap.data2.dataset2.InMemoryDatasetFramework;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.conf.Configuration;
@@ -83,12 +82,11 @@ public class NoSqlJobQueueTableTest extends JobQueueTableTest {
       }
     );
 
-    injector.getInstance(StructuredTableRegistry.class).initialize();
     StructuredTableAdmin tableAdmin = injector.getInstance(StructuredTableAdmin.class);
     transactionRunner = injector.getInstance(TransactionRunner.class);
 
-    StoreDefinition.JobQueueStore.createTables(tableAdmin, false);
-    StoreDefinition.AppMetadataStore.createTables(tableAdmin, false);
+    StoreDefinition.JobQueueStore.create(tableAdmin);
+    StoreDefinition.AppMetadataStore.create(tableAdmin);
   }
 
   @AfterClass

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/queue/SqlJobQueueTableTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/queue/SqlJobQueueTableTest.java
@@ -36,7 +36,6 @@ import io.cdap.cdap.data.runtime.StorageModule;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.sql.PostgresInstantiator;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.junit.AfterClass;
@@ -78,12 +77,11 @@ public class SqlJobQueueTableTest extends JobQueueTableTest {
       }
     );
 
-    injector.getInstance(StructuredTableRegistry.class).initialize();
     StructuredTableAdmin structuredTableAdmin = injector.getInstance(StructuredTableAdmin.class);
     transactionRunner = injector.getInstance(TransactionRunner.class);
 
-    StoreDefinition.JobQueueStore.createTables(structuredTableAdmin, false);
-    StoreDefinition.AppMetadataStore.createTables(structuredTableAdmin, false);
+    StoreDefinition.JobQueueStore.create(structuredTableAdmin);
+    StoreDefinition.AppMetadataStore.create(structuredTableAdmin);
   }
 
   @Override

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/store/DatasetBasedTimeScheduleStoreTest.java
@@ -47,7 +47,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.store.StoreDefinition;
@@ -105,7 +104,6 @@ public class DatasetBasedTimeScheduleStoreTest {
   public static void beforeClass() throws Exception {
     CConfiguration conf = CConfiguration.create();
     conf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder("data").getAbsolutePath());
-    // TODO: CDAP-14780 create sql based test by passing in cconf with sql parameter
     injector = Guice.createInjector(new ConfigModule(conf),
                                     new NonCustomLocationUnitTestModule(),
                                     new InMemoryDiscoveryModule(),
@@ -128,9 +126,7 @@ public class DatasetBasedTimeScheduleStoreTest {
                                     });
     txService = injector.getInstance(TransactionManager.class);
     txService.startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
     dsOpsService = injector.getInstance(DatasetOpExecutorService.class);
     dsOpsService.startAndWait();
     dsService = injector.getInstance(DatasetService.class);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -117,7 +117,6 @@ import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
 import io.cdap.cdap.security.spi.authentication.UnauthenticatedException;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.metadata.MetadataMutation;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.store.StoreDefinition;
@@ -265,11 +264,8 @@ public abstract class AppFabricTestBase {
     }
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
     // Define all StructuredTable before starting any services that need StructuredTable
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class),
-                                    structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
     metadataStorage = injector.getInstance(MetadataStorage.class);
     metadataStorage.createIndex();
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/profile/ProfileServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/profile/ProfileServiceTest.java
@@ -92,10 +92,7 @@ public abstract class ProfileServiceTest {
 
   @Before
   public void beforeTest() throws IOException, TableAlreadyExistsException {
-    StructuredTableAdmin tableAdmin = getTableAdmin();
-    if (tableAdmin.getSpecification(StoreDefinition.ProfileStore.PROFILE_STORE_TABLE) == null) {
-      StoreDefinition.ProfileStore.createTables(tableAdmin, false);
-    }
+    StoreDefinition.ProfileStore.create(getTableAdmin());
     profileService = getProfileService();
     profileService.clear();
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/reporting/SqlProgramHeartBeatTableTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/reporting/SqlProgramHeartBeatTableTest.java
@@ -16,14 +16,22 @@
 
 package io.cdap.cdap.reporting;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.sql.PostgresInstantiator;
-import io.cdap.cdap.spi.data.sql.PostgresSqlStructuredTableAdmin;
-import io.cdap.cdap.spi.data.sql.SqlStructuredTableRegistry;
-import io.cdap.cdap.spi.data.sql.SqlTransactionRunner;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -31,7 +39,6 @@ import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import javax.sql.DataSource;
 
 public class SqlProgramHeartBeatTableTest extends ProgramHeartBeatTableTest {
   @ClassRule
@@ -41,13 +48,24 @@ public class SqlProgramHeartBeatTableTest extends ProgramHeartBeatTableTest {
 
   @BeforeClass
   public static void beforeClass() throws IOException, TableAlreadyExistsException {
-    pg = PostgresInstantiator.createAndStart(TEMP_FOLDER.newFolder());
-    DataSource dataSource = pg.getPostgresDatabase();
-    StructuredTableRegistry registry = new SqlStructuredTableRegistry(dataSource);
-    registry.initialize();
-    StructuredTableAdmin structuredTableAdmin = new PostgresSqlStructuredTableAdmin(registry, dataSource);
-    transactionRunner = new SqlTransactionRunner(structuredTableAdmin, dataSource);
-    StoreDefinition.createAllTables(structuredTableAdmin, registry);
+    CConfiguration cConf = CConfiguration.create();
+    pg = PostgresInstantiator.createAndStart(cConf, TEMP_FOLDER.newFolder());
+
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new LocalLocationModule(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new StorageModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+        }
+      }
+    );
+
+    transactionRunner = injector.getInstance(TransactionRunner.class);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/security/SqlDefaultSecretStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/security/SqlDefaultSecretStoreTest.java
@@ -16,13 +16,21 @@
 
 package io.cdap.cdap.security;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.data.security.DefaultSecretStore;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.sql.PostgresInstantiator;
-import io.cdap.cdap.spi.data.sql.PostgresSqlStructuredTableAdmin;
-import io.cdap.cdap.spi.data.sql.SqlStructuredTableRegistry;
-import io.cdap.cdap.spi.data.sql.SqlTransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.junit.AfterClass;
@@ -31,7 +39,6 @@ import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import javax.sql.DataSource;
 
 /**
  * Tests {@link DefaultSecretStore} with Sql storage implementation.
@@ -45,15 +52,24 @@ public class SqlDefaultSecretStoreTest extends DefaultSecretStoreTest {
 
   @BeforeClass
   public static void setup() throws Exception {
-    pg = PostgresInstantiator.createAndStart(TEMP_FOLDER.newFolder());
-    DataSource dataSource = pg.getPostgresDatabase();
-    SqlStructuredTableRegistry registry = new SqlStructuredTableRegistry(dataSource);
-    registry.initialize();
-    StructuredTableAdmin structuredTableAdmin =
-      new PostgresSqlStructuredTableAdmin(registry, dataSource);
-    TransactionRunner transactionRunner = new SqlTransactionRunner(structuredTableAdmin, dataSource);
-    store = new DefaultSecretStore(transactionRunner);
-    StoreDefinition.SecretStore.createTable(structuredTableAdmin, false);
+    CConfiguration cConf = CConfiguration.create();
+
+    pg = PostgresInstantiator.createAndStart(cConf, TEMP_FOLDER.newFolder());
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new LocalLocationModule(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new StorageModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+        }
+      }
+    );
+
+    store = new DefaultSecretStore(injector.getInstance(TransactionRunner.class));
+    StoreDefinition.SecretStore.create(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -566,6 +566,9 @@ public final class Constants {
 
     public static final String DATA_EVENT_TOPIC = "data.event.topic";
 
+    public static final String STORAGE_EXTENSION_DIR = "data.storage.extensions.dir";
+    public static final String STORAGE_EXTENSION_PROPERTY_PREFIX = "data.storage.properties.";
+
     public static final String DATA_STORAGE_IMPLEMENTATION = "data.storage.implementation";
     public static final String DATA_STORAGE_NOSQL = "nosql";
     public static final String DATA_STORAGE_SQL = "postgresql";

--- a/cdap-common/src/main/java/io/cdap/cdap/extension/AbstractExtensionLoader.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/extension/AbstractExtensionLoader.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -84,6 +85,17 @@ public abstract class AbstractExtensionLoader<EXTENSION_TYPE, EXTENSION> {
   private final LoadingCache<EXTENSION_TYPE, AtomicReference<EXTENSION>> extensionsCache;
   private final LoadingCache<File, ServiceLoader<EXTENSION>> serviceLoaderCache;
   private Map<EXTENSION_TYPE, EXTENSION> allExtensions;
+
+  protected static Set<String> createPackageSets(Set<String> resources) {
+    return resources.stream()
+      .filter(resource -> resource.endsWith(".class"))
+      .map(resource -> {
+        int idx = resource.lastIndexOf("/");
+        return idx < 0 ? "" : resource.substring(0, idx).replace('/', '.');
+      })
+      .filter(s -> !s.isEmpty())
+      .collect(Collectors.toSet());
+  }
 
   @SuppressWarnings("unchecked")
   public AbstractExtensionLoader(String extDirs) {

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -834,6 +834,11 @@
   </property>
 
   <property>
+    <name>data.storage.extensions.dir</name>
+    <value>/opt/cdap/master/ext/storageproviders</value>
+  </property>
+
+  <property>
     <name>data.storage.implementation</name>
     <value>nosql</value>
     <description>

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data/runtime/StorageModule.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data/runtime/StorageModule.java
@@ -17,26 +17,14 @@
 
 package io.cdap.cdap.data.runtime;
 
-import com.google.inject.Inject;
-import com.google.inject.Injector;
 import com.google.inject.PrivateModule;
-import com.google.inject.Provider;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
-import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.common.conf.Constants;
+import com.google.inject.Singleton;
+import io.cdap.cdap.spi.data.StorageProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.common.CachedStructuredTableRegistry;
-import io.cdap.cdap.spi.data.nosql.NoSqlStructuredTableAdmin;
-import io.cdap.cdap.spi.data.nosql.NoSqlStructuredTableRegistry;
-import io.cdap.cdap.spi.data.nosql.NoSqlTransactionRunner;
-import io.cdap.cdap.spi.data.sql.PostgresSqlStructuredTableAdmin;
-import io.cdap.cdap.spi.data.sql.RetryingSqlTransactionRunner;
-import io.cdap.cdap.spi.data.sql.SqlStructuredTableRegistry;
-import io.cdap.cdap.spi.data.sql.jdbc.DataSourceProvider;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
+import io.cdap.cdap.spi.data.common.DefaultStorageProvider;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
-
-import javax.sql.DataSource;
 
 /**
  * Module to provide the binding for the new storage spi
@@ -45,123 +33,30 @@ public class StorageModule extends PrivateModule {
 
   @Override
   protected void configure() {
-    bind(TransactionRunner.class).toProvider(TransactionRunnerProvider.class).in(Scopes.SINGLETON);
-    bind(StructuredTableAdmin.class).toProvider(StructuredTableAdminProvider.class).in(Scopes.SINGLETON);
-    bind(StructuredTableRegistry.class).toProvider(StructuredTableRegistryProvider.class).in(Scopes.SINGLETON);
-    bind(DataSourceProvider.class).in(Scopes.SINGLETON);
-    bind(DataSource.class).toProvider(DataSourceProvider.class).in(Scopes.SINGLETON);
+    bind(StorageProvider.class).to(DefaultStorageProvider.class).in(Scopes.SINGLETON);
 
+    expose(StorageProvider.class);
     expose(TransactionRunner.class);
     expose(StructuredTableAdmin.class);
-    expose(StructuredTableRegistry.class);
-    expose(DataSource.class);
   }
 
-  /**
-   * Transaction runner provider to provide the {@link TransactionRunner} class, the actual implementation will be
-   * based on the configuration file.
-   */
-  private static final class TransactionRunnerProvider implements Provider<TransactionRunner> {
-
-    private final CConfiguration cConf;
-    private final Injector injector;
-
-    @Inject
-    TransactionRunnerProvider(CConfiguration cConf, Injector injector) {
-      this.cConf = cConf;
-      this.injector = injector;
-    }
-
-    @Override
-    public TransactionRunner get() {
-      String storageImpl = cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION);
-      if (storageImpl == null) {
-        throw new IllegalStateException("No storage implementation is specified in the configuration file");
-      }
-
-      storageImpl = storageImpl.toLowerCase();
-      if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
-        return injector.getInstance(NoSqlTransactionRunner.class);
-      }
-
-      if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
-        return injector.getInstance(RetryingSqlTransactionRunner.class);
-      }
-
-      throw new UnsupportedOperationException(
-        String.format("%s is not a supported storage implementation, the supported implementations are %s and %s",
-                      storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+  @Provides
+  @Singleton
+  private TransactionRunner provideTransactionRunner(StorageProvider storageProvider) {
+    try {
+      return storageProvider.getTransactionRunner();
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to create TransactionRunner", e);
     }
   }
 
-  /**
-   * Structure table admin provider to provide the {@link StructuredTableAdmin} class, the actual implementation
-   * will be based on the configuration file.
-   */
-  private static final class StructuredTableAdminProvider implements Provider<StructuredTableAdmin> {
-
-    private final CConfiguration cConf;
-    private final Injector injector;
-
-    @Inject
-    StructuredTableAdminProvider(CConfiguration cConf, Injector injector) {
-      this.cConf = cConf;
-      this.injector = injector;
-    }
-
-    @Override
-    public StructuredTableAdmin get() {
-      String storageImpl = cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION);
-      if (storageImpl == null) {
-        throw new IllegalStateException("No storage implementation is specified in the configuration file");
-      }
-
-      storageImpl = storageImpl.toLowerCase();
-      if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
-        return injector.getInstance(NoSqlStructuredTableAdmin.class);
-      }
-      if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
-        return injector.getInstance(PostgresSqlStructuredTableAdmin.class);
-      }
-      throw new UnsupportedOperationException(
-        String.format("%s is not a supported storage implementation, the supported implementations are %s and %s",
-                      storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
-    }
-  }
-
-  /**
-   * Structure table registry provider to provide the {@link StructuredTableRegistry} class, the actual implementation
-   * will be based on the configuration file.
-   */
-  private static final class StructuredTableRegistryProvider implements Provider<StructuredTableRegistry> {
-    private final CConfiguration cConf;
-    private final Injector injector;
-
-    @Inject
-    StructuredTableRegistryProvider(CConfiguration cConf, Injector injector) {
-      this.cConf = cConf;
-      this.injector = injector;
-    }
-
-    @Override
-    public StructuredTableRegistry get() {
-      String storageImpl = cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION);
-      if (storageImpl == null) {
-        throw new IllegalStateException("No storage implementation is specified in the configuration file");
-      }
-
-      storageImpl = storageImpl.toLowerCase();
-      if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_NOSQL)) {
-        NoSqlStructuredTableRegistry registry = injector.getInstance(NoSqlStructuredTableRegistry.class);
-        return new CachedStructuredTableRegistry(registry);
-      }
-      if (storageImpl.equals(Constants.Dataset.DATA_STORAGE_SQL)) {
-        SqlStructuredTableRegistry registry = injector.getInstance(SqlStructuredTableRegistry.class);
-        return new CachedStructuredTableRegistry(registry);
-      }
-      throw new UnsupportedOperationException(
-        String.format("%s is not a supported storage implementation, the supported implementations are %s and %s",
-                      storageImpl, Constants.Dataset.DATA_STORAGE_NOSQL, Constants.Dataset.DATA_STORAGE_SQL));
+  @Provides
+  @Singleton
+  private StructuredTableAdmin provideStructuredTableAdmin(StorageProvider storageProvider) {
+    try {
+      return storageProvider.getStructuredTableAdmin();
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to create StructuredTableAdmin", e);
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/CachedStructuredTableRegistry.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/CachedStructuredTableRegistry.java
@@ -21,7 +21,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.table.StructuredTableId;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,11 +52,6 @@ public class CachedStructuredTableRegistry implements StructuredTableRegistry {
           return getSpecificationFromDelegate(tableId);
         }
       });
-  }
-
-  @Override
-  public void initialize() throws IOException {
-    delegate.initialize();
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/DefaultStorageProvider.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/DefaultStorageProvider.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data.common;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.api.metrics.MetricsCollector;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.spi.data.StorageProvider;
+import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.nosql.NoSqlStorageProvider;
+import io.cdap.cdap.spi.data.sql.PostgreSqlStorageProvider;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+
+/**
+ * A {@link StorageProvider} that delegates to the actual storage provider implementation based on the configuration.
+ */
+public class DefaultStorageProvider implements StorageProvider {
+
+  private final Injector injector;
+  private final CConfiguration cConf;
+  private final SConfiguration sConf;
+  private final String storageImpl;
+  private final StorageProviderExtensionLoader extensionLoader;
+  private final MetricsCollector metricsCollector;
+  private volatile StorageProvider delegate;
+
+  @Inject
+  DefaultStorageProvider(Injector injector, CConfiguration cConf, SConfiguration sConf,
+                         StorageProviderExtensionLoader extensionLoader,
+                         MetricsCollectionService metricsCollectionService) {
+    this.injector = injector;
+    this.cConf = cConf;
+    this.sConf = sConf;
+    this.storageImpl = cConf.get(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION);
+    this.extensionLoader = extensionLoader;
+    this.metricsCollector = metricsCollectionService.getContext(Constants.Metrics.STORAGE_METRICS_TAGS);
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (delegate != null) {
+      delegate.close();
+    }
+  }
+
+  @Override
+  public String getName() {
+    // The name doesn't matter, as it is not used
+    return "system";
+  }
+
+  @Override
+  public StructuredTableAdmin getStructuredTableAdmin() throws Exception {
+    return getDelegate().getStructuredTableAdmin();
+  }
+
+  @Override
+  public TransactionRunner getTransactionRunner() throws Exception {
+    return getDelegate().getTransactionRunner();
+  }
+
+  /**
+   * Returns the {@link StorageProvider} to use based on configuration.
+   */
+  private StorageProvider getDelegate() throws Exception {
+    StorageProvider provider = this.delegate;
+    if (provider != null) {
+      return provider;
+    }
+    synchronized (this) {
+      provider = this.delegate;
+      if (provider != null) {
+        return provider;
+      }
+
+      switch (storageImpl.toLowerCase()) {
+        case Constants.Dataset.DATA_STORAGE_NOSQL:
+          provider = injector.getInstance(NoSqlStorageProvider.class);
+          break;
+        case Constants.Dataset.DATA_STORAGE_SQL:
+          provider = injector.getInstance(PostgreSqlStorageProvider.class);
+          break;
+        default:
+          provider = extensionLoader.get(storageImpl);
+      }
+
+      if (provider == null) {
+        throw new IllegalArgumentException("Unsupported storage implementation " + storageImpl);
+      }
+
+      provider.initialize(new DefaultStorageProviderContext(cConf, sConf, provider.getName(), metricsCollector));
+
+      this.delegate = provider;
+      return provider;
+    }
+  }
+}

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/DefaultStorageProviderContext.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/DefaultStorageProviderContext.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data.common;
+
+import io.cdap.cdap.api.metrics.MetricsCollector;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.spi.data.StorageProviderContext;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Default implementation of the {@link StorageProviderContext}.
+ */
+final class DefaultStorageProviderContext implements StorageProviderContext {
+
+  private final Map<String, String> cConf;
+  private final Map<String, String> sConf;
+  private final MetricsCollector metricsCollector;
+
+  DefaultStorageProviderContext(CConfiguration cConf, SConfiguration sConf,
+                                String storageImpl, MetricsCollector metricsCollector) {
+    String propertiesPrefix = Constants.Dataset.STORAGE_EXTENSION_PROPERTY_PREFIX + storageImpl + ".";
+    this.cConf = Collections.unmodifiableMap(cConf.getPropsWithPrefix(propertiesPrefix));
+    this.sConf = Collections.unmodifiableMap(sConf.getPropsWithPrefix(propertiesPrefix));
+    this.metricsCollector = metricsCollector;
+  }
+
+  @Override
+  public MetricsCollector getMetricsCollector() {
+    return metricsCollector;
+  }
+
+  @Override
+  public Map<String, String> getConfiguration() {
+    return cConf;
+  }
+
+  @Override
+  public Map<String, String> getSecurityConfiguration() {
+    return sConf;
+  }
+}

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/StorageProviderExtensionLoader.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/StorageProviderExtensionLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.internal.provision;
+package io.cdap.cdap.spi.data.common;
 
 import com.google.inject.Inject;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -22,47 +22,43 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.lang.ClassPathResources;
 import io.cdap.cdap.common.lang.FilterClassLoader;
 import io.cdap.cdap.extension.AbstractExtensionLoader;
-import io.cdap.cdap.runtime.spi.provisioner.Provisioner;
+import io.cdap.cdap.spi.data.StorageProvider;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
- * Loads provisioners from the extensions directory.
+ * A extension loader for {@link StorageProvider}.
  */
-public class ProvisionerExtensionLoader extends AbstractExtensionLoader<String, Provisioner>
-  implements ProvisionerProvider {
+final class StorageProviderExtensionLoader extends AbstractExtensionLoader<String, StorageProvider> {
 
   private static final Set<String> ALLOWED_RESOURCES = createAllowedResources();
   private static final Set<String> ALLOWED_PACKAGES = createPackageSets(ALLOWED_RESOURCES);
 
   private static Set<String> createAllowedResources() {
+    // Only allow Storage SPI classes.
     try {
-      return ClassPathResources.getResourcesWithDependencies(Provisioner.class.getClassLoader(), Provisioner.class);
+      return ClassPathResources.getResourcesWithDependencies(StorageProviderExtensionLoader.class.getClassLoader(),
+                                                             StorageProvider.class);
     } catch (IOException e) {
-      throw new RuntimeException("Failed to trace dependencies for provisioner extension. " +
-                                   "Usage of provisioner might fail.", e);
+      throw new RuntimeException("Failed to trace dependencies for storage provider extension. " +
+                                   "Usage of storage provider might fail.", e);
     }
   }
 
   @Inject
-  ProvisionerExtensionLoader(CConfiguration cConf) {
-    super(cConf.get(Constants.Provisioner.EXTENSIONS_DIR));
+  StorageProviderExtensionLoader(CConfiguration cConf) {
+    super(cConf.get(Constants.Dataset.STORAGE_EXTENSION_DIR));
   }
 
   @Override
-  protected Set<String> getSupportedTypesForProvider(Provisioner provisioner) {
-    return Collections.singleton(provisioner.getSpec().getName());
+  protected Set<String> getSupportedTypesForProvider(StorageProvider storageProvider) {
+    return Collections.singleton(storageProvider.getName());
   }
 
   @Override
   protected FilterClassLoader.Filter getExtensionParentClassLoaderFilter() {
-    // filter all non-spi classes to provide isolation from CDAP's classes. For example, dataproc provisioner uses
-    // a different guava than CDAP's guava.
     return new FilterClassLoader.Filter() {
       @Override
       public boolean acceptResource(String resource) {
@@ -74,15 +70,5 @@ public class ProvisionerExtensionLoader extends AbstractExtensionLoader<String, 
         return ALLOWED_PACKAGES.contains(packageName);
       }
     };
-  }
-
-  @Override
-  public Map<String, Provisioner> loadProvisioners() {
-    Map<String, Provisioner> provisioners = new HashMap<>();
-    // always include the native provisioner
-    Provisioner nativeProvisioner = new NativeProvisioner();
-    provisioners.put(nativeProvisioner.getSpec().getName(), nativeProvisioner);
-    provisioners.putAll(getAll());
-    return provisioners;
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/StructuredTableRegistry.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/StructuredTableRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,10 +14,12 @@
  * the License.
  */
 
-package io.cdap.cdap.spi.data.table;
+package io.cdap.cdap.spi.data.common;
 
 import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 
 import java.io.IOException;
 import javax.annotation.Nullable;
@@ -27,12 +29,6 @@ import javax.annotation.Nullable;
  */
 @Beta
 public interface StructuredTableRegistry {
-  /**
-   * Initializes the underlying storage for the registry.
-   *
-   * @throws IOException if not able to write to the underlying storage
-   */
-  void initialize() throws IOException;
 
   /**
    * Register a table specification.

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStorageProvider.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStorageProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data.nosql;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.cdap.cdap.api.dataset.DatasetDefinition;
+import io.cdap.cdap.api.dataset.table.Table;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.spi.data.StorageProvider;
+import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import org.apache.tephra.TransactionSystemClient;
+
+/**
+ * A {@link StorageProvider} implementation that uses CDAP {@link Table} dataset as the storage engine.
+ */
+public class NoSqlStorageProvider implements StorageProvider {
+
+  private final NoSqlStructuredTableAdmin admin;
+  private final TransactionRunner txRunner;
+
+  @Inject
+  NoSqlStorageProvider(CConfiguration cConf,
+                       @Named(Constants.Dataset.TABLE_TYPE_NO_TX) DatasetDefinition registryTableDef,
+                       @Named(Constants.Dataset.TABLE_TYPE) DatasetDefinition tableDefinition,
+                       TransactionSystemClient txClient, MetricsCollectionService metricsCollectionService) {
+    this.admin = new NoSqlStructuredTableAdmin(tableDefinition, new NoSqlStructuredTableRegistry(registryTableDef));
+    this.txRunner = new NoSqlTransactionRunner(admin, txClient, metricsCollectionService, cConf);
+  }
+
+  @Override
+  public String getName() {
+    return Constants.Dataset.DATA_STORAGE_NOSQL;
+  }
+
+  @Override
+  public StructuredTableAdmin getStructuredTableAdmin() {
+    return admin;
+  }
+
+  @Override
+  public TransactionRunner getTransactionRunner() {
+    return txRunner;
+  }
+}

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlTransactionRunner.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlTransactionRunner.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.spi.data.nosql;
 
-import com.google.inject.Inject;
 import io.cdap.cdap.api.Transactional;
 import io.cdap.cdap.api.dataset.Dataset;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
@@ -45,9 +44,8 @@ public class NoSqlTransactionRunner implements TransactionRunner {
   private final MetricsCollectionService metricsCollectionService;
   private final boolean emitTimeMetrics;
 
-  @Inject
-  public NoSqlTransactionRunner(NoSqlStructuredTableAdmin tableAdmin, TransactionSystemClient txClient,
-                                MetricsCollectionService metricsCollectionService, CConfiguration cConf) {
+  NoSqlTransactionRunner(NoSqlStructuredTableAdmin tableAdmin, TransactionSystemClient txClient,
+                         MetricsCollectionService metricsCollectionService, CConfiguration cConf) {
     this.tableAdmin = tableAdmin;
     this.transactional = Transactions.createTransactionalWithRetry(
       NoSQLTransactionals.createTransactional(txClient, new TableDatasetSupplier() {

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStructuredTable.java
@@ -58,15 +58,15 @@ import javax.annotation.Nullable;
 /**
  * Sql structured table implementation.
  */
-public class PostgresSqlStructuredTable implements StructuredTable {
-  private static final Logger LOG = LoggerFactory.getLogger(PostgresSqlStructuredTable.class);
+public class PostgreSqlStructuredTable implements StructuredTable {
+  private static final Logger LOG = LoggerFactory.getLogger(PostgreSqlStructuredTable.class);
   private static final int SCAN_FETCH_SIZE = 100;
 
   private final Connection connection;
   private final StructuredTableSchema tableSchema;
   private final FieldValidator fieldValidator;
 
-  public PostgresSqlStructuredTable(Connection connection, StructuredTableSchema tableSchema) {
+  public PostgreSqlStructuredTable(Connection connection, StructuredTableSchema tableSchema) {
     this.connection = connection;
     this.tableSchema = tableSchema;
     this.fieldValidator = new FieldValidator(tableSchema);
@@ -582,7 +582,7 @@ public class PostgresSqlStructuredTable implements StructuredTable {
    * @throws SQLException
    */
   private int setFields(PreparedStatement statement, Iterable<? extends Field<?>> fields,
-                           int beginIndex) throws SQLException {
+                        int beginIndex) throws SQLException {
     int index = beginIndex;
     for (Field<?> keyField : fields) {
       setField(statement, keyField, index);
@@ -812,6 +812,9 @@ public class PostgresSqlStructuredTable implements StructuredTable {
     StringBuilder statement =  new StringBuilder("SELECT COUNT(*) FROM ").append(tableSchema.getTableId().getName());
     boolean whereAdded = false;
     for (Range range: ranges) {
+      fieldValidator.validatePrimaryKeys(range.getBegin(), true);
+      fieldValidator.validatePrimaryKeys(range.getEnd(), true);
+
       if (!range.getBegin().isEmpty() || !range.getEnd().isEmpty()) {
         if (!whereAdded) {
           // first WHERE condition

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableContext.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableContext.java
@@ -24,9 +24,8 @@ import io.cdap.cdap.spi.data.StructuredTableInstantiationException;
 import io.cdap.cdap.spi.data.TableNotFoundException;
 import io.cdap.cdap.spi.data.common.MetricStructuredTable;
 import io.cdap.cdap.spi.data.table.StructuredTableId;
-import io.cdap.cdap.spi.data.table.StructuredTableSchema;
-import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 
+import java.io.IOException;
 import java.sql.Connection;
 
 /**
@@ -47,14 +46,14 @@ public class SqlStructuredTableContext implements StructuredTableContext {
   }
 
   @Override
-  public StructuredTable getTable(
-    StructuredTableId tableId) throws StructuredTableInstantiationException, TableNotFoundException {
-    StructuredTableSpecification specification = admin.getSpecification(tableId);
-    if (specification == null) {
-      throw new TableNotFoundException(tableId);
+  public StructuredTable getTable(StructuredTableId tableId)
+    throws StructuredTableInstantiationException, TableNotFoundException {
+
+    try {
+      return new MetricStructuredTable(tableId, new PostgreSqlStructuredTable(connection, admin.getSchema(tableId)),
+                                       metricsCollector, emitTimeMetrics);
+    } catch (IOException e) {
+      throw new StructuredTableInstantiationException(tableId, "Failed to get the table schema", e);
     }
-    return new MetricStructuredTable(
-      tableId, new PostgresSqlStructuredTable(connection, new StructuredTableSchema(specification)),
-      metricsCollector, emitTimeMetrics);
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/jdbc/MetricsDataSource.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/jdbc/MetricsDataSource.java
@@ -31,13 +31,14 @@ import javax.sql.DataSource;
 /**
  * A metrics data source that will emit metrics about the number of connections.
  */
-public class MetricsDataSource implements DataSource {
+public class MetricsDataSource implements DataSource, AutoCloseable {
+
   private final DataSource dataSource;
   private final MetricsCollectionService metricsCollectionService;
-  private final ObjectPool objectPool;
+  private final ObjectPool<?> objectPool;
 
   public MetricsDataSource(DataSource dataSource, MetricsCollectionService metricsCollectionService,
-                           ObjectPool objectPool) {
+                           ObjectPool<?> objectPool) {
     this.dataSource = dataSource;
     this.metricsCollectionService = metricsCollectionService;
     this.objectPool = objectPool;
@@ -104,5 +105,12 @@ public class MetricsDataSource implements DataSource {
   @Override
   public Logger getParentLogger() throws SQLFeatureNotSupportedException {
     return dataSource.getParentLogger();
+  }
+
+  @Override
+  public void close() throws Exception {
+    if (dataSource instanceof AutoCloseable) {
+      ((AutoCloseable) dataSource).close();
+    }
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/NamespaceTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/NamespaceTable.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.store;
 
-import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.proto.NamespaceMeta;
@@ -30,6 +29,7 @@ import io.cdap.cdap.spi.data.table.field.Fields;
 import io.cdap.cdap.spi.data.table.field.Range;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -63,7 +63,7 @@ public final class NamespaceTable {
     Field<String> nameField = Fields.stringField(StoreDefinition.NamespaceStore.NAMESPACE_FIELD, metadata.getName());
     Field<String> metadataField =
       Fields.stringField(StoreDefinition.NamespaceStore.NAMESPACE_METADATA_FIELD, GSON.toJson(metadata));
-    table.upsert(ImmutableList.of(nameField, metadataField));
+    table.upsert(Arrays.asList(nameField, metadataField));
   }
 
   /**
@@ -86,8 +86,8 @@ public final class NamespaceTable {
    * @param id id of the namespace
    */
   public void delete(NamespaceId id) throws IOException {
-    table.delete(
-      ImmutableList.of(Fields.stringField(StoreDefinition.NamespaceStore.NAMESPACE_FIELD, id.getEntityName())));
+    table.delete(Collections.singleton(Fields.stringField(StoreDefinition.NamespaceStore.NAMESPACE_FIELD,
+                                                          id.getEntityName())));
   }
 
   /**

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -69,7 +69,6 @@ import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import io.cdap.http.HttpHandler;
@@ -136,8 +135,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     txManager.startAndWait();
     TransactionRunner transactionRunner = injector.getInstance(TransactionRunner.class);
     StructuredTableAdmin structuredTableAdmin = injector.getInstance(StructuredTableAdmin.class);
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    StoreDefinition.createAllTables(structuredTableAdmin, structuredTableRegistry);
+    StoreDefinition.createAllTables(structuredTableAdmin);
     InMemoryTxSystemClient txSystemClient = new InMemoryTxSystemClient(txManager);
     TransactionSystemClientService txSystemClientService = new DelegatingTransactionSystemClientService(txSystemClient);
 

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -82,7 +82,6 @@ import io.cdap.cdap.security.impersonation.OwnerStore;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import io.cdap.common.ContentProvider;
@@ -196,8 +195,7 @@ public abstract class DatasetServiceTestBase {
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
     StructuredTableAdmin structuredTableAdmin = injector.getInstance(StructuredTableAdmin.class);
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    StoreDefinition.createAllTables(structuredTableAdmin, structuredTableRegistry);
+    StoreDefinition.createAllTables(structuredTableAdmin);
     TransactionSystemClient txSystemClient = injector.getInstance(TransactionSystemClient.class);
     TransactionSystemClientService txSystemClientService =
       new DelegatingTransactionSystemClientService(txSystemClient);

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
@@ -63,8 +63,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
@@ -150,9 +148,8 @@ public class DatasetOpExecutorServiceTest {
 
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
 
     dsOpExecService = injector.getInstance(DatasetOpExecutorService.class);
     dsOpExecService.startAndWait();
@@ -169,13 +166,6 @@ public class DatasetOpExecutorServiceTest {
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
     namespaceAdmin.create(NamespaceMeta.DEFAULT);
     namespaceAdmin.create(new NamespaceMeta.Builder().setName(bob.getParent()).build());
-    StructuredTableAdmin tableAdmin = injector.getInstance(StructuredTableAdmin.class);
-    StructuredTableRegistry registry = injector.getInstance(StructuredTableRegistry.class);
-    try {
-      StoreDefinition.createAllTables(tableAdmin, registry);
-    } catch (IOException | TableAlreadyExistsException e) {
-      throw new RuntimeException("Failed to create the system tables", e);
-    }
   }
 
   @After

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/metadata/lineage/NoSqlLineageTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/metadata/lineage/NoSqlLineageTableTest.java
@@ -16,11 +16,11 @@
 
 package io.cdap.cdap.data2.metadata.lineage;
 
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.nosql.NoSqlStructuredTableAdmin;
-import io.cdap.cdap.spi.data.nosql.NoSqlStructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.junit.BeforeClass;
@@ -34,13 +34,12 @@ public class NoSqlLineageTableTest extends LineageTableTest {
 
   @BeforeClass
   public static void beforeClass() throws IOException, TableAlreadyExistsException {
-    StructuredTableAdmin structuredTableAdmin =
-      dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableAdmin.class);
+    CConfiguration cConf = dsFrameworkUtil.getConfiguration();
+    cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
+
+    StructuredTableAdmin structuredTableAdmin = dsFrameworkUtil.getInjector().getInstance(StructuredTableAdmin.class);
     transactionRunner = dsFrameworkUtil.getInjector().getInstance(TransactionRunner.class);
-    NoSqlStructuredTableRegistry registry =
-      dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableRegistry.class);
-    registry.initialize();
-    StoreDefinition.createAllTables(structuredTableAdmin, registry);
+    StoreDefinition.createAllTables(structuredTableAdmin);
   }
 
 }

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/metadata/lineage/SqlLineageTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/metadata/lineage/SqlLineageTableTest.java
@@ -16,14 +16,22 @@
 
 package io.cdap.cdap.data2.metadata.lineage;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.sql.PostgresInstantiator;
-import io.cdap.cdap.spi.data.sql.PostgresSqlStructuredTableAdmin;
-import io.cdap.cdap.spi.data.sql.SqlStructuredTableRegistry;
-import io.cdap.cdap.spi.data.sql.SqlTransactionRunner;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -31,7 +39,6 @@ import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import javax.sql.DataSource;
 
 public class SqlLineageTableTest extends LineageTableTest {
   @ClassRule
@@ -41,13 +48,24 @@ public class SqlLineageTableTest extends LineageTableTest {
 
   @BeforeClass
   public static void beforeClass() throws IOException, TableAlreadyExistsException {
-    pg = PostgresInstantiator.createAndStart(TEMP_FOLDER.newFolder());
-    DataSource dataSource = pg.getPostgresDatabase();
-    StructuredTableRegistry registry = new SqlStructuredTableRegistry(dataSource);
-    registry.initialize();
-    StructuredTableAdmin structuredTableAdmin = new PostgresSqlStructuredTableAdmin(registry, dataSource);
-    transactionRunner = new SqlTransactionRunner(structuredTableAdmin, dataSource);
-    StoreDefinition.createAllTables(structuredTableAdmin, registry);
+    CConfiguration cConf = CConfiguration.create();
+    pg = PostgresInstantiator.createAndStart(cConf, TEMP_FOLDER.newFolder());
+
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new LocalLocationModule(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new StorageModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+        }
+      }
+    );
+
+    transactionRunner = injector.getInstance(TransactionRunner.class);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/metadata/lineage/field/NoSqlFieldLineageTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/metadata/lineage/field/NoSqlFieldLineageTableTest.java
@@ -16,12 +16,12 @@
 
 package io.cdap.cdap.data2.metadata.lineage.field;
 
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.nosql.NoSqlStructuredTableAdmin;
-import io.cdap.cdap.spi.data.nosql.NoSqlStructuredTableRegistry;
-import io.cdap.cdap.spi.data.nosql.NoSqlTransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -34,13 +34,12 @@ public class NoSqlFieldLineageTableTest extends FieldLineageTableTest {
 
   @BeforeClass
   public static void beforeClass() throws IOException, TableAlreadyExistsException {
-    StructuredTableAdmin structuredTableAdmin =
-      dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableAdmin.class);
-    transactionRunner = dsFrameworkUtil.getInjector().getInstance(NoSqlTransactionRunner.class);
-    NoSqlStructuredTableRegistry registry =
-      dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableRegistry.class);
-    registry.initialize();
-    StoreDefinition.createAllTables(structuredTableAdmin, registry);
+    CConfiguration cConf = dsFrameworkUtil.getConfiguration();
+    cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
+
+    StructuredTableAdmin structuredTableAdmin = dsFrameworkUtil.getInjector().getInstance(StructuredTableAdmin.class);
+    transactionRunner = dsFrameworkUtil.getInjector().getInstance(TransactionRunner.class);
+    StoreDefinition.createAllTables(structuredTableAdmin);
   }
 
 }

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/metadata/lineage/field/SqlFieldLineageTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/metadata/lineage/field/SqlFieldLineageTableTest.java
@@ -16,14 +16,22 @@
 
 package io.cdap.cdap.data2.metadata.lineage.field;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.sql.PostgresInstantiator;
-import io.cdap.cdap.spi.data.sql.PostgresSqlStructuredTableAdmin;
-import io.cdap.cdap.spi.data.sql.SqlStructuredTableRegistry;
-import io.cdap.cdap.spi.data.sql.SqlTransactionRunner;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -31,7 +39,6 @@ import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import javax.sql.DataSource;
 
 public class SqlFieldLineageTableTest extends FieldLineageTableTest {
   @ClassRule
@@ -41,13 +48,24 @@ public class SqlFieldLineageTableTest extends FieldLineageTableTest {
 
   @BeforeClass
   public static void beforeClass() throws IOException, TableAlreadyExistsException {
-    pg = PostgresInstantiator.createAndStart(TEMP_FOLDER.newFolder());
-    DataSource dataSource = pg.getPostgresDatabase();
-    StructuredTableRegistry registry = new SqlStructuredTableRegistry(dataSource);
-    registry.initialize();
-    StructuredTableAdmin structuredTableAdmin = new PostgresSqlStructuredTableAdmin(registry, dataSource);
-    transactionRunner = new SqlTransactionRunner(structuredTableAdmin, dataSource);
-    StoreDefinition.createAllTables(structuredTableAdmin, registry);
+    CConfiguration cConf = CConfiguration.create();
+    pg = PostgresInstantiator.createAndStart(cConf, TEMP_FOLDER.newFolder());
+
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new LocalLocationModule(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new StorageModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+        }
+      }
+    );
+
+    transactionRunner = injector.getInstance(TransactionRunner.class);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/registry/NoSqlUsageTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/registry/NoSqlUsageTableTest.java
@@ -16,12 +16,12 @@
 
 package io.cdap.cdap.data2.registry;
 
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.nosql.NoSqlStructuredTableAdmin;
-import io.cdap.cdap.spi.data.nosql.NoSqlStructuredTableRegistry;
-import io.cdap.cdap.spi.data.nosql.NoSqlTransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -34,12 +34,11 @@ public class NoSqlUsageTableTest extends UsageTableTest {
 
   @BeforeClass
   public static void beforeClass() throws IOException, TableAlreadyExistsException {
-    StructuredTableAdmin structuredTableAdmin =
-      dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableAdmin.class);
-    transactionRunner = dsFrameworkUtil.getInjector().getInstance(NoSqlTransactionRunner.class);
-    NoSqlStructuredTableRegistry registry =
-      dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableRegistry.class);
-    registry.initialize();
-    StoreDefinition.createAllTables(structuredTableAdmin, registry);
+    CConfiguration cConf = dsFrameworkUtil.getConfiguration();
+    cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
+
+    StructuredTableAdmin structuredTableAdmin = dsFrameworkUtil.getInjector().getInstance(StructuredTableAdmin.class);
+    transactionRunner = dsFrameworkUtil.getInjector().getInstance(TransactionRunner.class);
+    StoreDefinition.createAllTables(structuredTableAdmin);
   }
 }

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/registry/SqlUsageTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/registry/SqlUsageTableTest.java
@@ -16,14 +16,22 @@
 
 package io.cdap.cdap.data2.registry;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.sql.PostgresInstantiator;
-import io.cdap.cdap.spi.data.sql.PostgresSqlStructuredTableAdmin;
-import io.cdap.cdap.spi.data.sql.SqlStructuredTableRegistry;
-import io.cdap.cdap.spi.data.sql.SqlTransactionRunner;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -31,7 +39,6 @@ import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
-import javax.sql.DataSource;
 
 public class SqlUsageTableTest extends UsageTableTest {
   @ClassRule
@@ -41,13 +48,24 @@ public class SqlUsageTableTest extends UsageTableTest {
 
   @BeforeClass
   public static void beforeClass() throws IOException, TableAlreadyExistsException {
-    pg = PostgresInstantiator.createAndStart(TEMP_FOLDER.newFolder());
-    DataSource dataSource = pg.getPostgresDatabase();
-    StructuredTableRegistry registry = new SqlStructuredTableRegistry(dataSource);
-    registry.initialize();
-    StructuredTableAdmin structuredTableAdmin = new PostgresSqlStructuredTableAdmin(registry, dataSource);
-    transactionRunner = new SqlTransactionRunner(structuredTableAdmin, dataSource);
-    StoreDefinition.createAllTables(structuredTableAdmin, registry);
+    CConfiguration cConf = CConfiguration.create();
+    pg = PostgresInstantiator.createAndStart(cConf, TEMP_FOLDER.newFolder());
+
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new LocalLocationModule(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new StorageModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+        }
+      }
+    );
+
+    transactionRunner = injector.getInstance(TransactionRunner.class);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/common/CachedStructuredTableRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/common/CachedStructuredTableRegistryTest.java
@@ -17,8 +17,6 @@
 package io.cdap.cdap.spi.data.common;
 
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistryTest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,14 +35,12 @@ public abstract class CachedStructuredTableRegistryTest extends StructuredTableR
   public void testCachedRegistryRead() throws IOException, TableAlreadyExistsException {
     // Get cached registry
     StructuredTableRegistry cachedRegistry = getStructuredTableRegistry();
-    cachedRegistry.initialize();
     // Assert empty
     Assert.assertTrue(cachedRegistry.isEmpty());
     Assert.assertNull(cachedRegistry.getSpecification(TABLE1));
 
     // Get non-cached registry
     StructuredTableRegistry nonCachedRegistry = getNonCachedStructuredTableRegistry();
-    nonCachedRegistry.initialize();
     // Assert empty
     Assert.assertTrue(nonCachedRegistry.isEmpty());
     Assert.assertNull(nonCachedRegistry.getSpecification(TABLE1));
@@ -69,14 +65,12 @@ public abstract class CachedStructuredTableRegistryTest extends StructuredTableR
   public void testCachedRegistryWrite() throws IOException, TableAlreadyExistsException {
     // Get cached registry
     StructuredTableRegistry cachedRegistry = getStructuredTableRegistry();
-    cachedRegistry.initialize();
     // Assert empty
     Assert.assertTrue(cachedRegistry.isEmpty());
     Assert.assertNull(cachedRegistry.getSpecification(TABLE1));
 
     // Get non-cached registry
     StructuredTableRegistry nonCachedRegistry = getNonCachedStructuredTableRegistry();
-    nonCachedRegistry.initialize();
     // Assert empty
     Assert.assertTrue(nonCachedRegistry.isEmpty());
     Assert.assertNull(nonCachedRegistry.getSpecification(TABLE1));

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/common/SqlCachedStructuredTableRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/common/SqlCachedStructuredTableRegistryTest.java
@@ -19,12 +19,12 @@ package io.cdap.cdap.spi.data.common;
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
 import io.cdap.cdap.spi.data.sql.PostgresInstantiator;
 import io.cdap.cdap.spi.data.sql.SqlStructuredTableRegistry;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
-import org.junit.Assert;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.IOException;
 import javax.sql.DataSource;
 
 /**
@@ -34,17 +34,21 @@ public class SqlCachedStructuredTableRegistryTest extends CachedStructuredTableR
   @ClassRule
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
+  private static EmbeddedPostgres pg;
   private static StructuredTableRegistry registry;
   private static SqlStructuredTableRegistry sqlRegistry;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    EmbeddedPostgres pg = PostgresInstantiator.createAndStart(TEMP_FOLDER.newFolder());
+    pg = PostgresInstantiator.createAndStart(TEMP_FOLDER.newFolder());
     DataSource dataSource = pg.getPostgresDatabase();
-    // TODO: CDAP-14780 Use injector once JDBC driver is wired up in StorageModule
     sqlRegistry = new SqlStructuredTableRegistry(dataSource);
     registry = new CachedStructuredTableRegistry(sqlRegistry);
-    Assert.assertTrue(registry instanceof CachedStructuredTableRegistry);
+  }
+
+  @AfterClass
+  public static void finish() throws IOException {
+    pg.close();
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/common/StructuredTableRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/common/StructuredTableRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2021 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,9 +14,11 @@
  * the License.
  */
 
-package io.cdap.cdap.spi.data.table;
+package io.cdap.cdap.spi.data.common;
 
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 import io.cdap.cdap.spi.data.table.field.FieldType;
 import io.cdap.cdap.spi.data.table.field.Fields;
 import org.junit.After;
@@ -67,7 +69,6 @@ public abstract class StructuredTableRegistryTest {
   @Test
   public void testRegistry() throws Exception {
     StructuredTableRegistry registry = getStructuredTableRegistry();
-    registry.initialize();
 
     // Assert empty
     Assert.assertTrue(registry.isEmpty());

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableConcurrencyTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableConcurrencyTest.java
@@ -21,7 +21,6 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.StructuredTableConcurrencyTest;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -40,7 +39,7 @@ public class NoSqlStructuredTableConcurrencyTest extends StructuredTableConcurre
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
   private static TransactionManager txManager;
-  private static NoSqlStructuredTableAdmin noSqlTableAdmin;
+  private static StructuredTableAdmin noSqlTableAdmin;
   private static TransactionRunner transactionRunner;
 
   @Override
@@ -61,11 +60,8 @@ public class NoSqlStructuredTableConcurrencyTest extends StructuredTableConcurre
 
     CConfiguration cConf = dsFrameworkUtil.getConfiguration();
     cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
-    noSqlTableAdmin = dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableAdmin.class);
-    transactionRunner = dsFrameworkUtil.getInjector().getInstance(NoSqlTransactionRunner.class);
-    StructuredTableRegistry registry =
-      dsFrameworkUtil.getInjector().getInstance(StructuredTableRegistry.class);
-    registry.initialize();
+    noSqlTableAdmin = dsFrameworkUtil.getInjector().getInstance(StructuredTableAdmin.class);
+    transactionRunner = dsFrameworkUtil.getInjector().getInstance(TransactionRunner.class);
   }
 
   @AfterClass

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableRegistryTest.java
@@ -16,9 +16,13 @@
 
 package io.cdap.cdap.spi.data.nosql;
 
+import com.google.inject.Key;
+import com.google.inject.name.Names;
+import io.cdap.cdap.api.dataset.DatasetDefinition;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.data2.dataset2.DatasetFrameworkTestUtil;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistryTest;
+import io.cdap.cdap.spi.data.common.StructuredTableRegistry;
+import io.cdap.cdap.spi.data.common.StructuredTableRegistryTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.tephra.TransactionManager;
@@ -31,13 +35,14 @@ import org.junit.ClassRule;
  */
 public class NoSqlStructuredTableRegistryTest extends StructuredTableRegistryTest {
   @ClassRule
-  public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
+  public static final DatasetFrameworkTestUtil DS_FRAMEWORK_UTIL = new DatasetFrameworkTestUtil();
 
   private static TransactionManager txManager;
 
   @Override
   protected StructuredTableRegistry getStructuredTableRegistry() {
-    return dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableRegistry.class);
+    return new NoSqlStructuredTableRegistry(DS_FRAMEWORK_UTIL.getInjector().getInstance(
+      Key.get(DatasetDefinition.class, Names.named(Constants.Dataset.TABLE_TYPE_NO_TX))));
   }
 
   @BeforeClass

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
@@ -26,7 +26,6 @@ import io.cdap.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import io.cdap.cdap.data2.dataset2.lib.table.MDSKey;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.StructuredTableTest;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.table.StructuredTableSchema;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import org.apache.hadoop.conf.Configuration;
@@ -57,7 +56,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
   private static final StructuredTableSchema SCHEMA = new StructuredTableSchema(SIMPLE_SPEC);
 
   private static TransactionManager txManager;
-  private static NoSqlStructuredTableAdmin noSqlTableAdmin;
+  private static StructuredTableAdmin noSqlTableAdmin;
   private static TransactionRunner transactionRunner;
 
   @Override
@@ -78,11 +77,8 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
 
     CConfiguration cConf = dsFrameworkUtil.getConfiguration();
     cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
-    noSqlTableAdmin = dsFrameworkUtil.getInjector().getInstance(NoSqlStructuredTableAdmin.class);
-    transactionRunner = dsFrameworkUtil.getInjector().getInstance(NoSqlTransactionRunner.class);
-    StructuredTableRegistry registry =
-      dsFrameworkUtil.getInjector().getInstance(StructuredTableRegistry.class);
-    registry.initialize();
+    noSqlTableAdmin = dsFrameworkUtil.getInjector().getInstance(StructuredTableAdmin.class);
+    transactionRunner = dsFrameworkUtil.getInjector().getInstance(TransactionRunner.class);
   }
 
   @AfterClass

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableConcurrencyTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableConcurrencyTest.java
@@ -28,7 +28,6 @@ import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.data.runtime.StorageModule;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.StructuredTableConcurrencyTest;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -39,7 +38,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 
 /**
- * Tests concurrent operations on {@link PostgresSqlStructuredTable}.
+ * Tests concurrent operations on {@link PostgreSqlStructuredTable}.
  */
 public class SqlStructuredTableConcurrencyTest extends StructuredTableConcurrencyTest {
   @ClassRule
@@ -65,11 +64,10 @@ public class SqlStructuredTableConcurrencyTest extends StructuredTableConcurrenc
       }
     );
 
-    injector.getInstance(StructuredTableRegistry.class).initialize();
     tableAdmin = injector.getInstance(StructuredTableAdmin.class);
     transactionRunner = injector.getInstance(TransactionRunner.class);
 
-    Assert.assertEquals(PostgresSqlStructuredTableAdmin.class, tableAdmin.getClass());
+    Assert.assertEquals(PostgreSqlStructuredTableAdmin.class, tableAdmin.getClass());
     Assert.assertEquals(RetryingSqlTransactionRunner.class, transactionRunner.getClass());
   }
 

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableRegistryTest.java
@@ -17,12 +17,14 @@
 package io.cdap.cdap.spi.data.sql;
 
 import com.opentable.db.postgres.embedded.EmbeddedPostgres;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistryTest;
+import io.cdap.cdap.spi.data.common.StructuredTableRegistry;
+import io.cdap.cdap.spi.data.common.StructuredTableRegistryTest;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.IOException;
 import javax.sql.DataSource;
 
 /**
@@ -32,14 +34,21 @@ public class SqlStructuredTableRegistryTest extends StructuredTableRegistryTest 
   @ClassRule
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
+  private static EmbeddedPostgres pg;
   private static StructuredTableRegistry registry;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    EmbeddedPostgres pg = PostgresInstantiator.createAndStart(TEMP_FOLDER.newFolder());
+    pg = PostgresInstantiator.createAndStart(TEMP_FOLDER.newFolder());
     DataSource dataSource = pg.getPostgresDatabase();
     registry = new SqlStructuredTableRegistry(dataSource);
   }
+
+  @AfterClass
+  public static void finish() throws IOException {
+    pg.close();
+  }
+
   @Override
   protected StructuredTableRegistry getStructuredTableRegistry() {
     return registry;

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableTest.java
@@ -29,7 +29,6 @@ import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.data.runtime.StorageModule;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.StructuredTableTest;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -61,11 +60,10 @@ public class SqlStructuredTableTest extends StructuredTableTest {
       }
     );
 
-    injector.getInstance(StructuredTableRegistry.class).initialize();
     tableAdmin = injector.getInstance(StructuredTableAdmin.class);
     transactionRunner = injector.getInstance(TransactionRunner.class);
 
-    Assert.assertEquals(PostgresSqlStructuredTableAdmin.class, tableAdmin.getClass());
+    Assert.assertEquals(PostgreSqlStructuredTableAdmin.class, tableAdmin.getClass());
     Assert.assertEquals(RetryingSqlTransactionRunner.class, transactionRunner.getClass());
   }
 

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/jdbc/DataSourceProviderTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/jdbc/DataSourceProviderTest.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.common.test.AppJarHelper;
+import io.cdap.cdap.spi.data.sql.PostgreSqlStorageProvider;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -58,8 +59,8 @@ public class DataSourceProviderTest {
 
     SConfiguration sConf = SConfiguration.create();
 
-    DataSourceProvider instantiator = new DataSourceProvider(cConf, sConf, new NoOpMetricsCollectionService());
-    DataSource dataSource = instantiator.get();
+    DataSource dataSource = PostgreSqlStorageProvider.createDataSource(cConf, sConf,
+                                                                       new NoOpMetricsCollectionService());
     Assert.assertNotNull(dataSource);
     Enumeration<Driver> drivers = DriverManager.getDrivers();
     Driver loadedDriver = null;

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/store/DefaultOwnerStoreTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/store/DefaultOwnerStoreTest.java
@@ -38,14 +38,10 @@ import io.cdap.cdap.security.impersonation.OwnerStore;
 import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.nosql.NoSqlStructuredTableAdmin;
-import io.cdap.cdap.spi.data.nosql.NoSqlTransactionRunner;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.table.field.Range;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import org.apache.tephra.TransactionManager;
-import org.apache.tephra.TransactionSystemClient;
 import org.apache.tephra.runtime.TransactionInMemoryModule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -92,14 +88,9 @@ public class DefaultOwnerStoreTest extends OwnerStoreTest {
     );
 
     injector.getInstance(TransactionManager.class).startAndWait();
-    injector.getInstance(StructuredTableRegistry.class).initialize();
 
-    StructuredTableAdmin structuredTableAdmin = injector.getInstance(StructuredTableAdmin.class);
-    txRunner =
-      new NoSqlTransactionRunner(injector.getInstance(NoSqlStructuredTableAdmin.class),
-                                 injector.getInstance(TransactionSystemClient.class),
-                                 new NoOpMetricsCollectionService(), cConf);
-    StoreDefinition.OwnerStore.createTables(structuredTableAdmin, false);
+    txRunner = injector.getInstance(TransactionRunner.class);
+    StoreDefinition.OwnerStore.create(injector.getInstance(StructuredTableAdmin.class));
     ownerStore = new DefaultOwnerStore(txRunner);
   }
 

--- a/cdap-explore/src/test/java/io/cdap/cdap/explore/service/BaseHiveExploreServiceTest.java
+++ b/cdap-explore/src/test/java/io/cdap/cdap/explore/service/BaseHiveExploreServiceTest.java
@@ -70,8 +70,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionManager;
@@ -160,9 +158,8 @@ public class BaseHiveExploreServiceTest {
     transactionManager.startAndWait();
     transactionSystemClient = injector.getInstance(TransactionSystemClient.class);
 
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
+
     dsOpService = injector.getInstance(DatasetOpExecutorService.class);
     dsOpService.startAndWait();
 
@@ -181,14 +178,6 @@ public class BaseHiveExploreServiceTest {
 
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
     namespacePathLocator = injector.getInstance(NamespacePathLocator.class);
-
-    StructuredTableAdmin tableAdmin = injector.getInstance(StructuredTableAdmin.class);
-    StructuredTableRegistry registry = injector.getInstance(StructuredTableRegistry.class);
-    try {
-      StoreDefinition.createAllTables(tableAdmin, registry);
-    } catch (IOException | TableAlreadyExistsException e) {
-      throw new RuntimeException("Failed to create the system tables", e);
-    }
 
     // create namespaces
     // This happens when you create a namespace via REST APIs. However, since we do not start AppFabricServer in

--- a/cdap-explore/src/test/java/io/cdap/cdap/explore/service/ExploreDisabledTest.java
+++ b/cdap-explore/src/test/java/io/cdap/cdap/explore/service/ExploreDisabledTest.java
@@ -62,8 +62,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.Transaction;
@@ -74,7 +72,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -96,9 +93,8 @@ public class ExploreDisabledTest {
     transactionManager = injector.getInstance(TransactionManager.class);
     transactionManager.startAndWait();
 
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
+
     dsOpExecutor = injector.getInstance(DatasetOpExecutorService.class);
     dsOpExecutor.startAndWait();
 
@@ -114,14 +110,6 @@ public class ExploreDisabledTest {
     }
 
     datasetFramework = injector.getInstance(DatasetFramework.class);
-
-    StructuredTableAdmin tableAdmin = injector.getInstance(StructuredTableAdmin.class);
-    StructuredTableRegistry registry = injector.getInstance(StructuredTableRegistry.class);
-    try {
-      StoreDefinition.createAllTables(tableAdmin, registry);
-    } catch (IOException | TableAlreadyExistsException e) {
-      throw new RuntimeException("Failed to create the system tables", e);
-    }
 
     namespaceAdmin = injector.getInstance(NamespaceAdmin.class);
     NamespacePathLocator namespacePathLocator = injector.getInstance(NamespacePathLocator.class);

--- a/cdap-explore/src/test/java/io/cdap/cdap/explore/service/InMemoryExploreServiceTest.java
+++ b/cdap-explore/src/test/java/io/cdap/cdap/explore/service/InMemoryExploreServiceTest.java
@@ -53,7 +53,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import io.cdap.cdap.test.SlowTests;
 import org.apache.hadoop.conf.Configuration;
@@ -118,9 +117,7 @@ public class InMemoryExploreServiceTest {
     transactionManager = injector.getInstance(TransactionManager.class);
     transactionManager.startAndWait();
 
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
     dsOpService = injector.getInstance(DatasetOpExecutorService.class);
     dsOpService.startAndWait();
 

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayTestBase.java
@@ -56,7 +56,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.spi.authorization.NoOpAccessController;
 import io.cdap.cdap.security.spi.authorization.PermissionManager;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.http.Header;
@@ -184,8 +183,7 @@ public abstract class GatewayTestBase {
     txService = injector.getInstance(TransactionManager.class);
     txService.startAndWait();
     // Define all StructuredTable before starting any services that need StructuredTable
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class),
-                                    injector.getInstance(StructuredTableRegistry.class));
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
     metadataStorage = injector.getInstance(MetadataStorage.class);
     metadataStorage.createIndex();
     metadataService = injector.getInstance(MetadataService.class);

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/log/LogHttpHandlerTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/log/LogHttpHandlerTest.java
@@ -71,7 +71,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
@@ -152,9 +151,7 @@ public class LogHttpHandlerTest {
 
     transactionManager = injector.getInstance(TransactionManager.class);
     transactionManager.startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
     dsOpService = injector.getInstance(DatasetOpExecutorService.class);
     dsOpService.startAndWait();
 

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
@@ -54,7 +54,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import org.apache.http.Header;
@@ -173,9 +172,7 @@ public abstract class MetricsSuiteTestBase {
 
     transactionManager = injector.getInstance(TransactionManager.class);
     transactionManager.startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
 
     dsOpService = injector.getInstance(DatasetOpExecutorService.class);
     dsOpService.startAndWait();

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
@@ -97,7 +97,6 @@ import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.store.SecureStoreService;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.hbase.HBaseDDLExecutor;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.store.StoreDefinition;
@@ -644,9 +643,8 @@ public class MasterServiceMain extends DaemonMain {
 
       try {
         // Define all StructuredTable before starting any services that need StructuredTable
-        StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class),
-                                        injector.getInstance(StructuredTableRegistry.class));
-      } catch (IOException | TableAlreadyExistsException e) {
+        StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
+      } catch (IOException e) {
         throw new RuntimeException("Unable to create the system tables.", e);
       }
       metadataStorage = injector.getInstance(MetadataStorage.class);

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MessagingServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MessagingServiceMain.java
@@ -93,9 +93,4 @@ public class MessagingServiceMain extends AbstractServiceMain<EnvironmentOptions
                                      Constants.Logging.COMPONENT_NAME,
                                      Constants.Service.MESSAGING_SERVICE);
   }
-
-  @Override
-  protected void initializeDataSourceConnection(CConfiguration cConf) {
-    // no-op since we use leveldb in messaging service
-  }
 }

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMain.java
@@ -120,9 +120,4 @@ public class MetricsServiceMain extends AbstractServiceMain<EnvironmentOptions> 
                                      Constants.Logging.COMPONENT_NAME,
                                      Constants.Service.METRICS);
   }
-
-  @Override
-  protected void initializeDataSourceConnection(CConfiguration cConf) {
-    // no-op since we use leveldb for metrics
-  }
 }

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
@@ -93,9 +93,4 @@ public class RouterServiceMain extends AbstractServiceMain<EnvironmentOptions> {
         Constants.Logging.COMPONENT_NAME,
         Constants.Service.GATEWAY);
   }
-
-  @Override
-  protected void initializeDataSourceConnection(CConfiguration cConf) {
-    // no-op since we don't connect to dataset in router service
-  }
 }

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
@@ -39,8 +39,6 @@ import io.cdap.cdap.security.auth.TokenManager;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.twill.zookeeper.ZKClientService;
 
@@ -88,12 +86,7 @@ public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> 
     services.add(new AbstractIdleService() {
       @Override
       protected void startUp() throws Exception {
-        try {
-          StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class),
-                                          injector.getInstance(StructuredTableRegistry.class));
-        } catch (TableAlreadyExistsException e) {
-          // ignore
-        }
+        StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
       }
 
       @Override

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/StorageMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/StorageMain.java
@@ -41,8 +41,6 @@ import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import io.cdap.cdap.security.spi.authorization.NoOpAccessController;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.TableAlreadyExistsException;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.tephra.TransactionSystemClient;
@@ -101,16 +99,7 @@ public class StorageMain {
     Injector injector = Guice.createInjector(modules);
 
     // Create stores definitions
-    StructuredTableRegistry tableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    StructuredTableAdmin tableAdmin = injector.getInstance(StructuredTableAdmin.class);
-
-    try {
-      StoreDefinition.createAllTables(tableAdmin, tableRegistry);
-      LOG.info("Storage definitions creation completed");
-    } catch (TableAlreadyExistsException e) {
-      // Ignore the error
-      LOG.debug("Store table already exists", e);
-    }
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
 
     // Create metadata tables
     try (MetadataStorage metadataStorage = injector.getInstance(MetadataStorage.class)) {

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -101,7 +101,6 @@ import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.server.ExternalAuthenticationServer;
 import io.cdap.cdap.security.store.SecureStoreService;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.conf.Configuration;
@@ -253,8 +252,7 @@ public class StandaloneMain {
       txService.startAndWait();
     }
     // Define all StructuredTable before starting any services that need StructuredTable
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class),
-                                    injector.getInstance(StructuredTableRegistry.class));
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
     metadataStorage.createIndex();
 
     metricsCollectionService.startAndWait();

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StorageProvider.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StorageProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data;
+
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+
+/**
+ * Interface for storage provider to implement for exposing storage capability.
+ */
+public interface StorageProvider extends AutoCloseable {
+
+  /**
+   * Initialization of the storage provide. This method will be called after the constructor
+   * and before any method is being called.
+   *
+   * @param context a context object providing interaction with the CDAP platform.
+   * @throws Exception if the storage provider failed to initialize itself
+   */
+  default void initialize(StorageProviderContext context) throws Exception {
+    // no-op
+  }
+
+  /**
+   * Returns the name of this storage provider. The name needs to match with the configuration provided through
+   * {@code data.storage.implementation}.
+   */
+  String getName();
+
+  /**
+   * Returns the {@link StructuredTableAdmin} implementation for this storage.
+   */
+  StructuredTableAdmin getStructuredTableAdmin() throws Exception;
+
+  /**
+   * Returns the {@link TransactionRunner} implementation for performing transactional operations for this storage.
+   */
+  TransactionRunner getTransactionRunner() throws Exception;
+
+  /**
+   * Release any resources held by this storage provider.
+   */
+  @Override
+  default void close() throws Exception {
+    // no-op
+  }
+}

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StorageProviderContext.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StorageProviderContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data;
+
+import io.cdap.cdap.api.metrics.MetricsCollector;
+
+import java.util.Map;
+
+/**
+ * The context for {@link StorageProvider} to interact with the CDAP platform.
+ */
+public interface StorageProviderContext {
+
+  /**
+   * A {@link MetricsCollector} for the storage provider to emit metrics.
+   */
+  MetricsCollector getMetricsCollector();
+
+  /**
+   * Configurations for the storage provider. It contains all the CDAP configurations that are prefixed with
+   * {@code data.storage.properties.[storage_provider_name].} with the prefixed stripped.
+   */
+  Map<String, String> getConfiguration();
+
+  /**
+   * Configurations for the storage provider. It contains all the CDAP security configurations that are prefixed with
+   * {@code data.storage.properties.[storage_provider_name].} with the prefixed stripped.
+   */
+  Map<String, String> getSecurityConfiguration();
+}

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTableAdmin.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTableAdmin.java
@@ -18,10 +18,10 @@ package io.cdap.cdap.spi.data;
 
 import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.spi.data.table.StructuredTableId;
+import io.cdap.cdap.spi.data.table.StructuredTableSchema;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 
 import java.io.IOException;
-import javax.annotation.Nullable;
 
 /**
  * Defines admin operations on a {@link StructuredTable}.
@@ -38,13 +38,23 @@ public interface StructuredTableAdmin {
   void create(StructuredTableSpecification spec) throws IOException, TableAlreadyExistsException;
 
   /**
-   * Get the {@link StructuredTableSpecification} corresponding to the given table id.
+   * Checks if the given table exists.
    *
-   * @param tableId the table id
-   * @return the specification for the table
+   * @param tableId the name of the table
+   * @return {@code true} if the table exists, {@code false} otherwise.
+   * @throws IOException if there is an error check the table existence
    */
-  @Nullable
-  StructuredTableSpecification getSpecification(StructuredTableId tableId);
+  boolean exists(StructuredTableId tableId) throws IOException;
+
+  /**
+   * Gets the {@link StructuredTableSchema} of the given table.
+   *
+   * @param tableId the name of the table
+   * @return the {@link StructuredTableSchema} of the table
+   * @throws IOException if there is an error for getting the table schema
+   * @throws TableNotFoundException if the table doesn't exist
+   */
+  StructuredTableSchema getSchema(StructuredTableId tableId) throws IOException, TableNotFoundException;
 
   /**
    * Drop the StructuredTable synchronously. After this method is called, the existing table will get deleted. If the

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/field/FieldType.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/field/FieldType.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.annotation.Beta;
 
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -32,12 +33,22 @@ public final class FieldType {
    * Supported data types.
    */
   public enum Type {
-    INTEGER,
-    LONG,
-    FLOAT,
-    DOUBLE,
-    STRING,
-    BYTES
+    INTEGER(Collections.emptySet()),
+    LONG(Collections.singleton(INTEGER)),
+    FLOAT(Collections.emptySet()),
+    DOUBLE(Collections.singleton(FLOAT)),
+    STRING(Collections.emptySet()),
+    BYTES(Collections.emptySet());
+
+    private final Set<Type> compatibleTypes;
+
+    Type(Set<Type> compatibleTypes) {
+      this.compatibleTypes = Collections.unmodifiableSet(new HashSet<>(compatibleTypes));
+    }
+
+    public boolean isCompatible(Type type) {
+      return this == type || compatibleTypes.contains(type);
+    }
   }
 
   /**

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/field/FieldValidator.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/field/FieldValidator.java
@@ -48,7 +48,7 @@ public final class FieldValidator {
     if (expected == null) {
       throw new InvalidFieldException(tableSchema.getTableId(), fieldName);
     }
-    if (!expected.equals(actual)) {
+    if (!expected.isCompatible(actual)) {
       throw new InvalidFieldException(tableSchema.getTableId(), fieldName, expected, actual);
     }
 

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/FieldTypeTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/FieldTypeTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data;
+
+import io.cdap.cdap.spi.data.table.field.FieldType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+
+/**
+ * Unit tests for {@link FieldType}.
+ */
+public class FieldTypeTest {
+
+  @Test
+  public void testSelfCompatible() {
+    for (FieldType.Type type : FieldType.Type.values()) {
+      Assert.assertTrue(type.isCompatible(type));
+    }
+  }
+
+  @Test
+  public void testCompatible() {
+    Assert.assertTrue(FieldType.Type.LONG.isCompatible(FieldType.Type.INTEGER));
+    Assert.assertTrue(FieldType.Type.DOUBLE.isCompatible(FieldType.Type.FLOAT));
+  }
+
+  @Test
+  public void testIncompatible() {
+    // These four types shouldn't be compatible with others except itself
+    for (FieldType.Type type : EnumSet.of(FieldType.Type.INTEGER, FieldType.Type.FLOAT,
+                                          FieldType.Type.STRING, FieldType.Type.BYTES)) {
+      for (FieldType.Type otherType : FieldType.Type.values()) {
+        if (type != otherType) {
+          Assert.assertFalse(type.isCompatible(otherType));
+        }
+      }
+    }
+
+    // Long and Double only compatible with Integer and Float respectively (and itself)
+    Assert.assertTrue(
+      Arrays.stream(FieldType.Type.values())
+        .filter(f -> EnumSet.complementOf(EnumSet.of(FieldType.Type.LONG, FieldType.Type.INTEGER)).contains(f))
+        .noneMatch(FieldType.Type.LONG::isCompatible));
+
+    Assert.assertTrue(
+      Arrays.stream(FieldType.Type.values())
+        .filter(f -> EnumSet.complementOf(EnumSet.of(FieldType.Type.DOUBLE, FieldType.Type.FLOAT)).contains(f))
+        .noneMatch(FieldType.Type.DOUBLE::isCompatible));
+  }
+}

--- a/cdap-system-app-unit-test/src/test/java/io/cdap/cdap/test/SystemAppTestBaseTest.java
+++ b/cdap-system-app-unit-test/src/test/java/io/cdap/cdap/test/SystemAppTestBaseTest.java
@@ -52,7 +52,7 @@ public class SystemAppTestBaseTest extends SystemAppTestBase {
   public void testTableOperations() throws Exception {
     StructuredTableAdmin tableAdmin = getStructuredTableAdmin();
     StructuredTableId id = new StructuredTableId("t0");
-    Assert.assertNull(tableAdmin.getSpecification(id));
+    Assert.assertFalse(tableAdmin.exists(id));
 
     String keyCol = "key";
     String valCol = "val";

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -133,7 +133,6 @@ import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
 import io.cdap.cdap.security.spi.authorization.AccessController;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.store.StoreDefinition;
 import io.cdap.cdap.test.internal.ApplicationManagerFactory;
@@ -335,8 +334,7 @@ public class TestBase {
     metadataService.startAndWait();
 
     // Define all StructuredTable before starting any services that need StructuredTable
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class),
-                                    injector.getInstance(StructuredTableRegistry.class));
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
 
     dsOpService = injector.getInstance(DatasetOpExecutorService.class);
     dsOpService.startAndWait();

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/loader/MetricsWriterExtensionLoader.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/loader/MetricsWriterExtensionLoader.java
@@ -48,16 +48,6 @@ public class MetricsWriterExtensionLoader extends AbstractExtensionLoader<String
     }
   }
 
-  private static Set<String> createPackageSets(Set<String> resources) {
-    return resources.stream()
-      .map(resource -> {
-        int idx = resource.lastIndexOf("/");
-        return idx < 0 ? "" : resource.substring(0, idx).replace('/', '.');
-      })
-      .filter(s -> !s.isEmpty())
-      .collect(Collectors.toSet());
-  }
-
   @Inject
   public MetricsWriterExtensionLoader(CConfiguration cConf) {
     super(cConf.get(Constants.Metrics.METRICS_WRITER_EXTENSIONS_DIR));

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/LocalLogAppenderResilientTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/LocalLogAppenderResilientTest.java
@@ -62,7 +62,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionManager;
@@ -136,9 +135,7 @@ public class LocalLogAppenderResilientTest {
 
     TransactionManager txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
 
     DatasetOpExecutorService opExecutorService = injector.getInstance(DatasetOpExecutorService.class);
     opExecutorService.startAndWait();

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/TestDistributedLogReader.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/TestDistributedLogReader.java
@@ -41,7 +41,6 @@ import io.cdap.cdap.logging.read.LogEvent;
 import io.cdap.cdap.logging.read.LogOffset;
 import io.cdap.cdap.logging.read.ReadRange;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import io.cdap.cdap.test.SlowTests;
@@ -100,9 +99,7 @@ public class TestDistributedLogReader extends KafkaTestBase {
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
 
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
 
     // Generate logs for LOGGING_CONTEXT_BOTH, that contains logs in file, both file and kafka, and only in kafka
     LoggingContextAccessor.setLoggingContext(LOGGING_CONTEXT_BOTH);

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/file/TestFileLogging.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/file/TestFileLogging.java
@@ -51,7 +51,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -113,9 +112,7 @@ public class TestFileLogging {
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
 
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.LogFileMetaStore.createTables(injector.getInstance(StructuredTableAdmin.class), false);
+    StoreDefinition.LogFileMetaStore.create(injector.getInstance(StructuredTableAdmin.class));
 
     LogAppender appender = injector.getInstance(LocalLogAppender.class);
     new LogAppenderInitializer(appender).initialize("TestFileLogging");

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/system/CDAPLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/system/CDAPLogAppenderTest.java
@@ -53,7 +53,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.conf.Configuration;
@@ -115,9 +114,7 @@ public class CDAPLogAppenderTest {
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
 
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.LogFileMetaStore.createTables(injector.getInstance(StructuredTableAdmin.class), false);
+    StoreDefinition.LogFileMetaStore.create(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/system/LogFileManagerTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/system/LogFileManagerTest.java
@@ -44,7 +44,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.conf.Configuration;
@@ -101,9 +100,7 @@ public class LogFileManagerTest {
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
 
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.LogFileMetaStore.createTables(injector.getInstance(StructuredTableAdmin.class), false);
+    StoreDefinition.LogFileMetaStore.create(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/clean/FileMetadataCleanerTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/clean/FileMetadataCleanerTest.java
@@ -49,7 +49,6 @@ import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredRow;
 import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.table.field.Fields;
 import io.cdap.cdap.spi.data.table.field.Range;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
@@ -112,9 +111,7 @@ public class FileMetadataCleanerTest {
 
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.LogFileMetaStore.createTables(injector.getInstance(StructuredTableAdmin.class), false);
+    StoreDefinition.LogFileMetaStore.create(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/clean/LogCleanerTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/clean/LogCleanerTest.java
@@ -44,7 +44,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.conf.Configuration;
@@ -99,9 +98,7 @@ public class LogCleanerTest {
 
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.LogFileMetaStore.createTables(injector.getInstance(StructuredTableAdmin.class), false);
+    StoreDefinition.LogFileMetaStore.create(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/framework/distributed/DistributedLogFrameworkTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/framework/distributed/DistributedLogFrameworkTest.java
@@ -64,7 +64,6 @@ import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.tephra.TransactionManager;
@@ -118,9 +117,7 @@ public class DistributedLogFrameworkTest {
     injector.getInstance(KafkaClientService.class).startAndWait();
     injector.getInstance(BrokerService.class).startAndWait();
     injector.getInstance(TransactionManager.class).startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @After

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/read/FileMetadataTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/read/FileMetadataTest.java
@@ -46,7 +46,6 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.hadoop.conf.Configuration;
@@ -103,9 +102,7 @@ public class FileMetadataTest {
 
     txManager = injector.getInstance(TransactionManager.class);
     txManager.startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.LogFileMetaStore.createTables(injector.getInstance(StructuredTableAdmin.class), false);
+    StoreDefinition.LogFileMetaStore.create(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorManagerServiceTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorManagerServiceTest.java
@@ -37,7 +37,6 @@ import io.cdap.cdap.internal.io.SchemaGenerator;
 import io.cdap.cdap.metrics.process.loader.MetricsWriterProvider;
 import io.cdap.cdap.metrics.store.MetricDatasetFactory;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.tephra.TransactionManager;
 import org.junit.Assert;
@@ -61,9 +60,7 @@ public class MessagingMetricsProcessorManagerServiceTest extends MetricsProcesso
   public void persistMetricsTests() throws Exception {
 
     injector.getInstance(TransactionManager.class).startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
     injector.getInstance(DatasetOpExecutorService.class).startAndWait();
     injector.getInstance(DatasetService.class).startAndWait();
 

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MetricsProcessorServiceTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MetricsProcessorServiceTest.java
@@ -36,7 +36,6 @@ import io.cdap.cdap.internal.io.SchemaGenerator;
 import io.cdap.cdap.metrics.process.loader.MetricsWriterProvider;
 import io.cdap.cdap.metrics.store.MetricDatasetFactory;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.table.StructuredTableRegistry;
 import io.cdap.cdap.store.StoreDefinition;
 import org.apache.tephra.TransactionManager;
 import org.junit.Assert;
@@ -62,9 +61,7 @@ public class MetricsProcessorServiceTest extends MetricsProcessorServiceTestBase
   @Test
   public void testMetricsProcessor() throws Exception {
     injector.getInstance(TransactionManager.class).startAndWait();
-    StructuredTableRegistry structuredTableRegistry = injector.getInstance(StructuredTableRegistry.class);
-    structuredTableRegistry.initialize();
-    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class), structuredTableRegistry);
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
     injector.getInstance(DatasetOpExecutorService.class).startAndWait();
     injector.getInstance(DatasetService.class).startAndWait();
 


### PR DESCRIPTION
- Added StorageProvider to storage SPI and implementations to support extension based storage engine.
- Removed StructuredTableRegistry from SPI as it is the implementation details of the current Table and PostgreSQL implementations.
- Changed the StructureTableAdmin API to replace the getSpecification method with exists and getSchema methods.
- Added method to check for compatibility between StructuredTableSchema and StructuredTableSpecification.
  - The schema of the actual table might be different than the specification in terms of data type. However, as long as the
    table can store data correctly without losing precision, it is considered as compatible.
- Refactored and code cleanup around StoreDefinition class and its usages.
- Unify StructuredTable related unit tests to use always Guice injector for creating StructuredTableAdmin and TransactionRunner.