### PR TITLE
[CDAP-18785] Add metrics to flow-control

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -536,9 +536,9 @@ public class ProgramLifecycleService {
 
     boolean done = false;
     try {
-      if (maxConcurrentRuns >= 0 && maxConcurrentRuns < count.getRunsCount()) {
+      if (maxConcurrentRuns >= 0 && maxConcurrentRuns < count.getLaunchingCount() + count.getRunningCount()) {
         String msg =
-          String.format("Program %s cannot start because the maximum of %d concurrent running runs is allowed",
+          String.format("Program %s cannot start because the maximum of %d outstanding runs is allowed",
                         programId, maxConcurrentRuns);
         LOG.info(msg);
 
@@ -564,7 +564,7 @@ public class ProgramLifecycleService {
       done = true;
     } finally {
       if (!done) {
-        runRecordMonitorService.removeRequest(programRunId);
+        runRecordMonitorService.removeRequest(programRunId, false);
       }
     }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -928,6 +928,14 @@ public final class Constants {
     }
 
     /**
+     * Flow control metrics
+     */
+    public static final class FlowControl {
+      public static final String WORKFLOWS_LAUNCHING_COUNT = "flowcontrol.workflows.launching.count";
+      public static final String WORKFLOWS_RUNNING_COUNT = "flowcontrol.workflows.running.count";
+    }
+
+    /**
      * Program metrics
      */
     public static final class Program {


### PR DESCRIPTION
Adding two metrics to flow-control:
1. gauge metric for launching programs
2. gauge metric for running programs

Also modifies the logic for counting running programs to only count workflows program type (instead of all program types).
