### PR TITLE
[CDAP-18322] Fixing SystemAuthenticationContext userID and credential setting and pipeline deploy http handler auth check

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ArtifactHttpHandler.java
@@ -67,9 +67,13 @@ import io.cdap.cdap.proto.artifact.ArtifactSortOrder;
 import io.cdap.cdap.proto.artifact.ArtifactSummaryProperties;
 import io.cdap.cdap.proto.artifact.PluginInfo;
 import io.cdap.cdap.proto.artifact.PluginSummary;
+import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.Ids;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
+import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.BodyConsumer;
@@ -135,15 +139,20 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final CapabilityReader capabilityReader;
   private final File tmpDir;
+  private final AccessEnforcer accessEnforcer;
+  private final AuthenticationContext authenticationContext;
 
   @Inject
   ArtifactHttpHandler(CConfiguration cConf, ArtifactRepository artifactRepository,
-                      NamespaceQueryAdmin namespaceQueryAdmin, CapabilityReader capabilityReader) {
+                      NamespaceQueryAdmin namespaceQueryAdmin, CapabilityReader capabilityReader,
+                      AccessEnforcer accessEnforcer, AuthenticationContext authenticationContext) {
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.artifactRepository = artifactRepository;
     this.capabilityReader = capabilityReader;
     this.tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
                            cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+    this.accessEnforcer = accessEnforcer;
+    this.authenticationContext = authenticationContext;
   }
 
   @POST
@@ -666,6 +675,13 @@ public class ArtifactHttpHandler extends AbstractHttpHandler {
         throw new BadRequestException(String.format("Invalid PluginClasses '%s'.", pluginClasses), e);
       }
     }
+
+    // Perform auth checks outside BodyConsumer as only the first http request containing auth header
+    // to populate SecurityRequestContext while http chunk doesn't. BodyConsumer runs in the thread
+    // that processes the last http chunk.
+    accessEnforcer.enforce(new ApplicationId(namespace.getNamespace(), artifactName),
+                           authenticationContext.getPrincipal(),
+                           StandardPermission.CREATE);
 
     try {
       // copy the artifact contents to local tmp directory


### PR DESCRIPTION
Two issues:
1. Fixing SystemAuthenticationContext userID and credential setting:
   - It is possible to set userId without userCredential. This happens when we launch program
     using userId stored in program options' system args. It is insecure to only use
     userId as user credential. This is a tech debt that should be cleaned. When it happens,
     we use system internal identity, assuming proper authorization checks are done at http
     handler layer upon receiving requests, where we have end user's credential.
2. Fixing auth check in pipeline deploy and artifact deploy
   - Incoming requests can be chunked and the thread processing the last chunk has an emtpy
     SecurityRequestContext as http chunk has no auth header. As a result, we need to perform
     auth checks when processing the initial http request.