### PR TITLE
[CDAP-18613] Tethering control plane operations

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -112,6 +112,9 @@ import io.cdap.cdap.internal.pipeline.SynchronousPipelineFactory;
 import io.cdap.cdap.internal.profile.ProfileService;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
 import io.cdap.cdap.internal.sysapp.SystemAppManagementService;
+import io.cdap.cdap.internal.tethering.TetheringClientHandler;
+import io.cdap.cdap.internal.tethering.TetheringHandler;
+import io.cdap.cdap.internal.tethering.TetheringServerHandler;
 import io.cdap.cdap.metadata.LocalPreferencesFetcherInternal;
 import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.pipeline.PipelineFactory;
@@ -389,6 +392,9 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(ProvisionerHttpHandler.class);
       handlerBinder.addBinding().to(BootstrapHttpHandler.class);
       handlerBinder.addBinding().to(FileFetcherHttpHandlerInternal.class);
+      handlerBinder.addBinding().to(TetheringHandler.class);
+      handlerBinder.addBinding().to(TetheringServerHandler.class);
+      handlerBinder.addBinding().to(TetheringClientHandler.class);
 
       for (Class<? extends HttpHandler> handlerClass : handlerClasses) {
         handlerBinder.addBinding().to(handlerClass);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/NamespaceAllocation.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/NamespaceAllocation.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Namespace and resource quota associated with a tether.
+ */
+public class NamespaceAllocation {
+  private final String namespace;
+  private final String cpuLimit;
+  private final String memoryLimit;
+
+  public NamespaceAllocation(String namespace, @Nullable String cpuLimit, @Nullable String memoryLimit) {
+    this.namespace = namespace;
+    this.cpuLimit = cpuLimit;
+    this.memoryLimit = memoryLimit;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  @Nullable
+  public String getCpuLimit() {
+    return cpuLimit;
+  }
+
+  @Nullable
+  public String getMemoryLimit() {
+    return memoryLimit;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    NamespaceAllocation that = (NamespaceAllocation) other;
+    return Objects.equals(this.namespace, that.namespace) &&
+      Objects.equals(this.cpuLimit, that.cpuLimit) &&
+      Objects.equals(this.memoryLimit, that.memoryLimit);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, cpuLimit, memoryLimit);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/PeerAlreadyExistsException.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/PeerAlreadyExistsException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.cdap.internal.tethering;
+
+import io.cdap.cdap.common.BadRequestException;
+
+/**
+ * Thrown when a tethered peer already exists.
+ */
+public class PeerAlreadyExistsException extends BadRequestException {
+  public PeerAlreadyExistsException(String peerName, TetheringStatus tetheringStatus) {
+    super(String.format("Peer %s already exists in state %s", peerName, tetheringStatus));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/PeerBase.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/PeerBase.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.cdap.internal.tethering;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Information about a tethered peer.
+ */
+public class PeerBase {
+  private final String name;
+  private final String endpoint;
+  private final TetheringStatus tetheringStatus;
+  private final PeerMetadata metadata;
+
+  public PeerBase(String name, @Nullable String endpoint, TetheringStatus tetheringStatus, PeerMetadata metadata) {
+    this.name = name;
+    this.endpoint = endpoint;
+    this.tetheringStatus = tetheringStatus;
+    this.metadata = metadata;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Nullable
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public TetheringStatus getTetheringStatus() {
+    return tetheringStatus;
+  }
+
+  public PeerMetadata getMetadata() {
+    return metadata;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    PeerBase that = (PeerBase) other;
+    return Objects.equals(this.name, that.name) &&
+      Objects.equals(this.endpoint, that.endpoint) &&
+      Objects.equals(this.tetheringStatus, that.tetheringStatus) &&
+      Objects.equals(this.metadata, that.metadata);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, endpoint, tetheringStatus, metadata);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/PeerInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/PeerInfo.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Peer information that's persisted in the tethering store.
+ */
+public class PeerInfo extends PeerBase {
+  private final long lastConnectionTime;
+
+  public PeerInfo(String name, @Nullable String endpoint, TetheringStatus tetheringStatus, PeerMetadata metadata) {
+    this(name, endpoint, tetheringStatus, metadata, 0);
+  }
+
+  public PeerInfo(String name, @Nullable String endpoint, TetheringStatus tetheringStatus,
+                  PeerMetadata metadata, long lastConnectionTime) {
+    super(name, endpoint, tetheringStatus, metadata);
+    this.lastConnectionTime = lastConnectionTime;
+  }
+
+  public long getLastConnectionTime() {
+    return lastConnectionTime;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!super.equals(other)) {
+      return false;
+    }
+    PeerInfo that = (PeerInfo) other;
+    return Objects.equals(this.lastConnectionTime, that.lastConnectionTime);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), lastConnectionTime);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/PeerMetadata.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/PeerMetadata.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Metadata about a tethered peer.
+ */
+public class PeerMetadata {
+  private final List<NamespaceAllocation> namespaceAllocations;
+  // metadata associated with the peer. ex: project, region when peer is located
+  private final Map<String, String> metadata;
+
+  public PeerMetadata(List<NamespaceAllocation> namespaceAllocations, Map<String, String> metadata) {
+    this.namespaceAllocations = namespaceAllocations;
+    this.metadata = metadata;
+  }
+
+  public List<NamespaceAllocation> getNamespaceAllocations() {
+    return namespaceAllocations;
+  }
+
+  public Map<String, String> getMetadata() {
+    return metadata;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    PeerMetadata that = (PeerMetadata) other;
+    return Objects.equals(this.namespaceAllocations, that.namespaceAllocations) &&
+      Objects.equals(this.metadata, that.metadata);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespaceAllocations, metadata);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/PeerNotFoundException.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/PeerNotFoundException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.cdap.internal.tethering;
+
+import io.cdap.cdap.common.NotFoundException;
+
+/**
+ * Thrown when a tethered peer is not found.
+ */
+public class PeerNotFoundException extends NotFoundException {
+  public PeerNotFoundException(String peerName) {
+    super(String.format("Peer %s not found", peerName));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/PeerState.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/PeerState.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import java.util.Objects;
+
+/**
+ * Information about tethered peers that's returned by REST APIs.
+ */
+public class PeerState extends PeerBase {
+  private final TetheringConnectionStatus connectionStatus;
+
+  public PeerState(String name, String endpoint, TetheringStatus tetheringStatus, PeerMetadata metadata,
+                   TetheringConnectionStatus connectionStatus) {
+    super(name, endpoint, tetheringStatus, metadata);
+    this.connectionStatus = connectionStatus;
+  }
+
+  public boolean isActive() {
+    return connectionStatus == TetheringConnectionStatus.ACTIVE;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!super.equals(other)) {
+      return false;
+    }
+    PeerState that = (PeerState) other;
+    return Objects.equals(this.connectionStatus, that.connectionStatus);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), connectionStatus);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringActionRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringActionRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+/**
+ * Request to perform tethering action on the server. Action can be "accept" or "reject".
+ */
+public class TetheringActionRequest {
+  private final String action;
+
+  public TetheringActionRequest(String action) {
+    this.action = action;
+  }
+
+  public String getAction() {
+    return action;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteAuthenticator;
+import io.cdap.cdap.common.service.AbstractRetryableScheduledService;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.internal.app.store.AppMetadataStore;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+
+/**
+ * The main class to run the remote agent service.
+ */
+public class TetheringAgentService extends AbstractRetryableScheduledService {
+  private static final Logger LOG = LoggerFactory.getLogger(TetheringAgentService.class);
+  private static final Gson GSON = new Gson();
+  private static final String CONNECT_CONTROL_CHANNEL = "/v3/tethering/controlchannels/";
+  private static final String SUBSCRIBER = "tether.agent";
+
+  private final CConfiguration cConf;
+  private final long connectionInterval;
+  private final TetheringStore store;
+  private final String instanceName;
+  private final TransactionRunner transactionRunner;
+  private final Map<String, String> lastMessageIds;
+
+  @Inject
+  TetheringAgentService(CConfiguration cConf, TransactionRunner transactionRunner, TetheringStore store) {
+    super(RetryStrategies.fromConfiguration(cConf, "tethering.agent."));
+    this.connectionInterval = TimeUnit.SECONDS.toMillis(cConf.getLong(Constants.Tethering.CONNECTION_INTERVAL));
+    this.cConf = cConf;
+    this.transactionRunner = transactionRunner;
+    this.store = store;
+    this.instanceName = cConf.get(Constants.INSTANCE_NAME);
+    this.lastMessageIds = new HashMap<>();
+  }
+
+  @Override
+  protected void doStartUp() throws InstantiationException, IllegalAccessException {
+    Class<? extends RemoteAuthenticator> authClass = cConf.getClass(Constants.Tethering.CLIENT_AUTHENTICATOR_CLASS,
+                                                                    null,
+                                                                    RemoteAuthenticator.class);
+    if (authClass != null) {
+      RemoteAuthenticator.setDefaultAuthenticator(authClass.newInstance());
+    }
+    initializeMessageIds();
+  }
+
+  @Override
+  protected long runTask() {
+    List<PeerInfo> peers;
+    try {
+      peers = store.getPeers().stream()
+        // Ignore peers in REJECTED state.
+        .filter(p -> p.getTetheringStatus() != TetheringStatus.REJECTED)
+        .collect(Collectors.toList());
+    } catch (IOException e) {
+      LOG.warn("Failed to get peer information", e);
+      return connectionInterval;
+    }
+    for (PeerInfo peer : peers) {
+      try {
+        Preconditions.checkArgument(peer.getEndpoint() != null,
+                                    "Peer %s doesn't have an endpoint", peer.getName());
+        String uri = CONNECT_CONTROL_CHANNEL + instanceName;
+        String lastMessageId = lastMessageIds.get(peer);
+        if (lastMessageId != null) {
+          uri = uri + "?messageId=" + URLEncoder.encode(lastMessageId, "UTF-8");
+        }
+        HttpResponse resp = TetheringUtils.sendHttpRequest(HttpMethod.GET, new URI(peer.getEndpoint())
+          .resolve(uri));
+        switch (resp.getResponseCode()) {
+          case HttpURLConnection.HTTP_OK:
+            handleResponse(resp, peer);
+            break;
+          case HttpURLConnection.HTTP_NOT_FOUND:
+            handleNotFound(peer);
+            break;
+          case HttpURLConnection.HTTP_FORBIDDEN:
+            handleForbidden(peer);
+            break;
+          default:
+            LOG.error("Peer {} returned unexpected error code {} body {}",
+                      peer.getName(), resp.getResponseCode(),
+                      resp.getResponseBodyAsString(StandardCharsets.UTF_8));
+        }
+      } catch (Exception e) {
+        LOG.debug("Failed to create control channel to {}", peer, e);
+      }
+    }
+
+    // Update last message ids in the store for all peers
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
+      for (Map.Entry<String, String> entry : lastMessageIds.entrySet()) {
+        appMetadataStore.persistSubscriberState(entry.getKey(), SUBSCRIBER, entry.getValue());
+      }
+    });
+
+    return connectionInterval;
+  }
+
+  private void handleNotFound(PeerInfo peerInfo) throws IOException {
+    // Update last connection timestamp.
+    store.updatePeerTimestamp(peerInfo.getName());
+
+    TetheringConnectionRequest tetherRequest = new TetheringConnectionRequest(
+      peerInfo.getMetadata().getNamespaceAllocations());
+    try {
+      URI endpoint = new URI(peerInfo.getEndpoint()).resolve(TetheringClientHandler.CREATE_TETHER + instanceName);
+      HttpResponse response = TetheringUtils.sendHttpRequest(HttpMethod.PUT,
+                                                             endpoint,
+                                                             GSON.toJson(tetherRequest));
+      if (response.getResponseCode() != 200) {
+        LOG.error("Failed to initiate tether with peer {}, response body: {}, code: {}",
+                  peerInfo.getName(), response.getResponseBody(), response.getResponseCode());
+      }
+    } catch (URISyntaxException | IOException e) {
+      LOG.error("Failed to send tether request to peer {}, endpoint {}",
+                peerInfo.getName(), peerInfo.getEndpoint());
+    }
+  }
+
+  private void initializeMessageIds() {
+    List<String> peers;
+    try {
+      peers = store.getPeers().stream()
+        .map(PeerInfo::getName)
+        .collect(Collectors.toList());
+    } catch (IOException e) {
+      LOG.warn("Failed to get peer information", e);
+      return;
+    }
+
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
+      for (String peer : peers) {
+        String messageId = appMetadataStore.retrieveSubscriberState(peer, SUBSCRIBER);
+        lastMessageIds.put(peer, messageId);
+      }
+    });
+  }
+
+
+  private void handleForbidden(PeerInfo peerInfo) throws IOException {
+    // Set tethering status to rejected.
+    store.updatePeerStatusAndTimestamp(peerInfo.getName(), TetheringStatus.REJECTED);
+  }
+
+  private void handleResponse(HttpResponse resp, PeerInfo peerInfo) throws IOException {
+    if (peerInfo.getTetheringStatus() == TetheringStatus.PENDING) {
+      LOG.debug("Peer {} transitioned to ACCEPTED state", peerInfo.getName());
+      store.updatePeerStatusAndTimestamp(peerInfo.getName(), TetheringStatus.ACCEPTED);
+    } else {
+      // Update last connection timestamp.
+      store.updatePeerTimestamp(peerInfo.getName());
+    }
+    processTetherControlResponse(resp.getResponseBodyAsString(StandardCharsets.UTF_8), peerInfo);
+  }
+
+  private void processTetherControlResponse(String message, PeerInfo peerInfo) {
+    TetheringControlResponse[] responses = GSON.fromJson(message, TetheringControlResponse[].class);
+    for (TetheringControlResponse response : responses) {
+      TetheringControlMessage controlMessage = response.getControlMessage();
+      switch (controlMessage.getType()) {
+        case KEEPALIVE:
+          LOG.trace("Got keepalive from {}", peerInfo.getName());
+          break;
+        case RUN_PIPELINE:
+          // TODO: add processing logic
+          break;
+      }
+    }
+
+    if (responses.length > 0) {
+      String lastMessageId = responses[responses.length - 1].getLastMessageId();
+      lastMessageIds.put(peerInfo.getName(), lastMessageId);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringClientHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringClientHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import javax.inject.Inject;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+
+/**
+ * {@link io.cdap.http.HttpHandler} to manage tethering client v3 REST APIs
+ */
+@Path(Constants.Gateway.API_VERSION_3)
+public class TetheringClientHandler extends AbstractHttpHandler {
+  private static final Gson GSON = new Gson();
+  static final String CREATE_TETHER = "/v3/tethering/connections/";
+
+  private final TetheringStore store;
+
+  @Inject
+  TetheringClientHandler(TetheringStore store) {
+    this.store = store;
+  }
+
+  /**
+   * Initiates tethering with the server.
+   */
+  @PUT
+  @Path("/tethering/create")
+  public void createTethering(FullHttpRequest request, HttpResponder responder) throws Exception {
+    String content = request.content().toString(StandardCharsets.UTF_8);
+    TetheringCreationRequest tetheringCreationRequest = GSON.fromJson(content, TetheringCreationRequest.class);
+    List<NamespaceAllocation> namespaces = tetheringCreationRequest.getNamespaceAllocations();
+    PeerMetadata peerMetadata = new PeerMetadata(namespaces, tetheringCreationRequest.getMetadata());
+    PeerInfo peerInfo = new PeerInfo(tetheringCreationRequest.getPeer(), tetheringCreationRequest.getEndpoint(),
+                                     TetheringStatus.PENDING, peerMetadata);
+    store.addPeer(peerInfo);
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringConnectionRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringConnectionRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import java.util.List;
+
+/**
+ * Tethering request sent from the {@link TetheringAgentService} to
+ * the tethering server.
+ */
+public class TetheringConnectionRequest {
+  private final List<NamespaceAllocation> namespaceAllocations;
+
+  public TetheringConnectionRequest(List<NamespaceAllocation> namespaceAllocations) {
+    this.namespaceAllocations = namespaceAllocations;
+  }
+
+  public List<NamespaceAllocation> getNamespaceAllocations() {
+    return namespaceAllocations;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringConnectionStatus.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringConnectionStatus.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+/**
+ * Connectivity status of a tethering.
+ */
+public enum TetheringConnectionStatus {
+  INACTIVE,
+  ACTIVE
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringControlMessage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringControlMessage.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import java.util.Objects;
+
+/**
+ * Control messages sent from tether server to the client.
+ */
+public class TetheringControlMessage {
+  /**
+   * Control messages type.
+   */
+  public enum Type {
+    KEEPALIVE,
+    RUN_PIPELINE
+  }
+
+  private final Type type;
+  private final byte[] payload;
+
+  public TetheringControlMessage(Type type) {
+    this(type, new byte[0]);
+  }
+
+  public TetheringControlMessage(Type type, byte[] payload) {
+    this.type = type;
+    this.payload = payload;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public byte[] getPayload() {
+    return payload;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    TetheringControlMessage that = (TetheringControlMessage) o;
+    return Objects.equals(type, that.type) &&
+      Objects.equals(payload, that.payload);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, payload);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringControlResponse.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringControlResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import javax.annotation.Nullable;
+
+/**
+ * Heartbeat response sent to tether agent.
+ */
+public class TetheringControlResponse {
+  // id of the last control message sent by the server.
+  @Nullable
+  private final String lastMessageId;
+  // control message sent by server.
+  private final TetheringControlMessage controlMessage;
+
+  public TetheringControlResponse(@Nullable String lastMessageId, TetheringControlMessage controlMessage) {
+    this.lastMessageId = lastMessageId;
+    this.controlMessage = controlMessage;
+  }
+
+  public String getLastMessageId() {
+    return lastMessageId;
+  }
+
+  public TetheringControlMessage getControlMessage() {
+    return controlMessage;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringCreationRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringCreationRequest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tethering request that's sent to the client.
+ */
+public class TetheringCreationRequest {
+  // Name of the peer
+  private final String peer;
+  // Server endpoint
+  private final String endpoint;
+  // CDAP namespaces
+  private final List<NamespaceAllocation> namespaceAllocations;
+  // Metadata associated with this tethering
+  private final Map<String, String> metadata;
+
+  public TetheringCreationRequest(String peer, String endpoint,
+                                  List<NamespaceAllocation> namespaceAllocations, Map<String, String> metadata) {
+    this.peer = peer;
+    this.endpoint = endpoint;
+    this.namespaceAllocations = namespaceAllocations;
+    this.metadata = metadata;
+  }
+
+  public String getPeer() {
+    return peer;
+  }
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public List<NamespaceAllocation> getNamespaceAllocations() {
+    return namespaceAllocations;
+  }
+
+  public Map<String, String> getMetadata() {
+    return metadata;
+  }
+
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringHandler.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.messaging.TopicNotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.TopicId;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HandlerContext;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.inject.Inject;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * {@link io.cdap.http.HttpHandler} to manage tethering v3 REST APIs that are common to client and server.
+ */
+@Path(Constants.Gateway.API_VERSION_3)
+public class TetheringHandler extends AbstractHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(TetheringHandler.class);
+  private static final Gson GSON = new GsonBuilder().create();
+
+  private final CConfiguration cConf;
+  private final TetheringStore store;
+  private final MessagingService messagingService;
+  private final String topicPrefix;
+
+  // Connection timeout in seconds.
+  private int connectionTimeout;
+
+  @Inject
+  TetheringHandler(CConfiguration cConf, TetheringStore store, MessagingService messagingService) {
+    this.cConf = cConf;
+    this.store = store;
+    this.messagingService = messagingService;
+    this.topicPrefix = cConf.get(Constants.Tethering.TOPIC_PREFIX);
+  }
+
+  @Override
+  public void init(HandlerContext context) {
+    super.init(context);
+    connectionTimeout = cConf.getInt(Constants.Tethering.CONNECTION_TIMEOUT_SECONDS,
+                                     Constants.Tethering.DEFAULT_CONNECTION_TIMEOUT_SECONDS);
+  }
+
+  /**
+   * Returns status of tethered peers.
+   */
+  @GET
+  @Path("/tethering/connections")
+  public void getTethers(HttpRequest request, HttpResponder responder) throws IOException {
+    List<PeerState> peerStateList = new ArrayList<>();
+    for (PeerInfo peer : store.getPeers()) {
+      peerStateList.add(createPeerState(peer));
+    }
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(peerStateList));
+  }
+
+  /**
+   * Returns tether status of a peer.
+   */
+  @GET
+  @Path("/tethering/connections/{peer}")
+  public void getTether(HttpRequest request, HttpResponder responder, @PathParam("peer") String peer)
+    throws PeerNotFoundException, IOException {
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(createPeerState(store.getPeer(peer))));
+  }
+
+  /**
+   * Deletes a tether.
+   */
+  @DELETE
+  @Path("/tethering/connections/{peer}")
+  public void deleteTether(HttpRequest request, HttpResponder responder, @PathParam("peer") String peer)
+    throws PeerNotFoundException, IOException {
+    store.deletePeer(peer);
+    // Remove per-peer tethering topic if we're running on the server
+    if (cConf.getBoolean(Constants.Tethering.TETHERING_SERVER_ENABLED)) {
+      TopicId topic = new TopicId(NamespaceId.SYSTEM.getNamespace(),
+                                  topicPrefix + peer);
+      try {
+        messagingService.deleteTopic(topic);
+      } catch (TopicNotFoundException e) {
+        LOG.info("Topic {} was not found", topic.getTopic());
+      }
+    }
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  private PeerState createPeerState(PeerInfo peerInfo) {
+    TetheringConnectionStatus connectionStatus = TetheringConnectionStatus.INACTIVE;
+    if (System.currentTimeMillis() - peerInfo.getLastConnectionTime() < connectionTimeout * 1000L) {
+      connectionStatus = TetheringConnectionStatus.ACTIVE;
+    }
+    return new PeerState(peerInfo.getName(), peerInfo.getEndpoint(), peerInfo.getTetheringStatus(),
+                         peerInfo.getMetadata(), connectionStatus);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringServerHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringServerHandler.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.api.messaging.Message;
+import io.cdap.cdap.api.messaging.MessageFetcher;
+import io.cdap.cdap.api.messaging.TopicAlreadyExistsException;
+import io.cdap.cdap.api.messaging.TopicNotFoundException;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.ForbiddenException;
+import io.cdap.cdap.common.NotImplementedException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.messaging.TopicMetadata;
+import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.TopicId;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HandlerContext;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * {@link io.cdap.http.HttpHandler} to manage tethering server v3 REST APIs
+ */
+@Path(Constants.Gateway.API_VERSION_3)
+public class TetheringServerHandler extends AbstractHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(TetheringServerHandler.class);
+  private static final Gson GSON = new GsonBuilder().create();
+  private static final int MAX_CHUNK_SIZE = 4096;
+  private final CConfiguration cConf;
+  private final TetheringStore store;
+  private final MessagingService messagingService;
+  private final MultiThreadMessagingContext messagingContext;
+  private final String topicPrefix;
+
+  @Inject
+  TetheringServerHandler(CConfiguration cConf, TetheringStore store, MessagingService messagingService) {
+    this.cConf = cConf;
+    this.store = store;
+    this.messagingService = messagingService;
+    this.messagingContext = new MultiThreadMessagingContext(messagingService);
+    this.topicPrefix = cConf.get(Constants.Tethering.TOPIC_PREFIX);
+  }
+
+  @Override
+  public void init(HandlerContext context) {
+    super.init(context);
+  }
+
+  /**
+   * Sends control commands to the client.
+   */
+  @GET
+  @Path("/tethering/controlchannels/{peer}")
+  public void connectControlChannel(FullHttpRequest request, HttpResponder responder, @PathParam("peer") String peer,
+                                    @QueryParam("messageId") String messageId)
+    throws IOException, NotImplementedException, PeerNotFoundException, ForbiddenException, BadRequestException {
+    checkTetheringServerEnabled();
+    store.updatePeerTimestamp(peer);
+    TetheringStatus tetheringStatus = store.getPeer(peer).getTetheringStatus();
+    if (tetheringStatus == TetheringStatus.PENDING) {
+      throw new PeerNotFoundException(String.format("Peer %s not found", peer));
+    } else if (tetheringStatus == TetheringStatus.REJECTED) {
+      responder.sendStatus(HttpResponseStatus.FORBIDDEN);
+      throw new ForbiddenException(String.format("Peer %s is not authorized", peer));
+    }
+
+    List<TetheringControlResponse> controlResponses = new ArrayList<>();
+    MessageFetcher fetcher = messagingContext.getMessageFetcher();
+    TopicId topic = new TopicId(NamespaceId.SYSTEM.getNamespace(), topicPrefix + peer);
+    String lastMessageId = messageId;
+    try (CloseableIterator<Message> iterator =
+           fetcher.fetch(topic.getNamespace(), topic.getTopic(), 1, messageId)) {
+      while (iterator.hasNext()) {
+        Message message = iterator.next();
+        TetheringControlMessage controlMessage = GSON.fromJson(message.getPayloadAsString(StandardCharsets.UTF_8),
+                                                               TetheringControlMessage.class);
+        lastMessageId = message.getId();
+        controlResponses.add(new TetheringControlResponse(lastMessageId, controlMessage));
+      }
+    } catch (TopicNotFoundException e) {
+      LOG.warn("Received control connection from peer {} that's not tethered", peer);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(String.format("Invalid message id %s", messageId));
+    }
+
+    if (controlResponses.isEmpty()) {
+      controlResponses.add(new TetheringControlResponse(
+        lastMessageId, new TetheringControlMessage(TetheringControlMessage.Type.KEEPALIVE)));
+    }
+    responder.sendJson(HttpResponseStatus.OK,
+                       GSON.toJson(controlResponses.toArray(new TetheringControlResponse[0]),
+                                   TetheringControlResponse[].class));
+  }
+
+  /**
+   * Creates a tethering with a client.
+   */
+  @PUT
+  @Path("/tethering/connections/{peer}")
+  public void createTethering(FullHttpRequest request, HttpResponder responder, @PathParam("peer") String peer)
+    throws NotImplementedException, IOException {
+    checkTetheringServerEnabled();
+
+    String content = request.content().toString(StandardCharsets.UTF_8);
+    TetheringConnectionRequest tetherRequest = GSON.fromJson(content, TetheringConnectionRequest.class);
+    TopicId topicId = new TopicId(NamespaceId.SYSTEM.getNamespace(),
+                                  topicPrefix + peer);
+    try {
+      messagingService.createTopic(new TopicMetadata(topicId, Collections.emptyMap()));
+    } catch (TopicAlreadyExistsException e) {
+      LOG.warn("Topic {} already exists", topicId);
+    } catch (IOException e) {
+      LOG.error("Failed to create topic {}", topicId, e);
+      throw e;
+    }
+
+    // We don't need to keep track of the client metadata on the server side.
+    PeerMetadata peerMetadata = new PeerMetadata(tetherRequest.getNamespaceAllocations(), Collections.emptyMap());
+    // We don't store the peer endpoint on the server side because the connection is initiated by the client.
+    PeerInfo peerInfo = new PeerInfo(peer, null, TetheringStatus.PENDING, peerMetadata);
+    try {
+      store.addPeer(peerInfo);
+    } catch (PeerAlreadyExistsException pae) {
+      // Peer is already configured, treat this as a no-op.
+      responder.sendStatus(HttpResponseStatus.OK);
+      return;
+    } catch (Exception e) {
+      try {
+        messagingService.deleteTopic(topicId);
+      } catch (Exception ex) {
+        e.addSuppressed(ex);
+      }
+      throw new IOException("Failed to create tethering with peer " + peer, e);
+    }
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  /**
+   * Accepts/rejects the tethering request.
+   */
+  @POST
+  @Path("/tethering/connections/{peer}")
+  public void tetheringAction(FullHttpRequest request, HttpResponder responder, @PathParam("peer") String peer)
+    throws NotImplementedException, BadRequestException, PeerNotFoundException, IOException {
+    String content = request.content().toString(StandardCharsets.UTF_8);
+    TetheringActionRequest tetheringActionRequest = GSON.fromJson(content, TetheringActionRequest.class);
+    TetheringStatus tetheringStatus;
+    switch (tetheringActionRequest.getAction()) {
+      case "accept":
+        tetheringStatus = TetheringStatus.ACCEPTED;
+        break;
+      case "reject":
+        tetheringStatus = TetheringStatus.REJECTED;
+        break;
+      default:
+        throw new BadRequestException(String.format("Invalid action: %s", tetheringActionRequest.getAction()));
+    }
+    updateTetherStatus(responder, peer, tetheringStatus);
+  }
+
+  private void checkTetheringServerEnabled() throws NotImplementedException {
+    if (!cConf.getBoolean(Constants.Tethering.TETHERING_SERVER_ENABLED)) {
+      throw new NotImplementedException("Tethering is not enabled");
+    }
+  }
+
+  private void updateTetherStatus(HttpResponder responder, String peer, TetheringStatus newStatus)
+    throws NotImplementedException, PeerNotFoundException, IOException {
+    checkTetheringServerEnabled();
+    PeerInfo peerInfo = store.getPeer(peer);
+    if (peerInfo.getTetheringStatus() == TetheringStatus.PENDING) {
+      store.updatePeerStatus(peerInfo.getName(), newStatus);
+    } else {
+      LOG.info("Cannot update tether state to {} as current state state is {}",
+               newStatus, peerInfo.getTetheringStatus());
+    }
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringStatus.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringStatus.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+/**
+ * Status of a tether.
+ */
+public enum TetheringStatus {
+  PENDING,
+  ACCEPTED,
+  REJECTED
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringStore.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.spi.data.StructuredRow;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import io.cdap.cdap.store.StoreDefinition;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.inject.Inject;
+
+/**
+ * Store for tethering data.
+ */
+public class TetheringStore {
+  private static final Gson GSON = new GsonBuilder().create();
+
+  private final TransactionRunner transactionRunner;
+
+  @Inject
+  TetheringStore(TransactionRunner transactionRunner) {
+    this.transactionRunner = transactionRunner;
+  }
+
+  /**
+   * Adds a peer.
+   *
+   * @param peerInfo peer information
+   * @throws IOException if inserting into the table fails
+   */
+  public void addPeer(PeerInfo peerInfo) throws IOException, PeerAlreadyExistsException {
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable tetheringTable = context.getTable(StoreDefinition.TetheringStore.TETHERING);
+      Collection<Field<?>> key = ImmutableList.of(
+        Fields.stringField(StoreDefinition.TetheringStore.PEER_NAME_FIELD, peerInfo.getName()));
+      Optional<StructuredRow> row = tetheringTable.read(key);
+      if (row.isPresent()) {
+        PeerInfo peer = getPeerInfo(row.get());
+        throw new PeerAlreadyExistsException(peer.getName(), peer.getTetheringStatus());
+      }
+      Collection<Field<?>> fields = new ArrayList<>();
+      fields.add(Fields.stringField(StoreDefinition.TetheringStore.PEER_NAME_FIELD, peerInfo.getName()));
+      fields.add(Fields.stringField(StoreDefinition.TetheringStore.PEER_URI_FIELD, peerInfo.getEndpoint()));
+      fields.add(Fields.stringField(StoreDefinition.TetheringStore.TETHERING_STATE_FIELD,
+                                    peerInfo.getTetheringStatus().toString()));
+      fields.add(Fields.longField(StoreDefinition.TetheringStore.LAST_CONNECTION_TIME_FIELD, 0L));
+      fields.add(Fields.stringField(StoreDefinition.TetheringStore.PEER_METADATA_FIELD,
+                                    GSON.toJson(peerInfo.getMetadata())));
+      tetheringTable.upsert(fields);
+    }, IOException.class, PeerAlreadyExistsException.class);
+  }
+
+  /**
+   * Updates tethering status and last connection time for a peer.
+   *
+   * @param peerName name of the peer
+   * @param tetheringStatus status of tetherinf with the peer
+   * @throws IOException if updating the table fails
+   */
+    public void updatePeerStatusAndTimestamp(String peerName, TetheringStatus tetheringStatus) throws IOException {
+    TransactionRunners.run(transactionRunner, context -> {
+      Collection<Field<?>> fields = new ArrayList<>();
+      fields.add(Fields.stringField(StoreDefinition.TetheringStore.PEER_NAME_FIELD, peerName));
+      fields.add(Fields.stringField(StoreDefinition.TetheringStore.TETHERING_STATE_FIELD, tetheringStatus.toString()));
+      fields.add(Fields.longField(StoreDefinition.TetheringStore.LAST_CONNECTION_TIME_FIELD,
+                                  System.currentTimeMillis()));
+      StructuredTable tetheringTable = context.getTable(StoreDefinition.TetheringStore.TETHERING);
+      tetheringTable.update(fields);
+    }, IOException.class);
+  }
+
+  /**
+   * Updates tethering status for a peer.
+   *
+   * @param peerName name of the peer
+   * @param tetheringStatus status of tethering with the peer
+   * @throws IOException if updating the table fails
+   */
+  public void updatePeerStatus(String peerName, TetheringStatus tetheringStatus) throws IOException {
+    TransactionRunners.run(transactionRunner, context -> {
+      Collection<Field<?>> fields = new ArrayList<>();
+      fields.add(Fields.stringField(StoreDefinition.TetheringStore.PEER_NAME_FIELD, peerName));
+      fields.add(Fields.stringField(StoreDefinition.TetheringStore.TETHERING_STATE_FIELD, tetheringStatus.toString()));
+      StructuredTable tetheringTable = context.getTable(StoreDefinition.TetheringStore.TETHERING);
+      tetheringTable.update(fields);
+    }, IOException.class);
+  }
+
+  /**
+   * Updates the last connection timestamp for the peer.
+   *
+   * @param peerName name of the peer
+   * @throws IOException if updating the table fails
+   */
+  public void updatePeerTimestamp(String peerName) throws IOException {
+    TransactionRunners.run(transactionRunner, context -> {
+      Collection<Field<?>> fields = new ArrayList<>();
+      fields.add(Fields.stringField(StoreDefinition.TetheringStore.PEER_NAME_FIELD, peerName));
+      fields.add(Fields.longField(StoreDefinition.TetheringStore.LAST_CONNECTION_TIME_FIELD,
+                                  System.currentTimeMillis()));
+      StructuredTable tetheringTable = context.getTable(StoreDefinition.TetheringStore.TETHERING);
+      tetheringTable.update(fields);
+    }, IOException.class);
+  }
+
+  /**
+   * Deletes a peer
+   *
+   * @param peerName name of the peer
+   * @throws IOException if deleting the table fails
+   * @throws PeerNotFoundException if the peer is not found
+   */
+  public void deletePeer(String peerName) throws IOException, PeerNotFoundException {
+    TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable tetheringTable = context.getTable(StoreDefinition.TetheringStore.TETHERING);
+      // throw PeerNotFoundException if peer doesn't exist
+      getPeer(tetheringTable, peerName);
+      tetheringTable
+        .delete(Collections.singleton(Fields.stringField(StoreDefinition.TetheringStore.PEER_NAME_FIELD, peerName)));
+    }, IOException.class, PeerNotFoundException.class);
+  }
+
+  /**
+   * Get information about all tethered peers
+   *
+   * @return information about status of tethered peers
+   * @throws IOException if reading from the database fails
+   */
+  public List<PeerInfo> getPeers() throws IOException {
+    List<PeerInfo> peers = new ArrayList<>();
+    return TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable tetheringTable = context
+        .getTable(StoreDefinition.TetheringStore.TETHERING);
+      try (CloseableIterator<StructuredRow> iterator = tetheringTable.scan(Range.all(), Integer.MAX_VALUE)) {
+        iterator.forEachRemaining(row -> {
+          peers.add(getPeerInfo(row));
+        });
+        return peers;
+      }
+    }, IOException.class);
+  }
+
+  /**
+   * Get information about a peer
+   *
+   * @return information about status of a peer
+   * @throws IOException if reading from the database fails
+   * @throws PeerNotFoundException if the peer is not found
+   */
+  public PeerInfo getPeer(String peerName) throws IOException, PeerNotFoundException {
+    return TransactionRunners.run(transactionRunner, context -> {
+      StructuredTable tetheringTable = context
+        .getTable(StoreDefinition.TetheringStore.TETHERING);
+      Optional<StructuredRow> row = getPeer(tetheringTable, peerName);
+      return getPeerInfo(row.get());
+    }, PeerNotFoundException.class, IOException.class);
+  }
+
+  private Optional<StructuredRow> getPeer(StructuredTable tetheringTable, String peerName)
+    throws IOException, PeerNotFoundException {
+    Collection<Field<?>> key = ImmutableList.of(
+      Fields.stringField(StoreDefinition.TetheringStore.PEER_NAME_FIELD, peerName));
+    Optional<StructuredRow> row = tetheringTable.read(key);
+    if (!row.isPresent()) {
+      throw new PeerNotFoundException(peerName);
+    }
+    return tetheringTable.read(key);
+  }
+
+  private PeerInfo getPeerInfo(StructuredRow row) {
+    String peerName = row.getString(StoreDefinition.TetheringStore.PEER_NAME_FIELD);
+    String endpoint = row.getString(StoreDefinition.TetheringStore.PEER_URI_FIELD);
+    TetheringStatus tetheringStatus = TetheringStatus.valueOf(
+      row.getString(StoreDefinition.TetheringStore.TETHERING_STATE_FIELD));
+    PeerMetadata peerMetadata = GSON.fromJson(row.getString(StoreDefinition.TetheringStore.PEER_METADATA_FIELD),
+                                              PeerMetadata.class);
+    long lastConnectionTime = row.getLong(StoreDefinition.TetheringStore.LAST_CONNECTION_TIME_FIELD);
+    return new PeerInfo(peerName, endpoint, tetheringStatus, peerMetadata, lastConnectionTime);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringUtils.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.common.net.HttpHeaders;
+import io.cdap.cdap.common.internal.remote.RemoteAuthenticator;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequestConfig;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+
+import java.io.IOException;
+import java.net.URI;
+import javax.annotation.Nullable;
+
+/**
+ * Utility functions for tethering.
+ */
+public final class TetheringUtils {
+  // Connection timeout = 5 seconds.
+  private static final int TIMEOUT_MS = 5000;
+
+  private TetheringUtils() {
+  }
+
+  public static HttpResponse sendHttpRequest(HttpMethod method, URI endpoint) throws IOException {
+    return sendHttpRequest(method, endpoint, null);
+  }
+
+  public static HttpResponse sendHttpRequest(HttpMethod method, URI endpoint, @Nullable String content)
+    throws IOException {
+   HttpRequest.Builder builder;
+    switch (method) {
+      case GET:
+        builder = HttpRequest.get(endpoint.toURL());
+        break;
+      case PUT:
+        builder = HttpRequest.put(endpoint.toURL());
+        break;
+      case POST:
+        builder = HttpRequest.post(endpoint.toURL());
+        break;
+      case DELETE:
+        builder = HttpRequest.delete(endpoint.toURL());
+        break;
+      default:
+        throw new RuntimeException("Unexpected HTTP method: " + method);
+    }
+    if (content != null && !content.isEmpty()) {
+      builder.withBody(content);
+    }
+
+    // Add Authorization header.
+    RemoteAuthenticator authenticator = RemoteAuthenticator.getDefaultAuthenticator();
+    if (authenticator != null) {
+      builder.addHeader(HttpHeaders.AUTHORIZATION,
+                        String.format("%s %s", authenticator.getType(), authenticator.getCredentials()));
+    }
+    return HttpRequests.execute(builder.build(), new HttpRequestConfig(TIMEOUT_MS, TIMEOUT_MS));
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/MockTetheringServerHandler.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/MockTetheringServerHandler.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Assert;
+
+import java.nio.charset.StandardCharsets;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * Mock tethering server handler used in unit tests.
+ */
+@Path(Constants.Gateway.API_VERSION_3)
+public class MockTetheringServerHandler extends AbstractHttpHandler {
+  private static final Gson GSON = new Gson();
+  private HttpResponseStatus responseStatus = HttpResponseStatus.OK;
+  private boolean tetheringCreated = false;
+
+  @GET
+  @Path("/tethering/controlchannels/{peer}")
+  public void getControlChannels(HttpRequest request, HttpResponder responder,
+                                 @PathParam("peer") String peer,
+                                 @QueryParam("messageId") String messageId) {
+    Assert.assertEquals(TetheringClientHandlerTest.CLIENT_INSTANCE, peer);
+    if (responseStatus != HttpResponseStatus.OK) {
+      responder.sendStatus(responseStatus);
+      return;
+    }
+    TetheringControlMessage keepalive = new TetheringControlMessage(TetheringControlMessage.Type.KEEPALIVE);
+    TetheringControlResponse[] responses =  { new TetheringControlResponse(messageId, keepalive) };
+    responder.sendJson(responseStatus, GSON.toJson(responses, TetheringControlResponse[].class));
+  }
+
+  @PUT
+  @Path("/tethering/connections/{peer}")
+  public void createTether(FullHttpRequest request, HttpResponder responder, @PathParam("peer") String peer) {
+    String content = request.content().toString(StandardCharsets.UTF_8);
+    TetheringConnectionRequest tetherRequest = GSON.fromJson(content, TetheringConnectionRequest.class);
+    Assert.assertEquals(TetheringClientHandlerTest.CLIENT_INSTANCE, peer);
+    Assert.assertEquals(TetheringClientHandlerTest.NAMESPACES, tetherRequest.getNamespaceAllocations());
+    tetheringCreated = true;
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  public void setResponseStatus(HttpResponseStatus responseStatus) {
+    this.responseStatus = responseStatus;
+  }
+
+  public boolean isTetheringCreated() {
+    return tetheringCreated;
+  }
+
+  public void setTetheringCreated(boolean tetheringCreated) {
+    this.tetheringCreated = tetheringCreated;
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringClientHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringClientHandlerTest.java
@@ -1,0 +1,423 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Service;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.PrivateModule;
+import com.google.inject.Scopes;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.client.config.ClientConfig;
+import io.cdap.cdap.client.config.ConnectionConfig;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
+import io.cdap.cdap.data.runtime.TransactionExecutorModule;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
+import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.store.StoreDefinition;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import io.cdap.http.NettyHttpService;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.runtime.TransactionModules;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class TetheringClientHandlerTest {
+  private static final Gson GSON = new Gson();
+  public static final String CLIENT_INSTANCE = "tethering-client";
+  public static final String NAMESPACE_1 = "ns1";
+  public static final String NAMESPACE_2 = "ns2";
+  public static final String NAMESPACE_3 = "ns3";
+  public static final List<NamespaceAllocation> NAMESPACES = ImmutableList.of(
+    new NamespaceAllocation(NAMESPACE_1, "1", "1Gi"),
+    new NamespaceAllocation(NAMESPACE_2, "2", "2Gi"),
+    new NamespaceAllocation(NAMESPACE_3, null, null));
+  public static final String SERVER_INSTANCE = "my-instance";
+  public static final String PROJECT = "my-project";
+  public static final String  LOCATION = "us-west1";
+  private static CConfiguration cConf;
+  private static TetheringStore tetheringStore;
+  private static Injector injector;
+  private static TransactionManager txManager;
+
+  private NettyHttpService serverService;
+  private ClientConfig serverConfig;
+  private NettyHttpService clientService;
+  private ClientConfig clientConfig;
+  private MockTetheringServerHandler serverHandler;
+  private TetheringAgentService tetheringAgentService;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    cConf = CConfiguration.create();
+    injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new TransactionModules().getInMemoryModules(),
+      new TransactionExecutorModule(),
+      new InMemoryDiscoveryModule(),
+      new MessagingServerRuntimeModule().getInMemoryModules(),
+      new StorageModule(),
+      new PrivateModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+          expose(MetricsCollectionService.class);
+        }
+      });
+    tetheringStore = new TetheringStore(injector.getInstance(TransactionRunner.class));
+    txManager = injector.getInstance(TransactionManager.class);
+    txManager.startAndWait();
+
+  }
+
+  @AfterClass
+  public static void teardown() throws Exception {
+    if (txManager != null) {
+      txManager.stopAndWait();
+    }
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    // Define all StructuredTable before starting any services that need StructuredTable
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
+    CConfiguration conf = CConfiguration.create();
+    serverHandler = new MockTetheringServerHandler();
+    serverService = new CommonNettyHttpServiceBuilder(conf, getClass().getSimpleName() + "_server")
+      .setHttpHandlers(serverHandler).build();
+    serverService.start();
+    serverConfig = ClientConfig.builder()
+      .setConnectionConfig(
+        ConnectionConfig.builder()
+          .setHostname(serverService.getBindAddress().getHostName())
+          .setPort(serverService.getBindAddress().getPort())
+          .setSSLEnabled(false)
+          .build()).build();
+
+    cConf.setInt(Constants.Tethering.CONNECTION_INTERVAL, 1);
+    cConf.setInt(Constants.Tethering.CONNECTION_TIMEOUT_SECONDS, 5);
+    cConf.set(Constants.INSTANCE_NAME, CLIENT_INSTANCE);
+
+    MessagingService messagingService = injector.getInstance(MessagingService.class);
+    clientService = new CommonNettyHttpServiceBuilder(conf, getClass().getSimpleName() + "_client")
+      .setHttpHandlers(new TetheringClientHandler(tetheringStore),
+                       new TetheringHandler(cConf, tetheringStore, messagingService))
+      .build();
+    clientService.start();
+    clientConfig = ClientConfig.builder()
+      .setConnectionConfig(
+        ConnectionConfig.builder()
+          .setHostname(clientService.getBindAddress().getHostName())
+          .setPort(clientService.getBindAddress().getPort())
+          .setSSLEnabled(false)
+          .build()).build();
+
+    tetheringAgentService = new TetheringAgentService(cConf, injector.getInstance(TransactionRunner.class),
+                                                      tetheringStore);
+    Assert.assertEquals(Service.State.RUNNING, tetheringAgentService.startAndWait());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    Assert.assertEquals(Service.State.TERMINATED, tetheringAgentService.stopAndWait());
+
+  }
+
+  @Test
+  public void testResendTetheringRequests()
+    throws InterruptedException, IOException, PeerNotFoundException, PeerAlreadyExistsException {
+    Map<String, String> metadata = ImmutableMap.of("project", PROJECT,
+                                                   "location", LOCATION);
+    PeerMetadata peerMetadata = new PeerMetadata(NAMESPACES, metadata);
+    PeerInfo peer = new PeerInfo(SERVER_INSTANCE, serverConfig.getConnectionConfig().getURI().toString(),
+                                 TetheringStatus.PENDING, peerMetadata);
+
+    // Server returns 404 before tethering has been accepted by admin on server side.
+    serverHandler.setResponseStatus(HttpResponseStatus.NOT_FOUND);
+
+    // Add peer in PENDING state
+    tetheringStore.addPeer(peer);
+
+    // Remote agent should send a tethering request to peer in PENDING state if it
+    // responds with 404.
+    waitForTetheringCreated();
+
+    // cleanup
+    tetheringStore.deletePeer(SERVER_INSTANCE);
+  }
+
+  @Test
+  public void testTetheringAccept() throws Exception {
+    // Server returns 404 before tethering has been accepted by admin on server side.
+    serverHandler.setResponseStatus(HttpResponseStatus.NOT_FOUND);
+
+    // Client initiates tethering with the server
+    createTethering(SERVER_INSTANCE, PROJECT, LOCATION, NAMESPACES);
+
+    // Server accepts tethering
+    serverHandler.setResponseStatus(HttpResponseStatus.OK);
+
+    String serverEndpoint = serverConfig.getConnectionConfig().getURI().toString();
+    // Tethering state should transition to accepted on the client.
+    waitForTetheringStatus(TetheringStatus.ACCEPTED, SERVER_INSTANCE, serverEndpoint,
+                           PROJECT, LOCATION, NAMESPACES, true);
+
+    // Duplicate tethering request should be fail.
+    createTethering(SERVER_INSTANCE, PROJECT, LOCATION, NAMESPACES, TetheringStatus.ACCEPTED,
+                    HttpResponseStatus.BAD_REQUEST);
+
+    // Tethering rejection should be ignored when tether is accepted.
+    serverHandler.setResponseStatus(HttpResponseStatus.FORBIDDEN);
+    waitForTetheringStatus(TetheringStatus.ACCEPTED, SERVER_INSTANCE, serverEndpoint,
+                           PROJECT, LOCATION, NAMESPACES, true);
+
+    // Make server respond with 500 error for control messages.
+    serverHandler.setResponseStatus(HttpResponseStatus.INTERNAL_SERVER_ERROR);
+    Thread.sleep(cConf.getInt(Constants.Tethering.CONNECTION_TIMEOUT_SECONDS) * 1000);
+    // Control channel state should become inactive
+    waitForTetheringStatus(TetheringStatus.ACCEPTED, SERVER_INSTANCE, serverEndpoint,
+                           PROJECT, LOCATION, NAMESPACES, false);
+    // Stop returning an error from the server.
+    serverHandler.setResponseStatus(HttpResponseStatus.OK);
+    // Control channel should become active
+    waitForTetheringStatus(TetheringStatus.ACCEPTED, SERVER_INSTANCE, serverEndpoint,
+                           PROJECT, LOCATION, NAMESPACES, true);
+
+    // cleanup
+    deleteTethering(SERVER_INSTANCE);
+  }
+
+  @Test
+  public void testTetheringReject() throws Exception {
+    // Server returns 404 before tethering has been accepted or rejected by admin on server side.
+    serverHandler.setResponseStatus(HttpResponseStatus.NOT_FOUND);
+
+    // Client initiate tethering with the server
+    createTethering(SERVER_INSTANCE, PROJECT, LOCATION, NAMESPACES);
+
+    // Duplicate tethering request should fail
+    createTethering(SERVER_INSTANCE, PROJECT, LOCATION, NAMESPACES, HttpResponseStatus.BAD_REQUEST);
+
+    String serverEndpoint = serverConfig.getConnectionConfig().getURI().toString();
+    // Control channel should be active at this point.
+    waitForTetheringStatus(TetheringStatus.PENDING, SERVER_INSTANCE, serverEndpoint,
+                           PROJECT, LOCATION, NAMESPACES, true);
+
+    // Server rejects tethering
+    serverHandler.setResponseStatus(HttpResponseStatus.FORBIDDEN);
+    // Tethering state should be updated to rejected
+    waitForTetheringStatus(TetheringStatus.REJECTED, SERVER_INSTANCE, serverEndpoint,
+                           PROJECT, LOCATION, NAMESPACES, true);
+
+    // Server sends unexpected 200. It should be ignored.
+    serverHandler.setResponseStatus(HttpResponseStatus.OK);
+    waitForTetheringStatus(TetheringStatus.REJECTED, SERVER_INSTANCE, serverEndpoint,
+                           PROJECT, LOCATION, NAMESPACES, true);
+
+    // Tethering request should be fail as tethering has already been rejected.
+    createTethering(SERVER_INSTANCE, PROJECT, LOCATION, NAMESPACES, TetheringStatus.REJECTED,
+                    HttpResponseStatus.BAD_REQUEST);
+
+    // cleanup
+    deleteTethering(SERVER_INSTANCE);
+  }
+
+  @Test
+  public void testTetherStatus() throws IOException, InterruptedException {
+    // Tethering does not exist, should return 404.
+    HttpRequest request = HttpRequest.builder(HttpMethod.GET,
+                                              clientConfig.resolveURL("tethering/connections/" + SERVER_INSTANCE))
+      .build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(HttpResponseStatus.NOT_FOUND.code(), response.getResponseCode());
+
+    // Server returns 404 before tethering has been accepted or rejected by admin on server side.
+    serverHandler.setResponseStatus(HttpResponseStatus.NOT_FOUND);
+
+    // Client initiate tethering with the server
+    createTethering(SERVER_INSTANCE, PROJECT, LOCATION, NAMESPACES);
+
+    // Tethering status for the peer should be returned.
+    request = HttpRequest.builder(HttpMethod.GET,
+                                  clientConfig.resolveURL("tethering/connections/" + SERVER_INSTANCE))
+      .build();
+    response = HttpRequests.execute(request);
+    Assert.assertEquals(HttpResponseStatus.OK.code(), response.getResponseCode());
+    PeerState peerState = GSON.fromJson(response.getResponseBodyAsString(), PeerState.class);
+    Assert.assertEquals(SERVER_INSTANCE, peerState.getName());
+    Assert.assertEquals(TetheringStatus.PENDING, peerState.getTetheringStatus());
+    Assert.assertTrue(peerState.isActive());
+    Assert.assertEquals(serverConfig.getConnectionConfig().getURI().toString(), peerState.getEndpoint());
+    Assert.assertEquals(PROJECT, peerState.getMetadata().getMetadata().get("project"));
+    Assert.assertEquals(LOCATION, peerState.getMetadata().getMetadata().get("location"));
+    Assert.assertEquals(NAMESPACES, peerState.getMetadata().getNamespaceAllocations());
+
+    // cleanup
+    deleteTethering(SERVER_INSTANCE);
+  }
+
+  @Test
+  public void testDeletePendingTether() throws IOException, InterruptedException {
+    // Server returns 404 before tethering has been accepted or rejected by admin on server side.
+    serverHandler.setResponseStatus(HttpResponseStatus.NOT_FOUND);
+
+    // Client initiate tethering with the server
+    createTethering(SERVER_INSTANCE, PROJECT, LOCATION, NAMESPACES);
+
+    // Delete tethering on the client.
+    deleteTethering(SERVER_INSTANCE);
+  }
+
+  @Test
+  public void testGetTetheringUnknownPeer() throws IOException {
+    HttpRequest request = HttpRequest.builder(HttpMethod.GET,
+                                              clientConfig.resolveURL("tethering/connections/unknonwn_peer"))
+      .build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(HttpResponseStatus.NOT_FOUND.code(), response.getResponseCode());
+  }
+
+  @Test
+  public void testDeleteTetheringUnknownPeer() throws IOException {
+    HttpRequest request = HttpRequest.builder(HttpMethod.DELETE,
+                                              clientConfig.resolveURL("tethering/connections/unknonwn_peer"))
+      .build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(HttpResponseStatus.NOT_FOUND.code(), response.getResponseCode());
+  }
+
+  private void deleteTethering(String instance) throws IOException {
+    HttpRequest request = HttpRequest.builder(HttpMethod.DELETE,
+                                              clientConfig.resolveURL("tethering/connections/" + instance))
+      .build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(HttpResponseStatus.OK.code(), response.getResponseCode());
+  }
+
+  private void createTethering(String instance, String project, String location,
+                               List<NamespaceAllocation> namespaceAllocations)
+    throws IOException, InterruptedException {
+    createTethering(instance, project, location, namespaceAllocations,
+                    TetheringStatus.PENDING);
+  }
+
+  private void createTethering(String instance, String project, String location,
+                               List<NamespaceAllocation> namespaceAllocations,
+                               HttpResponseStatus expectedResponseStatus)
+    throws IOException, InterruptedException {
+    createTethering(instance, project, location, namespaceAllocations,
+                    TetheringStatus.PENDING, expectedResponseStatus);
+  }
+
+  private void createTethering(String instance, String project, String location,
+                               List<NamespaceAllocation> namespaceAllocations, TetheringStatus expectedTetheringStatus)
+    throws IOException, InterruptedException {
+    createTethering(instance, project, location, namespaceAllocations, expectedTetheringStatus, HttpResponseStatus.OK);
+  }
+
+
+  private void createTethering(String instance, String project, String location,
+                               List<NamespaceAllocation> namespaceAllocations, TetheringStatus expectedTetheringStatus,
+                               HttpResponseStatus expectedResponseStatus)
+    throws IOException, InterruptedException {
+    // Send tethering request
+    Map<String, String> metadata = ImmutableMap.of("project", project, "location", location);
+    TetheringCreationRequest tetheringRequest = new TetheringCreationRequest(instance,
+                                                                          serverConfig.getConnectionConfig().getURI()
+                                                                      .toString(),
+                                                                          NAMESPACES,
+                                                                          metadata);
+    HttpRequest request = HttpRequest.builder(HttpMethod.PUT, clientConfig.resolveURL("tethering/create"))
+      .withBody(GSON.toJson(tetheringRequest))
+      .build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(expectedResponseStatus.code(), response.getResponseCode());
+
+    waitForTetheringStatus(expectedTetheringStatus, tetheringRequest.getPeer(), tetheringRequest.getEndpoint(),
+                           project, location, namespaceAllocations, true);
+  }
+
+  private void waitForTetheringStatus(TetheringStatus tetheringStatus, String instanceName, String endpoint,
+                                      String project, String location, List<NamespaceAllocation> namespaces,
+                                      boolean expectActive)
+    throws IOException, InterruptedException {
+    List<PeerState> peers = new ArrayList<>();
+    for (int retry = 0; retry < 5; ++retry) {
+      HttpRequest request = HttpRequest.builder(HttpMethod.GET, clientConfig.resolveURL("tethering/connections"))
+        .build();
+      HttpResponse response = HttpRequests.execute(request);
+      Assert.assertEquals(HttpResponseStatus.OK.code(), response.getResponseCode());
+      Type type = new TypeToken<List<PeerState>>() {
+      }.getType();
+      peers = GSON.fromJson(response.getResponseBodyAsString(), type);
+      Assert.assertEquals(1, peers.size());
+      if (peers.get(0).getTetheringStatus() == tetheringStatus
+        && peers.get(0).isActive() == expectActive) {
+        break;
+      }
+      Thread.sleep(500);
+    }
+    Assert.assertEquals(1, peers.size());
+    PeerState peer = peers.get(0);
+    Assert.assertEquals(tetheringStatus, peer.getTetheringStatus());
+    Assert.assertEquals(instanceName, peer.getName());
+    Assert.assertEquals(endpoint, peer.getEndpoint());
+    Assert.assertEquals(project, peer.getMetadata().getMetadata().get("project"));
+    Assert.assertEquals(location, peer.getMetadata().getMetadata().get("location"));
+    Assert.assertEquals(namespaces, peer.getMetadata().getNamespaceAllocations());
+    Assert.assertEquals(expectActive, peer.isActive());
+  }
+
+  private void waitForTetheringCreated() throws InterruptedException {
+    for (int retry = 0; retry < 5; ++retry) {
+      if (serverHandler.isTetheringCreated()) {
+        return;
+      }
+      Thread.sleep(500);
+    }
+    Assert.assertTrue(serverHandler.isTetheringCreated());
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringServerHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringServerHandlerTest.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Service;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.PrivateModule;
+import com.google.inject.Scopes;
+import io.cdap.cdap.api.messaging.TopicNotFoundException;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.client.config.ClientConfig;
+import io.cdap.cdap.client.config.ConnectionConfig;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
+import io.cdap.cdap.data.runtime.TransactionExecutorModule;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.messaging.TopicMetadata;
+import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.TopicId;
+import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.store.StoreDefinition;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import io.cdap.http.NettyHttpService;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.tephra.TransactionManager;
+import org.apache.tephra.runtime.TransactionModules;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+
+public class TetheringServerHandlerTest {
+  private static final Gson GSON = new GsonBuilder().create();
+  private static final List<NamespaceAllocation> NAMESPACES = ImmutableList.of(
+    new NamespaceAllocation("testns1", "1", "2Gi"),
+    new NamespaceAllocation("testns2", null, null));
+  private static TetheringStore tetheringStore;
+  private static MessagingService messagingService;
+  private static CConfiguration cConf;
+  private static Injector injector;
+  private static TransactionManager txManager;
+  private static String topicPrefix;
+
+  private NettyHttpService service;
+  private ClientConfig config;
+
+  @BeforeClass
+  public static void setup() {
+    cConf = CConfiguration.create();
+    topicPrefix = cConf.get(Constants.Tethering.TOPIC_PREFIX);
+    injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new TransactionModules().getInMemoryModules(),
+      new TransactionExecutorModule(),
+      new InMemoryDiscoveryModule(),
+      new MessagingServerRuntimeModule().getInMemoryModules(),
+      new StorageModule(),
+      new PrivateModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+          expose(MetricsCollectionService.class);
+        }
+      });
+    tetheringStore = new TetheringStore(injector.getInstance(TransactionRunner.class));
+    messagingService = injector.getInstance(MessagingService.class);
+    if (messagingService instanceof Service) {
+      ((Service) messagingService).startAndWait();
+    }
+    txManager = injector.getInstance(TransactionManager.class);
+    txManager.startAndWait();
+  }
+
+  @AfterClass
+  public static void teardown() {
+    if (txManager != null) {
+      txManager.stopAndWait();
+    }
+    if (messagingService instanceof Service) {
+      ((Service) messagingService).stopAndWait();
+    }
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    // Define all StructuredTable before starting any services that need StructuredTable
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
+    cConf.setBoolean(Constants.Tethering.TETHERING_SERVER_ENABLED, true);
+    cConf.setInt(Constants.Tethering.CONNECTION_TIMEOUT_SECONDS, 1);
+    service = new CommonNettyHttpServiceBuilder(CConfiguration.create(), getClass().getSimpleName())
+      .setHttpHandlers(new TetheringServerHandler(cConf, tetheringStore, messagingService),
+                       new TetheringHandler(cConf, tetheringStore, messagingService))
+      .build();
+    service.start();
+    config = ClientConfig.builder()
+      .setConnectionConfig(
+        ConnectionConfig.builder()
+          .setHostname(service.getBindAddress().getHostName())
+          .setPort(service.getBindAddress().getPort())
+          .setSSLEnabled(false)
+          .build()).build();
+  }
+
+  @Test
+  public void testAcceptTether() throws IOException, InterruptedException {
+    // Tethering is initiated by peer
+    createTethering("xyz", NAMESPACES);
+    // Tethering status should be PENDING
+    expectTetheringStatus("xyz", TetheringStatus.PENDING, NAMESPACES, TetheringConnectionStatus.INACTIVE);
+
+    // Duplicate tether initiation should be ignored
+    createTethering("xyz", NAMESPACES);
+    // Tethering status should be PENDING
+    expectTetheringStatus("xyz", TetheringStatus.PENDING, NAMESPACES, TetheringConnectionStatus.INACTIVE);
+
+    // Server should respond with 404 because tether is still pending.
+    expectTetheringControlResponse("xyz", HttpResponseStatus.NOT_FOUND);
+
+    // User accepts tethering
+    acceptTethering();
+    expectTetheringStatus("xyz", TetheringStatus.ACCEPTED, NAMESPACES, TetheringConnectionStatus.ACTIVE);
+
+    // Duplicate accept tethering should be ignored
+    acceptTethering();
+    expectTetheringControlResponse("xyz", HttpResponseStatus.OK);
+    expectTetheringStatus("xyz", TetheringStatus.ACCEPTED, NAMESPACES, TetheringConnectionStatus.ACTIVE);
+
+    // Reject tethering should be ignored
+    rejectTethering();
+    expectTetheringControlResponse("xyz", HttpResponseStatus.OK);
+
+    // Tethering initiation should be ignored
+    createTethering("xyz", NAMESPACES);
+    expectTetheringControlResponse("xyz", HttpResponseStatus.OK);
+    expectTetheringStatus("xyz", TetheringStatus.ACCEPTED, NAMESPACES, TetheringConnectionStatus.ACTIVE);
+
+    // Wait until we don't receive any control messages from the peer for upto the timeout interval.
+    Thread.sleep(cConf.getInt(Constants.Tethering.CONNECTION_TIMEOUT_SECONDS) * 1000);
+    expectTetheringStatus("xyz", TetheringStatus.ACCEPTED, NAMESPACES, TetheringConnectionStatus.INACTIVE);
+
+    // Delete tethering
+    deleteTethering();
+  }
+
+  @Test
+  public void testRejectTether() throws IOException, InterruptedException {
+    // Tethering is initiated by peer
+    createTethering("xyz", NAMESPACES);
+    // Tethering status should be PENDING
+    expectTetheringStatus("xyz", TetheringStatus.PENDING, NAMESPACES, TetheringConnectionStatus.INACTIVE);
+
+    // User rejects tethering
+    rejectTethering();
+    // Server should return 403 when tethering is rejected.
+    expectTetheringControlResponse("xyz", HttpResponseStatus.FORBIDDEN);
+    expectTetheringStatus("xyz", TetheringStatus.REJECTED, NAMESPACES, TetheringConnectionStatus.ACTIVE);
+
+
+    // Duplicate reject tethering should be ignored
+    rejectTethering();
+    expectTetheringControlResponse("xyz", HttpResponseStatus.FORBIDDEN);
+    expectTetheringStatus("xyz", TetheringStatus.REJECTED, NAMESPACES, TetheringConnectionStatus.ACTIVE);
+
+    // Accept tethering should be ignored
+    acceptTethering();
+    expectTetheringControlResponse("xyz", HttpResponseStatus.FORBIDDEN);
+    expectTetheringStatus("xyz", TetheringStatus.REJECTED, NAMESPACES, TetheringConnectionStatus.ACTIVE);
+
+    // Delete tethering
+    deleteTethering();
+  }
+
+  @Test
+  public void testConnectControlChannelUnknownPeer() throws IOException {
+    HttpRequest request = HttpRequest.builder(HttpMethod.GET,
+                                              config.resolveURL("/tethering/controlchannels/bad_peer")).build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(HttpResponseStatus.NOT_FOUND.code(), response.getResponseCode());
+  }
+
+  @Test
+  public void testInvalidAction() throws IOException {
+    // Create tethering
+    createTethering("xyz", NAMESPACES);
+
+    TetheringActionRequest invalidAction = new TetheringActionRequest("foo");
+    // Perform invalid action, should get BAD_REQUEST error
+    HttpRequest request = HttpRequest.builder(HttpMethod.POST,
+                                              config.resolveURL("tethering/connections/xyz"))
+      .withBody(GSON.toJson(invalidAction))
+      .build();
+    HttpResponse response = HttpRequests.execute(request);
+    Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.code(), response.getResponseCode());
+
+    // Delete tethering
+    deleteTethering();
+  }
+
+  @Test
+  public void testTetheringTopic() throws IOException, TopicNotFoundException {
+    // Create tethering
+    createTethering("xyz", NAMESPACES);
+
+    TopicId topic = new TopicId(NamespaceId.SYSTEM.getNamespace(),
+                                topicPrefix + "xyz");
+    // Per-peer messaging topic should be created
+    TopicMetadata metadata = messagingService.getTopic(topic);
+    Assert.assertEquals(topic, metadata.getTopicId());
+
+    // Delete tethering
+    deleteTethering();
+
+    // Messaging topic should be deleted
+    try {
+      messagingService.getTopic(topic);
+      Assert.fail(String.format("Messaging topic %s was not deleted", topic.getTopic()));
+    } catch (TopicNotFoundException ignored) {
+    }
+  }
+
+  @Test
+  public void testInvalidMessageId() throws IOException {
+    // Create tethering
+    createTethering("xyz", NAMESPACES);
+
+    // User accepts tethering
+    acceptTethering();
+
+    // control message with invalid message id should return BAD_REQUEST
+    HttpRequest.Builder builder = HttpRequest.builder(HttpMethod.GET,
+                                                      config.resolveURL(
+                                                        "tethering/controlchannels/xyz?messageId=abcd"));
+    HttpResponse response = HttpRequests.execute(builder.build());
+    Assert.assertEquals(HttpResponseStatus.BAD_REQUEST.code(), response.getResponseCode());
+
+    // Delete tethering
+    deleteTethering();
+  }
+
+  private void expectTetheringControlResponse(String peerName, HttpResponseStatus status) throws IOException {
+
+    HttpRequest.Builder builder = HttpRequest.builder(HttpMethod.GET,
+                                                      config.resolveURL("tethering/controlchannels/" + peerName));
+    HttpResponse response = HttpRequests.execute(builder.build());
+    Assert.assertEquals(status.code(), response.getResponseCode());
+  }
+
+  private void createTethering(String peerName, List<NamespaceAllocation> namespaces) throws IOException {
+    TetheringConnectionRequest tetheringRequest = new TetheringConnectionRequest(namespaces);
+    doHttpRequest(HttpMethod.PUT, "tethering/connections/" + peerName, GSON.toJson(tetheringRequest));
+  }
+
+  private List<PeerState> getTetheringStatus() throws IOException {
+    Type type = new TypeToken<List<PeerState>>() { }.getType();
+    String responseBody = doHttpRequest(HttpMethod.GET, "tethering/connections");
+    return GSON.fromJson(responseBody, type);
+  }
+
+  private void expectTetheringStatus(String peerName, TetheringStatus tetheringStatus,
+                                     List<NamespaceAllocation> namespaces, TetheringConnectionStatus connectionStatus)
+    throws IOException {
+    List<PeerState> peerStateList = getTetheringStatus();
+    Assert.assertEquals(1, peerStateList.size());
+    PeerMetadata expectedPeerMetadata = new PeerMetadata(namespaces, Collections.emptyMap());
+    PeerState expectedPeerInfo = new PeerState(peerName, null, tetheringStatus,
+                                               expectedPeerMetadata, connectionStatus);
+    Assert.assertEquals(expectedPeerInfo, peerStateList.get(0));
+  }
+
+  private void deleteTethering() throws IOException {
+    doHttpRequest(HttpMethod.DELETE, "tethering/connections/xyz");
+  }
+
+  private void acceptTethering() throws IOException {
+    TetheringActionRequest request = new TetheringActionRequest("accept");
+    doHttpRequest(HttpMethod.POST, "tethering/connections/xyz", GSON.toJson(request));
+  }
+
+  private void rejectTethering() throws IOException {
+    TetheringActionRequest request = new TetheringActionRequest("reject");
+    doHttpRequest(HttpMethod.POST, "tethering/connections/xyz", GSON.toJson(request));
+  }
+
+  private String doHttpRequest(HttpMethod method, String endpoint, @Nullable String body) throws IOException {
+    HttpRequest.Builder builder = HttpRequest.builder(method, config.resolveURL(endpoint));
+    if (body != null) {
+      builder = builder.withBody(body);
+    }
+    HttpResponse response = HttpRequests.execute(builder.build());
+    Assert.assertEquals(HttpResponseStatus.OK.code(), response.getResponseCode());
+    return response.getResponseBodyAsString(StandardCharsets.UTF_8);
+  }
+
+  private String doHttpRequest(HttpMethod method, String endpoint) throws IOException {
+    return doHttpRequest(method, endpoint, null);
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -141,6 +141,7 @@ public final class Constants {
     public static final String PREVIEW_HTTP = "preview";
     public static final String SECURE_STORE_SERVICE = "secure.store.service";
     public static final String LOG_BUFFER_SERVICE = "log.buffer.service";
+    public static final String REMOTE_AGENT_SERVICE = "remote.agent.service";
   }
 
   /**
@@ -1777,5 +1778,25 @@ public final class Constants {
     public static final String MAX_RETRY_TIMES = "support.bundle.max.retry.times";
     public static final String MAX_THREAD_TIMEOUT = "support.bundle.max.thread.timeout";
     public static final String SYSTEM_LOG_START_TIME = "support.bundle.system.log.start.time";
+  }
+
+  public static final class Tethering {
+    public static final String TETHERING_SERVER_ENABLED = "tethering.server.enabled";
+    /**
+     * Prefix of per-client TMS topic used on the tethering server.
+     */
+    public static final String TOPIC_PREFIX = "tethering.topic.prefix";
+    /**
+     * Interval for connecting to the server.
+     */
+    public static final String CONNECTION_INTERVAL = "tethering.connection.interval.secs";
+
+    /**
+     * Tethering connection timeout.
+     */
+    public static final String CONNECTION_TIMEOUT_SECONDS = "tethering.connection.timeout.seconds";
+    public static final int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 60;
+
+    public static final String CLIENT_AUTHENTICATOR_CLASS = "tethering.client.authenticator.class";
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4480,7 +4480,7 @@
     </description>
   </property>
 
-  <property>CommonDirectiveExecutor
+  <property>
     <name>task.worker.preload.artifacts</name>
     <value></value>
     <description>
@@ -4656,6 +4656,63 @@
     <value>1</value>
     <description>
       system log start 1 day ago to collect logs
+    </description>
+  </property>
+
+ <property>
+   <name>tethering.agent.connection.interval.secs</name>
+   <value>10</value>
+   <description>
+     Interval for connecting to the tethering server.
+   </description>
+ </property>
+
+<property>
+    <name>tethering.agent.retry.policy.base.delay.ms</name>
+    <value>10000</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>tethering.agent.retry.policy.max.retries</name>
+    <value>8640</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <property>
+    <name>tethering.agent.retry.policy.max.time.secs</name>
+    <value>86400</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>tethering.agent.retry.policy.type</name>
+    <value>fixed.delay</value>
+    <description>
+      The type of retry policy for metrics publishing. Allowed options:
+      "none", "fixed.delay", or "exponential.backoff".
+    </description>
+  </property>
+
+  <property>
+    <name>tethering.topic.prefix</name>
+    <value>tethering_</value>
+    <description>
+      TMS topic prefix used on tethering server
+    </description>
+  </property>
+
+  <property>
+    <name>tethering.server.enabled</name>
+    <value>false</value>
+    <description>
+      Determines if tethering server shouuld be enabled.
     </description>
   </property>
 </configuration>

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
@@ -68,6 +68,7 @@ public final class StoreDefinition {
     FieldLineageStore.create(tableAdmin);
     LogFileMetaStore.create(tableAdmin);
     CapabilitiesStore.create(tableAdmin);
+    TetheringStore.create(tableAdmin);
   }
 
   /**
@@ -1008,6 +1009,34 @@ public final class StoreDefinition {
     public static void create(StructuredTableAdmin tableAdmin) throws IOException {
       createIfNotExists(tableAdmin, CAPABILITIES_TABLE_SPEC);
       createIfNotExists(tableAdmin, CAPABILITY_OPERATIONS_TABLE_SPEC);
+    }
+  }
+
+  /**
+   * Schema for tethering
+   */
+  public static final class TetheringStore {
+    public static final StructuredTableId TETHERING = new StructuredTableId("tethering");
+
+    public static final String PEER_NAME_FIELD = "name";
+    public static final String PEER_URI_FIELD = "uri";
+    public static final String TETHERING_STATE_FIELD = "state";
+    public static final String LAST_CONNECTION_TIME_FIELD = "last_connection_time";
+    public static final String PEER_METADATA_FIELD = "metadata";
+
+    public static final StructuredTableSpecification TETHERING_TABLE_SPEC =
+      new StructuredTableSpecification.Builder()
+        .withId(TETHERING)
+        .withFields(Fields.stringType(PEER_NAME_FIELD),
+                    Fields.stringType(PEER_URI_FIELD),
+                    Fields.stringType(TETHERING_STATE_FIELD),
+                    Fields.longType(LAST_CONNECTION_TIME_FIELD),
+                    Fields.stringType(PEER_METADATA_FIELD))
+        .withPrimaryKeys(PEER_NAME_FIELD)
+        .build();
+
+    public static void create(StructuredTableAdmin tableAdmin) throws IOException {
+      createIfNotExists(tableAdmin, TETHERING_TABLE_SPEC);
     }
   }
 }

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/TetheringAgentServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/TetheringAgentServiceMain.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import com.google.common.util.concurrent.Service;
+import com.google.inject.Binding;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.PrivateModule;
+import com.google.inject.Scopes;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.app.guice.NamespaceAdminModule;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.logging.LoggingContext;
+import io.cdap.cdap.common.logging.ServiceLoggingContext;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
+import io.cdap.cdap.internal.tethering.TetheringAgentService;
+import io.cdap.cdap.master.spi.environment.MasterEnvironment;
+import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
+import io.cdap.cdap.metrics.collect.LocalMetricsCollectionService;
+import io.cdap.cdap.proto.id.NamespaceId;
+import org.apache.tephra.runtime.TransactionModules;
+import org.apache.twill.zookeeper.ZKClientService;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Main class for running remote agent service in Kubernetes.
+ */
+public class
+TetheringAgentServiceMain extends AbstractServiceMain<EnvironmentOptions> {
+  /**
+   * Main entry point
+   */
+  public static void main(String[] args) throws Exception {
+    main(TetheringAgentServiceMain.class, args);
+  }
+
+  @Override
+  protected List<Module> getServiceModules(MasterEnvironment masterEnv,
+                                           EnvironmentOptions options, CConfiguration cConf) {
+    return Arrays.asList(
+      new ConfigModule(cConf),
+      new SystemDatasetRuntimeModule().getStandaloneModules(),
+      new TransactionModules().getSingleNodeModules(),
+      new NamespaceAdminModule().getStandaloneModules(),
+      new StorageModule(),
+      new PrivateModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(LocalMetricsCollectionService.class).in(Scopes.SINGLETON);
+          expose(MetricsCollectionService.class);
+          bind(TetheringAgentService.class).in(Scopes.SINGLETON);
+          expose(TetheringAgentService.class);
+        }
+      });
+  }
+
+  @Override
+  protected void addServices(Injector injector, List<? super Service> services,
+                             List<? super AutoCloseable> closeableResources,
+                             MasterEnvironment masterEnv, MasterEnvironmentContext masterEnvContext,
+                             EnvironmentOptions options) {
+    Binding<ZKClientService> zkBinding = injector.getExistingBinding(Key.get(ZKClientService.class));
+    if (zkBinding != null) {
+      services.add(zkBinding.getProvider().get());
+    }
+    services.add(injector.getInstance(TetheringAgentService.class));
+  }
+
+  @Nullable
+  @Override
+  protected LoggingContext getLoggingContext(EnvironmentOptions options) {
+    return new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
+                                     Constants.Logging.COMPONENT_NAME,
+                                     Constants.Service.REMOTE_AGENT_SERVICE);
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/NamespaceMeta.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/NamespaceMeta.java
@@ -190,6 +190,11 @@ public final class NamespaceMeta {
       return this;
     }
 
+    public Builder setConfig(Map<String, String> configMap) {
+      this.configMap = configMap;
+      return this;
+    }
+
     public NamespaceMeta build() {
       // combine the keytab URI with the version if the version is not 0
       String uri = keytabURIVersion == 0 ? keytabURIWithoutVersion : keytabURIWithoutVersion + "#" + keytabURIVersion;


### PR DESCRIPTION
Add support for establishing tethering between client and server.

* Add APIs to create, accept, reject, delete and get status of tethering
* Add RemoteAgent Service which is responsible for polling the server for commands
* On the server, commands are written to a per-peer TMS topic, sent to the peer when polled.