### PR TITLE
[CDAP-18841] Add tether peer name to run record

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -148,4 +148,9 @@ public final class ProgramOptionConstants {
    * spec
    */
   public static final String APPLICATION_CLASS = "applicationClass";
+
+  /**
+   * Option for name of tethered peer, if any, that has initiated the program run
+   */
+  public static final String PEER_NAME = "peer";
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -528,9 +528,8 @@ public class AppMetadataStore {
       // Update the parent Workflow run record by adding node id and program run id in the properties
       Map<String, String> properties = new HashMap<>(record.getProperties());
       properties.put(workflowNodeId, programRunId.getRun());
-      writeToStructuredTableWithPrimaryKeys(
-        runRecordFields, RunRecordDetail.builder(record).setProperties(properties).setSourceId(sourceId).build(),
-        getRunRecordsTable(), StoreDefinition.AppMetadataStore.RUN_RECORD_DATA);
+      writeToRunRecordTableWithPrimaryKeys(
+        runRecordFields, RunRecordDetail.builder(record).setProperties(properties).setSourceId(sourceId).build());
     }
   }
 
@@ -586,6 +585,7 @@ public class AppMetadataStore {
       .setSystemArgs(systemArgs)
       .setCluster(cluster)
       .setProfileId(profileId.get())
+      .setPeerName(systemArgs.get(ProgramOptionConstants.PEER_NAME))
       .setSourceId(sourceId)
       .setArtifactId(artifactId)
       .setPrincipal(systemArgs.get(ProgramOptionConstants.PRINCIPAL))
@@ -645,8 +645,7 @@ public class AppMetadataStore {
       .setCluster(cluster)
       .setSourceId(sourceId)
       .build();
-    writeToStructuredTableWithPrimaryKeys(
-      key, meta, getRunRecordsTable(), StoreDefinition.AppMetadataStore.RUN_RECORD_DATA);
+    writeToRunRecordTableWithPrimaryKeys(key, meta);
     LOG.trace("Recorded {} for program {}", ProgramRunClusterStatus.PROVISIONED, programRunId);
     return meta;
   }
@@ -685,8 +684,7 @@ public class AppMetadataStore {
       .setCluster(cluster)
       .setSourceId(sourceId)
       .build();
-    writeToStructuredTableWithPrimaryKeys(
-      key, meta, getRunRecordsTable(), StoreDefinition.AppMetadataStore.RUN_RECORD_DATA);
+    writeToRunRecordTableWithPrimaryKeys(key, meta);
     LOG.trace("Recorded {} for program {}", ProgramRunClusterStatus.DEPROVISIONING, programRunId);
     return meta;
   }
@@ -726,8 +724,7 @@ public class AppMetadataStore {
       .setCluster(cluster)
       .setSourceId(sourceId)
       .build();
-    writeToStructuredTableWithPrimaryKeys(
-      key, meta, getRunRecordsTable(), StoreDefinition.AppMetadataStore.RUN_RECORD_DATA);
+    writeToRunRecordTableWithPrimaryKeys(key, meta);
     LOG.trace("Recorded {} for program {}", ProgramRunClusterStatus.DEPROVISIONED, programRunId);
     return meta;
   }
@@ -766,8 +763,7 @@ public class AppMetadataStore {
       .setCluster(cluster)
       .setSourceId(sourceId)
       .build();
-    writeToStructuredTableWithPrimaryKeys(
-      key, meta, getRunRecordsTable(), StoreDefinition.AppMetadataStore.RUN_RECORD_DATA);
+    writeToRunRecordTableWithPrimaryKeys(key, meta);
     LOG.trace("Recorded {} for program {}", ProgramRunClusterStatus.ORPHANED, programRunId);
     return meta;
   }
@@ -802,6 +798,7 @@ public class AppMetadataStore {
       .setProperties(getRecordProperties(systemArgs, runtimeArgs))
       .setSystemArgs(systemArgs)
       .setProfileId(profileId.orElse(null))
+      .setPeerName(systemArgs.get(ProgramOptionConstants.PEER_NAME))
       .setArtifactId(artifactId)
       .setSourceId(sourceId)
       .setPrincipal(systemArgs.get(ProgramOptionConstants.PRINCIPAL))
@@ -818,8 +815,7 @@ public class AppMetadataStore {
   private void writeNewRunRecord(RunRecordDetail meta, String typeRunRecordCompleted) throws IOException {
     List<Field<?>> fields = getProgramRunInvertedTimeKey(typeRunRecordCompleted,
                                                          meta.getProgramRunId(), meta.getStartTs());
-    writeToStructuredTableWithPrimaryKeys(fields, meta, getRunRecordsTable(),
-                                          StoreDefinition.AppMetadataStore.RUN_RECORD_DATA);
+    writeToRunRecordTableWithPrimaryKeys(fields, meta);
     List<Field<?>> countKey = getProgramCountPrimaryKeys(TYPE_COUNT, meta.getProgramRunId().getParent());
     getProgramCountsTable().increment(countKey, StoreDefinition.AppMetadataStore.COUNTS, 1L);
   }
@@ -866,8 +862,7 @@ public class AppMetadataStore {
       .setTwillRunId(twillRunId)
       .setSourceId(sourceId)
       .build();
-    writeToStructuredTableWithPrimaryKeys(
-      key, meta, getRunRecordsTable(), StoreDefinition.AppMetadataStore.RUN_RECORD_DATA);
+    writeToRunRecordTableWithPrimaryKeys(key, meta);
     LOG.trace("Recorded {} for program {}", ProgramRunStatus.STARTING, programRunId);
     return meta;
   }
@@ -914,8 +909,7 @@ public class AppMetadataStore {
       .setTwillRunId(twillRunId)
       .setSourceId(sourceId)
       .build();
-    writeToStructuredTableWithPrimaryKeys(
-      key, meta, getRunRecordsTable(), StoreDefinition.AppMetadataStore.RUN_RECORD_DATA);
+    writeToRunRecordTableWithPrimaryKeys(key, meta);
     LOG.trace("Recorded {} for program {}", ProgramRunStatus.RUNNING, programRunId);
     return meta;
   }
@@ -990,8 +984,7 @@ public class AppMetadataStore {
       }
     }
     RunRecordDetail meta = builder.build();
-    writeToStructuredTableWithPrimaryKeys(
-      key, meta, getRunRecordsTable(), StoreDefinition.AppMetadataStore.RUN_RECORD_DATA);
+    writeToRunRecordTableWithPrimaryKeys(key, meta);
     LOG.trace("Recorded {} for program {}", toStatus, programRunId);
     return meta;
   }
@@ -1038,8 +1031,7 @@ public class AppMetadataStore {
       .setTerminateTs(terminateTsSecs)
       .setSourceId(sourceId)
       .build();
-    writeToStructuredTableWithPrimaryKeys(
-      key, meta, getRunRecordsTable(), StoreDefinition.AppMetadataStore.RUN_RECORD_DATA);
+    writeToRunRecordTableWithPrimaryKeys(key, meta);
     LOG.trace("Recorded {} for program {}", ProgramRunStatus.STOPPING, programRunId);
     return meta;
   }
@@ -1086,8 +1078,7 @@ public class AppMetadataStore {
       .setStatus(runStatus)
       .setSourceId(sourceId)
       .build();
-    writeToStructuredTableWithPrimaryKeys(
-      key, meta, getRunRecordsTable(), StoreDefinition.AppMetadataStore.RUN_RECORD_DATA);
+    writeToRunRecordTableWithPrimaryKeys(key, meta);
     LOG.trace("Recorded {} for program {}", runStatus, programRunId);
     return meta;
   }
@@ -1862,6 +1853,13 @@ public class AppMetadataStore {
   private void writeToStructuredTableWithPrimaryKeys(
     List<Field<?>> keys, Object data, StructuredTable table, String field) throws IOException {
     keys.add(Fields.stringField(field, GSON.toJson(data)));
+    table.upsert(keys);
+  }
+
+  private void writeToRunRecordTableWithPrimaryKeys(List<Field<?>> keys, RunRecordDetail meta) throws IOException {
+    StructuredTable table = getRunRecordsTable();
+    keys.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_RECORD_DATA, GSON.toJson(meta)));
+    keys.add(Fields.stringField(StoreDefinition.AppMetadataStore.PEER_NAME, meta.getPeerName()));
     table.upsert(keys);
   }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/internal/app/store/RunRecordDetail.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/internal/app/store/RunRecordDetail.java
