### PR TITLE
Fix tagNameToHuman conversion in MetricsQueryHelper 

### DIFF
--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsQueryHelper.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsQueryHelper.java
@@ -458,7 +458,9 @@ public class MetricsQueryHelper {
   private Map<String, String> tagNamesToHuman(Map<String, String> tagValues) {
     Map<String, String> humanTagValues = Maps.newHashMap();
     for (Map.Entry<String, String> tag : tagValues.entrySet()) {
-      humanTagValues.put(tagNameToHuman.get(tag.getKey()), tag.getValue());
+      String tagName = tagNameToHuman.get(tag.getKey());
+      tagName = tagName != null ? tagName : tag.getKey();
+      humanTagValues.put(tagName, tag.getValue());
     }
     return humanTagValues;
   }


### PR DESCRIPTION
If TagName is not found in mapping, it returns "null" as TagName.
Adding a similar fix as we do for tagValues - https://github.com/cdapio/cdap/blob/develop/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsQueryHelper.java#L221