### PR TITLE
Added logic to control which stages must be pushed down or skipped from SQL engine execution.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/AutoJoinerTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/AutoJoinerTest.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.etl.api.join.JoinField;
 import io.cdap.cdap.etl.mock.batch.MockExternalSource;
 import io.cdap.cdap.etl.mock.batch.MockSQLEngine;
 import io.cdap.cdap.etl.mock.batch.MockSQLEngineWithCapabilities;
+import io.cdap.cdap.etl.mock.batch.MockSQLEngineWithStageSettings;
 import io.cdap.cdap.etl.mock.batch.MockSink;
 import io.cdap.cdap.etl.mock.batch.MockSinkWithWriteCapability;
 import io.cdap.cdap.etl.mock.batch.MockSource;
@@ -282,6 +283,33 @@ public class AutoJoinerTest extends HydratorTestBase {
                                                      expected, expectedSchema, Engine.SPARK);
   }
 
+  @Test
+  public void testBroadcastJoinUsingSQLEngineWithIncludedStages() throws Exception {
+    Schema expectedSchema = Schema.recordOf("purchases.users",
+                                            Schema.Field.of("purchases_region", Schema.of(Schema.Type.STRING)),
+                                            Schema.Field.of("purchases_purchase_id", Schema.of(Schema.Type.INT)),
+                                            Schema.Field.of("purchases_user_id", Schema.of(Schema.Type.INT)),
+                                            Schema.Field.of("users_region", Schema.of(Schema.Type.STRING)),
+                                            Schema.Field.of("users_user_id", Schema.of(Schema.Type.INT)),
+                                            Schema.Field.of("users_name", Schema.of(Schema.Type.STRING)));
+    Set<StructuredRecord> expected = new HashSet<>();
+    expected.add(StructuredRecord.builder(expectedSchema)
+                   .set("purchases_region", "us")
+                   .set("purchases_purchase_id", 123)
+                   .set("purchases_user_id", 0)
+                   .set("users_region", "us")
+                   .set("users_user_id", 0)
+                   .set("users_name", "alice").build());
+
+    testSimpleAutoJoinUsingSQLEngineWithStageSettings(Arrays.asList("users", "purchases"),
+                                                      Collections.singletonList("users"),
+                                                      expected,
+                                                      expectedSchema,
+                                                      "",
+                                                      "join",
+                                                      Engine.SPARK);
+  }
+
 
   @Test
   public void testAutoInnerJoin() throws Exception {
@@ -327,6 +355,33 @@ public class AutoJoinerTest extends HydratorTestBase {
                                      expectedSchema, Engine.SPARK);
     testSimpleAutoJoinUsingSQLEngineWithCapabilities(Arrays.asList("users", "purchases"), Collections.emptyList(),
                                                      expected, expectedSchema, Engine.SPARK);
+  }
+
+  @Test
+  public void testAutoInnerJoinUsingSQLEngineWithExcludedStages() throws Exception {
+    Schema expectedSchema = Schema.recordOf("purchases.users",
+                                            Schema.Field.of("purchases_region", Schema.of(Schema.Type.STRING)),
+                                            Schema.Field.of("purchases_purchase_id", Schema.of(Schema.Type.INT)),
+                                            Schema.Field.of("purchases_user_id", Schema.of(Schema.Type.INT)),
+                                            Schema.Field.of("users_region", Schema.of(Schema.Type.STRING)),
+                                            Schema.Field.of("users_user_id", Schema.of(Schema.Type.INT)),
+                                            Schema.Field.of("users_name", Schema.of(Schema.Type.STRING)));
+    Set<StructuredRecord> expected = new HashSet<>();
+    expected.add(StructuredRecord.builder(expectedSchema)
+                   .set("purchases_region", "us")
+                   .set("purchases_purchase_id", 123)
+                   .set("purchases_user_id", 0)
+                   .set("users_region", "us")
+                   .set("users_user_id", 0)
+                   .set("users_name", "alice").build());
+
+    testSimpleAutoJoinUsingSQLEngineWithStageSettings(Arrays.asList("users", "purchases"),
+                                                      Collections.singletonList("users"),
+                                                      expected,
+                                                      expectedSchema,
+                                                      "",
+                                                      "join",
+                                                      Engine.SPARK);
   }
 
   @Test
