### PR TITLE
[CDAP-18733] Refactor connection metrics

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionHandler.java
@@ -166,8 +166,11 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
       contextAccessEnforcer.enforce(new ConnectionEntityId(namespace, ConnectionId.getConnectionId(connection)),
                                     StandardPermission.GET);
       Connection conn = store.getConnection(new ConnectionId(namespaceSummary, connection));
-      metrics.count(Constants.Metrics.Connection.CONNECTION_GET_COUNT, 1);
-      metrics.count(Constants.Metrics.Connection.getConnGetMetric(conn.getConnectionType()), 1);
+      Metrics child = metrics.child(ImmutableMap.of(Constants.Metrics.Tag.APP_ENTITY_TYPE,
+                                                    Constants.CONNECTION_SERVICE_NAME,
+                                                    Constants.Metrics.Tag.APP_ENTITY_TYPE_NAME,
+                                                    conn.getConnectionType()));
+      child.count(Constants.Metrics.Connection.CONNECTION_GET_COUNT, 1);
       responder.sendJson(conn);
     });
   }
@@ -205,8 +208,11 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
                                                  creationRequest.getDescription(), false, false,
                                                  now, now, creationRequest.getPlugin());
       store.saveConnection(connectionId, connectionInfo, creationRequest.overWrite());
-      metrics.count(Constants.Metrics.Connection.CONNECTION_COUNT, 1);
-      metrics.count(Constants.Metrics.Connection.getCountMetric(connectionInfo.getConnectionType()), 1);
+      Metrics child = metrics.child(ImmutableMap.of(Constants.Metrics.Tag.APP_ENTITY_TYPE,
+                                                    Constants.CONNECTION_SERVICE_NAME,
+                                                    Constants.Metrics.Tag.APP_ENTITY_TYPE_NAME,
+                                                    connectionInfo.getConnectionType()));
+      child.count(Constants.Metrics.Connection.CONNECTION_COUNT, 1);
       responder.sendStatus(HttpURLConnection.HTTP_OK);
     });
   }
@@ -231,8 +237,11 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
                                     StandardPermission.DELETE);
       Connection oldConnection = store.getConnection(connectionId);
       store.deleteConnection(connectionId);
-      metrics.count(Constants.Metrics.Connection.CONNECTION_DELETED_COUNT, 1);
-      metrics.count(Constants.Metrics.Connection.getDeletedMetric(oldConnection.getConnectionType()), 1);
+      Metrics child = metrics.child(ImmutableMap.of(Constants.Metrics.Tag.APP_ENTITY_TYPE,
+                                                    Constants.CONNECTION_SERVICE_NAME,
+                                                    Constants.Metrics.Tag.APP_ENTITY_TYPE_NAME,
+                                                    oldConnection.getConnectionType()));
+      child.count(Constants.Metrics.Connection.CONNECTION_DELETED_COUNT, 1);
       responder.sendStatus(HttpURLConnection.HTTP_OK);
     });
   }
@@ -321,8 +330,11 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
       } else {
         browseLocally(namespaceSummary.getName(), browseRequest, conn, responder);
       }
-      metrics.count(Constants.Metrics.Connection.CONNECTION_BROWSE_COUNT, 1);
-      metrics.count(Constants.Metrics.Connection.getBrowseMetric(conn.getConnectionType()), 1);
+      Metrics child = metrics.child(ImmutableMap.of(Constants.Metrics.Tag.APP_ENTITY_TYPE,
+                                                    Constants.CONNECTION_SERVICE_NAME,
+                                                    Constants.Metrics.Tag.APP_ENTITY_TYPE_NAME,
+                                                    conn.getConnectionType()));
+      child.count(Constants.Metrics.Connection.CONNECTION_BROWSE_COUNT, 1);
     });
   }
 
@@ -384,11 +396,13 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
       } else {
         sampleLocally(namespaceSummary.getName(), sampleRequestString, conn, responder);
       }
