### PR TITLE
[CDAP-18587] Fetch artifacts in spark-driver from workflow pod instead of appfabric

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -382,19 +382,6 @@ public final class Constants {
   }
 
   /**
-   * Spark on k8s
-   */
-  public static final class Spark {
-    public static final class Driver {
-      public static final String ADDRESS = "driver.artifact.fetcher.bind.address";
-      public static final String PORT = "driver.artifact.fetcher.bind.port";
-      public static final String EXEC_THREADS = "driver.artifact.fetcher.exec.threads";
-      public static final String BOSS_THREADS = "driver.artifact.fetcher.boss.threads";
-      public static final String WORKER_THREADS = "driver.artifact.fetcher.worker.threads";
-    }
-  }
-
-  /**
    * Environment configurations.
    */
   public static final class Environment {

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4360,15 +4360,7 @@
 
   <!-- Spark on k8s  -->
   <property>
-    <name>driver.artifact.fetcher.bind.address</name>
-    <value>0.0.0.0</value>
-    <description>
-      The bind address for artifact fetcher service
-    </description>
-  </property>
-
-  <property>
-    <name>driver.artifact.fetcher.bind.port</name>
+    <name>artifact.fetcher.bind.port</name>
     <value>11013</value>
     <description>
       The bind port for artifact fetcher service

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/Constant.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/Constant.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.runtime.spark;
+
+/**
+ * Constants used by spark extension are all defined here.
+ */
+public class Constant {
+  /**
+   * Spark on k8s
+   */
+  public static final class Spark {
+    public static final class ArtifactFetcher {
+      public static final String PORT = "artifact.fetcher.bind.port";
+    }
+
+    public static final class Driver {
+      public static final String EXEC_THREADS = "driver.artifact.fetcher.exec.threads";
+      public static final String BOSS_THREADS = "driver.artifact.fetcher.boss.threads";
+      public static final String WORKER_THREADS = "driver.artifact.fetcher.worker.threads";
+    }
+  }
+}

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -121,6 +121,7 @@ public final class SparkRuntimeContextProvider {
   static final String PROGRAM_JAR_EXPANDED_NAME = "program.jar.expanded.zip";
   static final String PROGRAM_JAR_NAME = "program.jar";
   static final String EXECUTOR_CLASSLOADER_NAME = "org.apache.spark.repl.ExecutorClassLoader";
+  public static final String ARTIFACTS_DIRECTORY_NAME = "artifacts_archive.jar";
 
   private static volatile SparkRuntimeContext sparkRuntimeContext;
   private static String masterEnvName;

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/k8s/SparkContainerDriverLauncher.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/k8s/SparkContainerDriverLauncher.java
@@ -29,8 +29,11 @@ import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.plugin.Plugin;
 import io.cdap.cdap.app.runtime.Arguments;
 import io.cdap.cdap.app.runtime.ProgramOptions;
+import io.cdap.cdap.app.runtime.spark.SparkRuntimeContextProvider;
 import io.cdap.cdap.app.runtime.spark.distributed.SparkContainerLauncher;
+import io.cdap.cdap.app.runtime.spark.service.ArtifactFetcherService;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.SupplierProviderBridge;
@@ -40,9 +43,7 @@ import io.cdap.cdap.common.lang.jar.BundleJarUtil;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import io.cdap.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
-import io.cdap.cdap.internal.app.spark.ArtifactFetcherService;
 import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizer;
-import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
 import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
@@ -57,15 +58,19 @@ import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.FileAlreadyExistsException;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -76,6 +81,7 @@ import java.util.zip.GZIPInputStream;
  * Spark container launcher for launching spark drivers, and also allowing spark executors to fetch artifacts from it.
  */
 public class SparkContainerDriverLauncher {
+  private static final Logger LOG = LoggerFactory.getLogger(SparkContainerDriverLauncher.class);
   private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
     .registerTypeAdapter(Arguments.class, new ArgumentsCodec())
     .registerTypeAdapter(ProgramOptions.class, new ProgramOptionsCodec())
@@ -86,6 +92,8 @@ public class SparkContainerDriverLauncher {
   private static final String PROGRAM_ID_KEY = "cdap.spark.program.id";
   private static final String DEFAULT_DELEGATE_CLASS = "org.apache.spark.deploy.SparkSubmit";
   private static final String DELEGATE_CLASS_FLAG = "--delegate-class";
+  private static final String ARTIFACT_FETCHER_URI_FLAG = "--artifact-fetcher-uri";
+  private static final String ARTIFACT_FETCHER_ENDPOINT = Constants.Gateway.INTERNAL_API_VERSION_3 + "/artifacts/fetch";
 
   private static final String WORKING_DIRECTORY = "/opt/spark/work-dir/";
   private static final String SPARK_LOCAL_DIR = System.getenv("SPARK_LOCAL_DIRS") + "/";
@@ -97,10 +105,16 @@ public class SparkContainerDriverLauncher {
 
   public static void main(String[] args) throws Exception {
     String delegateClass = DEFAULT_DELEGATE_CLASS;
+    String artifactFetcherUri = null;
+//    TODO (CDAP-18515) Fix increments inside for-loop once CDAP-18515 is closed.
     List<String> delegateArgs = new ArrayList<>();
     for (int i = 0; i < args.length; i++) {
       if (args[i].equals(DELEGATE_CLASS_FLAG)) {
         delegateClass = args[i + 1];
+        i++;
+        continue;
+      } else if (args[i].equals(ARTIFACT_FETCHER_URI_FLAG)) {
+        artifactFetcherUri = args[i + 1];
         i++;
         continue;
       }
@@ -125,14 +139,60 @@ public class SparkContainerDriverLauncher {
     CConfiguration cConf = CConfiguration.create(new File(CCONF_PATH));
     Configuration hConf = new Configuration();
     hConf.addResource(new org.apache.hadoop.fs.Path("file:" + new File(HCONF_PATH).getAbsolutePath()));
-    ArtifactLocalizerClient fetchArtifacts = createArtifactLocalizerClient(cConf, hConf);
 
+    if (artifactFetcherUri == null) {
+      LOG.warn("Localizing artifacts from appfabric");
+      localizeArtifactsFromAppfabric(cConf, hConf);
+    } else {
+      try {
+        LOG.info(String.format("Localizing artifacts from %s", artifactFetcherUri));
+        localizeArtifactsBundle(artifactFetcherUri);
+      } catch (Exception e) {
+        LOG.warn(String.format("Localizing artifacts from appfabric due to %s", e.getMessage()));
+        localizeArtifactsFromAppfabric(cConf, hConf);
+      }
+    }
+
+    artifactFetcherService =
+      new ArtifactFetcherService(cConf, createBundle(new File(WORKING_DIRECTORY).getAbsoluteFile().toPath()));
+    artifactFetcherService.startAndWait();
+
+    SparkContainerLauncher.launch(delegateClass, delegateArgs.toArray(new String[delegateArgs.size()]), false, "k8s");
+  }
+
+  /**
+   * Localizes artifacts bundle from the provided uri, and unjar the bundle into
+   * {@link SparkContainerDriverLauncher#WORKING_DIRECTORY}.
+   *
+   * @param artifactFetcherUri uri for fetching artifacts bundle from.
+   * @throws Exception
+   */
+  private static void localizeArtifactsBundle(String artifactFetcherUri) throws Exception {
+    URL fetchArtifactURL =
+      new URL(String.format("%s%s", artifactFetcherUri, ARTIFACT_FETCHER_ENDPOINT));
+    HttpURLConnection connection = (HttpURLConnection) fetchArtifactURL.openConnection();
+    connection.connect();
+
+    Path bundleJarFile = new File(WORKING_DIRECTORY).toPath().resolve("bundle.jar");
+    try (InputStream in = connection.getInputStream()) {
+      Files.copy(in, bundleJarFile, StandardCopyOption.REPLACE_EXISTING);
+    } finally {
+      connection.disconnect();
+    }
+
+    BundleJarUtil.unJar(bundleJarFile.toFile(), new File(WORKING_DIRECTORY).getAbsoluteFile());
+    Files.delete(bundleJarFile);
+  }
+
+  private static void localizeArtifactsFromAppfabric(CConfiguration cConf, Configuration hConf) throws Exception {
+    ArtifactLocalizerClient fetchArtifacts = createArtifactLocalizerClient(cConf, hConf);
     ApplicationSpecification spec =
       GSON.fromJson(hConf.getRaw(CDAP_APP_SPEC_KEY), ApplicationSpecification.class);
     ProgramId programId = GSON.fromJson(hConf.getRaw(PROGRAM_ID_KEY), ProgramId.class);
 
     //Create plugin location for storing plugin jars
-    Path pluginsLocation = new File(WORKING_DIRECTORY).getAbsoluteFile().toPath().resolve("artifacts_archive.jar")
+    Path pluginsLocation = new File(WORKING_DIRECTORY).getAbsoluteFile().toPath()
+      .resolve(SparkRuntimeContextProvider.ARTIFACTS_DIRECTORY_NAME)
       .toAbsolutePath();
     Files.createDirectories(pluginsLocation);
 
@@ -157,14 +217,7 @@ public class SparkContainerDriverLauncher {
     File tempLocation = fetchArtifacts.localizeArtifact(spec.getArtifactId(), programId.getNamespace());
     BundleJarUtil.unJar(tempLocation, programJarLocation.resolve(PROGRAM_JAR_EXPANDED_NAME).toFile());
     Files.copy(tempLocation.toPath(), programJarLocation.resolve(PROGRAM_JAR_NAME));
-
-    artifactFetcherService =
-      new ArtifactFetcherService(cConf, createBundle(new File(WORKING_DIRECTORY).getAbsoluteFile().toPath()));
-    artifactFetcherService.startAndWait();
-
-    SparkContainerLauncher.launch(delegateClass, delegateArgs.toArray(new String[delegateArgs.size()]), false, "k8s");
   }
-
 
   private static ArtifactLocalizerClient createArtifactLocalizerClient(CConfiguration cConf, Configuration hConf)
     throws Exception {

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/service/ArtifactFetcherHttpHandler.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/service/ArtifactFetcherHttpHandler.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.internal.app.spark;
+package io.cdap.cdap.app.runtime.spark.service;
 
 
 import io.cdap.cdap.common.conf.Constants;

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/service/ArtifactFetcherService.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/service/ArtifactFetcherService.java
@@ -14,11 +14,11 @@
  * the License.
  */
 
-package io.cdap.cdap.internal.app.spark;
+package io.cdap.cdap.app.runtime.spark.service;
 
 import com.google.common.util.concurrent.AbstractIdleService;
+import io.cdap.cdap.app.runtime.spark.Constant;
 import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
 import io.cdap.http.NettyHttpService;
 import org.apache.twill.filesystem.Location;
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class ArtifactFetcherService extends AbstractIdleService {
   private static final Logger LOG = LoggerFactory.getLogger(ArtifactFetcherService.class);
+  private static final String BIND_ADDRESS = "0.0.0.0";
 
   private final NettyHttpService httpService;
 
@@ -40,11 +41,11 @@ public class ArtifactFetcherService extends AbstractIdleService {
       .setHttpHandlers(
         new ArtifactFetcherHttpHandler(bundleLocation)
       )
-      .setHost(cConf.get(Constants.Spark.Driver.ADDRESS))
-      .setPort(cConf.getInt(Constants.Spark.Driver.PORT))
-      .setExecThreadPoolSize(cConf.getInt(Constants.Spark.Driver.EXEC_THREADS))
-      .setBossThreadPoolSize(cConf.getInt(Constants.Spark.Driver.BOSS_THREADS))
-      .setWorkerThreadPoolSize(cConf.getInt(Constants.Spark.Driver.WORKER_THREADS))
+      .setHost(BIND_ADDRESS)
+      .setPort(cConf.getInt(Constant.Spark.ArtifactFetcher.PORT))
+      .setExecThreadPoolSize(cConf.getInt(Constant.Spark.Driver.EXEC_THREADS))
+      .setBossThreadPoolSize(cConf.getInt(Constant.Spark.Driver.BOSS_THREADS))
+      .setWorkerThreadPoolSize(cConf.getInt(Constant.Spark.Driver.WORKER_THREADS))
       .build();
   }
 

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
@@ -35,7 +35,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.twill.filesystem.LocationFactory;
 
-
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
@@ -91,7 +90,8 @@ public class MasterEnvironmentSparkSubmitter extends AbstractSparkSubmitter {
     Map<String, String> config = new HashMap<>();
     config.put(SparkConfig.DRIVER_ENV_PREFIX + "CDAP_LOG_DIR", ApplicationConstants.LOG_DIR_EXPANSION_VAR);
     config.put("spark.executorEnv.CDAP_LOG_DIR", ApplicationConstants.LOG_DIR_EXPANSION_VAR);
-    config.put("spark.executorEnv.ARTIFACT_FECTHER_PORT", cConf.get(Constants.Spark.Driver.PORT));
+    config.put("spark.executorEnv.ARTIFACT_FECTHER_PORT",
+               cConf.get(io.cdap.cdap.app.runtime.spark.Constant.Spark.ArtifactFetcher.PORT));
     config.putAll(generateOrGetSparkConfig().getConfigs());
     return config;
   }
@@ -109,6 +109,14 @@ public class MasterEnvironmentSparkSubmitter extends AbstractSparkSubmitter {
     String uri = String.format("http://%s:%d", socketAddress.getAddress().getHostAddress(), socketAddress.getPort());
     SparkRuntimeEnv.setProperty(SparkConfig.DRIVER_ENV_PREFIX + SparkRuntimeUtils.CDAP_SPARK_EXECUTION_SERVICE_URI,
                                 uri);
+
+    if (cConf.get(io.cdap.cdap.app.runtime.spark.Constant.Spark.ArtifactFetcher.PORT) != null) {
+      String artifactFetcherUri =
+        String.format("http://%s:%s", socketAddress.getAddress().getHostAddress(),
+                      cConf.get(io.cdap.cdap.app.runtime.spark.Constant.Spark.ArtifactFetcher.PORT));
+      SparkRuntimeEnv.setProperty(SparkConfig.DRIVER_ENV_PREFIX + "ARTIFACT_FECTHER_URI",
+                                  artifactFetcherUri);
+    }
     return Collections.emptyList();
   }
 

--- a/cdap-spark-core3_2.12/src/k8s/entrypoint.sh
+++ b/cdap-spark-core3_2.12/src/k8s/entrypoint.sh
@@ -93,6 +93,7 @@ case "$1" in
       io.cdap.cdap.app.runtime.spark.distributed.k8s.SparkContainerDriverLauncher
       --delegate-class org.apache.spark.deploy.SparkSubmit
       --conf "spark.driver.bindAddress=$SPARK_DRIVER_BIND_ADDRESS"
+      --artifact-fetcher-uri $ARTIFACT_FECTHER_URI
       --deploy-mode client
       "$@"
     )


### PR DESCRIPTION
Currently for cdap-on-k8s, both workflow and spark-driver pods fetch their artifact from app-fabric. Spark-executors fetch their artifacts from their spark-driver pod. Therefore, for every workflow run, app-fabric needs to serve artifacts twice. 

This PR addresses the above issue in order to make cdap-on-k8s more scalable as follows: a workflow pod still fetches its artifacts from app-fabric. However, spark-driver now fetches its required artifacts from workflow pod instead of app-fabric. 