### PR TITLE
CDAP-18578 - Allow Metricswriter to subscribe to metrics at different intervals

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -786,6 +786,21 @@ public final class Constants {
     public static final String AUTHORIZATION_METRICS_TAGS_ENABLED = "security.authorization.metrics.tags.enabled";
 
     /**
+     * Writer specific config for use subscriber in metadata key
+     */
+    public static final String WRITER_USE_SUBSCRIBER_METADATA_KEY = "metrics.writer.%s.use.subscriber.metadata.key";
+
+    /**
+     * Writer specific config for restricting write frequency
+     */
+    public static final String WRITER_LIMIT_WRITE_FREQ = "metrics.writer.%s.limit.write.freq";
+
+    /**
+     * Writer specific config for delay between writes
+     */
+    public static final String WRITER_WRITE_FREQUENCY_SECONDS = "metrics.writer.%s.write.frequency.seconds";
+
+    /**
      * Metric's dataset related constants.
      */
     public static final class Dataset {

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/DefaultMetadataHandler.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/DefaultMetadataHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metrics.process;
+
+import io.cdap.cdap.proto.id.TopicId;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Default implementation for {@link MetadataHandler}.
+ * Loads/saves metadata from/to {@link MetricsConsumerMetaTable}
+ */
+public class DefaultMetadataHandler implements MetadataHandler {
+
+  private final ConcurrentMap<MetricsMetaKey, TopicProcessMeta> topicProcessMetaMap;
+  private MetricsConsumerMetaTable metaTable;
+  private final String metricsPrefixForDelayMetrics;
+  private final MetricsMetaKeyProvider keyProvider;
+
+  public DefaultMetadataHandler(String metricsPrefixForDelayMetrics, MetricsMetaKeyProvider keyProvider) {
+    this.topicProcessMetaMap = new ConcurrentHashMap<>();
+    this.metricsPrefixForDelayMetrics = metricsPrefixForDelayMetrics;
+    this.keyProvider = keyProvider;
+  }
+
+  @Override
+  public void initCache(List<TopicId> metricsTopics, MetricsConsumerMetaTable metaTable) {
+    this.metaTable = metaTable;
+    Map<TopicId, MetricsMetaKey> keyMap = keyProvider.getKeys(metricsTopics);
+    for (Map.Entry<TopicId, MetricsMetaKey> keyEntry : keyMap.entrySet()) {
+      MetricsMetaKey topicIdMetaKey = keyEntry.getValue();
+      TopicProcessMeta topicProcessMeta = metaTable.getTopicProcessMeta(topicIdMetaKey);
+      if (topicProcessMeta == null || topicProcessMeta.getMessageId() == null) {
+        continue;
+      }
+      String oldestTsMetricName = String.format("%s.topic.%s.oldest.delay.ms",
+                                                metricsPrefixForDelayMetrics, keyEntry.getKey());
+      String latestTsMetricName = String.format("%s.topic.%s.latest.delay.ms",
+                                                metricsPrefixForDelayMetrics, keyEntry.getKey());
+      topicProcessMetaMap.put(topicIdMetaKey,
+                              new TopicProcessMeta(topicProcessMeta.getMessageId(),
+                                                   topicProcessMeta.getOldestMetricsTimestamp(),
+                                                   topicProcessMeta.getLatestMetricsTimestamp(),
+                                                   topicProcessMeta.getMessagesProcessed(),
+                                                   topicProcessMeta.getLastProcessedTimestamp(),
+                                                   oldestTsMetricName, latestTsMetricName));
+    }
+  }
+
+  @Override
+  public void updateCache(MetricsMetaKey key, TopicProcessMeta value) {
+    topicProcessMetaMap.put(key, value);
+  }
+
+  @Override
+  public void saveCache(Map<MetricsMetaKey, TopicProcessMeta> topicProcessMetaMap) {
+    // topicProcessMetaMap can be empty if the current thread fetches nothing
+    // while other threads keep fetching new metrics and haven't updated messageId's of the corresponding topics
+    if (topicProcessMetaMap.isEmpty()) {
+      return;
+    }
+    metaTable.saveMetricsProcessorStats(topicProcessMetaMap);
+  }
+
+  @Override
+  public TopicProcessMeta getTopicProcessMeta(MetricsMetaKey key) {
+    return topicProcessMetaMap.get(key);
+  }
+
+  @Override
+  public Map<MetricsMetaKey, TopicProcessMeta> getCache() {
+    //return a copy of current map
+    return new HashMap<>(topicProcessMetaMap);
+  }
+}

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/DefaultMetricsWriterContext.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/DefaultMetricsWriterContext.java
@@ -43,6 +43,6 @@ public class DefaultMetricsWriterContext implements MetricsWriterContext {
   }
 
   public Map<String, String> getProperties() {
-    return Collections.unmodifiableMap(properties);
+    return properties;
   }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorManagerService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorManagerService.java
@@ -103,7 +103,7 @@ public class MessagingMetricsProcessorManagerService extends AbstractIdleService
   protected void startUp() throws Exception {
     MetricStoreMetricsWriter metricsWriter = new MetricStoreMetricsWriter(metricStore);
     DefaultMetricsWriterContext context = new DefaultMetricsWriterContext(metricsContext,
-      cConf, metricsWriter.getID());
+                                                                          cConf, metricsWriter.getID());
     metricsWriter.initialize(context);
     this.metricsWriters.add(metricsWriter);
 
@@ -111,11 +111,13 @@ public class MessagingMetricsProcessorManagerService extends AbstractIdleService
       MetricsWriter writer = metricsWriterEntry.getValue();
       this.metricsWriters.add(writer);
       DefaultMetricsWriterContext metricsWriterContext = new DefaultMetricsWriterContext(metricsContext,
-        cConf, writer.getID());
+                                                                                         cConf, writer.getID());
       writer.initialize(metricsWriterContext);
     }
 
