### PR TITLE
[CDAP-18526] Map programs to k8s namespaces

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunnerTxTimeoutTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunnerTxTimeoutTest.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.internal.app.runtime.distributed;
 
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import io.cdap.cdap.api.app.AbstractApplication;
 import io.cdap.cdap.api.app.Application;
 import io.cdap.cdap.api.app.ApplicationSpecification;
@@ -38,6 +40,7 @@ import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.app.runtime.BasicArguments;
 import io.cdap.cdap.internal.app.runtime.SimpleProgramOptions;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
+import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.runtime.spi.SparkCompat;
@@ -74,15 +77,19 @@ public class DistributedProgramRunnerTxTimeoutTest {
       Id.Namespace.DEFAULT, new Id.Artifact(Id.Namespace.DEFAULT, "artifact", new ArtifactVersion("0.1")), app);
     app.configure(configurer, () -> null);
     appSpec = configurer.createSpecification("app", "1.0");
-    // System.out.println(new GsonBuilder().setPrettyPrinting().create().toJson(appSpec));
+    Injector injector = Guice.createInjector(new AppFabricTestModule(cConf));
 
     cConf.setInt(TxConstants.Manager.CFG_TX_MAX_TIMEOUT, 60);
-    serviceRunner = new DistributedServiceProgramRunner(cConf, yConf, null, ClusterMode.ON_PREMISE, null);
-    workerRunner = new DistributedWorkerProgramRunner(cConf, yConf, null, ClusterMode.ON_PREMISE, null);
-    mapreduceRunner = new DistributedMapReduceProgramRunner(cConf, yConf, null, ClusterMode.ON_PREMISE, null);
+    serviceRunner = new DistributedServiceProgramRunner(cConf, yConf, null, ClusterMode.ON_PREMISE, null,
+                                                        injector);
+    workerRunner = new DistributedWorkerProgramRunner(cConf, yConf, null, ClusterMode.ON_PREMISE, null,
+                                                      injector);
+    mapreduceRunner = new DistributedMapReduceProgramRunner(cConf, yConf, null, ClusterMode.ON_PREMISE, null,
+                                                            injector);
     sparkRunner = new DistributedSparkProgramRunner(SparkCompat.SPARK2_2_11, cConf, yConf, null, null,
-                                                    ClusterMode.ON_PREMISE, null);
-    workflowRunner = new DistributedWorkflowProgramRunner(cConf, yConf, null, ClusterMode.ON_PREMISE, null, null);
+                                                    ClusterMode.ON_PREMISE, null, injector);
+    workflowRunner = new DistributedWorkflowProgramRunner(cConf, yConf, null, ClusterMode.ON_PREMISE, null, null,
+                                                          injector);
   }
 
   @Test

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.runtime.distributed;
 
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
+import com.google.inject.Injector;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.common.RuntimeArguments;
 import io.cdap.cdap.api.mapreduce.MapReduceSpecification;