-      metrics.count(Constants.Metrics.Connection.CONNECTION_SAMPLE_COUNT, 1);
-      metrics.count(Constants.Metrics.Connection.getSampleMetric(conn.getConnectionType()), 1);
+      Metrics child = metrics.child(ImmutableMap.of(Constants.Metrics.Tag.APP_ENTITY_TYPE,
+                                                    Constants.CONNECTION_SERVICE_NAME,
+                                                    Constants.Metrics.Tag.APP_ENTITY_TYPE_NAME,
+                                                    conn.getConnectionType()));
+      child.count(Constants.Metrics.Connection.CONNECTION_SAMPLE_COUNT, 1);
       // sample will also generate the spec, so add the metric for it
-      metrics.count(Constants.Metrics.Connection.CONNECTION_SPEC_COUNT, 1);
-      metrics.count(Constants.Metrics.Connection.getSpecMetric(conn.getConnectionType()), 1);
+      child.count(Constants.Metrics.Connection.CONNECTION_SPEC_COUNT, 1);
     });
   }
 
@@ -462,8 +476,11 @@ public class ConnectionHandler extends AbstractDataPipelineHandler {
         specGenerationLocally(namespaceSummary.getName(), specRequest, conn, responder);
       }
 
-      metrics.count(Constants.Metrics.Connection.CONNECTION_SPEC_COUNT, 1);
-      metrics.count(Constants.Metrics.Connection.getSpecMetric(conn.getConnectionType()), 1);
+      Metrics child = metrics.child(ImmutableMap.of(Constants.Metrics.Tag.APP_ENTITY_TYPE,
+                                                    Constants.CONNECTION_SERVICE_NAME,
+                                                    Constants.Metrics.Tag.APP_ENTITY_TYPE_NAME,
+                                                    conn.getConnectionType()));
+      child.count(Constants.Metrics.Connection.CONNECTION_SPEC_COUNT, 1);
     });
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
@@ -82,30 +82,18 @@ public final class Constants {
       public static final String CONNECTION_BROWSE_COUNT = "connections.browse.count";
       public static final String CONNECTION_SAMPLE_COUNT = "connections.sample.count";
       public static final String CONNECTION_SPEC_COUNT = "connections.spec.count";
+    }
 
-      public static String getCountMetric(String connType) {
-        return String.format("connections.%s.count", connType);
-      }
+    /**
+     * NOTES:
+     * tag names must be unique (keeping all possible here helps to ensure that)
+     * tag names better be short to reduce the serialized metric value size
+     */
+    public static final class Tag {
 
-      public static String getDeletedMetric(String connType) {
-        return String.format("connections.%s.deleted.count", connType);
-      }
-
-      public static String getConnGetMetric(String connType) {
-        return String.format("connections.%s.get.count", connType);
-      }
-
-      public static String getBrowseMetric(String connType) {
-        return String.format("connections.%s.browse.count", connType);
-      }
-
-      public static String getSampleMetric(String connType) {
-        return String.format("connections.%s.sample.count", connType);
-      }
-
-      public static String getSpecMetric(String connType) {
-        return String.format("connections.%s.spec.count", connType);
-      }
+      //For app entity
+      public static final String APP_ENTITY_TYPE = "aet";
+      public static final String APP_ENTITY_TYPE_NAME = "tpe";
     }
   }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -849,6 +849,9 @@ public final class Constants {
       public static final String APP = "app";
 
       public static final String SERVICE = "srv";
+      //For app entity
+      public static final String APP_ENTITY_TYPE = "aet";
+      public static final String APP_ENTITY_TYPE_NAME = "tpe";
 
       public static final String WORKER = "wrk";
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4986,22 +4986,6 @@
   </property>
 
   <property>
-    <name>provisioner.system.properties.gcp-dataproc.root.url</name>
-    <value>dataproc.googleapis.com:443</value>
-    <description>
-      The default Root URL for Dataproc.
-    </description>
-  </property>
-
-  <property>
-    <name>provisioner.system.properties.gcp-existing-dataproc.root.url</name>
-    <value>dataproc.googleapis.com:443</value>
-    <description>
-      The default Root URL for Dataproc.
-    </description>
-  </property>
-
-  <property>
     <name>artifact.cache.bind.address</name>
     <value>0.0.0.0</value>
     <description>

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
+import com.google.cloud.dataproc.v1.ClusterControllerSettings;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Strings;
@@ -173,11 +174,15 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
       Map<String, String> systemLabels = getSystemLabels();
       return Optional.of(
         new DataprocRuntimeJobManager(new DataprocClusterInfo(context, clusterName, conf.getDataprocCredentials(),
-                                                              conf.getRootUrl(),
+                                                              getRootUrl(conf),
                                                               projectId, region, bucket, systemLabels)));
     } catch (Exception e) {
       throw new RuntimeException("Error while getting credentials for dataproc. ", e);
     }