+    String processorKey = String.format("metrics.processor.%s", instanceId);
     for (MetricsWriter metricsExtension : this.metricsWriters) {
+      MetricsMetaKeyProvider topicIdMetricsKeyProvider = getKeyProvider(metricsExtension, cConf);
       metricsProcessorServices.add(new MessagingMetricsProcessorService(
         cConf,
         metricDatasetFactory,
@@ -126,13 +128,25 @@ public class MessagingMetricsProcessorManagerService extends AbstractIdleService
         topicNumbers,
         metricsContext,
         metricsProcessIntervalMillis,
-        instanceId));
+        instanceId,
+        new DefaultMetadataHandler(processorKey, topicIdMetricsKeyProvider),
+        topicIdMetricsKeyProvider));
 
     }
 
     for (MessagingMetricsProcessorService processorService : metricsProcessorServices) {
       processorService.startAndWait();
     }
+  }
+
+  private MetricsMetaKeyProvider getKeyProvider(MetricsWriter writer, CConfiguration cConf) {
+    boolean useSubscriberInKey = getUseSubscriberInKey(writer, cConf);
+    return useSubscriberInKey ? new TopicSubscriberMetricsKeyProvider(writer.getID()) : new TopicIdMetricsKeyProvider();
+  }
+
+  private boolean getUseSubscriberInKey(MetricsWriter writer, CConfiguration cConf) {
+    String confKey = String.format(Constants.Metrics.WRITER_USE_SUBSCRIBER_METADATA_KEY, writer.getID());
+    return cConf.getBoolean(confKey, false);
   }
 
   @Override

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorService.java
@@ -53,20 +53,17 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 
 /**
  * Process metrics by consuming metrics being published to TMS.
@@ -88,18 +85,20 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
   private final long maxDelayMillis;
   private final int queueSize;
   private final BlockingDeque<MetricValues> metricsFromAllTopics;
-  private final ConcurrentMap<TopicIdMetaKey, TopicProcessMeta> topicProcessMetaMap;
   private final AtomicBoolean persistingFlag;
+  private final boolean limitWriteFrequency;
+  private final MetadataHandler metadataHandler;
+  private final MetricsMetaKeyProvider metricsMetaKeyProvider;
   // maximum number of milliseconds to sleep between each run of fetching & processing new metrics, the max sleep time
   // is 1 min
   private final long metricsProcessIntervalMillis;
   private final List<ProcessMetricsThread> processMetricsThreads;
   private final String processMetricName;
   private final String metricsPrefixForDelayMetrics;
+  private final int instanceId;
   private long metricsProcessedCount;
-
+  private AtomicLong lastPersistedTime;
   private MetricsConsumerMetaTable metaTable;
-
   private volatile boolean stopping;
 
   @Inject
@@ -109,12 +108,15 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
                                    SchemaGenerator schemaGenerator,
                                    DatumReaderFactory readerFactory,
                                    MetricsWriter metricsWriter,
+                                   MetadataHandler metadataHandler,
+                                   MetricsMetaKeyProvider metricsMetaKeyProvider,
                                    @Assisted Set<Integer> topicNumbers,
                                    @Assisted MetricsContext metricsContext,
                                    @Assisted Integer instanceId) {
     this(cConf, metricDatasetFactory, messagingService,
          schemaGenerator, readerFactory, metricsWriter, topicNumbers, metricsContext,
-         TimeUnit.SECONDS.toMillis(cConf.getInt(Constants.Metrics.METRICS_MINIMUM_RESOLUTION_SECONDS)), instanceId);
+         TimeUnit.SECONDS.toMillis(cConf.getInt(Constants.Metrics.METRICS_MINIMUM_RESOLUTION_SECONDS)), instanceId,
+         metadataHandler, metricsMetaKeyProvider);
   }
 
   @VisibleForTesting
@@ -127,9 +129,11 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
                                    Set<Integer> topicNumbers,
                                    MetricsContext metricsContext,
                                    long metricsProcessIntervalMillis,
-                                   int instanceId) {
+                                   int instanceId,
+                                   MetadataHandler metadataHandler,
+                                   MetricsMetaKeyProvider metricsMetaKeyProvider) {
     this.metricDatasetFactory = metricDatasetFactory;
-    this.metricsPrefixForDelayMetrics = String.format("metrics.processor.%s", instanceId);
+    this.metricsPrefixForDelayMetrics = String.format("metrics.processor.%s.%s", instanceId, metricsWriter.getID());
 
     String topicPrefix = cConf.get(Constants.Metrics.TOPIC_PREFIX);
     this.metricsTopics = topicNumbers.stream()
@@ -150,12 +154,14 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
     this.metricsContextMap = metricsContext.getTags();
     this.processMetricsThreads = new ArrayList<>();
     this.metricsFromAllTopics = new LinkedBlockingDeque<>(queueSize);
-    this.topicProcessMetaMap = new ConcurrentHashMap<>();
     this.persistingFlag = new AtomicBoolean();
     // the max sleep time will be 1 min
-    this.metricsProcessIntervalMillis = metricsProcessIntervalMillis < Constants.Metrics.PROCESS_INTERVAL_MILLIS ?
-      metricsProcessIntervalMillis : Constants.Metrics.PROCESS_INTERVAL_MILLIS;
+    this.metricsProcessIntervalMillis = resolveProcessingInterval(cConf, metricsWriter, metricsProcessIntervalMillis);
     this.processMetricName = String.format("metrics.%s.process.count", instanceId);
+    this.metadataHandler = metadataHandler;
+    this.metricsMetaKeyProvider = metricsMetaKeyProvider;
+    this.instanceId = instanceId;
+    this.limitWriteFrequency = shouldLimitWriteFrequency(metricsWriter, cConf);
   }
 
   private MetricsConsumerMetaTable getMetaTable() {
@@ -182,27 +188,29 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
   @Override
   protected void run() {
     LOG.info("Start running MessagingMetricsProcessorService for {}", metricsWriter.getID());
+
     MetricsConsumerMetaTable metaTable = getMetaTable();
     if (metaTable == null) {
       LOG.info("Could not get MetricsConsumerMetaTable, seems like we are being shut down");
       return;
     }
 
-    for (TopicId topic : metricsTopics) {
-      TopicProcessMeta topicProcessMeta = null;
-      TopicIdMetaKey topicRowKey = new TopicIdMetaKey(topic);
-      try {
-        topicProcessMeta = metaTable.getTopicProcessMeta(topicRowKey);
-      } catch (Exception e) {
-        LOG.warn("Cannot retrieve last processed MessageId for topic: {}", topic, e);
-      }
-      processMetricsThreads.add(new ProcessMetricsThread(topicRowKey, topicProcessMeta));
+    metadataHandler.initCache(metricsTopics, metaTable);
+    Map<TopicId, MetricsMetaKey> keys = metricsMetaKeyProvider.getKeys(metricsTopics);
+    for (Map.Entry<TopicId, MetricsMetaKey> keyEntry : keys.entrySet()) {
+      ProcessMetricsThread metricsThread = new ProcessMetricsThread(keyEntry.getKey(), keyEntry.getValue(),
+                                                                    String.format("processor-%s-%s", instanceId,
+                                                                                  metricsWriter.getID()));
+      processMetricsThreads.add(metricsThread);
     }
 
     if (!isRunning()) {
       return;
     }
 
+    // Initialize the last persisted time with current time.
+    // This will give time for the threads to populate some metrics before persisting
+    lastPersistedTime = new AtomicLong(System.currentTimeMillis());
     for (ProcessMetricsThread thread : processMetricsThreads) {
       thread.start();
     }
@@ -218,7 +226,20 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
 
     // Persist metricsFromAllTopics and messageId's after all ProcessMetricsThread's complete.
     // No need to make a copy of metricsFromAllTopics and topicProcessMetaMap because no thread is writing to them
-    persistMetricsAndTopicProcessMeta(metricsFromAllTopics, topicProcessMetaMap);
+    persistMetricsAndTopicProcessMeta(metricsFromAllTopics, metadataHandler.getCache());
+  }
+
+  private long resolveProcessingInterval(CConfiguration cConf, MetricsWriter metricsWriter, long defaultInterval) {
+    String writeFreqConfig = String.format(Constants.Metrics.WRITER_WRITE_FREQUENCY_SECONDS, metricsWriter.getID());
+    int writeFreq = cConf.getInt(writeFreqConfig, -1);
+    return writeFreq == -1 ?
+      Math.min(defaultInterval, Constants.Metrics.PROCESS_INTERVAL_MILLIS) : TimeUnit.SECONDS.toMillis(writeFreq);
+  }
+
+  private boolean shouldLimitWriteFrequency(MetricsWriter writer, CConfiguration cConf) {
+    // If there is no writer specific configuration, default to existing behavior of no limit
+    String confKey = String.format(Constants.Metrics.WRITER_LIMIT_WRITE_FREQ, writer.getID());
+    return cConf.getBoolean(confKey, false);
   }
 
   @Override
@@ -236,47 +257,34 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
    * metrics meta table
    *
    * @param metricValues        a deque of {@link MetricValues}
-   * @param topicProcessMetaMap a map with each key {@link TopicIdMetaKey} representing a topic and {@link
+   * @param topicProcessMetaMap a map with each key {@link MetricsMetaKey} representing a key and {@link
    *                            TopicProcessMeta} which has info on messageId and processing stats
    */
   private void persistMetricsAndTopicProcessMeta(Deque<MetricValues> metricValues,
-                                                 Map<TopicIdMetaKey, TopicProcessMeta> topicProcessMetaMap) {
+                                                 Map<MetricsMetaKey, TopicProcessMeta> topicProcessMetaMap) {
     try {
       if (!metricValues.isEmpty()) {
-        persistMetrics(metricValues, topicProcessMetaMap);
+        persistMetrics(metricValues);
       }
-      persistTopicProcessMeta(topicProcessMetaMap);
+      metadataHandler.saveCache(topicProcessMetaMap);
     } catch (Exception e) {
       LOG.warn("Failed to persist metrics.", e);
     }
   }
 
