### PR TITLE
[CDAP-18621] Allow overriding of idle ttl minutes value for dataproc clusters

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -426,7 +426,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       DataprocConf.COMPONENT_GATEWAY_ENABLED,
       DataprocConf.IMAGE_VERSION,
       DataprocConf.CLUSTER_META_DATA,
-      DataprocConf.SERVICE_ACCOUNT
+      DataprocConf.SERVICE_ACCOUNT,
+      DataprocConf.CLUSTER_IDLE_TTL_MINUTES
     ).contains(property);
   }
 

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
@@ -497,7 +497,8 @@
           "description": "Configure Dataproc to delete the cluster if it has been idle for longer than this many minutes. Clusters are normally deleted directly after a run ends, but this delete may fail in rare situations. For example, if permissions are revoked in the middle of a run, or if there is a Dataproc outage. Use this to ensure that clusters are eventually deleted even if the instance is unable to delete the cluster for any reason.",
           "widget-attributes": {
             "placeholder": "time in minutes",
-            "size": "medium"
+            "size": "medium",
+            "default": 30
           }
         },
         {


### PR DESCRIPTION
[CDAP-18621](https://cdap.atlassian.net/browse/CDAP-18621)
Reference, #13791