### PR TITLE
[Cherry-pick into 6.6] CDAP-18332: Introduce retries to all non-mutation RemoteDatasetFramework methods.

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1344,6 +1344,46 @@
     </description>
   </property>
 
+  <property>
+    <name>system.dataset.remote.retry.policy.base.delay.ms</name>
+    <value>100</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>system.dataset.remote.retry.policy.max.delay.ms</name>
+    <value>5000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>system.dataset.remote.retry.policy.max.retries</name>
+    <value>5000</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <property>
+    <name>system.dataset.remote.retry.policy.max.time.secs</name>
+    <value>7200</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>system.dataset.remote.retry.policy.type</name>
+    <value>exponential.backoff</value>
+    <description>
+      The type of retry policy for notification publish or subscription. Allowed options:
+      "none", "fixed.delay", or "exponential.backoff".
+    </description>
+  </property>
 
   <!-- Explore Service Configuration -->
 

--- a/cdap-data-fabric/pom.xml
+++ b/cdap-data-fabric/pom.xml
@@ -222,6 +222,10 @@
       <artifactId>kafka_2.11</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkRetryTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkRetryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.data2.datafabric.dataset;
+
+import io.cdap.cdap.common.ServiceUnavailableException;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import org.mockito.Mockito;
+
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+
+public class RemoteDatasetFrameworkRetryTest extends RemoteDatasetFrameworkTest {
+
+  @Override
+  protected RemoteDatasetFramework createFramework(AuthenticationContext authenticationContext,
+                                                   RemoteClientFactory remoteClientFactory) {
+    cConf.set("system.dataset.remote.retry.policy.base.delay.ms", "0");
+    cConf.set("system.dataset.remote.retry.policy.max.retries", "1");
+    RemoteClientFactory mockedFactory = Mockito.spy(remoteClientFactory);
+    Set<URL> failedURIs = new HashSet<>();
+    Mockito.doAnswer(i -> {
+      RemoteClient realClient = (RemoteClient) i.callRealMethod();
+      RemoteClient mocked = Mockito.spy(realClient);
+      Mockito.doAnswer(i2 -> {
+        HttpRequest request = i2.getArgumentAt(0, HttpRequest.class);
+        //Fail the first GET, allow the second
+        if (request.getMethod() == HttpMethod.GET && failedURIs.add(request.getURL())) {
+          throw new ServiceUnavailableException("service");
+        }
+        return i2.callRealMethod();
+      }).when(mocked).execute(Mockito.any());
+      return mocked;
+    }).when(mockedFactory).createRemoteClient(Mockito.any(), Mockito.any(), Mockito.any());
+    return super.createFramework(authenticationContext, mockedFactory);
+  }
+}

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -147,7 +147,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
     AuthenticationContext authenticationContext = injector.getInstance(AuthenticationContext.class);
     RemoteClientFactory remoteClientFactory = injector.getInstance(RemoteClientFactory.class);
 
-    framework = new RemoteDatasetFramework(cConf, registryFactory, authenticationContext, remoteClientFactory);
+    framework = createFramework(authenticationContext, remoteClientFactory);
     SystemDatasetInstantiatorFactory datasetInstantiatorFactory =
       new SystemDatasetInstantiatorFactory(locationFactory, framework, cConf);
 
@@ -191,6 +191,14 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
       () -> discoveryServiceClient.discover(Constants.Service.DATASET_MANAGER));
     Preconditions.checkNotNull(endpointStrategy.pick(5, TimeUnit.SECONDS),
                                "%s service is not up after 5 seconds", service);
+  }
+
+  /**
+   * This method allows to replace / mock remote clients
+   */
+  protected RemoteDatasetFramework createFramework(AuthenticationContext authenticationContext,
+                                                   RemoteClientFactory remoteClientFactory) {
+    return new RemoteDatasetFramework(cConf, registryFactory, authenticationContext, remoteClientFactory);
   }
 
   // Note: Cannot have these system namespace restrictions in system namespace since we use it internally in


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/13980