### PR TITLE
[CDAP-18651] Disable access enforcement in preview runners

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -250,7 +250,7 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     modules.add(new CoreSecurityRuntimeModule().getInMemoryModules());
     modules.add(new AuthenticationContextModules().getMasterWorkerModule());
     modules.add(new AuthorizationModule());
-    modules.add(new AuthorizationEnforcementModule().getMasterModule());
+    modules.add(new AuthorizationEnforcementModule().getNoOpModules());
     modules.add(Modules.override(
       new DataFabricModules("master").getDistributedModules()).with(new AbstractModule() {
       @Override

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizationEnforcementModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizationEnforcementModule.java
@@ -85,4 +85,18 @@ public class AuthorizationEnforcementModule extends RuntimeModule {
       }
     };
   }
+
+  /**
+   * Returns an {@link AbstractModule} containing bindings for a No-Op Access Enforcer. These modules should primarily
+   * be used in workers in which user code is executed which should not have any owned data to enforce access on.
+   */
+  public AbstractModule getNoOpModules() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(AccessEnforcer.class).to(NoOpAccessController.class).in(Scopes.SINGLETON);
+        bind(ContextAccessEnforcer.class).to(DefaultContextAccessEnforcer.class).in(Scopes.SINGLETON);
+      }
+    };
+  }
 }


### PR DESCRIPTION
Preview runners (or any other runners which execute user code) should generally not store any long-term data in which access enforcement would be required. As such, we want to avoid performing access enforcement in contexts in which user code is run.