@@ -836,6 +891,100 @@ public class AutoJoinerTest extends HydratorTestBase {
     } else {
       // Ensure no records are written to the SQL engine if the join contains a broadcast.
       Assert.assertEquals(0, MockSQLEngine.countLinesInDirectory(joinOutputDir));
+    }
+  }
+
+  private void testSimpleAutoJoinUsingSQLEngineWithStageSettings(List<String> required, List<String> broadcast,
+                                                                 Set<StructuredRecord> expected,
+                                                                 Schema expectedSchema,
+                                                                 String includedStages,
+                                                                 String excludedStages,
+                                                                 Engine engine) throws Exception {
+    File joinInputDir = TMP_FOLDER.newFolder();
+    File joinOutputDir = TMP_FOLDER.newFolder();
+
+    // Write input to simulate the join operation results
+    // If any of the sides of the operation is a join, then we don't need to write as the SQL engine won't be used.
+    if (broadcast.isEmpty()) {
+      String joinFile = "join-file1.txt";
+      MockSQLEngine.writeInput(new File(joinInputDir, joinFile).getAbsolutePath(), expected);
+    }
+
+    /*
+         users ------|
+                     |--> join --> sink
+         purchases --|
+
+
+         joinOn: users.region = purchases.region and users.user_id = purchases.user_id
+     */
+    String userInput = UUID.randomUUID().toString();
+    String purchaseInput = UUID.randomUUID().toString();
+    String output = UUID.randomUUID().toString();
+    String sqlEnginePlugin = UUID.randomUUID().toString();
+    ETLBatchConfig config = ETLBatchConfig.builder()
+      .setPushdownEnabled(true)
+      .setTransformationPushdown(
+        new ETLTransformationPushdown(MockSQLEngineWithStageSettings.getPlugin(sqlEnginePlugin,
+                                                                               joinInputDir.getAbsolutePath(),
+                                                                               joinOutputDir.getAbsolutePath(),
+                                                                               expectedSchema,
+                                                                               includedStages,
+                                                                               excludedStages)))
+      .addStage(new ETLStage("users", MockSource.getPlugin(userInput, USER_SCHEMA)))
+      .addStage(new ETLStage("purchases", MockSource.getPlugin(purchaseInput, PURCHASE_SCHEMA)))
+      .addStage(new ETLStage("join", MockAutoJoiner.getPlugin(Arrays.asList("purchases", "users"),
+                                                              Arrays.asList("region", "user_id"),
+                                                              required, broadcast, Collections.emptyList(), true)))
+      .addStage(new ETLStage("sink", MockSink.getPlugin(output)))
+      .addConnection("users", "join")
+      .addConnection("purchases", "join")
+      .addConnection("join", "sink")
+      .setEngine(engine)
+      .build();
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, config);
+    ApplicationId appId = NamespaceId.DEFAULT.app(UUID.randomUUID().toString());
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    // write input data
+    List<StructuredRecord> userData = Arrays.asList(USER_ALICE, USER_ALYCE, USER_BOB);
+    DataSetManager<Table> inputManager = getDataset(userInput);
+    MockSource.writeInput(inputManager, userData);
+
+    List<StructuredRecord> purchaseData = new ArrayList<>();
+    purchaseData.add(StructuredRecord.builder(PURCHASE_SCHEMA)
+                       .set("region", "us")
+                       .set("user_id", 0)
+                       .set("purchase_id", 123).build());
+    purchaseData.add(StructuredRecord.builder(PURCHASE_SCHEMA)
+                       .set("region", "us")
+                       .set("user_id", 2)
+                       .set("purchase_id", 456).build());
+    inputManager = getDataset(purchaseInput);
+    MockSource.writeInput(inputManager, purchaseData);
+
+    WorkflowManager workflowManager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    Map<String, String> args = Collections.singletonMap(MockAutoJoiner.PARTITIONS_ARGUMENT, "1");
+    workflowManager.startAndWaitForGoodRun(args, ProgramRunStatus.COMPLETED, 5, TimeUnit.MINUTES);
+
+    DataSetManager<Table> outputManager = getDataset(output);
+    List<StructuredRecord> outputRecords = MockSink.readOutput(outputManager);
+
+    Assert.assertEquals(expected, new HashSet<>(outputRecords));
+
+    validateMetric(5, appId, "join.records.in");
+    validateMetric(expected.size(), appId, "join.records.out");
+
+    // If a broadcast stage is set to execute in the engine, the engine must execute the stage
+    if (!includedStages.isEmpty() && !broadcast.isEmpty()) {
+      // Ensure all records were written to the SQL engine
+      Assert.assertEquals(5, MockSQLEngineWithStageSettings.countLinesInDirectory(joinOutputDir));
+    } else if (!excludedStages.isEmpty()) {
+      // Ensure no records are written to the SQL engine if the join contains a broadcast.
+      Assert.assertEquals(0, MockSQLEngineWithStageSettings.countLinesInDirectory(joinOutputDir));
+    } else {
+      Assert.fail("Should never happen");
     }
   }
 
