### PR TITLE
[CDAP-18322] Mount secret in sidecar ArtifactLocalizer but not in preview runner and task worker

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -167,9 +167,7 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
   }
 
   private void doInitialize(TwillContext context) throws Exception {
-    CConfiguration cConf = CConfiguration.create();
-    cConf.clear();
-    cConf.addResource(new File(getArgument("cConf")).toURI().toURL());
+    CConfiguration cConf = CConfiguration.create(new File(getArgument("cConf")).toURI().toURL());
 
     Configuration hConf = new Configuration();
     hConf.clear();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
@@ -188,7 +188,13 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
             SecurityContext securityContext = createSecurityContext();
             twillPreparer = ((SecureTwillPreparer) twillPreparer)
               .withSecurityContext(TaskWorkerTwillRunnable.class.getSimpleName(), securityContext);
-            // TODO CDAP-18095: Refactor to be secure-by-default in the future or fail-fast if it is not mounted.
+            // Mount secret in ArtifactLocalizer sidecar which only run trusted code,
+            // so requests originated by ArtifactLocalizer can run with system identity when internal auth
+            // is enabled.
+            twillPreparer = ((SecureTwillPreparer) twillPreparer)
+                .withSecretDisk(ArtifactLocalizerTwillRunnable.class.getSimpleName(),
+                                new SecretDisk(cConf.get(Constants.Twill.Security.MASTER_SECRET_DISK_NAME),
+                                               cConf.get(Constants.Twill.Security.MASTER_SECRET_DISK_PATH)));
             if (cConf.getBoolean(Constants.Twill.Security.WORKER_MOUNT_SECRET)) {
               String secretName = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_NAME);
               String secretPath = cConf.get(Constants.Twill.Security.WORKER_SECRET_DISK_PATH);

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -282,7 +282,7 @@
 
   <property>
     <name>twill.security.worker.mount.secret</name>
-    <value>true</value>
+    <value>false</value>
     <description>
       Whether to mount a secret disk in worker runnables.
     </description>

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -919,17 +919,13 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
     volumeMounts.add(new V1VolumeMount().name("workdir").mountPath(workDir));
     volumeMounts.addAll(Arrays.asList(extraMounts));
 
-    // Add secret disks as secret volume mounts
-    List<V1Volume> secretVolumes = new ArrayList<>();
-    if (secretDiskRunnables.containsKey(runnableName)) {
-      for (SecretDisk secretDisk : secretDiskRunnables.get(runnableName).getSecretDisks()) {
-        String secretName = secretDisk.getName();
-        String mountPath = secretDisk.getPath();
-        secretVolumes.add(new V1Volume().name(secretName).secret(new V1SecretVolumeSource()
-                                                                   .secretName(secretName)));
-        volumeMounts.add(new V1VolumeMount().name(secretName).mountPath(mountPath).readOnly(true));
-      }
-    }
+    // Mount all volumes including cdap-secret for init container as it runs system/trusted code.
+    List<V1VolumeMount> initContainerVolumeMounts = new ArrayList<>(volumeMounts);
+    // Mount all except cdap-secret for main container by default. If requested, cdap-secret will
+    // get mounted later.
+    List<V1VolumeMount> containerVolumeMounts =
+      volumeMounts.stream().filter(v -> !v.getName().equals(KubeMasterEnvironment.SECURITY_CONFIG_NAME))
+        .collect(Collectors.toList());
 
     // Setup the container environment. Inherit everything from the current pod.
     Map<String, String> initContainerEnvirons = podInfo.getContainerEnvironments().stream()
@@ -949,15 +945,14 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
       .withServiceAccountName(serviceAccountName)
       .withRuntimeClassName(podInfo.getRuntimeClassName())
       .addAllToVolumes(podInfo.getVolumes())
-      .addAllToVolumes(secretVolumes)
       .addToVolumes(podInfoVolume,
                     new V1Volume().name("workdir").emptyDir(new V1EmptyDirVolumeSource()))
       .withInitContainers(createContainer("file-localizer", podInfo.getContainerImage(),
                                           podInfo.getImagePullPolicy(), workDir, initContainerResourceRequirements,
-                                          volumeMounts, initContainerEnvirons, FileLocalizer.class,
+                                          initContainerVolumeMounts, initContainerEnvirons, FileLocalizer.class,
                                           runtimeConfigLocation.toURI().toString(),
                                           mainRuntimeSpec.getName()))
-      .withContainers(createContainers(runtimeSpecs, workDir, volumeMounts, args))
+      .withContainers(createContainers(runtimeSpecs, workDir, containerVolumeMounts, args))
       .withSecurityContext(podInfo.getSecurityContext())
       .withRestartPolicy(restartPolicy)
       .build();
@@ -973,9 +968,12 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
     RuntimeSpecification mainRuntimeSpec = getMainRuntimeSpecification(runtimeSpecs);
     environs.putAll(environments.get(mainRuntimeSpec.getName()));
 
+    List<V1VolumeMount> mounts;
+
+    mounts = addSecreteVolMountIfNeeded(mainRuntimeSpec, volumeMounts);
     containers.add(createContainer(mainRuntimeSpec.getName(), podInfo.getContainerImage(), podInfo.getImagePullPolicy(),
                                    workDir, createResourceRequirements(mainRuntimeSpec.getResourceSpecification()),
-                                   volumeMounts, environs, KubeTwillLauncher.class,
+                                   mounts, environs, KubeTwillLauncher.class,
                                    Stream.concat(Stream.of(mainRuntimeSpec.getName()), args.stream())
                                      .toArray(String[]::new)));
 
@@ -983,9 +981,10 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
       RuntimeSpecification spec = runtimeSpecs.get(name);
       // Add all environments for the runnable
       environs.putAll(environments.get(name));
+      mounts = addSecreteVolMountIfNeeded(spec, volumeMounts);
       containers.add(createContainer(name, podInfo.getContainerImage(), podInfo.getImagePullPolicy(), workDir,
                                      createResourceRequirements(spec.getResourceSpecification()),
-                                     volumeMounts, environs, KubeTwillLauncher.class,
+                                     mounts, environs, KubeTwillLauncher.class,
                                      Stream.concat(Stream.of(name), args.stream()).toArray(String[]::new)));
     }
 