@@ -70,9 +70,10 @@ public class RunRecordDetail extends RunRecord {
                             @Nullable Long terminateTs, ProgramRunStatus status,
                             @Nullable Map<String, String> properties, @Nullable Map<String, String> systemArgs,
                             @Nullable String twillRunId, ProgramRunCluster cluster, ProfileId profileId,
-                            byte[] sourceId, @Nullable ArtifactId artifactId, @Nullable String principal) {
+                            @Nullable String peerName, byte[] sourceId, @Nullable ArtifactId artifactId,
+                            @Nullable String principal) {
     super(programRunId.getRun(), startTs, runTs, stopTs, suspendTs, resumeTs, stoppingTs, terminateTs,
-          status, properties, cluster, profileId);
+          status, properties, cluster, profileId, peerName);
     this.programRunId = programRunId;
     this.systemArgs = systemArgs;
     this.twillRunId = twillRunId;
@@ -152,16 +153,17 @@ public class RunRecordDetail extends RunRecord {
       Objects.equal(this.getTerminateTs(), that.getTerminateTs()) &&
       Objects.equal(this.getStatus(), that.getStatus()) &&
       Objects.equal(this.getProperties(), that.getProperties()) &&
+      Objects.equal(this.getPeerName(), that.getPeerName()) &&
       Objects.equal(this.getTwillRunId(), that.getTwillRunId()) &&
       Arrays.equals(this.getSourceId(), that.getSourceId()) &&
       Objects.equal(this.getArtifactId(), that.getArtifactId()) &&
-      Objects.equal(this.principal, that.principal);
+      Objects.equal(this.getPrincipal(), that.getPrincipal());
   }
 
   @Override
   public int hashCode() {
     return Objects.hashCode(getProgramRunId(), getStartTs(), getRunTs(), getStopTs(), getSuspendTs(), getResumeTs(),
-                            getStoppingTs(), getTerminateTs(), getStatus(), getProperties(),
+                            getStoppingTs(), getTerminateTs(), getStatus(), getProperties(), getPeerName(),
                             getTwillRunId(), Arrays.hashCode(getSourceId()), getArtifactId(), getPrincipal());
   }
 
