### PR TITLE
[6.6 Cherry-pick][CDAP-18738]: Enable cluster reuse when skip delete is enabled.

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -614,7 +614,7 @@ final class DataprocConf {
     String initActions = getString(properties, "initActions");
     boolean runtimeJobManagerEnabled = Boolean.parseBoolean(properties.get(RUNTIME_JOB_MANAGER));
     String autoScalingPolicy = getString(properties, "autoScalingPolicy");
-    int idleTTL = getInt(properties, CLUSTER_IDLE_TTL_MINUTES, skipDelete ? 0 : CLUSTER_IDLE_TTL_MINUTES_DEFAULT);
+    int idleTTL = getInt(properties, CLUSTER_IDLE_TTL_MINUTES, CLUSTER_IDLE_TTL_MINUTES_DEFAULT);
 
     String tokenEndpoint = getString(properties, TOKEN_ENDPOINT_KEY);
     boolean secureBootEnabled = Boolean.parseBoolean(properties.getOrDefault(SECURE_BOOT_ENABLED, "false"));
@@ -623,7 +623,7 @@ final class DataprocConf {
       properties.getOrDefault(INTEGRITY_MONITORING_ENABLED, "false"));
 
     boolean clusterReuseEnabled = Boolean.parseBoolean(
-      properties.getOrDefault(CLUSTER_REUSE_ENABLED, "false"));
+      properties.getOrDefault(CLUSTER_REUSE_ENABLED, "true"));
     int clusterReuseThresholdMinutes = getInt(properties, CLUSTER_REUSE_THRESHOLD_MINUTES,
                                               CLUSTER_REUSE_THRESHOLD_MINUTES_DEFAULT);
     String clusterReuseKey = null;

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -270,7 +270,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
 
   private boolean isReuseSupported(DataprocConf conf) {
     return conf.isClusterReuseEnabled() && conf.isSkipDelete() &&
-      conf.getIdleTTLMinutes() > conf.getClusterReuseThresholdMinutes();
+      (conf.getIdleTTLMinutes() <= 0 || conf.getIdleTTLMinutes() > conf.getClusterReuseThresholdMinutes());
   }
 
   @Nullable

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -172,11 +172,6 @@ public class DataprocProvisionerTest {
     props.put("region", "region1");
     DataprocConf conf = DataprocConf.create(props);
     Assert.assertEquals(30, conf.getIdleTTLMinutes());
-
-    // when deleteSkip set to true fallback don't set the idleTTL
-    props.put("skipDelete", "true");
-    conf = DataprocConf.create(props);
-    Assert.assertEquals(0, conf.getIdleTTLMinutes());
   }
 
   @Test
@@ -289,6 +284,7 @@ public class DataprocProvisionerTest {
       .build();
     context.setProgramRunInfo(programRunInfo);
     context.setSparkCompat(SparkCompat.SPARK2_2_11);
+    context.addProperty(DataprocConf.CLUSTER_REUSE_ENABLED, "false");
 
     Mockito.when(dataprocClient.getCluster("cdap-app-runId")).thenReturn(Optional.empty());
     Mockito.when(dataprocClient.createCluster(Mockito.eq("cdap-app-runId"),
@@ -308,7 +304,6 @@ public class DataprocProvisionerTest {
     context.addProperty("accountKey", "testKey");
     context.addProperty(DataprocConf.PROJECT_ID_KEY, "testProject");
     context.addProperty("region", "testRegion");
-    context.addProperty(DataprocConf.CLUSTER_REUSE_ENABLED, "true");
     context.addProperty("idleTTL", "5");
     context.addProperty(DataprocConf.SKIP_DELETE, "true");
     context.setProfileName("testProfile");
@@ -354,7 +349,6 @@ public class DataprocProvisionerTest {
     context.addProperty("accountKey", "testKey");
     context.addProperty(DataprocConf.PROJECT_ID_KEY, "testProject");
     context.addProperty("region", "testRegion");
-    context.addProperty(DataprocConf.CLUSTER_REUSE_ENABLED, "true");
     context.addProperty("idleTTL", "5");
     context.addProperty(DataprocConf.SKIP_DELETE, "true");
     DataprocConf conf = DataprocConf.create(provisioner.createContextProperties(context));


### PR DESCRIPTION
 Set default TTL to 30 minutes to ensure no clusters are left behind accidentally.