### PR TITLE
[CDAP-18603] Adding basic support for Pagination in the getAllApps API

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.services.http;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closeables;
 import com.google.common.io.InputSupplier;
@@ -619,6 +620,24 @@ public abstract class AppFabricTestBase {
     HttpResponse response = doGet(getVersionedAPIPath("apps/", Constants.Gateway.API_VERSION_3_TOKEN, namespace));
     assertResponseCode(200, response);
     return readResponse(response, LIST_JSON_OBJECT_TYPE);
+  }
+
+  protected JsonObject getAppListForPaginatedApi(String namespace, int pageSize, String token,
+                                                 String filter) throws Exception {
+    String uri = "apps/?pageSize=" + pageSize;
+
+    if (token != null) {
+      uri += ("&pageToken=" + token);
+    }
+
+    if (!Strings.isNullOrEmpty(filter)) {
+      uri += ("&nameFilter=" + filter);
+    }
+
+    HttpResponse response = doGet(getVersionedAPIPath(uri,
+                                  Constants.Gateway.API_VERSION_3_TOKEN, namespace));
+    assertResponseCode(200, response);
+    return readResponse(response, JsonObject.class);
   }
 
   /**

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/PaginatedApplicationRecords.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/PaginatedApplicationRecords.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2016-2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.proto;
+
+import java.util.List;
+
+/**
+ * Result for getting Paginated Application Records
+ */
+public class PaginatedApplicationRecords {
+
+  public List<ApplicationRecord> getApplications() {
+    return applications;
+  }
+
+  public String getNextPageToken() {
+    return nextPageToken;
+  }
+
+  private final List<ApplicationRecord> applications;
+  private final String nextPageToken;
+
+  public PaginatedApplicationRecords(List<ApplicationRecord> applications, String nextPageToken) {
+    this.applications = applications;
+    this.nextPageToken = nextPageToken;
+  }
+}


### PR DESCRIPTION
What:
 Adding basic support for Pagination in the getAllApps API. This REST API endpoint can be used by the UI team for testing. 

Testing in Sandbox - 
<img width="1297" alt="Screen Shot 2022-01-12 at 7 27 48 PM" src="https://user-images.githubusercontent.com/12438767/149272157-61542b8d-3c7a-4287-ace8-93c14f2645fe.png">
<img width="1283" alt="Screen Shot 2022-01-12 at 7 28 04 PM" src="https://user-images.githubusercontent.com/12438767/149273261-99a0ba77-8091-4f82-b5b2-7652e35c2d4a.png">

<img width="1297" alt="Screen Shot 2022-01-12 at 7 28 20 PM" src="https://user-images.githubusercontent.com/12438767/149273270-633a624b-4773-4c38-bf4d-632b4349a37e.png">
<img width="1246" alt="Screen Shot 2022-01-12 at 7 28 37 PM" src="https://user-images.githubusercontent.com/12438767/149273282-70fa77d9-19ad-4a2e-afaa-577e5936621e.png">
<img width="1293" alt="Screen Shot 2022-01-12 at 7 35 47 PM" src="https://user-images.githubusercontent.com/12438767/149273319-425ecdb2-c2be-4a68-9cbd-033226b3768f.png">