+  }
+
+  protected String getRootUrl(DataprocConf conf) {
+    return Optional.ofNullable(conf.getRootUrl()).orElse(ClusterControllerSettings.getDefaultEndpoint());
   }
 
   @Override
@@ -194,7 +199,9 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
       return true;
     }
     return ImmutableSet.of(DataprocConf.RUNTIME_JOB_MANAGER, BUCKET, DataprocConf.TOKEN_ENDPOINT_KEY,
-                           DataprocConf.ENCRYPTION_KEY_NAME).contains(property);
+                           DataprocConf.ENCRYPTION_KEY_NAME, DataprocConf.ROOT_URL,
+                           DataprocConf.COMPUTE_HTTP_REQUEST_CONNECTION_TIMEOUT,
+                           DataprocConf.COMPUTE_HTTP_REQUEST_READ_TIMEOUT).contains(property);
   }
 
   /**

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -341,7 +341,8 @@ class DataprocClient implements AutoCloseable {
   private static ClusterControllerClient getClusterControllerClient(DataprocConf conf) throws IOException {
     CredentialsProvider credentialsProvider = FixedCredentialsProvider.create(conf.getDataprocCredentials());
 
-    String regionalEndpoint = conf.getRegion() + "-" + conf.getRootUrl();
+    String rootUrl = Optional.ofNullable(conf.getRootUrl()).orElse(ClusterControllerSettings.getDefaultEndpoint());
+    String regionalEndpoint = conf.getRegion() + "-" + rootUrl;
 
     ClusterControllerSettings controllerSettings = ClusterControllerSettings.newBuilder()
       .setCredentialsProvider(credentialsProvider)

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -89,9 +89,9 @@ final class DataprocConf {
   static final String AUTOSCALING_POLICY = "autoScalingPolicy";
 
   public static final String COMPUTE_HTTP_REQUEST_CONNECTION_TIMEOUT = "compute.request.connection.timeout.millis";
-  public static final int COMPUTE_HTTP_REQUEST_CONNECTION_TIMEOUT_DEFAULT = 20000;
+  private static final int COMPUTE_HTTP_REQUEST_CONNECTION_TIMEOUT_DEFAULT = 20000;
   public static final String COMPUTE_HTTP_REQUEST_READ_TIMEOUT = "compute.request.read.timeout.millis";
-  public static final int COMPUTE_HTTP_REQUEST_READ_TIMEOUT_DEFAULT = 20000;
+  private static final int COMPUTE_HTTP_REQUEST_READ_TIMEOUT_DEFAULT = 20000;
 
 
   private final String accountKey;

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -176,7 +176,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       labels.putAll(getReuseLabels(context, conf));
       labels.putAll(conf.getClusterLabels());
       LOG.info("Creating Dataproc cluster {} in project {}, in region {}, with image {}, with labels {}, endpoint {}",
-               clusterName, conf.getProjectId(), conf.getRegion(), imageDescription, labels, conf.getRootUrl());
+               clusterName, conf.getProjectId(), conf.getRegion(), imageDescription, labels, getRootUrl(conf));
 
       boolean privateInstance = Boolean.parseBoolean(getSystemContext().getProperties().get(PRIVATE_INSTANCE));
       ClusterOperationMetadata createOperationMeta = client.createCluster(clusterName, imageVersion,
@@ -456,10 +456,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       DataprocConf.IMAGE_VERSION,
       DataprocConf.CLUSTER_META_DATA,
       DataprocConf.SERVICE_ACCOUNT,
-      DataprocConf.CLUSTER_IDLE_TTL_MINUTES,
-      DataprocConf.ROOT_URL,
-      DataprocConf.COMPUTE_HTTP_REQUEST_CONNECTION_TIMEOUT,
-      DataprocConf.COMPUTE_HTTP_REQUEST_READ_TIMEOUT
+      DataprocConf.CLUSTER_IDLE_TTL_MINUTES
     ).contains(property);
   }
 

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/PredefinedAutoScaling.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/PredefinedAutoScaling.java
@@ -26,6 +26,7 @@ import com.google.cloud.dataproc.v1.AutoscalingPolicyServiceClient;
 import com.google.cloud.dataproc.v1.AutoscalingPolicyServiceSettings;
 import com.google.cloud.dataproc.v1.BasicAutoscalingAlgorithm;
 import com.google.cloud.dataproc.v1.BasicYarnAutoscalingConfig;
+import com.google.cloud.dataproc.v1.ClusterControllerSettings;
 import com.google.cloud.dataproc.v1.InstanceGroupAutoscalingPolicyConfig;
 import com.google.cloud.dataproc.v1.RegionName;
 import com.google.common.annotations.VisibleForTesting;
@@ -34,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Dataproc's Auto-Scaling policy Operations and configurations to be used when a pipeline is enabled with
@@ -157,7 +159,9 @@ public class PredefinedAutoScaling {
     throws IOException {
     CredentialsProvider credentialsProvider = FixedCredentialsProvider.create(dataprocConf.getDataprocCredentials());
 
-    String regionalEndpoint = dataprocConf.getRegion() + "-" + dataprocConf.getRootUrl();
+    String rootUrl = Optional.ofNullable(dataprocConf.getRootUrl())
+        .orElse(ClusterControllerSettings.getDefaultEndpoint());
+    String regionalEndpoint = dataprocConf.getRegion() + "-" + rootUrl;
 
     AutoscalingPolicyServiceSettings autoscalingPolicyServiceSettings = AutoscalingPolicyServiceSettings.newBuilder()
       .setCredentialsProvider(credentialsProvider)

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricStore.java
@@ -137,7 +137,8 @@ public class DefaultMetricStore implements MetricStore {
                        Constants.Metrics.Tag.SERVICE, Constants.Metrics.Tag.DATASET,
                        Constants.Metrics.Tag.RUN_ID, Constants.Metrics.Tag.HANDLER,
                        Constants.Metrics.Tag.METHOD, Constants.Metrics.Tag.INSTANCE_ID,
-                       Constants.Metrics.Tag.THREAD),
+                       Constants.Metrics.Tag.THREAD, Constants.Metrics.Tag.APP_ENTITY_TYPE,
+                       Constants.Metrics.Tag.APP_ENTITY_TYPE_NAME),
       // i.e. for service only
       ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP,
                        Constants.Metrics.Tag.SERVICE)));


### PR DESCRIPTION
These changes helps in using the global connection metrics for group by on basis of connectors. 
And eliminates the requirement for having separate metrics on basis of connectors.  

Total Connection Count Metric:
![Screen Shot 2022-02-23 at 9 26 09 PM](https://user-images.githubusercontent.com/88528384/155356831-183bb7be-a667-45a8-9966-80203ba39859.png)

GCS Connection Count Metric:
![Screen Shot 2022-02-23 at 9 26 48 PM](https://user-images.githubusercontent.com/88528384/155356946-6e06ef2d-c790-4515-8b9d-49d2b0011a68.png)

BQ Connection Count Metric:
![Screen Shot 2022-02-23 at 9 27 16 PM](https://user-images.githubusercontent.com/88528384/155357016-9f6870ce-f024-40ef-9dcf-ebf76effefb8.png)
