### PR TITLE
[CDAP-18627] Split preview leveldb store into 2 stores.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStore.java
@@ -61,6 +61,7 @@ import javax.annotation.Nullable;
  */
 public class DefaultPreviewStore implements PreviewStore {
   private static final DatasetId PREVIEW_TABLE_ID = NamespaceId.SYSTEM.dataset("preview.table");
+  private static final DatasetId PREVIEW_QUEUE_TABLE_ID = NamespaceId.SYSTEM.dataset("preview.queue.table");
   private static final byte[] DATA_ROW_KEY_PREFIX = Bytes.toBytes("dr");
   private static final byte[] META_ROW_KEY_PREFIX = Bytes.toBytes("mr");
   private static final byte[] TRACER = Bytes.toBytes("t");
@@ -69,7 +70,6 @@ public class DefaultPreviewStore implements PreviewStore {
   private static final byte[] RUN = Bytes.toBytes("r");
   private static final byte[] STATUS = Bytes.toBytes("s");
   private static final byte[] POLLERINFO = Bytes.toBytes("i");
-
   /*
    * Row storing the preview requests waiting for execution
    * |------------------------------------|--------------------|-----------------|
@@ -86,7 +86,8 @@ public class DefaultPreviewStore implements PreviewStore {
 
   private final AtomicLong counter = new AtomicLong(0L);
 
-  private final LevelDBTableCore table;
+  private final LevelDBTableCore previewTable;
+  private final LevelDBTableCore previewQueueTable;
   private final LevelDBTableService service;
 
   @Inject
@@ -94,7 +95,9 @@ public class DefaultPreviewStore implements PreviewStore {
     try {
       this.service = service;
       service.ensureTableExists(PREVIEW_TABLE_ID.getDataset());
-      this.table = new LevelDBTableCore(PREVIEW_TABLE_ID.getDataset(), service);
+      this.previewTable = new LevelDBTableCore(PREVIEW_TABLE_ID.getDataset(), service);
+      service.ensureTableExists(PREVIEW_QUEUE_TABLE_ID.getDataset());
+      this.previewQueueTable = new LevelDBTableCore(PREVIEW_QUEUE_TABLE_ID.getDataset(), service);
     } catch (IOException e) {
       throw new RuntimeException("Error creating preview table", e);
     }
@@ -109,9 +112,9 @@ public class DefaultPreviewStore implements PreviewStore {
       .add(tracerName).add(counter.getAndIncrement()).build();
 
     try {
-      table.put(mdsKey.getKey(), TRACER, Bytes.toBytes(tracerName), 1L);
-      table.put(mdsKey.getKey(), PROPERTY, Bytes.toBytes(propertyName), 1L);
-      table.put(mdsKey.getKey(), VALUE, Bytes.toBytes(gson.toJson(value)), 1L);
+      previewTable.put(mdsKey.getKey(), TRACER, Bytes.toBytes(tracerName), 1L);
+      previewTable.put(mdsKey.getKey(), PROPERTY, Bytes.toBytes(propertyName), 1L);
+      previewTable.put(mdsKey.getKey(), VALUE, Bytes.toBytes(gson.toJson(value)), 1L);
     } catch (IOException e) {
       String message = String.format("Error while putting property '%s' for application '%s' and tracer '%s' in" +
                                        " preview table.", propertyName, applicationId, tracerName);
@@ -128,7 +131,7 @@ public class DefaultPreviewStore implements PreviewStore {
     byte[] stopRowKey = new MDSKey(Bytes.stopKeyForPrefix(startRowKey)).getKey();
 
     Map<String, List<JsonElement>> result = new HashMap<>();
-    try (Scanner scanner = table.scan(startRowKey, stopRowKey, null, null, null)) {
+    try (Scanner scanner = previewTable.scan(startRowKey, stopRowKey, null, null, null)) {
       Row indexRow;
       while ((indexRow = scanner.next()) != null) {
         Map<byte[], byte[]> columns = indexRow.getColumns();
@@ -149,7 +152,7 @@ public class DefaultPreviewStore implements PreviewStore {
     byte[] startRowKey = getPreviewRowKeyBuilder(prefix, applicationId).build().getKey();
     byte[] stopRowKey = new MDSKey(Bytes.stopKeyForPrefix(startRowKey)).getKey();
     try {
-      table.deleteRange(startRowKey, stopRowKey, null, null);
+      previewTable.deleteRange(startRowKey, stopRowKey, null, null);
     } catch (IOException e) {
       String message = String.format("Error while removing preview data for application '%s'.", applicationId);
       throw new RuntimeException(message, e);
@@ -171,7 +174,7 @@ public class DefaultPreviewStore implements PreviewStore {
     Gson gson = new GsonBuilder().registerTypeAdapter(EntityId.class, new EntityIdTypeAdapter()).create();
     MDSKey mdsKey = getPreviewRowKeyBuilder(META_ROW_KEY_PREFIX, programRunId.getParent().getParent()).build();
     try {
-      table.put(mdsKey.getKey(), RUN, Bytes.toBytes(gson.toJson(programRunId)), 1L);
+      previewTable.put(mdsKey.getKey(), RUN, Bytes.toBytes(gson.toJson(programRunId)), 1L);
     } catch (IOException e) {
       throw new RuntimeException(String.format("Failed to put %s into preview store", programRunId), e);
     }
@@ -185,8 +188,8 @@ public class DefaultPreviewStore implements PreviewStore {
 
     Map<byte[], byte[]> row = null;
     try {
-      row = table.getRow(mdsKey.getKey(), new byte[][]{RUN},
-                                             null, null, -1, null);
+      row = previewTable.getRow(mdsKey.getKey(), new byte[][]{RUN},
+                                null, null, -1, null);
     } catch (IOException e) {
       throw new RuntimeException(String.format("Failed to get program run id for preview %s", applicationId), e);
     }
@@ -202,8 +205,8 @@ public class DefaultPreviewStore implements PreviewStore {
     Gson gson = new GsonBuilder().registerTypeAdapter(BasicThrowable.class, new BasicThrowableCodec()).create();
     MDSKey mdsKey = getPreviewRowKeyBuilder(META_ROW_KEY_PREFIX, applicationId).build();
     try {
-      table.put(mdsKey.getKey(), STATUS, Bytes.toBytes(gson.toJson(previewStatus)), 1L);
-      table.put(mdsKey.getKey(), APPID, Bytes.toBytes(gson.toJson(applicationId)), 1L);
+      previewTable.put(mdsKey.getKey(), STATUS, Bytes.toBytes(gson.toJson(previewStatus)), 1L);
+      previewTable.put(mdsKey.getKey(), APPID, Bytes.toBytes(gson.toJson(applicationId)), 1L);
     } catch (IOException e) {
       throw new RuntimeException(String.format("Failed to put preview status %s for preview %s",
                                                previewStatus, applicationId), e);
@@ -218,8 +221,8 @@ public class DefaultPreviewStore implements PreviewStore {
 
     Map<byte[], byte[]> row = null;
     try {
-      row = table.getRow(mdsKey.getKey(), new byte[][]{STATUS},
-                                             null, null, -1, null);
+      row = previewTable.getRow(mdsKey.getKey(), new byte[][]{STATUS},
+                                null, null, -1, null);
     } catch (IOException e) {
       throw new RuntimeException(String.format("Failed to get the preview status for preview %s", applicationId), e);
     }
@@ -242,8 +245,8 @@ public class DefaultPreviewStore implements PreviewStore {
       .build();
 
     try {
-      table.put(mdsKey.getKey(), APPID, Bytes.toBytes(gson.toJson(applicationId)), 1L);
-      table.put(mdsKey.getKey(), CONFIG, Bytes.toBytes(gson.toJson(appRequest)), 1L);
+      previewQueueTable.put(mdsKey.getKey(), APPID, Bytes.toBytes(gson.toJson(applicationId)), 1L);
+      previewQueueTable.put(mdsKey.getKey(), CONFIG, Bytes.toBytes(gson.toJson(appRequest)), 1L);
       long submitTimeInMillis = RunIds.getTime(applicationId.getApplication(), TimeUnit.MILLISECONDS);
       setPreviewStatus(applicationId, new PreviewStatus(PreviewStatus.Status.WAITING, submitTimeInMillis, null, null,
                                                         null));
@@ -265,7 +268,7 @@ public class DefaultPreviewStore implements PreviewStore {
       .build();
 
     try {
-      table.deleteRows(Collections.singleton(mdsKey.getKey()));
+      previewQueueTable.deleteRows(Collections.singleton(mdsKey.getKey()));
     } catch (IOException e) {
       throw new RuntimeException(String.format("Failed to remove application with id %s from waiting queue.",
                                                applicationId), e);
@@ -280,7 +283,7 @@ public class DefaultPreviewStore implements PreviewStore {
     byte[] stopRowKey = new MDSKey(Bytes.stopKeyForPrefix(startRowKey)).getKey();
 
     List<PreviewRequest> result = new ArrayList<>();
-    try (Scanner scanner = table.scan(startRowKey, stopRowKey, null, null, null)) {
+    try (Scanner scanner = previewQueueTable.scan(startRowKey, stopRowKey, null, null, null)) {
       Row indexRow;
       while ((indexRow = scanner.next()) != null) {
         Map<byte[], byte[]> columns = indexRow.getColumns();
@@ -320,7 +323,7 @@ public class DefaultPreviewStore implements PreviewStore {
     MDSKey mdsKey = getPreviewRowKeyBuilder(META_ROW_KEY_PREFIX, applicationId).build();
 
     try {
-      table.put(mdsKey.getKey(), POLLERINFO, pollerInfo, 1L);
+      previewTable.put(mdsKey.getKey(), POLLERINFO, pollerInfo, 1L);
     } catch (IOException e) {
       String msg = String.format("Error while setting the poller information %s for waiting preview application %s.",
                                  gson.toJson(pollerInfo), applicationId);
@@ -334,8 +337,8 @@ public class DefaultPreviewStore implements PreviewStore {
 
     Map<byte[], byte[]> row = null;
     try {
-      row = table.getRow(mdsKey.getKey(), new byte[][]{POLLERINFO},
-                         null, null, -1, null);
+      row = previewTable.getRow(mdsKey.getKey(), new byte[][]{POLLERINFO},
+                                null, null, -1, null);
     } catch (IOException e) {
       throw new RuntimeException(String.format("Failed to get the poller info for preview %s", applicationId), e);
     }
@@ -352,7 +355,7 @@ public class DefaultPreviewStore implements PreviewStore {
     byte[] stopRowKey = new MDSKey(Bytes.stopKeyForPrefix(startRowKey)).getKey();
 
     long currentTimeInSeconds = System.currentTimeMillis() / 1000;
-    try (Scanner scanner = table.scan(startRowKey, stopRowKey, null, null, null)) {
+    try (Scanner scanner = previewTable.scan(startRowKey, stopRowKey, null, null, null)) {
       Row indexRow;
       while ((indexRow = scanner.next()) != null) {
         Map<byte[], byte[]> columns = indexRow.getColumns();
@@ -383,5 +386,7 @@ public class DefaultPreviewStore implements PreviewStore {
   void clear() throws IOException {
     service.dropTable(PREVIEW_TABLE_ID.getDataset());
     service.ensureTableExists(PREVIEW_TABLE_ID.getDataset());
+    service.dropTable(PREVIEW_QUEUE_TABLE_ID.getDataset());
+    service.ensureTableExists(PREVIEW_QUEUE_TABLE_ID.getDataset());
   }
 }


### PR DESCRIPTION
One for data+metadata and the other for pending

Why:
Splitting into separate levelDB stores to minimize any potential
slow seek or scan operations, since this store has high deletion
rate, thus producing lots of deletion markers or tombstones.
As a result, it is fairly easy to cause very slow seek or scan
(e.g. calling seekToStart or using iterator.next() to find target row)
during implementation. Splitting minimizes/reduces the slowness.
Furthermore, a followup PR to enable compaction on these levelDB
will allow us compacting away these deletion markers frequently,
thus speeding up access operations.