### PR TITLE
[🍒  for 6.6][CDAP-18791] - Fix LevelDB memory usage

### DIFF
--- a/cdap-common/pom.xml
+++ b/cdap-common/pom.xml
@@ -209,6 +209,15 @@
       <artifactId>sshd-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.iq80.leveldb</groupId>
+      <artifactId>leveldb</artifactId>
+      <!-- leveldb 0.12 has conflicting guava 20 as a dependency. The uber jar shades guava -->
+      <classifier>uber</classifier>
+      <!-- This dependency is used for LevelDB rewriting only.
+           Rewriting would happen only if LevelDB is actually available -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>1.8.2</version>

--- a/cdap-common/src/main/java/io/cdap/cdap/common/leveldb/FileMetaDataUtil.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/leveldb/FileMetaDataUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.leveldb;
+
+import org.iq80.leveldb.impl.InternalKey;
+import org.iq80.leveldb.util.SizeOf;
+import org.iq80.leveldb.util.Slice;
+
+import javax.annotation.Nullable;
+
+/**
+ * Utility class for trimming down storage of keys passed to {@link org.iq80.leveldb.impl.FileMetaData#FileMetaData}
+ */
+public final class FileMetaDataUtil {
+  private FileMetaDataUtil() { }
+
+  /**
+   * Check if value holds a reference to a big array (more than needed to store a key) and create a copy of the key
+   * with minimum storage needed if so.
+   * @param value original key to be analyzed
+   * @return original key of it uses minimum storage, copy of the key if storage had to be trimmed,
+   * null if input is null
+   */
+  @Nullable
+  public static InternalKey normalize(@Nullable InternalKey value) {
+    if (value == null) {
+      return null;
+    }
+    Slice userKey = value.getUserKey();
+    if (userKey.getRawArray().length <= userKey.length()) {
+      return value;
+    }
+    return new InternalKey(value.getUserKey().copySlice(), value.getSequenceNumber(), value.getValueType());
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/leveldb/LevelDBClassRewriter.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/leveldb/LevelDBClassRewriter.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.leveldb;
+
+import io.cdap.cdap.common.lang.ClassRewriter;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.AdviceAdapter;
+import org.objectweb.asm.commons.Method;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.Executor;
+import javax.annotation.Nullable;
+
+/**
+ * Current java LevelDB implementation has a memory accumulation problem during compaction.
+ * Each {@link org.iq80.leveldb.impl.FileMetaData} object holds minimum and maximum keys for the file.
+ * And those keys may reside in a slice pointing to a byte array with the whole file. In this case
+ * instead of holding 20 bytes reference, we hold a multi-kb or even mb reference per file, leading to OOM
+ * on big compaction. The patch checks all {@link org.iq80.leveldb.impl.InternalKey} objects while they
+ * are created and if it received such heavy metadata reference, makes a copy of the key (usually few dozen bytes)
+ * and uses this lightweight metadata reference instead.
+ */
+public class LevelDBClassRewriter implements ClassRewriter {
+  /**
+   * Full filename of the {@link org.iq80.leveldb.impl.FileMetaData} class to be patched
+   */
+  private static final String FILE_META_DATA_CLASS_NAME = "org.iq80.leveldb.impl.FileMetaData";
+  /**
+   * Type of {@link FileMetaDataUtil} class that has normalization static methos to trim key storage down
+   */
+  private static final Type FILE_META_DATA_UTIL_TYPE = Type.getType(FileMetaDataUtil.class);
+  /**
+   * {@link Type} of {@link org.iq80.leveldb.impl.InternalKey}
+   */
+  private static final Type INTERNAL_KEY_TYPE = Type.getObjectType("org/iq80/leveldb/impl/InternalKey");
+  /**
+   * {@link org.iq80.leveldb.impl.FileMetaData#FileMetaData} {@link Method}
+   */
+  public static final Method FILE_META_DATA_CONSTRUCTOR = new Method("<init>", Type.VOID_TYPE, new Type[]{
+    Type.LONG_TYPE, Type.LONG_TYPE, INTERNAL_KEY_TYPE, INTERNAL_KEY_TYPE});
+  /**
+   * Parameter number for "smallest" parameter in {@link org.iq80.leveldb.impl.FileMetaData#FileMetaData}
+   */
+  public static final int SMALLEST_KEY_PARAM = 2;
+  /**
+   * Parameter number for "largest" parameter in {@link org.iq80.leveldb.impl.FileMetaData#FileMetaData}
+   */
+  public static final int LARGEST_KEY_PARAM = 3;
+  /**
+   * {@link FileMetaDataUtil#normalize} {@link Method}
+   */
+  private static final Method NORMALIZE_METHOD =
+    new Method("normalize", Type.getMethodDescriptor(INTERNAL_KEY_TYPE, INTERNAL_KEY_TYPE));
+
+  /**
+   * @param className class name inspected
+   * @return true if thi is {@link org.iq80.leveldb.impl.FileMetaData} class that needs to be rewritten
+   */
+  public boolean needRewrite(String className) {
+    return FILE_META_DATA_CLASS_NAME.equals(className);
+  }
+
+  /**
+   * Rewrites {@link org.iq80.leveldb.impl.FileMetaData#FileMetaData(long, long, InternalKey, InternalKey)} constructor
+   * to trim down heavy storage for keys passed as 3rd and 4th parameter.
+   * @param className name of the class - must be FileMetaData
+   * @param input an {@link InputStream} to provide the original bytecode of the class
+   * @return rewritten class bytecode
+   * @throws IOException if class can't be read
+   */
+  @Override
+  public byte[] rewriteClass(String className, InputStream input) throws IOException {
+    ClassReader cr = new ClassReader(input);
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+
+    cr.accept(new ClassVisitor(Opcodes.ASM7, cw) {
+      @Override
+      public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                       String signature, String[] exceptions) {
+
+        MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+        if (!FILE_META_DATA_CONSTRUCTOR.equals(new Method(name, descriptor))) {
+          return mv;
+        }
+        return new AdviceAdapter(Opcodes.ASM7, mv, access, name, descriptor) {
+          @Override
+          protected void onMethodEnter() {
+            loadArg(SMALLEST_KEY_PARAM);
+            invokeStatic(FILE_META_DATA_UTIL_TYPE, NORMALIZE_METHOD);
+            storeArg(SMALLEST_KEY_PARAM);
+            loadArg(LARGEST_KEY_PARAM);
+            invokeStatic(FILE_META_DATA_UTIL_TYPE, NORMALIZE_METHOD);
+            storeArg(LARGEST_KEY_PARAM);
+          }
+        };
+      }
+    }, 0);
+
+    return cw.toByteArray();
+  }
+
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/13922.

Patch LevelDB FileMetaData constructor to recreate key slices if they refer to large arrays (happens during compaction).