### PR TITLE
Make TrackingTaskAttemptContext class public to fix plugin issues

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingTaskAttemptContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingTaskAttemptContext.java
@@ -40,11 +40,11 @@ import java.net.URI;
 /**
  * Implementation of {@link TaskAttemptContext} that support bytes read/written counter.
  */
-final class TrackingTaskAttemptContext implements TaskAttemptContext {
+public final class TrackingTaskAttemptContext implements TaskAttemptContext {
 
   private final TaskAttemptContext delegate;
 
-  TrackingTaskAttemptContext(TaskAttemptContext delegate) {
+  public TrackingTaskAttemptContext(TaskAttemptContext delegate) {
     this.delegate = delegate;
   }
 


### PR DESCRIPTION
This PR makes `TrackingTaskAttemptContext` class public in order to address these bugs:

[PLUGIN-666](https://cdap.atlassian.net/browse/PLUGIN-666)
[PLUGIN-682](https://cdap.atlassian.net/browse/PLUGIN-682)
[CDAP-17950](https://cdap.atlassian.net/browse/CDAP-17950)