### PR TITLE
add existing app spec to runtime configurer

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/app/RuntimeConfigurer.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/app/RuntimeConfigurer.java
@@ -20,6 +20,7 @@ package io.cdap.cdap.api.app;
 import io.cdap.cdap.api.ServiceDiscoverer;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * The runtime configurer that can be got when the app is reconfigured before the actual program run
@@ -30,4 +31,11 @@ public interface RuntimeConfigurer extends ServiceDiscoverer {
    * @return A map of user argument key and value
    */
   Map<String, String> getRuntimeArguments();
+
+  /**
+   * @return The app spec generated when the app is initially deployed, null if there is no such spec, for example,
+   * for preview run, there is no existing app spec
+   */
+  @Nullable
+  ApplicationSpecification getDeployedApplicationSpec();
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/DefaultAppRuntimeConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/DefaultAppRuntimeConfigurer.java
@@ -17,12 +17,14 @@
 
 package io.cdap.cdap.app;
 
+import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.app.RuntimeConfigurer;
 import io.cdap.cdap.app.services.AbstractServiceDiscoverer;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Default app configurer for runtime deployment
@@ -30,12 +32,15 @@ import java.util.Map;
 public class DefaultAppRuntimeConfigurer extends AbstractServiceDiscoverer implements RuntimeConfigurer {
   private final RemoteClientFactory remoteClientFactory;
   private final Map<String, String> userArguments;
+  private final ApplicationSpecification deployedAppSpec;
 
   public DefaultAppRuntimeConfigurer(String namespace,
-                                     RemoteClientFactory remoteClientFactory, Map<String, String> userArguments) {
+                                     RemoteClientFactory remoteClientFactory, Map<String, String> userArguments,
+                                     @Nullable ApplicationSpecification deployedAppSpec) {
     super(namespace);
     this.remoteClientFactory = remoteClientFactory;
     this.userArguments = new HashMap<>(userArguments);
+    this.deployedAppSpec = deployedAppSpec;
   }
 
   @Override
@@ -44,6 +49,12 @@ public class DefaultAppRuntimeConfigurer extends AbstractServiceDiscoverer imple
   }
 
   @Override
+  public ApplicationSpecification getDeployedApplicationSpec() {
+    return deployedAppSpec;
+  }
+
+  @Override
+  @Nullable
   protected RemoteClientFactory getRemoteClientFactory() {
     return remoteClientFactory;
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeService.java
@@ -53,6 +53,7 @@ import io.cdap.cdap.common.twill.TwillAppNames;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.internal.app.deploy.ConfiguratorFactory;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
+import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentRuntimeInfo;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppSpecInfo;
 import io.cdap.cdap.internal.app.runtime.AbstractListener;
 import io.cdap.cdap.internal.app.runtime.BasicArguments;
@@ -332,7 +333,8 @@ public abstract class AbstractProgramRuntimeService extends AbstractIdleService 
     AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(
       artifactId, artifactDetail.getDescriptor().getLocation(), programId.getNamespaceId(), appClass,
       existingAppSpec.getName(), existingAppSpec.getAppVersion(), existingAppSpec.getConfiguration(), null, false,
-      true, options.getUserArguments().asMap());
+      new AppDeploymentRuntimeInfo(existingAppSpec, options.getUserArguments().asMap(),
+                                   options.getArguments().asMap()));
     Configurator configurator = this.configuratorFactory.create(deploymentInfo);
     ListenableFuture<ConfigResponse> future = configurator.config();
     ConfigResponse response = future.get(120, TimeUnit.SECONDS);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryConfigurator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryConfigurator.java
@@ -45,6 +45,7 @@ import io.cdap.cdap.common.lang.ClassLoaders;
 import io.cdap.cdap.common.lang.CombineClassLoader;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
+import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentRuntimeInfo;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppSpecInfo;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
@@ -80,9 +81,8 @@ public final class InMemoryConfigurator implements Configurator {
   private final PluginFinder pluginFinder;
   private final String appClassName;
   private final Id.Artifact artifactId;
-  private final boolean isRuntime;
-  private final Map<String, String> runtimeArguments;
   private final RemoteClientFactory remoteClientFactory;
+  private final AppDeploymentRuntimeInfo runtimeInfo;
 
   // These fields are needed to create the classLoader in the config method
   private final ArtifactRepository artifactRepository;
@@ -107,8 +107,7 @@ public final class InMemoryConfigurator implements Configurator {
     this.impersonator = impersonator;
     this.artifactRepository = artifactRepository;
     this.artifactLocation = deploymentInfo.getArtifactLocation();
-    this.isRuntime = deploymentInfo.isRuntime();
-    this.runtimeArguments = deploymentInfo.getUserArguments();
+    this.runtimeInfo = deploymentInfo.getRuntimeInfo();
     this.remoteClientFactory = remoteClientFactory;
   }
 
@@ -163,7 +162,9 @@ public final class InMemoryConfigurator implements Configurator {
     ) {
 
       RuntimeConfigurer runtimeConfigurer =
-        isRuntime ? new DefaultAppRuntimeConfigurer(appNamespace.getId(), remoteClientFactory, runtimeArguments) : null;
+        runtimeInfo != null ? new DefaultAppRuntimeConfigurer(
+          appNamespace.getId(), remoteClientFactory, runtimeInfo.getUserArguments(),
+          runtimeInfo.getExistingAppSpec()) : null;
       configurer = new DefaultAppConfigurer(
         appNamespace, artifactId, app, configString, pluginFinder, pluginInstantiator, runtimeConfigurer);
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
@@ -25,7 +25,6 @@ import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import org.apache.twill.filesystem.Location;
 
-import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -45,25 +44,24 @@ public class AppDeploymentInfo {
   private final KerberosPrincipalId ownerPrincipal;
   @SerializedName("update-schedules")
   private final boolean updateSchedules;
-  private final boolean isRuntime;
-  private final Map<String, String> userArguments;
+  private final AppDeploymentRuntimeInfo runtimeInfo;
 
   public AppDeploymentInfo(AppDeploymentInfo info, Location artifactLocation) {
     this(info.artifactId, artifactLocation, info.namespaceId, info.applicationClass, info.appName, info.appVersion,
-         info.configString, info.ownerPrincipal, info.updateSchedules, info.isRuntime, Collections.emptyMap());
+         info.configString, info.ownerPrincipal, info.updateSchedules, info.runtimeInfo);
   }
 
   public AppDeploymentInfo(ArtifactId artifactId, Location artifactLocation, NamespaceId namespaceId,
                            ApplicationClass applicationClass, @Nullable String appName, @Nullable String appVersion,
                            @Nullable String configString) {
     this(artifactId, artifactLocation, namespaceId, applicationClass, appName, appVersion, configString, null,
-         true, false, Collections.emptyMap());
+         true, null);
   }
 
   public AppDeploymentInfo(ArtifactId artifactId, Location artifactLocation, NamespaceId namespaceId,
                            ApplicationClass applicationClass, @Nullable String appName, @Nullable String appVersion,
                            @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal,
-                           boolean updateSchedules, boolean isRuntime, Map<String, String> userArguments) {
+                           boolean updateSchedules, @Nullable AppDeploymentRuntimeInfo runtimeInfo) {
     this.artifactId = artifactId;
     this.artifactLocation = artifactLocation;
     this.namespaceId = namespaceId;
@@ -73,8 +71,7 @@ public class AppDeploymentInfo {
     this.configString = configString;
     this.ownerPrincipal = ownerPrincipal;
     this.updateSchedules = updateSchedules;
-    this.isRuntime = isRuntime;
-    this.userArguments = userArguments;
+    this.runtimeInfo = runtimeInfo;
   }
 
   /**
@@ -149,16 +146,10 @@ public class AppDeploymentInfo {
   }
 
   /**
-   * @return true if this deployment happens at runtime before the program run, false otherwise
+   * @return the runtime info if the app is deployed at runtime, null if this is the initial deploy
    */
-  public boolean isRuntime() {
-    return isRuntime;
-  }
-
-  /**
-   * @return the runtime arguments for the app deployment, this is only used when isRuntime is true
-   */
-  public Map<String, String> getUserArguments() {
-    return userArguments;
+  @Nullable
+  public AppDeploymentRuntimeInfo getRuntimeInfo() {
+    return runtimeInfo;
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentRuntimeInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentRuntimeInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.internal.app.deploy.pipeline;
+
+import io.cdap.cdap.api.app.ApplicationSpecification;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * App deployment runtime information, including program options and existing app spec, existing app spec will be null
+ * if this is a preview run
+ */
+public class AppDeploymentRuntimeInfo {
+  private final ApplicationSpecification existingAppSpec;
+  private final Map<String, String> userArguments;
+  private final Map<String, String> systemArguments;
+
+  public AppDeploymentRuntimeInfo(@Nullable ApplicationSpecification existingAppSpec, Map<String, String> userArguments,
+                                  Map<String, String> systemArguments) {
+    this.existingAppSpec = existingAppSpec;
+    this.userArguments = userArguments;
+    this.systemArguments = systemArguments;
+  }
+
+  @Nullable
+  public ApplicationSpecification getExistingAppSpec() {
+    return existingAppSpec;
+  }
+
+  public Map<String, String> getUserArguments() {
+    return userArguments;
+  }
+
+  public Map<String, String> getSystemArguments() {
+    return systemArguments;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -64,6 +64,7 @@ import io.cdap.cdap.data2.registry.UsageRegistry;
 import io.cdap.cdap.internal.app.DefaultApplicationUpdateContext;
 import io.cdap.cdap.internal.app.deploy.ProgramTerminator;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
+import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentRuntimeInfo;
 import io.cdap.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDetail;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
@@ -642,7 +643,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(artifactId, artifactDetail.getDescriptor().getLocation(),
                                                              appId.getParent(), appClass, appId.getApplication(),
                                                              appId.getVersion(), updatedAppConfig, ownerPrincipal,
-                                                             updateSchedules, false, Collections.emptyMap());
+                                                             updateSchedules, null);
 
     Manager<AppDeploymentInfo, ApplicationWithPrograms> manager = managerFactory.create(programTerminator);
     // TODO: (CDAP-3258) Manager needs MUCH better error handling.
@@ -985,7 +986,8 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(
       Artifacts.toProtoArtifactId(namespaceId, artifactDetail.getDescriptor().getArtifactId()),
       artifactDetail.getDescriptor().getLocation(), namespaceId, appClass, appName,
-      appVersion, configStr, ownerPrincipal, updateSchedules, isPreview, userProps);
+      appVersion, configStr, ownerPrincipal, updateSchedules,
+      isPreview ? new AppDeploymentRuntimeInfo(null, userProps, Collections.emptyMap()) : null);
 
     Manager<AppDeploymentInfo, ApplicationWithPrograms> manager = managerFactory.create(programTerminator);
     // TODO: (CDAP-3258) Manager needs MUCH better error handling.


### PR DESCRIPTION
Add the existing app spec to runtime configurer so app can know what is already deployed. This is needed because the delta app expects a timestamp when the app is deployed. 