### PR TITLE
[CDAP-18694] Allow preview runner to fetch metadta from AppFab and use sidecar for fetching and caching aritfacts

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepository.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepository.java
@@ -64,7 +64,8 @@ public class RemoteArtifactRepository implements ArtifactRepository {
   @Override
   public CloseableClassLoader createArtifactClassLoader(ArtifactDescriptor artifactDescriptor,
                                                         EntityImpersonator entityImpersonator) throws IOException {
-    return artifactClassLoaderFactory.createClassLoader(artifactDescriptor.getLocation(), entityImpersonator);
+    Location location = getArtifactLocation(artifactDescriptor);
+    return artifactClassLoaderFactory.createClassLoader(location, entityImpersonator);
   }
 
   @Override
@@ -199,6 +200,14 @@ public class RemoteArtifactRepository implements ArtifactRepository {
   @Override
   public List<ArtifactDetail> getArtifactDetails(ArtifactRange range, int limit,
                                                  ArtifactSortOrder order) throws Exception {
-    throw new UnsupportedOperationException();
+    return artifactRepositoryReader.getArtifactDetails(range, limit, order);
+  }
+
+  /**
+   * Allow subclasses to modify artifact locations (e.g. {@link RemoteArtifactRepositoryWithLocalization}
+   * to download and cache artifact locally, subsequently return a local location.
+   */
+  protected Location getArtifactLocation(ArtifactDescriptor descriptor) throws IOException {
+    return descriptor.getLocation();
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepositoryReaderWithLocalization.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepositoryReaderWithLocalization.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.artifact;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.ArtifactNotFoundException;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
+import io.cdap.cdap.proto.id.ArtifactId;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+
+import java.io.IOException;
+
+/**
+ * {@link RemoteArtifactRepositoryReaderWithLocalization} is an extension of {@link RemoteArtifactRepositoryReader}
+ * that localizes artifacts and use their local locations in returned value.
+ *
+ * This implementation uses {@link ArtifactLocalizerClient} to fetch and cache the given artifact on the local
+ * file system.
+ */
+public class RemoteArtifactRepositoryReaderWithLocalization extends RemoteArtifactRepositoryReader {
+  private final ArtifactLocalizerClient artifactLocalizerClient;
+
+  @Inject
+  RemoteArtifactRepositoryReaderWithLocalization(LocationFactory locationFactory,
+                                                 RemoteClientFactory remoteClientFactory,
+                                                 ArtifactLocalizerClient artifactLocalizerClient) {
+    super(locationFactory, remoteClientFactory);
+    this.artifactLocalizerClient = artifactLocalizerClient;
+  }
+
+  @Override
+  protected Location getArtifactLocation(ArtifactDescriptor descriptor) throws IOException, ArtifactNotFoundException {
+    return Locations.toLocation(artifactLocalizerClient.getArtifactLocation(
+      new ArtifactId(descriptor.getNamespace(),
+                     descriptor.getArtifactId().getName(),
+                     descriptor.getArtifactId().getVersion().getVersion())));
+  }
+}
+

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepositoryWithLocalization.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteArtifactRepositoryWithLocalization.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.artifact;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.app.runtime.ProgramRunnerFactory;
+import io.cdap.cdap.common.ArtifactNotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
+import io.cdap.cdap.proto.id.ArtifactId;
+import org.apache.twill.filesystem.Location;
+
+import java.io.IOException;
+
+/**
+ * {@link RemoteArtifactRepositoryWithLocalization} is an extension of {@link RemoteArtifactRepository}
+ * that localizes artifacts and use their local locations in returned values.
+ *
+ * This implementation uses {@link ArtifactLocalizerClient} to download and cache artifacts on the local
+ * file system.
+ */
+public class RemoteArtifactRepositoryWithLocalization extends RemoteArtifactRepository {
+  private final ArtifactLocalizerClient artifactLocalizerClient;
+
+  @Inject
+  RemoteArtifactRepositoryWithLocalization(CConfiguration cConf, ArtifactRepositoryReader artifactRepositoryReader,
+                                           ProgramRunnerFactory programRunnerFactory,
+                                           ArtifactLocalizerClient artifactLocalizerClient) {
+    super(cConf, artifactRepositoryReader, programRunnerFactory);
+    this.artifactLocalizerClient = artifactLocalizerClient;
+  }
+
+  @Override
+  protected Location getArtifactLocation(ArtifactDescriptor descriptor) throws IOException {
+    ArtifactId artifactId = new ArtifactId(descriptor.getNamespace(),
+                       descriptor.getArtifactId().getName(),
+                       descriptor.getArtifactId().getVersion().getVersion());
+    try {
+      return Locations.toLocation(artifactLocalizerClient.getArtifactLocation(artifactId));
+    } catch (ArtifactNotFoundException e) {
+      throw new IOException(String.format("Artifact %s is not found", artifactId), e);
+    }
+  }
+}


### PR DESCRIPTION
What:
When artifact localizer is enabled, support preview runner to
fetch metadata and artifacts from AppFab instead of directly
from metadata DB (i.e. sql) and from distributed file system.

It actives this by making preview runner
* fetching metadata from AppFab via remote implementations of artifact repository, plugin finder, preference
* fetching artifact from AppFab via artifact localizer running in sidecar container.

Why:
To allow preview runner running with restricted permission (i.e.
no permission to access artifacts on distributed file system or
metadata in external database).