@@ -182,6 +184,7 @@ public class RunRecordDetail extends RunRecord {
       .add("properties", getProperties())
       .add("cluster", getCluster())
       .add("profile", getProfileId())
+      .add("peerName", getPeerName())
       .add("sourceId", getSourceId() == null ? null : Bytes.toHexString(getSourceId()))
       .add("artifactId", getArtifactId())
       .add("principal", getPrincipal())
@@ -287,7 +290,7 @@ public class RunRecordDetail extends RunRecord {
       // we don't want to throw exception while processing them
       return new RunRecordDetail(programRunId, startTs, runTs, stopTs, suspendTs, resumeTs, stoppingTs,
                                  terminateTs, status, properties, systemArgs, twillRunId, cluster,
-                                 profileId, sourceId, artifactId, principal);
+                                 profileId, peerName, sourceId, artifactId, principal);
     }
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/internal/app/store/RunRecordDetailWithExistingStatus.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/internal/app/store/RunRecordDetailWithExistingStatus.java
@@ -38,11 +38,11 @@ public final class RunRecordDetailWithExistingStatus extends RunRecordDetail {
                                             @Nullable Long stoppingTs, @Nullable Long terminateTs,
                                             ProgramRunStatus status, @Nullable Map<String, String> properties,
                                             @Nullable Map<String, String> systemArgs, @Nullable String twillRunId,
-                                            ProgramRunCluster cluster, ProfileId profileId, byte[] sourceId,
-                                            @Nullable ArtifactId artifactId, @Nullable String principal,
-                                            @Nullable ProgramRunStatus existingStatus) {
+                                            ProgramRunCluster cluster, ProfileId profileId, @Nullable String peerName,
+                                            byte[] sourceId, @Nullable ArtifactId artifactId,
+                                            @Nullable String principal, @Nullable ProgramRunStatus existingStatus) {
     super(programRunId, startTs, runTs, stopTs, suspendTs, resumeTs, stoppingTs, terminateTs, status, properties,
-          systemArgs, twillRunId, cluster, profileId, sourceId, artifactId, principal);
+          systemArgs, twillRunId, cluster, profileId, peerName, sourceId, artifactId, principal);
     this.existingStatus = existingStatus;
   }
 
