### PR TITLE
[CDAP-18766] Add retention time to run record counter entries

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -104,6 +104,7 @@ import io.cdap.cdap.internal.app.services.LocalRunRecordCorrectorService;
 import io.cdap.cdap.internal.app.services.NoopRunRecordCorrectorService;
 import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
 import io.cdap.cdap.internal.app.services.RunRecordCorrectorService;
+import io.cdap.cdap.internal.app.services.RunRecordMonitorService;
 import io.cdap.cdap.internal.app.services.ScheduledRunRecordCorrectorService;
 import io.cdap.cdap.internal.app.store.DefaultStore;
 import io.cdap.cdap.internal.bootstrap.guice.BootstrapModules;
@@ -334,6 +335,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
       bind(ArtifactStore.class).in(Scopes.SINGLETON);
       bind(ProfileService.class).in(Scopes.SINGLETON);
+      bind(RunRecordMonitorService.class).in(Scopes.SINGLETON);
       bind(ProgramLifecycleService.class).in(Scopes.SINGLETON);
       bind(SystemAppManagementService.class).in(Scopes.SINGLETON);
       bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -74,6 +74,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final Set<String> handlerHookNames;
   private final ProgramNotificationSubscriberService programNotificationSubscriberService;
   private final RunRecordCorrectorService runRecordCorrectorService;
+  private final RunRecordMonitorService runRecordCounterService;
   private final CoreSchedulerService coreSchedulerService;
   private final ProvisioningService provisioningService;
   private final BootstrapService bootstrapService;
@@ -106,7 +107,8 @@ public class AppFabricServer extends AbstractIdleService {
                          ProvisioningService provisioningService,
                          BootstrapService bootstrapService,
                          SystemAppManagementService systemAppManagementService,
-                         TransactionRunner transactionRunner) {
+                         TransactionRunner transactionRunner,
+                         RunRecordMonitorService runRecordCounterService) {
     this.hostname = hostname;
     this.discoveryService = discoveryService;
     this.handlers = handlers;
@@ -125,6 +127,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.bootstrapService = bootstrapService;
     this.systemAppManagementService = systemAppManagementService;
     this.transactionRunner = transactionRunner;
+    this.runRecordCounterService = runRecordCounterService;
   }
 
   /**
@@ -143,7 +146,8 @@ public class AppFabricServer extends AbstractIdleService {
         programRuntimeService.start(),
         programNotificationSubscriberService.start(),
         runRecordCorrectorService.start(),
-        coreSchedulerService.start()
+        coreSchedulerService.start(),
+        runRecordCounterService.start()
       )
     ).get();
 
@@ -194,6 +198,7 @@ public class AppFabricServer extends AbstractIdleService {
     programNotificationSubscriberService.stopAndWait();
     runRecordCorrectorService.stopAndWait();
     provisioningService.stopAndWait();
+    runRecordCounterService.stopAndWait();
   }
 
   private Cancellable startHttpService(NettyHttpService httpService) throws Exception {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/RunRecordMonitorService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/RunRecordMonitorService.java
@@ -16,34 +16,86 @@
 
 package io.cdap.cdap.internal.app.services;
 
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.inject.Inject;
 import io.cdap.cdap.app.runtime.ProgramRuntimeService;
+import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramRunId;
-import org.eclipse.jetty.util.ConcurrentHashSet;
+import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
- * Helper class to maintain and return total number of launching and running run-records.
+ * Maintain and return total number of launching and running run-records.
+ * This class is used by flow-control mechanism for launch requests.
+ * It also has a cleanup mechanism to automatically remove old (i.e., configurable) entries from the counter as a
+ * safe-guard mechanism.
  */
