### PR TITLE
[CDAP-18720] Kubernetes namespace creation for bootstrap namespaces

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -104,7 +104,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
 
     NamespaceMeta metadata = getNamespaceMeta(request);
 
-    if (isReserved(namespaceId)) {
+    if (NamespaceId.isReserved(namespaceId)) {
       throw new BadRequestException(String.format("Cannot create the namespace '%s'. '%s' is a reserved namespace.",
                                                   namespaceId, namespaceId));
     }
@@ -155,12 +155,6 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     NamespaceId namespaceId = new NamespaceId(namespace);
     namespaceAdmin.deleteDatasets(namespaceId);
     responder.sendStatus(HttpResponseStatus.OK);
-  }
-
-  private boolean isReserved(String namespaceId) {
-    return NamespaceId.DEFAULT.getNamespace().equals(namespaceId)
-      || NamespaceId.SYSTEM.getNamespace().equals(namespaceId)
-      || NamespaceId.CDAP.getNamespace().equals(namespaceId);
   }
 
   private NamespaceMeta getNamespaceMeta(FullHttpRequest request) throws BadRequestException {

--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -107,6 +107,11 @@
         <artifactId>mockito-core</artifactId>
         <scope>test</scope>
       </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-proto</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironmentTask;
 import io.cdap.cdap.master.spi.environment.spark.SparkConfig;
 import io.cdap.cdap.master.spi.environment.spark.SparkLocalizeResource;
 import io.cdap.cdap.master.spi.environment.spark.SparkSubmitContext;
+import io.cdap.cdap.proto.id.NamespaceId;
 import io.kubernetes.client.custom.Quantity;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
@@ -297,8 +298,8 @@ public class KubeMasterEnvironment implements MasterEnvironment {
 
   @Override
   public void onNamespaceCreation(String cdapNamespace, Map<String, String> properties) throws Exception {
-    // check if namespace creation is enabled from master config
-    if (!namespaceCreationEnabled) {
+    // check if namespace creation is enabled from master config or if cdapNamespace is a bootstrap namespace
+    if (!namespaceCreationEnabled || NamespaceId.isReserved(cdapNamespace)) {
       return;
     }
     String namespace = properties.get(NAMESPACE_PROPERTY);

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
@@ -69,6 +69,16 @@ public class KubeMasterEnvironmentTest {
   }
 
   @Test
+  public void testOnNamespaceCreationWithBootstrapNamespace() {
+    Map<String, String> properties = new HashMap<>();
+    try {
+      kubeMasterEnvironment.onNamespaceCreation("default", properties);
+    } catch (Exception e) {
+      Assert.fail("Kubernetes creation should not error for bootstrap namespace. Exception: " + e);
+    }
+  }
+
+  @Test
   public void testOnNamespaceCreationWithExistingNamespace() throws Exception {
     Map<String, String> properties = new HashMap<>();
     properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/NamespaceId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/NamespaceId.java
@@ -116,4 +116,10 @@ public class NamespaceId extends NamespacedEntityId {
   public static NamespaceId fromString(String string) {
     return EntityId.fromString(string, NamespaceId.class);
   }
+
+  public static boolean isReserved(String namespaceId) {
+    return DEFAULT.getNamespace().equals(namespaceId) ||
+      SYSTEM.getNamespace().equals(namespaceId) ||
+      CDAP.getNamespace().equals(namespaceId);
+  }
 }


### PR DESCRIPTION
Ignore creating custom Kubernetes namespaces for bootstrap CDAP namespaces (since they should map to the default Kube namespace)

JIRA: CDAP-18720