### PR TITLE
make cdap use cdap twill instead of apache twill

### DIFF
--- a/cdap-api/pom.xml
+++ b/cdap-api/pom.xml
@@ -60,7 +60,7 @@
       <artifactId>tephra-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-api</artifactId>
     </dependency>
     <dependency>

--- a/cdap-app-fabric/pom.xml
+++ b/cdap-app-fabric/pom.xml
@@ -132,7 +132,7 @@
       <artifactId>async-http-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-yarn</artifactId>
     </dependency>
     <dependency>

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -229,7 +229,7 @@
       </dependency>
 
       <dependency>
-        <groupId>org.apache.twill</groupId>
+        <groupId>io.cdap.twill</groupId>
         <artifactId>twill-core</artifactId>
         <version>${twill.version}</version>
         <exclusions>

--- a/cdap-client/pom.xml
+++ b/cdap-client/pom.xml
@@ -60,27 +60,27 @@
           <artifactId>libthrift</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.twill</groupId>
+          <groupId>io.cdap.twill</groupId>
           <artifactId>twill-discovery-api</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.twill</groupId>
+          <groupId>io.cdap.twill</groupId>
           <artifactId>twill-discovery-core</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.twill</groupId>
+          <groupId>io.cdap.twill</groupId>
           <artifactId>twill-common</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.twill</groupId>
+          <groupId>io.cdap.twill</groupId>
           <artifactId>twill-yarn</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.twill</groupId>
+          <groupId>io.cdap.twill</groupId>
           <artifactId>twill-core</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.twill</groupId>
+          <groupId>io.cdap.twill</groupId>
           <artifactId>twill-zookeeper</artifactId>
         </exclusion>
         <exclusion>

--- a/cdap-common/pom.xml
+++ b/cdap-common/pom.xml
@@ -129,31 +129,31 @@
       <artifactId>tephra-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-discovery-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-discovery-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-yarn</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-zookeeper</artifactId>
     </dependency>
     <dependency>

--- a/cdap-data-fabric/pom.xml
+++ b/cdap-data-fabric/pom.xml
@@ -119,6 +119,16 @@
     <dependency>
       <groupId>org.apache.tephra</groupId>
       <artifactId>tephra-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.twill</groupId>
+          <artifactId>twill-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.twill</groupId>
+          <artifactId>twill-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.cdap.http</groupId>
@@ -138,11 +148,11 @@
       <artifactId>libthrift</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-core</artifactId>
     </dependency>
     <dependency>

--- a/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
+++ b/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
@@ -563,7 +563,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.twill</groupId>
+        <groupId>io.cdap.twill</groupId>
         <artifactId>twill-core</artifactId>
         <version>${twill.version}</version>
         <exclusions>

--- a/cdap-explore-client/pom.xml
+++ b/cdap-explore-client/pom.xml
@@ -53,7 +53,7 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-common</artifactId>
     </dependency>
   </dependencies>

--- a/cdap-explore/pom.xml
+++ b/cdap-explore/pom.xml
@@ -104,7 +104,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-common</artifactId>
     </dependency>
     <dependency>

--- a/cdap-kafka/pom.xml
+++ b/cdap-kafka/pom.xml
@@ -41,7 +41,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-core</artifactId>
     </dependency>
   </dependencies>

--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -45,12 +45,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-api</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-discovery-api</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -93,7 +93,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-core</artifactId>
       <exclusions>
         <exclusion>

--- a/cdap-master-spi/pom.xml
+++ b/cdap-master-spi/pom.xml
@@ -37,11 +37,11 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-discovery-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-api</artifactId>
     </dependency>
   </dependencies>

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -125,33 +125,47 @@
     <dependency>
       <groupId>org.apache.tephra</groupId>
       <artifactId>tephra-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.twill</groupId>
+          <artifactId>twill-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.twill</groupId>
+          <artifactId>twill-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.twill</groupId>
+          <artifactId>twill-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-discovery-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-discovery-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-zookeeper</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-yarn</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-common</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-core</artifactId>
     </dependency>
     <dependency>

--- a/cdap-runtime-ext-dataproc/pom.xml
+++ b/cdap-runtime-ext-dataproc/pom.xml
@@ -90,7 +90,7 @@
       <artifactId>google-cloud-storage</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-yarn</artifactId>
       <exclusions>
         <!-- Exclude hadoop jars from twill yarn -->
@@ -105,7 +105,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-core</artifactId>
     </dependency>
     <dependency>