@@ -1933,15 +2082,15 @@ public class AutoJoinerTest extends HydratorTestBase {
 
     List<StructuredRecord> ageData = new ArrayList<>();
     ageData.add(StructuredRecord.builder(AGE_SCHEMA)
-                       .set("region", "us")
-                       .set("user_id", 10)
-                       .set("age", 20)
-                       .build());
+                  .set("region", "us")
+                  .set("user_id", 10)
+                  .set("age", 20)
+                  .build());
     ageData.add(StructuredRecord.builder(AGE_SCHEMA)
-                       .set("region", "us")
-                       .set("user_id", 1)
-                       .set("age", 30)
-                       .build());
+                  .set("region", "us")
+                  .set("user_id", 1)
+                  .set("age", 30)
+                  .build());
     inputManager = getDataset(ageInput);
     MockSource.writeInput(inputManager, ageData);
 
@@ -1962,17 +2111,17 @@ public class AutoJoinerTest extends HydratorTestBase {
       for (StructuredRecord sr : outputRecords) {
         actual.add(StructuredRecord.builder(expectedSchema)
                      .set("ages_region", sr.get("ages_region"))
-                     .set("ages_age",  sr.get("ages_age"))
-                     .set("ages_user_id",  sr.get("ages_user_id"))
+                     .set("ages_age", sr.get("ages_age"))
+                     .set("ages_user_id", sr.get("ages_user_id"))
                      .set("purchases_region", sr.get("purchases_region"))
-                     .set("purchases_purchase_id",  sr.get("purchases_purchase_id"))
-                     .set("purchases_user_id",  sr.get("purchases_user_id"))
-                     .set("users_region",  sr.get("users_region"))
-                     .set("users_user_id",  sr.get("users_user_id"))
-                     .set("users_name",  sr.get("users_name"))
-                     .set("interests_region",  sr.get("interests_region"))
-                     .set("interests_user_id",  sr.get("interests_user_id"))
-                     .set("interests_interest",  sr.get("interests_interest")).build());
+                     .set("purchases_purchase_id", sr.get("purchases_purchase_id"))
+                     .set("purchases_user_id", sr.get("purchases_user_id"))
+                     .set("users_region", sr.get("users_region"))
+                     .set("users_user_id", sr.get("users_user_id"))
+                     .set("users_name", sr.get("users_name"))
+                     .set("interests_region", sr.get("interests_region"))
+                     .set("interests_user_id", sr.get("interests_user_id"))
+                     .set("interests_interest", sr.get("interests_interest")).build());
       }
     }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngine.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/SQLEngine.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.etl.api.engine.sql;
 import io.cdap.cdap.api.RuntimeContext;
 import io.cdap.cdap.api.annotation.Beta;
 import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.PipelineConfigurable;
 import io.cdap.cdap.etl.api.SubmitterLifecycle;
 import io.cdap.cdap.etl.api.engine.sql.capability.PullCapability;
@@ -228,4 +229,38 @@ public interface SQLEngine<KEY_IN, VALUE_IN, KEY_OUT, VALUE_OUT>
   default Set<PushCapability> getPushCapabilities() {
     return Collections.emptySet();
   }
