### PR TITLE
Capture API response times as a metric and unit tests

### DIFF
--- a/cdap-common/pom.xml
+++ b/cdap-common/pom.xml
@@ -185,6 +185,10 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/HttpHeaderNames.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/HttpHeaderNames.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.http;
+
+/**
+ * Names for any Http headers introduced by CDAP should be placed here.
+ * This will help keeping the context about headers in one place.
+ */
+public final class HttpHeaderNames {
+  /**
+   * Store request start time. Header should not be deleted or modified.
+   */
+  public static final String CDAP_REQ_TIMESTAMP_HDR = "CDAP_REQ_TIMESTAMP_HDR";
+
+  // TODO move all other custom headers used by CDAP to this class. JIRA https://cdap.atlassian.net/browse/CDAP-18799
+
+  // to prevent instantiation of this class
+  private HttpHeaderNames() {}
+}

--- a/cdap-common/src/test/java/io/cdap/cdap/common/metrics/MetricsReporterHookTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/metrics/MetricsReporterHookTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2019 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.metrics;
+
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.api.metrics.MetricsContext;
+import io.cdap.http.internal.HandlerInfo;
+import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.Test;
+
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.anyInt;
+
+public class MetricsReporterHookTest {
+    static final String TESTSERVICENAME = "test.Service";
+    static final String TESTHANDLERNAME = "test.handler";
+    static final String TESTMETHODNAME = "testMethod";
+
+    @Test
+    public void testReponseTimeCollection() throws InterruptedException {
+        MetricsContext mockCollector = mock(MetricsContext.class);
+        MetricsCollectionService mockCollectionService = mock(MetricsCollectionService.class);
+        when(mockCollectionService.getContext(anyMap())).thenReturn(mockCollector);
+
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://ignore");
+        HandlerInfo handlerInfo = new HandlerInfo(TESTHANDLERNAME, TESTMETHODNAME);
+        MetricsReporterHook hook = new MetricsReporterHook(mockCollectionService, TESTSERVICENAME);
+
+        hook.preCall(request, null, handlerInfo);
+        hook.postCall(request, HttpResponseStatus.OK, handlerInfo);
+
+        verify(mockCollector).event(eq("response.latency"), anyLong());
+    }
+}


### PR DESCRIPTION
Showing diff to dist-metric-store branch to only capture relevant commits. Once dist-metric-store branch is merged into develop, I will rebase to develop.