### PR TITLE
[CDAP-18648] Add a service in app fabric to scan for programs in stopping status

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -108,6 +108,17 @@ public interface Store {
   void setRunning(ProgramRunId id, long runTime, @Nullable String twillRunId, byte[] sourceId);
 
   /**
+   * Logs stopping of a program run and persists program status to {@link ProgramRunStatus#STOPPING}.
+   *
+   * @param id run id of the program
+   * @param sourceId id of the source of program run status, which is proportional to the timestamp of
+   *                 when the current program run status is reached
+   * @param stoppingTime stopping timestamp in seconds
+   * @param terminateTs timestamp at which program should be in an end state calculated using graceful shutdown period
+   */
+  void setStopping(ProgramRunId id, byte[] sourceId, long stoppingTime, long terminateTs);
+
+  /**
    * Logs end of program run and sets the run status to one of: {@link ProgramRunStatus#COMPLETED},
    * or {@link ProgramRunStatus#KILLED}.
    *

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionService.java
@@ -56,7 +56,7 @@ class RemoteExecutionService extends AbstractRetryableScheduledService {
 
   RemoteExecutionService(CConfiguration cConf, ProgramRunId programRunId, ScheduledExecutorService scheduler,
                          RemoteProcessController processController, ProgramStateWriter programStateWriter) {
-    super(RetryStrategies.fromConfiguration(cConf, "system.runtime.monitor."));
+    super(RetryStrategies.fromConfiguration(cConf, Constants.Service.RUNTIME_MONITOR_RETRY_PREFIX));
     this.programRunId = programRunId;
     this.scheduler = scheduler;
     this.processController = processController;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
@@ -439,7 +439,8 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
    */
   private void initializeControllers(long startMillis) {
     int limit = cConf.getInt(Constants.RuntimeMonitor.INIT_BATCH_SIZE);
-    RetryStrategy retryStrategy = RetryStrategies.fromConfiguration(cConf, "system.runtime.monitor.");
+    RetryStrategy retryStrategy = RetryStrategies.fromConfiguration(cConf,
+                                                                    Constants.Service.RUNTIME_MONITOR_RETRY_PREFIX);
     AtomicReference<AppMetadataStore.Cursor> cursorRef = new AtomicReference<>(AppMetadataStore.Cursor.EMPTY);
     AtomicInteger count = new AtomicInteger();
     AtomicBoolean completed = new AtomicBoolean();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java
@@ -83,7 +83,7 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
   @Inject
   RuntimeClientService(CConfiguration cConf, MessagingService messagingService,
                        RuntimeClient runtimeClient, ProgramRunId programRunId) {
-    super(RetryStrategies.fromConfiguration(cConf, "system.runtime.monitor."));
+    super(RetryStrategies.fromConfiguration(cConf, Constants.Service.RUNTIME_MONITOR_RETRY_PREFIX));
     this.messagingContext = new MultiThreadMessagingContext(messagingService);
     this.pollTimeMillis = cConf.getLong(Constants.RuntimeMonitor.POLL_TIME_MS);
     this.gracefulShutdownMillis = cConf.getLong(Constants.RuntimeMonitor.GRACEFUL_SHUTDOWN_MS);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -75,6 +75,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final Set<String> handlerHookNames;
   private final ProgramNotificationSubscriberService programNotificationSubscriberService;
   private final RunRecordCorrectorService runRecordCorrectorService;
+  private final ProgramRunStatusMonitorService programRunStatusMonitorService;
   private final RunRecordMonitorService runRecordCounterService;
   private final CoreSchedulerService coreSchedulerService;
   private final ProvisioningService provisioningService;
@@ -101,6 +102,7 @@ public class AppFabricServer extends AbstractIdleService {
                          @Nullable MetricsCollectionService metricsCollectionService,
                          ProgramRuntimeService programRuntimeService,
                          RunRecordCorrectorService runRecordCorrectorService,
+                         ProgramRunStatusMonitorService programRunStatusMonitorService,
                          ApplicationLifecycleService applicationLifecycleService,
                          ProgramNotificationSubscriberService programNotificationSubscriberService,
                          @Named("appfabric.services.names") Set<String> servicesNames,
@@ -124,6 +126,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.applicationLifecycleService = applicationLifecycleService;
     this.programNotificationSubscriberService = programNotificationSubscriberService;
     this.runRecordCorrectorService = runRecordCorrectorService;
+    this.programRunStatusMonitorService = programRunStatusMonitorService;
     this.sslEnabled = cConf.getBoolean(Constants.Security.SSL.INTERNAL_ENABLED);
     this.coreSchedulerService = coreSchedulerService;
     this.provisioningService = provisioningService;
@@ -150,6 +153,7 @@ public class AppFabricServer extends AbstractIdleService {
         programRuntimeService.start(),
         programNotificationSubscriberService.start(),
         runRecordCorrectorService.start(),
+        programRunStatusMonitorService.start(),
         coreSchedulerService.start(),
         eventPublishManager.start(),
         runRecordCounterService.start()
@@ -202,6 +206,7 @@ public class AppFabricServer extends AbstractIdleService {
     applicationLifecycleService.stopAndWait();
     programNotificationSubscriberService.stopAndWait();
     runRecordCorrectorService.stopAndWait();
+    programRunStatusMonitorService.stopAndWait();
     provisioningService.stopAndWait();
     eventPublishManager.stopAndWait();
     runRecordCounterService.stopAndWait();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -155,7 +155,8 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
     super.doStartUp();
 
     int batchSize = cConf.getInt(Constants.RuntimeMonitor.INIT_BATCH_SIZE);
-    RetryStrategy retryStrategy = RetryStrategies.fromConfiguration(cConf, "system.runtime.monitor.");
+    RetryStrategy retryStrategy = RetryStrategies.fromConfiguration(cConf,
+                                                                    Constants.Service.RUNTIME_MONITOR_RETRY_PREFIX);
     long startTs = System.currentTimeMillis();
 
     Retries.runWithRetries(() -> store.scanActiveRuns(batchSize, (runRecordDetail) -> {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorService.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package io.cdap.cdap.internal.app.services;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.cdap.cdap.app.runtime.ProgramRuntimeService;
+import io.cdap.cdap.app.runtime.ProgramRuntimeService.RuntimeInfo;
+import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.service.AbstractRetryableScheduledService;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.internal.app.store.RunRecordDetail;
+import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import javax.inject.Inject;
+
+/**
+ * A service that periodically scans the store for program runs that are in Stopping state and
+ * force terminates them if they are running beyond the expected terminateTime.
+ */
+public class ProgramRunStatusMonitorService extends AbstractRetryableScheduledService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProgramRunStatusMonitorService.class);
+
+  private final Store store;
+  private final ProgramRuntimeService runtimeService;
+  private final int txBatchSize;
+  private final long intervalMillis;
+
+  @Inject
+  ProgramRunStatusMonitorService(CConfiguration cConf, Store store, ProgramRuntimeService runtimeService) {
+    this(cConf, store, runtimeService, cConf.getInt(Constants.AppFabric.PROGRAM_TERMINATOR_TX_BATCH_SIZE),
+         cConf.getLong(Constants.AppFabric.PROGRAM_TERMINATOR_INTERVAL_SECS));
+  }
+
+  @VisibleForTesting
+  ProgramRunStatusMonitorService(CConfiguration cConf, Store store, ProgramRuntimeService runtimeService,
+                                 int txBatchSize, long specifiedIntervalSecs) {
+    super(RetryStrategies.fromConfiguration(cConf, Constants.Service.RUNTIME_MONITOR_RETRY_PREFIX));
+    this.store = store;
+    this.runtimeService = runtimeService;
+    this.txBatchSize = txBatchSize;
+    if (specifiedIntervalSecs <= 0) {
+      LOG.warn("Invalid interval {} specified for the program terminator. Setting it to 5 minutes.",
+               specifiedIntervalSecs);
+      specifiedIntervalSecs = TimeUnit.MINUTES.toSeconds(5);
+    }
+    this.intervalMillis = TimeUnit.SECONDS.toMillis(specifiedIntervalSecs);
+  }
+
+  @Override
+  protected long runTask() {
+    Set<ProgramRunId> programsScannedForTermination = terminatePrograms();
+    if (!programsScannedForTermination.isEmpty()) {
+      LOG.info("{} programs with STOPPING status that were active beyond their graceful shutdown period" +
+                 " were attempted to be terminated.", programsScannedForTermination.size());
+    }
+    return this.intervalMillis;
+  }
+
+  /**
+   * This method scans the store for program runs that are in STOPPING state and checks their terminateTime.
+   * If terminateTime is in the past but the program is still active, then it stops the program.
+   *
+   * @return a set of programRunIds for which program termination was attempted
+   */
+  Set<ProgramRunId> terminatePrograms() {
+    // fetch all runs that are in stopping state that started at most a minute before current time.
+    // Specifying the entire time range should not be worse in performance
+    // than specifying a more restrictive time range because time range is just used as a read-time filter
+    long currentTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    Set<ProgramRunId> programScannedForTermination = new HashSet<>();
+    Predicate<RunRecordDetail> filter = createFilter(currentTimeInSecs, programScannedForTermination);
+    while (true) {
+      // runs are not guaranteed to come back in order of start time, so need to scan the entire time range
+      // each time. Should not be worse in performance than specifying a more restrictive time range
+      // because time range is just used as a read-time filter.
+      Map<ProgramRunId, RunRecordDetail> stoppingRuns = store.getRuns(
+        ProgramRunStatus.STOPPING, 0L, currentTimeInSecs - TimeUnit.MINUTES.toSeconds(1), txBatchSize, filter);
+      if (stoppingRuns.isEmpty()) {
+        break;
+      }
+      for (RunRecordDetail record : stoppingRuns.values()) {
+        ProgramRunId programRunId = record.getProgramRunId();
+        programScannedForTermination.add(programRunId);
+        RuntimeInfo runtimeInfo = runtimeService.lookup(programRunId.getParent(),
+                                                        RunIds.fromString(programRunId.getRun()));
+        if (runtimeInfo != null && runtimeInfo.getController() != null) {
+          LOG.info("Forcing the termination of program {} as it should have stopped at {} ",
+                   programRunId, record.getTerminateTs());
+          runtimeInfo.getController().stop();
+        }
+      }
+    }
+    return programScannedForTermination;
+  }
+
+  private Predicate<RunRecordDetail> createFilter(long currentTimeInSecs, Set<ProgramRunId> excludedIds) {
+    return record -> {
+      ProgramRunId programRunId = record.getProgramRunId();
+      if (excludedIds.contains(programRunId)) {
+        return false;
+      }
+      Long terminateTime = record.getTerminateTs();
+      if (terminateTime == null || terminateTime > currentTimeInSecs) {
+        return false;
+      }
+      return true;
+    };
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -1348,6 +1348,7 @@ public class AppMetadataStore {
       case STARTING:
       case RUNNING:
       case SUSPENDED:
+      case STOPPING:
         return getProgramRuns(programId, status, startTime, endTime, limit, filter, TYPE_RUN_RECORD_ACTIVE);
       default:
         return getProgramRuns(programId, status, startTime, endTime, limit, filter, TYPE_RUN_RECORD_COMPLETED);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -180,6 +180,13 @@ public class DefaultStore implements Store {
   }
 
   @Override
+  public void setStopping(ProgramRunId id, byte[] sourceId, long stoppingTsSecs, long terminateTsSecs) {
+    TransactionRunners.run(transactionRunner, context -> {
+      getAppMetadataStore(context).recordProgramStopping(id, sourceId, stoppingTsSecs, terminateTsSecs);
+    });
+  }
+
+  @Override
   public void setStop(ProgramRunId id, long endTime, ProgramRunStatus runStatus, byte[] sourceId) {
     setStop(id, endTime, runStatus, null, sourceId);
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorServiceTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.cdap.cdap.internal.app.services;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.cdap.app.guice.ClusterMode;
+import io.cdap.cdap.app.runtime.AbstractProgramRuntimeService;
+import io.cdap.cdap.app.runtime.NoOpProgramStateWriter;
+import io.cdap.cdap.app.runtime.ProgramController;
+import io.cdap.cdap.app.runtime.ProgramRuntimeService;
+import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.internal.app.runtime.SystemArguments;
+import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.store.DefaultStore;
+import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProfileId;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import org.apache.twill.api.RunId;
+import org.apache.twill.common.Cancellable;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+
+/**
+ * Unit test for {@link ProgramRunStatusMonitorService}
+ */
+public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
+  private static Store store;
+  private static CConfiguration cConf;
+
+  @BeforeClass
+  public static void setup() {
+    store = getInjector().getInstance(DefaultStore.class);
+    cConf = getInjector().getInstance(CConfiguration.class);
+  }
+
+  @After
+  public void clearStore() {
+    store.removeAll(NamespaceId.DEFAULT);
+  }
+
+  @Test
+  public void testStoppingProgramsBeyondTerminateTimeAreKilled() {
+    AtomicInteger sourceId = new AtomicInteger(0);
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
+    // set up a workflow for a program in Stopping state
+    Map<String, String> wfSystemArg = ImmutableMap.of(
+      ProgramOptionConstants.CLUSTER_MODE, ClusterMode.ISOLATED.name(),
+      SystemArguments.PROFILE_NAME, ProfileId.NATIVE.getScopedName());
+    ProgramRunId wfId = NamespaceId.DEFAULT.app("test").workflow("testWF").run(randomRunId());
+    store.setProvisioning(wfId, Collections.emptyMap(), wfSystemArg,
+                          Bytes.toBytes(sourceId.getAndIncrement()), artifactId);
+    store.setProvisioned(wfId, 0, Bytes.toBytes(sourceId.getAndIncrement()));
+    store.setStart(wfId, null, Collections.emptyMap(), Bytes.toBytes(sourceId.getAndIncrement()));
+    store.setRunning(wfId, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()), null,
+                     Bytes.toBytes(sourceId.getAndIncrement()));
+    long currentTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    store.setStopping(wfId, Bytes.toBytes(sourceId.getAndIncrement()), currentTimeInSecs, currentTimeInSecs);
+    CountDownLatch latch = new CountDownLatch(1);
+    ProgramRuntimeService testService = new AbstractProgramRuntimeService(
+      cConf, null, null, new NoOpProgramStateWriter(), null) {
+      @Nullable
+      public RuntimeInfo lookup(ProgramId programId, RunId runId) {
+        return getRuntimeInfo(programId, latch);
+      }
+    };
+    ProgramRunStatusMonitorService programRunStatusMonitorService
+      = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3);
+    Assert.assertEquals(1, latch.getCount());
+    programRunStatusMonitorService.terminatePrograms();
+    Assert.assertEquals(0, latch.getCount());
+  }
+
+  @Test
+  public void testStoppingProgramsWithFutureTerminateTimeAreInProgress() {
+    AtomicInteger sourceId = new AtomicInteger(0);
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
+
+    // set up a workflow
+    Map<String, String> wfSystemArg = ImmutableMap.of(
+      ProgramOptionConstants.CLUSTER_MODE, ClusterMode.ISOLATED.name(),
+      SystemArguments.PROFILE_NAME, ProfileId.NATIVE.getScopedName());
+    ProgramRunId wfId = NamespaceId.DEFAULT.app("test").workflow("testWF").run(randomRunId());
+    store.setProvisioning(wfId, Collections.emptyMap(), wfSystemArg,
+                          Bytes.toBytes(sourceId.getAndIncrement()), artifactId);
+    store.setProvisioned(wfId, 0, Bytes.toBytes(sourceId.getAndIncrement()));
+    store.setStart(wfId, null, Collections.emptyMap(), Bytes.toBytes(sourceId.getAndIncrement()));
+    store.setRunning(wfId, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()), null,
+                     Bytes.toBytes(sourceId.getAndIncrement()));
+    long currentTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    store.setStopping(wfId, Bytes.toBytes(sourceId.getAndIncrement()), currentTimeInSecs,
+                      currentTimeInSecs + currentTimeInSecs);
+    CountDownLatch latch = new CountDownLatch(1);
+    ProgramRuntimeService testService = new AbstractProgramRuntimeService(
+      cConf, null, null, new NoOpProgramStateWriter(), null) {
+      @Nullable
+      public RuntimeInfo lookup(ProgramId programId, RunId runId) {
+        return getRuntimeInfo(programId, latch);
+      }
+    };
+    ProgramRunStatusMonitorService programRunStatusMonitorService
+      = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3);
+    Assert.assertEquals(1, latch.getCount());
+    programRunStatusMonitorService.terminatePrograms();
+    Assert.assertEquals(1, latch.getCount());
+  }
+
+  @Test
+  public void testRunningProgramsAreInProgress() {
+    AtomicInteger sourceId = new AtomicInteger(0);
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
+
+    // set up a workflow
+    Map<String, String> wfSystemArg = ImmutableMap.of(
+      ProgramOptionConstants.CLUSTER_MODE, ClusterMode.ISOLATED.name(),
+      SystemArguments.PROFILE_NAME, ProfileId.NATIVE.getScopedName());
+    ProgramRunId wfId = NamespaceId.DEFAULT.app("test").workflow("testWF").run(randomRunId());
+    store.setProvisioning(wfId, Collections.emptyMap(), wfSystemArg,
+                          Bytes.toBytes(sourceId.getAndIncrement()), artifactId);
+    store.setProvisioned(wfId, 0, Bytes.toBytes(sourceId.getAndIncrement()));
+    store.setStart(wfId, null, Collections.emptyMap(), Bytes.toBytes(sourceId.getAndIncrement()));
+    store.setRunning(wfId, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()), null,
+                     Bytes.toBytes(sourceId.getAndIncrement()));
+    CountDownLatch latch = new CountDownLatch(1);
+    ProgramRuntimeService testService = new AbstractProgramRuntimeService(
+      cConf, null, null, new NoOpProgramStateWriter(), null) {
+      @Nullable
+      public RuntimeInfo lookup(ProgramId programId, RunId runId) {
+        return getRuntimeInfo(programId, latch);
+      }
+    };
+    ProgramRunStatusMonitorService programRunStatusMonitorService
+      = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3);
+    Assert.assertEquals(1, latch.getCount());
+    programRunStatusMonitorService.terminatePrograms();
+    Assert.assertEquals(1, latch.getCount());
+  }
+
+  private ProgramRuntimeService.RuntimeInfo getRuntimeInfo(ProgramId programId, CountDownLatch latch) {
+    return new ProgramRuntimeService.RuntimeInfo() {
+      public ProgramController getController() {
+        return getProgramController(latch);
+      }
+
+      @Override
+      public ProgramType getType() {
+        return null;
+      }
+
+      @Override
+      public ProgramId getProgramId() {
+        return programId;
+      }
+
+      @Nullable
+      @Override
+      public RunId getTwillRunId() {
+        return null;
+      }
+    };
+  }
+
+  private ProgramController getProgramController(CountDownLatch latch) {
+    return new ProgramController() {
+        @Override
+        public ProgramRunId getProgramRunId() {
+          return null;
+        }
+
+        @Override
+        public RunId getRunId() {
+          return null;
+        }
+
+        @Override
+        public ListenableFuture<ProgramController> suspend() {
+          return null;
+        }
+
+        @Override
+        public ListenableFuture<ProgramController> resume() {
+          return null;
+        }
+
+        public ListenableFuture<ProgramController> stop() {
+          latch.countDown();
+          return null;
+        }
+
+        @Override
+        public State getState() {
+          return null;
+        }
+
+        @Override
+        public Throwable getFailureCause() {
+          return null;
+        }
+
+        @Override
+        public Cancellable addListener(Listener listener, Executor executor) {
+          return null;
+        }
+
+        @Override
+        public ListenableFuture<ProgramController> command(String name, Object value) {
+          return null;
+        }
+      };
+  }
+
+  private RunId randomRunId() {
+    long startTime = ThreadLocalRandom.current().nextLong(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()));
+    return RunIds.generate(startTime);
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -147,6 +147,7 @@ public final class Constants {
     public static final String LOG_BUFFER_SERVICE = "log.buffer.service";
     public static final String REMOTE_AGENT_SERVICE = "remote.agent.service";
     public static final String ARTIFACT_CACHE_SERVICE = "artifact.cache.service";
+    public static final String RUNTIME_MONITOR_RETRY_PREFIX = "system.runtime.monitor.";
   }
 
   /**
@@ -232,6 +233,8 @@ public final class Constants {
     public static final String LOCAL_DATASET_DELETER_INTERVAL_SECONDS = "app.program.local.dataset.deleter.interval";
     public static final String LOCAL_DATASET_DELETER_INITIAL_DELAY_SECONDS
       = "app.program.local.dataset.deleter.initial.delay";
+    public static final String PROGRAM_TERMINATOR_INTERVAL_SECS = "app.program.terminator.interval.secs";
+    public static final String PROGRAM_TERMINATOR_TX_BATCH_SIZE = "app.program.terminator.tx.batch.size";
     public static final String SYSTEM_ARTIFACTS_DIR = "app.artifact.dir";
     public static final String SYSTEM_ARTIFACTS_MAX_PARALLELISM = "app.artifact.parallelism.max";
     public static final String PROGRAM_EXTRA_CLASSPATH = "app.program.extra.classpath";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -563,6 +563,25 @@
   </property>
 
   <property>
+    <name>app.program.terminator.interval.secs</name>
+    <value>300</value>
+    <description>
+      Interval in seconds of how often the program terminator thread will run;
+      this value should be greater than 0
+    </description>
+  </property>
+
+  <property>
+    <name>app.program.terminator.tx.batch.size</name>
+    <value>1000</value>
+    <description>
+      Number of run records being fetched per transaction for checking
+      if a program in stopping state is active beyond its terminateTime.
+      This value is directly proportional to the ${data.tx.timeout} setting.
+    </description>
+  </property>
+
+  <property>
     <name>app.program.runtime.extensions.dir</name>
     <value>/opt/cdap/master/ext/runtimes</value>
     <description>


### PR DESCRIPTION
On the app fabric side we need a service that continuously scans the store for programs that are in Stopping status. If a program in such a state is found to be running beyond the specified `terminateTime` it should be forced to terminate.

Testing:
This log line was printed in app fabric logs for a program that was in stopping state beyond its terminateTime
```
2022-03-03 23:55:10,822 - WARN  [program run terminator:i.c.c.i.a.s.ProgramRunStatusMonitorService@118] - 
Forcing the termination of program 
program_run:default.basic_streaming_v5.-SNAPSHOT.spark.DataStreamsSparkStreaming.a6336a91-9b4c-11ec-8f0a-56f80572d6b0 
as it is past its graceful shutdown period
```