### PR TITLE
[CDAP-18586] Deprecate getApplicationSpecification in ProgramStatusTriggerInfo

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/schedule/ProgramStatusTriggerInfo.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/schedule/ProgramStatusTriggerInfo.java
@@ -37,8 +37,15 @@ public interface ProgramStatusTriggerInfo extends TriggerInfo {
 
   /**
    * @return The application specification of the application that contains the triggering program.
+   * @deprecated Use {@link #getApplicationName()} instead if the application name is needed.
    */
+  @Deprecated
   ApplicationSpecification getApplicationSpecification();
+
+  /**
+   * @return The name of the application that contains the triggering program.
+   */
+  String getApplicationName();
 
   /**
    * @return The program type of the triggering program.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/DefaultProgramStatusTriggerInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/DefaultProgramStatusTriggerInfo.java
@@ -88,6 +88,11 @@ public class DefaultProgramStatusTriggerInfo extends AbstractTriggerInfo
   }
 
   @Override
+  public String getApplicationName() {
+    return applicationSpecification.getName();
+  }
+
+  @Override
   public ProgramType getProgramType() {
     return programType;
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/TriggeringScheduleInfoAdapterTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/TriggeringScheduleInfoAdapterTest.java
@@ -67,8 +67,8 @@ public class TriggeringScheduleInfoAdapterTest {
       (DefaultProgramStatusTriggerInfo) triggerInfos.get(0);
     DefaultProgramStatusTriggerInfo deserializedProgramStatusTriggerInfo =
       (DefaultProgramStatusTriggerInfo) deserializedScheduleInfo.getTriggerInfos().get(0);
-    Assert.assertEquals(expectedProgramStatusTriggerInfo.getApplicationSpecification().getName(),
-                        deserializedProgramStatusTriggerInfo.getApplicationSpecification().getName());
+    Assert.assertEquals(expectedProgramStatusTriggerInfo.getApplicationName(),
+                        deserializedProgramStatusTriggerInfo.getApplicationName());
     Assert.assertEquals(expectedProgramStatusTriggerInfo.getWorkflowToken().getAll(),
                         deserializedProgramStatusTriggerInfo.getWorkflowToken().getAll());
   }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/SmartWorkflow.java
@@ -410,7 +410,7 @@ public class SmartWorkflow extends AbstractWorkflow {
       if (value == null) {
         LOG.warn("Runtime argument '{}' is not found in run '{}' of the triggering pipeline '{}' " +
                    "in namespace '{}' ",
-                 sourceKey, triggerInfo.getRunId(), triggerInfo.getApplicationSpecification().getName(),
+                 sourceKey, triggerInfo.getRunId(), triggerInfo.getApplicationName(),
                  triggerInfo.getNamespace());
         continue;
       }
@@ -430,7 +430,7 @@ public class SmartWorkflow extends AbstractWorkflow {
       Map<String, String> pluginProperties = resolvedProperties.get(stageName);
       if (pluginProperties == null) {
         LOG.warn("No plugin properties can be found with stage name '{}' in triggering pipeline '{}' " +
-                   "in namespace '{}' ", mapping.getStageName(), triggerInfo.getApplicationSpecification().getName(),
+                   "in namespace '{}' ", mapping.getStageName(), triggerInfo.getApplicationName(),
                  triggerInfo.getNamespace());
         continue;
       }
@@ -443,7 +443,7 @@ public class SmartWorkflow extends AbstractWorkflow {
       String value = pluginProperties.get(sourceKey);
       if (value == null) {
         LOG.warn("No property with name '{}' can be found in plugin '{}' of the triggering pipeline '{}' " +
-                   "in namespace '{}' ", sourceKey, stageName, triggerInfo.getApplicationSpecification().getName(),
+                   "in namespace '{}' ", sourceKey, stageName, triggerInfo.getApplicationName(),
                  triggerInfo.getNamespace());
         continue;
       }


### PR DESCRIPTION
    Why:
    ApplicationSpecification can be fairly large due to it storing
    app config and plugin info. ProgramStatusTriggerInfo doesn't
    need entire application spec, only the application name for
    logging purpose.

    A large ProgramStatusTriggerInfo can be problematic because
    it is included in run record. Large run record may lead to
    out of memory issues.

    What:
    This PR does
    - deprecate getApplicationSpecification() API
    - introduce getApplicationName() API

    Once the API gets removed, we can replace ApplicationSpecification
    with Application name, so reduce the size of trigger info