### PR TITLE
[CDAP-18322] Fix 2 issues with internal auth: start tokenmanager sooner er and auth context for program

### DIFF
--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -132,6 +132,11 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
                              List<? super AutoCloseable> closeableResources,
                              MasterEnvironment masterEnv, MasterEnvironmentContext masterEnvContext,
                              EnvironmentOptions options) {
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
+      services.add(injector.getInstance(TokenManager.class));
+    }
+
     closeableResources.add(injector.getInstance(AccessControllerInstantiator.class));
     services.add(injector.getInstance(OperationalStatsService.class));
     services.add(injector.getInstance(SecureStoreService.class));
@@ -152,12 +157,8 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
                                                 RetryStrategies.exponentialDelay(200, 5000, TimeUnit.MILLISECONDS)));
     services.add(injector.getInstance(AppFabricServer.class));
 
-    CConfiguration cConf = injector.getInstance(CConfiguration.class);
     if (cConf.getBoolean(Constants.TaskWorker.POOL_ENABLE)) {
       services.add(injector.getInstance(TaskWorkerServiceLauncher.class));
-    }
-    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
-      services.add(injector.getInstance(TokenManager.class));
     }
 
     // Optionally adds the master environment task

--- a/cdap-security/src/main/java/io/cdap/cdap/security/auth/context/AuthenticationContextModules.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/auth/context/AuthenticationContextModules.java
@@ -115,11 +115,18 @@ public class AuthenticationContextModules {
     return new AbstractModule() {
       @Override
       protected void configure() {
-        String username = getUsername();
-        bind(AuthenticationContext.class)
-          .toInstance(new ProgramContainerAuthenticationContext(new Principal(username,
-                                                                              Principal.PrincipalType.USER,
-                                                                              loadRemoteCredentials(cConf))));
+        Credential remoteCredentials = loadRemoteCredentials(cConf);
+        if (remoteCredentials != null) {
+          String username = getUsername();
+          bind(AuthenticationContext.class)
+            .toInstance(new ProgramContainerAuthenticationContext(new Principal(username,
+                                                                                Principal.PrincipalType.USER,
+                                                                                loadRemoteCredentials(cConf))));
+        } else {
+          bind(new TypeLiteral<Class<? extends AuthenticationContext>>() { })
+            .toInstance(WorkerAuthenticationContext.class);
+          bind(AuthenticationContext.class).toProvider(MasterAuthenticationContextProvider.class);
+        }
         bind(InternalAuthenticator.class).toProvider(InternalAuthenticatorProvider.class);
       }
     };


### PR DESCRIPTION
1. Start TokenManager serivce first in the AppFab startup, since
   other services may depend on it during their startup process
   when internal auth is enabled.
2. Use WorkerAuthenticationContext for program containers