### PR TITLE
[CDAP-18322] Support executing connection requests remotely in worker pods

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionHandler.java
@@ -23,29 +23,25 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import io.cdap.cdap.api.annotation.TransactionControl;
 import io.cdap.cdap.api.annotation.TransactionPolicy;
-import io.cdap.cdap.api.artifact.ArtifactId;
-import io.cdap.cdap.api.data.format.StructuredRecord;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.api.macro.MacroParserOptions;
-import io.cdap.cdap.api.plugin.InvalidPluginConfigException;
-import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.cdap.api.service.http.HttpServiceRequest;
 import io.cdap.cdap.api.service.http.HttpServiceResponder;
 import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
 import io.cdap.cdap.api.service.http.SystemHttpServiceContext;
+import io.cdap.cdap.api.service.worker.RemoteExecutionException;
+import io.cdap.cdap.api.service.worker.RemoteTaskException;
+import io.cdap.cdap.api.service.worker.RunnableTaskRequest;
 import io.cdap.cdap.datapipeline.connection.ConnectionStore;
 import io.cdap.cdap.datapipeline.connection.DefaultConnectorConfigurer;
 import io.cdap.cdap.datapipeline.connection.DefaultConnectorContext;
-import io.cdap.cdap.datapipeline.connection.LimitingConnector;
-import io.cdap.cdap.etl.api.batch.BatchConnector;
 import io.cdap.cdap.etl.api.connector.BrowseRequest;
 import io.cdap.cdap.etl.api.connector.Connector;
 import io.cdap.cdap.etl.api.connector.ConnectorConfigurer;
 import io.cdap.cdap.etl.api.connector.ConnectorContext;
 import io.cdap.cdap.etl.api.connector.ConnectorSpec;
 import io.cdap.cdap.etl.api.connector.ConnectorSpecRequest;
-import io.cdap.cdap.etl.api.connector.DirectConnector;
 import io.cdap.cdap.etl.api.connector.SampleRequest;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.common.ArtifactSelectorProvider;
@@ -53,14 +49,12 @@ import io.cdap.cdap.etl.common.BasicArguments;
 import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
 import io.cdap.cdap.etl.common.OAuthMacroEvaluator;
 import io.cdap.cdap.etl.common.SecureStoreMacroEvaluator;
-import io.cdap.cdap.etl.proto.ArtifactSelectorConfig;
 import io.cdap.cdap.etl.proto.connection.Connection;
 import io.cdap.cdap.etl.proto.connection.ConnectionBadRequestException;
 import io.cdap.cdap.etl.proto.connection.ConnectionCreationRequest;
 import io.cdap.cdap.etl.proto.connection.ConnectionId;
 import io.cdap.cdap.etl.proto.connection.ConnectionNotFoundException;
 import io.cdap.cdap.etl.proto.connection.ConnectorDetail;
-import io.cdap.cdap.etl.proto.connection.PluginDetail;
 import io.cdap.cdap.etl.proto.connection.PluginInfo;
 import io.cdap.cdap.etl.proto.connection.SampleResponse;
 import io.cdap.cdap.etl.proto.connection.SampleResponseCodec;
@@ -72,7 +66,6 @@ import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ConnectionEntityId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.proto.id.SystemAppEntityId;
 import io.cdap.cdap.proto.security.ApplicationPermission;
 import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
@@ -82,12 +75,10 @@ import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import javax.annotation.Nullable;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -246,30 +237,38 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
         return;
       }
 
-      ConnectionCreationRequest creationRequest =
-        GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(), ConnectionCreationRequest.class);
+      String testRequestString = StandardCharsets.UTF_8.decode(request.getContent()).toString();
+      ConnectionCreationRequest testRequest = GSON.fromJson(testRequestString, ConnectionCreationRequest.class);
 
-      ServicePluginConfigurer pluginConfigurer =
-        getContext().createServicePluginConfigurer(namespaceSummary.getName());
-      ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
-      SimpleFailureCollector failureCollector = new SimpleFailureCollector();
-      ConnectorContext connectorContext = new DefaultConnectorContext(failureCollector, pluginConfigurer);
-      TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
-        new ArtifactSelectorProvider().getPluginSelector(creationRequest.getPlugin().getArtifact()));
-      try (Connector connector = getConnector(pluginConfigurer, creationRequest.getPlugin(),
-                                              namespaceSummary.getName(), pluginSelector)) {
-        connector.configure(connectorConfigurer);
-        try {
-          connector.test(connectorContext);
-          failureCollector.getOrThrowException();
-        } catch (ValidationException e) {
-          responder.sendJson(e.getFailures());
-          return;
-        }
+      if (getContext().isRemoteTaskEnabled()) {
+        executeRemotely(namespace, testRequestString, null, RemoteConnectionTestTask.class, responder);
+      } else {
+        testLocally(namespaceSummary.getName(), testRequest, responder);
       }
-
-      responder.sendStatus(HttpURLConnection.HTTP_OK);
     });
