### PR TITLE
[CDAP-18322] Fix connection manager "test connection" for remote execution.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionHandler.java
@@ -478,12 +478,7 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
         build();
     try {
       byte[] bytes = getContext().runTask(runnableTaskRequest);
-      if (bytes == null) {
-        responder.sendStatus(HttpURLConnection.HTTP_OK);
-      } else {
-        //convert the bytes received from remote worker to UTF-8 string
-        responder.sendString(new String(bytes, StandardCharsets.UTF_8));
-      }
+      responder.sendString(new String(bytes, StandardCharsets.UTF_8));
     } catch (RemoteExecutionException e) {
       //TODO CDAP-18787 - Handle other exceptions
       RemoteTaskException remoteTaskException = e.getCause();

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionBrowseTask.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionBrowseTask.java
@@ -51,11 +51,16 @@ public class RemoteConnectionBrowseTask extends RemoteConnectionTaskBase {
   private static final Gson GSON = new Gson();
 
   @Override
-  public String execute(SystemAppTaskContext systemAppContext, Connection connection,
-                        ServicePluginConfigurer servicePluginConfigurer, TrackedPluginSelector pluginSelector,
-                        String namespace, String request) throws Exception {
+  public String execute(SystemAppTaskContext systemAppContext,
+                        RemoteConnectionRequest request) throws Exception {
+    String namespace = request.getNamespace();
+    Connection connection = request.getConnection();
+    //Plugin selector and configurer
+    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
+      new ArtifactSelectorProvider().getPluginSelector(connection.getPlugin().getArtifact()));
+    ServicePluginConfigurer servicePluginConfigurer = systemAppContext.createServicePluginConfigurer(namespace);
 
-    BrowseRequest browseRequest = GSON.fromJson(request, BrowseRequest.class);
+    BrowseRequest browseRequest = GSON.fromJson(request.getRequest(), BrowseRequest.class);
     try (Connector connector = getConnector(systemAppContext, servicePluginConfigurer, connection.getPlugin(),
                                             namespace, pluginSelector)) {
       //configure and browse

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionSampleTask.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionSampleTask.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.etl.api.connector.ConnectorContext;
 import io.cdap.cdap.etl.api.connector.ConnectorSpec;
 import io.cdap.cdap.etl.api.connector.ConnectorSpecRequest;
 import io.cdap.cdap.etl.api.connector.SampleRequest;
+import io.cdap.cdap.etl.common.ArtifactSelectorProvider;
 import io.cdap.cdap.etl.proto.connection.Connection;
 import io.cdap.cdap.etl.proto.connection.ConnectorDetail;
 import io.cdap.cdap.etl.proto.connection.SampleResponse;
@@ -45,12 +46,16 @@ public class RemoteConnectionSampleTask extends RemoteConnectionTaskBase {
       .registerTypeAdapter(SampleResponse.class, new SampleResponseCodec()).setPrettyPrinting().create();
 
   @Override
-  public String execute(SystemAppTaskContext systemAppContext, Connection connection,
-                        ServicePluginConfigurer pluginConfigurer, TrackedPluginSelector pluginSelector,
-                        String namespace, String request) throws Exception {
+  public String execute(SystemAppTaskContext systemAppContext, RemoteConnectionRequest request) throws Exception {
+    String namespace = request.getNamespace();
+    Connection connection = request.getConnection();
+    //Plugin selector and configurer
+    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
+      new ArtifactSelectorProvider().getPluginSelector(connection.getPlugin().getArtifact()));
+    ServicePluginConfigurer pluginConfigurer = systemAppContext.createServicePluginConfigurer(namespace);
 
     ConnectorContext connectorContext = ConnectionUtils.getConnectorContext(pluginConfigurer);
-    SampleRequest sampleRequest = GSON.fromJson(request, SampleRequest.class);
+    SampleRequest sampleRequest = GSON.fromJson(request.getRequest(), SampleRequest.class);
     try (Connector connector = getConnector(systemAppContext, pluginConfigurer, connection.getPlugin(),
                                             namespace, pluginSelector)) {
       connector.configure(new DefaultConnectorConfigurer(pluginConfigurer));

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionTaskBase.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionTaskBase.java
@@ -52,16 +52,8 @@ public abstract class RemoteConnectionTaskBase implements RunnableTask {
     //De serialize all requests
     RemoteConnectionRequest connectionRequest = GSON.fromJson(context.getParam(),
                                                               RemoteConnectionRequest.class);
-    String namespace = connectionRequest.getNamespace();
-    Connection connection = connectionRequest.getConnection();
 
-    //Plugin selector and configurer
-    TrackedPluginSelector pluginSelector = new TrackedPluginSelector(
-      new ArtifactSelectorProvider().getPluginSelector(connection.getPlugin().getArtifact()));
-    ServicePluginConfigurer servicePluginConfigurer = systemAppContext.createServicePluginConfigurer(namespace);
-    //serialize the result as json and write the bytes
-    String executedResult = execute(systemAppContext, connection, servicePluginConfigurer, pluginSelector, namespace,
-                                    connectionRequest.getRequest());
+    String executedResult = execute(systemAppContext, connectionRequest);
     context.writeResult(executedResult.getBytes(StandardCharsets.UTF_8));
   }
 
@@ -69,18 +61,12 @@ public abstract class RemoteConnectionTaskBase implements RunnableTask {
    * execute method for specific tasks to implement
    *
    * @param systemAppContext        {@link SystemAppTaskContext}
-   * @param connection              {@link Connection}
-   * @param servicePluginConfigurer {@link ServicePluginConfigurer}
-   * @param pluginSelector          {@link TrackedPluginSelector}
-   * @param namespace               namespace string
-   * @param request                 request string
+   * @param request                 {@link RemoteConnectionRequest}
    * @return executed response as string
    * @throws Exception
    */
-  public abstract String execute(SystemAppTaskContext systemAppContext, Connection connection,
-                                 ServicePluginConfigurer servicePluginConfigurer, TrackedPluginSelector pluginSelector,
-                                 String namespace, String request) throws Exception;
-
+  public abstract String execute(SystemAppTaskContext systemAppContext,
+                                 RemoteConnectionRequest request) throws Exception;
   /**
    * Returns {@link Connector} after evaluating macros
    *


### PR DESCRIPTION
Why:
When remote execution is enabled, the remote execution in worker pod assumes
connection object exists while it is not the case for "test".