### PR TITLE
[CDAP-18696] Add flow control to launch requests

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -296,6 +296,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         recordedRunRecord =
           appMetadataStore.recordProgramRunning(programRunId, logicalStartTimeSecs, twillRunId, messageIdBytes);
         writeToHeartBeatTable(recordedRunRecord, logicalStartTimeSecs, programHeartbeatTable);
+        programLifecycleService.getRunRecordCounter().removeRequest(programRunId);
         break;
       case SUSPENDED:
         long suspendTime = getTimeSeconds(notification.getProperties(),
@@ -319,6 +320,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         recordedRunRecord = handleProgramCompletion(appMetadataStore, programHeartbeatTable,
                                                     programRunId, programRunStatus, notification,
                                                     messageIdBytes, runnables);
+        programLifecycleService.getRunRecordCounter().removeRequest(programRunId);
         break;
       case REJECTED:
         ProgramOptions programOptions = ProgramOptions.fromNotification(notification, GSON);
@@ -332,6 +334,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
                               programHeartbeatTable);
         getEmitMetricsRunnable(programRunId, recordedRunRecord,
                                Constants.Metrics.Program.PROGRAM_REJECTED_RUNS).ifPresent(runnables::add);
+        programLifecycleService.getRunRecordCounter().removeRequest(programRunId);
         break;
       default:
         // This should not happen

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/RunRecordCounter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/RunRecordCounter.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services;
+
+import io.cdap.cdap.app.runtime.ProgramRuntimeService;
+import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import org.eclipse.jetty.util.ConcurrentHashSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Helper class to maintain and return total number of launching and running run-records.
+ */
+public class RunRecordCounter {
+  private static final Logger LOG = LoggerFactory.getLogger(RunRecordCounter.class);
+
+  /**
+   * Contains ProgramRunIds of runs that have been accepted, but have not been added to metadata store plus
+   * all run records with {@link ProgramRunStatus#PENDING} or {@link ProgramRunStatus#STARTING} status.
+   */
+  private final Set<ProgramRunId> launchingSet;
+  private final ProgramRuntimeService runtimeService;
+
+  public RunRecordCounter(ProgramRuntimeService runtimeService) {
+    this.runtimeService = runtimeService;
+
+    launchingSet = new ConcurrentHashSet<>();
+  }
+
+  /**
+   * Add a new inflight launch request and return total number of launching and running program runs.
+   *
+   * @param programRunId run id associated with the launch request
+   * @return total number of launching and running program runs.
+   */
+  public Count addRequestAndGetCount(ProgramRunId programRunId) {
+    int launchingCount;
+    synchronized (this) {
+      launchingSet.add(programRunId);
+      launchingCount = launchingSet.size();
+    }
+
+    List<ProgramRuntimeService.RuntimeInfo> list = runtimeService
+      .listAll(ProgramType.WORKFLOW,
+               ProgramType.SERVICE,
+               ProgramType.MAPREDUCE,
+               ProgramType.SPARK,
+               ProgramType.WORKER,
+               ProgramType.CUSTOM_ACTION);
+
+    int runsCount = (int)
+      list.stream().filter(r -> isRunning(r.getController().getState().getRunStatus())).count()
+      + launchingCount;
+
+    LOG.debug("Adding request with runId {}. Counter now has {} concurrent launching and {} concurrent runs.",
+              programRunId, launchingCount, runsCount);
+    return new Count(launchingCount, runsCount);
+  }
+
+  /**
+   * Remove the request with the provided programRunId when the request is no longer lunching.
+   * I.e., not in-flight, not {@link ProgramRunStatus#PENDING} and not {@link ProgramRunStatus#STARTING}
+   *
+   * @param programRunId
+   */
+  public void removeRequest(ProgramRunId programRunId) {
+    LOG.debug("Removing request with runId {}", programRunId);
+    launchingSet.remove(programRunId);
+  }
+
+  private boolean isRunning(ProgramRunStatus status) {
+    if (status == ProgramRunStatus.RUNNING
+      || status == ProgramRunStatus.SUSPENDED
+      || status == ProgramRunStatus.RESUMING) {
+      return true;
+    }
+
+    return false;
+  }
+
+  class Count {
+    /**
+     * Total number of launch requests that have been accepted but still missing in metadata store +
+     * total number of run records with {@link ProgramRunStatus#PENDING} status +
+     * total number of run records with {@link ProgramRunStatus#STARTING} status
+     */
+    private final int launchingCount;
+
+    /**
+     * {@link this#launchingCount} +
+     * Total number of run records with {@link ProgramRunStatus#RUNNING status +
+     * Total number of run records with {@link ProgramRunStatus#SUSPENDED} status +
+     * Total number of run records with {@link ProgramRunStatus#RESUMING} status
+     */
+    private final int runsCount;
+
+    Count(int launchingCount, int runsCount) {
+      this.launchingCount = launchingCount;
+      this.runsCount = runsCount;
+    }
+
+    public int getLaunchingCount() {
+      return launchingCount;
+    }
+
+    public int getRunsCount() {
+      return runsCount;
+    }
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/TooManyRequestsException.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/TooManyRequestsException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common;
+
+import io.cdap.cdap.api.common.HttpErrorStatusProvider;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Thrown when there was a conflict.
+ */
+public class TooManyRequestsException extends Exception implements HttpErrorStatusProvider {
+
+  public TooManyRequestsException() {
+    super();
+  }
+
+  public TooManyRequestsException(String message) {
+    super(message);
+  }
+
+  public TooManyRequestsException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  @Override
+  public int getStatusCode() {
+    return HttpResponseStatus.TOO_MANY_REQUESTS.code();
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -241,6 +241,7 @@ public final class Constants {
 
     public static final String PROGRAM_TRANSACTION_CONTROL = "app.program.transaction.control";
     public static final String MAX_CONCURRENT_RUNS = "app.max.concurrent.runs";
+    public static final String MAX_CONCURRENT_LAUNCHING = "app.max.concurrent.launching";
     public static final String PROGRAM_LAUNCH_THREADS = "app.program.launch.threads";
 
     // A boolean value cConf entry to tell whether a ProgramRunner is running remotely (i.e. not inside app-fabric)

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -456,7 +456,17 @@
     <name>app.max.concurrent.runs</name>
     <value>-1</value>
     <description>
-      Maximum number of concurrent program runs allowed; set to -1 for unlimited
+      Maximum number of concurrent program runs allowed; set to -1 for unlimited.
+      Program runs are those with an active run record.
+    </description>
+  </property>
+
+  <property>
+    <name>app.max.concurrent.launching</name>
+    <value>-1</value>
+    <description>
+      Maximum number of concurrent launching runs allowed; set to -1 for unlimited.
+      Launching runs have an active run record with PENDING or STARTING status.
     </description>
   </property>
 


### PR DESCRIPTION
Add flow-control to launch requests by calculating number of launching and running programs, and rejecting a request if system is at max usage. 

Note: due to performance issues, total number of launching/running pipelines is being calculated from runtime service instead of metadata store. 