### PR TITLE
CDAP-18643 regenerate app spec for on premise program run

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationConfigurer.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationConfigurer.java
@@ -29,6 +29,8 @@ import io.cdap.cdap.api.worker.Worker;
 import io.cdap.cdap.api.workflow.Workflow;
 import io.cdap.cdap.internal.schedule.ScheduleCreationSpec;
 
+import javax.annotation.Nullable;
+
 /**
  * Configures a CDAP Application.
  */
@@ -119,4 +121,25 @@ public interface ApplicationConfigurer extends PluginConfigurer, DatasetConfigur
    * @return The {@link TriggerFactory} used to get triggers
    */
   TriggerFactory getTriggerFactory();
+
+  /**
+   * Return the runtime configurer that contains the runtime arguments and provides access for other runtime
+   * functionalities. This is used for the app to provide additional information for the newly generated app spec
+   * before each program run. This method will return null when the app initially gets deployed.
+   *
+   * @return the runtime configurer, or null if this is the initial deploy time.
+   */
+  @Nullable
+  default RuntimeConfigurer getRuntimeConfigurer() {
+    return null;
+  }
+
+  /**
+   * Return the namespace the app is deployed.
+   *
+   * @return the namespace the app is deployed
+   */
+  default String getDeployedNamespace() {
+    throw new UnsupportedOperationException("Getting deployed namespace is not supported");
+  }
 }

--- a/cdap-api/src/main/java/io/cdap/cdap/api/app/RuntimeConfigurer.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/app/RuntimeConfigurer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.api.app;
+
+import io.cdap.cdap.api.ServiceDiscoverer;
+
+import java.util.Map;
+
+/**
+ * The runtime configurer that can be got when the app is reconfigured before the actual program run
+ */
+public interface RuntimeConfigurer extends ServiceDiscoverer {
+
+  /**
+   * @return A map of user argument key and value
+   */
+  Map<String, String> getRuntimeArguments();
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/DefaultAppConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/DefaultAppConfigurer.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.app.Application;
 import io.cdap.cdap.api.app.ApplicationConfigurer;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.app.ProgramType;
+import io.cdap.cdap.api.app.RuntimeConfigurer;
 import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.mapreduce.MapReduce;
@@ -90,6 +91,7 @@ public class DefaultAppConfigurer extends AbstractConfigurer implements Applicat
   private final Map<String, WorkerSpecification> workers = new HashMap<>();
   private final Map<StructuredTableId, StructuredTableSpecification> systemTables = new HashMap<>();
   private final TriggerFactory triggerFactory;
+  private final RuntimeConfigurer runtimeConfigurer;
   private String name;
   private Map<MetadataScope, Metadata> appMetadata;
   private String description;
@@ -97,12 +99,13 @@ public class DefaultAppConfigurer extends AbstractConfigurer implements Applicat
   // passed app to be used to resolve default name and description
   @VisibleForTesting
   public DefaultAppConfigurer(Id.Namespace namespace, Id.Artifact artifactId, Application app) {
-    this(namespace, artifactId, app, "", null, null);
+    this(namespace, artifactId, app, "", null, null, null);
   }
 
   public DefaultAppConfigurer(Id.Namespace namespace, Id.Artifact artifactId, Application app, String configuration,
                               @Nullable PluginFinder pluginFinder,
-                              @Nullable PluginInstantiator pluginInstantiator) {
+                              @Nullable PluginInstantiator pluginInstantiator,
+                              @Nullable RuntimeConfigurer runtimeConfigurer) {
     super(namespace, artifactId, pluginFinder, pluginInstantiator);
     this.name = app.getClass().getSimpleName();
     this.description = "";
@@ -112,6 +115,7 @@ public class DefaultAppConfigurer extends AbstractConfigurer implements Applicat
     this.pluginInstantiator = pluginInstantiator;
     this.appMetadata = new HashMap<>();
     this.triggerFactory = new DefaultTriggerFactory(namespace.toEntityId());
+    this.runtimeConfigurer = runtimeConfigurer;
   }
 
   @Override
@@ -256,6 +260,17 @@ public class DefaultAppConfigurer extends AbstractConfigurer implements Applicat
         programName, schedulableProgramType));
     }
     return new DefaultScheduleBuilder(scheduleName, programName, triggerFactory);
