### PR TITLE
[CDAP-18619] Add Initialization SPI for Kubernetes Master Environment

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/DefaultLocalFileProvider.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/DefaultLocalFileProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.internal;
+
+import java.io.File;
+
+/**
+ * Provides a File object using local files.
+ */
+public class DefaultLocalFileProvider implements LocalFileProvider {
+
+  @Override
+  public File createNewFile(String name) {
+    return new File(name);
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/LocalFileProvider.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/LocalFileProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.internal;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * An interface providing a way of writing to local files.
+ */
+public interface LocalFileProvider {
+  /**
+   * Returns a new file based on the provided name.
+   * @param name The name of the file
+   * @return a new File object
+   * @throws IOException if creating a file fails
+   */
+  File createNewFile(String name) throws IOException;
+}

--- a/cdap-kubernetes-spi/pom.xml
+++ b/cdap-kubernetes-spi/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2021 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>cdap</artifactId>
+    <groupId>io.cdap.cdap</groupId>
+    <version>6.7.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>cdap-kubernetes-spi</artifactId>
+  <name>CDAP Kubernetes SPI</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <k8s.version>12.0.1</k8s.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.kubernetes</groupId>
+      <artifactId>client-java</artifactId>
+      <version>${k8s.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/cdap-kubernetes-spi/src/main/java/io/cdap/cdap/k8s/spi/environment/KubeEnvironmentInitializer.java
+++ b/cdap-kubernetes-spi/src/main/java/io/cdap/cdap/k8s/spi/environment/KubeEnvironmentInitializer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.spi.environment;
+
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+
+import java.util.Map;
+
+/**
+ * Pluggable SPI for initializing the Kubernetes master environment.
+ */
+public interface KubeEnvironmentInitializer {
+
+  /**
+   * Returns the specification for the k8s environment initializer.
+   *
+   * @return The k8s environment initializer specification
+   */
+  KubeEnvironmentInitializerSpecification getSpecification();
+
+  /**
+   * Called by KubeMasterEnvironment after the onNamespaceCreation hook is called.
+   *
+   * @param namespace The name of the namespace
+   * @param properties The properties for the namespace
+   * @param coreV1Api The reference used to call into k8s core APIs
+   */
+  void postNamespaceCreation(String namespace, Map<String, String> properties, CoreV1Api coreV1Api) throws Exception;
+
+  /**
+   * Called by KubeMasterEnvironment to modify the pod spec template for the driver pod used by Spark on Kubernetes.
+   *
+   * @param podSpec The pod specification to modify
+   */
+  void modifySparkDriverPodTemplate(V1PodSpec podSpec) throws Exception;
+
+  /**
+   * Called by KubeMasterEnvironment to modify the pod spec template for the executor pod used by Spark on Kubernetes.
+   *
+   * @param podSpec The pod specification to modify
+   */
+  void modifySparkExecutorPodTemplate(V1PodSpec podSpec) throws Exception;
+}

--- a/cdap-kubernetes-spi/src/main/java/io/cdap/cdap/k8s/spi/environment/KubeEnvironmentInitializerSpecification.java
+++ b/cdap-kubernetes-spi/src/main/java/io/cdap/cdap/k8s/spi/environment/KubeEnvironmentInitializerSpecification.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.spi.environment;
+
+import java.util.Objects;
+
+/**
+ * Defines the specification for a Kubernetes environment initializer.
+ */
+public class KubeEnvironmentInitializerSpecification {
+  private final String name;
+
+  public KubeEnvironmentInitializerSpecification(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    KubeEnvironmentInitializerSpecification that = (KubeEnvironmentInitializerSpecification) o;
+
+    return Objects.equals(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+}

--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -45,6 +45,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-kubernetes-spi</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.twill</groupId>
       <artifactId>twill-api</artifactId>
       <scope>provided</scope>
@@ -102,11 +114,11 @@
         </exclusion>
       </exclusions>
     </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <scope>test</scope>
-      </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/DefaultKubeMasterPathProvider.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/DefaultKubeMasterPathProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.util.Config;
+
+public class DefaultKubeMasterPathProvider implements KubeMasterPathProvider {
+
+  @Override
+  public String getMasterPath() {
+    // Spark master base path
+    String master;
+    // apiClient.getBasePath() returns path similar to https://10.8.0.1:443
+    try {
+      ApiClient apiClient = Config.defaultClient();
+      master = apiClient.getBasePath();
+    } catch (Exception e) {
+      // should not happen
+      throw new RuntimeException("Exception while getting kubernetes master path", e);
+    }
+    return master;
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeEnvironmentInitializerExtensionLoader.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeEnvironmentInitializerExtensionLoader.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import io.cdap.cdap.common.lang.ClassPathResources;
+import io.cdap.cdap.common.lang.FilterClassLoader;
+import io.cdap.cdap.extension.AbstractExtensionLoader;
+import io.cdap.cdap.k8s.spi.environment.KubeEnvironmentInitializer;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Loads Kubernetes environment initializers from the extensions directory.
+ */
+public class KubeEnvironmentInitializerExtensionLoader
+  extends AbstractExtensionLoader<String, KubeEnvironmentInitializer> implements KubeEnvironmentInitializerProvider {
+
+  private static final Set<String> ALLOWED_RESOURCES = createAllowedResources();
+  private static final Set<String> ALLOWED_PACKAGES = createPackageSets(ALLOWED_RESOURCES);
+
+  private static Set<String> createAllowedResources() {
+    try {
+      return ClassPathResources.getResourcesWithDependencies(KubeEnvironmentInitializer.class.getClassLoader(),
+                                                             KubeEnvironmentInitializer.class);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to trace dependencies for k8s environment initializer extension. " +
+                                   "Kubernetes environment initialization may fail.", e);
+    }
+  }
+
+  KubeEnvironmentInitializerExtensionLoader(String extensionDir) {
+    super(extensionDir);
+  }
+
+  @Override
+  protected Set<String> getSupportedTypesForProvider(KubeEnvironmentInitializer kubeEnvironmentInitializer) {
+    return Collections.singleton(kubeEnvironmentInitializer.getSpecification().getName());
+  }
+
+  @Override
+  protected FilterClassLoader.Filter getExtensionParentClassLoaderFilter() {
+    // filter all non-spi classes to provide isolation from CDAP's classes.
+    return new FilterClassLoader.Filter() {
+      @Override
+      public boolean acceptResource(String resource) {
+        return ALLOWED_RESOURCES.contains(resource);
+      }
+
+      @Override
+      public boolean acceptPackage(String packageName) {
+        return ALLOWED_PACKAGES.contains(packageName);
+      }
+    };
+  }
+
+  @Override
+  public Map<String, KubeEnvironmentInitializer> loadKubeEnvironmentInitializers() {
+    return getAll();
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeEnvironmentInitializerProvider.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeEnvironmentInitializerProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import io.cdap.cdap.k8s.spi.environment.KubeEnvironmentInitializer;
+
+import java.util.Map;
+
+/**
+ * Provides k8s environment initializers.
+ */
+public interface KubeEnvironmentInitializerProvider {
+  /**
+   * @return a map of names to Kubernetes environment initializers
+   */
+  Map<String, KubeEnvironmentInitializer> loadKubeEnvironmentInitializers();
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterPathProvider.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterPathProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+/**
+ * Provides the master path for the Kubernetes API client.
+ */
+public interface KubeMasterPathProvider {
+  /**
+   * @return Spark master base path
+   */
+  String getMasterPath();
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/NoOpKubeEnvironmentInitializerProvider.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/NoOpKubeEnvironmentInitializerProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import io.cdap.cdap.k8s.spi.environment.KubeEnvironmentInitializer;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Provides no initializers for the k8s environment.
+ */
+public class NoOpKubeEnvironmentInitializerProvider implements KubeEnvironmentInitializerProvider {
+  @Override
+  public Map<String, KubeEnvironmentInitializer> loadKubeEnvironmentInitializers() {
+    return Collections.emptyMap();
+  }
+}

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
@@ -16,25 +16,47 @@
 
 package io.cdap.cdap.master.environment.k8s;
 
+import io.cdap.cdap.common.internal.LocalFileProvider;
+import io.cdap.cdap.k8s.spi.environment.KubeEnvironmentInitializer;
+import io.cdap.cdap.master.spi.environment.spark.SparkConfig;
+import io.cdap.cdap.master.spi.environment.spark.SparkSubmitContext;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodSpec;
+import io.kubernetes.client.util.Yaml;
 import org.hamcrest.CoreMatchers;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
+import org.mockito.stubbing.Answer;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
+import static io.cdap.cdap.master.environment.k8s.KubeMasterEnvironment.SPARK_KUBERNETES_DRIVER_POD_TEMPLATE;
+import static io.cdap.cdap.master.environment.k8s.KubeMasterEnvironment.SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -47,16 +69,67 @@ public class KubeMasterEnvironmentTest {
 
   private CoreV1Api coreV1Api;
   private KubeMasterEnvironment kubeMasterEnvironment;
+  private ArrayList<File> filesToCleanup;
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  /**
+   * Provides a file in a provided temporary directory for testing.
+   */
+  private static class TemporaryLocalFileProvider implements LocalFileProvider {
+
+    private final TemporaryFolder temporaryFolder;
+
+    public TemporaryLocalFileProvider(TemporaryFolder temporaryFolder) {
+      this.temporaryFolder = temporaryFolder;
+    }
+
+    @Override
+    public File createNewFile(String name) throws IOException {
+      return temporaryFolder.newFile(name);
+    }
+  }
+
   @Before
-  public void init() {
+  public void init() throws Exception {
     coreV1Api = mock(CoreV1Api.class);
     kubeMasterEnvironment = new KubeMasterEnvironment();
+    kubeMasterEnvironment.setLocalFileProvider(new TemporaryLocalFileProvider(temporaryFolder));
     kubeMasterEnvironment.setCoreV1Api(coreV1Api);
     kubeMasterEnvironment.setNamespaceCreationEnabled();
+    kubeMasterEnvironment.setKubeEnvironmentInitializerProvider(new NoOpKubeEnvironmentInitializerProvider());
+    KubeMasterPathProvider mockKubeMasterPathProvider = mock(KubeMasterPathProvider.class);
+    when(mockKubeMasterPathProvider.getMasterPath()).thenReturn("https://127.0.0.1:443");
+    kubeMasterEnvironment.setKubeMasterPathProvider(mockKubeMasterPathProvider);
+    kubeMasterEnvironment.setAdditionalSparkConfs(Collections.emptyMap());
+    // Create a dummy file for the pod
+    File dummyFile = temporaryFolder.newFile();
+    filesToCleanup = new ArrayList<>();
+    filesToCleanup.add(dummyFile);
+    kubeMasterEnvironment.setPodInfoDir(new File("/tmp/"));
+    kubeMasterEnvironment.setPodLabelsFile(dummyFile);
+    kubeMasterEnvironment.setPodNameFile(dummyFile);
+    kubeMasterEnvironment.setPodUidFile(dummyFile);
+    kubeMasterEnvironment.setPodInfo(new PodInfo("pod-info", "pod-info-dir", dummyFile.getAbsolutePath(),
+                                                 dummyFile.getAbsolutePath(), UUID.randomUUID().toString(),
+                                                 dummyFile.getAbsolutePath(), KUBE_NAMESPACE, Collections.emptyMap(),
+                                                 Collections.emptyList(), "service-account", "runtime-class",
+                                                 Collections.emptyList(), "container-label-name", "container-image",
+                                                 Collections.emptyList(), Collections.emptyList(), null,
+                                                 "image-pull-policy"));
+  }
+
+  @After
+  public void cleanup() {
+    for (File file : filesToCleanup) {
+      if (!file.delete()) {
+        throw new IllegalStateException(String.format("Failed to cleanup file '%s'", file.getAbsolutePath()));
+      }
+    }
   }
 
   @Test
@@ -151,5 +224,196 @@ public class KubeMasterEnvironmentTest {
     } catch (Exception e) {
       Assert.fail("Kubernetes deletion should not error if namespace does not exist. Exception: " + e);
     }
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithSingleInitializer() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+
+    ArgumentCaptor<String> namespaceCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Map> propertiesCaptor = ArgumentCaptor.forClass(Map.class);
+    KubeEnvironmentInitializer mockKubeEnvInitializer = mock(KubeEnvironmentInitializer.class);
+    doNothing().when(mockKubeEnvInitializer).postNamespaceCreation(namespaceCaptor.capture(), propertiesCaptor.capture(), eq(coreV1Api));
+    kubeMasterEnvironment.setKubeEnvironmentInitializerProvider(new KubeEnvironmentInitializerProvider() {
+      @Override
+      public Map<String, KubeEnvironmentInitializer> loadKubeEnvironmentInitializers() {
+        Map<String, KubeEnvironmentInitializer> kubeEnvironmentInitializerMap = new HashMap<>();
+        kubeEnvironmentInitializerMap.put("mock-kube-env-init-1", mockKubeEnvInitializer);
+        return kubeEnvironmentInitializerMap;
+      }
+    });
+
+    try {
+      kubeMasterEnvironment.onNamespaceCreation(CDAP_NAMESPACE, properties);
+    } catch (Exception e) {
+      Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
+    }
+
+    // Verify initializer was called
+    verify(mockKubeEnvInitializer, times(1)).postNamespaceCreation(any(), any(), any());
+    Assert.assertEquals(namespaceCaptor.getValue(), CDAP_NAMESPACE);
+    Assert.assertEquals(propertiesCaptor.getValue(), properties);
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithMultipleInitializer() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+
+    ArgumentCaptor<String> namespaceCaptor1 = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Map> propertiesCaptor1 = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<String> namespaceCaptor2 = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Map> propertiesCaptor2 = ArgumentCaptor.forClass(Map.class);
+    KubeEnvironmentInitializer mockKubeEnvInitializer1 = mock(KubeEnvironmentInitializer.class);
+    doNothing().when(mockKubeEnvInitializer1).postNamespaceCreation(namespaceCaptor1.capture(), propertiesCaptor1.capture(), eq(coreV1Api));
+    KubeEnvironmentInitializer mockKubeEnvInitializer2 = mock(KubeEnvironmentInitializer.class);
+    doNothing().when(mockKubeEnvInitializer2).postNamespaceCreation(namespaceCaptor2.capture(), propertiesCaptor2.capture(), eq(coreV1Api));
+    kubeMasterEnvironment.setKubeEnvironmentInitializerProvider(() -> {
+      Map<String, KubeEnvironmentInitializer> kubeEnvironmentInitializerMap = new HashMap<>();
+      kubeEnvironmentInitializerMap.put("mock-kube-env-init-1", mockKubeEnvInitializer1);
+      kubeEnvironmentInitializerMap.put("mock-kube-env-init-2", mockKubeEnvInitializer2);
+      return kubeEnvironmentInitializerMap;
+    });
+
+    try {
+      kubeMasterEnvironment.onNamespaceCreation(CDAP_NAMESPACE, properties);
+    } catch (Exception e) {
+      Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
+    }
+
+    // Verify initializers were called
+    verify(mockKubeEnvInitializer1, times(1)).postNamespaceCreation(any(), any(), any());
+    Assert.assertEquals(namespaceCaptor1.getValue(), CDAP_NAMESPACE);
+    Assert.assertEquals(propertiesCaptor1.getValue(), properties);
+    verify(mockKubeEnvInitializer2, times(1)).postNamespaceCreation(any(), any(), any());
+    Assert.assertEquals(namespaceCaptor2.getValue(), CDAP_NAMESPACE);
+    Assert.assertEquals(propertiesCaptor2.getValue(), properties);
+  }
+
+  @Test
+  public void testOnNamespaceCreationInitializerExceptionPropagatesException() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+
+    ArgumentCaptor<String> namespaceCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Map> propertiesCaptor = ArgumentCaptor.forClass(Map.class);
+    KubeEnvironmentInitializer mockKubeEnvInitializer = mock(KubeEnvironmentInitializer.class);
+    doThrow(new Exception("post namespace creation error")).when(mockKubeEnvInitializer).postNamespaceCreation(namespaceCaptor.capture(), propertiesCaptor.capture(), eq(coreV1Api));
+    kubeMasterEnvironment.setKubeEnvironmentInitializerProvider(() -> {
+      Map<String, KubeEnvironmentInitializer> kubeEnvironmentInitializerMap = new HashMap<>();
+      kubeEnvironmentInitializerMap.put("post-namespace-error-env-init", mockKubeEnvInitializer);
+      return kubeEnvironmentInitializerMap;
+    });
+
+    try {
+      kubeMasterEnvironment.onNamespaceCreation(CDAP_NAMESPACE, properties);
+      Assert.fail("on namespace creation is expected to throw an exception if the initializer throws an exception");
+    } catch (Exception e) {
+      // Expected to throw an exception
+    }
+
+    // Verify initializer was called with expected arguments
+    verify(mockKubeEnvInitializer, times(1)).postNamespaceCreation(any(), any(), any());
+    Assert.assertEquals(namespaceCaptor.getValue(), CDAP_NAMESPACE);
+    Assert.assertEquals(propertiesCaptor.getValue(), properties);
+  }
+
+  @Test
+  public void testGenerateSparkSubmitConfigWithSparkDriverModifierInitializer() throws Exception {
+    String serviceAccountName = "spark-driver-modified";
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap());
+    KubeEnvironmentInitializer mockKubeEnvInitializer = mock(KubeEnvironmentInitializer.class);
+    // Implement mocked method to add a service account name to the pod spec for verification
+    Answer answer = invocation -> {
+      V1PodSpec podSpec = (V1PodSpec) invocation.getArguments()[0];
+      podSpec.setServiceAccountName(serviceAccountName);
+      return null;
+    };
+    doAnswer(answer).when(mockKubeEnvInitializer).modifySparkDriverPodTemplate(any());
+    doNothing().when(mockKubeEnvInitializer).modifySparkExecutorPodTemplate(any());
+    kubeMasterEnvironment.setKubeEnvironmentInitializerProvider(() -> {
+      Map<String, KubeEnvironmentInitializer> kubeEnvironmentInitializerMap = new HashMap<>();
+      kubeEnvironmentInitializerMap.put("spark-driver-template-modifier", mockKubeEnvInitializer);
+      return kubeEnvironmentInitializerMap;
+    });
+
+    SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
+
+    // Verify the service account name was set
+    Map<String, String> configs = sparkConfig.getConfigs();
+    File sparkDriverPodFile = new File(configs.get(SPARK_KUBERNETES_DRIVER_POD_TEMPLATE));
+    File sparkExecutorPodFile = new File(configs.get(SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE));
+    filesToCleanup.add(sparkDriverPodFile);
+    filesToCleanup.add(sparkExecutorPodFile);
+    V1Pod pod = Yaml.loadAs(sparkDriverPodFile, V1Pod.class);
+    Assert.assertEquals(pod.getSpec().getServiceAccountName(), serviceAccountName);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testGenerateSparkSubmitConfigPropagatesSparkDriverModifierInitializerException() throws Exception {
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap());
+    KubeEnvironmentInitializer mockKubeEnvInitializer = mock(KubeEnvironmentInitializer.class);
+    doThrow(new IllegalStateException("kube initializer spark driver modifier exception")).when(mockKubeEnvInitializer).modifySparkDriverPodTemplate(any());
+    doNothing().when(mockKubeEnvInitializer).modifySparkExecutorPodTemplate(any());
+    kubeMasterEnvironment.setKubeEnvironmentInitializerProvider(() -> {
+      Map<String, KubeEnvironmentInitializer> kubeEnvironmentInitializerMap = new HashMap<>();
+      kubeEnvironmentInitializerMap.put("spark-driver-modifier-exception-thrower", mockKubeEnvInitializer);
+      return kubeEnvironmentInitializerMap;
+    });
+
+    kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
+  }
+
+  @Test
+  public void testGenerateSparkSubmitConfigWithSparkExecutorModifierInitializer() throws Exception {
+    String serviceAccountName = "spark-executor-modified";
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap());
+    KubeEnvironmentInitializer mockKubeEnvInitializer = mock(KubeEnvironmentInitializer.class);
+    // Implement mocked method to add a service account name to the pod spec for verification
+    Answer answer = invocation -> {
+      V1PodSpec podSpec = (V1PodSpec) invocation.getArguments()[0];
+      podSpec.setServiceAccountName(serviceAccountName);
+      return null;
+    };
+    doNothing().when(mockKubeEnvInitializer).modifySparkDriverPodTemplate(any());
+    doAnswer(answer).when(mockKubeEnvInitializer).modifySparkExecutorPodTemplate(any());
+    kubeMasterEnvironment.setKubeEnvironmentInitializerProvider(() -> {
+      Map<String, KubeEnvironmentInitializer> kubeEnvironmentInitializerMap = new HashMap<>();
+      kubeEnvironmentInitializerMap.put("spark-executor-template-modifier", mockKubeEnvInitializer);
+      return kubeEnvironmentInitializerMap;
+    });
+
+    SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
+
+    // Verify the service account name was set
+    Map<String, String> configs = sparkConfig.getConfigs();
+    File sparkDriverPodFile = new File(configs.get(SPARK_KUBERNETES_DRIVER_POD_TEMPLATE));
+    File sparkExecutorPodFile = new File(configs.get(SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE));
+    filesToCleanup.add(sparkDriverPodFile);
+    filesToCleanup.add(sparkExecutorPodFile);
+    V1Pod pod = Yaml.loadAs(sparkExecutorPodFile, V1Pod.class);
+    Assert.assertEquals(pod.getSpec().getServiceAccountName(), serviceAccountName);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testGenerateSparkSubmitConfigPropagatesSparkExecutorModifierInitializerException() throws Exception {
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap());
+    KubeEnvironmentInitializer mockKubeEnvInitializer = mock(KubeEnvironmentInitializer.class);
+    doNothing().when(mockKubeEnvInitializer).modifySparkDriverPodTemplate(any());
+    doThrow(new IllegalStateException("kube initializer spark driver modifier exception")).when(mockKubeEnvInitializer).modifySparkExecutorPodTemplate(any());
+    kubeMasterEnvironment.setKubeEnvironmentInitializerProvider(() -> {
+      Map<String, KubeEnvironmentInitializer> kubeEnvironmentInitializerMap = new HashMap<>();
+      kubeEnvironmentInitializerMap.put("spark-executor-exception-thrower", mockKubeEnvInitializer);
+      return kubeEnvironmentInitializerMap;
+    });
+
+    kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2837,6 +2837,7 @@
         <module>cdap-hbase-compat-1.2-cdh5.7.0</module>
         <module>cdap-hbase-spi</module>
         <module>cdap-kubernetes</module>
+        <module>cdap-kubernetes-spi</module>
         <module>cdap-common</module>
         <module>cdap-docs-gen</module>
         <module>cdap-watchdog-api</module>


### PR DESCRIPTION
Context: When running CDAP in a Kubernetes environment, we want to support initializing the environment in an extensible manner, particularly when we launch Spark containers (drivers and executors) and when we create namespaces (i.e. we may wish to create various k8s resources associated with the namespace following namespace creation).