### PR TITLE
[cherryPick][CDAP-18603] Add basic support for Pagination for getAllApps

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.services.http;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closeables;
 import com.google.common.io.InputSupplier;
@@ -606,6 +607,24 @@ public abstract class AppFabricTestBase {
     HttpResponse response = doGet(getVersionedAPIPath("apps/", Constants.Gateway.API_VERSION_3_TOKEN, namespace));
     assertResponseCode(200, response);
     return readResponse(response, LIST_JSON_OBJECT_TYPE);
+  }
+
+  protected JsonObject getAppListForPaginatedApi(String namespace, int pageSize, String token,
+                                                 String filter) throws Exception {
+    String uri = "apps/?pageSize=" + pageSize;
+
+    if (token != null) {
+      uri += ("&pageToken=" + token);
+    }
+
+    if (!Strings.isNullOrEmpty(filter)) {
+      uri += ("&nameFilter=" + filter);
+    }
+
+    HttpResponse response = doGet(getVersionedAPIPath(uri,
+                                  Constants.Gateway.API_VERSION_3_TOKEN, namespace));
+    assertResponseCode(200, response);
+    return readResponse(response, JsonObject.class);
   }
 
   /**

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/PaginatedApplicationRecords.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/PaginatedApplicationRecords.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2016-2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.proto;
+
+import java.util.List;
+
+/**
+ * Result for getting Paginated Application Records
+ */
+public class PaginatedApplicationRecords {
+
+  public List<ApplicationRecord> getApplications() {
+    return applications;
+  }
+
+  public String getNextPageToken() {
+    return nextPageToken;
+  }
+
+  private final List<ApplicationRecord> applications;
+  private final String nextPageToken;
+
+  public PaginatedApplicationRecords(List<ApplicationRecord> applications, String nextPageToken) {
+    this.applications = applications;
+    this.nextPageToken = nextPageToken;
+  }
+}


### PR DESCRIPTION
Original PR - https://github.com/cdapio/cdap/pull/13821

What:
Adding basic support for Pagination in the getAllApps API. This REST API
endpoint can be used by the UI team for testing.