### PR TITLE
[CDAP-18848] Limit of 20K MetricValues can make metric service go OOM 

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2737,7 +2737,7 @@
 
   <property>
     <name>metrics.processor.queue.size</name>
-    <value>20000</value>
+    <value>1000</value>
     <description>
       Maximum size of a queue where the metrics processor temporarily stores
       newly-fetched metrics in-memory before persisting them


### PR DESCRIPTION
Single value can easily take ~20KB, lowering the batch size