### PR TITLE
[CDAP-18656] Adding BatchingConsumer and using Consumer in getApps

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -54,8 +54,10 @@ import io.cdap.cdap.common.InvalidArtifactException;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.AppFabric;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
+import io.cdap.cdap.common.utils.BatchingConsumer;
 import io.cdap.cdap.config.PreferencesService;
 import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
 import io.cdap.cdap.data2.registry.UsageRegistry;
@@ -104,6 +106,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -113,9 +116,11 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
@@ -149,6 +154,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
   private final AdminEventPublisher adminEventPublisher;
   private final Impersonator impersonator;
   private final CapabilityReader capabilityReader;
+  private final int batchSize;
 
   @Inject
   ApplicationLifecycleService(CConfiguration cConf,
@@ -163,6 +169,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     this.cConf = cConf;
     this.appUpdateSchedules = cConf.getBoolean(Constants.AppFabric.APP_UPDATE_SCHEDULES,
                                                Constants.AppFabric.DEFAULT_APP_UPDATE_SCHEDULES);
+    this.batchSize = cConf.getInt(AppFabric.STREAMING_BATCH_SIZE);
     this.store = store;
     this.scheduler = scheduler;
     this.usageRegistry = usageRegistry;
@@ -213,31 +220,91 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    * @return list of all applications in the namespace that satisfy the specified predicate
    */
   public List<ApplicationDetail> getApps(NamespaceId namespace,
-                                         Predicate<ApplicationDetail> predicate) throws Exception {
+      Predicate<ApplicationDetail> predicate) throws Exception {
 
-    Map<ApplicationId, ApplicationSpecification> appSpecs = new LinkedHashMap<>();
-    for (ApplicationSpecification appSpec : store.getAllApplications(namespace)) {
-      appSpecs.put(namespace.app(appSpec.getName(), appSpec.getAppVersion()), appSpec);
-    }
-    Set<? extends EntityId> visible = accessEnforcer.isVisible(appSpecs.keySet(),
-                                                                      authenticationContext.getPrincipal());
-    appSpecs.keySet().removeIf(id -> !visible.contains(id));
-
-    Map<ApplicationId, String> owners = ownerAdmin.getOwnerPrincipals(appSpecs.keySet());
     List<ApplicationDetail> result = new ArrayList<>();
-    for (Map.Entry<ApplicationId, ApplicationSpecification> entry : appSpecs.entrySet()) {
-      ApplicationDetail applicationDetail = ApplicationDetail.fromSpec(entry.getValue(), owners.get(entry.getKey()));
-      try {
-        capabilityReader.checkAllEnabled(entry.getValue());
-      } catch (CapabilityNotAvailableException ex) {
-        LOG.debug("Application {} is ignored due to exception.", applicationDetail.getName(), ex);
-        continue;
-      }
-      if (predicate.test(applicationDetail)) {
-        result.add(enforceApplicationDetailAccess(entry.getKey(), applicationDetail));
-      }
-    }
+    scanApplications(namespace, predicate, d -> result.add(d));
     return result;
+  }
+
+  /**
+   * Scans all applications in the specified namespace, filtered to only include applications with an artifact name
+   * in the set of specified names and an artifact version equal to the specified version. If the specified set
+   * is empty, no filtering is performed on artifact name. If the specified version is null, no filtering is done
+   * on artifact version.
+   *
+   * @param namespace the namespace to scan apps from
+   * @param artifactNames the set of returned artifact names. If empty, all artifact names are returned
+   * @param artifactVersion the artifact version to match. If null, all artifact versions are returned
+   * @param consumer a {@link Consumer} to consume each ApplicationDetail being scanned
+   */
+  public void scanApplications(NamespaceId namespace, Set<String> artifactNames,
+      @Nullable String artifactVersion,
+      Consumer<ApplicationDetail> consumer) {
+
+    Predicate<ApplicationDetail> predicate = getAppPredicate(artifactNames, artifactVersion);
+    scanApplications(namespace, predicate, consumer);
+  }
+
+  /**
+   * Scans all applications in the specified namespace, filtered to only include application details
+   * which satisfy the predicate
+   *
+   * @param namespace the namespace to scan apps from
+   * @param predicate the predicate that must be satisfied  by ApplicationDetail in order to be returned
+   * @param consumer a {@link Consumer} to consume each ApplicationDetail being scanned
+   */
+  public void scanApplications(NamespaceId namespace, Predicate<ApplicationDetail> predicate,
+      Consumer<ApplicationDetail> consumer) {
+    accessEnforcer.enforceOnParent(EntityType.DATASET, namespace,
+        authenticationContext.getPrincipal(), StandardPermission.LIST);
+
+    try (
+        BatchingConsumer<Entry<ApplicationId, ApplicationSpecification>> batchingConsumer = new BatchingConsumer<>(
+            list -> processApplications(list, predicate, consumer), batchSize
+        )
+    ) {
+
+      store.scanApplications(namespace, batchSize,
+          (appId, appSpec) -> {
+            batchingConsumer.accept(new SimpleEntry<>(appId, appSpec));
+          });
+    }
+  }
+
+  private void processApplications(List<Map.Entry<ApplicationId, ApplicationSpecification>> list,
+      Predicate<ApplicationDetail> predicate, Consumer<ApplicationDetail> consumer) {
+
+    Set<ApplicationId> appIds = list.stream().map(Map.Entry::getKey).collect(Collectors.toSet());
+
+    Set<? extends EntityId> visible = accessEnforcer.isVisible(appIds,
+        authenticationContext.getPrincipal());
+
+    list.removeIf(entry -> !visible.contains(entry.getKey()));
+    appIds.removeIf(id -> !visible.contains(id));
+
+    try {
+      Map<ApplicationId, String> owners = ownerAdmin.getOwnerPrincipals(appIds);
+
+      for (Map.Entry<ApplicationId, ApplicationSpecification> entry : list) {
+        ApplicationDetail applicationDetail = ApplicationDetail.fromSpec(entry.getValue(),
+            owners.get(entry.getKey()));
+
+        try {
+          capabilityReader.checkAllEnabled(entry.getValue());
+        } catch (CapabilityNotAvailableException ex) {
+          LOG.debug("Application {} is ignored due to exception.",
+              applicationDetail.getName(), ex);
+          continue;
+        }
+
+        if (predicate.test(applicationDetail)) {
+          consumer.accept(applicationDetail);
+        }
+      }
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
   }
 
   /**
@@ -299,7 +366,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     Set<NamespaceId> namespaces = new HashSet<>();
 
     JsonWriter jsonWriter = new JsonWriter(new OutputStreamWriter(zipOut, StandardCharsets.UTF_8));
-    store.scanApplications(20, (appId, appSpec) -> {
+    store.scanApplications(batchSize, (appId, appSpec) -> {
       // Skip the SYSTEM namespace apps
       if (NamespaceId.SYSTEM.equals(appId.getParent())) {
         return;

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -213,6 +213,7 @@ public final class Constants {
     public static final String REST_PORT = "app.rest.port";
     public static final String PROGRAM_JVM_OPTS = "app.program.jvm.opts";
     public static final String BACKLOG_CONNECTIONS = "app.connection.backlog";
+    public static final String STREAMING_BATCH_SIZE = "app.streaming.batch.size";
     public static final String EXEC_THREADS = "app.exec.threads";
     public static final String BOSS_THREADS = "app.boss.threads";
     public static final String WORKER_THREADS = "app.worker.threads";

--- a/cdap-common/src/main/java/io/cdap/cdap/common/utils/BatchingConsumer.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/utils/BatchingConsumer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2018-2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package io.cdap.cdap.common.utils;
+
+import com.google.common.base.Throwables;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Represents an operation that accepts a single input argument and returns no result.
+ * Like the Consumer, Batching Consumer is expected to operate via side-effects.
+ * This implements AutoCloseable so it must be closed. This class is not thread-safe.
+ *
+ * This is a functional interface whose functional method is accept(Object). It accepts a batch of objects
+ * and then calls the accept method of a child consumer which accepts a list of Objects.
+ * Type parameters:
+ * @param <T> – the type of the input to the operation
+ */
+public class BatchingConsumer<T> implements Consumer<T>, AutoCloseable {
+  private List<T> buffer;
+  private final int  batchSize;
+  private final Consumer<List<T>> child;
+
+  /**
+   * Constructs an instance of the BatchingConsumer
+   *
+   * @param child - the child consumer. It accepts a list of objects of type T and performs given operation
+   * @param batchSize - the number of objects the BatchingConsumer accepts before passing a list of these
+   * objects to the child consumer
+   */
+  public BatchingConsumer(Consumer<List<T>> child, int batchSize) {
+    this.child = child;
+    this.batchSize = batchSize;
+    this.buffer = new ArrayList<T>(batchSize);
+  }
+
+  /**
+   * Performs this operation on the given argument.
+   * Consumes batchSize number of input arguments, before calling the child consumer with a list
+   * of collected items in the batch.
+   * @param t - the input argument
+   */
+  public void accept(T t) {
+    buffer.add(t);
+    if (buffer.size() >= batchSize) {
+      child.accept(buffer);
+      buffer.clear();
+    }
+  }
+
+  /**
+   * Performs the given operation on remaining items in the buffer not processed by previous accept
+   * calls.
+   */
+  public void close() {
+    if (!buffer.isEmpty()) {
+      child.accept(buffer);
+    }
+    if (child instanceof AutoCloseable) {
+      try {
+        ((AutoCloseable) child).close();
+      } catch (Exception e) {
+        throw Throwables.propagate(e);
+      }
+    }
+  }
+}
+

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1465,6 +1465,14 @@
   </property>
 
   <property>
+    <name>app.streaming.batch.size</name>
+    <value>20</value>
+    <description>
+      Batch size for Batching Consumer for Scan Applications.
+    </description>
+  </property>
+
+  <property>
     <name>app.exec.threads</name>
     <value>20</value>
     <description>

--- a/cdap-common/src/test/java/io/cdap/cdap/common/utils/BatchingConsumerTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/utils/BatchingConsumerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2018-2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.utils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BatchingConsumerTest {
+
+  private static List<Integer> numbers = new ArrayList<>();
+  private static BatchingConsumer<Integer> batchingConsumer =
+      new BatchingConsumer<>(list -> list.forEach(n -> numbers.add(n)), 10);
+
+  @Before
+  public void setup() {
+    this.numbers.clear();
+  }
+
+  @Test
+  public void testAccept() {
+    boolean isOutputEmptyBeforeLastIteration = true;
+    for (int i = 0; i < 10; i++) {
+      batchingConsumer.accept(i);
+      isOutputEmptyBeforeLastIteration = (i < 9) && (numbers.isEmpty());
+    }
+
+    Assert.assertEquals(numbers.size(), 10);
+    Assert.assertFalse(isOutputEmptyBeforeLastIteration);
+  }
+
+  @Test
+  public void testClose() {
+    for (int i = 0; i < 13; i++) {
+      batchingConsumer.accept(i);
+    }
+    Assert.assertEquals(numbers.size(), 10);
+
+    batchingConsumer.close();
+    Assert.assertEquals(numbers.size(), 13);
+  }
+}


### PR DESCRIPTION
As part of Streaming API design, adding a BatchingConsumer class.
Using a scanApplications() method in getApps(), this uses the BatchingConsumer
and makes use of the Stores scanApplications method to do getApps. In next PR,
streaming will replace the getApps result.

Tested that getApps works in httpexecutor on local sandbox.