-  private void persistTopicProcessMeta(Map<TopicIdMetaKey, TopicProcessMeta> messageIds) {
-    try {
-      // messageIds can be empty if the current thread fetches nothing while other threads keep fetching new metrics
-      // and haven't updated messageId's of the corresponding topics
-      if (!messageIds.isEmpty()) {
-        metaTable.saveMetricsProcessorStats(messageIds);
-      }
-    } catch (Exception e) {
-      LOG.warn("Failed to update processing stats of consumed messages.", e);
-    }
-  }
 
   /**
    * Persist metrics into metric store
    *
    * @param metricValues a non-empty deque of {@link MetricValues}
    */
-  private void persistMetrics(Deque<MetricValues> metricValues,
-                              Map<TopicIdMetaKey, TopicProcessMeta> topicProcessMetaMap) {
+  private void persistMetrics(Deque<MetricValues> metricValues) {
     long now = System.currentTimeMillis();
     long lastMetricTime = metricValues.peekLast().getTimestamp();
     List<MetricValue> topicLevelDelays = new ArrayList<>();
 
     //write topic level delay metrics
-    for (Map.Entry<TopicIdMetaKey, TopicProcessMeta> entry : topicProcessMetaMap.entrySet()) {
-      TopicProcessMeta topicProcessMeta = entry.getValue();
+    for (TopicProcessMeta topicProcessMeta : metadataHandler.getCache().values()) {
       long delay = now - TimeUnit.SECONDS.toMillis(topicProcessMeta.getOldestMetricsTimestamp());
       topicLevelDelays.add(new MetricValue(topicProcessMeta.getOldestMetricsTimestampMetricName(),
                                            MetricType.GAUGE, delay));
@@ -290,38 +298,28 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
     metricValues.add(new MetricValues(metricsContextMap, TimeUnit.MILLISECONDS.toSeconds(now), processorMetrics));
     metricsWriter.write(metricValues);
     metricsProcessedCount += metricValues.size();
-    PROGRESS_LOG.debug("{} metrics persisted. Last metric's timestamp: {}",
-                       metricsProcessedCount, lastMetricTime);
+    PROGRESS_LOG.debug("{} metrics persisted with {}. Last metric's timestamp: {}",
+                       metricsProcessedCount, metricsWriter.getID(), lastMetricTime);
   }
 
   private class ProcessMetricsThread extends Thread {
 
-    private final TopicIdMetaKey topicIdMetaKey;
+    private final MetricsMetaKey metricsMetaKey;
+    private final TopicId topic;
     private final PayloadInputStream payloadInput;
     private final BinaryDecoder decoder;
     private final String oldestTsMetricName;
     private final String latestTsMetricName;
     private long lastMetricTimeSecs;
 
-    ProcessMetricsThread(TopicIdMetaKey topicIdMetaKey, @Nullable TopicProcessMeta topicProcessMeta) {
-      super(String.format("ProcessMetricsThread-%s", topicIdMetaKey.getTopicId()));
+    ProcessMetricsThread(TopicId topic, MetricsMetaKey metricsMetaKey, String processorName) {
+      //TODO - create a unique thread name
+      super(String.format("ProcessMetricsThread-%s-%s", topic, processorName));
       setDaemon(true);
-      oldestTsMetricName = String.format("%s.topic.%s.oldest.delay.ms",
-                                         metricsPrefixForDelayMetrics, topicIdMetaKey.getTopicId().getTopic());
-      latestTsMetricName = String.format("%s.topic.%s.latest.delay.ms",
-                                         metricsPrefixForDelayMetrics, topicIdMetaKey.getTopicId().getTopic());
-      if (topicProcessMeta != null && topicProcessMeta.getMessageId() != null) {
-        // message-id already for this topic in metaTable, we create a new TopicProcessMeta with existing values,
-        // write metric names and put it in map
-        byte[] persistedMessageId = topicProcessMeta.getMessageId();
-        topicProcessMetaMap.put(topicIdMetaKey,
-                                new TopicProcessMeta(persistedMessageId, topicProcessMeta.getOldestMetricsTimestamp(),
-                                                     topicProcessMeta.getLatestMetricsTimestamp(),
-                                                     topicProcessMeta.getMessagesProcessed(),
-                                                     topicProcessMeta.getLastProcessedTimestamp(),
-                                                     oldestTsMetricName, latestTsMetricName));
-      }
-      this.topicIdMetaKey = topicIdMetaKey;
+      oldestTsMetricName = String.format("%s.topic.%s.oldest.delay.ms", metricsPrefixForDelayMetrics, topic.getTopic());
+      latestTsMetricName = String.format("%s.topic.%s.latest.delay.ms", metricsPrefixForDelayMetrics, topic.getTopic());
+      this.metricsMetaKey = metricsMetaKey;
+      this.topic = topic;
       this.payloadInput = new PayloadInputStream();
       this.decoder = new BinaryDecoder(payloadInput);
     }
@@ -352,9 +350,9 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
     private long processMetrics() {
       long startTime = System.currentTimeMillis();
       try {
-        MessageFetcher fetcher = messagingService.prepareFetch(topicIdMetaKey.getTopicId());
+        MessageFetcher fetcher = messagingService.prepareFetch(topic);
         fetcher.setLimit(fetcherLimit);
-        TopicProcessMeta persistMetaInfo = topicProcessMetaMap.get(topicIdMetaKey);
+        TopicProcessMeta persistMetaInfo = metadataHandler.getTopicProcessMeta(metricsMetaKey);
         byte[] lastMessageId = null;
 
         if (persistMetaInfo != null) {
@@ -397,7 +395,7 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
           // update the last processed timestamp in local topic meta and update the topicProcessMetaMap with this
           // local topic meta for the topic
           localTopicProcessMeta.updateLastProcessedTimestamp();
-          topicProcessMetaMap.put(topicIdMetaKey, localTopicProcessMeta);
+          metadataHandler.updateCache(metricsMetaKey, localTopicProcessMeta);
         }
         // Try to persist metrics and messageId's of the last metrics to be persisted if no other thread is persisting
         tryPersist();
@@ -424,18 +422,15 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
      * Persist metrics and messageId's of the last metrics to be persisted if no other thread is persisting
      */
     private void tryPersist() {
-      // Ensure there's only one thread can persist metricsFromAllTopics and messageId's.
-      // This is because the underlying metrics table is not thread safe.
-      // If persistingFlag is false, set it to true and start persisting. Otherwise, log and return.
-      if (!persistingFlag.compareAndSet(false, true)) {
-        LOG.trace("There is another thread performing persisting. No need to persist in this thread.");
+      if (!canPersist()) {
         return;
       }
+
       try {
         // Make a copy of topicProcessMetaMap before copying metrics from metricsFromAllTopics to ensure that
         // topicMessageIdsCopy will not contain new MessageId's in metricsFromAllTopics but not in metricsCopy.
         // This guarantees the metrics corresponding to last persisted MessageId's of each topic are persisted.
-        Map<TopicIdMetaKey, TopicProcessMeta> topicProcessMetaMapCopy = new HashMap<>(topicProcessMetaMap);
+        Map<MetricsMetaKey, TopicProcessMeta> topicProcessMetaMapCopy = metadataHandler.getCache();
         // Remove at most queueSize of metrics from metricsFromAllTopics and put into metricsCopy to limit
         // the number of metrics being persisted each time
         Deque<MetricValues> metricsCopy = new LinkedList<>();
@@ -459,6 +454,36 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
         persistingFlag.set(false);
       }
     }
+  }
+
+  private boolean canPersist() {
+    // Check if writer has restriction on write frequency
+    if (writeFrequencyExceeded()) {
+      return false;
+    }
+    // Ensure there's only one thread can persist metricsFromAllTopics and messageId's.
+    // This is because the underlying metrics table is not thread safe.
+    // If persistingFlag is false, set it to true and start persisting. Otherwise, log and return.
+    if (!persistingFlag.compareAndSet(false, true)) {
+      LOG.trace("There is another thread performing persisting. No need to persist in this thread.");
+      return false;
+    }
+
+    return true;
+  }
+
+  private boolean writeFrequencyExceeded() {
+    if (!limitWriteFrequency) {
+      return false;
+    }
+    long currentTime = System.currentTimeMillis();
+    long updatedTime = lastPersistedTime.updateAndGet(
+      value -> (currentTime - value > metricsProcessIntervalMillis) ? currentTime : value);
+    if (updatedTime != currentTime) {
+      LOG.trace("Not enough time between writes.");
+      return true;
+    }
+    return false;
   }
 
   private class PayloadInputStream extends ByteArrayInputStream {

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MetadataHandler.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MetadataHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metrics.process;
+
+import io.cdap.cdap.proto.id.TopicId;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface for handling metrics metadata
+ */
+public interface MetadataHandler {
+
+  /**
+   * Initialize the cache (loading from existing store) for all the topics
+   *
+   * @param metricsTopics {@link List} of {@link TopicId}
+   * @param metaTable {@link MetricsConsumerMetaTable} to read from
+   */
+  void initCache(List<TopicId> metricsTopics, MetricsConsumerMetaTable metaTable);
+
+  /**
+   * Update the cache with new value for the given key.
+   *
+   * @param key   {@link MetricsMetaKey}
+   * @param value {@link TopicProcessMeta}
+   */
+  void updateCache(MetricsMetaKey key, TopicProcessMeta value);
+
+  /**
+   * Save the current cache (save to store)
+   *
+   * @param topicProcessMetaMap {@link Map} of {@link MetricsMetaKey} key and {@link TopicProcessMeta} values.
+   */
+  void saveCache(Map<MetricsMetaKey, TopicProcessMeta> topicProcessMetaMap);
+
+  /**
+   * Return value for the key from current cache
+   *
+   * @param key {@link MetricsMetaKey}
+   * @return value {@link TopicProcessMeta}
+   */
+  TopicProcessMeta getTopicProcessMeta(MetricsMetaKey key);
+
+  /**
+   * Return a copy of the current cache
+   *
+   * @return {@link Map<MetricsMetaKey, TopicProcessMeta>}
+   */
+  Map<MetricsMetaKey, TopicProcessMeta> getCache();
+
+}

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MetricsMetaKeyProvider.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MetricsMetaKeyProvider.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metrics.process;
+
+import io.cdap.cdap.proto.id.TopicId;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Provides {@link MetricsMetaKey} for {@link TopicId}
+ */
+public interface MetricsMetaKeyProvider {
+  /**
+   * Provide a {@link Map} with {@link TopicId} and
+   * {@link MetricsMetaKey} implementation for the given list of {@link TopicId}.
+   *
+   * @param topics {@link List<TopicId>}
+   * @return {@link Map<TopicId, MetricsMetaKey>}
+   */
+  Map<TopicId, MetricsMetaKey> getKeys(List<TopicId> topics);
+}

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/TopicIdMetricsKeyProvider.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/TopicIdMetricsKeyProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metrics.process;
+
+import io.cdap.cdap.proto.id.TopicId;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * TopicIdMetricsKeyProvider which provides a {@link TopicIdMetaKey} for each {@link TopicId}
+ */
+public class TopicIdMetricsKeyProvider implements MetricsMetaKeyProvider {
+
+  @Override
+  public Map<TopicId, MetricsMetaKey> getKeys(List<TopicId> topics) {
+    return topics.stream().collect(Collectors.toMap(topicId -> topicId, TopicIdMetaKey::new));
+  }
+}

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/TopicSubscriberMetaKey.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/TopicSubscriberMetaKey.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metrics.process;
+
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.proto.id.TopicId;
+
+import java.util.Arrays;
+
+/**
+ * TopicSubscriberMetaKey provides an implementation of {@link MetricsMetaKey}
+ * that uses {@link TopicId} and a {@link String} subscriberId
+ */
+public class TopicSubscriberMetaKey implements MetricsMetaKey {
+
+  private static final String KEY_FORMAT = "topic:%s:%s:subscriber:%s";
+  private static final String PRINT_FORMAT = "TopicSubscriberMetaKey{ key=%s }";
+
+  private final byte[] key;
+
+  TopicSubscriberMetaKey(TopicId topicId, String subscriberId) {
+    String formattedKey = String.format(KEY_FORMAT, topicId.getNamespace(), topicId.getTopic(), subscriberId);
+    this.key = Bytes.toBytes(formattedKey);
+  }
+
+  @Override
+  public byte[] getKey() {
+    return key;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TopicSubscriberMetaKey)) {
+      return false;
+    }
+    TopicSubscriberMetaKey that = (TopicSubscriberMetaKey) o;
+    return Arrays.equals(key, that.key);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(key);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(PRINT_FORMAT, Bytes.toString(key));
+  }
+}

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/TopicSubscriberMetricsKeyProvider.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/TopicSubscriberMetricsKeyProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metrics.process;
+
+import io.cdap.cdap.proto.id.TopicId;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * TopicSubscriberMetricsKeyProvider which provides a {@link TopicSubscriberMetaKey} for each {@link TopicId}
+ */
+public class TopicSubscriberMetricsKeyProvider implements MetricsMetaKeyProvider {
+
+  private final String subscriberId;
+
+  TopicSubscriberMetricsKeyProvider(String subscriberId) {
+    this.subscriberId = subscriberId;
+  }
+
+  @Override
+  public Map<TopicId, MetricsMetaKey> getKeys(List<TopicId> topics) {
+    return topics.stream()
+      .collect(Collectors.toMap(topicId -> topicId, topicId -> new TopicSubscriberMetaKey(topicId, subscriberId)));
+  }
+}

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorManagerServiceTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorManagerServiceTest.java
@@ -190,10 +190,10 @@ public class MessagingMetricsProcessorManagerServiceTest extends MetricsProcesso
       for (int i = 0; i < cConf.getInt(Constants.Metrics.MESSAGING_TOPIC_NUM); i++) {
         if (!systemMetricsMap.containsKey(
           String.format(
-            "metrics.processor.0.topic.metrics%s.oldest.delay.ms", i)) &&
+            "metrics.processor.0.METRICS_STORE.topic.metrics%s.oldest.delay.ms", i)) &&
           !systemMetricsMap.containsKey(
             String.format(
-              "metrics.processor.0.topic.metrics%s.latest.delay.ms", i))) {
+              "metrics.processor.0.METRICS_STORE.topic.metrics%s.latest.delay.ms", i))) {
           return false;
         }
       }

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/TopicIdMetricsKeyProviderTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/TopicIdMetricsKeyProviderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metrics.process;
+
+import io.cdap.cdap.proto.id.TopicId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test for {@link TopicIdMetricsKeyProvider}
+ */
+public class TopicIdMetricsKeyProviderTest {
+
+  @Test
+  public void testKeys() {
+    String namespace = "test";
+    String topicName = "topic0";
+    TopicId topicId = new TopicId(namespace, topicName);
+    Map<TopicId, MetricsMetaKey> actual = new TopicIdMetricsKeyProvider().getKeys(
+      Collections.singletonList(topicId));
+    Map<TopicId, MetricsMetaKey> expected = new HashMap<>();
+    expected.put(new TopicId(namespace, topicName), new TopicIdMetaKey(topicId));
+    Assert.assertEquals(expected, actual);
+  }
+}

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/TopicSubscriberMetricsKeyProviderTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/TopicSubscriberMetricsKeyProviderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metrics.process;
+
+import io.cdap.cdap.proto.id.TopicId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests for {@link TopicSubscriberMetricsKeyProvider}
+ */
+public class TopicSubscriberMetricsKeyProviderTest {
+
+  @Test
+  public void testKeys() {
+    String subscriberId = "test-subscriber";
+    String namespace = "test";
+    String topicName = "topic0";
+    TopicId topicId = new TopicId(namespace, topicName);
+    Map<TopicId, MetricsMetaKey> actual = new TopicSubscriberMetricsKeyProvider(subscriberId).getKeys(
+      Collections.singletonList(topicId));
+    Map<TopicId, MetricsMetaKey> expected = new HashMap<>();
+    expected.put(new TopicId(namespace, topicName), new TopicSubscriberMetaKey(topicId, subscriberId));
+    Assert.assertEquals(expected, actual);
+  }
+}


### PR DESCRIPTION
- Provide the option to use subscriber name in metrics metadata key. Created new interface MetricsMetaKeyProvider. Existing implementation uses only topic ID , additional implementation added for using subscriber name with topic ID. This allows tracking metadata independently for different writers.
- Provide option for restricting metrics write frequency. Currently multiple threads write to the MetricsWriter and there is no limit on the write frequency. Introduced a configuration to restrict write based on frequency configured by specific writers.
- Refactored code to extract metadata cache handling to DefaultMetadataHandler