### PR TITLE
Remove the word provisioner from tethering provisioner label

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringProvisioner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringProvisioner.java
@@ -44,7 +44,7 @@ public class TetheringProvisioner implements Provisioner {
 
   public static final String TETHERING_NAME = "tethering";
   private static final ProvisionerSpecification SPEC = new ProvisionerSpecification(
-    TETHERING_NAME, "Tethering Provisioner",
+    TETHERING_NAME, "Tethering",
     "Runs programs on an existing tethered CDAP instance. Does not provision any resources.");
 
   private MessagingService messagingService;


### PR DESCRIPTION
## Issue: [CDAP-18776](https://cdap.atlassian.net/browse/CDAP-18776)

This PR removes the word "Provisioner" from the tethering provisioner label.