### PR TITLE
Added stage name to SQL engine output

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngineOutput.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngineOutput.java
@@ -25,13 +25,24 @@ import java.util.Map;
  * to regular ones
  */
 public class SQLEngineOutput extends Output {
+  private final String stageName;
   private final String sqlEngineClassName;
   private final Map<String, String> arguments;
 
-  public SQLEngineOutput(String name, String sqlEngineClassName, Map<String, String> arguments) {
+  public SQLEngineOutput(String name, String stageName, String sqlEngineClassName, Map<String, String> arguments) {
     super(name);
+    this.stageName = stageName;
     this.sqlEngineClassName = sqlEngineClassName;
     this.arguments = arguments;
+  }
+
+  /**
+   * Gets the stage name for this output. This name is used to allocate metrics to the appropriate sink after the
+   * output is written into the SQL engine
+   * @return the stage name
+   */
+  public String getStageName() {
+    return stageName;
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSQLEngineAdapter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSQLEngineAdapter.java
@@ -728,8 +728,8 @@ public class BatchSQLEngineAdapter implements Closeable {
    * @return {@link SQLEngineJob<Boolean>} representing if the write operation succeded.
    */
   public SQLEngineJob<Boolean> write(String datasetName, SQLEngineOutput sqlEngineOutput) {
-    String outputDatasetName = sqlEngineOutput.getName();
-    SQLEngineWriteJobKey writeJobKey = new SQLEngineWriteJobKey(datasetName, outputDatasetName, SQLEngineJobType.WRITE);
+    String outputStageName = sqlEngineOutput.getStageName();
+    SQLEngineWriteJobKey writeJobKey = new SQLEngineWriteJobKey(datasetName, outputStageName, SQLEngineJobType.WRITE);
     // Run write job
     return runJob(writeJobKey, () -> {
       getDatasetForStage(datasetName);
@@ -742,8 +742,8 @@ public class BatchSQLEngineAdapter implements Closeable {
 
       // If the result was successful, add stage metrics.
       if (writeResult.isSuccessful()) {
-        DefaultStageMetrics stageMetrics = new DefaultStageMetrics(metrics, outputDatasetName);
-        StageStatisticsCollector statisticsCollector = statsCollectors.get(outputDatasetName);
+        DefaultStageMetrics stageMetrics = new DefaultStageMetrics(metrics, outputStageName);
+        StageStatisticsCollector statisticsCollector = statsCollectors.get(outputStageName);
 
         countRecordsIn(writeResult.getNumRecords(), statisticsCollector, stageMetrics);
         countRecordsOut(writeResult.getNumRecords(), statisticsCollector, stageMetrics);

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSinkWithWriteCapability.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSinkWithWriteCapability.java
@@ -47,6 +47,7 @@ public class MockSinkWithWriteCapability extends AbstractMockSink {
   public void prepareRun(BatchSinkContext context) throws Exception {
     super.prepareRun(context);
     context.addOutput(new SQLEngineOutput(NAME,
+                                          NAME,
                                           MockSQLEngineWithCapabilities.class.getName(),
                                           Collections.emptyMap()));
   }


### PR DESCRIPTION
Adding the stage name makes a clear distinction between the output name (reference name for Spark/MapReduce sinks) and the stage name (used by the SQL engine output).

This stage name is used when setting record counts for direct write jobs.