### PR TITLE
Added direct output support to SQL Engine operations

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/data/batch/Output.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/data/batch/Output.java
@@ -33,7 +33,7 @@ public abstract class Output {
   private String alias;
   private String namespace;
 
-  private Output(String name) {
+  protected Output(String name) {
     this.name = name;
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngine.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngine.java
@@ -35,6 +35,8 @@ import io.cdap.cdap.etl.api.engine.sql.request.SQLPushRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLRelationDefinition;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLTransformDefinition;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLTransformRequest;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLWriteRequest;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLWriteResult;
 import io.cdap.cdap.etl.api.relational.Engine;
 import io.cdap.cdap.etl.api.relational.Relation;
 
@@ -163,6 +165,16 @@ public interface SQLEngine<KEY_IN, VALUE_IN, KEY_OUT, VALUE_OUT>
    * @return the {@link SQLDataset} instance representing the output of this operation.
    */
   SQLDataset join(SQLJoinRequest joinRequest) throws SQLEngineException;
+
+  /**
+   * Consume a {@link SQLWriteRequest} and write this output into the SQL engine if possible
+   * @param writeRequest write request to consume
+   * @return true if the write request could be consumed, false otherwise
+   * @throws SQLEngineException if the write process fails unexpectedly.
+   */
+  default SQLWriteResult write(SQLWriteRequest writeRequest) throws SQLEngineException {
+    return SQLWriteResult.unsupported(writeRequest.getDatasetName());
+  }
 
   /**
    * Deletes all temporary datasets and cleans up all temporary data from the SQL engine.

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngineOutput.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngineOutput.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.engine.sql;
+
+import io.cdap.cdap.api.data.batch.Output;
+
+import java.util.Map;
+
+/**
+ * Sinks that want to employ optimization by an SQL Engine may push SQLEngine-specific outputs in addition
+ * to regular ones
+ */
+public class SQLEngineOutput extends Output {
+  private final String sqlEngineClassName;
+  private final Map<String, String> arguments;
+
+  public SQLEngineOutput(String name, String sqlEngineClassName, Map<String, String> arguments) {
+    super(name);
+    this.sqlEngineClassName = sqlEngineClassName;
+    this.arguments = arguments;
+  }
+
+  /**
+   * Gets the class name for the SQL engine implementation
+   * @return class name for the SQL engine implementation
+   */
+  public String getSqlEngineClassName() {
+    return sqlEngineClassName;
+  }
+
+  /**
+   * Get arguments used for output configuration
+   * @return arguments used for output configuration
+   */
+  public Map<String, String> getArguments() {
+    return arguments;
+  }
+
+  @Override
+  public String toString() {
+    return "SQLEngineOutput{" +
+      "name='" + getName() + '\'' +
+      ", sqlEngineClassName='" + sqlEngineClassName + '\'' +
+      "} ";
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLWriteRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLWriteRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.engine.sql.request;
+
+import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.etl.api.engine.sql.SQLEngineOutput;
+
+import java.io.Serializable;
+
+/**
+ * A request to perform write operation
+ */
+@Beta
+public class SQLWriteRequest implements Serializable {
+  private final String datasetName;
+  private final SQLEngineOutput output;
+
+  private static final long serialVersionUID = -4406859165903057913L;
+
+  /**
+   * Creates a new SQLWriteRequest instance
+   * @param datasetName dataset name
+   * @param output SQL engine output configuration
+   */
+  public SQLWriteRequest(String datasetName, SQLEngineOutput output) {
+    this.datasetName = datasetName;
+    this.output = output;
+  }
+
+  /**
+   * Get the name of the dataset that should be written to the sink.
+   */
+  public String getDatasetName() {
+    return datasetName;
+  }
+
+  /**
+   * Describes the sink destination
+   */
+  public SQLEngineOutput getOutput() {
+    return output;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLWriteResult.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLWriteResult.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.engine.sql.request;
+
+import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.etl.api.engine.sql.SQLEngineOutput;
+
+import java.io.Serializable;
+
+/**
+ * A request to perform write operation
+ */
+@Beta
+public class SQLWriteResult implements Serializable {
+  private final String datasetName;
+  private final SQLWriteOperationResult result;
+  private final long numRecords;
+
+  private static final long serialVersionUID = 7843665889511527477L;
+
+  /**
+   * Creates a new SQLWriteResult instance
+   * @param datasetName The name of the dataset (stage) that is being written
+   * @param result result of this write operation
+   * @param numRecords number of written records (if any)
+   */
+  public SQLWriteResult(String datasetName, SQLWriteOperationResult result, long numRecords) {
+    this.datasetName = datasetName;
+    this.result = result;
+    this.numRecords = numRecords;
+  }
+
+  /**
+   * Utility method to create an instance with a successful result
+   * @param datasetName dataset name
+   * @param numRecords number of written records
+   * @return new instance with a Success result and the number of specified records.
+   */
+  public static SQLWriteResult success(String datasetName, long numRecords) {
+    return new SQLWriteResult(datasetName, SQLWriteOperationResult.SUCCESS, numRecords);
+  }
+
+  /**
+   * Utility method to create an instance with an unsupported result
+   * @param datasetName dataset name
+   * @return new instance with an unsupported result status and no output records.
+   */
+  public static SQLWriteResult unsupported(String datasetName) {
+    return new SQLWriteResult(datasetName, SQLWriteOperationResult.UNSUPPORTED, 0);
+  }
+
+  /**
+   * Utility method to create an instance with a failed result
+   * @param datasetName dataset name
+   * @return new instance with an unsupported failed status and no output records.
+   */
+  public static SQLWriteResult faiure(String datasetName) {
+    return new SQLWriteResult(datasetName, SQLWriteOperationResult.FAILURE, 0);
+  }
+
+  /**
+   * Get the name of the dataset that should be written to the sink.
+   */
+  public String getDatasetName() {
+    return datasetName;
+  }
+
+  /**
+   * Get the result of the execution of this write operation.
+   */
+  public SQLWriteOperationResult getResult() {
+    return result;
+  }
+
+  /**
+   * Get the number of records that were written into the sink, if any.
+   */
+  public long getNumRecords() {
+    return numRecords;
+  }
+
+  /**
+   * Used to check if the write operation was successful
+   * @return true if successful, false otherwise.
+   */
+  public boolean isSuccessful() {
+    return result == SQLWriteOperationResult.SUCCESS;
+  }
+
+  public enum SQLWriteOperationResult {
+    SUCCESS,
+    FAILURE,
+    UNSUPPORTED
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/engine/SQLEngineJobKey.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/engine/SQLEngineJobKey.java
@@ -24,8 +24,8 @@ import java.util.Objects;
  * A job key is based on the dataset name and the SQL Engine Job Type.
  */
 public class SQLEngineJobKey {
-  private final String datasetName;
-  private final SQLEngineJobType jobType;
+  protected final String datasetName;
+  protected final SQLEngineJobType jobType;
 
   public SQLEngineJobKey(String datasetName, SQLEngineJobType jobType) {
     this.datasetName = datasetName;

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/engine/SQLEngineJobType.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/engine/SQLEngineJobType.java
@@ -22,5 +22,6 @@ package io.cdap.cdap.etl.engine;
 public enum SQLEngineJobType {
   PUSH,
   PULL,
-  EXECUTE
+  EXECUTE,
+  WRITE
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/engine/SQLEngineWriteJobKey.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/engine/SQLEngineWriteJobKey.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.engine;
+
+import java.util.Objects;
+
+/**
+ * Class used to represent a write job for a given dataset.
+ *
+ * Since one dataset can be written to multiple destinations, we use this class as a way to ensure we keep the
+ * dataset name consistent with our existing job keys.
+ */
+public class SQLEngineWriteJobKey extends SQLEngineJobKey {
+  private final String destinationDatasetName;
+
+  public SQLEngineWriteJobKey(String datasetName, String destinationDatasetName, SQLEngineJobType jobType) {
+    super(datasetName, jobType);
+    this.destinationDatasetName = destinationDatasetName;
+  }
+
+  public String getDestinationDatasetName() {
+    return destinationDatasetName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    SQLEngineWriteJobKey that = (SQLEngineWriteJobKey) o;
+    return Objects.equals(destinationDatasetName, that.destinationDatasetName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), destinationDatasetName);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLBackedCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLBackedCollection.java
@@ -16,7 +16,9 @@
 
 package io.cdap.cdap.etl.spark.batch;
 
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 import io.cdap.cdap.etl.spark.SparkCollection;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
 
 /**
  * Interface to denote collections where the underlying records are stored in a SQL engine.
@@ -24,4 +26,11 @@ import io.cdap.cdap.etl.spark.SparkCollection;
  * @param <T> type of elements in the spark collection
  */
 public interface SQLBackedCollection<T> extends SparkCollection<T> {
+  /**
+   * Method used to store results from the SQL engine into an output sink implemented in the same engine without
+   * having to read records into Spark.
+   * @param stageSpec Stage specification
+   * @return boolean specifying if this attempt was successful or not.
+   */
+  boolean tryStoreDirect(StageSpec stageSpec);
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineCollection.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.data.DatasetContext;
 import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
 import io.cdap.cdap.etl.api.batch.SparkCompute;
 import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.api.engine.sql.SQLEngineOutput;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLDataset;
 import io.cdap.cdap.etl.api.streaming.Windower;
 import io.cdap.cdap.etl.common.PhaseSpec;
@@ -179,6 +180,17 @@ public class SQLEngineCollection<T> implements SQLBackedCollection<T> {
   @Override
   public <U> SparkCollection<U> compute(StageSpec stageSpec, SparkCompute<T, U> compute) throws Exception {
     return pull().compute(stageSpec, compute);
+  }
+
+  public boolean tryStoreDirect(StageSpec stageSpec) {
+    SQLEngineOutput sqlEngineOutput = sinkFactory.getSQLEngineOutput(stageSpec.getName());
+    if (sqlEngineOutput != null) {
+      //Try writing directly
+      SQLEngineJob<Boolean> writeJob = adapter.write(datasetName, sqlEngineOutput);
+      adapter.waitForJobAndHandleException(writeJob);
+      return writeJob.waitFor();
+    }
+    return false;
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/AbstractMockSink.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/AbstractMockSink.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2015-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.mock.batch;
+
+import io.cdap.cdap.api.annotation.Macro;
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.api.data.batch.Output;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.dataset.DatasetProperties;
+import io.cdap.cdap.api.dataset.lib.KeyValue;
+import io.cdap.cdap.api.dataset.table.Put;
+import io.cdap.cdap.api.dataset.table.Row;
+import io.cdap.cdap.api.dataset.table.Scanner;
+import io.cdap.cdap.api.dataset.table.Table;
+import io.cdap.cdap.api.lineage.field.EndPoint;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.api.plugin.PluginConfig;
+import io.cdap.cdap.api.plugin.PluginPropertyField;
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.PipelineConfigurer;
+import io.cdap.cdap.etl.api.batch.BatchRuntimeContext;
+import io.cdap.cdap.etl.api.batch.BatchSink;
+import io.cdap.cdap.etl.api.batch.BatchSinkContext;
+import io.cdap.cdap.etl.api.lineage.field.FieldWriteOperation;
+import io.cdap.cdap.etl.proto.v2.ETLPlugin;
+import io.cdap.cdap.format.StructuredRecordStringConverter;
+import io.cdap.cdap.test.DataSetManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+/**
+ * Mock sink that writes records to a Table and has a utility method for getting all records written.
+ */
+public abstract class AbstractMockSink extends BatchSink<StructuredRecord, byte[], Put> {
+  public static final String INITIALIZED_COUNT_METRIC = "initialized.count";
+  private static final byte[] SCHEMA_COL = Bytes.toBytes("s");
+  private static final byte[] RECORD_COL = Bytes.toBytes("r");
+  private final AtomicLong inputCounter = new AtomicLong();
+  private final Config config;
+
+  public AbstractMockSink(Config config) {
+    this.config = config;
+  }
+
+  /**
+   * Config for the sink.
+   */
+  public static class Config extends PluginConfig {
+    @Macro
+    private ConnectionConfig connectionConfig;
+  }
+
+  /**
+   * Connection config for mock sink
+   */
+  public static class ConnectionConfig extends PluginConfig {
+    @Macro
+    private String tableName;
+  }
+
+  @Override
+  public void configurePipeline(PipelineConfigurer pipelineConfigurer) {
+    super.configurePipeline(pipelineConfigurer);
+    if (!config.containsMacro("tableName")) {
+      pipelineConfigurer.createDataset(config.connectionConfig.tableName, Table.class);
+    }
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) throws Exception {
+    if (!context.datasetExists(config.connectionConfig.tableName)) {
+      context.createDataset(config.connectionConfig.tableName, "table", DatasetProperties.EMPTY);
+    }
+    context.addOutput(Output.ofDataset(config.connectionConfig.tableName));
+    Schema schema = context.getInputSchema();
+    if (schema != null && schema.getFields() != null) {
+      schema.getFields().stream().map(Schema.Field::getName).collect(Collectors.toList())
+        .forEach(field -> context.record(Collections.singletonList(
+          new FieldWriteOperation("Mock sink " + field, "Write to mock sink",
+                                  EndPoint.of(context.getNamespace(), config.connectionConfig.tableName), field))));
+    }
+  }
+
+  @Override
+  public void initialize(BatchRuntimeContext context) throws Exception {
+    super.initialize(context);
+    context.getMetrics().count(INITIALIZED_COUNT_METRIC, 1);
+  }
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<KeyValue<byte[], Put>> emitter) throws Exception {
+    byte[] rowkey = Bytes.concat(
+      Bytes.toBytes(System.currentTimeMillis()),
+      Bytes.toBytes(inputCounter.incrementAndGet()),
+      Bytes.toBytes(UUID.randomUUID())
+    );
+    Put put = new Put(rowkey);
+    put.add(SCHEMA_COL, input.getSchema().toString());
+    put.add(RECORD_COL, StructuredRecordStringConverter.toJsonString(input));
+    emitter.emit(new KeyValue<>(rowkey, put));
+  }
+
+  /**
+   * Used to read the records written by this sink.
+   *
+   * @param tableManager dataset manager used to get the sink dataset to read from
+   */
+  public static List<StructuredRecord> readOutput(DataSetManager<Table> tableManager) throws Exception {
+    tableManager.flush();
+    Table table = tableManager.get();
+
+    try (Scanner scanner = table.scan(null, null)) {
+      List<StructuredRecord> records = new ArrayList<>();
+      Row row;
+      while ((row = scanner.next()) != null) {
+        Schema schema = Schema.parseJson(row.getString(SCHEMA_COL));
+        String recordStr = row.getString(RECORD_COL);
+        records.add(StructuredRecordStringConverter.fromJsonString(recordStr, schema));
+      }
+      return records;
+    }
+  }
+
+  /**
+   * Clear any records written to this sink.
+   *
+   * @param tableManager dataset manager used to get the sink dataset
+   */
+  public static void clear(DataSetManager<Table> tableManager) {
+    tableManager.flush();
+    Table table = tableManager.get();
+
+    try (Scanner scanner = table.scan(null, null)) {
+      Row row;
+      while ((row = scanner.next()) != null) {
+        table.delete(row.getRow());
+      }
+    }
+    tableManager.flush();
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSQLEngineWithCapabilities.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSQLEngineWithCapabilities.java
@@ -44,6 +44,8 @@ import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinDefinition;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLJoinRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPullRequest;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPushRequest;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLWriteRequest;
+import io.cdap.cdap.etl.api.engine.sql.request.SQLWriteResult;
 import io.cdap.cdap.etl.proto.v2.ETLPlugin;
 import io.cdap.cdap.format.StructuredRecordStringConverter;
 
@@ -167,6 +169,11 @@ public class MockSQLEngineWithCapabilities extends BatchSQLEngine<Object, Object
         return 1;
       }
     };
+  }
+
+  @Override
+  public SQLWriteResult write(SQLWriteRequest writeRequest) throws SQLEngineException {
+    return SQLWriteResult.success(writeRequest.getDatasetName(), 12345);
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSinkWithWriteCapability.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSinkWithWriteCapability.java
@@ -21,6 +21,8 @@ import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.plugin.PluginClass;
 import io.cdap.cdap.api.plugin.PluginPropertyField;
 import io.cdap.cdap.etl.api.batch.BatchSink;
+import io.cdap.cdap.etl.api.batch.BatchSinkContext;
+import io.cdap.cdap.etl.api.engine.sql.SQLEngineOutput;
 import io.cdap.cdap.etl.proto.v2.ETLPlugin;
 
 import java.util.Collections;
@@ -28,17 +30,25 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Mock sink that writes records to a Table and has a utility method for getting all records written.
+ * Mock sink that exposes direct write capabilities for the {@link MockSQLEngineWithCapabilities}
  */
 @Plugin(type = BatchSink.PLUGIN_TYPE)
-@Name(MockSink.NAME)
-public class MockSink extends AbstractMockSink {
+@Name(MockSinkWithWriteCapability.NAME)
+public class MockSinkWithWriteCapability extends AbstractMockSink {
 
-  public static final String NAME = "Mock";
+  public static final String NAME = "MockWithWriteCapability";
   public static final PluginClass PLUGIN_CLASS = getPluginClass();
 
-  public MockSink(Config config) {
+  public MockSinkWithWriteCapability(Config config) {
     super(config);
+  }
+
+  @Override
+  public void prepareRun(BatchSinkContext context) throws Exception {
+    super.prepareRun(context);
+    context.addOutput(new SQLEngineOutput(NAME,
+                                          MockSQLEngineWithCapabilities.class.getName(),
+                                          Collections.emptyMap()));
   }
 
   /**
@@ -71,7 +81,7 @@ public class MockSink extends AbstractMockSink {
     properties.put("connectionConfig", new PluginPropertyField("connectionConfig", "", "connectionconfig", true, true,
                                                                false, Collections.singleton("tableName")));
     return PluginClass.builder().setName(NAME).setType(BatchSink.PLUGIN_TYPE)
-      .setDescription("").setClassName(MockSink.class.getName()).setProperties(properties)
+      .setDescription("").setClassName(MockSinkWithWriteCapability.class.getName()).setProperties(properties)
       .setConfigFieldName("config").build();
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -56,6 +56,7 @@ import io.cdap.cdap.etl.mock.batch.MockRuntimeDatasetSource;
 import io.cdap.cdap.etl.mock.batch.MockSQLEngine;
 import io.cdap.cdap.etl.mock.batch.MockSQLEngineWithCapabilities;
 import io.cdap.cdap.etl.mock.batch.MockSink;
+import io.cdap.cdap.etl.mock.batch.MockSinkWithWriteCapability;
 import io.cdap.cdap.etl.mock.batch.MockSource;
 import io.cdap.cdap.etl.mock.batch.NodeStatesAction;
 import io.cdap.cdap.etl.mock.batch.NullErrorTransform;
@@ -114,7 +115,8 @@ public class HydratorTestBase extends TestBase {
     MockAction.PLUGIN_CLASS, FileMoveAction.PLUGIN_CLASS, FieldLineageAction.PLUGIN_CLASS,
     StringValueFilterCompute.PLUGIN_CLASS, FlattenErrorTransform.PLUGIN_CLASS, FilterErrorTransform.PLUGIN_CLASS,
     NullFieldSplitterTransform.PLUGIN_CLASS, TMSAlertPublisher.PLUGIN_CLASS, NullAlertTransform.PLUGIN_CLASS,
-    MockCondition.PLUGIN_CLASS, MockSource.PLUGIN_CLASS, MockSink.PLUGIN_CLASS,
+    MockCondition.PLUGIN_CLASS, MockSource.PLUGIN_CLASS,
+    MockSink.PLUGIN_CLASS, MockSinkWithWriteCapability.PLUGIN_CLASS,
     DistinctReducibleAggregator.PLUGIN_CLASS, FieldCountReducibleAggregator.PLUGIN_CLASS,
     FileConnector.PLUGIN_CLASS, IncapableSource.PLUGIN_CLASS, IncapableSink.PLUGIN_CLASS,
     LookupTransform.PLUGIN_CLASS, SleepTransform.PLUGIN_CLASS, NodeStatesAction.PLUGIN_CLASS,


### PR DESCRIPTION
This allows the SQL engine to write output directly to the sink (meaning it bypasses spark processing for supported sinks)