### PR TITLE
[CDAP-18789] Add artifact cache service

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/AbstractArtifactLocalizer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/AbstractArtifactLocalizer.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.worker.sidecar;
+
+import com.google.common.io.CharStreams;
+import com.google.common.net.HttpHeaders;
+import io.cdap.cdap.api.artifact.ArtifactScope;
+import io.cdap.cdap.api.retry.RetryableException;
+import io.cdap.cdap.common.ArtifactNotFoundException;
+import io.cdap.cdap.common.ServiceUnavailableException;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.service.RetryStrategy;
+import io.cdap.cdap.common.utils.DirUtils;
+import io.cdap.cdap.common.utils.FileUtils;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.common.http.HttpMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Base class for Artifact Localizer and Artifact Cache.
+ * Provides functionality to fetch and cache artifacts from a remote endpoint.
+ */
+public abstract class AbstractArtifactLocalizer {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractArtifactLocalizer.class);
+
+  protected final String dataDir;
+  protected final RetryStrategy retryStrategy;
+
+  protected AbstractArtifactLocalizer(String dataDir, RetryStrategy retryStrategy) {
+    this.dataDir = dataDir;
+    this.retryStrategy = retryStrategy;
+  }
+
+  /**
+   * fetchArtifact attempts to connect to app fabric to download the given artifact. This method will throw
+   * {@link RetryableException} in certain circumstances.
+   *
+   * @param artifactId The ArtifactId of the artifact to fetch
+   * @param remoteClient The remote client used to connect to appfabric on the peer
+   * @param artifactDir The directory where the artifact will be stored
+   * @return The Local Location for this artifact
+   * @throws IOException If an unexpected error occurs while writing the artifact to the filesystem
+   * @throws ArtifactNotFoundException If the given artifact does not exist
+   */
+  protected File fetchArtifact(ArtifactId artifactId, RemoteClient remoteClient, File artifactDir)
+    throws IOException, ArtifactNotFoundException {
+    Long lastModifiedTimestamp = getCurrentLastModifiedTimestamp(artifactDir);
+    HttpURLConnection urlConn = openConnection(artifactId, remoteClient);
+
+    try {
+      if (lastModifiedTimestamp != null) {
+        LOG.debug("Found existing local version for {} with timestamp {}", artifactId, lastModifiedTimestamp);
+
+        ZonedDateTime lastModifiedDate = ZonedDateTime
+          .ofInstant(Instant.ofEpochMilli(lastModifiedTimestamp), ZoneId.of("GMT"));
+        urlConn.setRequestProperty(HttpHeaders.IF_MODIFIED_SINCE, lastModifiedDate.format(
+          DateTimeFormatter.RFC_1123_DATE_TIME));
+      }
+
+      // If we get this response that means we already have the most up to date artifact
+      if (lastModifiedTimestamp != null && urlConn.getResponseCode() == HttpURLConnection.HTTP_NOT_MODIFIED) {
+        LOG.debug("Call to app fabric returned NOT_MODIFIED for {} with lastModifiedTimestamp of {}", artifactId,
+                  lastModifiedTimestamp);
+        File artifactJarLocation = getArtifactJarLocation(artifactDir, lastModifiedTimestamp);
+        if (!artifactJarLocation.exists()) {
+          throw new RetryableException(String.format("Locally cached artifact jar for %s is missing.",
+                                                     artifactId));
+        }
+        return artifactJarLocation;
+      }
+
+      throwIfError(urlConn, artifactId);
+
+      ZonedDateTime newModifiedDate = getLastModifiedHeader(urlConn);
+      long newTimestamp = newModifiedDate.toInstant().toEpochMilli();
+      File newLocation = getArtifactJarLocation(artifactDir, newTimestamp);
+      DirUtils.mkdirs(newLocation.getParentFile());
+
+      // Download the artifact to a temporary file then atomically rename it to the final name to
+      // avoid race conditions with multiple threads.
+      Path tempFile = Files.createTempFile(newLocation.getParentFile().toPath(),
+                                           String.valueOf(newTimestamp), ".jar");
+      return downloadArtifact(urlConn, newLocation.toPath(), tempFile);
+    } finally {
+      urlConn.disconnect();
+    }
+  }
+
+  /**
+   * Returns a {@link File} representing the cached jar for the given artifact and timestamp. The file path is:
+   * /<artifact_dir>/<last-modified-timestamp>.jar
+   */
+  private File getArtifactJarLocation(File artifactDir, long lastModifiedTimestamp) {
+    return artifactDir.toPath().resolve(String.format("%d.jar", lastModifiedTimestamp)).toFile();
+  }
+
+  /**
+   * Opens a connection to appfabric to fetch an artifact.
+   *
+   * @param artifactId the ArtifactId of the artifact to fetch
+   * @param remoteClient the remote client used to fetch the artifact
+   * @return the HttpURLConnection
+   * @throws IOException if there was an unexpected error
+   */
+  private HttpURLConnection openConnection(ArtifactId artifactId, RemoteClient remoteClient) throws IOException {
+    String namespaceId = artifactId.getNamespace();
+    ArtifactScope scope = ArtifactScope.USER;
+    // Cant use 'system' as the namespace in the request because that generates an error, the namespace doesnt matter
+    // as long as it exists. Using default because it will always be there
+    if (ArtifactScope.SYSTEM.toString().equalsIgnoreCase(namespaceId)) {
+      namespaceId = NamespaceId.DEFAULT.getEntityName();
+      scope = ArtifactScope.SYSTEM;
+    }
+    String url = String.format("namespaces/%s/artifacts/%s/versions/%s/download?scope=%s",
+                               namespaceId,
+                               artifactId.getArtifact(),
+                               artifactId.getVersion(),
+                               scope);
+    return remoteClient.openConnection(HttpMethod.GET, url);
+  }
+
+  /**
+   * Downloads an artifact using the provided {@link HttpURLConnection} and returns the location of the downloaded
+   * artifact.
+   *
+   * @param urlConn the HttpURLConnection
+   * @param destination the path where the artifact should be downloaded to
+   * @param tempFile the path to temporary file used during artifact download
+   * @return the location of the downloaded artifact
+   * @throws IOException if there was an unexpected error
+   */
+  private File downloadArtifact(HttpURLConnection urlConn, Path destination, Path tempFile) throws IOException {
+    try (InputStream in = urlConn.getInputStream()) {
+      Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
+      Files.move(tempFile, destination, StandardCopyOption.ATOMIC_MOVE,
+                 StandardCopyOption.REPLACE_EXISTING);
+    } finally {
+      Files.deleteIfExists(tempFile);
+    }
+    return destination.toFile();
+  }
+
+  /**
+   * This checks the local cache for this artifact and retrieves the timestamp for the newest cache entry, if this
+   * artifact is not cached it returns null
+   * @param artifactDir the directory containing artifacts
+   * @return timestamp of the newest cache entry if it exists, null otherwise
+   */
+  @Nullable
+  private Long getCurrentLastModifiedTimestamp(File artifactDir) {
+    // Check if we have cached jars in the artifact directory, if so return the latest modified timestamp.
+    return DirUtils.listFiles(artifactDir, File::isFile).stream()
+      .map(File::getName)
+      .map(FileUtils::getNameWithoutExtension)
+      .map(Long::valueOf)
+      .max(Long::compare)
+      .orElse(null);
+  }
+
+  /**
+   * Helper function for verifying, extracting and converting the Last-Modified header from the URL connection.
+   */
+  private ZonedDateTime getLastModifiedHeader(HttpURLConnection urlConn) {
+    Map<String, List<String>> headers = urlConn.getHeaderFields();
+    ZonedDateTime lastModified = headers.entrySet().stream()
+      .filter(headerEntry -> HttpHeaders.LAST_MODIFIED.equalsIgnoreCase(headerEntry.getKey()))
+      .map(Map.Entry::getValue)
+      .flatMap(Collection::stream)
+      .findFirst()
+      .map(s -> ZonedDateTime.parse(s, DateTimeFormatter.RFC_1123_DATE_TIME))
+      .orElse(null);
+
+    if (lastModified == null) {
+      // This should never happen since this endpoint should always set the header.
+      // If it does happen we should retry.
+      throw new RetryableException(String.format("The response from %s did not contain the %s header.",
+                                                 urlConn.getURL(), HttpHeaders.LAST_MODIFIED));
+    }
+
+    return lastModified;
+  }
+
+  /**
+   * Helper method for catching and throwing any errors that might have occurred when attempting to connect.
+   */
+  private void throwIfError(HttpURLConnection urlConn, ArtifactId artifactId)
+    throws IOException, ArtifactNotFoundException {
+    int responseCode = urlConn.getResponseCode();
+    if (responseCode == HttpURLConnection.HTTP_OK) {
+      return;
+    }
+
+    try (Reader reader = new InputStreamReader(urlConn.getErrorStream(), StandardCharsets.UTF_8)) {
+      String errMsg = CharStreams.toString(reader);
+      switch (responseCode) {
+        case HttpURLConnection.HTTP_NOT_FOUND:
+          throw new ArtifactNotFoundException(artifactId);
+        case HttpURLConnection.HTTP_UNAVAILABLE:
+          throw new ServiceUnavailableException(Constants.Service.APP_FABRIC_HTTP, errMsg);
+      }
+      throw new IOException(
+        String.format("Failed to fetch artifact %s from app-fabric due to %s", artifactId, errMsg));
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizer.java
@@ -14,16 +14,11 @@
 
 package io.cdap.cdap.internal.app.worker.sidecar;
 
-import com.google.common.io.CharStreams;
-import com.google.common.net.HttpHeaders;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.api.artifact.ArtifactInfo;
 import io.cdap.cdap.api.artifact.ArtifactManager;
-import io.cdap.cdap.api.artifact.ArtifactScope;
-import io.cdap.cdap.api.retry.RetryableException;
 import io.cdap.cdap.common.ArtifactNotFoundException;
-import io.cdap.cdap.common.ServiceUnavailableException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
@@ -32,35 +27,20 @@ import io.cdap.cdap.common.lang.jar.BundleJarUtil;
 import io.cdap.cdap.common.lang.jar.ClassLoaderFolder;
 import io.cdap.cdap.common.service.Retries;
 import io.cdap.cdap.common.service.RetryStrategies;
-import io.cdap.cdap.common.service.RetryStrategy;
 import io.cdap.cdap.common.utils.DirUtils;
-import io.cdap.cdap.common.utils.FileUtils;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactManagerFactory;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.common.http.HttpMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 
 /**
  * ArtifactLocalizer is responsible for fetching, caching and unpacking artifacts requested by the worker pod. The HTTP
@@ -92,36 +72,33 @@ import javax.annotation.Nullable;
  * NOTE: There is no need to invalidate the cache at any point since we will always need to call appfabric to confirm
  * that the cached version is the newest version available.
  */
-public class ArtifactLocalizer {
+public class ArtifactLocalizer extends AbstractArtifactLocalizer {
 
   private static final Logger LOG = LoggerFactory.getLogger(ArtifactLocalizer.class);
 
   private final CConfiguration cConf;
   private final ArtifactManagerFactory artifactManagerFactory;
   private final RemoteClient remoteClient;
-  private final RetryStrategy retryStrategy;
-  private final String dataDir;
 
   @Inject
   public ArtifactLocalizer(CConfiguration cConf, RemoteClientFactory remoteClientFactory,
                            ArtifactManagerFactory artifactManagerFactory) {
+    super(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
+          RetryStrategies.fromConfiguration(cConf, Constants.Service.TASK_WORKER + "."));
     this.cConf = cConf;
     this.artifactManagerFactory = artifactManagerFactory;
-  // TODO (CDAP-18047) verify SSL cert should be enabled.
+    // TODO (CDAP-18047) verify SSL cert should be enabled.
     this.remoteClient = remoteClientFactory.createRemoteClient(Constants.Service.APP_FABRIC_HTTP,
                                                                RemoteClientFactory.NO_VERIFY_HTTP_REQUEST_CONFIG,
                                                                Constants.Gateway.INTERNAL_API_VERSION_3);
-    this.retryStrategy = RetryStrategies.fromConfiguration(cConf, Constants.Service.TASK_WORKER + ".");
-    this.dataDir = cConf.get(Constants.CFG_LOCAL_DATA_DIR);
   }
 
   /**
-   * Gets the location on the local filesystem for the given artifact. This method handles fetching the artifact as well
-   * as caching it.
+   * Gets the location on the local filesystem for the given artifact. This method handles fetching the artifact as
+   * well as caching it.
    *
    * @param artifactId The ArtifactId of the artifact to fetch
    * @return The Local Location for this artifact
-   * @throws ArtifactNotFoundException if the given artifact does not exist
    * @throws IOException if there was an exception while fetching or caching the artifact
    * @throws Exception if there was an unexpected error
    */
@@ -158,7 +135,7 @@ public class ArtifactLocalizer {
     // It is guarantee that the jarLocation is a file, not a directory, as this is the class who cache unpacked
     // artifact.
     try (ClassLoaderFolder classLoaderFolder = BundleJarUtil.prepareClassLoaderFolder(
-        jarLocation, () -> DirUtils.createTempDir(unpackDir.getParentFile()))) {
+      jarLocation, () -> DirUtils.createTempDir(unpackDir.getParentFile()))) {
 
       Files.move(classLoaderFolder.getDir().toPath(), unpackDir.toPath(), StandardCopyOption.ATOMIC_MOVE,
                  StandardCopyOption.REPLACE_EXISTING);
@@ -167,137 +144,17 @@ public class ArtifactLocalizer {
   }
 
   /**
-   * fetchArtifact attempts to connect to app fabric to download the given artifact. This method will throw {@link
-   * RetryableException} in certain circumstances so using this with the
+   * fetchArtifact attempts to connect to app fabric to download the given artifact. This method will throw
+   * {@linkRetryableException} in certain circumstances.
    *
-   * @param artifactId the id of the artifact to fetch
-   * @return a File pointing to the locally cached jar of the newest version
+   * @param artifactId The ArtifactId of the artifact to fetch
+   * @return The Local Location for this artifact
    * @throws IOException If an unexpected error occurs while writing the artifact to the filesystem
    * @throws ArtifactNotFoundException If the given artifact does not exist
    */
   public File fetchArtifact(ArtifactId artifactId) throws IOException, ArtifactNotFoundException {
-    Long lastModifiedTimestamp = getCurrentLastModifiedTimestamp(artifactId);
-    String namespaceId = artifactId.getNamespace();
-    ArtifactScope scope = ArtifactScope.USER;
-    // Cant use 'system' as the namespace in the request because that generates an error, the namespace doesnt matter
-    // as long as it exists. Using default because it will always be there
-    if (ArtifactScope.SYSTEM.toString().equalsIgnoreCase(namespaceId)) {
-      namespaceId = NamespaceId.DEFAULT.getEntityName();
-      scope = ArtifactScope.SYSTEM;
-    }
-
-    String url = String.format("namespaces/%s/artifacts/%s/versions/%s/download?scope=%s",
-                               namespaceId,
-                               artifactId.getArtifact(),
-                               artifactId.getVersion(),
-                               scope);
-
-    HttpURLConnection urlConn = remoteClient.openConnection(HttpMethod.GET, url);
-    try {
-      if (lastModifiedTimestamp != null) {
-        LOG.debug("Found existing local version for {} with timestamp {}", artifactId, lastModifiedTimestamp);
-
-        ZonedDateTime lastModifiedDate = ZonedDateTime
-          .ofInstant(Instant.ofEpochMilli(lastModifiedTimestamp), ZoneId.of("GMT"));
-        urlConn.setRequestProperty(HttpHeaders.IF_MODIFIED_SINCE, lastModifiedDate.format(
-          DateTimeFormatter.RFC_1123_DATE_TIME));
-      }
-
-      // If we get this response that means we already have the most up to date artifact
-      if (lastModifiedTimestamp != null && urlConn.getResponseCode() == HttpURLConnection.HTTP_NOT_MODIFIED) {
-        LOG.debug("Call to app fabric returned NOT_MODIFIED for {} with lastModifiedTimestamp of {}", artifactId,
-                  lastModifiedTimestamp);
-        File artifactJarLocation = getArtifactJarLocation(artifactId, lastModifiedTimestamp);
-        if (!artifactJarLocation.exists()) {
-          throw new RetryableException(String.format("Locally cached artifact jar for %s is missing.",
-                                                     artifactId));
-        }
-        return artifactJarLocation;
-      }
-
-      throwIfError(urlConn, artifactId);
-
-      ZonedDateTime newModifiedDate = getLastModifiedHeader(urlConn);
-      long newTimestamp = newModifiedDate.toInstant().toEpochMilli();
-      File newLocation = getArtifactJarLocation(artifactId, newTimestamp);
-      DirUtils.mkdirs(newLocation.getParentFile());
-
-      // Download the artifact to a temporary file then atomically rename it to the final name to
-      // avoid race conditions with multiple threads.
-      Path tempFile = Files.createTempFile(newLocation.getParentFile().toPath(), String.valueOf(newTimestamp), ".jar");
-      try (InputStream in = urlConn.getInputStream()) {
-        Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
-        Files.move(tempFile, newLocation.toPath(), StandardCopyOption.ATOMIC_MOVE,
-                   StandardCopyOption.REPLACE_EXISTING);
-      } finally {
-        Files.deleteIfExists(tempFile);
-      }
-
-      return newLocation;
-    } finally {
-      urlConn.disconnect();
-    }
-  }
-
-  /**
-   * This checks the local cache for this artifact and retrieves the timestamp for the newest cache entry, if this
-   * artifact is not cached it returns null
-   */
-  @Nullable
-  private Long getCurrentLastModifiedTimestamp(ArtifactId artifactId) {
     File artifactDir = getArtifactDirLocation(artifactId);
-
-    // Check if we have cached jars in the artifact directory, if so return the latest modified timestamp.
-    return DirUtils.listFiles(artifactDir, File::isFile).stream()
-      .map(File::getName)
-      .map(FileUtils::getNameWithoutExtension)
-      .map(Long::valueOf)
-      .max(Long::compare)
-      .orElse(null);
-  }
-
-  /**
-   * Helper function for verifying, extracting and converting the Last-Modified header from the URL connection.
-   */
-  private ZonedDateTime getLastModifiedHeader(HttpURLConnection urlConn) {
-    Map<String, List<String>> headers = urlConn.getHeaderFields();
-    ZonedDateTime lastModified = headers.entrySet().stream()
-      .filter(headerEntry -> HttpHeaders.LAST_MODIFIED.equalsIgnoreCase(headerEntry.getKey()))
-      .map(Map.Entry::getValue)
-      .flatMap(Collection::stream)
-      .findFirst()
-      .map(s -> ZonedDateTime.parse(s, DateTimeFormatter.RFC_1123_DATE_TIME))
-      .orElse(null);
-
-    if (lastModified == null) {
-      // This should never happen since this endpoint should always set the header.
-      // If it does happen we should retry.
-      throw new RetryableException(String.format("The response from %s did not contain the %s header.",
-                                                 urlConn.getURL(), HttpHeaders.LAST_MODIFIED));
-    }
-
-    return lastModified;
-  }
-
-  /**
-   * Helper method for catching and throwing any errors that might have occurred when attempting to connect.
-   */
-  private void throwIfError(HttpURLConnection urlConn, ArtifactId artifactId)
-    throws IOException, ArtifactNotFoundException {
-    int responseCode = urlConn.getResponseCode();
-    if (responseCode == HttpURLConnection.HTTP_OK) {
-      return;
-    }
-
-    String errMsg = CharStreams.toString(new InputStreamReader(urlConn.getErrorStream(), StandardCharsets.UTF_8));
-    switch (responseCode) {
-      case HttpURLConnection.HTTP_NOT_FOUND:
-        throw new ArtifactNotFoundException(artifactId);
-      case HttpURLConnection.HTTP_UNAVAILABLE:
-        throw new ServiceUnavailableException(Constants.Service.APP_FABRIC_HTTP, errMsg);
-    }
-    throw new IOException(
-      String.format("Failed to fetch artifact %s from app-fabric due to %s", artifactId, errMsg));
+    return fetchArtifact(artifactId, remoteClient, artifactDir);
   }
 
   private Path getLocalPath(String dirName, ArtifactId artifactId) {
@@ -311,14 +168,6 @@ public class ArtifactLocalizer {
    */
   private File getArtifactDirLocation(ArtifactId artifactId) {
     return getLocalPath("artifacts", artifactId).toFile();
-  }
-
-  /**
-   * Returns a {@link File} representing the cached jar for the given artifact and timestamp. The file path is:
-   * /DATA_DIRECTORY/artifacts/<namespace>/<artifact-name>/<artifact-version>/<last-modified-timestamp>.jar
-   */
-  private File getArtifactJarLocation(ArtifactId artifactId, long lastModifiedTimestamp) {
-    return getLocalPath("artifacts", artifactId).resolve(String.format("%d.jar", lastModifiedTimestamp)).toFile();
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerCleaner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerCleaner.java
@@ -14,8 +14,6 @@
 
 package io.cdap.cdap.internal.app.worker.sidecar;
 
-import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.common.utils.FileUtils;
 import org.slf4j.Logger;
@@ -39,15 +37,15 @@ public class ArtifactLocalizerCleaner implements Runnable {
   private final Path cacheDir;
   private final int cacheCleanupInterval;
 
-  public ArtifactLocalizerCleaner(CConfiguration cConf) {
-    cacheDir = Paths.get(cConf.get(Constants.CFG_LOCAL_DATA_DIR));
-    cacheCleanupInterval = cConf.getInt(Constants.ArtifactLocalizer.CACHE_CLEANUP_INTERVAL_MIN);
+  public ArtifactLocalizerCleaner(Path cacheDir, int cacheCleanupInterval) {
+    this.cacheDir = cacheDir;
+    this.cacheCleanupInterval = cacheCleanupInterval;
   }
 
   @Override
   public void run() {
     try {
-      cleanupArtifactCache(cacheDir.resolve("artifacts").toFile());
+      cleanupArtifactCache(cacheDir.toFile());
     } catch (Exception e) {
       LOG.warn("ArtifactLocalizerService failed to clean up cache. Will retry again in {} minutes: {}",
                cacheCleanupInterval, e);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerService.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -61,7 +62,8 @@ public class ArtifactLocalizerService extends AbstractIdleService {
       .build();
 
     this.cacheCleanupInterval = cConf.getInt(Constants.ArtifactLocalizer.CACHE_CLEANUP_INTERVAL_MIN);
-    this.cleaner = new ArtifactLocalizerCleaner(cConf);
+    String cacheDir = cConf.get(Constants.CFG_LOCAL_DATA_DIR);
+    this.cleaner = new ArtifactLocalizerCleaner(Paths.get(cacheDir).resolve("artifacts"), cacheCleanupInterval);
   }
 
   @Override
@@ -69,7 +71,7 @@ public class ArtifactLocalizerService extends AbstractIdleService {
     LOG.debug("Starting ArtifactLocalizerService");
     httpService.start();
     scheduledExecutorService = Executors
-      .newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("artifact-cache-cleaner"));
+      .newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("artifact-localizer-cleaner"));
     scheduledExecutorService.scheduleAtFixedRate(cleaner, cacheCleanupInterval, cacheCleanupInterval, TimeUnit.MINUTES);
 
     artifactLocalizer.preloadArtifacts(

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/ArtifactCache.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/ArtifactCache.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteAuthenticator;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.service.Retries;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.internal.app.worker.sidecar.AbstractArtifactLocalizer;
+import io.cdap.cdap.proto.id.ArtifactId;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+/**
+ * ArtifactCache is responsible for fetching and caching artifacts from tethered peers. The HTTP
+ * endpoints are defined in {@link ArtifactCacheHttpHandlerInternal}.
+ *
+ * Artifacts will be cached using the following file structure:
+ * /DATA_DIRECTORY/peers/<peer-name>/artifacts/<namespace>/<artifact-name>/<artifact-version>/
+ * <last-modified-timestamp>.jar
+ *
+ */
+public class ArtifactCache extends AbstractArtifactLocalizer {
+  @Inject
+  ArtifactCache(CConfiguration cConf) throws InstantiationException, IllegalAccessException {
+    super(cConf.get(Constants.ArtifactCache.LOCAL_DATA_DIR),
+          RetryStrategies.fromConfiguration(cConf, Constants.Service.ARTIFACT_CACHE + "."));
+    Class<? extends RemoteAuthenticator> authClass = cConf.getClass(Constants.Tethering.CLIENT_AUTHENTICATOR_CLASS,
+                                                                    null,
+                                                                    RemoteAuthenticator.class);
+    if (authClass != null) {
+      RemoteAuthenticator authenticator = authClass.newInstance();
+      RemoteAuthenticator.setDefaultAuthenticator(authenticator);
+    }
+  }
+
+  /**
+   * Gets the location on the local filesystem for the given artifact. This method handles fetching the artifact as
+   * well as caching it.
+   *
+   * @param artifactId The ArtifactId of the artifact to fetch
+   * @param peer The name of the tethered peer
+   * @param remoteClient The remote client used to connect to appfabric on the peer
+   * @return The Local Location for this artifact
+   * @throws IOException if there was an exception while fetching or caching the artifact
+   * @throws Exception if there was an unexpected error
+   */
+  public File getArtifact(ArtifactId artifactId, String peer, RemoteClient remoteClient) throws Exception {
+    File artifactDir = getArtifactDirLocation(artifactId, peer);
+    return Retries.callWithRetries(() -> fetchArtifact(artifactId, remoteClient, artifactDir), retryStrategy);
+  }
+
+  /**
+   * Returns a {@link File} representing the cache directory jars for the given artifact belonging to a tethered peer.
+   * The file path is:
+   * /DATA_DIRECTORY/peers/<peer-name>/</peer-name>artifacts/<namespace>/<artifact-name>/<artifact-version>/
+   */
+  private File getArtifactDirLocation(ArtifactId artifactId, String peerName) {
+    return Paths.get(dataDir, "peers", peerName, "artifacts", artifactId.getNamespace(),
+                     artifactId.getArtifact(), artifactId.getVersion()).toFile();
+
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/ArtifactCacheHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/ArtifactCacheHttpHandlerInternal.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.common.HttpErrorStatusProvider;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.http.LocationBodyProducer;
+import io.cdap.cdap.common.internal.remote.NoOpInternalAuthenticator;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.proto.BasicThrowable;
+import io.cdap.cdap.proto.codec.BasicThrowableCodec;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.common.http.HttpRequestConfig;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.filesystem.Location;
+
+import java.io.File;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+@Path(Constants.Gateway.INTERNAL_API_VERSION_3)
+public class ArtifactCacheHttpHandlerInternal extends AbstractHttpHandler {
+  private static final Gson GSON = new GsonBuilder().registerTypeAdapter(BasicThrowable.class,
+                                                                         new BasicThrowableCodec()).create();
+  private final ArtifactCache cache;
+  private final TetheringStore tetheringStore;
+  public ArtifactCacheHttpHandlerInternal(ArtifactCache cache, TetheringStore tetheringStore) {
+    this.cache = cache;
+    this.tetheringStore = tetheringStore;
+  }
+
+  @GET
+  @Path("peers/{peer}/namespaces/{namespace-id}/artifacts/{artifact-name}/versions/{artifact-version}")
+  public void fetchArtifact(HttpRequest request, HttpResponder responder,
+                            @PathParam("peer") String peer,
+                            @PathParam("namespace-id") String namespaceId,
+                            @PathParam("artifact-name") String artifactName,
+                            @PathParam("artifact-version") String artifactVersion) throws Exception {
+    ArtifactId artifactId = new ArtifactId(namespaceId, artifactName, artifactVersion);
+    try {
+      String endpoint = tetheringStore.getPeer(peer).getEndpoint();
+      RemoteClientFactory factory = new RemoteClientFactory(new NoOpDiscoveryServiceClient(endpoint),
+                                                            new NoOpInternalAuthenticator());
+      HttpRequestConfig config = new DefaultHttpRequestConfig(true);
+      RemoteClient remoteClient = factory.createRemoteClient("", config,
+                                                             Constants.Gateway.INTERNAL_API_VERSION_3);
+
+      File artifactPath = cache.getArtifact(artifactId, peer, remoteClient);
+      Location artifactLocation = Locations.toLocation(artifactPath);
+        responder.sendContent(HttpResponseStatus.OK, new LocationBodyProducer(artifactLocation),
+                            new DefaultHttpHeaders().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM));
+    } catch (Exception ex) {
+      if (ex instanceof HttpErrorStatusProvider) {
+        HttpResponseStatus status = HttpResponseStatus.valueOf(((HttpErrorStatusProvider) ex).getStatusCode());
+        responder.sendString(status, exceptionToJson(ex));
+      } else {
+        responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, exceptionToJson(ex));
+      }
+    }
+  }
+
+  /**
+   * Return json representation of an exception.
+   * Used to propagate exception across network for better surfacing errors and debuggability.
+   */
+  private String exceptionToJson(Exception ex) {
+    BasicThrowable basicThrowable = new BasicThrowable(ex);
+    return GSON.toJson(basicThrowable);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/ArtifactCacheService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/ArtifactCacheService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
+import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerCleaner;
+import io.cdap.http.NettyHttpService;
+import org.apache.twill.common.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Paths;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Launches an HTTP server for fetching and cache artifacts from remote CDAP instances.
+ * Artifacts belonging to each peer are cached using the following file structure:
+ * /DATA_DIRECTORY/peers/<peer-name>/</peer>artifacts/<namespace>/<artifact-name>/<artifact-version>/
+ * <last-modified-timestamp>.jar
+ */
+public class ArtifactCacheService extends AbstractIdleService {
+  private static final Logger LOG = LoggerFactory.getLogger(ArtifactCacheService.class);
+
+  private final NettyHttpService httpService;
+  private final ArtifactLocalizerCleaner cleaner;
+  private final int cacheCleanupInterval;
+  private ScheduledExecutorService scheduledExecutorService;
+
+  @Inject
+  public ArtifactCacheService(CConfiguration cConf, ArtifactCache cache, TetheringStore store) {
+    httpService = new CommonNettyHttpServiceBuilder(cConf, "artifact.cache")
+      .setHttpHandlers(new ArtifactCacheHttpHandlerInternal(cache, store))
+      .setHost(cConf.get(Constants.ArtifactCache.ADDRESS))
+      .setPort(cConf.getInt(Constants.ArtifactCache.PORT))
+      .setBossThreadPoolSize(cConf.getInt(Constants.ArtifactCache.BOSS_THREADS))
+      .setWorkerThreadPoolSize(cConf.getInt(Constants.ArtifactCache.WORKER_THREADS))
+      .build();
+    cacheCleanupInterval = cConf.getInt(Constants.ArtifactCache.CACHE_CLEANUP_INTERVAL_MIN);
+    String cacheDir = cConf.get(Constants.ArtifactCache.LOCAL_DATA_DIR);
+    cleaner = new ArtifactLocalizerCleaner(Paths.get(cacheDir).resolve("peers"), cacheCleanupInterval);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.info("Starting ArtifactCacheService");
+    httpService.start();
+    scheduledExecutorService = Executors
+      .newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("artifact-cache-cleaner"));
+    scheduledExecutorService.scheduleAtFixedRate(cleaner, cacheCleanupInterval, cacheCleanupInterval, TimeUnit.MINUTES);
+    LOG.info("ArtifactCacheService started");
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.info("Stopping ArtifactCacheService");
+    httpService.stop(1, 2, TimeUnit.SECONDS);
+    scheduledExecutorService.shutdownNow();
+    LOG.info("ArtifactCacheService stopped");
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/NoOpDiscoveryServiceClient.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/NoOpDiscoveryServiceClient.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import io.cdap.cdap.master.spi.discovery.DefaultServiceDiscovered;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.discovery.ServiceDiscovered;
+
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+
+/**
+ * A DiscoveryServiceClient implementation that will always return the same url.
+ */
+public class NoOpDiscoveryServiceClient implements DiscoveryServiceClient {
+  private URL url;
+
+  public NoOpDiscoveryServiceClient(String url) throws MalformedURLException {
+    this.url = new URL(url);
+  }
+  @Override
+  public ServiceDiscovered discover(String name) {
+    DefaultServiceDiscovered serviceDiscovered = new DefaultServiceDiscovered(name);
+    Discoverable discoverable = new Discoverable(name, InetSocketAddress.createUnresolved(url.getHost(),
+                                                                                          url.getPort()));
+    serviceDiscovered.setDiscoverables(Collections.singleton(discoverable));
+    return serviceDiscovered;
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/ArtifactCacheServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/ArtifactCacheServiceTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.common.test.AppJarHelper;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.worker.TaskWorkerServiceTest;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import org.apache.commons.io.IOUtils;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collections;
+
+/**
+ * Test for Artifact Cache service.
+ */
+public class ArtifactCacheServiceTest extends AppFabricTestBase {
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+  private static final String PEER_NAME = "peer";
+
+  private CConfiguration cConf;
+  private TetheringStore tetheringStore;
+  private ArtifactCacheService artifactCacheService;
+  private ArtifactRepository artifactRepository;
+  private Id.Artifact artifactId;
+  private Location appJar;
+
+  private CConfiguration createCConf() throws IOException {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.ArtifactCache.ADDRESS, InetAddress.getLoopbackAddress().getHostName());
+    cConf.setInt(Constants.ArtifactCache.PORT, 11030);
+    cConf.set(Constants.ArtifactCache.LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+    return cConf;
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    cConf = createCConf();
+    tetheringStore = getInjector().getInstance(TetheringStore.class);
+    ArtifactCache artifactCache = new ArtifactCache(cConf);
+    artifactCacheService = new ArtifactCacheService(cConf, artifactCache, tetheringStore);
+    artifactCacheService.startAndWait();
+    getInjector().getInstance(ArtifactRepository.class).clear(NamespaceId.DEFAULT);
+    Id.Artifact.from(Id.Namespace.DEFAULT, "some-task", "1.0.0-SNAPSHOT");
+    LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);
+    appJar = AppJarHelper.createDeploymentJar(locationFactory, TaskWorkerServiceTest.TestRunnableClass.class);
+    artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "some-task", "1.0.0-SNAPSHOT");
+    File appJarFile = new File(tmpFolder.newFolder(),
+                               String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
+    Locations.linkOrCopy(appJar, appJarFile);
+    artifactRepository = getInjector().getInstance(ArtifactRepository.class);
+    artifactRepository.addArtifact(artifactId, appJarFile);
+    addPeer();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    artifactCacheService.stopAndWait();
+    artifactRepository.deleteArtifact(artifactId);
+    appJar.delete();
+    deletePeer();
+  }
+
+  private byte[] getArtifactBytes(String peerName) throws IOException, URISyntaxException {
+
+    URL url = getURL(peerName);
+    HttpRequest httpRequest = HttpRequest.builder(HttpMethod.GET, url).build();
+    HttpResponse httpResponse = HttpRequests.execute(httpRequest);
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, httpResponse.getResponseCode());
+    return httpResponse.getResponseBody();
+  }
+
+  private URL getURL(String peerName) throws URISyntaxException, MalformedURLException {
+    return getURL(peerName, artifactId);
+  }
+
+  private URL getURL(String peerName, Id.Artifact artifactId) throws URISyntaxException, MalformedURLException {
+    String urlPath = String.format("/peers/%s/namespaces/%s/artifacts/%s/versions/%s",
+                                   peerName, artifactId.toEntityId().getNamespace(),
+                                   artifactId.toEntityId().getArtifact(),
+                                   artifactId.toEntityId().getVersion());
+
+    return new URI(String.format("http://%s:%d/v3Internal/%s",
+                                 cConf.get(Constants.ArtifactCache.ADDRESS),
+                                 cConf.getInt(Constants.ArtifactCache.PORT),
+                                 urlPath)).toURL();
+  }
+
+  private void addPeer() throws PeerAlreadyExistsException, IOException {
+    NamespaceAllocation namespaceAllocation = new NamespaceAllocation("default", null,
+                                                                      null);
+    PeerMetadata peerMetadata = new PeerMetadata(Collections.singletonList(namespaceAllocation),
+                                                 Collections.emptyMap(), null);
+    PeerInfo peerInfo = new PeerInfo(PEER_NAME, getEndPoint("").toString(),
+                                     TetheringStatus.ACCEPTED, peerMetadata, System.currentTimeMillis());
+    tetheringStore.addPeer(peerInfo);
+  }
+
+  private void deletePeer() throws PeerNotFoundException, IOException {
+    tetheringStore.deletePeer(PEER_NAME);
+  }
+
+  @Test
+  public void testFetchArtifact() throws Exception {
+    byte[] artifact = getArtifactBytes(PEER_NAME);
+    byte[] expectedBytes = IOUtils.toByteArray(appJar.getInputStream());
+    Assert.assertArrayEquals(artifact, expectedBytes);
+  }
+
+  @Test
+  public void testFetchArtifactUnknownPeer() throws Exception {
+    URL url = getURL("unknownpeer");
+    HttpRequest httpRequest = HttpRequest.builder(HttpMethod.GET, url).build();
+    HttpResponse httpResponse = HttpRequests.execute(httpRequest);
+    Assert.assertEquals(HttpURLConnection.HTTP_NOT_FOUND, httpResponse.getResponseCode());
+  }
+
+  @Test
+  public void testArtifactNotFound() throws Exception {
+    Id.Artifact notFoundArtifact = Id.Artifact.from(Id.Namespace.DEFAULT, "other-task", "2.0.0-SNAPSHOT");
+    URL url = getURL(PEER_NAME, notFoundArtifact);
+    HttpRequest httpRequest = HttpRequest.builder(HttpMethod.GET, url).build();
+    HttpResponse httpResponse = HttpRequests.execute(httpRequest);
+    Assert.assertEquals(HttpURLConnection.HTTP_NOT_FOUND, httpResponse.getResponseCode());
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/ArtifactCacheTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/ArtifactCacheTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.internal.remote.NoOpInternalAuthenticator;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.common.test.AppJarHelper;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.worker.TaskWorkerServiceTest;
+import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerCleaner;
+import io.cdap.common.http.HttpRequestConfig;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+/**
+ * Test for Artifact Cache.
+ */
+public class ArtifactCacheTest extends AppFabricTestBase {
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testArtifactCache() throws Exception {
+    LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);
+    ArtifactRepository artifactRepository = getInjector().getInstance(ArtifactRepository.class);
+
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "some-task", "1.0.0-SNAPSHOT");
+    Location appJar = AppJarHelper.createDeploymentJar(locationFactory, TaskWorkerServiceTest.TestRunnableClass.class);
+    File appJarFile = new File(tmpFolder.newFolder(),
+                               String.format("%s-%s.jar", artifactId.getName(), artifactId.getVersion().getVersion()));
+
+    Locations.linkOrCopy(appJar, appJarFile);
+    artifactRepository.addArtifact(artifactId, appJarFile);
+
+    CConfiguration cConf = CConfiguration.create();
+    String cacheDir = tmpFolder.toString();
+    cConf.set(Constants.ArtifactCache.LOCAL_DATA_DIR, cacheDir);
+    TetheringStore store = getInjector().getInstance(TetheringStore.class);
+    ArtifactCache cache = new ArtifactCache(cConf);
+    // Add a couple of tethered peers
+    addPeer(store, "peer1");
+    addPeer(store, "peer2");
+
+    RemoteClientFactory factory = new RemoteClientFactory(new NoOpDiscoveryServiceClient(getEndPoint("").toString()),
+                                                          new NoOpInternalAuthenticator());
+    HttpRequestConfig config = new DefaultHttpRequestConfig(true);
+    RemoteClient remoteClient = factory.createRemoteClient("", config,
+                                                           Constants.Gateway.INTERNAL_API_VERSION_3);
+    // Get artifact from first peer
+    File peer1ArtifactPath = cache.getArtifact(artifactId.toEntityId(), "peer1", remoteClient);
+    // Get the artifact again. The same path was returned
+    Assert.assertEquals(peer1ArtifactPath, cache.getArtifact(artifactId.toEntityId(), "peer1", remoteClient));
+
+    // Get artifact from another peer. It should be cached in a different path
+    File peer2ArtifactPath = cache.getArtifact(artifactId.toEntityId(), "peer2", remoteClient);
+    Assert.assertNotEquals(peer1ArtifactPath, peer2ArtifactPath);
+
+    // Delete and recreate the artifact to update the last modified date
+    artifactRepository.deleteArtifact(artifactId);
+    // This sleep is needed to delay the file copy so that the lastModified time on the file is different
+    Thread.sleep(1000);
+    artifactRepository.addArtifact(artifactId, appJarFile);
+    // Artifact should be cached in a different path
+    File newPeer1ArtifactPath = cache.getArtifact(artifactId.toEntityId(), "peer1", remoteClient);
+    Assert.assertNotEquals(peer1ArtifactPath, newPeer1ArtifactPath);
+
+    // Run the artifact cleaner
+    ArtifactLocalizerCleaner cleaner = new ArtifactLocalizerCleaner(Paths.get(cacheDir).resolve("peers"), 1);
+    cleaner.run();
+    // Older artifact should been deleted
+    Assert.assertFalse(peer1ArtifactPath.exists());
+    // Latest artifact should still be cached
+    Assert.assertTrue(newPeer1ArtifactPath.exists());
+  }
+
+  private void addPeer(TetheringStore tetheringStore, String peerName) throws PeerAlreadyExistsException, IOException {
+    NamespaceAllocation namespaceAllocation = new NamespaceAllocation("default", null,
+                                                                      null);
+    PeerMetadata peerMetadata = new PeerMetadata(Collections.singletonList(namespaceAllocation),
+                                                 Collections.emptyMap(), null);
+    PeerInfo peerInfo = new PeerInfo(peerName, getEndPoint("").toString(),
+                                     TetheringStatus.ACCEPTED, peerMetadata, System.currentTimeMillis());
+    tetheringStore.addPeer(peerInfo);
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -132,6 +132,7 @@ public final class Constants {
     public static final String TASK_WORKER = "task.worker";
     public static final String ARTIFACT_LOCALIZER = "artifact.localizer";
     public static final String SYSTEM_METRICS_EXPORTER = "system.metrics.exporter";
+    public static final String ARTIFACT_CACHE = "artifact.cache";
 
     public static final String SERVICE_INSTANCE_TABLE_NAME = "cdap.services.instances";
     /** Scheduler queue name to submit the master service app. */
@@ -144,6 +145,7 @@ public final class Constants {
     public static final String SECURE_STORE_SERVICE = "secure.store.service";
     public static final String LOG_BUFFER_SERVICE = "log.buffer.service";
     public static final String REMOTE_AGENT_SERVICE = "remote.agent.service";
+    public static final String ARTIFACT_CACHE_SERVICE = "artifact.cache.service";
   }
 
   /**
@@ -1862,5 +1864,22 @@ public final class Constants {
     public static final int DEFAULT_CONNECTION_TIMEOUT_SECONDS = 60;
 
     public static final String CLIENT_AUTHENTICATOR_CLASS = "tethering.client.authenticator.class";
+  }
+
+  public static final class ArtifactCache {
+
+    /**
+     * Artifact cache service clean up configurations
+     */
+    public static final String CACHE_CLEANUP_INTERVAL_MIN = "artifact.cache.cache.cleanup.interval.min";
+    public static final String LOCAL_DATA_DIR = "artifact.cache.local.data.dir";
+
+    /**
+     * Artifact cache http handler configuration
+     */
+    public static final String ADDRESS = "artifact.cache.bind.address";
+    public static final String PORT = "artifact.cache.bind.port";
+    public static final String BOSS_THREADS = "artifact.cache.boss.threads";
+    public static final String WORKER_THREADS = "artifact.cache.worker.threads";
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3837,6 +3837,51 @@
     </description>
   </property>
 
+  <!-- Retry configuration for artifact cache -->
+  <!-- Use an exponential delay that cap at 2 seconds interval -->
+  <property>
+    <name>artifact.cache.retry.policy.base.delay.ms</name>
+    <value>10</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>artifact.cache.retry.policy.max.delay.ms</name>
+    <value>2000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <!-- Set to Integer max value, so the retry attempts end based on artifact.cache.retry.policy.max.time.secs -->
+  <property>
+    <name>artifact.cache.retry.policy.max.retries</name>
+    <value>2147483647</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <!-- Set to 60s to match the default http request timeout -->
+  <property>
+    <name>artifact.cache.retry.policy.max.time.secs</name>
+    <value>60</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>artifact.cache.retry.policy.type</name>
+    <value>exponential.backoff</value>
+    <description>
+      The type of retry policy for programs. Allowed options:
+      "none", "fixed.delay", or "exponential.backoff".
+    </description>
+  </property>
+
   <!-- Router Configuration -->
 
   <property>
@@ -4927,6 +4972,54 @@
     <value>dataproc.googleapis.com:443</value>
     <description>
       The default Root URL for Dataproc.
+    </description>
+  </property>
+
+  <property>
+    <name>artifact.cache.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      The bind address for artifact service.
+    </description>
+  </property>
+
+  <property>
+    <name>artifact.cache.bind.port</name>
+    <value>0</value>
+    <description>
+      The port to bind the artifact cache service to.
+    </description>
+  </property>
+
+  <property>
+    <name>artifact.cache.worker.threads</name>
+    <value>10</value>
+    <description>
+      The number of worker threads in the artifact cache service.
+    </description>
+  </property>
+
+  <property>
+    <name>artifact.cache.boss.threads</name>
+    <value>1</value>
+    <description>
+      The number of boss threads in the artifact cache service.
+    </description>
+  </property>
+
+  <property>
+    <name>artifact.cache.local.data.dir</name>
+    <value>${local.data.dir}/artifact.cache</value>
+    <description>
+      The local data directory for the artifact cache container.
+    </description>
+  </property>
+
+  <property>
+    <name>artifact.cache.cache.cleanup.interval.min</name>
+    <value>60</value>
+    <description>
+      The interval (in minutes) that the cleanup service will delete old artifact cache files.
     </description>
   </property>
 </configuration>

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/ArtifactCacheServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/ArtifactCacheServiceMain.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import com.google.common.util.concurrent.Service;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.PrivateModule;
+import com.google.inject.Scopes;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.logging.LoggingContext;
+import io.cdap.cdap.common.logging.ServiceLoggingContext;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.internal.tethering.ArtifactCacheService;
+import io.cdap.cdap.master.spi.environment.MasterEnvironment;
+import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
+import io.cdap.cdap.metrics.collect.LocalMetricsCollectionService;
+import io.cdap.cdap.proto.id.NamespaceId;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Main class for running artifact cache service in Kubernetes.
+ */
+public class ArtifactCacheServiceMain extends AbstractServiceMain<EnvironmentOptions> {
+  /**
+   * Main entry point
+   */
+  public static void main(String[] args) throws Exception {
+    main(ArtifactCacheServiceMain.class, args);
+  }
+
+  @Override
+  protected List<Module> getServiceModules(MasterEnvironment masterEnv,
+                                           EnvironmentOptions options, CConfiguration cConf) {
+    return Arrays.asList(
+      new ConfigModule(cConf),
+      new StorageModule(),
+      new PrivateModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(LocalMetricsCollectionService.class).in(Scopes.SINGLETON);
+          expose(MetricsCollectionService.class);
+          bind(ArtifactCacheService.class).in(Scopes.SINGLETON);
+          expose(ArtifactCacheService.class);
+        }
+      });
+  }
+
+  @Override
+  protected void addServices(Injector injector, List<? super Service> services,
+                             List<? super AutoCloseable> closeableResources,
+                             MasterEnvironment masterEnv, MasterEnvironmentContext masterEnvContext,
+                             EnvironmentOptions options) {
+    services.add(injector.getInstance(ArtifactCacheService.class));
+  }
+
+  @Nullable
+  @Override
+  protected LoggingContext getLoggingContext(EnvironmentOptions options) {
+    return new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
+                                     Constants.Logging.COMPONENT_NAME,
+                                     Constants.Service.ARTIFACT_CACHE_SERVICE);
+  }
+}


### PR DESCRIPTION
Add ArtifactCache (and corresponding service ArtifactCacheService) that caches artifacts belonging to tethered cdap instances. It's very similar to ArtifactLocalizer. The main different is that It opens a connection to a remote app fabric (endpoint is fetched from the tethering store) instead of connecting to local appfabric using the remote client.
Artifacts belongin to a tethered peer are cached at `/DATA_DIRECTORY/peers/<peer-name></peer-name>/artifacts/<namespace>/<artifact-name>/<artifact-version>/`