### PR TITLE
[CDAP-18626] Revive artifact-fetching-and-caching-WITHOUT-unpacking API

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
@@ -106,6 +106,20 @@ public class ArtifactLocalizer {
   }
 
   /**
+   * Gets the location on the local filesystem for the given artifact. This method handles fetching the artifact as well
+   * as caching it.
+   *
+   * @param artifactId The ArtifactId of the artifact to fetch
+   * @return The Local Location for this artifact
+   * @throws ArtifactNotFoundException if the given artifact does not exist
+   * @throws IOException if there was an exception while fetching or caching the artifact
+   * @throws Exception if there was an unexpected error
+   */
+  public File getArtifact(ArtifactId artifactId) throws Exception {
+    return Retries.callWithRetries(() -> fetchArtifact(artifactId), retryStrategy);
+  }
+
+  /**
    * Gets the location on the local filesystem for the directory that contains the unpacked artifact. This method
    * handles fetching, caching and unpacking the artifact.
    *

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerClient.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerClient.java
@@ -54,6 +54,19 @@ public class ArtifactLocalizerClient {
   }
 
   /**
+   * Gets the location on the local filesystem for the given artifact. This method handles fetching the artifact as well
+   * as caching it.
+   *
+   * @param artifactId The ArtifactId of the artifact to fetch
+   * @return The Local Location for this artifact
+   * @throws ArtifactNotFoundException if the given artifact does not exist
+   * @throws IOException if there was an exception while fetching or caching the artifact
+   */
+  public File getArtifactLocation(ArtifactId artifactId) throws IOException, ArtifactNotFoundException {
+    return sendRequest(artifactId, false);
+  }
+
+  /**
    * Gets the location on the local filesystem for the directory that contains the unpacked artifact. This method
    * handles fetching, caching and unpacking the artifact.
    *
@@ -63,6 +76,10 @@ public class ArtifactLocalizerClient {
    * @throws IOException if there was an exception while fetching, caching or unpacking the artifact
    */
   public File getUnpackedArtifactLocation(ArtifactId artifactId) throws IOException, ArtifactNotFoundException {
+    return sendRequest(artifactId, true);
+  }
+
+  private File sendRequest(ArtifactId artifactId, boolean unpack) throws IOException, ArtifactNotFoundException {
     String urlPath = String.format("/artifact/namespaces/%s/artifacts/%s/versions/%s",
                                    artifactId.getNamespace(), artifactId.getArtifact(), artifactId.getVersion());
     URL url;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerHttpHandlerInternal.java
@@ -32,9 +32,11 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.io.File;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 
 /**
  * Internal {@link HttpHandler} for Artifact Localizer.
@@ -56,11 +58,13 @@ public class ArtifactLocalizerHttpHandlerInternal extends AbstractHttpHandler {
   public void artifact(HttpRequest request, HttpResponder responder,
                        @PathParam("namespace-id") String namespaceId,
                        @PathParam("artifact-name") String artifactName,
-                       @PathParam("artifact-version") String artifactVersion) {
-
+                       @PathParam("artifact-version") String artifactVersion,
+                       @QueryParam("unpack") @DefaultValue("true") boolean unpack) throws Exception {
     ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersion);
     try {
-      File artifactPath = artifactLocalizer.getAndUnpackArtifact(artifactId);
+      File artifactPath = unpack
+        ? artifactLocalizer.getAndUnpackArtifact(artifactId)
+        : artifactLocalizer.getArtifact(artifactId);
       responder.sendString(HttpResponseStatus.OK, artifactPath.toString());
     } catch (Exception ex) {
       if (ex instanceof HttpErrorStatusProvider) {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
@@ -151,4 +151,47 @@ public class ArtifactLocalizerServiceTest extends AppFabricTestBase {
     Assert.assertTrue(files.size() > 1);
     Assert.assertTrue(files.stream().anyMatch(s -> s.equals("META-INF")));
   }
+
+  @Test
+  public void testArtifact() throws Exception {
+    LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);
+    ArtifactRepository artifactRepository = getInjector().getInstance(ArtifactRepository.class);
+    ArtifactLocalizerClient client = new ArtifactLocalizerClient(cConf);
+
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "some-task", "1.0.0-SNAPSHOT");
+    Location appJar = AppJarHelper.createDeploymentJar(locationFactory, TaskWorkerServiceTest.TestRunnableClass.class);
+    File appJarFile = new File(tmpFolder.newFolder(),
+                               String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
+    File newAppJarFile = new File(tmpFolder.newFolder(),
+                                  String.format("%s-%s-copy.jar", artifactId.getName(),
+                                                artifactId.getVersion().getVersion()));
+    Locations.linkOrCopy(appJar, appJarFile);
+    appJar.delete();
+    artifactRepository.addArtifact(artifactId, appJarFile);
+
+    File artifactPath = client.getArtifactLocation(artifactId.toEntityId());
+
+    // Make sure the artifact was actually cached
+    Assert.assertTrue(artifactPath.exists());
+
+    // Call the sidecar again and make sure the same path was returned
+    File sameArtifactPath = client.getArtifactLocation(artifactId.toEntityId());
+    Assert.assertEquals(artifactPath, sameArtifactPath);
+
+    // Delete and recreate the artifact to update the last modified date
+    artifactRepository.deleteArtifact(artifactId);
+
+    // This sleep is needed to delay the file copy so that the lastModified time on the file is different
+    Thread.sleep(1000);
+
+    // Wait a bit before recreating the artifact to make sure the last modified time is different
+    Files.copy(appJarFile, newAppJarFile);
+    artifactRepository.addArtifact(artifactId, newAppJarFile);
+
+    File newArtifactPath = client.getArtifactLocation(artifactId.toEntityId());
+
+    //Make sure the two paths arent the same and that the old one is gone
+    Assert.assertNotEquals(artifactPath, newArtifactPath);
+    Assert.assertTrue(newArtifactPath.exists());
+  }
 }


### PR DESCRIPTION
Why:
To allow preview runner running with restricted permission (i.e.
no permission to access artifacts on distributed file system or
metadata in external database), we need an API for preview runner
to fetch and cache artifact.

What:
Add back the APIs for ArtifactLocalizer to fetch artifact jar.