### PR TITLE
[CDAP-18322] Support executing connection requests remotely in worker pods

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionUtils.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
+import io.cdap.cdap.api.plugin.InvalidPluginConfigException;
+import io.cdap.cdap.api.plugin.PluginProperties;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.datapipeline.connection.LimitingConnector;
+import io.cdap.cdap.etl.api.batch.BatchConnector;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.connector.ConnectorContext;
+import io.cdap.cdap.etl.api.connector.DirectConnector;
+import io.cdap.cdap.etl.api.connector.SampleRequest;
+import io.cdap.cdap.etl.common.BasicArguments;
+import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
+import io.cdap.cdap.etl.common.OAuthMacroEvaluator;
+import io.cdap.cdap.etl.common.SecureStoreMacroEvaluator;
+import io.cdap.cdap.etl.proto.connection.ConnectionBadRequestException;
+import io.cdap.cdap.etl.proto.connection.ConnectorDetail;
+import io.cdap.cdap.etl.proto.connection.PluginInfo;
+import io.cdap.cdap.etl.proto.connection.SampleResponse;
+import io.cdap.cdap.etl.spec.TrackedPluginSelector;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.ws.rs.BadRequestException;
+
+public class ConnectionUtils {
+
+  private ConnectionUtils() {
+    // prevent instantiation of util class.
+  }
+
+  public static Connector getConnector(ServicePluginConfigurer configurer, PluginInfo pluginInfo,
+                                       TrackedPluginSelector pluginSelector, MacroEvaluator macroEvaluator,
+                                       MacroParserOptions options) {
+    Connector connector = null;
+    try {
+      connector = configurer.usePlugin(pluginInfo.getType(), pluginInfo.getName(), UUID.randomUUID().toString(),
+                                       PluginProperties.builder().addAll(pluginInfo.getProperties()).build(),
+                                       pluginSelector, macroEvaluator, options);
+    } catch (InvalidPluginConfigException e) {
+      throw new ConnectionBadRequestException(
+        String.format("Unable to instantiate connector plugin: %s", e.getMessage()), e);
+    }
+
+    if (connector == null) {
+      throw new ConnectionBadRequestException(String.format("Unable to find connector '%s'", pluginInfo.getName()));
+    }
+    return connector;
+  }
+
+  /**
+   * Return {@link SampleResponse} for the connector
+   *
+   * @param connector
+   * @param connectorContext
+   * @param sampleRequest
+   * @param detail
+   * @param pluginConfigurer
+   * @return
+   * @throws IOException
+   */
+  public static SampleResponse getSampleResponse(Connector connector, ConnectorContext connectorContext,
+                                                 SampleRequest sampleRequest, ConnectorDetail detail,
+                                                 ServicePluginConfigurer pluginConfigurer) throws IOException {
+    if (connector instanceof DirectConnector) {
+      DirectConnector directConnector = (DirectConnector) connector;
+      List<StructuredRecord> sample = directConnector.sample(connectorContext, sampleRequest);
+      return new SampleResponse(detail, sample.isEmpty() ? null : sample.get(0).getSchema(), sample);
+    }
+    if (connector instanceof BatchConnector) {
+      LimitingConnector limitingConnector = new LimitingConnector((BatchConnector) connector, pluginConfigurer);
+      List<StructuredRecord> sample = limitingConnector.sample(connectorContext, sampleRequest);
+      return new SampleResponse(detail, sample.isEmpty() ? null : sample.get(0).getSchema(), sample);
+    }
+    throw new BadRequestException("Connector is not supported. " +
+                                    "The supported connector should be DirectConnector or BatchConnector.");
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionBrowseTask.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionBrowseTask.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.RunnableTaskContext;
+import io.cdap.cdap.api.service.worker.SystemAppTaskContext;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorConfigurer;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorContext;
+import io.cdap.cdap.etl.api.connector.BrowseDetail;
+import io.cdap.cdap.etl.api.connector.BrowseRequest;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.connector.ConnectorContext;
+import io.cdap.cdap.etl.common.ArtifactSelectorProvider;
+import io.cdap.cdap.etl.common.BasicArguments;
+import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
+import io.cdap.cdap.etl.common.OAuthMacroEvaluator;
+import io.cdap.cdap.etl.common.SecureStoreMacroEvaluator;
+import io.cdap.cdap.etl.proto.connection.Connection;
+import io.cdap.cdap.etl.proto.connection.PluginInfo;
+import io.cdap.cdap.etl.proto.validation.SimpleFailureCollector;
+import io.cdap.cdap.etl.spec.TrackedPluginSelector;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * {@link RunnableTask} for executing connection browsing remotely
+ */
+public class RemoteConnectionBrowseTask extends RemoteConnectionTaskBase {
+
+  private static final Gson GSON = new Gson();
+
+  @Override
+  public void execute(RunnableTaskContext context,
+                      SystemAppTaskContext systemAppContext) throws Exception {
+    //De serialize all requests
+    RemoteConnectionRequest connectionBrowseRequest = GSON.fromJson(context.getParam(),
+                                                                    RemoteConnectionRequest.class);
+    String namespace = connectionBrowseRequest.getNamespace();
+    BrowseRequest browseRequest = GSON.fromJson(connectionBrowseRequest.getRequest(), BrowseRequest.class);
+    Connection connection = connectionBrowseRequest.getConnection();
+
+    //Plugin selector and configurer
+    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
+      new ArtifactSelectorProvider().getPluginSelector(connection.getPlugin().getArtifact()));
+    ServicePluginConfigurer servicePluginConfigurer = systemAppContext.createServicePluginConfigurer(namespace);
+    try (Connector connector = getConnector(systemAppContext, servicePluginConfigurer, connection.getPlugin(),
+                                            namespace, pluginSelector)) {
+      //configure and browse
+      connector.configure(new DefaultConnectorConfigurer(servicePluginConfigurer));
+      ConnectorContext connectorContext = new DefaultConnectorContext(new SimpleFailureCollector(),
+                                                                      servicePluginConfigurer);
+      BrowseDetail browseDetail = connector.browse(connectorContext, browseRequest);
+      //serialize the result as json and write the bytes
+      context.writeResult(GSON.toJson(browseDetail).getBytes());
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionRequest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import io.cdap.cdap.etl.proto.connection.Connection;
+
+import javax.annotation.Nullable;
+
+/**
+ * Request class remote connection tasks
+ */
+public class RemoteConnectionRequest {
+
+  private String namespace;
+  private String request;
+  private Connection connection;
+
+  RemoteConnectionRequest(String namespace, String request, @Nullable Connection connection) {
+    this.namespace = namespace;
+    this.request = request;
+    this.connection = connection;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getRequest() {
+    return request;
+  }
+
+  @Nullable
+  public Connection getConnection() {
+    return connection;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionSampleTask.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionSampleTask.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.RunnableTaskContext;
+import io.cdap.cdap.api.service.worker.SystemAppTaskContext;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorConfigurer;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorContext;
+import io.cdap.cdap.datapipeline.connection.LimitingConnector;
+import io.cdap.cdap.etl.api.batch.BatchConnector;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.connector.ConnectorConfigurer;
+import io.cdap.cdap.etl.api.connector.ConnectorContext;
+import io.cdap.cdap.etl.api.connector.ConnectorSpec;
+import io.cdap.cdap.etl.api.connector.ConnectorSpecRequest;
+import io.cdap.cdap.etl.api.connector.DirectConnector;
+import io.cdap.cdap.etl.api.connector.SampleRequest;
+import io.cdap.cdap.etl.common.ArtifactSelectorProvider;
+import io.cdap.cdap.etl.common.BasicArguments;
+import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
+import io.cdap.cdap.etl.common.OAuthMacroEvaluator;
+import io.cdap.cdap.etl.common.SecureStoreMacroEvaluator;
+import io.cdap.cdap.etl.proto.ArtifactSelectorConfig;
+import io.cdap.cdap.etl.proto.connection.Connection;
+import io.cdap.cdap.etl.proto.connection.ConnectorDetail;
+import io.cdap.cdap.etl.proto.connection.PluginDetail;
+import io.cdap.cdap.etl.proto.connection.PluginInfo;
+import io.cdap.cdap.etl.proto.connection.SampleResponse;
+import io.cdap.cdap.etl.proto.connection.SampleResponseCodec;
+import io.cdap.cdap.etl.proto.validation.SimpleFailureCollector;
+import io.cdap.cdap.etl.spec.TrackedPluginSelector;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.ws.rs.BadRequestException;
+
+/**
+ * {@link RunnableTask} for executing connection data sampling remotely
+ */
+public class RemoteConnectionSampleTask extends RemoteConnectionTaskBase {
+
+  private static final Gson GSON =
+    new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+      .registerTypeAdapter(SampleResponse.class, new SampleResponseCodec()).setPrettyPrinting().create();
+
+  @Override
+  public void execute(RunnableTaskContext context, SystemAppTaskContext systemAppContext) throws Exception {
+    //De serialize all requests
+    RemoteConnectionRequest remoteConnectionSampleTask = GSON.fromJson(context.getParam(),
+                                                                       RemoteConnectionRequest.class);
+    String namespace = remoteConnectionSampleTask.getNamespace();
+    SampleRequest sampleRequest = GSON.fromJson(remoteConnectionSampleTask.getRequest(), SampleRequest.class);
+    Connection connection = remoteConnectionSampleTask.getConnection();
+    String connectionName = connection.getName();
+
+    ServicePluginConfigurer pluginConfigurer = systemAppContext.createServicePluginConfigurer(namespace);
+    ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
+    SimpleFailureCollector failureCollector = new SimpleFailureCollector();
+    ConnectorContext connectorContext = new DefaultConnectorContext(failureCollector, pluginConfigurer);
+    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
+      new ArtifactSelectorProvider().getPluginSelector(connection.getPlugin().getArtifact()));
+
+    try (Connector connector = getConnector(systemAppContext, pluginConfigurer, connection.getPlugin(),
+                                            namespace, pluginSelector)) {
+      connector.configure(new DefaultConnectorConfigurer(pluginConfigurer));
+      ConnectorSpecRequest specRequest = ConnectorSpecRequest.builder().setPath(sampleRequest.getPath())
+        .setConnection(connectionName)
+        .setProperties(sampleRequest.getProperties()).build();
+      ConnectorSpec spec = connector.generateSpec(connectorContext, specRequest);
+      ConnectorDetail detail = getConnectorDetail(pluginSelector.getSelectedArtifact(), spec);
+      SampleResponse sampleResponse = ConnectionUtils.getSampleResponse(connector, connectorContext, sampleRequest,
+                                                                        detail, pluginConfigurer);
+      context.writeResult(GSON.toJson(sampleResponse).getBytes(StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionSpecTask.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionSpecTask.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.RunnableTaskContext;
+import io.cdap.cdap.api.service.worker.SystemAppTaskContext;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorConfigurer;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorContext;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.connector.ConnectorConfigurer;
+import io.cdap.cdap.etl.api.connector.ConnectorContext;
+import io.cdap.cdap.etl.api.connector.ConnectorSpec;
+import io.cdap.cdap.etl.api.connector.ConnectorSpecRequest;
+import io.cdap.cdap.etl.common.ArtifactSelectorProvider;
+import io.cdap.cdap.etl.common.BasicArguments;
+import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
+import io.cdap.cdap.etl.common.OAuthMacroEvaluator;
+import io.cdap.cdap.etl.common.SecureStoreMacroEvaluator;
+import io.cdap.cdap.etl.proto.ArtifactSelectorConfig;
+import io.cdap.cdap.etl.proto.connection.Connection;
+import io.cdap.cdap.etl.proto.connection.ConnectorDetail;
+import io.cdap.cdap.etl.proto.connection.PluginDetail;
+import io.cdap.cdap.etl.proto.connection.PluginInfo;
+import io.cdap.cdap.etl.proto.connection.SpecGenerationRequest;
+import io.cdap.cdap.etl.proto.validation.SimpleFailureCollector;
+import io.cdap.cdap.etl.spec.TrackedPluginSelector;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * {@link RunnableTask} for executing connection spec generation remotely
+ */
+public class RemoteConnectionSpecTask extends RemoteConnectionTaskBase {
+  private static final Gson GSON =
+    new GsonBuilder().registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+      .setPrettyPrinting().create();
+
+  @Override
+  public void execute(RunnableTaskContext context, SystemAppTaskContext systemAppContext) throws Exception {
+    //De serialize all requests
+    RemoteConnectionRequest remoteConnectionSpecTask = GSON.fromJson(context.getParam(),
+                                                                     RemoteConnectionRequest.class);
+    String namespace = remoteConnectionSpecTask.getNamespace();
+    SpecGenerationRequest specRequest = GSON.fromJson(remoteConnectionSpecTask.getRequest(),
+                                                      SpecGenerationRequest.class);
+    Connection connection = remoteConnectionSpecTask.getConnection();
+    String connectionString = connection.getName();
+
+    ServicePluginConfigurer pluginConfigurer = systemAppContext.createServicePluginConfigurer(namespace);
+    ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
+    SimpleFailureCollector failureCollector = new SimpleFailureCollector();
+    ConnectorContext connectorContext = new DefaultConnectorContext(failureCollector, pluginConfigurer);
+    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
+      new ArtifactSelectorProvider().getPluginSelector(connection.getPlugin().getArtifact()));
+
+
+    try (Connector connector = getConnector(systemAppContext, pluginConfigurer, connection.getPlugin(), namespace,
+                                            pluginSelector)) {
+      connector.configure(connectorConfigurer);
+      ConnectorSpecRequest connectorSpecRequest = ConnectorSpecRequest.builder().setPath(specRequest.getPath())
+        .setConnection(connection.getName())
+        .setProperties(specRequest.getProperties()).build();
+      ConnectorSpec spec = connector.generateSpec(connectorContext, connectorSpecRequest);
+      context.writeResult(GSON.toJson(getConnectorDetail(pluginSelector.getSelectedArtifact(),
+                                                         spec)).getBytes(StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionTaskBase.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionTaskBase.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.RunnableTaskContext;
+import io.cdap.cdap.api.service.worker.SystemAppTaskContext;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorConfigurer;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorContext;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.connector.ConnectorConfigurer;
+import io.cdap.cdap.etl.api.connector.ConnectorContext;
+import io.cdap.cdap.etl.api.connector.ConnectorSpec;
+import io.cdap.cdap.etl.api.connector.ConnectorSpecRequest;
+import io.cdap.cdap.etl.common.ArtifactSelectorProvider;
+import io.cdap.cdap.etl.common.BasicArguments;
+import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
+import io.cdap.cdap.etl.common.OAuthMacroEvaluator;
+import io.cdap.cdap.etl.common.SecureStoreMacroEvaluator;
+import io.cdap.cdap.etl.proto.ArtifactSelectorConfig;
+import io.cdap.cdap.etl.proto.connection.Connection;
+import io.cdap.cdap.etl.proto.connection.ConnectorDetail;
+import io.cdap.cdap.etl.proto.connection.PluginDetail;
+import io.cdap.cdap.etl.proto.connection.PluginInfo;
+import io.cdap.cdap.etl.proto.connection.SpecGenerationRequest;
+import io.cdap.cdap.etl.proto.validation.SimpleFailureCollector;
+import io.cdap.cdap.etl.spec.TrackedPluginSelector;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Base class for {@link RunnableTask} for connection handling
+ */
+public abstract class RemoteConnectionTaskBase implements RunnableTask {
+
+  private static final Gson GSON = new Gson();
+
+  @Override
+  public void run(RunnableTaskContext context) throws Exception {
+    //Get SystemAppTaskContext
+    SystemAppTaskContext systemAppContext = context.getRunnableTaskSystemAppContext();
+    execute(context, systemAppContext);
+  }
+
+  /**
+   * execute method for child class to implement
+   *
+   * @param context              {@link RunnableTaskContext}
+   * @param systemAppTaskContext {@link SystemAppTaskContext}
+   * @throws Exception
+   */
+  protected abstract void execute(RunnableTaskContext context,
+                                  SystemAppTaskContext systemAppTaskContext) throws Exception;
+
+  /**
+   * Returns {@link Connector} after evaluating macros
+   *
+   * @param systemAppContext {@link SystemAppTaskContext}
+   * @param configurer       {@link ServicePluginConfigurer}
+   * @param pluginInfo       {@link PluginInfo}
+   * @param namespace        namespace string
+   * @param pluginSelector   {@link TrackedPluginSelector}
+   * @return
+   * @throws Exception
+   */
+  protected Connector getConnector(SystemAppTaskContext systemAppContext, ServicePluginConfigurer configurer,
+                                   PluginInfo pluginInfo, String namespace,
+                                   TrackedPluginSelector pluginSelector) throws Exception {
+
+    Map<String, String> arguments = systemAppContext.getPreferencesForNamespace(namespace, true);
+    Map<String, MacroEvaluator> evaluators = ImmutableMap.of(
+      SecureStoreMacroEvaluator.FUNCTION_NAME, new SecureStoreMacroEvaluator(namespace, systemAppContext),
+      OAuthMacroEvaluator.FUNCTION_NAME, new OAuthMacroEvaluator(systemAppContext)
+    );
+    MacroEvaluator macroEvaluator = new DefaultMacroEvaluator(new BasicArguments(arguments), evaluators,
+                                                              Collections.singleton(OAuthMacroEvaluator.FUNCTION_NAME));
+    MacroParserOptions options = MacroParserOptions.builder()
+      .skipInvalidMacros()
+      .setEscaping(false)
+      .setFunctionWhitelist(evaluators.keySet())
+      .build();
+    return ConnectionUtils.getConnector(configurer, pluginInfo, pluginSelector, macroEvaluator, options);
+  }
+
+  /**
+   * Returns {@link ConnectorDetail} with all plugins
+   *
+   * @param artifactId
+   * @param spec
+   * @return
+   */
+  protected ConnectorDetail getConnectorDetail(ArtifactId artifactId, ConnectorSpec spec) {
+    ArtifactSelectorConfig artifact = new ArtifactSelectorConfig(artifactId.getScope().name(),
+                                                                 artifactId.getName(),
+                                                                 artifactId.getVersion().getVersion());
+    Set<PluginDetail> relatedPlugins = new HashSet<>();
+    spec.getRelatedPlugins().forEach(pluginSpec -> relatedPlugins.add(
+      new PluginDetail(pluginSpec.getName(), pluginSpec.getType(), pluginSpec.getProperties(), artifact,
+                       spec.getSchema())));
+    return new ConnectorDetail(relatedPlugins);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionTestTask.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionTestTask.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.macro.MacroEvaluator;
+import io.cdap.cdap.api.macro.MacroParserOptions;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.RunnableTaskContext;
+import io.cdap.cdap.api.service.worker.SystemAppTaskContext;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorConfigurer;
+import io.cdap.cdap.datapipeline.connection.DefaultConnectorContext;
+import io.cdap.cdap.etl.api.connector.Connector;
+import io.cdap.cdap.etl.api.connector.ConnectorConfigurer;
+import io.cdap.cdap.etl.api.connector.ConnectorContext;
+import io.cdap.cdap.etl.api.validation.ValidationException;
+import io.cdap.cdap.etl.common.ArtifactSelectorProvider;
+import io.cdap.cdap.etl.common.BasicArguments;
+import io.cdap.cdap.etl.common.DefaultMacroEvaluator;
+import io.cdap.cdap.etl.common.OAuthMacroEvaluator;
+import io.cdap.cdap.etl.common.SecureStoreMacroEvaluator;
+import io.cdap.cdap.etl.proto.connection.Connection;
+import io.cdap.cdap.etl.proto.connection.ConnectionCreationRequest;
+import io.cdap.cdap.etl.proto.connection.PluginInfo;
+import io.cdap.cdap.etl.proto.validation.SimpleFailureCollector;
+import io.cdap.cdap.etl.spec.TrackedPluginSelector;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * {@link RunnableTask} for executing connection creation/test remotely
+ */
+public class RemoteConnectionTestTask extends RemoteConnectionTaskBase {
+
+  private static final Gson GSON = new Gson();
+
+  @Override
+  protected void execute(RunnableTaskContext context, SystemAppTaskContext systemAppContext) throws Exception {
+    //De serialize all requests
+    RemoteConnectionRequest remoteConnectionTestRequest =
+      GSON.fromJson(context.getParam(),
+                    RemoteConnectionRequest.class);
+
+    String namespace = remoteConnectionTestRequest.getNamespace();
+
+    ConnectionCreationRequest connectionCreationRequest =
+      GSON.fromJson(remoteConnectionTestRequest.getRequest(), ConnectionCreationRequest.class);
+
+    ServicePluginConfigurer pluginConfigurer = systemAppContext.createServicePluginConfigurer(namespace);
+    ConnectorConfigurer connectorConfigurer = new DefaultConnectorConfigurer(pluginConfigurer);
+    SimpleFailureCollector failureCollector = new SimpleFailureCollector();
+    ConnectorContext connectorContext = new DefaultConnectorContext(failureCollector, pluginConfigurer);
+    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
+      new ArtifactSelectorProvider().getPluginSelector(connectionCreationRequest.getPlugin().getArtifact()));
+    try (Connector connector = getConnector(systemAppContext, pluginConfigurer, connectionCreationRequest.getPlugin(),
+                                            namespace, pluginSelector)) {
+      connector.configure(connectorConfigurer);
+      try {
+        connector.test(connectorContext);
+        failureCollector.getOrThrowException();
+      } catch (ValidationException e) {
+        context.writeResult(GSON.toJson(e.getFailures()).getBytes(StandardCharsets.UTF_8));
+        return;
+      }
+    }
+  }
+}

--- a/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/worker/SystemAppTaskContext.java
+++ b/cdap-system-app-api/src/main/java/io/cdap/cdap/api/service/worker/SystemAppTaskContext.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.api.service.http.ServicePluginConfigurer;
 
 import java.io.IOException;
 import java.util.Map;
@@ -50,6 +51,13 @@ public interface SystemAppTaskContext extends ServiceDiscoverer, SecureStore, Au
    * @return a dynamic plugin configurer that must be closed
    */
   PluginConfigurer createPluginConfigurer(String namespace) throws IOException;
+
+  /**
+   * Create a {@link ServicePluginConfigurer} that can be used to instantiate plugins with macro evaluation
+   * @param namespace the namespace for user scoped plugins.
+   * @return a plugin configurer specifically for service.
+   */
+  ServicePluginConfigurer createServicePluginConfigurer(String namespace);
 
   /**
    * Evaluates macros using provided macro evaluator with the provided parsing options.


### PR DESCRIPTION
Why:
Connection requests (e.g. /test /browse /sample etc) runs a plugin which
execute user provided code. Allow them to run in seperate worker pods
for better security.