### PR TITLE
Added new interface used to identify all plugin wrappers.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/PluginWrapper.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/PluginWrapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common.plugin;
+
+/**
+ * Interface used to denote plugin wrappers. This interface exposes a method that can be used to get the wrapped
+ * plugin instance.
+ * @param <T> type of the plugin wrapped by this instance.
+ */
+public interface PluginWrapper<T> {
+  /**
+   * Gets the wrapper plugin instance
+   * @return wrapped plugin instance
+   */
+  T getWrapped();
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedAction.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedAction.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Callable;
  * Wrapper around {@link Action} that makes sure logging, classloading, and other pipeline capabilities
  * are setup correctly.
  */
-public class WrappedAction extends Action {
+public class WrappedAction extends Action implements PluginWrapper<Action> {
   private final Action action;
   private final Caller caller;
 
@@ -49,5 +49,10 @@ public class WrappedAction extends Action {
       action.run(context);
       return null;
     });
+  }
+
+  @Override
+  public Action getWrapped() {
+    return action;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedBatchAggregator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedBatchAggregator.java
@@ -34,7 +34,9 @@ import java.util.concurrent.Callable;
  * @param <GROUP_VALUE> group value type. Must be a supported type
  * @param <OUT> output object type
  */
-public class WrappedBatchAggregator<GROUP_KEY, GROUP_VALUE, OUT> extends BatchAggregator<GROUP_KEY, GROUP_VALUE, OUT> {
+public class WrappedBatchAggregator<GROUP_KEY, GROUP_VALUE, OUT>
+  extends BatchAggregator<GROUP_KEY, GROUP_VALUE, OUT>
+  implements PluginWrapper<BatchAggregator<GROUP_KEY, GROUP_VALUE, OUT>> {
   private final BatchAggregator<GROUP_KEY, GROUP_VALUE, OUT> aggregator;
   private final Caller caller;
   private final OperationTimer operationTimer;
@@ -113,5 +115,10 @@ public class WrappedBatchAggregator<GROUP_KEY, GROUP_VALUE, OUT> extends BatchAg
     } finally {
       operationTimer.reset();
     }
+  }
+
+  @Override
+  public BatchAggregator<GROUP_KEY, GROUP_VALUE, OUT> getWrapped() {
+    return aggregator;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedBatchJoiner.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedBatchJoiner.java
@@ -35,7 +35,9 @@ import java.util.concurrent.Callable;
  * @param <INPUT_RECORD> type of input record. Must be a supported type
  * @param <OUT> type of output object
  */
-public class WrappedBatchJoiner<JOIN_KEY, INPUT_RECORD, OUT> extends BatchJoiner<JOIN_KEY, INPUT_RECORD, OUT> {
+public class WrappedBatchJoiner<JOIN_KEY, INPUT_RECORD, OUT>
+  extends BatchJoiner<JOIN_KEY, INPUT_RECORD, OUT>
+  implements PluginWrapper<BatchJoiner<JOIN_KEY, INPUT_RECORD, OUT>> {
   private final BatchJoiner<JOIN_KEY, INPUT_RECORD, OUT> joiner;
   private final Caller caller;
   private final OperationTimer operationTimer;
@@ -123,5 +125,10 @@ public class WrappedBatchJoiner<JOIN_KEY, INPUT_RECORD, OUT> extends BatchJoiner
     } finally {
       operationTimer.reset();
     }
+  }
+
+  @Override
+  public BatchJoiner<JOIN_KEY, INPUT_RECORD, OUT> getWrapped() {
+    return joiner;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedBatchSink.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedBatchSink.java
@@ -34,7 +34,9 @@ import java.util.concurrent.Callable;
  * @param <KEY_OUT> type of output key
  * @param <VAL_OUT> type of output value
  */
-public class WrappedBatchSink<IN, KEY_OUT, VAL_OUT> extends BatchSink<IN, KEY_OUT, VAL_OUT> {
+public class WrappedBatchSink<IN, KEY_OUT, VAL_OUT>
+  extends BatchSink<IN, KEY_OUT, VAL_OUT>
+  implements PluginWrapper<BatchSink<IN, KEY_OUT, VAL_OUT>> {
   private final BatchSink<IN, KEY_OUT, VAL_OUT> batchSink;
   private final Caller caller;
   private final OperationTimer operationTimer;
@@ -98,5 +100,10 @@ public class WrappedBatchSink<IN, KEY_OUT, VAL_OUT> extends BatchSink<IN, KEY_OU
       batchSink.onRunFinish(succeeded, context);
       return null;
     });
+  }
+
+  @Override
+  public BatchSink<IN, KEY_OUT, VAL_OUT> getWrapped() {
+    return batchSink;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedBatchSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedBatchSource.java
@@ -33,7 +33,9 @@ import java.util.concurrent.Callable;
  * @param <VAL_IN> the input value type
  * @param <OUT> the output type
  */
-public class WrappedBatchSource<KEY_IN, VAL_IN, OUT> extends BatchSource<KEY_IN, VAL_IN, OUT> {
+public class WrappedBatchSource<KEY_IN, VAL_IN, OUT>
+  extends BatchSource<KEY_IN, VAL_IN, OUT>
+  implements PluginWrapper<BatchSource<KEY_IN, VAL_IN, OUT>> {
   private final BatchSource<KEY_IN, VAL_IN, OUT> batchSource;
   private final Caller caller;
   private final OperationTimer operationTimer;
@@ -96,5 +98,10 @@ public class WrappedBatchSource<KEY_IN, VAL_IN, OUT> extends BatchSource<KEY_IN,
       batchSource.configurePipeline(pipelineConfigurer);
       return null;
     });
+  }
+
+  @Override
+  public BatchSource<KEY_IN, VAL_IN, OUT> getWrapped() {
+    return batchSource;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedErrorTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedErrorTransform.java
@@ -33,7 +33,9 @@ import java.util.concurrent.Callable;
  * @param <IN> the type of error record
  * @param <OUT> the type of output record
  */
-public class WrappedErrorTransform<IN, OUT> extends ErrorTransform<IN, OUT> {
+public class WrappedErrorTransform<IN, OUT>
+  extends ErrorTransform<IN, OUT>
+  implements PluginWrapper<ErrorTransform<IN, OUT>> {
   private final ErrorTransform<IN, OUT> transform;
   private final Caller caller;
   private final OperationTimer operationTimer;
@@ -90,4 +92,8 @@ public class WrappedErrorTransform<IN, OUT> extends ErrorTransform<IN, OUT> {
     }
   }
 
+  @Override
+  public ErrorTransform<IN, OUT> getWrapped() {
+    return transform;
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedPostAction.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedPostAction.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Callable;
  * Wrapper around {@link PostAction} that makes sure logging, classloading, and other pipeline capabilities
  * are setup correctly.
  */
-public class WrappedPostAction extends PostAction {
+public class WrappedPostAction extends PostAction implements PluginWrapper<PostAction> {
   private final PostAction postAction;
   private final Caller caller;
 
@@ -49,5 +49,10 @@ public class WrappedPostAction extends PostAction {
       postAction.run(context);
       return null;
     });
+  }
+
+  @Override
+  public PostAction getWrapped() {
+    return postAction;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedReduceAggregator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedReduceAggregator.java
@@ -35,7 +35,8 @@ import java.util.concurrent.Callable;
  * @param <OUT> output object type
  */
 public class WrappedReduceAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT>
-  extends BatchReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT> {
+  extends BatchReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT>
+  implements PluginWrapper<BatchReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT>> {
   private final BatchReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT> aggregator;
   private final Caller caller;
   private final OperationTimer operationTimer;
@@ -143,5 +144,10 @@ public class WrappedReduceAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT>
     } finally {
       operationTimer.reset();
     }
+  }
+
+  @Override
+  public BatchReducibleAggregator<GROUP_KEY, GROUP_VALUE, AGG_VALUE, OUT> getWrapped() {
+    return aggregator;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedSplitterTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedSplitterTransform.java
@@ -19,7 +19,6 @@ package io.cdap.cdap.etl.common.plugin;
 import io.cdap.cdap.etl.api.MultiOutputEmitter;
 import io.cdap.cdap.etl.api.MultiOutputPipelineConfigurer;
 import io.cdap.cdap.etl.api.SplitterTransform;
-import io.cdap.cdap.etl.api.StageSubmitterContext;
 import io.cdap.cdap.etl.api.TransformContext;
 
 import java.util.concurrent.Callable;
@@ -31,7 +30,9 @@ import java.util.concurrent.Callable;
  * @param <T> type of input record
  * @param <E> type of error records emitted. Usually the same as the input record type
  */
-public class WrappedSplitterTransform<T, E> extends SplitterTransform<T, E> {
+public class WrappedSplitterTransform<T, E>
+  extends SplitterTransform<T, E>
+  implements PluginWrapper<SplitterTransform<T, E>> {
 
   private final SplitterTransform<T, E> transform;
   private final Caller caller;
@@ -79,5 +80,10 @@ public class WrappedSplitterTransform<T, E> extends SplitterTransform<T, E> {
     } finally {
       operationTimer.reset();
     }
+  }
+
+  @Override
+  public SplitterTransform<T, E> getWrapped() {
+    return transform;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/WrappedTransform.java
@@ -31,7 +31,7 @@ import java.util.concurrent.Callable;
  * @param <IN> type of input
  * @param <OUT> type of output
  */
-public class WrappedTransform<IN, OUT> extends Transform<IN, OUT> {
+public class WrappedTransform<IN, OUT> extends Transform<IN, OUT> implements PluginWrapper<Transform<IN, OUT>> {
   private final Transform<IN, OUT> transform;
   private final Caller caller;
   private final OperationTimer operationTimer;
@@ -93,5 +93,10 @@ public class WrappedTransform<IN, OUT> extends Transform<IN, OUT> {
     } finally {
       operationTimer.reset();
     }
+  }
+
+  @Override
+  public Transform<IN, OUT> getWrapped() {
+    return transform;
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -61,6 +61,7 @@ import io.cdap.cdap.etl.common.PipelinePhase;
 import io.cdap.cdap.etl.common.RecordInfo;
 import io.cdap.cdap.etl.common.Schemas;
 import io.cdap.cdap.etl.common.StageStatisticsCollector;
+import io.cdap.cdap.etl.common.plugin.PluginWrapper;
 import io.cdap.cdap.etl.planner.CombinerDag;
 import io.cdap.cdap.etl.planner.Dag;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
@@ -454,6 +455,11 @@ public abstract class SparkPipelineRunner {
     Map<String, SparkCollection<Object>> inputDataCollections, Object plugin) {
 
     Optional<EmittedRecords.Builder> declarativeBuilder = Optional.empty();
+
+    // If this is a wrapped plugin instance, get the underlying implementation.
+    while (plugin instanceof PluginWrapper) {
+      plugin = ((PluginWrapper<?>) plugin).getWrapped();
+    }
 
     if (plugin instanceof RelationalTransform) {
       RelationalTransform transform = (RelationalTransform) plugin;


### PR DESCRIPTION
This allows us to "unwrap" the underlying plugins and use this instance when evaluating if this Plugin implements a certain interface.

We use this to evaluate if the wrapped plugin is a RelationalTransform when trying to use the Relational Transform API.