### PR TITLE
[CDAP-18626] Revive artifact-fetching-and-caching-WITHOUT-unpacking API  (address comment)

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
@@ -130,7 +130,7 @@ public class ArtifactLocalizer {
    * @throws Exception if there was an unexpected error
    */
   public File getAndUnpackArtifact(ArtifactId artifactId) throws Exception {
-    File jarLocation = Retries.callWithRetries(() -> fetchArtifact(artifactId), retryStrategy);
+    File jarLocation = getArtifact(artifactId);
     File unpackDir = getUnpackLocalPath(artifactId, Long.parseLong(jarLocation.getName().split("\\.")[0]));
     if (unpackDir.exists()) {
       LOG.debug("Found unpack directory as {}", unpackDir);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerClient.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerClient.java
@@ -80,8 +80,9 @@ public class ArtifactLocalizerClient {
   }
 
   private File sendRequest(ArtifactId artifactId, boolean unpack) throws IOException, ArtifactNotFoundException {
-    String urlPath = String.format("/artifact/namespaces/%s/artifacts/%s/versions/%s",
-                                   artifactId.getNamespace(), artifactId.getArtifact(), artifactId.getVersion());
+    String urlPath = String.format("/artifact/namespaces/%s/artifacts/%s/versions/%s?unpack=%b",
+                                   artifactId.getNamespace(), artifactId.getArtifact(), artifactId.getVersion(),
+                                   unpack);
     URL url;
     try {
       url = new URI(sidecarBaseURL + urlPath).toURL();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
@@ -173,6 +173,7 @@ public class ArtifactLocalizerServiceTest extends AppFabricTestBase {
 
     // Make sure the artifact was actually cached
     Assert.assertTrue(artifactPath.exists());
+    Assert.assertTrue(artifactPath.isFile());
 
     // Call the sidecar again and make sure the same path was returned
     File sameArtifactPath = client.getArtifactLocation(artifactId.toEntityId());


### PR DESCRIPTION
Why:
To allow preview runner running with restricted permission (i.e.
no permission to access artifacts on distributed file system or
metadata in external database), we need an API for preview runner
to fetch and cache artifact.

What:
Add back the APIs for ArtifactLocalizer to fetch artifact jar.