### PR TITLE
[CDAP-18748] Set pending/starting runs in run record counter upon app-fabric restart

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -158,7 +158,10 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         return;
       }
       try {
-        if (runRecordDetail.getStatus() == ProgramRunStatus.STARTING) {
+        if (runRecordDetail.getStatus() == ProgramRunStatus.PENDING) {
+          programLifecycleService.getRunRecordCounter().addRequest(runRecordDetail.getProgramRunId());
+        } else if (runRecordDetail.getStatus() == ProgramRunStatus.STARTING) {
+          programLifecycleService.getRunRecordCounter().addRequest(runRecordDetail.getProgramRunId());
           // It is unknown what is the state of program runs in STARTING state.
           // A STARTING message is published again to retry STARTING logic.
           ProgramOptions programOptions =


### PR DESCRIPTION
Currently run record counter value is set to zero upon app-fabric restart. The goal of this PR is to read pending/starting run records from DB upon app-fabric restart, and set run record counter accordingly. 

Also improves logging in run record counter. 