### PR TITLE
[CDAP-18694] Create artifact localizer sidecar for preview runner when enabled in cConf

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -379,6 +379,8 @@ public final class Constants {
     public static final String CONTAINER_MEMORY_MULTIPLIER = "preview.runner.container.memory.multiplier";
     public static final String CONTAINER_HEAP_RESERVED_RATIO = "preview.runner.container.java.heap.memory.ratio";
     public static final String CONTAINER_PRIORITY_CLASS_NAME = "preview.runner.container.priority.class.name";
+
+    public static final String ARTIFACT_LOCALIZER_ENABLED = "preview.runner.artifact.localizer.enabled";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3236,6 +3236,18 @@
   </property>
 
   <property>
+    <name>preview.runner.artifact.localizer.enabled</name>
+    <value>false</value>
+    <description>
+      Whether to enable artifact localizer sidecar container to fetch and cache artifacts.
+      When set to true, artifacts are accessed through side-car container instead of directly
+      by preview runners. This is intended to be used in the situation where preview runner
+      doesn't or is refrained from accessing jar file directly (e.g. due to security reason
+      as preview runner may execute arbitrary user provided code)
+    </description>
+  </property>
+
+  <property>
     <name>service.retry.policy.base.delay.ms</name>
     <value>100</value>
     <description>


### PR DESCRIPTION
Why:
Preview runner may run arbitrary user code, so in some deployment
env it may be refrained from accessing artifact jar directly
(e.g. CDAP deployed in GKE and artifacts stored in GCS)

What:
This change adds an option to allow starting up artifact localizer
sidecar container, which can fetch and cache artifact on behalf
this preview runner (to be implemented in next PR)