### PR TITLE
[CDAP-18694] Refactor ArtifactRepository createArtifactClassLoader to take ArtifactDescriptor instead of just location

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryConfigurator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryConfigurator.java
@@ -43,6 +43,7 @@ import io.cdap.cdap.common.lang.CombineClassLoader;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppSpecInfo;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.Artifacts;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
@@ -113,8 +114,11 @@ public final class InMemoryConfigurator implements Configurator {
 
     // Create the classloader
     EntityImpersonator classLoaderImpersonator = new EntityImpersonator(artifactId.toEntityId(), impersonator);
-    try (CloseableClassLoader classLoader = artifactRepository.createArtifactClassLoader(artifactLocation,
-                                                                                         classLoaderImpersonator)) {
+    try (CloseableClassLoader classLoader =
+           artifactRepository.createArtifactClassLoader(new ArtifactDescriptor(artifactId.getNamespace().getId(),
+                                                                               artifactId.toArtifactId(),
+                                                                               artifactLocation),
+                                                        classLoaderImpersonator)) {
       SettableFuture<ConfigResponse> result = SettableFuture.create();
 
       Object appMain = classLoader.loadClass(appClassName).newInstance();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/DeployDatasetModulesStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/DeployDatasetModulesStage.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.dataset.module.DatasetModule;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.pipeline.AbstractStage;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
@@ -76,8 +77,12 @@ public class DeployDatasetModulesStage extends AbstractStage<ApplicationDeployab
                                                 ownerPrincipal);
 
       EntityImpersonator classLoaderImpersonator = new EntityImpersonator(input.getArtifactId(), impersonator);
-      try (CloseableClassLoader classLoader = artifactRepository.createArtifactClassLoader(input.getArtifactLocation(),
-                                                                                           classLoaderImpersonator)) {
+      try (CloseableClassLoader classLoader =
+             artifactRepository.createArtifactClassLoader(
+               new ArtifactDescriptor(input.getArtifactId().getNamespace(),
+                                      input.getArtifactId().toApiArtifactId(),
+                                      input.getArtifactLocation()),
+               classLoaderImpersonator)) {
         deployer.deployModules(input.getApplicationId().getParent(),
                                datasetModules,
                                input.getArtifactLocation(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactRepository.java
@@ -53,15 +53,14 @@ import javax.annotation.Nullable;
 public interface ArtifactRepository extends ArtifactRepositoryReader {
 
   /**
-   * Create a classloader that uses the artifact at the specified location to load classes, with access to
+   * Create a classloader that uses the artifact specified by {@link ArtifactDescriptor} to load classes, with access to
    * packages that all program type has access to.
    * It delegates to {@link ArtifactClassLoaderFactory#createClassLoader(Location, EntityImpersonator)}.
    *
    * @see ArtifactClassLoaderFactory
    */
-  CloseableClassLoader createArtifactClassLoader(Location artifactLocation,
+  CloseableClassLoader createArtifactClassLoader(ArtifactDescriptor artifactDescriptor,
                                                  EntityImpersonator entityImpersonator) throws IOException;
-
   /**
    * Clear all artifacts in the given namespace. This method is only intended to be called by unit tests, and
    * when a namespace is being deleted.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/AuthorizationArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/AuthorizationArtifactRepository.java
@@ -81,9 +81,9 @@ public class AuthorizationArtifactRepository implements ArtifactRepository {
   }
 
   @Override
-  public CloseableClassLoader createArtifactClassLoader(Location artifactLocation,
+  public CloseableClassLoader createArtifactClassLoader(ArtifactDescriptor artifactDescriptor,
                                                         EntityImpersonator entityImpersonator) throws IOException {
-    return delegate.createArtifactClassLoader(artifactLocation, entityImpersonator);
+    return delegate.createArtifactClassLoader(artifactDescriptor, entityImpersonator);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactRepository.java
@@ -139,8 +139,8 @@ public class DefaultArtifactRepository implements ArtifactRepository {
 
   @Override
   public CloseableClassLoader createArtifactClassLoader(
-    Location artifactLocation, EntityImpersonator entityImpersonator) throws IOException {
-    return artifactClassLoaderFactory.createClassLoader(ImmutableList.of(artifactLocation).iterator(),
+    ArtifactDescriptor artifactDescriptor, EntityImpersonator entityImpersonator) throws IOException {
+    return artifactClassLoaderFactory.createClassLoader(ImmutableList.of(artifactDescriptor.getLocation()).iterator(),
                                                         entityImpersonator);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepository.java
@@ -62,9 +62,9 @@ public class RemoteArtifactRepository implements ArtifactRepository {
   }
 
   @Override
-  public CloseableClassLoader createArtifactClassLoader(Location artifactLocation,
+  public CloseableClassLoader createArtifactClassLoader(ArtifactDescriptor artifactDescriptor,
                                                         EntityImpersonator entityImpersonator) throws IOException {
-    return artifactClassLoaderFactory.createClassLoader(artifactLocation, entityImpersonator);
+    return artifactClassLoaderFactory.createClassLoader(artifactDescriptor.getLocation(), entityImpersonator);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -552,7 +552,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
                                           allowedArtifactScopes, allowSnapshot);
 
     try (CloseableClassLoader artifactClassLoader =
-      artifactRepository.createArtifactClassLoader(artifactDetail.getDescriptor().getLocation(),
+      artifactRepository.createArtifactClassLoader(artifactDetail.getDescriptor(),
                                                    classLoaderImpersonator)) {
       Object appMain = artifactClassLoader.loadClass(appClass.getClassName()).newInstance();
       // Run config update logic for the application to generate updated config.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppTask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppTask.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.common.guice.SupplierProviderBridge;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactManagerFactory;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.Artifacts;
@@ -99,7 +100,9 @@ public class SystemAppTask implements RunnableTask {
     EntityImpersonator classLoaderImpersonator = new EntityImpersonator(artifactId.toEntityId(), impersonator);
 
     try (CloseableClassLoader artifactClassLoader =
-           artifactRepository.createArtifactClassLoader(Locations.toLocation(artifactLocation),
+           artifactRepository.createArtifactClassLoader(new ArtifactDescriptor(artifactId.getNamespace().getId(),
+                                                                               artifactId.toArtifactId(),
+                                                                               Locations.toLocation(artifactLocation)),
                                                         classLoaderImpersonator);
          SystemAppTaskContext systemAppTaskContext = buildTaskSystemAppContext(injector, systemAppNamespace,
                                                                                systemAppArtifactId,


### PR DESCRIPTION
Why:
To support preivew running using sidecar container for fetching
and caching artifacts, it will require RemoteArtifactRepository
to fetch jar and create classload altogether as part of
the createArtifactClassLoader() call. By passing ArtifactDescriptor
it allows createArtifactClassLoader() to extract artifactId
for fetching artifact in case of RemoteArtifactRepository being
the implementation.