### PR TITLE
CDAP-18864: Adding logic for system pods to accept tasks

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerHttpHandlerInternal.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.worker.system;
+
+import com.codahale.metrics.Metric;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Singleton;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.api.service.worker.RunnableTaskContext;
+import io.cdap.cdap.api.service.worker.RunnableTaskParam;
+import io.cdap.cdap.api.service.worker.RunnableTaskRequest;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.SystemWorker;
+import io.cdap.cdap.internal.app.worker.RunnableTaskLauncher;
+import io.cdap.cdap.internal.app.worker.TaskDetails;
+import io.cdap.cdap.proto.BasicThrowable;
+import io.cdap.cdap.proto.codec.BasicThrowableCodec;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.BodyProducer;
+import io.cdap.http.HttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.common.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Internal {@link HttpHandler} for Task worker.
+ */
+@Singleton
+@Path(Constants.Gateway.INTERNAL_API_VERSION_3 + "/system")
+public class SystemWorkerHttpHandlerInternal extends AbstractHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(SystemWorkerHttpHandlerInternal.class);
+  private static final Gson GSON = new GsonBuilder().registerTypeAdapter(BasicThrowable.class,
+      new BasicThrowableCodec()).create();
+  private static final String SUCCESS = "success";
+  private static final String FAILURE = "failure";
+  private final int requestLimit;
+
+  private final RunnableTaskLauncher runnableTaskLauncher;
+
+  /**
+   * Holds the total number of requests that have been executed by this handler that should count toward max allowed.
+   */
+  private final AtomicInteger requestProcessedCount = new AtomicInteger(0);
+
+  private final MetricsCollectionService metricsCollectionService;
+
+  public SystemWorkerHttpHandlerInternal(CConfiguration cConf, MetricsCollectionService metricsCollectionService) {
+    this.runnableTaskLauncher = new RunnableTaskLauncher(cConf);
+    this.metricsCollectionService = metricsCollectionService;
+    this.requestLimit = cConf.getInt(Constants.SystemWorker.REQUEST_LIMIT);
+  }
+
+  private void emitMetrics(TaskDetails taskDetails) {
+    long time = System.currentTimeMillis() - taskDetails.getStartTime();
+    Map<String, String> metricTags = new HashMap<>();
+    metricTags.put(Constants.Metrics.Tag.CLASS, taskDetails.getClassName());
+    metricTags.put(Constants.Metrics.Tag.STATUS, taskDetails.isSuccess() ? SUCCESS : FAILURE);
+    metricsCollectionService.getContext(metricTags).increment(Constants.Metrics.SystemWorker.REQUEST_COUNT, 1L);
+    metricsCollectionService.getContext(metricTags).gauge(Constants.Metrics.SystemWorker.REQUEST_LATENCY_MS, time);
+  }
+
+  @POST
+  @Path("/run")
+  public void run(FullHttpRequest request, HttpResponder responder) {
+    if (requestProcessedCount.incrementAndGet() > requestLimit) {
+      responder.sendStatus(HttpResponseStatus.TOO_MANY_REQUESTS);
+      return;
+    }
+
+
+    long startTime = System.currentTimeMillis();
+    String className = null;
+    try {
+      RunnableTaskRequest runnableTaskRequest =
+          GSON.fromJson(request.content().toString(StandardCharsets.UTF_8), RunnableTaskRequest.class);
+      className = getTaskClassName(runnableTaskRequest);
+      RunnableTaskContext runnableTaskContext = runnableTaskLauncher.launchRunnableTask(runnableTaskRequest);
+      TaskDetails taskDetails = new TaskDetails(true, className, startTime);
+      emitMetrics(taskDetails);
+      responder.sendContent(HttpResponseStatus.OK,
+          new RunnableTaskBodyProducer(runnableTaskContext, taskDetails),
+          new DefaultHttpHeaders().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM));
+    } catch (ClassNotFoundException | ClassCastException ex) {
+      responder.sendString(HttpResponseStatus.BAD_REQUEST, exceptionToJson(ex), EmptyHttpHeaders.INSTANCE);
+    } catch (Exception ex) {
+      LOG.error("Failed to run task {}", request.content().toString(StandardCharsets.UTF_8), ex);
+      responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, exceptionToJson(ex), EmptyHttpHeaders.INSTANCE);
+    }
+    requestProcessedCount.decrementAndGet();
+  }
+
+  private String getTaskClassName(RunnableTaskRequest runnableTaskRequest) {
+    return Optional.ofNullable(runnableTaskRequest.getParam())
+        .map(RunnableTaskParam::getEmbeddedTaskRequest)
+        .map(RunnableTaskRequest::getClassName)
+        .orElse(runnableTaskRequest.getClassName());
+  }
+
+  /**
+   * Return json representation of an exception.
+   * Used to propagate exception across network for better surfacing errors and debuggability.
+   */
+  private String exceptionToJson(Exception ex) {
+    BasicThrowable basicThrowable = new BasicThrowable(ex);
+    return GSON.toJson(basicThrowable);
+  }
+
+  private static class RunnableTaskBodyProducer extends BodyProducer {
+    private final ByteBuffer response;
+    private final TaskDetails taskDetails;
+    private boolean done = false;
+
+    RunnableTaskBodyProducer(RunnableTaskContext context, TaskDetails taskDetails) {
+      this.response = context.getResult();
+      this.taskDetails = taskDetails;
+    }
+
+    @Override
+    public ByteBuf nextChunk() {
+      if (done) {
+        return Unpooled.EMPTY_BUFFER;
+      }
+
+      done = true;
+      return Unpooled.wrappedBuffer(response);
+    }
+
+    @Override
+    public void finished() {}
+
+    @Override
+    public void handleError(@Nullable Throwable cause) {
+      LOG.error("Error when sending chunks", cause);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerService.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.worker.system;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.common.discovery.ResolvingDiscoverable;
+import io.cdap.cdap.common.discovery.URIScheme;
+import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
+import io.cdap.cdap.common.security.HttpsEnabler;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactManagerFactory;
+import io.cdap.cdap.internal.app.worker.RunnableTaskLauncher;
+import io.cdap.http.ChannelPipelineModifier;
+import io.cdap.http.NettyHttpService;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpContentDecompressor;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.discovery.DiscoveryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Launches an HTTP server for receiving and handling {@link RunnableTask}
+ */
+public class SystemWorkerService extends AbstractIdleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SystemWorkerService.class);
+  private static final Gson GSON = new Gson();
+
+  private final CConfiguration cConf;
+  private final DiscoveryService discoveryService;
+  private final NettyHttpService httpService;
+  private final ArtifactManagerFactory artifactManagerFactory;
+  private final RunnableTaskLauncher taskLauncher;
+  private Cancellable cancelDiscovery;
+  private InetSocketAddress bindAddress;
+  private MetricsCollectionService metricsCollectionService;
+
+  @Inject
+  SystemWorkerService(CConfiguration cConf,
+      SConfiguration sConf,
+      DiscoveryService discoveryService,
+      ArtifactManagerFactory artifactManagerFactory, MetricsCollectionService metricsCollectionService) {
+    this.cConf = cConf;
+    this.discoveryService = discoveryService;
+    this.artifactManagerFactory = artifactManagerFactory;
+    this.taskLauncher = new RunnableTaskLauncher(cConf);
+    this.metricsCollectionService = metricsCollectionService;
+
+    NettyHttpService.Builder builder = new CommonNettyHttpServiceBuilder(cConf, Constants.Service.SYSTEM_WORKER)
+        .setHost(cConf.get(Constants.SystemWorker.ADDRESS))
+        .setPort(cConf.getInt(Constants.SystemWorker.PORT))
+        .setExecThreadPoolSize(cConf.getInt(Constants.TaskWorker.EXEC_THREADS))
+        .setBossThreadPoolSize(cConf.getInt(Constants.TaskWorker.BOSS_THREADS))
+        .setWorkerThreadPoolSize(cConf.getInt(Constants.TaskWorker.WORKER_THREADS))
+        .setChannelPipelineModifier(new ChannelPipelineModifier() {
+          @Override
+          public void modify(ChannelPipeline pipeline) {
+            pipeline.addAfter("compressor", "decompressor", new HttpContentDecompressor());
+          }
+        })
+        .setHttpHandlers(new SystemWorkerHttpHandlerInternal(cConf, metricsCollectionService));
+
+    if (cConf.getBoolean(Constants.Security.SSL.INTERNAL_ENABLED)) {
+      new HttpsEnabler().configureKeyStore(cConf, sConf).enable(builder);
+    }
+    this.httpService = builder.build();
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    LOG.debug("Starting SystemWorkerService");
+    httpService.start();
+    bindAddress = httpService.getBindAddress();
+    cancelDiscovery = discoveryService.register(
+        ResolvingDiscoverable.of(URIScheme.createDiscoverable(Constants.Service.SYSTEM_WORKER, httpService)));
+    LOG.debug("Starting SystemWorkerService has completed");
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    LOG.debug("Shutting down SystemWorkerService");
+    httpService.stop(1, 2, TimeUnit.SECONDS);
+    cancelDiscovery.cancel();
+    LOG.debug("Shutting down SystemWorkerService has completed");
+  }
+
+  @VisibleForTesting
+  public InetSocketAddress getBindAddress() {
+    return bindAddress;
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.worker.system;
+
+import com.google.common.util.concurrent.Service.State;
+import com.google.gson.Gson;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.RunnableTaskContext;
+import io.cdap.cdap.api.service.worker.RunnableTaskRequest;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.proto.BasicThrowable;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequests;
+import io.cdap.common.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.twill.discovery.InMemoryDiscoveryService;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+
+public class SystemWorkerServiceTest {
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  private static final Logger LOG = LoggerFactory.getLogger(SystemWorkerServiceTest.class);
+  private static final Gson GSON = new Gson();
+
+  private SystemWorkerService systemWorkerService;
+
+  private CConfiguration createCConf() {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.SystemWorker.ADDRESS, "localhost");
+    cConf.setInt(Constants.SystemWorker.PORT, 0);
+    cConf.setBoolean(Constants.Security.SSL.INTERNAL_ENABLED, false);
+    cConf.setInt(Constants.SystemWorker.REQUEST_LIMIT, 5);
+    return cConf;
+  }
+
+  private SConfiguration createSConf() {
+    return SConfiguration.create();
+  }
+
+  @Before
+  public void beforeTest() {
+    CConfiguration cConf = createCConf();
+    SConfiguration sConf = createSConf();
+
+    SystemWorkerService systemWorkerService = new SystemWorkerService(cConf, sConf, new InMemoryDiscoveryService(),
+        (namespaceId, retryStrategy) -> null,
+        new NoOpMetricsCollectionService());
+    systemWorkerService.startAndWait();
+    this.systemWorkerService = systemWorkerService;
+  }
+
+  @After
+  public void afterTest() {
+    if (systemWorkerService != null) {
+      systemWorkerService.stopAndWait();
+      systemWorkerService = null;
+    }
+  }
+
+
+
+
+  @Test
+  public void testStartAndStopWithValidRequest() throws IOException {
+    InetSocketAddress addr = systemWorkerService.getBindAddress();
+    URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
+
+    // Post valid request
+    String want = "100";
+    RunnableTaskRequest req =
+        RunnableTaskRequest.getBuilder(SystemWorkerServiceTest.TestRunnableClass.class.getName()).withParam(want)
+        .build();
+    String reqBody = GSON.toJson(req);
+    HttpResponse response = HttpRequests.execute(
+        HttpRequest.post(uri.resolve("/v3Internal/system/run").toURL())
+            .withBody(reqBody).build(),
+        new DefaultHttpRequestConfig(false));
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
+    Assert.assertEquals(want, response.getResponseBodyAsString());
+  }
+
+  @Test
+  public void testStartAndStopWithInvalidRequest() throws Exception {
+    InetSocketAddress addr = systemWorkerService.getBindAddress();
+    URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
+
+    // Post invalid request
+    RunnableTaskRequest noClassReq = RunnableTaskRequest.getBuilder("NoClass").build();
+    String reqBody = GSON.toJson(noClassReq);
+    HttpResponse response = HttpRequests.execute(
+        HttpRequest.post(uri.resolve("/v3Internal/system/run").toURL())
+            .withBody(reqBody).build(),
+        new DefaultHttpRequestConfig(false));
+    Assert.assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, response.getResponseCode());
+    BasicThrowable basicThrowable;
+    basicThrowable = GSON.fromJson(response.getResponseBodyAsString(), BasicThrowable.class);
+    Assert.assertTrue(basicThrowable.getClassName().contains("java.lang.ClassNotFoundException"));
+    Assert.assertNotNull(basicThrowable.getMessage());
+    Assert.assertTrue(basicThrowable.getMessage().contains("NoClass"));
+    Assert.assertNotEquals(basicThrowable.getStackTraces().length, 0);
+  }
+
+  @Test
+  public void testValidConcurrentRequests() throws Exception {
+    InetSocketAddress addr = systemWorkerService.getBindAddress();
+    URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
+
+    RunnableTaskRequest request =
+        RunnableTaskRequest.getBuilder(SystemWorkerServiceTest.TestRunnableClass.class.getName()).
+        withParam("1000").build();
+
+    String reqBody = GSON.toJson(request);
+    List<Callable<HttpResponse>> calls = new ArrayList<>();
+    int concurrentRequests = 2;
+
+    for (int i = 0; i < concurrentRequests; i++) {
+      calls.add(
+          () -> HttpRequests.execute(
+              HttpRequest.post(uri.resolve("/v3Internal/system/run").toURL())
+                  .withBody(reqBody).build(),
+              new DefaultHttpRequestConfig(false))
+      );
+    }
+
+    List<Future<HttpResponse>> responses = Executors.newFixedThreadPool(concurrentRequests).invokeAll(calls);
+    int okResponse = 0;
+    int conflictResponse = 0;
+    for (int i = 0; i < concurrentRequests; i++) {
+      if (responses.get(i).get().getResponseCode() == HttpResponseStatus.OK.code()) {
+        okResponse++;
+      } else if (responses.get(i).get().getResponseCode() == HttpResponseStatus.TOO_MANY_REQUESTS.code()) {
+        conflictResponse++;
+      }
+    }
+    Assert.assertEquals(2, okResponse);
+    Assert.assertEquals(concurrentRequests, okResponse + conflictResponse);
+  }
+
+  @Test
+  public void testInvalidConcurrentRequests() throws Exception {
+    InetSocketAddress addr = systemWorkerService.getBindAddress();
+    URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
+
+    RunnableTaskRequest request =
+        RunnableTaskRequest.getBuilder(SystemWorkerServiceTest.TestRunnableClass.class.getName()).
+            withParam("1000").build();
+
+    String reqBody = GSON.toJson(request);
+    List<Callable<HttpResponse>> calls = new ArrayList<>();
+    int concurrentRequests = 6;
+
+    for (int i = 0; i < concurrentRequests; i++) {
+      calls.add(
+          () -> HttpRequests.execute(
+              HttpRequest.post(uri.resolve("/v3Internal/system/run").toURL())
+                  .withBody(reqBody).build(),
+              new DefaultHttpRequestConfig(false))
+      );
+    }
+
+    List<Future<HttpResponse>> responses = Executors.newFixedThreadPool(concurrentRequests).invokeAll(calls);
+    int okResponse = 0;
+    int conflictResponse = 0;
+    for (int i = 0; i < concurrentRequests; i++) {
+      if (responses.get(i).get().getResponseCode() == HttpResponseStatus.OK.code()) {
+        okResponse++;
+      } else if (responses.get(i).get().getResponseCode() == HttpResponseStatus.TOO_MANY_REQUESTS.code()) {
+        conflictResponse++;
+      }
+    }
+    Assert.assertEquals(5, okResponse);
+    Assert.assertEquals(1, conflictResponse);
+    Assert.assertEquals(concurrentRequests, okResponse + conflictResponse);
+  }
+
+
+
+  public static class TestRunnableClass implements RunnableTask {
+    @Override
+    public void run(RunnableTaskContext context) throws Exception {
+      if (!context.getParam().equals("")) {
+        Thread.sleep(Integer.parseInt(context.getParam()));
+      }
+      context.writeResult(context.getParam().getBytes(StandardCharsets.UTF_8));
+    }
+  }
+
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerTwillRunnableTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerTwillRunnableTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.worker.system;
+
+import com.google.inject.Injector;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactManagerFactory;
+import io.cdap.cdap.internal.app.runtime.distributed.MockMasterEnvironment;
+import io.cdap.cdap.master.environment.MasterEnvironments;
+import io.cdap.cdap.proto.id.NamespaceId;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+
+public class SystemWorkerTwillRunnableTest {
+  @Test
+  public void testInjector() {
+    MasterEnvironments.setMasterEnvironment(new MockMasterEnvironment());
+    Injector injector = SystemWorkerTwillRunnable.createInjector(CConfiguration.create(), new Configuration());
+    injector.getInstance(ArtifactManagerFactory.class).create(NamespaceId.SYSTEM, RetryStrategies.noRetry());
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -130,6 +130,7 @@ public final class Constants {
     public static final String RUNTIME = "runtime";
     public static final String AUTHENTICATION = "authentication";
     public static final String TASK_WORKER = "task.worker";
+    public static final String SYSTEM_WORKER = "system.worker";
     public static final String ARTIFACT_LOCALIZER = "artifact.localizer";
     public static final String SYSTEM_METRICS_EXPORTER = "system.metrics.exporter";
     public static final String ARTIFACT_CACHE = "artifact.cache";
@@ -460,6 +461,15 @@ public final class Constants {
     public static final String CONTAINER_MEMORY_MB = "system.worker.container.memory.mb";
     public static final String CONTAINER_CORES = "system.worker.container.num.cores";
     public static final String CONTAINER_COUNT = "system.worker.container.count";
+    public static final String LOCAL_DATA_DIR = "task.worker.local.data.dir";
+
+    /**
+     * System worker http handler configuration
+     */
+    public static final String ADDRESS = "system.worker.bind.address";
+    public static final String PORT = "system.worker.bind.port";
+    public static final String REQUEST_LIMIT = "system.worker.request.limit";
+    public static final String METRIC_PREFIX = "task.worker.";
   }
 
   /**
@@ -994,6 +1004,15 @@ public final class Constants {
         "client." + Constants.TaskWorker.METRIC_PREFIX + "request.count";
       public static final String CLIENT_REQUEST_LATENCY_MS =
         "client." + Constants.TaskWorker.METRIC_PREFIX + "request.latency.millis";
+    }
+
+    public static final class SystemWorker {
+      public static final String REQUEST_COUNT = Constants.SystemWorker.METRIC_PREFIX + "request.count";
+      public static final String REQUEST_LATENCY_MS = Constants.SystemWorker.METRIC_PREFIX + "request.latency.millis";
+      public static final String CLIENT_REQUEST_COUNT =
+          "client." + Constants.SystemWorker.METRIC_PREFIX + "request.count";
+      public static final String CLIENT_REQUEST_LATENCY_MS =
+          "client." + Constants.SystemWorker.METRIC_PREFIX + "request.latency.millis";
     }
 
     /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4759,6 +4759,31 @@
   </property>
 
   <property>
+    <name>system.worker.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      The bind address for system worker service.
+    </description>
+  </property>
+
+  <property>
+    <name>system.worker.bind.port</name>
+    <value>11020</value>
+    <description>
+      The port to bind the system worker service to.
+    </description>
+  </property>
+
+  <property>
+    <name>system.worker.request.limit</name>
+    <value>10</value>
+    <description>
+      Number of requests accepted by system worker pods.
+    </description>
+  </property>
+
+
+  <property>
     <name>artifact.localizer.container.num.cores</name>
     <value>1</value>
     <description>


### PR DESCRIPTION
This PR is for adding logic to system worker pods to accept system tasks. The diff is from the branch(CDAP-18337) which is used to bring up system pods.
At a high level, this is different from worker pods in the following key ways
1. No logic for pod restart. Worker pods die and respawn under different circumstances (for eg, after execution of a task)
2. Limit on number of requests per system pod. This is set to a default of 10 but will be updated via experimentation.
