### PR TITLE
[CDAP-18322] Save user principal of preview request to set up SecurityRequestContext when running preview

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRequest.java
@@ -21,6 +21,9 @@ import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.artifact.preview.PreviewConfig;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.security.Principal;
+
+import javax.annotation.Nullable;
 
 /**
  * Represents the preview application request.
@@ -28,14 +31,16 @@ import io.cdap.cdap.proto.id.ProgramId;
 public class PreviewRequest {
   private final ProgramId program;
   private final AppRequest<?> appRequest;
+  private final Principal principal;
 
-  public PreviewRequest(ProgramId program, AppRequest<?> appRequest) {
+  public PreviewRequest(ProgramId program, AppRequest<?> appRequest, @Nullable Principal principal) {
     this.program = program;
     this.appRequest = appRequest;
+    this.principal = principal;
   }
 
-  public PreviewRequest(ApplicationId applicationId, AppRequest<?> appRequest) {
-    this(getProgramIdFromRequest(applicationId, appRequest), appRequest);
+  public PreviewRequest(ApplicationId applicationId, AppRequest<?> appRequest, @Nullable Principal principal) {
+    this(getProgramIdFromRequest(applicationId, appRequest), appRequest, principal);
   }
 
   public ProgramId getProgram() {
@@ -44,6 +49,11 @@ public class PreviewRequest {
 
   public AppRequest<?> getAppRequest() {
     return appRequest;
+  }
+
+  @Nullable
+  public Principal getPrincipal() {
+    return principal;
   }
 
   private static ProgramId getProgramIdFromRequest(ApplicationId preview, AppRequest request) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/preview/PreviewStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/preview/PreviewStore.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.security.Principal;
 
 import java.util.List;
 import java.util.Map;
@@ -99,8 +100,9 @@ public interface PreviewStore {
    * is added to the store.
    * @param applicationId the application id corresponding to the request
    * @param appRequest preview request configuration
+   * @param principal the principle who made preview request
    */