@@ -80,8 +80,8 @@ public final class RunRecordDetailWithExistingStatus extends RunRecordDetail {
       // we don't want to throw exception while processing them
       return new RunRecordDetailWithExistingStatus(programRunId, startTs, runTs, stopTs, suspendTs, resumeTs,
                                                    stoppingTs, terminateTs, status, properties, systemArgs,
-                                                   twillRunId, cluster, profileId, sourceId, artifactId, principal,
-                                                   existingStatus);
+                                                   twillRunId, cluster, profileId, peerName, sourceId, artifactId,
+                                                   principal, existingStatus);
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
@@ -381,6 +381,7 @@ public final class StoreDefinition {
     public static final String RUN_STATUS = "run_status";
     public static final String RUN_START_TIME = "run_start_time";
     public static final String RUN_RECORD_DATA = "run_record_data";
+    public static final String PEER_NAME = "peer_name";
     public static final String WORKFLOW_DATA = "workflow_data";
     public static final String COUNT_TYPE = "count_type";
     public static final String COUNTS = "counts";
@@ -425,7 +426,8 @@ public final class StoreDefinition {
                     Fields.stringType(PROGRAM_FIELD),
                     Fields.longType(RUN_START_TIME),
                     Fields.stringType(RUN_FIELD),
-                    Fields.stringType(RUN_RECORD_DATA))
+                    Fields.stringType(RUN_RECORD_DATA),
+                    Fields.stringType(PEER_NAME))
         .withPrimaryKeys(RUN_STATUS, NAMESPACE_FIELD, APPLICATION_FIELD, VERSION_FIELD, PROGRAM_TYPE_FIELD,
                          PROGRAM_FIELD, RUN_START_TIME, RUN_FIELD)
         .build();

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/RunRecord.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/RunRecord.java
@@ -74,6 +74,10 @@ public class RunRecord {
   @SerializedName("profile")
   private final ProfileId profileId;
 
+  // the name of the tethered peer that the program was initiated by, if any
+  @SerializedName("peerName")
+  private final String peerName;
+
   /**
    * @deprecated use {@link #builder()} instead.
    */
@@ -81,7 +85,7 @@ public class RunRecord {
   public RunRecord(String pid, long startTs, @Nullable Long runTs, @Nullable Long stopTs, @Nullable Long suspendTs,
                    @Nullable Long resumeTs, @Nullable Long stoppingTs, @Nullable Long terminateTs,
                    ProgramRunStatus status, @Nullable Map<String, String> properties, ProgramRunCluster cluster,
-                   ProfileId profileId) {
+                   ProfileId profileId, @Nullable String peerName) {
     this.pid = pid;
     this.startTs = startTs;
     this.runTs = runTs;
@@ -95,6 +99,7 @@ public class RunRecord {
       Collections.unmodifiableMap(new LinkedHashMap<>(properties));
     this.cluster = cluster;
     this.profileId = profileId;
+    this.peerName = peerName;
   }
 
   /**
@@ -104,7 +109,7 @@ public class RunRecord {
     this(otherRunRecord.getPid(), otherRunRecord.getStartTs(), otherRunRecord.getRunTs(), otherRunRecord.getStopTs(),
          otherRunRecord.getSuspendTs(), otherRunRecord.getResumeTs(), otherRunRecord.getStoppingTs(),
          otherRunRecord.getTerminateTs(), otherRunRecord.getStatus(), otherRunRecord.getProperties(),
-         otherRunRecord.getCluster(), otherRunRecord.getProfileId());
+         otherRunRecord.getCluster(), otherRunRecord.getProfileId(), otherRunRecord.getPeerName());
   }
 
   public String getPid() {
@@ -163,6 +168,11 @@ public class RunRecord {
     return profileId == null ? ProfileId.NATIVE : profileId;
   }
 
+  @Nullable
+  public String getPeerName() {
+    return peerName;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -185,13 +195,14 @@ public class RunRecord {
       Objects.equals(this.status, that.status) &&
       Objects.equals(this.properties, that.properties) &&
       Objects.equals(this.cluster, that.cluster) &&
-      Objects.equals(this.profileId, that.profileId);
+      Objects.equals(this.profileId, that.profileId) &&
+      Objects.equals(this.peerName, that.peerName);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(pid, startTs, runTs, stopTs, suspendTs, resumeTs, stoppingTs, terminateTs, status,
-                        properties, cluster, profileId);
+                        properties, cluster, profileId, peerName);
   }
 
   @Override
@@ -209,6 +220,7 @@ public class RunRecord {
       ", properties=" + properties +
       ", cluster=" + cluster +
       ", profile=" + profileId +
+      ", peerName=" + peerName +
       '}';
   }
 
@@ -246,6 +258,7 @@ public class RunRecord {
     protected Map<String, String> properties;
     protected ProgramRunCluster cluster;
     protected ProfileId profileId;
+    protected String peerName;
 
     protected Builder() {
       properties = new HashMap<>();
@@ -264,6 +277,7 @@ public class RunRecord {
       properties = new HashMap<>(other.getProperties());
       cluster = other.getCluster();
       profileId = other.getProfileId();
+      peerName = other.getPeerName();
     }
 
     public T setStatus(ProgramRunStatus status) {
@@ -327,6 +341,11 @@ public class RunRecord {
       return (T) this;
     }
 
+    public T setPeerName(String peerName) {
+      this.peerName = peerName;
+      return (T) this;
+    }
+
     public RunRecord build() {
       if (pid == null) {
         throw new IllegalArgumentException("Run record run id must be specified.");
@@ -341,7 +360,7 @@ public class RunRecord {
         throw new IllegalArgumentException("Run record status must be specified.");
       }
       return new RunRecord(pid, startTs, runTs, stopTs, suspendTs, resumeTs, stoppingTs, terminateTs,
-                           status, properties, cluster, profileId);
+                           status, properties, cluster, profileId, peerName);
     }
   }
 }


### PR DESCRIPTION
- Add nullable peer name to RunRecord in order to keep track of the tethered instance that initiated the run (if it exists).
- Update ProgramLifecycleHttpHandler to omit RunRecords initiated by a tethered instance

JIRA: CDAP-18841