### PR TITLE
CDAP-18010: Include namespace in ArtifactDescriptor

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactDescriptor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactDescriptor.java
@@ -20,12 +20,14 @@ import io.cdap.cdap.api.artifact.ArtifactId;
 import org.apache.twill.filesystem.Location;
 
 import java.net.URI;
+import java.util.Objects;
 
 /**
  * Uniquely describes an artifact. Artifact descriptors are ordered by scope,
  * then by name, and finally by version.
  */
 public final class ArtifactDescriptor implements Comparable<ArtifactDescriptor> {
+  private final String namespace;
   private final ArtifactId artifactId;
 
   /**
@@ -37,14 +39,20 @@ public final class ArtifactDescriptor implements Comparable<ArtifactDescriptor> 
   private final transient Location location;
   private final URI locationURI;
 
-  public ArtifactDescriptor(ArtifactId artifactId, Location location) {
+  public ArtifactDescriptor(String namespace, ArtifactId artifactId, Location location) {
+    this.namespace = namespace;
     this.artifactId = artifactId;
     this.location = location;
     this.locationURI = location.toURI();
   }
 
+  public String getNamespace() {
+    return namespace;
+  }
+
   /**
    * get artifact Id
+   *
    * @return {@link ArtifactId}
    */
   public ArtifactId getArtifactId() {
@@ -53,6 +61,7 @@ public final class ArtifactDescriptor implements Comparable<ArtifactDescriptor> 
 
   /**
    * get location of artifact
+   *
    * @return {@link Location} of artifact
    */
   public Location getLocation() {
@@ -66,7 +75,8 @@ public final class ArtifactDescriptor implements Comparable<ArtifactDescriptor> 
   @Override
   public String toString() {
     return "ArtifactDescriptor{" +
-      "artifactId=" + artifactId +
+      " artifactId=" + artifactId +
+      ", namespace=" + namespace +
       ", locationURI=" + locationURI +
       ", location=" + location +
       '}';
@@ -87,11 +97,15 @@ public final class ArtifactDescriptor implements Comparable<ArtifactDescriptor> 
 
   @Override
   public int hashCode() {
-    return artifactId.hashCode();
+    return Objects.hash(namespace, artifactId);
   }
 
   @Override
   public int compareTo(ArtifactDescriptor other) {
+    int code = getNamespace().compareTo(other.getNamespace());
+    if (code != 0) {
+      return code;
+    }
     return getArtifactId().compareTo(other.getArtifactId());
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepositoryReader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepositoryReader.java
@@ -93,7 +93,8 @@ public class RemoteArtifactRepositoryReader implements ArtifactRepositoryReader 
     
     Location artifactLocation = Locations
         .getLocationFromAbsolutePath(locationFactory, detail.getDescriptor().getLocationURI().getPath());
-    return new ArtifactDetail(new ArtifactDescriptor(detail.getDescriptor().getArtifactId(), artifactLocation),
+    return new ArtifactDetail(new ArtifactDescriptor(detail.getDescriptor().getNamespace(),
+                                                     detail.getDescriptor().getArtifactId(), artifactLocation),
                               detail.getMeta());
   }
 
@@ -154,7 +155,8 @@ public class RemoteArtifactRepositoryReader implements ArtifactRepositoryReader 
     for (ArtifactDetail detail : details) {
       Location artifactLocation = locationFactory.create(detail.getDescriptor().getLocationURI());
       detailList.add(
-        new ArtifactDetail(new ArtifactDescriptor(detail.getDescriptor().getArtifactId(), artifactLocation),
+        new ArtifactDetail(new ArtifactDescriptor(detail.getDescriptor().getNamespace(),
+                                                  detail.getDescriptor().getArtifactId(), artifactLocation),
                            detail.getMeta()));
     }
     return detailList;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
@@ -116,7 +116,8 @@ public class RemotePluginFinder implements PluginFinder {
 
         Location artifactLocation = getArtifactLocation(Artifacts.toProtoArtifactId(pluginNamespaceId,
                                                                                     selected.getKey()));
-        return Maps.immutableEntry(new ArtifactDescriptor(selected.getKey(), artifactLocation), selected.getValue());
+        return Maps.immutableEntry(new ArtifactDescriptor(pluginNamespaceId.getEntityName(),
+                                                          selected.getKey(), artifactLocation), selected.getValue());
       }, retryStrategy);
     } catch (PluginNotExistsException e) {
       throw e;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
@@ -206,7 +206,8 @@ public class AbstractProgramRuntimeServiceTest {
       protected ArtifactDetail getArtifactDetail(ArtifactId artifactId) throws IOException, ArtifactNotFoundException {
         io.cdap.cdap.api.artifact.ArtifactId id = new io.cdap.cdap.api.artifact.ArtifactId(
           "dummy", new ArtifactVersion("1.0"), ArtifactScope.USER);
-        return new ArtifactDetail(new ArtifactDescriptor(id, Locations.toLocation(TEMP_FOLDER.newFile())),
+        return new ArtifactDetail(new ArtifactDescriptor(NamespaceId.DEFAULT.getEntityName(),
+                                                         id, Locations.toLocation(TEMP_FOLDER.newFile())),
                                   new ArtifactMeta(ArtifactClasses.builder().build()));
       }
     };
@@ -446,7 +447,8 @@ public class AbstractProgramRuntimeServiceTest {
     protected ArtifactDetail getArtifactDetail(ArtifactId artifactId) throws IOException {
       io.cdap.cdap.api.artifact.ArtifactId id = new io.cdap.cdap.api.artifact.ArtifactId(
         "dummy", new ArtifactVersion("1.0"), ArtifactScope.USER);
-      return new ArtifactDetail(new ArtifactDescriptor(id, Locations.toLocation(TEMP_FOLDER.newFile())),
+      return new ArtifactDetail(new ArtifactDescriptor(NamespaceId.DEFAULT.getNamespace(),
+                                                       id, Locations.toLocation(TEMP_FOLDER.newFile())),
                                 new ArtifactMeta(ArtifactClasses.builder().build()));
     }
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
@@ -81,6 +81,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -156,7 +157,8 @@ public class RemoteConfiguratorTest {
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, AllProgramsApp.class);
     ArtifactId artifactId = NamespaceId.DEFAULT.artifact(AllProgramsApp.class.getSimpleName(), "1.0.0");
 
-    artifacts.put(artifactId, new ArtifactDetail(new ArtifactDescriptor(artifactId.toApiArtifactId(), appJar),
+    artifacts.put(artifactId, new ArtifactDetail(new ArtifactDescriptor(artifactId.getNamespace(),
+                                                                        artifactId.toApiArtifactId(), appJar),
                                                  new ArtifactMeta(ArtifactClasses.builder().build())));
 
     AppDeploymentInfo info = new AppDeploymentInfo(artifactId, appJar, NamespaceId.DEFAULT,
@@ -209,7 +211,8 @@ public class RemoteConfiguratorTest {
     Location appJar = AppJarHelper.createDeploymentJar(locationFactory, ConfigTestApp.class);
     ArtifactId artifactId = NamespaceId.DEFAULT.artifact(ConfigTestApp.class.getSimpleName(), "1.0.0");
 
-    artifacts.put(artifactId, new ArtifactDetail(new ArtifactDescriptor(artifactId.toApiArtifactId(), appJar),
+    artifacts.put(artifactId, new ArtifactDetail(new ArtifactDescriptor(artifactId.getNamespace(),
+                                                                        artifactId.toApiArtifactId(), appJar),
                                                  new ArtifactMeta(ArtifactClasses.builder().build())));
 
     AppDeploymentInfo info = new AppDeploymentInfo(artifactId, appJar, NamespaceId.DEFAULT,


### PR DESCRIPTION
This is part 1 of isolating artifact inspection.

Why:
Running artifact inspection in isolation requires artifact ids
for fetching them from appfabric. ArtifactDescriptor is available
in the artifact inspection process but it doesn't contain namespace.

Cherry-pick into 6.5 release branch as a follow-up PR requires 
this namespace in artifact detail 