### PR TITLE
[CDAP-18627] LevelDB increasing default block size 1K -> 8K

### DIFF
--- a/cdap-standalone/src/main/resources/cdap-site.xml
+++ b/cdap-standalone/src/main/resources/cdap-site.xml
@@ -91,7 +91,7 @@
 
   <property>
     <name>data.local.storage.blocksize</name>
-    <value>1024</value>
+    <value>8192</value>
     <description>
       Block size in bytes for data fabric when in CDAP Local Sandbox
     </description>


### PR DESCRIPTION
Why:
Larger block size is preferred for scan access pattern.
This is the typical access pattern in CDAP.