### PR TITLE
[CDAP-18322] Refactoring: Move artifact sidecar cache prewarming from TaskWorkerService to ArtifactLocalizerService

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
@@ -17,6 +17,9 @@ package io.cdap.cdap.internal.app.worker.sidecar;
 import com.google.common.io.CharStreams;
 import com.google.common.net.HttpHeaders;
 import com.google.inject.Inject;
+import io.cdap.cdap.api.artifact.ApplicationClass;
+import io.cdap.cdap.api.artifact.ArtifactInfo;
+import io.cdap.cdap.api.artifact.ArtifactManager;
 import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.retry.RetryableException;
 import io.cdap.cdap.common.ArtifactNotFoundException;
@@ -32,6 +35,7 @@ import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.common.service.RetryStrategy;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.common.utils.FileUtils;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactManagerFactory;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.common.http.HttpMethod;
@@ -55,6 +59,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -91,12 +96,17 @@ public class ArtifactLocalizer {
 
   private static final Logger LOG = LoggerFactory.getLogger(ArtifactLocalizer.class);
 
+  private final CConfiguration cConf;
+  private final ArtifactManagerFactory artifactManagerFactory;
   private final RemoteClient remoteClient;
   private final RetryStrategy retryStrategy;
   private final String dataDir;
 
   @Inject
-  public ArtifactLocalizer(CConfiguration cConf, RemoteClientFactory remoteClientFactory) {
+  public ArtifactLocalizer(CConfiguration cConf, RemoteClientFactory remoteClientFactory,
+                           ArtifactManagerFactory artifactManagerFactory) {
+    this.cConf = cConf;
+    this.artifactManagerFactory = artifactManagerFactory;
   // TODO (CDAP-18047) verify SSL cert should be enabled.
     this.remoteClient = remoteClientFactory.createRemoteClient(Constants.Service.APP_FABRIC_HTTP,
                                                                RemoteClientFactory.NO_VERIFY_HTTP_REQUEST_CONFIG,
@@ -318,5 +328,28 @@ public class ArtifactLocalizer {
    */
   private File getUnpackLocalPath(ArtifactId artifactId, long lastModifiedTimestamp) {
     return getLocalPath("unpacked", artifactId).resolve(String.valueOf(lastModifiedTimestamp)).toFile();
+  }
+
+  public void preloadArtifacts(Set<String> artifactNames) throws IOException, ArtifactNotFoundException {
+    ArtifactManager artifactManager = artifactManagerFactory.create(
+      NamespaceId.SYSTEM, RetryStrategies.fromConfiguration(cConf, Constants.Service.TASK_WORKER + "."));
+
+    for (ArtifactInfo info : artifactManager.listArtifacts()) {
+      if (artifactNames.contains(info.getName()) && info.getParents().isEmpty()) {
+        String className = info.getClasses().getApps().stream()
+          .findFirst()
+          .map(ApplicationClass::getClassName)
+          .orElse(null);
+
+        LOG.info("Preloading artifact {}:{}-{}", info.getScope(), info.getName(), info.getVersion());
+
+        ArtifactId artifactId = NamespaceId.SYSTEM.artifact(info.getName(), info.getVersion());
+        try {
+          fetchArtifact(artifactId);
+        } catch (Exception e) {
+          LOG.debug("Failed to preload artifact {}", artifactId);
+        }
+      }
+    }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerService.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
-import java.util.concurrent.ExecutionException;
+import java.util.HashSet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +40,8 @@ public class ArtifactLocalizerService extends AbstractIdleService {
 
   private static final Logger LOG = LoggerFactory.getLogger(ArtifactLocalizerService.class);
 
+  private final CConfiguration cConf;
+  private final ArtifactLocalizer artifactLocalizer;
   private final NettyHttpService httpService;
   private final ArtifactLocalizerCleaner cleaner;
   private final int cacheCleanupInterval;
@@ -48,6 +50,8 @@ public class ArtifactLocalizerService extends AbstractIdleService {
   @Inject
   ArtifactLocalizerService(CConfiguration cConf,
                            ArtifactLocalizer artifactLocalizer) {
+    this.cConf = cConf;
+    this.artifactLocalizer = artifactLocalizer;
     this.httpService = new CommonNettyHttpServiceBuilder(cConf, Constants.Service.TASK_WORKER)
       .setHost(InetAddress.getLoopbackAddress().getHostName())
       .setPort(cConf.getInt(Constants.ArtifactLocalizer.PORT))
@@ -67,6 +71,10 @@ public class ArtifactLocalizerService extends AbstractIdleService {
     scheduledExecutorService = Executors
       .newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("artifact-cache-cleaner"));
     scheduledExecutorService.scheduleAtFixedRate(cleaner, cacheCleanupInterval, cacheCleanupInterval, TimeUnit.MINUTES);
+
+    artifactLocalizer.preloadArtifacts(
+      new HashSet<>(cConf.getTrimmedStringCollection(Constants.TaskWorker.PRELOAD_ARTIFACTS)));
+    
     LOG.debug("Starting ArtifactLocalizerService has completed");
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerTwillRunnable.java
@@ -25,6 +25,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import io.cdap.cdap.app.guice.DistributedArtifactManagerModule;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
@@ -117,6 +118,7 @@ public class ArtifactLocalizerTwillRunnable extends AbstractTwillRunnable {
         modules.add(new ZKClientModule());
       }
     }
+    modules.add(new DistributedArtifactManagerModule());
 
     return Guice.createInjector(modules);
   }


### PR DESCRIPTION
Why:
ArtifactLocalizer sidecar pattern can be enabled for both task worker
and preview runner, moving artifact cache prewarming to ArtifactLocalizerService
avoid duplicating the logic in preview runner and task worker service.