### PR TITLE
Refetching dataset as the transaction expires when job ends

### DIFF
--- a/cdap-unit-test/src/test/java/io/cdap/cdap/admin/AdminAppTestRun.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/admin/AdminAppTestRun.java
@@ -329,6 +329,7 @@ public class AdminAppTestRun extends TestFrameworkTestBase {
     manager.waitForRun(ProgramRunStatus.COMPLETED, 180, TimeUnit.SECONDS);
 
     // validate that there are no counts for "you" and "me", and the the other counts are accurate
+    countsManager = getDataset("counts");
     countsManager.flush(); // need to start a new tx to see the output of MR
     Assert.assertEquals(2, Bytes.toInt(countsManager.get().read("world")));
     Assert.assertEquals(1, Bytes.toInt(countsManager.get().read("hello")));


### PR DESCRIPTION
The dataset transaction has a timeout of 30s . 
Recent changes have increased the runtime of the program, which resulted in this timeout. 

Getting the dataset again to start a new transaction . 

The test is taking 9-10 seconds on local, but taking 35-40 seconds on BUT ( used to take 20 - 25 on BUT before this started failing)  