@@ -27,6 +28,7 @@ import io.cdap.cdap.app.runtime.ProgramController;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHelper;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramRunId;
@@ -50,8 +52,12 @@ public final class DistributedMapReduceProgramRunner extends DistributedProgramR
   @Inject
   DistributedMapReduceProgramRunner(CConfiguration cConf, YarnConfiguration hConf,
                                     Impersonator impersonator, ClusterMode clusterMode,
-                                    @Constants.AppFabric.ProgramRunner TwillRunner twillRunner) {
+                                    @Constants.AppFabric.ProgramRunner TwillRunner twillRunner,
+                                    Injector injector) {
     super(cConf, hConf, impersonator, clusterMode, twillRunner);
+    if (!cConf.getBoolean(Constants.AppFabric.PROGRAM_REMOTE_RUNNER, false)) {
+      this.namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
+    }
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.runtime.distributed;
 
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
+import com.google.inject.Injector;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.service.ServiceSpecification;
 import io.cdap.cdap.app.guice.ClusterMode;
@@ -26,6 +27,7 @@ import io.cdap.cdap.app.runtime.ProgramController;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.security.impersonation.Impersonator;
@@ -45,8 +47,11 @@ public class DistributedServiceProgramRunner extends DistributedProgramRunner
   @Inject
   DistributedServiceProgramRunner(CConfiguration cConf, YarnConfiguration hConf,
                                   Impersonator impersonator, ClusterMode clusterMode,
-                                  @Constants.AppFabric.ProgramRunner TwillRunner twillRunner) {
+                                  @Constants.AppFabric.ProgramRunner TwillRunner twillRunner, Injector injector) {
     super(cConf, hConf, impersonator, clusterMode, twillRunner);
+    if (!cConf.getBoolean(Constants.AppFabric.PROGRAM_REMOTE_RUNNER, false)) {
+      this.namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
+    }
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.runtime.distributed;
 
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
+import com.google.inject.Injector;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.worker.WorkerSpecification;
 import io.cdap.cdap.app.guice.ClusterMode;
@@ -26,6 +27,7 @@ import io.cdap.cdap.app.runtime.ProgramController;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramRunId;
@@ -45,8 +47,12 @@ public class DistributedWorkerProgramRunner extends DistributedProgramRunner
   @Inject
   DistributedWorkerProgramRunner(CConfiguration cConf, YarnConfiguration hConf,
                                  Impersonator impersonator, ClusterMode clusterMode,
-                                 @Constants.AppFabric.ProgramRunner TwillRunner twillRunner) {
+                                 @Constants.AppFabric.ProgramRunner TwillRunner twillRunner,
+                                 Injector injector) {
     super(cConf, hConf, impersonator, clusterMode, twillRunner);
+    if (!cConf.getBoolean(Constants.AppFabric.PROGRAM_REMOTE_RUNNER, false)) {
+      this.namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
+    }
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closeables;
 import com.google.inject.Inject;
+import com.google.inject.Injector;
 import io.cdap.cdap.api.Resources;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.common.RuntimeArguments;
@@ -41,6 +42,7 @@ import io.cdap.cdap.app.runtime.ProgramRunner;
 import io.cdap.cdap.app.runtime.ProgramRunnerFactory;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.internal.app.runtime.BasicArguments;
 import io.cdap.cdap.internal.app.runtime.SimpleProgramOptions;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
@@ -81,9 +83,13 @@ public final class DistributedWorkflowProgramRunner extends DistributedProgramRu
   DistributedWorkflowProgramRunner(CConfiguration cConf, YarnConfiguration hConf,
                                    Impersonator impersonator, ClusterMode clusterMode,
                                    @Constants.AppFabric.ProgramRunner TwillRunner twillRunner,
-                                   @Constants.AppFabric.ProgramRunner ProgramRunnerFactory programRunnerFactory) {
+                                   @Constants.AppFabric.ProgramRunner ProgramRunnerFactory programRunnerFactory,
+                                   Injector injector) {
     super(cConf, hConf, impersonator, clusterMode, twillRunner);
     this.programRunnerFactory = programRunnerFactory;
+    if (!cConf.getBoolean(Constants.AppFabric.PROGRAM_REMOTE_RUNNER, false)) {
+      this.namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
+    }
   }
 
   @Override

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunnerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.distributed;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.cdap.cdap.app.guice.ClusterMode;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.internal.guice.AppFabricTestModule;
+import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.store.DefaultNamespaceStore;
+import io.cdap.cdap.store.StoreDefinition;
+import org.apache.tephra.TransactionManager;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class DistributedProgramRunnerTest {
+
+  private static final String NAMESPACE = "namespace";
+  private static final Map<String, String> CONFIGS = Collections.singletonMap("property_1", "value_1");
+
+  private static DefaultNamespaceStore nsStore;
+  private static DistributedProgramRunner distributedProgramRunner;
+  private static NamespaceQueryAdmin namespaceQueryAdmin;
+  private static TransactionManager txManager;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    Injector injector = Guice.createInjector(new AppFabricTestModule(CConfiguration.create()));
+    nsStore = new DefaultNamespaceStore(injector.getInstance(TransactionRunner.class));
+    namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
+    txManager = injector.getInstance(TransactionManager.class);
+    txManager.startAndWait();
+
+    // Define all StructuredTable before starting any services that need StructuredTable
+    StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
+
+    distributedProgramRunner = new DistributedServiceProgramRunner(cConf, null, null, ClusterMode.ON_PREMISE, null,
+                                                                   injector);
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    txManager.stopAndWait();
+  }
+
+  @Test
+  public void testGetNamespaceConfigs() throws Exception {
+    NamespaceMeta meta = new NamespaceMeta.Builder().setName(NAMESPACE).setConfig(CONFIGS).build();
+    nsStore.create(meta);
+
+    Map<String, String> foundNamespaceConfigs = distributedProgramRunner.getNamespaceConfigs(NAMESPACE);
+    Assert.assertTrue(foundNamespaceConfigs.entrySet().containsAll(CONFIGS.entrySet()));
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/discovery/KubeDiscoveryService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/discovery/KubeDiscoveryService.java
@@ -467,7 +467,8 @@ public class KubeDiscoveryService implements DiscoveryService, DiscoveryServiceC
       if (port == null) {
         return null;
       }
-      return new Discoverable(name, InetSocketAddress.createUnresolved(hostname, port), payload);
+      String namespacedHostName = String.format("%s.%s", hostname, namespace);
+      return new Discoverable(name, InetSocketAddress.createUnresolved(namespacedHostName, port), payload);
     }
   }
 }

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.app.runtime.spark.distributed;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
+import com.google.inject.Injector;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.common.RuntimeArguments;
 import io.cdap.cdap.api.spark.Spark;
@@ -36,6 +37,7 @@ import io.cdap.cdap.app.runtime.spark.SparkRuntimeContextConfig;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.lang.FilterClassLoader;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.common.twill.ProgramRuntimeClassAcceptor;
 import io.cdap.cdap.internal.app.runtime.batch.distributed.MapReduceContainerHelper;
 import io.cdap.cdap.internal.app.runtime.distributed.DistributedProgramRunner;
@@ -84,10 +86,14 @@ public final class DistributedSparkProgramRunner extends DistributedProgramRunne
   public DistributedSparkProgramRunner(SparkCompat sparkComat, CConfiguration cConf, YarnConfiguration hConf,
                                        Impersonator impersonator, LocationFactory locationFactory,
                                        ClusterMode clusterMode,
-                                       @Constants.AppFabric.ProgramRunner TwillRunner twillRunner) {
+                                       @Constants.AppFabric.ProgramRunner TwillRunner twillRunner,
+                                       Injector injector) {
     super(cConf, hConf, impersonator, clusterMode, twillRunner);
     this.sparkCompat = sparkComat;
     this.locationFactory = locationFactory;
+    if (!cConf.getBoolean(Constants.AppFabric.PROGRAM_REMOTE_RUNNER, false)) {
+      this.namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
+    }
   }
 
   @Override


### PR DESCRIPTION
Changes to support launching programs on non-default Kubernetes namespace:
- Update `DistributedProgramRunner` to get Kubernetes namespace properties from CDAP namespace config and pass it to `TwillPreparer`
- Modify Kubernetes job cleaner to scan and delete jobs across all namespaces
- Update `KubeTwillPreparer` to use the non-default Kubernetes namespace and to add a resource limit (if the namespace has one) during resource creation
- Update `KubeMasterEnvironment` to copy volumes (since the runnable cannot access them in the default namespace) and service account (since the resource expects a service account in the same namespace) during new namespace creation. Modify clusterRoleBinding and add a namespaced roleBinding for the new service account
- Update `KubeDiscoveryService` to include the namespace in the hostname and to always discover on the default namespace

Kubernetes RBAC changes needed:
- Modify existing `cdap-role` to be a `ClusterRole`. This is needed so new service accounts have access to the resources in their (non-default) namespace
- Create a new `ClusterRole` and `ClusterRoleBinding` to give the existing `cdap` service account access to resources across namespaces. This is needed for new namespace creation and so the service account in the non-default namespace has access to appfabric service (in the default namespace)

JIRA: CDAP-18526