### PR TITLE
Add input and output schemas to RelationalTransformContext.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/RelationalTranformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/RelationalTranformContext.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.etl.api.relational;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.TransformContext;
 
 import java.util.Set;
@@ -43,6 +44,19 @@ public interface RelationalTranformContext {
    * @return set of all input relation names
    */
   Set<String> getInputRelationNames();
+
+  /**
+   * Gets schema for input stage
+   * @param inputStage input name
+   * @return relation corresponding to the given input
+   */
+  Schema getInputSchema(String inputStage);
+
+  /**
+   * Gets the output schema for this transform context
+   * @return output schema
+   */
+  Schema getOutputSchema();
 
   /**
    * sets the primary output relation for the transform

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BasicRelationalTransformContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BasicRelationalTransformContext.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.etl.spark.batch;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.relational.Engine;
 import io.cdap.cdap.etl.api.relational.Relation;
 import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
@@ -30,12 +31,19 @@ import java.util.Set;
 public class BasicRelationalTransformContext implements RelationalTranformContext {
   private final Engine engine;
   private final Map<String, Relation> inputMap;
+  private final Map<String, Schema> inputSchemas;
+  private final Schema outputSchema;
   private Relation outputRelation;
 
 
-  public BasicRelationalTransformContext(Engine engine, Map<String, Relation> inputMap) {
+  public BasicRelationalTransformContext(Engine engine,
+                                         Map<String, Relation> inputMap,
+                                         Map<String, Schema> inputSchemas,
+                                         Schema outputSchema) {
     this.engine = engine;
     this.inputMap = inputMap;
+    this.inputSchemas = inputSchemas;
+    this.outputSchema = outputSchema;
   }
 
   @Override
@@ -51,6 +59,16 @@ public class BasicRelationalTransformContext implements RelationalTranformContex
   @Override
   public Set<String> getInputRelationNames() {
     return Collections.unmodifiableSet(inputMap.keySet());
+  }
+
+  @Override
+  public Schema getInputSchema(String inputStage) {
+    return inputSchemas.get(inputStage);
+  }
+
+  @Override
+  public Schema getOutputSchema() {
+    return outputSchema;
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSQLEngineAdapter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSQLEngineAdapter.java
@@ -678,15 +678,14 @@ public class BatchSQLEngineAdapter implements Closeable {
    * @return resulting collection or empty optional if tranform can't be done with this engine
    */
   public Optional<SQLEngineJob<SQLDataset>> tryRelationalTransform(StageSpec stageSpec,
-                                                          RelationalTransform transform,
-                                                          Map<String, SparkCollection<Object>> input) {
+                                                                   RelationalTransform transform,
+                                                                   Map<String, SparkCollection<Object>> input) {
     Map<String, Relation> inputRelations = input.entrySet().stream().collect(Collectors.toMap(
       Map.Entry::getKey,
       e -> sqlEngine.getRelation(new SQLRelationDefinition(e.getKey(), stageSpec.getInputSchemas().get(e.getKey())))
     ));
     BasicRelationalTransformContext pluginContext = new BasicRelationalTransformContext(
-      getSQLRelationalEngine(),
-      inputRelations);
+      getSQLRelationalEngine(), inputRelations, stageSpec.getInputSchemas(), stageSpec.getOutputSchema());
     if (!transform.transform(pluginContext)) {
       //Plugin was not able to do relational tranform with this engine
       return Optional.empty();


### PR DESCRIPTION
This way the plugins can use this information when building relational transform operations.