### PR TITLE
[CDAP-18842] Include stream and replication jobs when calculating total number of running programs for flow control 

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/RunRecordMonitorService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/RunRecordMonitorService.java
@@ -104,10 +104,10 @@ public class RunRecordMonitorService extends AbstractScheduledService {
   }
 
   /**
-   * Add a new in-flight launch request and return total number of launching and running workflows.
+   * Add a new in-flight launch request and return total number of launching and running programs.
    *
    * @param programRunId run id associated with the launch request
-   * @return total number of launching and running workflow runs.
+   * @return total number of launching and running program runs.
    */
   public Count addRequestAndGetCount(ProgramRunId programRunId) throws Exception {
     if (RunIds.getTime(programRunId.getRun(), TimeUnit.MILLISECONDS) == -1) {
@@ -120,9 +120,9 @@ public class RunRecordMonitorService extends AbstractScheduledService {
       launchingCount = launchingQueue.size();
     }
 
-    int runningCount = getWorkflowsRunningCount();
+    int runningCount = getProgramsRunningCount();
 
-    LOG.info("Counter has {} concurrent launching and {} running workflows.", launchingCount, runningCount);
+    LOG.info("Counter has {} concurrent launching and {} running programs.", launchingCount, runningCount);
     return new Count(launchingCount, runningCount);
   }
 
@@ -133,7 +133,7 @@ public class RunRecordMonitorService extends AbstractScheduledService {
    */
   public void addRequest(ProgramRunId programRunId) {
     launchingQueue.add(programRunId);
-    emitMetrics(Constants.Metrics.FlowControl.WORKFLOWS_LAUNCHING_COUNT, launchingQueue.size());
+    emitMetrics(Constants.Metrics.FlowControl.LAUNCHING_COUNT, launchingQueue.size());
     LOG.info("Added request with runId {}.", programRunId);
   }
 
@@ -142,17 +142,17 @@ public class RunRecordMonitorService extends AbstractScheduledService {
    * I.e., not in-flight, not in {@link ProgramRunStatus#PENDING} and not in {@link ProgramRunStatus#STARTING}
    *
    * @param programRunId      of the request to be removed from launching queue.
-   * @param emitRunningChange if true, also updates {@link Constants.Metrics.FlowControl#WORKFLOWS_RUNNING_COUNT}
+   * @param emitRunningChange if true, also updates {@link Constants.Metrics.FlowControl#RUNNING_COUNT}
    */
   public void removeRequest(ProgramRunId programRunId, boolean emitRunningChange) {
     if (launchingQueue.remove(programRunId)) {
       LOG.info("Removed request with runId {}. Counter has {} concurrent launching requests.",
                programRunId, launchingQueue.size());
-      emitMetrics(Constants.Metrics.FlowControl.WORKFLOWS_LAUNCHING_COUNT, launchingQueue.size());
+      emitMetrics(Constants.Metrics.FlowControl.LAUNCHING_COUNT, launchingQueue.size());
     }
 
     if (emitRunningChange) {
-      emitMetrics(Constants.Metrics.FlowControl.WORKFLOWS_RUNNING_COUNT, getWorkflowsRunningCount());
+      emitMetrics(Constants.Metrics.FlowControl.RUNNING_COUNT, getProgramsRunningCount());
     }
   }
 
@@ -172,16 +172,27 @@ public class RunRecordMonitorService extends AbstractScheduledService {
       // Queue head might have already been removed. So instead of calling poll, we call remove.
       if (launchingQueue.remove(programRunId)) {
         LOG.info("Removing request with runId {} due to expired retention time.", programRunId);
-        emitMetrics(Constants.Metrics.FlowControl.WORKFLOWS_LAUNCHING_COUNT, launchingQueue.size());
+        emitMetrics(Constants.Metrics.FlowControl.LAUNCHING_COUNT, launchingQueue.size());
       }
     }
   }
 
-  private int getWorkflowsRunningCount() {
+  /**
+   * Returns the total number of programs in running state.
+   * The count includes batch (i.e., {@link ProgramType#WORKFLOW}),
+   * streaming (i.e., {@link ProgramType#SPARK}) with no parent and
+   * replication (i.e., {@link ProgramType#WORKER}) jobs.
+   *
+   * @return
+   */
+  private int getProgramsRunningCount() {
     List<ProgramRuntimeService.RuntimeInfo> list = runtimeService
-      .listAll(ProgramType.WORKFLOW);
+      .listAll(ProgramType.WORKFLOW, ProgramType.WORKER, ProgramType.SPARK, ProgramType.MAPREDUCE);
 
-    return (int) list.stream().filter(r -> isRunning(r.getController().getState().getRunStatus())).count();
+    return (int) list.stream()
+      .filter(r ->
+                isRunning(r.getController().getState().getRunStatus()))
+      .count();
   }
 
   private boolean isRunning(ProgramRunStatus status) {

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -932,8 +932,8 @@ public final class Constants {
      * Flow control metrics
      */
     public static final class FlowControl {
-      public static final String WORKFLOWS_LAUNCHING_COUNT = "flowcontrol.workflows.launching.count";
-      public static final String WORKFLOWS_RUNNING_COUNT = "flowcontrol.workflows.running.count";
+      public static final String LAUNCHING_COUNT = "flowcontrol.launching.count";
+      public static final String RUNNING_COUNT = "flowcontrol.running.count";
     }
 
     /**


### PR DESCRIPTION
Why: currently, we only count the total number of running programs with workflow type in order to decide whether to accept/reject a new launch request. 

This PR includes programs with worker type (i.e. for replication) , MR and also Spark (i.e., for streams).