+  }
+
+  @Override
+  @Nullable
+  public RuntimeConfigurer getRuntimeConfigurer() {
+    return runtimeConfigurer;
+  }
+
+  @Override
+  public String getDeployedNamespace() {
+    return deployNamespace.getId();
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/DefaultAppRuntimeConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/DefaultAppRuntimeConfigurer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.app;
+
+import io.cdap.cdap.api.app.RuntimeConfigurer;
+import io.cdap.cdap.app.services.AbstractServiceDiscoverer;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Default app configurer for runtime deployment
+ */
+public class DefaultAppRuntimeConfigurer extends AbstractServiceDiscoverer implements RuntimeConfigurer {
+  private final RemoteClientFactory remoteClientFactory;
+  private final Map<String, String> userArguments;
+
+  public DefaultAppRuntimeConfigurer(String namespace,
+                                     RemoteClientFactory remoteClientFactory, Map<String, String> userArguments) {
+    super(namespace);
+    this.remoteClientFactory = remoteClientFactory;
+    this.userArguments = new HashMap<>(userArguments);
+  }
+
+  @Override
+  public Map<String, String> getRuntimeArguments() {
+    return userArguments;
+  }
+
+  @Override
+  protected RemoteClientFactory getRemoteClientFactory() {
+    return remoteClientFactory;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java
@@ -203,6 +203,8 @@ public class PreviewRunnerModule extends PrivateModule {
         .implement(Configurator.class, InMemoryConfigurator.class)
         .build(ConfiguratorFactory.class)
     );
+    // expose this binding so program runner modules can use
+    expose(ConfiguratorFactory.class);
 
     install(
       new FactoryModuleBuilder()

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -22,16 +22,21 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.api.common.RuntimeArguments;
 import io.cdap.cdap.api.plugin.Plugin;
+import io.cdap.cdap.app.deploy.ConfigResponse;
+import io.cdap.cdap.app.deploy.Configurator;
 import io.cdap.cdap.app.guice.ClusterMode;
 import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.program.ProgramDescriptor;
@@ -46,6 +51,9 @@ import io.cdap.cdap.common.lang.jar.BundleJarUtil;
 import io.cdap.cdap.common.lang.jar.ClassLoaderFolder;
 import io.cdap.cdap.common.twill.TwillAppNames;
 import io.cdap.cdap.common.utils.DirUtils;
+import io.cdap.cdap.internal.app.deploy.ConfiguratorFactory;
+import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
+import io.cdap.cdap.internal.app.deploy.pipeline.AppSpecInfo;
 import io.cdap.cdap.internal.app.runtime.AbstractListener;
 import io.cdap.cdap.internal.app.runtime.BasicArguments;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
@@ -86,10 +94,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
@@ -114,6 +124,7 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
   private final ProgramRunnerFactory programRunnerFactory;
   private final ArtifactRepository noAuthArtifactRepository;
   private final ProgramStateWriter programStateWriter;
+  private final ConfiguratorFactory configuratorFactory;
   private ProgramRunnerFactory remoteProgramRunnerFactory;
   private TwillRunnerService remoteTwillRunnerService;
   private ExecutorService executor;
@@ -121,13 +132,15 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
   protected AbstractProgramRuntimeService(CConfiguration cConf,
                                           ProgramRunnerFactory programRunnerFactory,
                                           ArtifactRepository noAuthArtifactRepository,
-                                          ProgramStateWriter programStateWriter) {
+                                          ProgramStateWriter programStateWriter,
+                                          ConfiguratorFactory configuratorFactory) {
     this.cConf = cConf;
     this.runtimeInfosLock = new ReentrantReadWriteLock();
     this.runtimeInfos = HashBasedTable.create();
     this.programRunnerFactory = programRunnerFactory;
     this.noAuthArtifactRepository = noAuthArtifactRepository;
     this.programStateWriter = programStateWriter;
+    this.configuratorFactory = configuratorFactory;
   }
 
   /**
@@ -160,7 +173,6 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
       : Optional.ofNullable(remoteProgramRunnerFactory).orElseThrow(UnsupportedOperationException::new)
     ).create(programId.getType());
 
-
     File tempDir = createTempDirectory(programId, runId);
     AtomicReference<Runnable> cleanUpTaskRef = new AtomicReference<>(createCleanupTask(tempDir, runner));
     DelayedProgramController controller = new DelayedProgramController(programRunId);
@@ -172,14 +184,32 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
         // Get the artifact details and save it into the program options.
         ArtifactId artifactId = programDescriptor.getArtifactId();
         ArtifactDetail artifactDetail = getArtifactDetail(artifactId);
+        ApplicationSpecification appSpec = programDescriptor.getApplicationSpecification();
+        ProgramDescriptor newProgramDescriptor = programDescriptor;
+
+        boolean isPreview = Boolean.valueOf(
+          options.getArguments().getOption(ProgramOptionConstants.IS_PREVIEW, "false"));
+        // do the app spec regeneration if the mode is on premise, for isolated mode, the regeneration is done on the
+        // runtime environment before the program launch
+        // for preview we already have a resolved app spec, so no need to regenerate the app spec again
+        if (!isPreview && appSpec != null && ClusterMode.ON_PREMISE.equals(clusterMode)) {
+          try {
+            ApplicationSpecification generatedAppSpec =
+              regenerateAppSpec(artifactDetail, programId, artifactId, appSpec, options);
+            appSpec = generatedAppSpec != null ? generatedAppSpec : appSpec;
+            newProgramDescriptor = new ProgramDescriptor(programDescriptor.getProgramId(), appSpec);
+          } catch (Exception e) {
+            LOG.warn("Failed to regenerate the app spec for program {}, using the existing app spec", programId);
+          }
+        }
         ProgramOptions runtimeProgramOptions = updateProgramOptions(artifactId, programId, options, runId);
 
         // Take a snapshot of all the plugin artifacts used by the program
         ProgramOptions optionsWithPlugins = createPluginSnapshot(runtimeProgramOptions, programId, tempDir,
-                                                                 programDescriptor.getApplicationSpecification());
+                                                                 newProgramDescriptor.getApplicationSpecification());
 
         // Create and run the program
-        Program executableProgram = createProgram(cConf, runner, programDescriptor, artifactDetail, tempDir);
+        Program executableProgram = createProgram(cConf, runner, newProgramDescriptor, artifactDetail, tempDir);
         cleanUpTaskRef.set(createCleanupTask(cleanUpTaskRef.get(), executableProgram));
 
         controller.setProgramController(runner.run(executableProgram, optionsWithPlugins));
@@ -279,6 +309,41 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
                                                programId.getProgram(), runId.getId()));
     dir.mkdirs();
     return dir;
+  }
+
+  /**
+   * Regenerates the app spec before the program start
+   *
+   * @return the regenerated app spec, or null if there is any exception generating the app spec.
+   */
+  @Nullable
+  private ApplicationSpecification regenerateAppSpec(
+    ArtifactDetail artifactDetail, ProgramId programId, ArtifactId artifactId,
+    ApplicationSpecification existingAppSpec,
+    ProgramOptions options) throws InterruptedException, ExecutionException, TimeoutException {
+    ApplicationClass appClass = Iterables.getFirst(artifactDetail.getMeta().getClasses().getApps(), null);
+    if (appClass == null) {
+      // This should never happen.
+      throw new IllegalStateException(String.format(
+        "No application class found in artifact '%s' in namespace '%s'.",
+        artifactDetail.getDescriptor().getArtifactId(), programId.getNamespace()));
+    }
+
+    AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(
+      artifactId, artifactDetail.getDescriptor().getLocation(), programId.getNamespaceId(), appClass,
+      existingAppSpec.getName(), existingAppSpec.getAppVersion(), existingAppSpec.getConfiguration(), null, false,
+      true, options.getUserArguments().asMap());
+    Configurator configurator = this.configuratorFactory.create(deploymentInfo);
+    ListenableFuture<ConfigResponse> future = configurator.config();
+    ConfigResponse response = future.get(120, TimeUnit.SECONDS);
+    
+    if (response.getExitCode() == 0) {
+      AppSpecInfo appSpecInfo = response.getAppSpecInfo();
+      if (appSpecInfo != null && appSpecInfo.getAppSpec() != null) {
+        return appSpecInfo.getAppSpec();
+      }
+    }
+    return null;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -667,7 +667,8 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
           try {
             applicationLifecycleService.deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
                                                   artifactSummary, configString, createProgramTerminator(),
-                                                  ownerPrincipalId, appRequest.canUpdateSchedules());
+                                                  ownerPrincipalId, appRequest.canUpdateSchedules(), false,
+                                                  Collections.emptyMap());
           } catch (DatasetManagementException e) {
             if (e.getCause() instanceof UnauthorizedException) {
               throw (UnauthorizedException) e.getCause();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.internal.app.deploy.pipeline;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.annotations.SerializedName;
 import io.cdap.cdap.api.app.Application;
 import io.cdap.cdap.api.artifact.ApplicationClass;
@@ -26,6 +25,8 @@ import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import org.apache.twill.filesystem.Location;
 
+import java.util.Collections;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -44,23 +45,25 @@ public class AppDeploymentInfo {
   private final KerberosPrincipalId ownerPrincipal;
   @SerializedName("update-schedules")
   private final boolean updateSchedules;
+  private final boolean isRuntime;
+  private final Map<String, String> userArguments;
 
   public AppDeploymentInfo(AppDeploymentInfo info, Location artifactLocation) {
     this(info.artifactId, artifactLocation, info.namespaceId, info.applicationClass, info.appName, info.appVersion,
-         info.configString, info.ownerPrincipal, info.updateSchedules);
+         info.configString, info.ownerPrincipal, info.updateSchedules, info.isRuntime, Collections.emptyMap());
   }
 
-  @VisibleForTesting
   public AppDeploymentInfo(ArtifactId artifactId, Location artifactLocation, NamespaceId namespaceId,
                            ApplicationClass applicationClass, @Nullable String appName, @Nullable String appVersion,
                            @Nullable String configString) {
-    this(artifactId, artifactLocation, namespaceId, applicationClass, appName, appVersion, configString, null, true);
+    this(artifactId, artifactLocation, namespaceId, applicationClass, appName, appVersion, configString, null,
+         true, false, Collections.emptyMap());
   }
 
   public AppDeploymentInfo(ArtifactId artifactId, Location artifactLocation, NamespaceId namespaceId,
                            ApplicationClass applicationClass, @Nullable String appName, @Nullable String appVersion,
                            @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal,
-                           boolean updateSchedules) {
+                           boolean updateSchedules, boolean isRuntime, Map<String, String> userArguments) {
     this.artifactId = artifactId;
     this.artifactLocation = artifactLocation;
     this.namespaceId = namespaceId;
@@ -70,6 +73,8 @@ public class AppDeploymentInfo {
     this.configString = configString;
     this.ownerPrincipal = ownerPrincipal;
     this.updateSchedules = updateSchedules;
+    this.isRuntime = isRuntime;
+    this.userArguments = userArguments;
   }
 
   /**
@@ -141,5 +146,19 @@ public class AppDeploymentInfo {
    */
   public boolean canUpdateSchedules() {
     return updateSchedules;
+  }
+
+  /**
+   * @return true if this deployment happens at runtime before the program run, false otherwise
+   */
+  public boolean isRuntime() {
+    return isRuntime;
+  }
+
+  /**
+   * @return the runtime arguments for the app deployment, this is only used when isRuntime is true
+   */
+  public Map<String, String> getUserArguments() {
+    return userArguments;
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -133,4 +133,9 @@ public final class ProgramOptionConstants {
    * Option for requirements of various plugins present in the program
    */
   public static final String PLUGIN_REQUIREMENTS = "pluginRequirements";
+
+  /**
+   * Option for whether the program is in preview mode
+   */
+  public static final String IS_PREVIEW = "isPreview";
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.lang.Delegator;
 import io.cdap.cdap.common.twill.TwillAppNames;
+import io.cdap.cdap.internal.app.deploy.ConfiguratorFactory;
 import io.cdap.cdap.internal.app.runtime.AbstractListener;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDetail;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
@@ -89,8 +90,9 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
                                    // privileges needed for artifacts
                                    @Named(AppFabricServiceRuntimeModule.NOAUTH_ARTIFACT_REPO)
                                      ArtifactRepository noAuthArtifactRepository,
-                                   Impersonator impersonator, ProgramStateWriter programStateWriter) {
-    super(cConf, programRunnerFactory, noAuthArtifactRepository, programStateWriter);
+                                   Impersonator impersonator, ProgramStateWriter programStateWriter,
+                                   ConfiguratorFactory configuratorFactory) {
+    super(cConf, programRunnerFactory, noAuthArtifactRepository, programStateWriter, configuratorFactory);
     this.twillRunner = twillRunner;
     this.store = store;
     this.impersonator = impersonator;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/InMemoryProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/InMemoryProgramRuntimeService.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.app.runtime.ProgramRuntimeService;
 import io.cdap.cdap.app.runtime.ProgramStateWriter;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.internal.app.deploy.ConfiguratorFactory;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.proto.ProgramType;
@@ -60,8 +61,8 @@ public final class InMemoryProgramRuntimeService extends AbstractProgramRuntimeS
                                 @Named(AppFabricServiceRuntimeModule.NOAUTH_ARTIFACT_REPO)
                                   ArtifactRepository noAuthArtifactRepository,
                                 @Named(Constants.Service.MASTER_SERVICES_BIND_ADDRESS) InetAddress hostname,
-                                ProgramStateWriter programStateWriter) {
-    super(cConf, programRunnerFactory, noAuthArtifactRepository, programStateWriter);
+                                ProgramStateWriter programStateWriter, ConfiguratorFactory configuratorFactory) {
+    super(cConf, programRunnerFactory, noAuthArtifactRepository, programStateWriter, configuratorFactory);
     this.hostname = hostname.getCanonicalHostName();
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -611,6 +611,8 @@ public class ProgramLifecycleService {
    * @param programId the {@link ProgramId} to start/stop
    * @param overrides the arguments to override in the program's configured user arguments before starting
    * @param debug {@code true} if the program is to be started in debug mode, {@code false} otherwise
+   * @param isPreview true if the program is for preview run, for preview run, the app is already deployed with resolved
+   *                  properties, so no need to regenerate app spec again
    * @return {@link ProgramController}
    * @throws ConflictException if the specified program is already running, and if concurrent runs are not allowed
    * @throws NotFoundException if the specified program or the app it belongs to is not found in the specified namespace
@@ -619,7 +621,8 @@ public class ProgramLifecycleService {
    *                               a user requires {@link ApplicationPermission#EXECUTE} on the program
    * @throws Exception if there were other exceptions checking if the current user is authorized to start the program
    */
-  public ProgramController start(ProgramId programId, Map<String, String> overrides, boolean debug) throws Exception {
+  public ProgramController start(ProgramId programId, Map<String, String> overrides, boolean debug,
+                                 boolean isPreview) throws Exception {
     accessEnforcer.enforce(programId, authenticationContext.getPrincipal(), ApplicationPermission.EXECUTE);
     checkConcurrentExecution(programId);
 
@@ -627,6 +630,7 @@ public class ProgramLifecycleService {
     addAppCDAPVersion(programId, sysArgs);
     sysArgs.put(ProgramOptionConstants.SKIP_PROVISIONING, "true");
     sysArgs.put(SystemArguments.PROFILE_NAME, ProfileId.NATIVE.getScopedName());
+    sysArgs.put(ProgramOptionConstants.IS_PREVIEW, Boolean.toString(isPreview));
     Map<String, String> userArgs = propertiesResolver.getUserProperties(programId);
     if (overrides != null) {
       userArgs.putAll(overrides);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SystemProgramManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SystemProgramManagementService.java
@@ -120,7 +120,7 @@ public class SystemProgramManagementService extends AbstractRetryableScheduledSe
       Map<String, String> overrides = enabledProgramsMap.get(programId).asMap();
       LOG.debug("Starting program {} with args {}", programId, overrides);
       try {
-        programLifecycleService.start(programId, overrides, false);
+        programLifecycleService.start(programId, overrides, false, false);
       } catch (ConflictException ex) {
         // Ignore if the program is already running.
         LOG.debug("Program {} is already running.", programId);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTask.java
@@ -32,6 +32,7 @@ import io.cdap.cdap.app.deploy.ConfigResponse;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.deploy.InMemoryConfigurator;
@@ -108,16 +109,18 @@ public class ConfiguratorTask implements RunnableTask {
     private final ArtifactRepository artifactRepository;
     private final CConfiguration cConf;
     private final ArtifactLocalizerClient artifactLocalizerClient;
+    private final RemoteClientFactory remoteClientFactory;
 
     @Inject
     ConfiguratorTaskRunner(Impersonator impersonator, PluginFinder pluginFinder,
                            ArtifactRepository artifactRepository, CConfiguration cConf,
-                           ArtifactLocalizerClient artifactLocalizerClient) {
+                           ArtifactLocalizerClient artifactLocalizerClient, RemoteClientFactory remoteClientFactory) {
       this.impersonator = impersonator;
       this.pluginFinder = pluginFinder;
       this.artifactRepository = artifactRepository;
       this.cConf = cConf;
       this.artifactLocalizerClient = artifactLocalizerClient;
+      this.remoteClientFactory = remoteClientFactory;
     }
 
     public ConfigResponse configure(AppDeploymentInfo info) throws Exception {
@@ -130,7 +133,8 @@ public class ConfiguratorTask implements RunnableTask {
       // Creates a new deployment info with the newly fetched artifact
       AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(info, artifactLocation);
       InMemoryConfigurator configurator = new InMemoryConfigurator(cConf, pluginFinder, impersonator,
-                                                                   artifactRepository, deploymentInfo);
+                                                                   artifactRepository, remoteClientFactory,
+                                                                   deploymentInfo);
       try {
         return configurator.config().get(120, TimeUnit.SECONDS);
       } catch (ExecutionException e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/executor/AppCreator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/executor/AppCreator.java
@@ -33,6 +33,8 @@ import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 
+import java.util.Collections;
+
 /**
  * Creates an application if it doesn't already exist.
  */
@@ -63,7 +65,7 @@ public class AppCreator extends BaseStepExecutor<AppCreator.Arguments> {
     try {
       appLifecycleService.deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
                                     artifactSummary, configString, x -> { },
-                                    ownerPrincipalId, arguments.canUpdateSchedules());
+                                    ownerPrincipalId, arguments.canUpdateSchedules(), false, Collections.emptyMap());
     } catch (NotFoundException | UnauthorizedException | InvalidArtifactException e) {
       // these exceptions are for sure not retry-able. It's hard to tell if the others are, so we just try retrying
       // up to the default time limit

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
@@ -309,7 +309,8 @@ class CapabilityApplier {
     String configString = application.getConfig() == null ? null : GSON.toJson(application.getConfig());
     applicationLifecycleService
       .deployApp(applicationId.getParent(), applicationId.getApplication(), applicationId.getVersion(),
-                 application.getArtifact(), configString, NOOP_PROGRAM_TERMINATOR, null, null);
+                 application.getArtifact(), configString, NOOP_PROGRAM_TERMINATOR, null, null, false,
+                 Collections.emptyMap());
   }
 
   @VisibleForTesting

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
@@ -16,14 +16,12 @@
 
 package io.cdap.cdap.internal.sysapp;
 
-import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.dataset.DatasetManagementException;
 import io.cdap.cdap.api.retry.RetryableException;
 import io.cdap.cdap.app.program.ProgramDescriptor;
-import io.cdap.cdap.common.ApplicationNotFoundException;
 import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.common.InvalidArtifactException;
 import io.cdap.cdap.common.NotFoundException;
@@ -119,7 +117,8 @@ public class SystemAppEnableExecutor {
     try {
       return appLifecycleService.deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
                                            artifactSummary, configString, x -> { },
-                                           ownerPrincipalId, arguments.canUpdateSchedules());
+                                           ownerPrincipalId, arguments.canUpdateSchedules(), false,
+                                           Collections.emptyMap());
 
     } catch (UnauthorizedException | InvalidArtifactException e) {
       throw e;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
@@ -189,7 +189,8 @@ public class AbstractProgramRuntimeServiceTest {
 
     final Program program = createDummyProgram();
     final ProgramRuntimeService runtimeService =
-      new AbstractProgramRuntimeService(CConfiguration.create(), runnerFactory, null, new NoOpProgramStateWriter()) {
+      new AbstractProgramRuntimeService(CConfiguration.create(), runnerFactory, null,
+                                        new NoOpProgramStateWriter(), null) {
       @Override
       public ProgramLiveInfo getLiveInfo(ProgramId programId) {
         return new ProgramLiveInfo(programId, "runtime") { };
@@ -409,7 +410,7 @@ public class AbstractProgramRuntimeServiceTest {
                                         @Nullable Program program,
                                         @Nullable ArtifactRepository artifactRepository,
                                         @Nullable RuntimeInfo extraInfo) {
-      super(cConf, programRunnerFactory, artifactRepository, new NoOpProgramStateWriter());
+      super(cConf, programRunnerFactory, artifactRepository, new NoOpProgramStateWriter(), null);
       this.program = program;
       this.extraInfo = extraInfo;
     }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -118,7 +118,7 @@ public class ConfiguratorTest {
 
     // Create a configurator that is testable. Provide it a application.
     Configurator configurator = new InMemoryConfigurator(conf, pluginFinder, new DefaultImpersonator(cConf, null),
-                                                         artifactRepo, appDeploymentInfo);
+                                                         artifactRepo, null, appDeploymentInfo);
     // Extract response from the configurator.
     ListenableFuture<ConfigResponse> result = configurator.config();
     ConfigResponse response = result.get(10, TimeUnit.SECONDS);
@@ -162,7 +162,7 @@ public class ConfiguratorTest {
 
     // Create a configurator that is testable. Provide it an application.
     Configurator configurator = new InMemoryConfigurator(conf, pluginFinder, new DefaultImpersonator(cConf, null),
-                                                         artifactRepo, appDeploymentInfo);
+                                                         artifactRepo, null, appDeploymentInfo);
 
     ListenableFuture<ConfigResponse> result = configurator.config();
     ConfigResponse response = result.get(10, TimeUnit.SECONDS);
@@ -184,7 +184,7 @@ public class ConfiguratorTest {
 
     Configurator configuratorWithoutConfig = new InMemoryConfigurator(conf, pluginFinder,
                                                                       new DefaultImpersonator(cConf, null),
-                                                                      artifactRepo, appDeploymentInfo);
+                                                                      artifactRepo, null, appDeploymentInfo);
     result = configuratorWithoutConfig.config();
     response = result.get(10, TimeUnit.SECONDS);
     Assert.assertNotNull(response);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/RunRecordCorrectorServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/RunRecordCorrectorServiceTest.java
@@ -166,8 +166,8 @@ public class RunRecordCorrectorServiceTest extends AppFabricTestBase {
 
     // Use a ProgramRuntimeService that only reports running state based on a set of know ids
     final Map<ProgramId, RunId> runningSet = new HashMap<>();
-    ProgramRuntimeService programRuntimeService = new AbstractProgramRuntimeService(cConf, null, null,
-                                                                                    new NoOpProgramStateWriter()) {
+    ProgramRuntimeService programRuntimeService = new AbstractProgramRuntimeService(
+      cConf, null, null, new NoOpProgramStateWriter(), null) {
 
       @Override
       public ProgramLiveInfo getLiveInfo(ProgramId programId) {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
@@ -42,6 +42,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -100,8 +101,8 @@ public class SystemProgramManagementServiceTest extends AppFabricTestBase {
     Assert.assertEquals(ProgramStatus.STOPPED.name(), getProgramStatus(programId));
     assertProgramRuns(programId, ProgramRunStatus.RUNNING, 0);
     //Run the program manually twice to test pruning. One run should be killed
-    programLifecycleService.start(programId, new HashMap<>(), false);
-    programLifecycleService.start(programId, new HashMap<>(), false);
+    programLifecycleService.start(programId, new HashMap<>(), false, false);
+    programLifecycleService.start(programId, new HashMap<>(), false, false);
     assertProgramRuns(programId, ProgramRunStatus.RUNNING, 2);
     progmMgmtSvc.setProgramsEnabled(enabledServices);
     progmMgmtSvc.runTask();
@@ -123,6 +124,6 @@ public class SystemProgramManagementServiceTest extends AppFabricTestBase {
     applicationLifecycleService.deployApp(NamespaceId.SYSTEM, APP_NAME, VERSION, summary, null,
                                           programId -> {
                                             // no-op
-                                          }, null, false);
+                                          }, null, false, false, Collections.emptyMap());
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityManagementServiceTest.java
@@ -544,7 +544,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       });
     Iterable<ProgramDescriptor> programs = applicationWithPrograms.getPrograms();
     for (ProgramDescriptor program : programs) {
-      programLifecycleService.start(program.getProgramId(), new HashMap<>(), false);
+      programLifecycleService.start(program.getProgramId(), new HashMap<>(), false, false);
     }
     ProgramId programId = new ProgramId(applicationId, ProgramType.WORKFLOW,
                                         CapabilitySleepingWorkflowApp.SleepWorkflow.class.getSimpleName());
@@ -571,7 +571,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
     //try starting programs
     for (ProgramDescriptor program : programs) {
       try {
-        programLifecycleService.start(program.getProgramId(), new HashMap<>(), false);
+        programLifecycleService.start(program.getProgramId(), new HashMap<>(), false, false);
         Assert.fail("expecting exception");
       } catch (CapabilityNotAvailableException ex) {
         //expecting exception
@@ -624,7 +624,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       });
     Iterable<ProgramDescriptor> programs = applicationWithPrograms.getPrograms();
     for (ProgramDescriptor program : programs) {
-      programLifecycleService.start(program.getProgramId(), new HashMap<>(), false);
+      programLifecycleService.start(program.getProgramId(), new HashMap<>(), false, false);
     }
     ProgramId programId = new ProgramId(applicationId, ProgramType.WORKFLOW,
                                         CapabilitySleepingWorkflowPluginApp.SleepWorkflow.class.getSimpleName());
@@ -651,7 +651,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
     //try starting programs
     for (ProgramDescriptor program : programs) {
       try {
-        programLifecycleService.start(program.getProgramId(), new HashMap<>(), false);
+        programLifecycleService.start(program.getProgramId(), new HashMap<>(), false, false);
         Assert.fail("expecting exception");
       } catch (CapabilityNotAvailableException ex) {
         //expecting exception

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteValidationTask.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteValidationTask.java
@@ -105,7 +105,8 @@ public class RemoteValidationTask implements RunnableTask {
       macroProperties -> systemAppContext
         .evaluateMacros(namespace, macroProperties, macroEvaluator, macroParserOptions);
     PluginConfigurer pluginConfigurer = systemAppContext.createPluginConfigurer(namespace);
-    StageValidationResponse validationResponse = ValidationUtils.validate(validationRequest, pluginConfigurer, macroFn);
+    StageValidationResponse validationResponse = ValidationUtils.validate(namespace, validationRequest,
+                                                                          pluginConfigurer, macroFn);
 
     // If the validation success and if it only involves system artifacts, then we don't need to restart task runner
     if (validationResponse.getFailures().isEmpty()) {

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ValidationHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ValidationHandler.java
@@ -174,7 +174,7 @@ public class ValidationHandler extends AbstractSystemHttpServiceHandler {
     Function<Map<String, String>, Map<String, String>> macroFn =
       macroProperties -> getContext().evaluateMacros(namespace, macroProperties, macroEvaluator, macroParserOptions);
     String validationResponse = GSON.toJson(ValidationUtils.validate(
-      validationRequest, getContext().createServicePluginConfigurer(namespace), macroFn));
+      namespace, validationRequest, getContext().createServicePluginConfigurer(namespace), macroFn));
     responder.sendString(validationResponse);
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ValidationUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ValidationUtils.java
@@ -40,7 +40,6 @@ import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * Utility functions for common pipeline validation code
@@ -63,7 +62,7 @@ public final class ValidationUtils {
    * @param macroFn           {@link Function} for evaluating macros
    * @return {@link StageValidationResponse} in json format
    */
-  public static StageValidationResponse validate(StageValidationRequest validationRequest,
+  public static StageValidationResponse validate(String namespace, StageValidationRequest validationRequest,
                                                  PluginConfigurer pluginConfigurer,
                                                  Function<Map<String, String>, Map<String, String>> macroFn) {
 
@@ -71,8 +70,8 @@ public final class ValidationUtils {
     ValidatingConfigurer validatingConfigurer = new ValidatingConfigurer(pluginConfigurer);
     // Batch or Streaming doesn't matter for a single stage.
     PipelineSpecGenerator<ETLBatchConfig, BatchPipelineSpec> pipelineSpecGenerator =
-      new BatchPipelineSpecGenerator(validatingConfigurer, Collections.emptySet(), Collections.emptySet(),
-                                     Engine.SPARK);
+      new BatchPipelineSpecGenerator(namespace, validatingConfigurer, null, Collections.emptySet(),
+                                     Collections.emptySet(), Engine.SPARK);
 
     DefaultStageConfigurer stageConfigurer = new DefaultStageConfigurer(stageConfig.getName());
     for (StageSchema stageSchema : validationRequest.getInputSchemas()) {

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/service/ValidationUtilsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/service/ValidationUtilsTest.java
@@ -16,9 +16,6 @@
 
 package io.cdap.cdap.datapipeline.service;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
-import com.google.gson.Gson;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.macro.InvalidMacroException;
 import io.cdap.cdap.api.macro.MacroEvaluator;
@@ -27,28 +24,20 @@ import io.cdap.cdap.api.plugin.InvalidPluginConfigException;
 import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.api.plugin.PluginProperties;
-import io.cdap.cdap.api.plugin.PluginPropertyField;
 import io.cdap.cdap.api.plugin.PluginSelector;
-import io.cdap.cdap.etl.api.batch.BatchSource;
 import io.cdap.cdap.etl.mock.batch.MockSource;
-import io.cdap.cdap.etl.proto.v2.ETLPlugin;
 import io.cdap.cdap.etl.proto.v2.ETLStage;
 import io.cdap.cdap.etl.proto.v2.validation.StageSchema;
 import io.cdap.cdap.etl.proto.v2.validation.StageValidationRequest;
 import io.cdap.cdap.etl.proto.v2.validation.StageValidationResponse;
-import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
-import io.cdap.cdap.internal.lang.Fields;
-import io.cdap.cdap.internal.lang.Reflections;
+import io.cdap.cdap.proto.id.NamespaceId;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Tests for ValidationUtils
@@ -64,7 +53,8 @@ public class ValidationUtilsTest {
       etlStage, Collections
       .singletonList(testStageSchema), false);
     StageValidationResponse stageValidationResponse = ValidationUtils
-      .validate(validationRequest, getPluginConfigurer(MockSource.PLUGIN_CLASS), properties -> properties);
+      .validate(NamespaceId.DEFAULT.getNamespace(),
+                validationRequest, getPluginConfigurer(MockSource.PLUGIN_CLASS), properties -> properties);
     Assert.assertTrue(stageValidationResponse.getFailures().isEmpty());
   }
 
@@ -77,7 +67,8 @@ public class ValidationUtilsTest {
       etlStage, Collections
       .singletonList(testStageSchema), false);
     StageValidationResponse stageValidationResponse = ValidationUtils
-      .validate(validationRequest, getPluginConfigurer(MockSource.PLUGIN_CLASS), properties -> properties);
+      .validate(NamespaceId.DEFAULT.getNamespace(),
+                validationRequest, getPluginConfigurer(MockSource.PLUGIN_CLASS), properties -> properties);
     Assert.assertEquals(1, stageValidationResponse.getFailures().size());
   }
 
@@ -91,8 +82,9 @@ public class ValidationUtilsTest {
       .singletonList(testStageSchema), false);
     String testtable = "testtable";
     StageValidationResponse stageValidationResponse = ValidationUtils
-      .validate(validationRequest, getPluginConfigurer(MockSource.PLUGIN_CLASS), properties -> {
-        HashMap<String, String> propertiesCopy = new HashMap<>(properties);
+      .validate(NamespaceId.DEFAULT.getNamespace(), validationRequest,
+                getPluginConfigurer(MockSource.PLUGIN_CLASS), properties -> {
+        Map<String, String> propertiesCopy = new HashMap<>(properties);
         if (propertiesCopy.getOrDefault("tableName", "").equals("@{tName}")) {
           propertiesCopy.put("tableName", testtable);
         }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsApp.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsApp.java
@@ -38,7 +38,8 @@ public class DataStreamsApp extends AbstractApplication<DataStreamsConfig> {
 
     DataStreamsPipelineSpec spec;
     try {
-      spec = new DataStreamsPipelineSpecGenerator(getConfigurer(),
+      spec = new DataStreamsPipelineSpecGenerator(getConfigurer().getDeployedNamespace(), getConfigurer(),
+                                                  getConfigurer().getRuntimeConfigurer(),
                                                   ImmutableSet.of(StreamingSource.PLUGIN_TYPE),
                                                   ImmutableSet.of(BatchSink.PLUGIN_TYPE, SparkSink.PLUGIN_TYPE,
                                                                   AlertPublisher.PLUGIN_TYPE)).generateSpec(config);

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.datastreams;
 
 import io.cdap.cdap.api.DatasetConfigurer;
+import io.cdap.cdap.api.app.RuntimeConfigurer;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.etl.api.Engine;
 import io.cdap.cdap.etl.api.FailureCollector;
@@ -28,6 +29,7 @@ import io.cdap.cdap.etl.spec.PipelineSpecGenerator;
 import org.apache.hadoop.fs.Path;
 
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Generates specs for data stream pipelines.
@@ -35,10 +37,10 @@ import java.util.Set;
 public class DataStreamsPipelineSpecGenerator
   extends PipelineSpecGenerator<DataStreamsConfig, DataStreamsPipelineSpec> {
 
-  <T extends PluginConfigurer & DatasetConfigurer> DataStreamsPipelineSpecGenerator(T configurer,
-                                                                                    Set<String> sourcePluginTypes,
-                                                                                    Set<String> sinkPluginTypes) {
-    super(configurer, sourcePluginTypes, sinkPluginTypes, Engine.SPARK);
+  <T extends PluginConfigurer & DatasetConfigurer> DataStreamsPipelineSpecGenerator(
+    String namespace, T configurer, @Nullable RuntimeConfigurer runtimeConfigurer, Set<String> sourcePluginTypes,
+    Set<String> sinkPluginTypes) {
+    super(namespace, configurer, runtimeConfigurer, sourcePluginTypes, sinkPluginTypes, Engine.SPARK);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/ETLMapReduce.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/mapreduce/ETLMapReduce.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.api.ProgramLifecycle;
 import io.cdap.cdap.api.ProgramStatus;
 import io.cdap.cdap.api.annotation.TransactionControl;
 import io.cdap.cdap.api.annotation.TransactionPolicy;
+import io.cdap.cdap.api.app.RuntimeConfigurer;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.api.mapreduce.AbstractMapReduce;
@@ -62,6 +63,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * MapReduce Driver for ETL Batch Applications.
@@ -94,12 +96,17 @@ public class ETLMapReduce extends AbstractMapReduce {
 
   // this is only visible at configure time, not at runtime
   private final BatchPhaseSpec phaseSpec;
+  private final RuntimeConfigurer runtimeConfigurer;
+  private final String deployedNamespace;
 
   private final Set<String> connectorDatasets;
 
-  public ETLMapReduce(BatchPhaseSpec phaseSpec, Set<String> connectorDatasets) {
+  public ETLMapReduce(BatchPhaseSpec phaseSpec, Set<String> connectorDatasets,
+                      @Nullable RuntimeConfigurer runtimeConfigurer, String deployedNamespace) {
     this.phaseSpec = phaseSpec;
     this.connectorDatasets = connectorDatasets;
+    this.runtimeConfigurer = runtimeConfigurer;
+    this.deployedNamespace = deployedNamespace;
   }
 
   @Override
@@ -109,7 +116,7 @@ public class ETLMapReduce extends AbstractMapReduce {
 
     // register the plugins at program level so that the program can be failed by the platform early in case of
     // plugin requirements not being meet
-    phaseSpec.getPhase().registerPlugins(getConfigurer());
+    phaseSpec.getPhase().registerPlugins(getConfigurer(), runtimeConfigurer, deployedNamespace);
 
     // Set resources for mapper, reducer and driver
     setMapperResources(phaseSpec.getResources());

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/BatchPipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/batch/BatchPipelineSpecGenerator.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.etl.batch;
 
 import io.cdap.cdap.api.DatasetConfigurer;
+import io.cdap.cdap.api.app.RuntimeConfigurer;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.etl.api.Engine;
 import io.cdap.cdap.etl.api.validation.ValidationException;
@@ -29,17 +30,18 @@ import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 import io.cdap.cdap.etl.spec.PipelineSpecGenerator;
 
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Generates a pipeline spec for batch apps.
  */
 public class BatchPipelineSpecGenerator extends PipelineSpecGenerator<ETLBatchConfig, BatchPipelineSpec> {
 
-  public <T extends PluginConfigurer & DatasetConfigurer> BatchPipelineSpecGenerator(T configurer,
-                                                                                     Set<String> sourcePluginTypes,
-                                                                                     Set<String> sinkPluginTypes,
-                                                                                     Engine engine) {
-    super(configurer, sourcePluginTypes, sinkPluginTypes, engine);
+  public <T extends PluginConfigurer & DatasetConfigurer> BatchPipelineSpecGenerator(
+    String namespace,
+    T configurer, @Nullable RuntimeConfigurer runtimeConfigurer, Set<String> sourcePluginTypes,
+    Set<String> sinkPluginTypes, Engine engine) {
+    super(namespace, configurer, runtimeConfigurer, sourcePluginTypes, sinkPluginTypes, engine);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ConnectionRegistryMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ConnectionRegistryMacroEvaluator.java
@@ -30,10 +30,10 @@ import java.util.Set;
 public class ConnectionRegistryMacroEvaluator implements MacroEvaluator {
   public static final String FUNCTION_NAME = "conn";
 
-  private final Set<String> connectionIds;
+  private final Set<String> connectionNames;
 
   public ConnectionRegistryMacroEvaluator() {
-    this.connectionIds = new HashSet<>();
+    this.connectionNames = new HashSet<>();
   }
 
   @Override
@@ -49,14 +49,14 @@ public class ConnectionRegistryMacroEvaluator implements MacroEvaluator {
       throw new InvalidMacroException("Macro '" + FUNCTION_NAME + "' should have exactly 1 arguments");
     }
 
-    connectionIds.add(ConnectionId.getConnectionId(args[0]));
+    connectionNames.add(ConnectionId.getConnectionId(args[0]));
 
     throw new InvalidMacroException("The '" + FUNCTION_NAME
                                       + "' macro function doesn't support evaluating the connection macro " +
                                       "for connection '" + args[0] + "'");
   }
 
-  public Set<String> getConnectionIds() {
-    return connectionIds;
+  public Set<String> getUsedConnections() {
+    return connectionNames;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
@@ -65,6 +65,7 @@ import io.cdap.cdap.etl.proto.v2.ETLTransformationPushdown;
 import io.cdap.cdap.etl.proto.v2.spec.PipelineSpec;
 import io.cdap.cdap.etl.proto.v2.spec.PluginSpec;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.proto.id.NamespaceId;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -133,8 +134,8 @@ public class PipelineSpecGeneratorTest {
     pluginConfigurer.addMockPlugin(BatchJoiner.PLUGIN_TYPE, "mockautojoiner", new MockAutoJoin(), artifactIds);
     pluginConfigurer.addMockPlugin(BatchSQLEngine.PLUGIN_TYPE, "mocksqlengine", new MockSQLEngine(), artifactIds);
 
-    specGenerator = new BatchPipelineSpecGenerator(pluginConfigurer,
-                                                   ImmutableSet.of(BatchSource.PLUGIN_TYPE),
+    specGenerator = new BatchPipelineSpecGenerator(NamespaceId.DEFAULT.getNamespace(), pluginConfigurer,
+                                                   null, ImmutableSet.of(BatchSource.PLUGIN_TYPE),
                                                    ImmutableSet.of(BatchSink.PLUGIN_TYPE),
                                                    Engine.MAPREDUCE);
   }
@@ -867,7 +868,8 @@ public class PipelineSpecGeneratorTest {
       .setEngine(Engine.MAPREDUCE)
       .build();
 
-    new BatchPipelineSpecGenerator(pluginConfigurer, ImmutableSet.of(BatchSource.PLUGIN_TYPE),
+    new BatchPipelineSpecGenerator(NamespaceId.DEFAULT.getNamespace(),
+                                   pluginConfigurer, null, ImmutableSet.of(BatchSource.PLUGIN_TYPE),
                                    ImmutableSet.of(BatchSink.PLUGIN_TYPE), Engine.MAPREDUCE)
       .generateSpec(config);
   }
@@ -894,7 +896,8 @@ public class PipelineSpecGeneratorTest {
       .setNumOfRecordsPreview(100)
       .build();
 
-    PipelineSpec actual = new BatchPipelineSpecGenerator(pluginConfigurer, ImmutableSet.of(BatchSource.PLUGIN_TYPE),
+    PipelineSpec actual = new BatchPipelineSpecGenerator(NamespaceId.DEFAULT.getNamespace(), pluginConfigurer, null,
+                                                         ImmutableSet.of(BatchSource.PLUGIN_TYPE),
                                                          ImmutableSet.of(BatchSink.PLUGIN_TYPE), Engine.MAPREDUCE)
       .generateSpec(config);
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
@@ -22,6 +22,7 @@ import com.google.gson.GsonBuilder;
 import io.cdap.cdap.api.ProgramStatus;
 import io.cdap.cdap.api.annotation.TransactionControl;
 import io.cdap.cdap.api.annotation.TransactionPolicy;
+import io.cdap.cdap.api.app.RuntimeConfigurer;
 import io.cdap.cdap.api.data.batch.InputFormatProvider;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.macro.MacroEvaluator;
@@ -44,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Configures and sets up runs of {@link BatchSparkPipelineDriver}.
@@ -59,10 +61,14 @@ public class ETLSpark extends AbstractSpark {
     .create();
 
   private final BatchPhaseSpec phaseSpec;
+  private final RuntimeConfigurer runtimeConfigurer;
+  private final String deployedNamespace;
   private Finisher finisher;
 
-  public ETLSpark(BatchPhaseSpec phaseSpec) {
+  public ETLSpark(BatchPhaseSpec phaseSpec, @Nullable RuntimeConfigurer runtimeConfigurer, String deployedNamespace) {
     this.phaseSpec = phaseSpec;
+    this.runtimeConfigurer = runtimeConfigurer;
+    this.deployedNamespace = deployedNamespace;
   }
 
   @Override
@@ -72,7 +78,7 @@ public class ETLSpark extends AbstractSpark {
 
     // register the plugins at program level so that the program can be failed by the platform early in case of
     // plugin requirements not being meet
-    phaseSpec.getPhase().registerPlugins(getConfigurer());
+    phaseSpec.getPhase().registerPlugins(getConfigurer(), runtimeConfigurer, deployedNamespace);
 
     setMainClass(BatchSparkPipelineDriver.class);
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -82,6 +82,7 @@ import io.cdap.cdap.etl.mock.transform.FlattenErrorTransform;
 import io.cdap.cdap.etl.mock.transform.IdentityTransform;
 import io.cdap.cdap.etl.mock.transform.IntValueFilterTransform;
 import io.cdap.cdap.etl.mock.transform.NullFieldSplitterTransform;
+import io.cdap.cdap.etl.mock.transform.PluginValidationTransform;
 import io.cdap.cdap.etl.mock.transform.SleepTransform;
 import io.cdap.cdap.etl.mock.transform.StringValueFilterTransform;
 import io.cdap.cdap.proto.id.ApplicationId;
@@ -118,7 +119,8 @@ public class HydratorTestBase extends TestBase {
     DistinctReducibleAggregator.PLUGIN_CLASS, FieldCountReducibleAggregator.PLUGIN_CLASS,
     FileConnector.PLUGIN_CLASS, IncapableSource.PLUGIN_CLASS, IncapableSink.PLUGIN_CLASS,
     LookupTransform.PLUGIN_CLASS, SleepTransform.PLUGIN_CLASS, NodeStatesAction.PLUGIN_CLASS,
-    DistinctAggregator.PLUGIN_CLASS, NullErrorTransform.PLUGIN_CLASS, ExceptionTransform.PLUGIN_CLASS
+    DistinctAggregator.PLUGIN_CLASS, NullErrorTransform.PLUGIN_CLASS, ExceptionTransform.PLUGIN_CLASS,
+    PluginValidationTransform.PLUGIN_CLASS
   );
   private static final Set<PluginClass> STREAMING_MOCK_PLUGINS = ImmutableSet.of(
     io.cdap.cdap.etl.mock.spark.streaming.MockSource.PLUGIN_CLASS,

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/transform/PluginValidationTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/transform/PluginValidationTransform.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.etl.mock.transform;
+
+import com.google.common.collect.ImmutableSet;
+import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.api.plugin.PluginConfig;
+import io.cdap.cdap.api.plugin.PluginProperties;
+import io.cdap.cdap.api.plugin.PluginPropertyField;
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.StageSubmitterContext;
+import io.cdap.cdap.etl.api.Transform;
+import io.cdap.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This transform is basically identity transform but can be used to validate the plugin config can be set as macro
+ */
+@Plugin(type = Transform.PLUGIN_TYPE)
+@Name(PluginValidationTransform.PLUGIN_NAME)
+public class PluginValidationTransform extends Transform<StructuredRecord, StructuredRecord> {
+  public static final String PLUGIN_NAME = "PluginValidation";
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private final Config config;
+
+  public PluginValidationTransform(Config config) {
+    this.config = config;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    if (!config.containsMacro("plugin1") && !config.containsMacro("plugin1Type")) {
+      pipelineConfigurer.usePlugin(config.connectionConfig.plugin1Type, config.connectionConfig.plugin1,
+                                   config.connectionConfig.plugin1, PluginProperties.builder().build());
+    }
+
+    if (!config.containsMacro("plugin2") && !config.containsMacro("plugin2Type")) {
+      pipelineConfigurer.usePlugin(config.plugin2Type, config.plugin2,
+                                   config.plugin2, PluginProperties.builder().build());
+    }
+  }
+
+  @Override
+  public void prepareRun(StageSubmitterContext context) throws Exception {
+    super.prepareRun(context);
+    Object plugin1 = context.newPluginInstance(config.connectionConfig.plugin1);
+    Object plugin2 = context.newPluginInstance(config.plugin2);
+    if (plugin1 == null || plugin2 == null) {
+      throw new RuntimeException(String.format("Both %s and %s should get instantiated.",
+                                               config.connectionConfig.plugin1, config.plugin2));
+    }
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
+    emitter.emit(input);
+  }
+
+  /**
+   * Config for the source.
+   */
+  public static class Config extends PluginConfig {
+    @Macro
+    public ConnectionConfig connectionConfig;
+
+    @Macro
+    public String plugin2;
+
+    @Macro
+    public String plugin2Type;
+  }
+
+  /**
+   * Connection Config for mock source
+   */
+  public static class ConnectionConfig extends PluginConfig {
+    @Macro
+    public String plugin1;
+
+    @Macro
+    public String plugin1Type;
+  }
+
+  public static ETLPlugin getPlugin(String plugin1, String plugin1Type, String plugin2, String plugin2Type) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("plugin1", plugin1);
+    properties.put("plugin1Type", plugin1Type);
+    properties.put("plugin2", plugin2);
+    properties.put("plugin2Type", plugin2Type);
+    return new ETLPlugin(PLUGIN_NAME, Transform.PLUGIN_TYPE, properties, null);
+  }
+
+  public static ETLPlugin getPluginUsingConnection(String connectionName, String plugin2, String plugin2Type) {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("connectionConfig", String.format("${conn(%s)}", connectionName));
+    properties.put("plugin2", plugin2);
+    properties.put("plugin2Type", plugin2Type);
+    return new ETLPlugin(PLUGIN_NAME, Transform.PLUGIN_TYPE, properties, null);
+  }
+
+  private static PluginClass getPluginClass() {
+    Map<String, PluginPropertyField> properties = new HashMap<>();
+    properties.put("connectionConfig", new PluginPropertyField("connectionConfig", "", "connectionconfig", true, true,
+                                                               false, ImmutableSet.of("plugin1", "plugin1Type")));
+    properties.put("plugin1", new PluginPropertyField("plugin1", "", "string", true, true));
+    properties.put("plugin1Type", new PluginPropertyField("plugin1Type", "", "string", true, true));
+    properties.put("plugin2", new PluginPropertyField("plugin2", "", "string", true, true));
+    properties.put("plugin2Type", new PluginPropertyField("plugin2Type", "", "string", true, true));
+    return PluginClass.builder().setName(PLUGIN_NAME).setType(Transform.PLUGIN_TYPE)
+             .setDescription("").setClassName(PluginValidationTransform.class.getName()).setProperties(properties)
+             .setConfigFieldName("config").build();
+  }
+}


### PR DESCRIPTION
Regenerate the app spec for on-premise program run, isolated run will come in next pr.

This pr will solve:
1. Everything other than secure related macros will get finalized before program run, so connections can be editable.
2. The plugin related config can now be macro enabled, since the new app spec will include all the plugins that will be used in the pipeline run. A good example will be format plugins and jdbc plugins, and any plugins that is used in connection related configs.