### PR TITLE
[CDAP-18647] Set max limit on number of preview records

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewManager.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.app.preview;
 import com.google.gson.JsonElement;
 import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.config.Config;
 import io.cdap.cdap.logging.read.LogReader;
 import io.cdap.cdap.metrics.query.MetricsQueryHelper;
 import io.cdap.cdap.proto.artifact.AppRequest;
@@ -42,7 +43,7 @@ public interface PreviewManager {
    * @return the {@link ApplicationId} assigned to the preview run
    * @throws Exception if there were any error during starting preview
    */
-  ApplicationId start(NamespaceId namespace, AppRequest<?> request) throws Exception;
+  ApplicationId start(NamespaceId namespace, AppRequest<? extends Map<String, Object>> request) throws Exception;
 
   /**
    * Get the status of the preview.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/preview/PreviewHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/preview/PreviewHttpHandler.java
@@ -93,7 +93,7 @@ public class PreviewHttpHandler extends AbstractLogHttpHandler {
                     @PathParam("namespace-id") String namespaceId) throws Exception {
     NamespaceId namespace = new NamespaceId(namespaceId);
     try (Reader reader = new InputStreamReader(new ByteBufInputStream(request.content()), StandardCharsets.UTF_8)) {
-      AppRequest<?> appRequest = GSON.fromJson(reader, AppRequest.class);
+      AppRequest<Map<String, Object>> appRequest = GSON.fromJson(reader, AppRequest.class);
       responder.sendString(HttpResponseStatus.OK, GSON.toJson(previewManager.start(namespace, appRequest)));
     } catch (JsonSyntaxException e) {
       throw new BadRequestException("Request body is invalid json: " + e.getMessage());

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -370,6 +370,7 @@ public final class Constants {
     public static final String MESSAGING_TOPIC = "preview.messaging.topic";
     public static final String DATA_CLEANUP_INTERVAL_SECONDS = "preview.data.cleanup.interval.seconds";
     public static final String DATA_TTL_SECONDS = "preview.data.ttl.seconds";
+    public static final String MAX_NUM_OF_RECORDS = "preview.max.num.records";
 
     public static final String CONTAINER_COUNT = "preview.runner.container.count";
     public static final String CONTAINER_DISK_SIZE_GB = "preview.runner.container.disk.size.gb";
@@ -382,6 +383,9 @@ public final class Constants {
     public static final String CONTAINER_PRIORITY_CLASS_NAME = "preview.runner.container.priority.class.name";
 
     public static final String ARTIFACT_LOCALIZER_ENABLED = "preview.runner.artifact.localizer.enabled";
+
+    // Config map key for number of records in preview request
+    public static final String PREVIEW_REQUEST_NUM_OF_RECORDS = "numOfRecordsPreview";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3253,6 +3253,14 @@
   </property>
 
   <property>
+    <name>preview.max.num.records</name>
+    <value>5000</value>
+    <description>
+      The maximum number of records that can be set in preview configuration.
+    </description>
+  </property>
+
+  <property>
     <name>service.retry.policy.base.delay.ms</name>
     <value>100</value>
     <description>


### PR DESCRIPTION
[CDAP-18647](https://cdap.atlassian.net/browse/CDAP-18647). Created a new property in cdap-default.xml which has the maximum number of records that can be configured for running the preview. 