-  void add(ApplicationId applicationId, AppRequest appRequest);
+  void add(ApplicationId applicationId, AppRequest appRequest, @Nullable Principal principal);
 
   /**
    * @return list of all waiting requests in waiting state sorted by submit time

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -209,7 +209,7 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
     ApplicationId previewApp = namespace.app(RunIds.generate().getId());
     accessEnforcer.enforce(previewApp, authenticationContext.getPrincipal(), ApplicationPermission.PREVIEW);
     ProgramId programId = getProgramIdFromRequest(previewApp, appRequest);
-    PreviewRequest previewRequest = new PreviewRequest(programId, appRequest);
+    PreviewRequest previewRequest = new PreviewRequest(programId, appRequest, authenticationContext.getPrincipal());
 
     if (state() != State.RUNNING) {
       throw new IllegalStateException("Preview service is not running. Cannot start preview for " + programId);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRequestQueue.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRequestQueue.java
@@ -103,7 +103,9 @@ public class DefaultPreviewRequestQueue implements PreviewRequestQueue {
 
   @Override
   public void add(PreviewRequest previewRequest) {
-    previewStore.add(previewRequest.getProgram().getParent(), previewRequest.getAppRequest());
+    previewStore.add(previewRequest.getProgram().getParent(),
+                     previewRequest.getAppRequest(),
+                     previewRequest.getPrincipal());
     if (!requestQueue.offer(previewRequest)) {
       previewStore.remove(previewRequest.getProgram().getParent());
       throw new IllegalStateException(String.format("Preview request waiting queue is full with %d requests.",

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/RemotePreviewRequestFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/RemotePreviewRequestFetcher.java
@@ -24,11 +24,11 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpResponse;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -62,6 +62,10 @@ public class RemotePreviewRequestFetcher implements PreviewRequestFetcher {
     HttpResponse httpResponse = remoteClientInternal.execute(request);
     if (httpResponse.getResponseCode() == 200) {
       PreviewRequest previewRequest = GSON.fromJson(httpResponse.getResponseBodyAsString(), PreviewRequest.class);
+      if (previewRequest != null && previewRequest.getPrincipal() != null) {
+        SecurityRequestContext.setUserId(previewRequest.getPrincipal().getName());
+        SecurityRequestContext.setUserCredential(previewRequest.getPrincipal().getFullCredential());
+      }
       return Optional.ofNullable(previewRequest);
     }
     throw new IOException(String.format("Received status code:%s and body: %s", httpResponse.getResponseCode(),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewRunnerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewRunnerServiceTest.java
@@ -72,7 +72,7 @@ public class PreviewRunnerServiceTest {
     runnerService.startAndWait();
 
     ProgramId programId = NamespaceId.DEFAULT.app("app").program(ProgramType.WORKFLOW, "workflow");
-    fetcher.addRequest(new PreviewRequest(programId, null));
+    fetcher.addRequest(new PreviewRequest(programId, null, null));
 
     Tasks.waitFor(true, () -> mockRunner.requests.get(programId) != null,
                   5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
@@ -93,7 +93,7 @@ public class PreviewRunnerServiceTest {
     runnerService.startAndWait();
 
     ProgramId programId = NamespaceId.DEFAULT.app("app").program(ProgramType.WORKFLOW, "workflow");
-    fetcher.addRequest(new PreviewRequest(programId, null));
+    fetcher.addRequest(new PreviewRequest(programId, null, null));
     Tasks.waitFor(true, () -> mockRunner.requests.get(programId) != null,
                   50, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/preview/DefaultPreviewStoreTest.java
@@ -36,7 +36,10 @@ import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.artifact.preview.PreviewConfig;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.security.Credential;
+import io.cdap.cdap.proto.security.Principal;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.yarn.webapp.hamlet.Hamlet;
 import org.apache.twill.api.RunId;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -155,7 +158,7 @@ public class DefaultPreviewStoreTest {
 
     RunId id1 = RunIds.generate();
     ApplicationId applicationId = new ApplicationId("ns1", id1.getId());
-    store.add(applicationId, testRequest);
+    store.add(applicationId, testRequest, null);
     List<PreviewRequest> allWaiting = store.getAllInWaitingState();
     Assert.assertEquals(1, allWaiting.size());
 
@@ -169,9 +172,9 @@ public class DefaultPreviewStoreTest {
 
     // add 2 requests to the queue
     ApplicationId applicationId2 = new ApplicationId("ns1", RunIds.generate().getId());
-    store.add(applicationId2, testRequest);
+    store.add(applicationId2, testRequest, null);
     ApplicationId applicationId3 = new ApplicationId("ns1", RunIds.generate().getId());
-    store.add(applicationId3, testRequest);
+    store.add(applicationId3, testRequest, null);
 
     allWaiting = store.getAllInWaitingState();
     Assert.assertEquals(2, allWaiting.size());
@@ -184,6 +187,21 @@ public class DefaultPreviewStoreTest {
     Assert.assertEquals(applicationId3, allWaiting.get(0).getProgram().getParent());
 
     store.setPreviewRequestPollerInfo(applicationId3, pollerInfo);
+    allWaiting = store.getAllInWaitingState();
+    Assert.assertEquals(0, allWaiting.size());
+
+    // Add a preview request that has a principle associated with it
+    ApplicationId applicationId4 = new ApplicationId("ns1", RunIds.generate().getId());
+    Principal principal = new Principal("userForApplicationId4",
+                                        Principal.PrincipalType.USER,
+                                        new Credential("userForApplicationId4Credential",
+                                                       Credential.CredentialType.EXTERNAL));
+    store.add(applicationId4, testRequest, principal);
+    allWaiting = store.getAllInWaitingState();
+    Assert.assertEquals(1, allWaiting.size());
+    Assert.assertEquals(applicationId4, allWaiting.get(0).getProgram().getParent());
+    Assert.assertTrue(allWaiting.get(0).getPrincipal().equals(principal));
+    store.setPreviewRequestPollerInfo(applicationId4, pollerInfo);
     allWaiting = store.getAllInWaitingState();
     Assert.assertEquals(0, allWaiting.size());
   }
@@ -202,9 +220,9 @@ public class DefaultPreviewStoreTest {
     String thirdApplication = RunIds.generate(System.currentTimeMillis()).getId();
     ApplicationId thirdApplicationId = new ApplicationId(NamespaceMeta.DEFAULT.getName(), thirdApplication);
 
-    store.add(firstApplicationId, testRequest);
-    store.add(secondApplicationId, testRequest);
-    store.add(thirdApplicationId, testRequest);
+    store.add(firstApplicationId, testRequest, null);
+    store.add(secondApplicationId, testRequest, null);
+    store.add(thirdApplicationId, testRequest, null);
 
     // set poller info so that it gets removed from WAITING state
     store.setPreviewRequestPollerInfo(firstApplicationId, null);


### PR DESCRIPTION
What:
This PR saves user principle along with preview request, then later
populates SecurityRequestContext when running preview in preview runner.

Why:
This allows other services (e.g. appfab) to perform authorization checks
on requests from preview runner (e.g. fetching artifact metadata). Without
this change there is no end user credential associated with outbound requests
from preview runner.