### PR TITLE
[CDAP-18627] Enable levelDB periodic compaction (once per 7 days)

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1464,7 +1464,7 @@ public final class Constants {
   public static final int DEFAULT_DATA_LEVELDB_BLOCKSIZE = 1024;
   public static final long DEFAULT_DATA_LEVELDB_CACHESIZE = 1024 * 1024 * 100;
   public static final boolean DEFAULT_DATA_LEVELDB_FSYNC = true;
-  public static final long DEFAULT_DATA_LEVELDB_COMPACTION_INTERVAL_SECONDS = 0;
+  public static final long DEFAULT_DATA_LEVELDB_COMPACTION_INTERVAL_SECONDS = 3600 * 24 * 7L;
   public static final int DEFAULT_DATA_LEVELDB_COMPACTION_LEVEL_MIN = 0;
   public static final int DEFAULT_DATA_LEVELDB_COMPACTION_LEVEL_MAX = 4;
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
@@ -49,7 +49,6 @@ import java.net.URLEncoder;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -141,7 +140,6 @@ public class LevelDBTableService implements AutoCloseable {
         },
         (long) (ThreadLocalRandom.current().nextDouble() * compactionInterval.getSeconds()),
         TimeUnit.SECONDS);
-      compact(entry.getKey());
     }
   }
 


### PR DESCRIPTION
Also randomize compactions timings of tables.

Why:
periodic compaction allows us to recycle disk space and discard
tombstones/deletion-markers. This can improve levelDB access latency.