+
+  /**
+   * Check if the supplied input schema is supported by the SQL engine
+   * @param schema input schema to validate
+   * @return boolean specifying if the input schema is supported.
+   */
+  default boolean supportsInputSchema(Schema schema) {
+    return true;
+  }
+
+  /**
+   * Check if the supplied output schema is supported by the SQL engine
+   * @param schema output schema to validate
+   * @return boolean specifying if the output schema is supported.
+   */
+  default boolean supportsOutputSchema(Schema schema) {
+    return true;
+  }
+
+  /**
+   * Defines which stages should be pushed down even when the platform doesn't select these stages for push down.
+   * @return Set containing stage names to push down to the SQL Engine
+   */
+  default Set<String> getIncludedStageNames() {
+    return Collections.emptySet();
+  };
+
+  /**
+   * Defines which stages should not be pushed down even when the platform determines the stage must be pushed down
+   * @return Set containing stage names to exclude from pushing down to the SQL Engine
+   */
+  default Set<String> getExcludedStageNames() {
+    return Collections.emptySet();
+  };
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -463,7 +463,7 @@ public abstract class SparkPipelineRunner {
 
     if (plugin instanceof RelationalTransform) {
       RelationalTransform transform = (RelationalTransform) plugin;
-      for (SparkCollectionRelationalEngine engine : getRelationalEngines(stageData)) {
+      for (SparkCollectionRelationalEngine engine : getRelationalEngines(stageSpec, stageData)) {
         if (!transform.canUseEngine(engine.getRelationalEngine())) {
           continue;
         }
@@ -484,7 +484,8 @@ public abstract class SparkPipelineRunner {
    * @param stageData input collection
    * @return list of engines to try
    */
-  protected Iterable<SparkCollectionRelationalEngine> getRelationalEngines(SparkCollection<Object> stageData) {
+  protected Iterable<SparkCollectionRelationalEngine> getRelationalEngines(StageSpec stageSpec,
+                                                                           SparkCollection<Object> stageData) {
     //TODO CDAP-18608: Add Spark engine here
     return Collections.emptyList();
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
@@ -317,6 +317,16 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
       return false;
     }
 
+    // Explicitly skip this stage if the stage is configured as an excluded stage.
+    if (shouldForceSkipSQLEngine(stageName)) {
+      return false;
+    }
+
+    // Explicitly include this stage if the stage is configured as an included stage.
+    if (shouldForcePushToSQLEngine(stageName)) {
+      return true;
+    }
+
     boolean containsBroadcastStage = false;
 
     for (JoinStage stage : joinDefinition.getStages()) {
@@ -336,23 +346,53 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
   }
 
   /**
+   * Check if this stage is configured as a stage that should be pushed to the SQL engine
+   * @param stageName stage name
+   * @return boolean stating if this stage should always try to be executed in the SQL engine.
+   */
+  protected boolean shouldForcePushToSQLEngine(String stageName) {
+    return sqlEngineAdapter != null && sqlEngineAdapter.getIncludedStageNames().contains(stageName);
+  }
+
+  /**
+   * Check if this stage is configured as a stage that should never be pushed to the SQL engine
+   * @param stageName stage name
+   * @return boolean stating if this stage should always be skipped from executing in the SQL engine.
+   */
+  protected boolean shouldForceSkipSQLEngine(String stageName) {
+    return sqlEngineAdapter != null && sqlEngineAdapter.getExcludedStageNames().contains(stageName);
+  }
+
+  /**
    * If SQL Engine is present, supports relational transform and current stage data is already
    * provided by SQL engine, adds SQL Engine implementation of relational engine
    * @param stageData
    * @return
    */
   @Override
-  protected Iterable<SparkCollectionRelationalEngine> getRelationalEngines(SparkCollection<Object> stageData) {
-    if (sqlEngineAdapter == null || !sqlEngineAdapter.supportsRelationalTranform()
-      || !(stageData instanceof SQLBackedCollection)) {
+  protected Iterable<SparkCollectionRelationalEngine> getRelationalEngines(StageSpec stageSpec,
+                                                                           SparkCollection<Object> stageData) {
+    if (sqlEngineAdapter == null || !sqlEngineAdapter.supportsRelationalTranform()) {
       //Relational transform on SQL engine is not supported
-      return super.getRelationalEngines(stageData);
+      return super.getRelationalEngines(stageSpec, stageData);
     }
+
+    // Explicitly skip this stage if the stage is configured as an excluded stage.
+    if (shouldForceSkipSQLEngine(stageSpec.getName())) {
+      return super.getRelationalEngines(stageSpec, stageData);
+    }
+
+    // If this stage is not pushed down and it's not in the included stages, we can skip relational transformation
+    // in the SQL engine.
+    if (!(stageData instanceof SQLBackedCollection) && !shouldForcePushToSQLEngine(stageSpec.getName())) {
+      return super.getRelationalEngines(stageSpec, stageData);
+    }
+
     SQLEngineRelationalEngine relationalEngine = new SQLEngineRelationalEngine(
       sec, functionCacheFactory, jsc, new SQLContext(jsc), datasetContext, sinkFactory, sqlEngineAdapter);
     return Iterables.concat(
       Collections.singletonList(relationalEngine),
-      super.getRelationalEngines(stageData)
+      super.getRelationalEngines(stageSpec, stageData)
     );
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineCollection.java
@@ -200,7 +200,15 @@ public class SQLEngineCollection<T> implements SQLBackedCollection<T> {
 
   @Override
   public boolean tryStoreDirect(StageSpec stageSpec) {
-    SQLEngineOutput sqlEngineOutput = sinkFactory.getSQLEngineOutput(stageSpec.getName());
+    String stageName = stageSpec.getName();
+
+    // Check if this stage should be excluded from executing in the SQL engine
+    if (adapter.getExcludedStageNames().contains(stageName)) {
+      return false;
+    }
+
+    // Get SQLEngineOutput instance for this stage
+    SQLEngineOutput sqlEngineOutput = sinkFactory.getSQLEngineOutput(stageName);
     if (sqlEngineOutput != null) {
       //Try writing directly
       SQLEngineJob<Boolean> writeJob = adapter.write(datasetName, sqlEngineOutput);

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -55,6 +55,7 @@ import io.cdap.cdap.etl.mock.batch.MockRuntimeDatasetSink;
 import io.cdap.cdap.etl.mock.batch.MockRuntimeDatasetSource;
 import io.cdap.cdap.etl.mock.batch.MockSQLEngine;
 import io.cdap.cdap.etl.mock.batch.MockSQLEngineWithCapabilities;
+import io.cdap.cdap.etl.mock.batch.MockSQLEngineWithStageSettings;
 import io.cdap.cdap.etl.mock.batch.MockSink;
 import io.cdap.cdap.etl.mock.batch.MockSinkWithWriteCapability;
 import io.cdap.cdap.etl.mock.batch.MockSource;
@@ -107,7 +108,7 @@ public class HydratorTestBase extends TestBase {
   private static final Set<PluginClass> BATCH_MOCK_PLUGINS = ImmutableSet.of(
     FieldCountAggregator.PLUGIN_CLASS, IdentityAggregator.PLUGIN_CLASS, GroupFilterAggregator.PLUGIN_CLASS,
     MockJoiner.PLUGIN_CLASS, MockAutoJoiner.PLUGIN_CLASS, MockSQLEngine.PLUGIN_CLASS,
-    MockSQLEngineWithCapabilities.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
+    MockSQLEngineWithCapabilities.PLUGIN_CLASS, MockSQLEngineWithStageSettings.PLUGIN_CLASS, DupeFlagger.PLUGIN_CLASS,
     MockRuntimeDatasetSink.PLUGIN_CLASS, MockRuntimeDatasetSource.PLUGIN_CLASS,
     MockExternalSource.PLUGIN_CLASS, MockExternalSink.PLUGIN_CLASS,
     DoubleTransform.PLUGIN_CLASS, AllErrorTransform.PLUGIN_CLASS, IdentityTransform.PLUGIN_CLASS,
@@ -171,8 +172,10 @@ public class HydratorTestBase extends TestBase {
                       BATCH_MOCK_PLUGINS,
                       io.cdap.cdap.etl.mock.batch.MockSource.class,
                       io.cdap.cdap.etl.mock.batch.MockSink.class,
-                      MockExternalSource.class, MockExternalSink.class, MockSQLEngine.class,
+                      MockExternalSource.class, MockExternalSink.class,
+                      MockSQLEngine.class,
                       MockSQLEngineWithCapabilities.class,
+                      MockSQLEngineWithStageSettings.class,
                       DoubleTransform.class, AllErrorTransform.class, IdentityTransform.class,
                       IntValueFilterTransform.class, StringValueFilterTransform.class,
                       FieldCountAggregator.class, FieldsPrefixTransform.class,


### PR DESCRIPTION
Added additional methods to ensure that input and output schemas for stages are supported by the SQL engine. This is useful when verifying if all input and output types in an aggregation are supported by the SQL engine.