+  }
+
+  private void testLocally(String namespace, ConnectionCreationRequest creationRequest,
+                           HttpServiceResponder responder) throws IOException {
+    ServicePluginConfigurer pluginConfigurer =
+      getContext().createServicePluginConfigurer(namespace);
+    ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
+    SimpleFailureCollector failureCollector = new SimpleFailureCollector();
+    ConnectorContext connectorContext = new DefaultConnectorContext(failureCollector, pluginConfigurer);
+    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
+      new ArtifactSelectorProvider().getPluginSelector(creationRequest.getPlugin().getArtifact()));
+    try (Connector connector = getConnector(pluginConfigurer, creationRequest.getPlugin(),
+                                            namespace, pluginSelector)) {
+      connector.configure(connectorConfigurer);
+      try {
+        connector.test(connectorContext);
+        failureCollector.getOrThrowException();
+      } catch (ValidationException e) {
+        responder.sendJson(e.getFailures());
+        return;
+      }
+    }
+    responder.sendStatus(HttpURLConnection.HTTP_OK);
   }
 
   /**
@@ -290,9 +289,8 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
 
       contextAccessEnforcer.enforce(new ConnectionEntityId(namespace, ConnectionId.getConnectionId(connection)),
                                     ApplicationPermission.PREVIEW);
-
-      BrowseRequest browseRequest =
-        GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(), BrowseRequest.class);
+      String browseRequestString = StandardCharsets.UTF_8.decode(request.getContent()).toString();
+      BrowseRequest browseRequest = GSON.fromJson(browseRequestString, BrowseRequest.class);
 
       if (browseRequest == null) {
         responder.sendError(HttpURLConnection.HTTP_BAD_REQUEST, "The request body is empty");
@@ -304,20 +302,29 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
         return;
       }
 
-      ServicePluginConfigurer pluginConfigurer =
-        getContext().createServicePluginConfigurer(namespaceSummary.getName());
-      ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
-      ConnectorContext connectorContext = new DefaultConnectorContext(new SimpleFailureCollector(), pluginConfigurer);
       Connection conn = store.getConnection(new ConnectionId(namespaceSummary, connection));
 
-      TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
-        new ArtifactSelectorProvider().getPluginSelector(conn.getPlugin().getArtifact()));
-      try (Connector connector = getConnector(pluginConfigurer, conn.getPlugin(), namespaceSummary.getName(),
-                                              pluginSelector)) {
-        connector.configure(connectorConfigurer);
-        responder.sendJson(connector.browse(connectorContext, browseRequest));
+      if (getContext().isRemoteTaskEnabled()) {
+        executeRemotely(namespace, browseRequestString, conn, RemoteConnectionBrowseTask.class, responder);
+      } else {
+        browseLocally(namespaceSummary.getName(), browseRequest, conn, responder);
       }
     });
+  }
+
+  private void browseLocally(String namespace, BrowseRequest browseRequest,
+                             Connection conn, HttpServiceResponder responder) throws IOException {
+    ServicePluginConfigurer pluginConfigurer =
+      getContext().createServicePluginConfigurer(namespace);
+    ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
+    ConnectorContext connectorContext = new DefaultConnectorContext(new SimpleFailureCollector(), pluginConfigurer);
+
+    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
+      new ArtifactSelectorProvider().getPluginSelector(conn.getPlugin().getArtifact()));
+    try (Connector connector = getConnector(pluginConfigurer, conn.getPlugin(), namespace, pluginSelector)) {
+      connector.configure(connectorConfigurer);
+      responder.sendJson(connector.browse(connectorContext, browseRequest));
+    }
   }
 
   /**
@@ -335,10 +342,11 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
                             "Sampling connection in system namespace is currently not supported");
         return;
       }
+
       contextAccessEnforcer.enforce(new ConnectionEntityId(namespace, ConnectionId.getConnectionId(connection)),
                                     ApplicationPermission.PREVIEW);
-      SampleRequest sampleRequest =
-        GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(), SampleRequest.class);
+      String sampleRequestString = StandardCharsets.UTF_8.decode(request.getContent()).toString();
+      SampleRequest sampleRequest = GSON.fromJson(sampleRequestString, SampleRequest.class);
 
       if (sampleRequest == null) {
         responder.sendError(HttpURLConnection.HTTP_BAD_REQUEST, "The request body is empty");
@@ -355,44 +363,46 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
         return;
       }
 
-      ServicePluginConfigurer pluginConfigurer =
-        getContext().createServicePluginConfigurer(namespaceSummary.getName());
-      ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
-      ConnectorContext connectorContext = new DefaultConnectorContext(new SimpleFailureCollector(), pluginConfigurer);
       Connection conn = store.getConnection(new ConnectionId(namespaceSummary, connection));
 
-      PluginInfo plugin = conn.getPlugin();
-      // use tracked selector to get exact plugin version that gets selected since the passed version can be null
-      TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
-        new ArtifactSelectorProvider().getPluginSelector(plugin.getArtifact()));
-      try (Connector connector = getConnector(pluginConfigurer, plugin, namespaceSummary.getName(), pluginSelector)) {
-        connector.configure(connectorConfigurer);
-        ConnectorSpecRequest specRequest = ConnectorSpecRequest.builder().setPath(sampleRequest.getPath())
-                                             .setConnection(connection)
-                                             .setProperties(sampleRequest.getProperties()).build();
-        ConnectorSpec spec = connector.generateSpec(connectorContext, specRequest);
-        ConnectorDetail detail = getConnectorDetail(pluginSelector.getSelectedArtifact(), spec);
-
-        if (connector instanceof DirectConnector) {
-          DirectConnector directConnector = (DirectConnector) connector;
-          List<StructuredRecord> sample = directConnector.sample(connectorContext, sampleRequest);
-          responder.sendString(GSON.toJson(
-            new SampleResponse(detail, sample.isEmpty() ? null : sample.get(0).getSchema(), sample)));
-          return;
-        }
-        if (connector instanceof BatchConnector) {
-          LimitingConnector limitingConnector = new LimitingConnector((BatchConnector) connector, pluginConfigurer);
-          List<StructuredRecord> sample = limitingConnector.sample(connectorContext, sampleRequest);
-          responder.sendString(GSON.toJson(
-            new SampleResponse(detail, sample.isEmpty() ? null : sample.get(0).getSchema(), sample)));
-          return;
-        }
-        // should not happen
-        responder.sendError(
-          HttpURLConnection.HTTP_BAD_REQUEST,
-          "Connector is not supported. The supported connector should be DirectConnector or BatchConnector.");
+      if (getContext().isRemoteTaskEnabled()) {
+        executeRemotely(namespace, sampleRequestString, conn, RemoteConnectionSampleTask.class, responder);
+      } else {
+        sampleLocally(namespaceSummary.getName(), sampleRequestString, conn, responder);
       }
     });
+  }
+
+  private void sampleLocally(String namespace, String sampleRequestString,
+                             Connection conn, HttpServiceResponder responder) throws IOException {
+    SampleRequest sampleRequest = GSON.fromJson(sampleRequestString, SampleRequest.class);
+
+    ServicePluginConfigurer pluginConfigurer =
+      getContext().createServicePluginConfigurer(namespace);
+    ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
+    ConnectorContext connectorContext = new DefaultConnectorContext(new SimpleFailureCollector(), pluginConfigurer);
+
+    PluginInfo plugin = conn.getPlugin();
+    // use tracked selector to get exact plugin version that gets selected since the passed version can be null
+    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
+      new ArtifactSelectorProvider().getPluginSelector(plugin.getArtifact()));
+    try (Connector connector = getConnector(pluginConfigurer, plugin, namespace, pluginSelector)) {
+      connector.configure(connectorConfigurer);
+      ConnectorSpecRequest specRequest = ConnectorSpecRequest.builder().setPath(sampleRequest.getPath())
+        .setConnection(conn.getName())
+        .setProperties(sampleRequest.getProperties()).build();
+      ConnectorSpec spec = connector.generateSpec(connectorContext, specRequest);
+      ConnectorDetail detail = ConnectionUtils.getConnectorDetail(pluginSelector.getSelectedArtifact(), spec);
+
+      try {
+        SampleResponse sampleResponse = ConnectionUtils.getSampleResponse(connector, connectorContext, sampleRequest,
+                                                                          detail, pluginConfigurer);
+        responder.sendString(GSON.toJson(sampleResponse));
+      } catch (BadRequestException e) {
+        // should not happen
+        responder.sendError(HttpURLConnection.HTTP_BAD_REQUEST, e.getMessage());
+      }
+    }
   }
 
   /**
@@ -413,9 +423,8 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
 
       contextAccessEnforcer.enforce(new ConnectionEntityId(namespace, ConnectionId.getConnectionId(connection)),
                                     ApplicationPermission.PREVIEW);
-
-      SpecGenerationRequest specRequest =
-        GSON.fromJson(StandardCharsets.UTF_8.decode(request.getContent()).toString(), SpecGenerationRequest.class);
+      String specGenerationRequestString = StandardCharsets.UTF_8.decode(request.getContent()).toString();
+      SpecGenerationRequest specRequest = GSON.fromJson(specGenerationRequestString, SpecGenerationRequest.class);
 
       if (specRequest == null) {
         responder.sendError(HttpURLConnection.HTTP_BAD_REQUEST, "The request body is empty");
@@ -426,37 +435,35 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
         responder.sendError(HttpURLConnection.HTTP_BAD_REQUEST, "Path is not provided in the sample request");
         return;
       }
-
-      ServicePluginConfigurer pluginConfigurer =
-        getContext().createServicePluginConfigurer(namespaceSummary.getName());
-      ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
-      ConnectorContext connectorContext = new DefaultConnectorContext(new SimpleFailureCollector(), pluginConfigurer);
       Connection conn = store.getConnection(new ConnectionId(namespaceSummary, connection));
 
-      // use tracked selector to get exact plugin version that gets selected since the passed version can be null
-      TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
-        new ArtifactSelectorProvider().getPluginSelector(conn.getPlugin().getArtifact()));
-      try (Connector connector = getConnector(pluginConfigurer, conn.getPlugin(), namespaceSummary.getName(),
-                                              pluginSelector)) {
-        connector.configure(connectorConfigurer);
-        ConnectorSpecRequest connectorSpecRequest = ConnectorSpecRequest.builder().setPath(specRequest.getPath())
-                                                      .setConnection(connection)
-                                                      .setProperties(specRequest.getProperties()).build();
-        ConnectorSpec spec = connector.generateSpec(connectorContext, connectorSpecRequest);
-        responder.sendString(GSON.toJson(getConnectorDetail(pluginSelector.getSelectedArtifact(), spec)));
+      if (getContext().isRemoteTaskEnabled()) {
+        executeRemotely(namespace, specGenerationRequestString, conn, RemoteConnectionSpecTask.class, responder);
+      } else {
+        specGenerationLocally(namespaceSummary.getName(), specRequest, conn, responder);
       }
     });
   }
 
-  private ConnectorDetail getConnectorDetail(ArtifactId artifactId, ConnectorSpec spec) {
-    ArtifactSelectorConfig artifact = new ArtifactSelectorConfig(artifactId.getScope().name(),
-                                                                 artifactId.getName(),
-                                                                 artifactId.getVersion().getVersion());
-    Set<PluginDetail> relatedPlugins = new HashSet<>();
-    spec.getRelatedPlugins().forEach(pluginSpec -> relatedPlugins.add(
-      new PluginDetail(pluginSpec.getName(), pluginSpec.getType(), pluginSpec.getProperties(), artifact,
-                       spec.getSchema())));
-    return new ConnectorDetail(relatedPlugins);
+  private void specGenerationLocally(String namespace, SpecGenerationRequest specRequest,
+                                     Connection conn, HttpServiceResponder responder) throws IOException {
+    ServicePluginConfigurer pluginConfigurer =
+      getContext().createServicePluginConfigurer(namespace);
+    ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
+    ConnectorContext connectorContext = new DefaultConnectorContext(new SimpleFailureCollector(), pluginConfigurer);
+
+    // use tracked selector to get exact plugin version that gets selected since the passed version can be null
+    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
+      new ArtifactSelectorProvider().getPluginSelector(conn.getPlugin().getArtifact()));
+    try (Connector connector = getConnector(pluginConfigurer, conn.getPlugin(), namespace,
+                                            pluginSelector)) {
+      connector.configure(connectorConfigurer);
+      ConnectorSpecRequest connectorSpecRequest = ConnectorSpecRequest.builder().setPath(specRequest.getPath())
+        .setConnection(conn.getName())
+        .setProperties(specRequest.getProperties()).build();
+      ConnectorSpec spec = connector.generateSpec(connectorContext, connectorSpecRequest);
+      responder.sendString(GSON.toJson(ConnectionUtils.getConnectorDetail(pluginSelector.getSelectedArtifact(), spec)));
+    }
   }
 
   private Connector getConnector(ServicePluginConfigurer configurer, PluginInfo pluginInfo,
@@ -474,20 +481,7 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
                                  .setEscaping(false)
                                  .setFunctionWhitelist(evaluators.keySet())
                                  .build();
-    Connector connector;
-    try {
-      connector = configurer.usePlugin(pluginInfo.getType(), pluginInfo.getName(), UUID.randomUUID().toString(),
-                                       PluginProperties.builder().addAll(pluginInfo.getProperties()).build(),
-                                       pluginSelector, macroEvaluator, options);
-    } catch (InvalidPluginConfigException e) {
-      throw new ConnectionBadRequestException(
-        String.format("Unable to instantiate connector plugin: %s", e.getMessage()), e);
-    }
-
-    if (connector == null) {
-      throw new ConnectionBadRequestException(String.format("Unable to find connector '%s'", pluginInfo.getName()));
-    }
-    return connector;
+    return ConnectionUtils.getConnector(configurer, pluginInfo, pluginSelector, macroEvaluator, options);
   }
 
   private void checkPutConnectionPermissions(ConnectionId connectionId) {
@@ -505,5 +499,49 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
       contextAccessEnforcer.enforce(new ConnectionEntityId(connectionId.getNamespace().getName(),
                                                            connectionId.getConnectionId()), StandardPermission.CREATE);
     }
+  }
+
+  /**
+   * Common method for all remote executions.
+   * Remote request is created, executed and response is added to {@link HttpServiceResponder}
+   * @param namespace namespace string
+   * @param request Serialized request string
+   * @param connection {@link Connection} details if present
+   * @param remoteExecutionTaskClass Remote execution task class
+   * @param responder {@link HttpServiceResponder} for the http request.
+   */
+  private void executeRemotely(String namespace, String request, @Nullable Connection connection,
+                               Class<? extends RemoteConnectionTaskBase> remoteExecutionTaskClass,
+                               HttpServiceResponder responder)  {
+    RemoteConnectionRequest remoteRequest = new RemoteConnectionRequest(namespace, request, connection);
+    RunnableTaskRequest runnableTaskRequest =
+      RunnableTaskRequest.getBuilder(remoteExecutionTaskClass.getName()).
+        withParam(GSON.toJson(remoteRequest)).
+        build();
+    try {
+      byte[] bytes = getContext().runTask(runnableTaskRequest);
+      if (bytes == null) {
+        responder.sendStatus(HttpURLConnection.HTTP_OK);
+      } else {
+        //convert the bytes received from remote worker to UTF-8 string
+        responder.sendString(new String(bytes, StandardCharsets.UTF_8));
+      }
+    } catch (RemoteExecutionException e) {
+      //TODO CDAP-18787 - Handle other exceptions
+      RemoteTaskException remoteTaskException = e.getCause();
+      responder.sendError(
+        getExceptionCode(remoteTaskException.getRemoteExceptionClassName(), remoteTaskException.getMessage(),
+                         namespace), remoteTaskException.getMessage());
+    } catch (Exception e) {
+      responder.sendError(HttpURLConnection.HTTP_INTERNAL_ERROR, e.getMessage());
+    }
+  }
+
+  private int getExceptionCode(String exceptionClass, String exceptionMessage, String namespace) {
+    if (IllegalArgumentException.class.getName().equals(exceptionClass)
+      || BadRequestException.class.getName().equals(exceptionClass)) {
+      return HttpURLConnection.HTTP_BAD_REQUEST;
+    }
+    return HttpURLConnection.HTTP_INTERNAL_ERROR;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionUtils.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
+import io.cdap.cdap.api.plugin.InvalidPluginConfigException;
+import io.cdap.cdap.api.plugin.PluginProperties;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorContext;
+import io.cdap.cdap.datapipeline.connection.LimitingConnector;
+import io.cdap.cdap.etl.api.batch.BatchConnector;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.connector.ConnectorContext;
+import io.cdap.cdap.etl.api.connector.ConnectorSpec;
+import io.cdap.cdap.etl.api.connector.DirectConnector;
+import io.cdap.cdap.etl.api.connector.SampleRequest;
+import io.cdap.cdap.etl.proto.ArtifactSelectorConfig;
+import io.cdap.cdap.etl.proto.connection.ConnectionBadRequestException;
+import io.cdap.cdap.etl.proto.connection.ConnectorDetail;
+import io.cdap.cdap.etl.proto.connection.PluginDetail;
+import io.cdap.cdap.etl.proto.connection.PluginInfo;
+import io.cdap.cdap.etl.proto.connection.SampleResponse;
+import io.cdap.cdap.etl.proto.validation.SimpleFailureCollector;
+import io.cdap.cdap.etl.spec.TrackedPluginSelector;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import javax.ws.rs.BadRequestException;
+
+public final class ConnectionUtils {
+
+  private ConnectionUtils() {
+    // prevent instantiation of util class.
+  }
+
+  /**
+   * Returns {@link Connector}
+   * @return {@link Connector}
+   */
+  public static Connector getConnector(ServicePluginConfigurer configurer, PluginInfo pluginInfo,
+                                       TrackedPluginSelector pluginSelector, MacroEvaluator macroEvaluator,
+                                       MacroParserOptions options) {
+    Connector connector = null;
+    try {
+      connector = configurer.usePlugin(pluginInfo.getType(), pluginInfo.getName(), UUID.randomUUID().toString(),
+                                       PluginProperties.builder().addAll(pluginInfo.getProperties()).build(),
+                                       pluginSelector, macroEvaluator, options);
+    } catch (InvalidPluginConfigException e) {
+      throw new ConnectionBadRequestException(
+        String.format("Unable to instantiate connector plugin: %s", e.getMessage()), e);
+    }
+
+    if (connector == null) {
+      throw new ConnectionBadRequestException(String.format("Unable to find connector '%s'", pluginInfo.getName()));
+    }
+    return connector;
+  }
+
+  /**
+   * Return {@link SampleResponse} for the connector
+   *
+   * @throws IOException
+   */
+  public static SampleResponse getSampleResponse(Connector connector, ConnectorContext connectorContext,
+                                                 SampleRequest sampleRequest, ConnectorDetail detail,
+                                                 ServicePluginConfigurer pluginConfigurer) throws IOException {
+    if (connector instanceof DirectConnector) {
+      DirectConnector directConnector = (DirectConnector) connector;
+      List<StructuredRecord> sample = directConnector.sample(connectorContext, sampleRequest);
+      return new SampleResponse(detail, sample.isEmpty() ? null : sample.get(0).getSchema(), sample);
+    }
+    if (connector instanceof BatchConnector) {
+      LimitingConnector limitingConnector = new LimitingConnector((BatchConnector) connector, pluginConfigurer);
+      List<StructuredRecord> sample = limitingConnector.sample(connectorContext, sampleRequest);
+      return new SampleResponse(detail, sample.isEmpty() ? null : sample.get(0).getSchema(), sample);
+    }
+    throw new BadRequestException("Connector is not supported. " +
+                                    "The supported connector should be DirectConnector or BatchConnector.");
+  }
+
+  /**
+   * Returns {@link ConnectorDetail} with all plugins
+   *
+   * @return {@link ConnectorDetail}
+   */
+  public static ConnectorDetail getConnectorDetail(ArtifactId artifactId, ConnectorSpec spec) {
+    ArtifactSelectorConfig artifact = new ArtifactSelectorConfig(artifactId.getScope().name(),
+                                                                 artifactId.getName(),
+                                                                 artifactId.getVersion().getVersion());
+    Set<PluginDetail> relatedPlugins = new HashSet<>();
+    spec.getRelatedPlugins().forEach(pluginSpec -> relatedPlugins.add(
+      new PluginDetail(pluginSpec.getName(), pluginSpec.getType(), pluginSpec.getProperties(), artifact,
+                       spec.getSchema())));
+    return new ConnectorDetail(relatedPlugins);
+  }
+
+  /**
+   * Returns a {@link ConnectorContext}
+   * @return {@link ConnectorContext}
+   */
+  public static ConnectorContext getConnectorContext(ServicePluginConfigurer pluginConfigurer) {
+    SimpleFailureCollector failureCollector = new SimpleFailureCollector();
+    return new DefaultConnectorContext(failureCollector, pluginConfigurer);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionBrowseTask.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionBrowseTask.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.RunnableTaskContext;
+import io.cdap.cdap.api.service.worker.SystemAppTaskContext;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorConfigurer;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorContext;
+import io.cdap.cdap.etl.api.connector.BrowseDetail;
+import io.cdap.cdap.etl.api.connector.BrowseRequest;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.connector.ConnectorContext;
+import io.cdap.cdap.etl.common.ArtifactSelectorProvider;
+import io.cdap.cdap.etl.common.BasicArguments;
+import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
+import io.cdap.cdap.etl.common.OAuthMacroEvaluator;
+import io.cdap.cdap.etl.common.SecureStoreMacroEvaluator;
+import io.cdap.cdap.etl.proto.connection.Connection;
+import io.cdap.cdap.etl.proto.connection.PluginInfo;
+import io.cdap.cdap.etl.proto.validation.SimpleFailureCollector;
+import io.cdap.cdap.etl.spec.TrackedPluginSelector;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * {@link RunnableTask} for executing connection browsing remotely
+ */
+public class RemoteConnectionBrowseTask extends RemoteConnectionTaskBase {
+
+  private static final Gson GSON = new Gson();
+
+  @Override
+  public String execute(SystemAppTaskContext systemAppContext, Connection connection,
+                        ServicePluginConfigurer servicePluginConfigurer, TrackedPluginSelector pluginSelector,
+                        String namespace, String request) throws Exception {
+
+    BrowseRequest browseRequest = GSON.fromJson(request, BrowseRequest.class);
+    try (Connector connector = getConnector(systemAppContext, servicePluginConfigurer, connection.getPlugin(),
+                                            namespace, pluginSelector)) {
+      //configure and browse
+      connector.configure(new DefaultConnectorConfigurer(servicePluginConfigurer));
+      ConnectorContext connectorContext = new DefaultConnectorContext(new SimpleFailureCollector(),
+                                                                      servicePluginConfigurer);
+      BrowseDetail browseDetail = connector.browse(connectorContext, browseRequest);
+      return GSON.toJson(browseDetail);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import io.cdap.cdap.etl.proto.connection.Connection;
+
+import javax.annotation.Nullable;
+
+/**
+ * Request class remote connection tasks
+ */
+public class RemoteConnectionRequest {
+
+  private String namespace;
+  private String request;
+  private Connection connection;
+
+  RemoteConnectionRequest(String namespace, String request, @Nullable Connection connection) {
+    this.namespace = namespace;
+    this.request = request;
+    this.connection = connection;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getRequest() {
+    return request;
+  }
+
+  @Nullable
+  public Connection getConnection() {
+    return connection;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionSampleTask.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionSampleTask.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.SystemAppTaskContext;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorConfigurer;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.connector.ConnectorContext;
+import io.cdap.cdap.etl.api.connector.ConnectorSpec;
+import io.cdap.cdap.etl.api.connector.ConnectorSpecRequest;
+import io.cdap.cdap.etl.api.connector.SampleRequest;
+import io.cdap.cdap.etl.proto.connection.Connection;
+import io.cdap.cdap.etl.proto.connection.ConnectorDetail;
+import io.cdap.cdap.etl.proto.connection.SampleResponse;
+import io.cdap.cdap.etl.proto.connection.SampleResponseCodec;
+import io.cdap.cdap.etl.spec.TrackedPluginSelector;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+
+/**
+ * {@link RunnableTask} for executing connection data sampling remotely
+ */
+public class RemoteConnectionSampleTask extends RemoteConnectionTaskBase {
+
+  private static final Gson GSON =
+    new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+      .registerTypeAdapter(SampleResponse.class, new SampleResponseCodec()).setPrettyPrinting().create();
+
+  @Override
+  public String execute(SystemAppTaskContext systemAppContext, Connection connection,
+                        ServicePluginConfigurer pluginConfigurer, TrackedPluginSelector pluginSelector,
+                        String namespace, String request) throws Exception {
+
+    ConnectorContext connectorContext = ConnectionUtils.getConnectorContext(pluginConfigurer);
+    SampleRequest sampleRequest = GSON.fromJson(request, SampleRequest.class);
+    try (Connector connector = getConnector(systemAppContext, pluginConfigurer, connection.getPlugin(),
+                                            namespace, pluginSelector)) {
+      connector.configure(new DefaultConnectorConfigurer(pluginConfigurer));
+      ConnectorSpecRequest specRequest = ConnectorSpecRequest.builder().setPath(sampleRequest.getPath())
+        .setConnection(connection.getName())
+        .setProperties(sampleRequest.getProperties()).build();
+      ConnectorSpec spec = connector.generateSpec(connectorContext, specRequest);
+      ConnectorDetail detail = ConnectionUtils.getConnectorDetail(pluginSelector.getSelectedArtifact(), spec);
+      SampleResponse sampleResponse = ConnectionUtils.getSampleResponse(connector, connectorContext, sampleRequest,
+                                                                        detail, pluginConfigurer);
+      return GSON.toJson(sampleResponse);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionSpecTask.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionSpecTask.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.SystemAppTaskContext;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorConfigurer;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.connector.ConnectorConfigurer;
+import io.cdap.cdap.etl.api.connector.ConnectorContext;
+import io.cdap.cdap.etl.api.connector.ConnectorSpec;
+import io.cdap.cdap.etl.api.connector.ConnectorSpecRequest;
+import io.cdap.cdap.etl.proto.connection.Connection;
+import io.cdap.cdap.etl.proto.connection.SpecGenerationRequest;
+import io.cdap.cdap.etl.spec.TrackedPluginSelector;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+
+/**
+ * {@link RunnableTask} for executing connection spec generation remotely
+ */
+public class RemoteConnectionSpecTask extends RemoteConnectionTaskBase {
+  private static final Gson GSON =
+    new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+      .setPrettyPrinting().create();
+
+  @Override
+  public String execute(SystemAppTaskContext systemAppContext, Connection connection,
+                        ServicePluginConfigurer pluginConfigurer, TrackedPluginSelector pluginSelector,
+                        String namespace, String request) throws Exception {
+
+    ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
+    ConnectorContext connectorContext = ConnectionUtils.getConnectorContext(pluginConfigurer);
+    SpecGenerationRequest specRequest = GSON.fromJson(request, SpecGenerationRequest.class);
+    try (Connector connector = getConnector(systemAppContext, pluginConfigurer, connection.getPlugin(), namespace,
+                                            pluginSelector)) {
+      connector.configure(connectorConfigurer);
+      ConnectorSpecRequest connectorSpecRequest = ConnectorSpecRequest.builder().setPath(specRequest.getPath())
+        .setConnection(connection.getName())
+        .setProperties(specRequest.getProperties()).build();
+      ConnectorSpec spec = connector.generateSpec(connectorContext, connectorSpecRequest);
+      return GSON.toJson(ConnectionUtils.getConnectorDetail(pluginSelector.getSelectedArtifact(), spec));
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionTaskBase.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionTaskBase.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.RunnableTaskContext;
+import io.cdap.cdap.api.service.worker.SystemAppTaskContext;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.common.ArtifactSelectorProvider;
+import io.cdap.cdap.etl.common.BasicArguments;
+import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
+import io.cdap.cdap.etl.common.OAuthMacroEvaluator;
+import io.cdap.cdap.etl.common.SecureStoreMacroEvaluator;
+import io.cdap.cdap.etl.proto.connection.Connection;
+import io.cdap.cdap.etl.proto.connection.PluginInfo;
+import io.cdap.cdap.etl.spec.TrackedPluginSelector;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Base class for {@link RunnableTask} for connection handling
+ */
+public abstract class RemoteConnectionTaskBase implements RunnableTask {
+
+  private static final Gson GSON = new Gson();
+
+  @Override
+  public void run(RunnableTaskContext context) throws Exception {
+    //Get SystemAppTaskContext
+    SystemAppTaskContext systemAppContext = context.getRunnableTaskSystemAppContext();
+    //De serialize all requests
+    RemoteConnectionRequest connectionRequest = GSON.fromJson(context.getParam(),
+                                                              RemoteConnectionRequest.class);
+    String namespace = connectionRequest.getNamespace();
+    Connection connection = connectionRequest.getConnection();
+
+    //Plugin selector and configurer
+    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
+      new ArtifactSelectorProvider().getPluginSelector(connection.getPlugin().getArtifact()));
+    ServicePluginConfigurer servicePluginConfigurer = systemAppContext.createServicePluginConfigurer(namespace);
+    //serialize the result as json and write the bytes
+    String executedResult = execute(systemAppContext, connection, servicePluginConfigurer, pluginSelector, namespace,
+                                    connectionRequest.getRequest());
+    context.writeResult(executedResult.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * execute method for specific tasks to implement
+   *
+   * @param systemAppContext        {@link SystemAppTaskContext}
+   * @param connection              {@link Connection}
+   * @param servicePluginConfigurer {@link ServicePluginConfigurer}
+   * @param pluginSelector          {@link TrackedPluginSelector}
+   * @param namespace               namespace string
+   * @param request                 request string
+   * @return executed response as string
+   * @throws Exception
+   */
+  public abstract String execute(SystemAppTaskContext systemAppContext, Connection connection,
+                                 ServicePluginConfigurer servicePluginConfigurer, TrackedPluginSelector pluginSelector,
+                                 String namespace, String request) throws Exception;
+
+  /**
+   * Returns {@link Connector} after evaluating macros
+   *
+   * @param systemAppContext {@link SystemAppTaskContext}
+   * @param configurer       {@link ServicePluginConfigurer}
+   * @param pluginInfo       {@link PluginInfo}
+   * @param namespace        namespace string
+   * @param pluginSelector   {@link TrackedPluginSelector}
+   * @return {@link Connector}
+   * @throws Exception
+   */
+  protected Connector getConnector(SystemAppTaskContext systemAppContext, ServicePluginConfigurer configurer,
+                                   PluginInfo pluginInfo, String namespace,
+                                   TrackedPluginSelector pluginSelector) throws Exception {
+
+    Map<String, String> arguments = systemAppContext.getPreferencesForNamespace(namespace, true);
+    Map<String, MacroEvaluator> evaluators = ImmutableMap.of(
+      SecureStoreMacroEvaluator.FUNCTION_NAME, new SecureStoreMacroEvaluator(namespace, systemAppContext),
+      OAuthMacroEvaluator.FUNCTION_NAME, new OAuthMacroEvaluator(systemAppContext)
+    );
+    MacroEvaluator macroEvaluator = new DefaultMacroEvaluator(new BasicArguments(arguments), evaluators,
+                                                              Collections.singleton(OAuthMacroEvaluator.FUNCTION_NAME));
+    MacroParserOptions options = MacroParserOptions.builder()
+      .skipInvalidMacros()
+      .setEscaping(false)
+      .setFunctionWhitelist(evaluators.keySet())
+      .build();
+    return ConnectionUtils.getConnector(configurer, pluginInfo, pluginSelector, macroEvaluator, options);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionTestTask.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionTestTask.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.SystemAppTaskContext;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorConfigurer;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorContext;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.connector.ConnectorConfigurer;
+import io.cdap.cdap.etl.api.connector.ConnectorContext;
+import io.cdap.cdap.etl.api.validation.ValidationException;
+import io.cdap.cdap.etl.proto.connection.Connection;
+import io.cdap.cdap.etl.proto.connection.ConnectionCreationRequest;
+import io.cdap.cdap.etl.proto.validation.SimpleFailureCollector;
+import io.cdap.cdap.etl.spec.TrackedPluginSelector;
+
+/**
+ * {@link RunnableTask} for executing connection creation/test remotely
+ */
+public class RemoteConnectionTestTask extends RemoteConnectionTaskBase {
+
+  private static final Gson GSON = new Gson();
+
+  @Override
+  public String execute(SystemAppTaskContext systemAppContext, Connection connection,
+                        ServicePluginConfigurer pluginConfigurer, TrackedPluginSelector pluginSelector,
+                        String namespace, String request) throws Exception {
+    ConnectionCreationRequest connectionCreationRequest = GSON.fromJson(request, ConnectionCreationRequest.class);
+
+    ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
+    SimpleFailureCollector failureCollector = new SimpleFailureCollector();
+    ConnectorContext connectorContext = new DefaultConnectorContext(failureCollector, pluginConfigurer);
+    try (Connector connector = getConnector(systemAppContext, pluginConfigurer, connectionCreationRequest.getPlugin(),
+                                            namespace, pluginSelector)) {
+      connector.configure(connectorConfigurer);
+      try {
+        connector.test(connectorContext);
+        failureCollector.getOrThrowException();
+        return "";
+      } catch (ValidationException e) {
+        return GSON.toJson(e.getFailures());
+      }
+    }
+  }
+}

--- a/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/worker/SystemAppTaskContext.java
+++ b/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/worker/SystemAppTaskContext.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
 
 import java.io.IOException;
 import java.util.Map;
@@ -50,6 +51,13 @@ public interface SystemAppTaskContext extends ServiceDiscoverer, SecureStore, Au
    * @return a dynamic plugin configurer that must be closed
    */
   PluginConfigurer createPluginConfigurer(String namespace) throws IOException;
+
+  /**
+   * Create a {@link ServicePluginConfigurer} that can be used to instantiate plugins with macro evaluation
+   * @param namespace the namespace for user scoped plugins.
+   * @return a plugin configurer specifically for service.
+   */
+  ServicePluginConfigurer createServicePluginConfigurer(String namespace);
 
   /**
    * Evaluates macros using provided macro evaluator with the provided parsing options.


### PR DESCRIPTION
Why:
Connection requests (e.g. /test /browse /sample etc) runs a plugin which
execute user provided code. Allow them to run in seperate worker pods
for better security.