### PR TITLE
Fixes recursion to have a group per a unescaped block, not per each c…

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/program/ManifestFields.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/program/ManifestFields.java
@@ -64,7 +64,7 @@ public final class ManifestFields {
    * matching the complete package information pattern.
    */
   private static final Pattern EXPORT_PACKAGE_PATTERN =
-    Pattern.compile("([\\w.]+)(?:;[\\w\\-.]+:?=(?:(?:\"(?:\\\\.|[^\\\"])+\")|[\\w\\-.]+))*,?");
+    Pattern.compile("([\\w.]+)(?:;[\\w\\-.]+:?=(?:(?:\"(?:\\\\.|[^\\\\\"]++)+\")|[\\w\\-.]+))*,?");
 
   /**
    * Parses the manifest {@link #EXPORT_PACKAGE} attribute and returns a set of export packages.


### PR DESCRIPTION
…har. Otherwise we get stack overflow on long matches (~2K chars)

Tested on kube environment. Doesnt occur in ~30 runs