### PR TITLE
CDAP-18745 increase retry timeout for conn macro

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
  * Class which contains common logic about retry logic
  */
 abstract class AbstractServiceRetryableMacroEvaluator implements MacroEvaluator {
-  private static final long TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
+  private static final long TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(600);
   private static final long RETRY_BASE_DELAY_MILLIS = 200L;
   private static final long RETRY_MAX_DELAY_MILLIS = TimeUnit.SECONDS.toMillis(5);
   private static final double RETRY_DELAY_MULTIPLIER = 1.2d;


### PR DESCRIPTION
Increase connection macro retry timeout, 30 secs is too short for platform restart, using 10 mins to be consistent with secure store retry timeout