@@ -1113,6 +1112,20 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
   private V1VolumeMount createDiskMount(StatefulDisk disk) {
     return new V1VolumeMount().name(cleanse(disk.getName(), 254)).mountPath(disk.getMountPath());
   }
+
+  private List<V1VolumeMount> addSecreteVolMountIfNeeded(RuntimeSpecification runtimeSpec, List<V1VolumeMount> mounts) {
+    List<V1VolumeMount> updatedMounts = new ArrayList<>(mounts);
+    // Add secret disks as secret volume mounts
+    if (secretDiskRunnables.containsKey(runtimeSpec.getName())) {
+      for (SecretDisk secretDisk : secretDiskRunnables.get(runtimeSpec.getName()).getSecretDisks()) {
+        String secretName = secretDisk.getName();
+        String mountPath = secretDisk.getPath();
+        updatedMounts.add(new V1VolumeMount().name(secretName).mountPath(mountPath).readOnly(true));
+      }
+    }
+    return updatedMounts;
+  }
+
 
   /**
    * Class to hold information about stateful runnable.

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -111,9 +111,10 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   static final String NAMESPACE_CPU_LIMIT_PROPERTY = "k8s.namespace.cpu.limits";
   static final String NAMESPACE_MEMORY_LIMIT_PROPERTY = "k8s.namespace.memory.limits";
 
+  public static final String SECURITY_CONFIG_NAME = "cdap-security";
   // Contains the list of configuration / secret names coming from the Pod information, which are
   // needed to propagate to deployments created via the KubeTwillRunnerService
-  private static final Set<String> CONFIG_NAMES = ImmutableSet.of("cdap-conf", "hadoop-conf");
+  private static final Set<String> CONFIG_NAMES = ImmutableSet.of("cdap-conf", "hadoop-conf", "cdap-security");
   private static final Set<String> CUSTOM_VOLUME_PREFIX = ImmutableSet.of("cdap-cm-vol-", "cdap-se-vol-");
 
   private static final String MASTER_MAX_INSTANCES = "master.service.max.instances";


### PR DESCRIPTION
Why:
cdap-secret shouldn't be exposed to preview runner and task worker containers
which run user provided and untrusted code. But it can be mounted in sidecar
ArtifactLocalizer container which only run system/trusted code. Mounting
the secret there allows requests originated by ArtifactLocalizer to be authenticated
as system code to perform system-level operations (e.g. fetching artifacts to
prewarm local caches for task worker containers)