### PR TITLE
[CDAP-18713] Add Workload Identity Setup Support for K8s Environment

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -192,6 +192,7 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
         masterEnv.onNamespaceCreation(namespace.getNamespace(), metadata.getConfig().getConfigs());
       }
     } catch (Throwable t) {
+      LOG.error(String.format("Failed to create namespace '%s'", namespace.getNamespace()), t);
       // failed to create namespace in underlying storage so delete the namespace meta stored in the store earlier
       deleteNamespaceMeta(metadata.getNamespaceId());
       throw new NamespaceCannotBeCreatedException(namespace, t);

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/DefaultLocalFileProvider.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/DefaultLocalFileProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.common;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Provides a File object using local files. Creates the folders up to the file if they do not exist.
+ * Does NOT create the file prior to returning a writable {@link File} object.
+ */
+public class DefaultLocalFileProvider implements LocalFileProvider {
+
+  @Override
+  public File getWritableFileRef(String path) throws IOException {
+    Path parentDirPath = Paths.get(path).getParent();
+    if (parentDirPath != null) {
+      File parentDir = new File(parentDirPath.toString());
+      if (!parentDir.exists() || !parentDir.isDirectory()) {
+        if (!parentDir.mkdirs()) {
+          throw new IOException(String.format("Failed to create parent directories for file '%s'", path));
+        }
+      }
+    }
+    return new File(path);
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/LocalFileProvider.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/LocalFileProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.common;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * An interface providing a way of writing to local files.
+ * Provides a pluggable interface for unit-testing file-based logic.
+ */
+public interface LocalFileProvider {
+  /**
+   * Returns a writable file object reference based on the provided name.
+   * Creates any necessary directories for the object prior to returning the reference.
+   *
+   * @param path The path of the file
+   * @return a File object
+   */
+  File getWritableFileRef(String path) throws IOException;
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/identity/GCPWorkloadIdentityCredential.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/identity/GCPWorkloadIdentityCredential.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.identity;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents a GCP credential meant for serialization. For additional information see step 6 of
+ * https://cloud.google.com/anthos/multicluster-management/fleets/workload-identity#impersonate_a_service_account
+ */
+public class GCPWorkloadIdentityCredential {
+
+  /**
+   * Represents the source of the credential.
+   */
+  public class CredentialSource {
+    @SerializedName("file")
+    private final String file;
+
+    private CredentialSource(String file) {
+      this.file = file;
+    }
+  }
+
+  /**
+   * Represents the type of credential.
+   */
+  public enum CredentialType {
+    @SerializedName("external_account")
+    EXTERNAL_ACCOUNT
+  }
+
+  /**
+   * Represents the type of token.
+   */
+  public enum TokenType {
+    @SerializedName("urn:ietf:params:oauth:token-type:jwt")
+    JWT
+  }
+
+  @SerializedName("type")
+  private final CredentialType type;
+
+  @SerializedName("audience")
+  private final String audience;
+
+  @SerializedName("service_account_impersonation_url")
+  private final String serviceAccountImpersonationURL;
+
+  @SerializedName("subject_token_type")
+  private final TokenType subjectTokenType;
+
+  @SerializedName("token_url")
+  private final String tokenURL;
+
+  @SerializedName("credential_source")
+  private final CredentialSource credentialSource;
+
+  public GCPWorkloadIdentityCredential(CredentialType type, String audience, String serviceAccountImpersonationURL,
+                                       TokenType subjectTokenType, String tokenURL, String credentialSourceFile) {
+    this.type = type;
+    this.audience = audience;
+    this.serviceAccountImpersonationURL = serviceAccountImpersonationURL;
+    this.subjectTokenType = subjectTokenType;
+    this.tokenURL = tokenURL;
+    this.credentialSource = new CredentialSource(credentialSourceFile);
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/DefaultKubeMasterPathProvider.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/DefaultKubeMasterPathProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.util.Config;
+
+public class DefaultKubeMasterPathProvider implements KubeMasterPathProvider {
+
+  @Override
+  public String getMasterPath() {
+    // Spark master base path
+    String master;
+    // apiClient.getBasePath() returns path similar to https://10.8.0.1:443
+    try {
+      ApiClient apiClient = Config.defaultClient();
+      master = apiClient.getBasePath();
+    } catch (Exception e) {
+      // should not happen
+      throw new RuntimeException("Exception while getting kubernetes master path", e);
+    }
+    return master;
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterPathProvider.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterPathProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+/**
+ * Provides the master path for the Kubernetes API client.
+ */
+public interface KubeMasterPathProvider {
+  /**
+   * @return Spark master base path
+   */
+  String getMasterPath();
+}

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/common/DefaultLocalFileProviderTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/common/DefaultLocalFileProviderTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.common;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Random;
+
+/**
+ * Tests for DefaultLocalFileProvider.
+ */
+public class DefaultLocalFileProviderTest {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  /**
+   * Appends random byte data to an empty file, reads it back, and asserts it is the same as previously written.
+   */
+  private void assertWrittenToFile(File file) throws IOException {
+    Random random = new Random();
+    byte[] expectedRandBytes = new byte[256];
+    random.nextBytes(expectedRandBytes);
+    try (FileOutputStream outputStream = new FileOutputStream(file)) {
+      outputStream.write(expectedRandBytes);
+    }
+    byte[] receivedBytes = new byte[256];
+    try (FileInputStream inputStream = new FileInputStream(file)) {
+      inputStream.read(receivedBytes);
+    }
+    Assert.assertArrayEquals(expectedRandBytes, receivedBytes);
+  }
+
+  @Test
+  public void testAbsolutePathFileIsWritable() throws Exception {
+    Path filePath = temporaryFolder.getRoot().toPath().resolve("file.txt");
+    DefaultLocalFileProvider defaultLocalFileProvider = new DefaultLocalFileProvider();
+    File file = defaultLocalFileProvider.getWritableFileRef(filePath.toString());
+    assertWrittenToFile(file);
+  }
+
+  @Test
+  public void testAbsolutePathFileWithNonexistentParentDirectoryIsIsWritable() throws Exception {
+    Path filePath = temporaryFolder.getRoot().toPath().resolve("tmp/abc/file.txt");
+    DefaultLocalFileProvider defaultLocalFileProvider = new DefaultLocalFileProvider();
+    File file = defaultLocalFileProvider.getWritableFileRef(filePath.toString());
+    assertWrittenToFile(file);
+  }
+
+  @Test
+  public void testMultipleAbsolutePathFilesWithNonexistentParentDirectoryAreWritable() throws Exception {
+    DefaultLocalFileProvider defaultLocalFileProvider = new DefaultLocalFileProvider();
+    Path filePath1 = temporaryFolder.getRoot().toPath().resolve("tmp/abc/dec/file1.txt");
+    Path filePath2 = temporaryFolder.getRoot().toPath().resolve("tmp/abc/dec/file2.txt");
+    Path filePath3 = temporaryFolder.getRoot().toPath().resolve("tmp/abc/file3.txt");
+    Path filePath4 = temporaryFolder.getRoot().toPath().resolve("tmp/file4.txt");
+    File file1 = defaultLocalFileProvider.getWritableFileRef(filePath1.toString());
+    File file2 = defaultLocalFileProvider.getWritableFileRef(filePath2.toString());
+    File file3 = defaultLocalFileProvider.getWritableFileRef(filePath3.toString());
+    File file4 = defaultLocalFileProvider.getWritableFileRef(filePath4.toString());
+    assertWrittenToFile(file1);
+    assertWrittenToFile(file2);
+    assertWrittenToFile(file3);
+    assertWrittenToFile(file4);
+  }
+}

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/common/TemporaryLocalFileProvider.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/common/TemporaryLocalFileProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.common;
+
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Provides a file in a provided temporary directory for testing.
+ * The temporary local file provider will pre-create the writable file reference prior to returning it to the caller.
+ */
+public class TemporaryLocalFileProvider implements LocalFileProvider {
+
+  private final TemporaryFolder temporaryFolder;
+
+  public TemporaryLocalFileProvider(TemporaryFolder temporaryFolder) {
+    this.temporaryFolder = temporaryFolder;
+  }
+
+  @Override
+  public File getWritableFileRef(String path) throws IOException {
+    Path parentDirPath = Paths.get(path).getParent();
+    if (parentDirPath != null) {
+      File parentDir = new File(temporaryFolder.getRoot().getPath(), parentDirPath.toString());
+      if (!parentDir.exists() || !parentDir.isDirectory()) {
+        List<String> folders = new ArrayList<>();
+        for (Iterator<Path> pathIterator = parentDirPath.iterator(); pathIterator.hasNext();) {
+          folders.add(pathIterator.next().toString());
+        }
+        temporaryFolder.newFolder(folders.toArray(new String[0]));
+      }
+    }
+    return temporaryFolder.newFile(path);
+  }
+}

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/common/TemporaryLocalFileProviderTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/common/TemporaryLocalFileProviderTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.common;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Random;
+
+/**
+ * Tests for TemporaryLocalFileProvider.
+ */
+public class TemporaryLocalFileProviderTest {
+
+  /**
+   * Appends random byte data to an empty file, reads it back, and asserts it is the same as previously written.
+   */
+  private void assertWrittenToFile(File file) throws IOException {
+    Random random = new Random();
+    byte[] expectedRandBytes = new byte[256];
+    random.nextBytes(expectedRandBytes);
+    try (FileOutputStream outputStream = new FileOutputStream(file)) {
+      outputStream.write(expectedRandBytes);
+    }
+    byte[] receivedBytes = new byte[256];
+    try (FileInputStream inputStream = new FileInputStream(file)) {
+      inputStream.read(receivedBytes);
+    }
+    Assert.assertArrayEquals(expectedRandBytes, receivedBytes);
+  }
+
+  @Test
+  public void testRelativePathFileIsWritableAndCleanedUp() throws Exception {
+    TemporaryFolder temporaryFolder = new TemporaryFolder();
+    temporaryFolder.create();
+    TemporaryLocalFileProvider temporaryLocalFileProvider = new TemporaryLocalFileProvider(temporaryFolder);
+    File temporaryFile = temporaryLocalFileProvider.getWritableFileRef("file.txt");
+    assertWrittenToFile(temporaryFile);
+    temporaryFolder.delete();
+    Assert.assertFalse(temporaryFile.exists());
+  }
+
+  @Test
+  public void testAbsolutePathFileIsIsWritableAndCleanedUp() throws Exception {
+    TemporaryFolder temporaryFolder = new TemporaryFolder();
+    temporaryFolder.create();
+    TemporaryLocalFileProvider temporaryLocalFileProvider = new TemporaryLocalFileProvider(temporaryFolder);
+    File temporaryFile = temporaryLocalFileProvider.getWritableFileRef("/tmp/abc/dec/file.txt");
+    assertWrittenToFile(temporaryFile);
+    temporaryFolder.delete();
+    Assert.assertFalse(temporaryFile.exists());
+  }
+
+  @Test
+  public void testMultipleAbsolutePathFilesAreWritableAndCleanedUp() throws Exception {
+    TemporaryFolder temporaryFolder = new TemporaryFolder();
+    temporaryFolder.create();
+    TemporaryLocalFileProvider temporaryLocalFileProvider = new TemporaryLocalFileProvider(temporaryFolder);
+    File temporaryFile1 = temporaryLocalFileProvider.getWritableFileRef("/tmp/abc/dec/file1.txt");
+    File temporaryFile2 = temporaryLocalFileProvider.getWritableFileRef("/tmp/abc/dec/file2.txt");
+    File temporaryFile3 = temporaryLocalFileProvider.getWritableFileRef("/tmp/abc/file3.txt");
+    File temporaryFile4 = temporaryLocalFileProvider.getWritableFileRef("/tmp/file4.txt");
+    assertWrittenToFile(temporaryFile1);
+    assertWrittenToFile(temporaryFile2);
+    assertWrittenToFile(temporaryFile3);
+    assertWrittenToFile(temporaryFile4);
+    temporaryFolder.delete();
+    Assert.assertFalse(temporaryFile1.exists());
+    Assert.assertFalse(temporaryFile2.exists());
+    Assert.assertFalse(temporaryFile3.exists());
+    Assert.assertFalse(temporaryFile4.exists());
+  }
+}

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
@@ -16,25 +16,46 @@
 
 package io.cdap.cdap.master.environment.k8s;
 
+import io.cdap.cdap.k8s.common.TemporaryLocalFileProvider;
+import io.cdap.cdap.master.spi.environment.spark.SparkConfig;
+import io.cdap.cdap.master.spi.environment.spark.SparkSubmitContext;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1ConfigMapProjection;
+import io.kubernetes.client.openapi.models.V1Container;
+import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1KeyToPath;
 import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1ProjectedVolumeSource;
+import io.kubernetes.client.openapi.models.V1ServiceAccountTokenProjection;
+import io.kubernetes.client.openapi.models.V1Volume;
+import io.kubernetes.client.openapi.models.V1VolumeMount;
+import io.kubernetes.client.openapi.models.V1VolumeProjection;
+import io.kubernetes.client.util.Yaml;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -51,12 +72,33 @@ public class KubeMasterEnvironmentTest {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
   @Before
-  public void init() {
+  public void init() throws IOException {
     coreV1Api = mock(CoreV1Api.class);
     kubeMasterEnvironment = new KubeMasterEnvironment();
     kubeMasterEnvironment.setCoreV1Api(coreV1Api);
     kubeMasterEnvironment.setNamespaceCreationEnabled();
+    kubeMasterEnvironment.setLocalFileProvider(new TemporaryLocalFileProvider(temporaryFolder));
+    KubeMasterPathProvider mockKubeMasterPathProvider = mock(KubeMasterPathProvider.class);
+    when(mockKubeMasterPathProvider.getMasterPath()).thenReturn("https://127.0.0.1:443");
+    kubeMasterEnvironment.setKubeMasterPathProvider(mockKubeMasterPathProvider);
+    kubeMasterEnvironment.setAdditionalSparkConfs(Collections.emptyMap());
+    // Create a dummy file for the pod
+    File dummyFile = temporaryFolder.newFile();
+    kubeMasterEnvironment.setPodInfoDir(new File("/tmp/"));
+    kubeMasterEnvironment.setPodLabelsFile(dummyFile);
+    kubeMasterEnvironment.setPodNameFile(dummyFile);
+    kubeMasterEnvironment.setPodUidFile(dummyFile);
+    kubeMasterEnvironment.setPodInfo(new PodInfo("pod-info", "pod-info-dir", dummyFile.getAbsolutePath(),
+                                                 dummyFile.getAbsolutePath(), UUID.randomUUID().toString(),
+                                                 dummyFile.getAbsolutePath(), KUBE_NAMESPACE, Collections.emptyMap(),
+                                                 Collections.emptyList(), "service-account", "runtime-class",
+                                                 Collections.emptyList(), "container-label-name", "container-image",
+                                                 Collections.emptyList(), Collections.emptyList(), null,
+                                                 "image-pull-policy"));
   }
 
   @Test
@@ -108,6 +150,7 @@ public class KubeMasterEnvironmentTest {
     } catch (Exception e) {
       Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
     }
+    verify(coreV1Api, times(0)).createNamespacedConfigMap(any(), any(), any(), any(), any());
   }
 
   @Test
@@ -151,5 +194,191 @@ public class KubeMasterEnvironmentTest {
     } catch (Exception e) {
       Assert.fail("Kubernetes deletion should not error if namespace does not exist. Exception: " + e);
     }
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithWorkloadIdentityEnabled() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    String workloadIdentityPool = "test-workload-pool";
+    String workloadIdentityGCPServiceAccount = "test-service-account@test-project-id.iam.gserviceaccount.com";
+    String workloadIdentityProvider = "https://gkehub.googleapis.com/projects/test-project-id/locations/global/" +
+      "memberships/test-cluster";
+    kubeMasterEnvironment.setNamespaceCreationEnabled();
+    kubeMasterEnvironment.setWorkloadIdentityEnabled();
+    kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
+    kubeMasterEnvironment.setWorkloadIdentityGcpServiceAccountName(workloadIdentityGCPServiceAccount);
+    kubeMasterEnvironment.setWorkloadIdentityProvider(workloadIdentityProvider);
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+    when(coreV1Api.readNamespacedConfigMap(eq(KUBE_NAMESPACE), eq("workload-identity-config"), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "config map not found"));
+    try {
+      kubeMasterEnvironment.onNamespaceCreation(CDAP_NAMESPACE, properties);
+    } catch (Exception e) {
+      Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
+    }
+    verify(coreV1Api, times(1)).createNamespacedConfigMap(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithWorkloadIdentityEnabledDoesNotCreateExistingConfigMap() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    String workloadIdentityPool = "test-workload-pool";
+    String workloadIdentityGCPServiceAccount = "test-service-account@test-project-id.iam.gserviceaccount.com";
+    String workloadIdentityProvider = "https://gkehub.googleapis.com/projects/test-project-id/locations/global/" +
+      "memberships/test-cluster";
+    kubeMasterEnvironment.setNamespaceCreationEnabled();
+    kubeMasterEnvironment.setWorkloadIdentityEnabled();
+    kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
+    kubeMasterEnvironment.setWorkloadIdentityGcpServiceAccountName(workloadIdentityGCPServiceAccount);
+    kubeMasterEnvironment.setWorkloadIdentityProvider(workloadIdentityProvider);
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+    when(coreV1Api.readNamespacedConfigMap(eq(KUBE_NAMESPACE), eq("workload-identity-config"), any(), any(), any()))
+      .thenReturn(new V1ConfigMap().metadata(new V1ObjectMeta().name("workload-identity-config")
+                                               .namespace(KUBE_NAMESPACE)));
+    try {
+      kubeMasterEnvironment.onNamespaceCreation(CDAP_NAMESPACE, properties);
+    } catch (Exception e) {
+      Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
+    }
+    verify(coreV1Api, times(0)).createNamespacedConfigMap(any(), any(), any(), any(), any());
+  }
+
+
+  @Test(expected = IOException.class)
+  public void testOnNamespaceCreationWithWorkloadIdentityEnabledReadConfigMapPropagatesException() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    String workloadIdentityPool = "test-workload-pool";
+    String workloadIdentityGCPServiceAccount = "test-service-account@test-project-id.iam.gserviceaccount.com";
+    String workloadIdentityProvider = "https://gkehub.googleapis.com/projects/test-project-id/locations/global/" +
+      "memberships/test-cluster";
+    kubeMasterEnvironment.setNamespaceCreationEnabled();
+    kubeMasterEnvironment.setWorkloadIdentityEnabled();
+    kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
+    kubeMasterEnvironment.setWorkloadIdentityGcpServiceAccountName(workloadIdentityGCPServiceAccount);
+    kubeMasterEnvironment.setWorkloadIdentityProvider(workloadIdentityProvider);
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+    when(coreV1Api.readNamespacedConfigMap(any(), any(), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_INTERNAL_ERROR, "internal error"));
+    when(coreV1Api.createNamespacedConfigMap(any(), any(), any(), any(), any())).thenThrow(new ApiException());
+    kubeMasterEnvironment.onNamespaceCreation(CDAP_NAMESPACE, properties);
+  }
+
+  @Test(expected = ApiException.class)
+  public void testOnNamespaceCreationWithWorkloadIdentityEnabledCreateNamespacePropagatesException() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    String workloadIdentityPool = "test-workload-pool";
+    String workloadIdentityGCPServiceAccount = "test-service-account@test-project-id.iam.gserviceaccount.com";
+    String workloadIdentityProvider = "https://gkehub.googleapis.com/projects/test-project-id/locations/global/" +
+      "memberships/test-cluster";
+    kubeMasterEnvironment.setNamespaceCreationEnabled();
+    kubeMasterEnvironment.setWorkloadIdentityEnabled();
+    kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
+    kubeMasterEnvironment.setWorkloadIdentityGcpServiceAccountName(workloadIdentityGCPServiceAccount);
+    kubeMasterEnvironment.setWorkloadIdentityProvider(workloadIdentityProvider);
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+    when(coreV1Api.readNamespacedConfigMap(eq(KUBE_NAMESPACE), eq("workload-identity-config"), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "config map not found"));
+    when(coreV1Api.createNamespacedConfigMap(any(), any(), any(), any(), any())).thenThrow(new ApiException());
+    kubeMasterEnvironment.onNamespaceCreation(CDAP_NAMESPACE, properties);
+  }
+
+  private void assertContainsVolume(V1Pod pod, V1Volume expectedVolume) {
+    for (V1Volume volume : pod.getSpec().getVolumes()) {
+      if (volume.getName().equals(expectedVolume.getName())) {
+        Assert.assertEquals(expectedVolume, volume);
+        return;
+      }
+    }
+    Assert.fail(String.format("Expected volume '%s' not found in pod spec '%s'", expectedVolume.getName(),
+                              pod.getMetadata().getName()));
+  }
+
+  private void assertContainersContainVolumeMount(V1Pod pod, V1VolumeMount expectedVolumeMount) {
+    for (V1Container container : pod.getSpec().getContainers()) {
+      for (V1VolumeMount volumeMount : container.getVolumeMounts()) {
+        if (volumeMount.getName().equals(expectedVolumeMount.getName())) {
+          Assert.assertEquals(expectedVolumeMount, volumeMount);
+          return;
+        }
+      }
+      Assert.fail(String.format("Expected volume mount '%s' not found in container '%s' for pod '%s'",
+                                expectedVolumeMount.getName(),
+                                container.getName(),
+                                pod.getMetadata().getName()));
+    }
+  }
+
+  private void assertContainersContainEnvVar(V1Pod pod, V1EnvVar expectedEnvVar) {
+    for (V1Container container : pod.getSpec().getContainers()) {
+      for (V1EnvVar envVar : container.getEnv()) {
+        if (envVar.getName().equals(expectedEnvVar.getName())) {
+          Assert.assertEquals(expectedEnvVar, envVar);
+          return;
+        }
+      }
+      Assert.fail(String.format("Expected environment variable '%s' not found in container '%s' for pod '%s'",
+                                expectedEnvVar.getName(),
+                                container.getName(),
+                                pod.getMetadata().getName()));
+    }
+  }
+
+  @Test
+  public void testGenerateSparkConfigWithWorkloadIdentityEnabled() throws Exception {
+    String workloadIdentityPool = "test-workload-pool";
+    String workloadIdentityGCPServiceAccount = "test-service-account@test-project-id.iam.gserviceaccount.com";
+    String workloadIdentityProvider = "https://gkehub.googleapis.com/projects/test-project-id/locations/global/" +
+      "memberships/test-cluster";
+    kubeMasterEnvironment.setWorkloadIdentityEnabled();
+    kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
+    kubeMasterEnvironment.setWorkloadIdentityGcpServiceAccountName(workloadIdentityGCPServiceAccount);
+    kubeMasterEnvironment.setWorkloadIdentityProvider(workloadIdentityProvider);
+    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTTLSeconds(172800L);
+
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap());
+
+    SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
+
+    // Verify volume, volume mount, and environment variables are set for workload identity
+    Map<String, String> configs = sparkConfig.getConfigs();
+    File sparkDriverPodFile = new File(configs.get(KubeMasterEnvironment.SPARK_KUBERNETES_DRIVER_POD_TEMPLATE));
+    File sparkExecutorPodFile = new File(configs.get(KubeMasterEnvironment.SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE));
+    V1Pod driverPod = Yaml.loadAs(sparkDriverPodFile, V1Pod.class);
+    V1Pod executorPod = Yaml.loadAs(sparkExecutorPodFile, V1Pod.class);
+
+    // NOTE: Several of these values are hard-coded to ensure that it is not changed by accident as it can cause other
+    // pieces to fail. If one of the values changed, the other constants must be validated!
+    V1ServiceAccountTokenProjection workloadIdentityKSATokenProjection = new V1ServiceAccountTokenProjection()
+      .path("token")
+      .expirationSeconds(172800L)
+      .audience(workloadIdentityPool);
+    V1ConfigMapProjection workloadIdentityGSAConfigMapProjection = new V1ConfigMapProjection()
+      .name("workload-identity-config")
+      .optional(false)
+      .addItemsItem(new V1KeyToPath().key("config").path("google-application-credentials.json"));
+    V1Volume expectedWorkloadIdentityProjectedVolume = new V1Volume().name("gcp-ksa")
+      .projected(new V1ProjectedVolumeSource()
+                   .defaultMode(420)
+                   .addSourcesItem(new V1VolumeProjection().serviceAccountToken(workloadIdentityKSATokenProjection))
+                   .addSourcesItem(new V1VolumeProjection().configMap(workloadIdentityGSAConfigMapProjection)));
+    V1VolumeMount expectedWorkloadIdentityProjectedVolumeMount = new V1VolumeMount().name("gcp-ksa")
+      .mountPath("/var/run/secrets/tokens/gcp-ksa").readOnly(true);
+    V1EnvVar expectedGoogleApplicationCredentialsEnvVar = new V1EnvVar().name("GOOGLE_APPLICATION_CREDENTIALS")
+      .value("/var/run/secrets/tokens/gcp-ksa/google-application-credentials.json");
+    // Verify pod specs
+    assertContainsVolume(driverPod, expectedWorkloadIdentityProjectedVolume);
+    assertContainersContainVolumeMount(driverPod, expectedWorkloadIdentityProjectedVolumeMount);
+    assertContainersContainEnvVar(driverPod, expectedGoogleApplicationCredentialsEnvVar);
+    assertContainsVolume(executorPod, expectedWorkloadIdentityProjectedVolume);
+    assertContainersContainVolumeMount(executorPod, expectedWorkloadIdentityProjectedVolumeMount);
+    assertContainersContainEnvVar(executorPod, expectedGoogleApplicationCredentialsEnvVar);
   }
 }


### PR DESCRIPTION
Adds support for initializing GCP workload identity configurations as described in the [Fleet Workload Identity](https://cloud.google.com/anthos/multicluster-management/fleets/workload-identity) documentation.