### PR TITLE
[CDAP-18879] Only bind RemoteAuthenticator for TetheringAgentService to external usages

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import javax.inject.Named;
 
 /**
  * The main class to run the remote agent service.
@@ -61,6 +62,8 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
   private static final Gson GSON = new Gson();
   private static final String CONNECT_CONTROL_CHANNEL = "/v3/tethering/controlchannels/";
   private static final String SUBSCRIBER = "tether.agent";
+
+  public static final String REMOTE_TETHERING_AUTHENTICATOR = "remoteTetheringAuthenticator";
 
   private final CConfiguration cConf;
   private final long connectionInterval;
@@ -75,7 +78,8 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
 
   @Inject
   TetheringAgentService(CConfiguration cConf, TransactionRunner transactionRunner, TetheringStore store,
-                        MessagingService messagingService, RemoteAuthenticator remoteAuthenticator) {
+                        MessagingService messagingService,
+                        @Named(REMOTE_TETHERING_AUTHENTICATOR) RemoteAuthenticator remoteAuthenticator) {
     super(RetryStrategies.fromConfiguration(cConf, "tethering.agent."));
     this.connectionInterval = TimeUnit.SECONDS.toMillis(cConf.getLong(Constants.Tethering.CONNECTION_INTERVAL));
     this.cConf = cConf;

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/TetheringAgentServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/TetheringAgentServiceMain.java
@@ -61,8 +61,9 @@ public class TetheringAgentServiceMain extends AbstractServiceMain<EnvironmentOp
                                            EnvironmentOptions options, CConfiguration cConf) {
     return Arrays.asList(
       new ConfigModule(cConf),
-      // TODO CDAP-18879: Fix RemoteAuthenticator bindings to separate internal and remote HTTP calls.
-      RemoteAuthenticatorModules.getDefaultModule(Constants.Tethering.CLIENT_AUTHENTICATOR_NAME),
+      RemoteAuthenticatorModules.getDefaultModule(TetheringAgentService.REMOTE_TETHERING_AUTHENTICATOR,
+                                                  Constants.Tethering.CLIENT_AUTHENTICATOR_NAME),
+      RemoteAuthenticatorModules.getDefaultModule(),
       new SystemDatasetRuntimeModule().getStandaloneModules(),
       new TransactionModules().getSingleNodeModules(),
       new NamespaceAdminModule().getStandaloneModules(),


### PR DESCRIPTION
Context: TetheringAgentService currently binds all usages of `RemoteAuthenticator` to use the configuration specified for the client. In reality, we only want to bind the specific `RemoteAuthenticator` used for making tethering calls to the client configuration because those calls will be made to a different CDAP instance (whereas publishing TMS happens in the same instance).