### PR TITLE
[CDAP-18680] Fix issue with pipelines failing when app-fabric restarts

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
@@ -219,6 +220,15 @@ public interface Store {
    * @return map of logged runs
    */
   int countActiveRuns(@Nullable Integer limit);
+
+  /**
+   * Scans for active (i.e STARTING or RUNNING or SUSPENDED) run records
+   *
+   * @param txBatchSize maximum number of applications to scan in one transaction to
+   *                    prevent holding a single transaction for too long
+   * @param consumer a {@link Consumer} to consume each application being scanned
+   */
+  void scanActiveRuns(int txBatchSize, Consumer<RunRecordDetail> consumer);
 
   /**
    * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records against a given NamespaceId.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
@@ -481,6 +481,15 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
    * service.
    */
   private boolean createControllerIfNeeded(RunRecordDetail runRecordDetail) {
+    // Controller only needs to be created for program runs in RUNNING or SUSPENDED state.
+    // Program runs in PENDING and STARTING state will eventually start and controller will be created later.
+    if (runRecordDetail.getStatus() != ProgramRunStatus.RUNNING
+      && runRecordDetail.getStatus() != ProgramRunStatus.SUSPENDED) {
+      LOG.debug("Skip creating controller for run {} with status {}", runRecordDetail.getProgramRunId(),
+                runRecordDetail.getStatus());
+      return false;
+    }
+
     Map<String, String> systemArgs = runRecordDetail.getSystemArgs();
     try {
       ClusterMode clusterMode = ClusterMode.valueOf(systemArgs.getOrDefault(ProgramOptionConstants.CLUSTER_MODE,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -32,9 +32,13 @@ import io.cdap.cdap.api.workflow.WorkflowSpecification;
 import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.app.runtime.ProgramStateWriter;
+import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.service.Retries;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.common.service.RetryStrategy;
 import io.cdap.cdap.common.utils.ImmutablePair;
 import io.cdap.cdap.common.utils.ProjectInfo;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
@@ -114,6 +118,8 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
   private final Queue<Runnable> tasks;
   private final MetricsCollectionService metricsCollectionService;
   private Set<ProgramCompletionNotifier> programCompletionNotifiers;
+  private final CConfiguration cConf;
+  private final Store store;
 
   @Inject
   ProgramNotificationSubscriberService(MessagingService messagingService, CConfiguration cConf,
@@ -121,7 +127,8 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
                                        ProvisionerNotifier provisionerNotifier,
                                        ProgramLifecycleService programLifecycleService,
                                        ProvisioningService provisioningService,
-                                       ProgramStateWriter programStateWriter, TransactionRunner transactionRunner) {
+                                       ProgramStateWriter programStateWriter, TransactionRunner transactionRunner,
+                                       Store store) {
     super("program.status", cConf, cConf.get(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC),
           cConf.getInt(Constants.AppFabric.STATUS_EVENT_FETCH_SIZE),
           cConf.getLong(Constants.AppFabric.STATUS_EVENT_POLL_DELAY_MILLIS),
@@ -134,6 +141,42 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
     this.tasks = new LinkedList<>();
     this.metricsCollectionService = metricsCollectionService;
     this.programCompletionNotifiers = Collections.emptySet();
+    this.cConf = cConf;
+    this.store = store;
+  }
+
+  @Override
+  protected void doStartUp() throws Exception {
+    super.doStartUp();
+
+    int batchSize = cConf.getInt(Constants.RuntimeMonitor.INIT_BATCH_SIZE);
+    RetryStrategy retryStrategy = RetryStrategies.fromConfiguration(cConf, "system.runtime.monitor.");
+    long startTs = System.currentTimeMillis();
+
+    Retries.runWithRetries(() -> store.scanActiveRuns(batchSize, (runRecordDetail) -> {
+      if (runRecordDetail.getStartTs() > startTs) {
+        return;
+      }
+      try {
+        if (runRecordDetail.getStatus() == ProgramRunStatus.STARTING) {
+          // It is unknown what is the state of program runs in STARTING state.
+          // A STARTING message is published again to retry STARTING logic.
+          ProgramOptions programOptions =
+            new SimpleProgramOptions(runRecordDetail.getProgramRunId().getParent(),
+                                     new BasicArguments(runRecordDetail.getSystemArgs()),
+                                     new BasicArguments(runRecordDetail.getUserArgs()));
+          LOG.debug("Retrying to start run {}.", runRecordDetail.getProgramRunId());
+          programStateWriter.start(runRecordDetail.getProgramRunId(),
+                                   programOptions,
+                                   null,
+                                   this.store.loadProgram(runRecordDetail.getProgramRunId().getParent()));
+        }
+      } catch (Exception e) {
+        ProgramRunId programRunId = runRecordDetail.getProgramRunId();
+        LOG.warn("Retrying to start run {} failed. Marking it as failed.", programRunId, e);
+        programStateWriter.error(programRunId, e);
+      }
+    }), retryStrategy, e -> true);
   }
 
   @Inject(optional = true)
@@ -263,27 +306,65 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
     RunRecordDetail recordedRunRecord;
     switch (programRunStatus) {
       case STARTING:
+        try {
+          RunRecordDetail runRecordDetail = appMetadataStore.getRun(programRunId);
+          if (runRecordDetail != null
+            && runRecordDetail.getStatus() != ProgramRunStatus.PENDING
+            && runRecordDetail.getStatus() != ProgramRunStatus.STARTING) {
+            //This is an invalid state transition happening. Valid state transitions are:
+            // PENDING => STARTING : normal state transition
+            // STARTING => STARTING : state transition after app-fabric restart
+            LOG.debug("Ignoring unexpected request to transition program run {} from {} state to program " +
+                        "STARTING state.", programRunId, runRecordDetail.getStatus());
+            return;
+          }
+        } catch (IllegalStateException ex) {
+          LOG.error("Request to transition program run {} from non-existent state to program STARTING state " +
+                      "but multiple run IDs exist.", programRunId);
+        }
+
         String systemArgumentsString = properties.get(ProgramOptionConstants.SYSTEM_OVERRIDES);
         Map<String, String> systemArguments = systemArgumentsString == null ?
           Collections.emptyMap() : GSON.fromJson(systemArgumentsString, STRING_STRING_MAP);
         boolean isInWorkflow = systemArguments.containsKey(ProgramOptionConstants.WORKFLOW_NAME);
         boolean skipProvisioning = Boolean.parseBoolean(systemArguments.get(ProgramOptionConstants.SKIP_PROVISIONING));
+
+        ProgramOptions prgOptions = ProgramOptions.fromNotification(notification, GSON);
+        ProgramDescriptor prgDescriptor =
+          GSON.fromJson(properties.get(ProgramOptionConstants.PROGRAM_DESCRIPTOR), ProgramDescriptor.class);
+
         // if this is a preview run or a program within a workflow, we don't actually need to provision a cluster
         // instead, we skip forward past the provisioning and provisioned states and go straight to starting.
+        // if this is NOT a preview run or a program within a workflow (i.e., else case), program is started and its
+        // state changes into Starting.
         if (isInWorkflow || skipProvisioning) {
-          ProgramOptions programOptions = ProgramOptions.fromNotification(notification, GSON);
-          ProgramDescriptor programDescriptor =
-            GSON.fromJson(properties.get(ProgramOptionConstants.PROGRAM_DESCRIPTOR), ProgramDescriptor.class);
-          appMetadataStore.recordProgramProvisioning(programRunId, programOptions.getUserArguments().asMap(),
-                                                     programOptions.getArguments().asMap(), messageIdBytes,
-                                                     programDescriptor.getArtifactId().toApiArtifactId());
+          appMetadataStore.recordProgramProvisioning(programRunId, prgOptions.getUserArguments().asMap(),
+                                                     prgOptions.getArguments().asMap(), messageIdBytes,
+                                                     prgDescriptor.getArtifactId().toApiArtifactId());
           appMetadataStore.recordProgramProvisioned(programRunId, 0, messageIdBytes);
+        } else {
+          runnables.add(() -> {
+            String oldUser = SecurityRequestContext.getUserId();
+            try {
+              SecurityRequestContext.setUserId(prgOptions.getArguments().getOption(ProgramOptionConstants.USER_ID));
+              try {
+                programLifecycleService.startInternal(prgDescriptor, prgOptions, programRunId);
+              } catch (Exception e) {
+                LOG.error("Failed to start program {}", programRunId, e);
+                programStateWriter.error(programRunId, e);
+              }
+            } finally {
+              SecurityRequestContext.setUserId(oldUser);
+            }
+          });
         }
+
         recordedRunRecord = appMetadataStore.recordProgramStart(programRunId, twillRunId,
                                                                 systemArguments, messageIdBytes);
         writeToHeartBeatTable(recordedRunRecord,
                               RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS),
                               programHeartbeatTable);
+
         break;
       case RUNNING:
         long logicalStartTimeSecs = getTimeSeconds(notification.getProperties(),
@@ -553,21 +634,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
           .ifPresent(profileId -> emitProvisioningTimeMetric(programRunId, profileId,
                                                              programOptions, provisioningTime));
 
-        // start the program run
-        return Optional.of(() -> {
-          String oldUser = SecurityRequestContext.getUserId();
-          try {
-            SecurityRequestContext.setUserId(userId);
-            try {
-              programLifecycleService.startInternal(programDescriptor, newProgramOptions, programRunId);
-            } catch (Exception e) {
-              LOG.error("Failed to start program {}", programRunId, e);
-              programStateWriter.error(programRunId, e);
-            }
-          } finally {
-            SecurityRequestContext.setUserId(oldUser);
-          }
-        });
+        break;
       case DEPROVISIONING:
         RunRecordDetail recordedMeta = appMetadataStore.recordProgramDeprovisioning(programRunId, messageIdBytes);
         // If we skipped recording the run status, that means this was a duplicate message,


### PR DESCRIPTION
Why: currently a pipeline fails if it is in STARTING state and app-fabric restarts. This PR addresses the issue as follows:

- The logic for running a program run in a cluster is moved (from when program run's cluster state changes to PROVISIONED) to when a program run's state changes to STARTING.
- The above change allows us to retry running a program run when app-fabric restarts. 
- When app-fabric restarts, only controllers for RUNNING/SUSPENDED program runs are created. Note that before this PR, app-fabric tried to create controller for any active program run (i.e., program run in any of the following states: PENDING/STARTING/RUNNING/SUSPENDED).

Note: this PR assumes that launching dataproc and k8s jobs are idempotent. https://github.com/cdapio/cdap/pull/13792 addresses idempotency for dataproc and k8s jobs. 