### PR TITLE
Add classes for fields to support BQ pushdown for aggregations

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/Field.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/Field.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+public abstract class Field {
+  protected String fieldName;
+  protected String alias;
+
+  public Field(String fieldName) {
+    this(fieldName, null);
+  }
+
+  public Field(String fieldName, @Nullable String alias) {
+    this.fieldName = fieldName;
+    this.alias = alias;
+  }
+
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  @Nullable
+  public String getAlias() {
+    return alias;
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (this == that) {
+      return true;
+    }
+    if (that == null || getClass() != that.getClass()) {
+      return false;
+    }
+    Field field = (Field) that;
+    return Objects.equals(fieldName, field.fieldName) &&
+        Objects.equals(alias, field.alias);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fieldName, alias);
+  }
+
+  @Override
+  public String toString() {
+    return "Field{" +
+        "field='" + fieldName + '\'' +
+        ", alias='" + alias + '\'' +
+        '}';
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/AggregationField.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/AggregationField.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.aggregation;
+
+import io.cdap.cdap.etl.api.Field;
+
+import java.util.Objects;
+
+public class AggregationField extends Field {
+  private String aggregateFunction;
+
+  public AggregationField(String fieldName, String alias, String aggregateFunction) {
+    super(fieldName, alias);
+    this.aggregateFunction = aggregateFunction;
+  }
+
+  public String getAggregateFunction() {
+    return aggregateFunction;
+  }
+
+  @Override
+  public boolean equals(Object that) {
+    if (this == that) {
+      return true;
+    }
+    if (that == null || getClass() != that.getClass()) {
+      return false;
+    }
+    AggregationField field = (AggregationField) that;
+    return Objects.equals(fieldName, field.getFieldName()) &&
+      Objects.equals(alias, field.getAlias()) &&
+      Objects.equals(aggregateFunction, field.getAggregateFunction());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fieldName, alias, aggregateFunction);
+  }
+
+  @Override
+  public String toString() {
+    return "AggregationField{" +
+      "field='" + fieldName + '\'' +
+      ", aggregateFunction='" + aggregateFunction + '\'' +
+      ", alias='" + alias + '\'' +
+      '}';
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/GroupByField.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/GroupByField.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.aggregation;
+
+import io.cdap.cdap.etl.api.Field;
+
+public class GroupByField extends Field {
+  public GroupByField(String fieldName) {
+    super(fieldName);
+  }
+
+  public GroupByField(String fieldName, String alias) {
+    super(fieldName, alias);
+  }
+
+  @Override
+  public String toString() {
+    return "GroupByField{" +
+      "field='" + fieldName + '\'' +
+      ", alias='" + alias + '\'' +
+      '}';
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinField.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/join/JoinField.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.etl.api.join;
 
 import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.etl.api.Field;
 
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -25,32 +26,20 @@ import javax.annotation.Nullable;
  * The name of a field and an optional alias to rename it to.
  */
 @Beta
-public class JoinField {
+public class JoinField extends Field {
   private final String stageName;
-  private final String fieldName;
-  private final String alias;
 
   public JoinField(String stageName, String fieldName) {
     this(stageName, fieldName, null);
   }
 
   public JoinField(String stageName, String fieldName, @Nullable String alias) {
+    super(fieldName, alias);
     this.stageName = stageName;
-    this.fieldName = fieldName;
-    this.alias = alias;
   }
 
   public String getStageName() {
     return stageName;
-  }
-
-  public String getFieldName() {
-    return fieldName;
-  }
-
-  @Nullable
-  public String getAlias() {
-    return alias;
   }
 
   @Override
@@ -74,7 +63,7 @@ public class JoinField {
 
   @Override
   public String toString() {
-    return "Field{" +
+    return "JoinField{" +
       "stage='" + stageName + '\'' +
       ", field='" + fieldName + '\'' +
       ", alias='" + alias + '\'' +


### PR DESCRIPTION
This PR adds a class hierarchy for fields to be used in aggregation definitions, which will in turn be used for BQ pushdowns for aggregations.

Cherry-picked version of #13732 after test failures were fixed.