### PR TITLE
CDAP-18389 fail if bad macro is provided

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginInstantiator.java
@@ -597,7 +597,7 @@ public class PluginInstantiator implements Closeable {
           // if child property is required and it is missing, add it to missing properties and continue
           if (childProperty.isRequired() && !macroFields.contains(child) &&
                 !properties.getProperties().containsKey(child)) {
-            missingProperties.add(name);
+            missingProperties.add(child);
             missing = true;
             continue;
           }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionHandler.java
@@ -478,7 +478,6 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
     MacroEvaluator macroEvaluator = new DefaultMacroEvaluator(new BasicArguments(arguments), evaluators,
                                                               Collections.singleton(OAuthMacroEvaluator.FUNCTION_NAME));
     MacroParserOptions options = MacroParserOptions.builder()
-                                 .skipInvalidMacros()
                                  .setEscaping(false)
                                  .setFunctionWhitelist(evaluators.keySet())
                                  .build();

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionTaskBase.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteConnectionTaskBase.java
@@ -90,7 +90,6 @@ public abstract class RemoteConnectionTaskBase implements RunnableTask {
     MacroEvaluator macroEvaluator = new DefaultMacroEvaluator(new BasicArguments(arguments), evaluators,
                                                               Collections.singleton(OAuthMacroEvaluator.FUNCTION_NAME));
     MacroParserOptions options = MacroParserOptions.builder()
-      .skipInvalidMacros()
       .setEscaping(false)
       .setFunctionWhitelist(evaluators.keySet())
       .build();


### PR DESCRIPTION
Fail if the macro is invalid when getting connector to provide clear error message. 
Also fix a bug on missing properties are not set correctly on child