### PR TITLE
[CDAP-18627] Remove confusing createEndKey(byte[] row) which just calls createStartKey(row)

### DIFF
--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
@@ -205,7 +205,7 @@ public class LevelDBTableCore {
 
     DBIterator iterator = getDB().iterator();
     seekToStart(iterator, startRow);
-    byte[] endKey = stopRow == null ? null : createEndKey(stopRow);
+    byte[] endKey = stopRow == null ? null : createStartKey(stopRow);
     return new LevelDBScanner(iterator, endKey, filter, columns, tx);
   }
 
@@ -386,7 +386,7 @@ public class LevelDBTableCore {
     DB db = getDB();
     DBIterator iterator = db.iterator();
     seekToStart(iterator, startRow);
-    byte[] endKey = stopRow == null ? null : createEndKey(stopRow);
+    byte[] endKey = stopRow == null ? null : createStartKey(stopRow);
 
     DBIterator deleteIterator = db.iterator();
     seekToStart(deleteIterator, startRow);
@@ -538,10 +538,6 @@ public class LevelDBTableCore {
 
   private static byte[] createStartKey(byte[] row) { // the first possible key of a row
     return KeyValue.getKey(row, DATA_COLFAM, null, KeyValue.LATEST_TIMESTAMP, KeyValue.Type.Maximum);
-  }
-
-  private static byte[] createEndKey(byte[] row) {
-    return createStartKey(row); // the first key of the stop is the first to be excluded
   }
 
   private static byte[] createStartKey(byte[] row, byte[] column) {


### PR DESCRIPTION
Why:
 private static byte[] createEndKey(byte[] row) {
    return createStartKey(row); // the first key of the stop is the first to be excluded
  }
This method is confusing as it is NOT creating end key for a row,
instead it assumes the row passed in is the end-row (i.e. excluded) for a scan.