### PR TITLE
Updated Aggregation Definition classes to have a key-value pair for Select expressions.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/AggregationDefinition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/AggregationDefinition.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.etl.api.relational.Expression;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Specifies how an aggregation should be executed.
@@ -28,24 +29,24 @@ import java.util.List;
 @Beta
 public abstract class AggregationDefinition {
   private final List<Expression> groupByExpressions;
-  private final List<Expression> selectExpressions;
+  private final Map<String, Expression> selectExpressions;
 
   /**
    * Creates a default {@link AggregationDefinition} object with empty lists for group by and select expressions.
    */
   protected AggregationDefinition() {
     groupByExpressions = Collections.emptyList();
-    selectExpressions = Collections.emptyList();
+    selectExpressions = Collections.emptyMap();
   }
 
   /**
    * Creates an {@link AggregationDefinition} object with the specified lists of expression for grouping and selection.
    * @param groupByExpressions A {@link List} of {@link Expression} objects for grouping.
-   * @param selectExpressions A {@link List} of {@link Expression} objects for selection.
+   * @param selectExpressions A {@link Map} with {@link String} keys and {@link Expression} values for selection.
    */
-  protected AggregationDefinition(List<Expression> groupByExpressions, List<Expression> selectExpressions) {
+  protected AggregationDefinition(List<Expression> groupByExpressions, Map<String, Expression> selectExpressions) {
     this.groupByExpressions = Collections.unmodifiableList(groupByExpressions);
-    this.selectExpressions = Collections.unmodifiableList(selectExpressions);
+    this.selectExpressions = Collections.unmodifiableMap(selectExpressions);
   }
 
   /**
@@ -58,9 +59,9 @@ public abstract class AggregationDefinition {
 
   /**
    * Get the list of expressions which are to be selected.
-   * @return {@link List} of {@link Expression} objects to be selected.
+   * @return {@link Map} with {@link String} keys and {@link Expression} values to be selected.
    */
-  public List<Expression> getSelectExpressions() {
+  public Map<String, Expression> getSelectExpressions() {
     return selectExpressions;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/DeduplicateAggregationDefinition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/DeduplicateAggregationDefinition.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -39,7 +40,7 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
   List<FilterExpression> filterExpressions;
 
   private DeduplicateAggregationDefinition(List<Expression> groupByExpressions,
-                                           List<Expression> selectExpressions,
+                                           Map<String, Expression> selectExpressions,
                                            List<FilterExpression> filterExpressions) {
     super(groupByExpressions, selectExpressions);
     this.filterExpressions = filterExpressions;
@@ -129,12 +130,12 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
    */
   public static class Builder {
     private List<Expression> groupByExpressions;
-    private List<Expression> selectExpressions;
+    private Map<String, Expression> selectExpressions;
     List<FilterExpression> filterExpressions;
 
     public Builder() {
       groupByExpressions = Collections.emptyList();
-      selectExpressions = Collections.emptyList();
+      selectExpressions = Collections.emptyMap();
       filterExpressions = new ArrayList<>();
     }
 
@@ -167,7 +168,7 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
      * @param selectExpressions list of {@link Expression}s to select.
      * @return a {@link Builder} with the currently built {@link DeduplicateAggregationDefinition}.
      */
-    public Builder select(List<Expression> selectExpressions) {
+    public Builder select(Map<String, Expression> selectExpressions) {
       this.selectExpressions = selectExpressions;
       return this;
     }
@@ -175,11 +176,13 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
     /**
      * Sets the list of expressions to select to the specified expressions.
      * Any existing list of select expressions is overwritten.
-     * @param selectExpressions {@link Expression}s to select.
+     * @param key the key to use for this expression
+     * @param expression expression to use
      * @return a {@link Builder} with the currently built {@link DeduplicateAggregationDefinition}.
      */
-    public Builder select(Expression... selectExpressions) {
-      return select(Arrays.asList(selectExpressions));
+    public Builder select(String key, Expression expression) {
+      this.selectExpressions.put(key, expression);
+      return this;
     }
 
     /**
@@ -200,8 +203,7 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
      * The filter function is applied to the respective filter expression for all the records for which the values
      * of the dedup expressions specified in <code>dedupOn</code> is the same, and the resultant row is extracted
      * by the dedup operation.
-     * @param filterExpressions a {@link List} of {@link SimpleEntry} pairs of
-     *                          an {@link Expression} and a {@link FilterFunction}.
+     * @param filterExpressions a {@link List} of {@link FilterExpression}.
      * @return a {@link Builder} with the currently built {@link DeduplicateAggregationDefinition}.
      */
     public Builder filterDuplicatesBy(List<FilterExpression> filterExpressions) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/GroupByAggregationDefinition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/GroupByAggregationDefinition.java
@@ -21,13 +21,15 @@ import io.cdap.cdap.etl.api.relational.Expression;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 
 /**
  * Specifies how a group by operation should be executed.
  */
 public class GroupByAggregationDefinition extends AggregationDefinition {
-  private GroupByAggregationDefinition(List<Expression> groupByExpressions, List<Expression> selectExpressions) {
+  private GroupByAggregationDefinition(List<Expression> groupByExpressions,
+                                       Map<String, Expression> selectExpressions) {
     super(groupByExpressions, selectExpressions);
   }
 
@@ -44,11 +46,11 @@ public class GroupByAggregationDefinition extends AggregationDefinition {
    */
   public static class Builder {
     private List<Expression> groupByExpressions;
-    private List<Expression> selectExpressions;
+    private Map<String, Expression> selectExpressions;
 
     public Builder() {
       groupByExpressions = Collections.emptyList();
-      selectExpressions = Collections.emptyList();
+      selectExpressions = Collections.emptyMap();
     }
 
     /**
@@ -78,7 +80,7 @@ public class GroupByAggregationDefinition extends AggregationDefinition {
      * @param selectExpressions list of {@link Expression}s to select.
      * @return a {@link Builder} with the currently built {@link GroupByAggregationDefinition}.
      */
-    public Builder select(List<Expression> selectExpressions) {
+    public Builder select(Map<String, Expression> selectExpressions) {
       this.selectExpressions = selectExpressions;
       return this;
     }
@@ -86,11 +88,13 @@ public class GroupByAggregationDefinition extends AggregationDefinition {
     /**
      * Sets the list of expressions to select to the specified expressions.
      * Any existing list of select expressions is overwritten.
-     * @param selectExpressions {@link Expression}s to select.
+     * @param key the key to use for this expression
+     * @param expression expression to use
      * @return a {@link Builder} with the currently built {@link GroupByAggregationDefinition}.
      */
-    public Builder select(Expression... selectExpressions) {
-      return select(Arrays.asList(selectExpressions));
+    public Builder select(String key, Expression expression) {
+      this.selectExpressions.put(key, expression);
+      return this;
     }
 
     /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/aggregation/DeduplicateAggregationDefinitionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/aggregation/DeduplicateAggregationDefinitionTest.java
@@ -24,7 +24,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -34,7 +36,7 @@ public class DeduplicateAggregationDefinitionTest {
   @Test
   public void testDefinitionBuild() {
     List<Expression> dedupExpressions = new ArrayList<>();
-    List<Expression> selectExpressions = new ArrayList<>();
+    Map<String, Expression> selectExpressions = new HashMap<>();
     List<DeduplicateAggregationDefinition.FilterExpression> filterExpressions = new ArrayList<>();
 
     ExpressionFactory<String> factory = new ExpressionFactory<String>() {
@@ -68,9 +70,9 @@ public class DeduplicateAggregationDefinitionTest {
       ageExpression, DeduplicateAggregationDefinition.FilterFunction.MIN));
 
     dedupExpressions.add(factory.compile("firstName"));
-    selectExpressions.add(factory.compile("employeeId"));
-    selectExpressions.add(factory.compile("firstName"));
-    selectExpressions.add(factory.compile("lastName"));
+    selectExpressions.put("employeeId", factory.compile("employeeId"));
+    selectExpressions.put("firstName", factory.compile("firstName"));
+    selectExpressions.put("lastName", factory.compile("lastName"));
 
     DeduplicateAggregationDefinition definition = DeduplicateAggregationDefinition.builder()
       .dedupOn(dedupExpressions)

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/aggregation/GroupByAggregationDefinitionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/aggregation/GroupByAggregationDefinitionTest.java
@@ -24,7 +24,9 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -34,7 +36,7 @@ public class GroupByAggregationDefinitionTest {
   @Test
   public void testDefinitionBuild() {
     List<Expression> groupByExpressions = new ArrayList<>();
-    List<Expression> selectExpressions = new ArrayList<>();
+    Map<String, Expression> selectExpressions = new HashMap<>();
     ExpressionFactory<String> factory = new ExpressionFactory<String>() {
       @Override
       public ExpressionFactoryType<String> getType() {
@@ -64,8 +66,8 @@ public class GroupByAggregationDefinitionTest {
 
     groupByExpressions.add(factory.compile("department"));
     groupByExpressions.add(factory.compile("managerId"));
-    selectExpressions.add(factory.compile("count(*)"));
-    selectExpressions.add(factory.compile("sum(salary)"));
+    selectExpressions.put("num_employees", factory.compile("count(*)"));
+    selectExpressions.put("total_salaries", factory.compile("sum(salary)"));
 
     GroupByAggregationDefinition definition = GroupByAggregationDefinition.builder()
       .groupBy(groupByExpressions)


### PR DESCRIPTION
 This way, the key can be used as a column alias, and the value used when building SQL.
 
 For example, for something like:
 
 ```
 selectedColumns {
   "total_salary": "sum(salary)",
   "num_employees": "count(id)",
 }
 ```
 
 The end result would be:
 
 ```
 SELECT
   sum(salary) as total_salary,
   count(id) as num_employees
 FROM
   ...
```