--- a/cdap-runtime-spi/pom.xml
+++ b/cdap-runtime-spi/pom.xml
@@ -36,7 +36,7 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-api</artifactId>
     </dependency>
   </dependencies>

--- a/cdap-security/pom.xml
+++ b/cdap-security/pom.xml
@@ -79,7 +79,7 @@
       <artifactId>logback-classic</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-zookeeper</artifactId>
     </dependency>
     <dependency>

--- a/cdap-spark-core2_2.11/pom.xml
+++ b/cdap-spark-core2_2.11/pom.xml
@@ -67,7 +67,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-api</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -148,15 +148,15 @@
           <artifactId>fastutil</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.twill</groupId>
+          <groupId>io.cdap.twill</groupId>
           <artifactId>twill-core</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.twill</groupId>
+          <groupId>io.cdap.twill</groupId>
           <artifactId>twill-discovery-core</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.twill</groupId>
+          <groupId>io.cdap.twill</groupId>
           <artifactId>twill-zookeeper</artifactId>
         </exclusion>
       </exclusions>

--- a/cdap-spark-core3_2.12/pom.xml
+++ b/cdap-spark-core3_2.12/pom.xml
@@ -66,7 +66,7 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-api</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -158,15 +158,15 @@
           <artifactId>fastutil</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.twill</groupId>
+          <groupId>io.cdap.twill</groupId>
           <artifactId>twill-core</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.twill</groupId>
+          <groupId>io.cdap.twill</groupId>
           <artifactId>twill-discovery-core</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.twill</groupId>
+          <groupId>io.cdap.twill</groupId>
           <artifactId>twill-zookeeper</artifactId>
         </exclusion>
       </exclusions>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -158,15 +158,15 @@
       <artifactId>tephra-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-discovery-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-discovery-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-core</artifactId>
       <exclusions>
         <exclusion>

--- a/cdap-unit-test/pom.xml
+++ b/cdap-unit-test/pom.xml
@@ -122,7 +122,7 @@
       <artifactId>tephra-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-api</artifactId>
     </dependency>
     <dependency>

--- a/cdap-watchdog/pom.xml
+++ b/cdap-watchdog/pom.xml
@@ -82,13 +82,23 @@
     <dependency>
       <groupId>org.apache.tephra</groupId>
       <artifactId>tephra-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.twill</groupId>
+          <artifactId>twill-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.twill</groupId>
+          <artifactId>twill-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.twill</groupId>
+      <groupId>io.cdap.twill</groupId>
       <artifactId>twill-core</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <tez.version>0.8.4</tez.version>
     <tink.version>1.6.0</tink.version>
     <thrift.version>0.9.3</thrift.version>
-    <twill.version>0.14.0</twill.version>
+    <twill.version>1.0.0-SNAPSHOT</twill.version>
     <unboundid.version>2.3.6</unboundid.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <opentable.version>0.13.1</opentable.version>
@@ -229,7 +229,7 @@
         <version>${rs-api.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.twill</groupId>
+        <groupId>io.cdap.twill</groupId>
         <artifactId>twill-api</artifactId>
         <version>${twill.version}</version>
       </dependency>
@@ -283,6 +283,14 @@
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.twill</groupId>
+            <artifactId>twill-common</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.twill</groupId>
+            <artifactId>twill-core</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -499,12 +507,12 @@
         <version>${commons.cli.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.twill</groupId>
+        <groupId>io.cdap.twill</groupId>
         <artifactId>twill-common</artifactId>
         <version>${twill.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.twill</groupId>
+        <groupId>io.cdap.twill</groupId>
         <artifactId>twill-core</artifactId>
         <version>${twill.version}</version>
         <exclusions>
@@ -523,17 +531,17 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.twill</groupId>
+        <groupId>io.cdap.twill</groupId>
         <artifactId>twill-discovery-api</artifactId>
         <version>${twill.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.twill</groupId>
+        <groupId>io.cdap.twill</groupId>
         <artifactId>twill-discovery-core</artifactId>
         <version>${twill.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.twill</groupId>
+        <groupId>io.cdap.twill</groupId>
         <artifactId>twill-yarn</artifactId>
         <version>${twill.version}</version>
         <exclusions>
@@ -596,7 +604,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.apache.twill</groupId>
+        <groupId>io.cdap.twill</groupId>
         <artifactId>twill-zookeeper</artifactId>
         <version>${twill.version}</version>
         <exclusions>


### PR DESCRIPTION
Apache twill is archived and read only.

Make cdap use cdap twill for continued development