-public class RunRecordCounter {
-  private static final Logger LOG = LoggerFactory.getLogger(RunRecordCounter.class);
+public class RunRecordMonitorService extends AbstractScheduledService {
+  private static final Logger LOG = LoggerFactory.getLogger(RunRecordMonitorService.class);
 
   /**
    * Contains ProgramRunIds of runs that have been accepted, but have not been added to metadata store plus
    * all run records with {@link ProgramRunStatus#PENDING} or {@link ProgramRunStatus#STARTING} status.
    */
-  private final Set<ProgramRunId> launchingSet;
+  private final BlockingQueue<ProgramRunId> launchingQueue;
   private final ProgramRuntimeService runtimeService;
+  private final long ageThresholdSec;
+  private final CConfiguration cConf;
+  private ScheduledExecutorService executor;
 
-  public RunRecordCounter(ProgramRuntimeService runtimeService) {
+  @Inject
+  public RunRecordMonitorService(CConfiguration cConf, ProgramRuntimeService runtimeService) {
     this.runtimeService = runtimeService;
+    this.cConf = cConf;
 
-    launchingSet = new ConcurrentHashSet<>();
+    launchingQueue = new PriorityBlockingQueue<>(128, Comparator.comparingLong(
+      o -> RunIds.getTime(o.getRun(), TimeUnit.MILLISECONDS)));
+    ageThresholdSec = cConf.getLong(Constants.AppFabric.MONITOR_RECORD_AGE_THRESHOLD_SECONDS);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("RunRecordMonitorService started.");
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+    LOG.info("RunRecordMonitorService successfully shut down.");
+  }
+
+  @Override
+  protected void runOneIteration() throws Exception {
+    cleanupQueue();
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedRateSchedule(0,
+                                          cConf.getInt(Constants.AppFabric.MONITOR_CLEANUP_INTERVAL_SECONDS),
+                                          TimeUnit.SECONDS);
+  }
+
+  @Override
+  protected final ScheduledExecutorService executor() {
+    executor = Executors.newSingleThreadScheduledExecutor(
+      Threads.createDaemonThreadFactory("run-record-monitor-service-cleanup-scheduler"));
+    return executor;
   }
 
   /**
@@ -52,11 +104,15 @@ public class RunRecordCounter {
    * @param programRunId run id associated with the launch request
    * @return total number of launching and running program runs.
    */
-  public Count addRequestAndGetCount(ProgramRunId programRunId) {
+  public Count addRequestAndGetCount(ProgramRunId programRunId) throws Exception {
+    if (RunIds.getTime(programRunId.getRun(), TimeUnit.MILLISECONDS) == -1) {
+      throw new Exception("None time-based UUIDs are not supported");
+    }
+
     int launchingCount;
     synchronized (this) {
       addRequest(programRunId);
-      launchingCount = launchingSet.size();
+      launchingCount = launchingQueue.size();
     }
 
     List<ProgramRuntimeService.RuntimeInfo> list = runtimeService
@@ -81,7 +137,7 @@ public class RunRecordCounter {
    * @param programRunId run id associated with the launch request
    */
   public void addRequest(ProgramRunId programRunId) {
-    launchingSet.add(programRunId);
+    launchingQueue.add(programRunId);
     LOG.info("Added request with runId {}.", programRunId);
   }
 
@@ -92,10 +148,26 @@ public class RunRecordCounter {
    * @param programRunId
    */
   public void removeRequest(ProgramRunId programRunId) {
-    if (launchingSet.contains(programRunId)) {
-      launchingSet.remove(programRunId);
+    if (launchingQueue.remove(programRunId)) {
       LOG.info("Removed request with runId {}. Counter has {} concurrent launching requests.",
-                programRunId, launchingSet.size());
+               programRunId, launchingQueue.size());
+    }
+  }
+
+  private void cleanupQueue() {
+    while (true) {
+      ProgramRunId programRunId = launchingQueue.peek();
+      if (programRunId == null ||
+        RunIds.getTime(programRunId.getRun(), TimeUnit.MILLISECONDS) + (ageThresholdSec * 1000) >=
+          System.currentTimeMillis()) {
+        //Queue is empty or queue head has not expired yet.
+        return;
+      }
+      // Queue head might have already been removed. So instead of calling poll, we call remove.
+      if (launchingQueue.remove(programRunId)) {
+        LOG.info("Removing request with runId {} due to expired retention time.", programRunId);
+      }
+
     }
   }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -243,6 +243,10 @@ public final class Constants {
     public static final String PROGRAM_TRANSACTION_CONTROL = "app.program.transaction.control";
     public static final String MAX_CONCURRENT_RUNS = "app.max.concurrent.runs";
     public static final String MAX_CONCURRENT_LAUNCHING = "app.max.concurrent.launching";
+    public static final String MONITOR_RECORD_AGE_THRESHOLD_SECONDS =
+      "run.record.monitor.record.age.threshold.seconds";
+    public static final String MONITOR_CLEANUP_INTERVAL_SECONDS =
+      "run.record.monitor.cleanup.interval.seconds";
     public static final String PROGRAM_LAUNCH_THREADS = "app.program.launch.threads";
 
     // A boolean value cConf entry to tell whether a ProgramRunner is running remotely (i.e. not inside app-fabric)

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -471,6 +471,26 @@
   </property>
 
   <property>
+    <name>run.record.monitor.record.age.threshold.seconds</name>
+    <value>3600</value>
+    <description>
+      Maximum amount of time (in seconds) in which a run record is retained in run record monitor.
+      This is to safe guard launch requests flow-control such that if a request is somehow stuck in PENDING/STARTING
+      state, it will be dropped from after the threshold.
+      Note that run.record.monitor.cleanup.interval.seconds might be needed to changed if this config changes.
+    </description>
+  </property>
+
+  <property>
+    <name>run.record.monitor.cleanup.interval.seconds</name>
+    <value>300</value>
+    <description>
+      Cleanup interval (in seconds) in which run record monitor service cleanup logic runs to delete old entries.
+      Note that run.record.monitor.record.age.threshold.seconds might be needed to changed if this config changes.
+    </description>
+  </property>
+
+  <property>
     <name>app.program.launch.threads</name>
     <value>20</value>
     <description>


### PR DESCRIPTION
Add retention time to run record counter entries. Thus, old (configurable) entries will be removed from the counter. This is to safe-guard flow-control against potential (existing or future) bugs in which runs get stuck in PENDING/STARTING state indefinitely, and therefore, eventually no new launch request is allowed. 