### PR TITLE
[CDAP-18927] Send program state updates to local TMS when running in …

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
@@ -148,7 +148,8 @@ public class DistributedProgramContainerModule extends AbstractModule {
     modules.add(new IOModule());
     modules.add(new DFSLocationModule());
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
-    modules.add(new MessagingClientModule());
+    boolean tetheringEnabled = programOpts.getArguments().getOption(ProgramOptionConstants.PEER_NAME) != null;
+    modules.add(new MessagingClientModule(tetheringEnabled));
     modules.add(new AuditModule());
     modules.add(new AuthorizationEnforcementModule().getDistributedModules());
     modules.add(new SecureStoreClientModule());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/MessagingProgramStateWriter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/MessagingProgramStateWriter.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.inject.name.Named;
 import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.app.runtime.Arguments;
 import io.cdap.cdap.app.runtime.ProgramOptions;
@@ -32,6 +33,7 @@ import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import io.cdap.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.proto.BasicThrowable;
 import io.cdap.cdap.proto.Notification;
 import io.cdap.cdap.proto.ProgramRunStatus;
@@ -56,7 +58,9 @@ public final class MessagingProgramStateWriter implements ProgramStateWriter {
 
 
   @Inject
-  public MessagingProgramStateWriter(CConfiguration cConf, MessagingService messagingService) {
+  public MessagingProgramStateWriter(CConfiguration cConf,
+                                     @Named(MessagingClientModule.PROGRAM_MESSAGING)
+                                       MessagingService messagingService) {
     this(new MessagingProgramStatePublisher(messagingService,
                                             NamespaceId.SYSTEM.topic(cConf.get(
                                               Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC)),

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClient.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClient.java
@@ -62,10 +62,11 @@ public class RemoteClient {
   private final String discoverableServiceName;
   private final String basePath;
   private final RemoteAuthenticator remoteAuthenticator;
+  private final boolean skipRewriteUrl;
 
   RemoteClient(InternalAuthenticator internalAuthenticator, DiscoveryServiceClient discoveryClient,
                String discoverableServiceName, HttpRequestConfig httpRequestConfig, String basePath,
-               RemoteAuthenticator remoteAuthenticator) {
+               RemoteAuthenticator remoteAuthenticator, boolean skipRewriteUrl) {
     this.internalAuthenticator = internalAuthenticator;
     this.discoverableServiceName = discoverableServiceName;
     this.httpRequestConfig = httpRequestConfig;
@@ -73,6 +74,7 @@ public class RemoteClient {
     String cleanBasePath = basePath.startsWith("/") ? basePath.substring(1) : basePath;
     this.basePath = cleanBasePath.endsWith("/") ? cleanBasePath : cleanBasePath + "/";
     this.remoteAuthenticator = remoteAuthenticator;
+    this.skipRewriteUrl = skipRewriteUrl;
   }
 
   /**
@@ -227,7 +229,7 @@ public class RemoteClient {
    * Rewrites the given URL based on the runtime service.
    */
   private URL rewriteURL(URL url) {
-    if (url.getPort() != 0) {
+    if (url.getPort() != 0 || skipRewriteUrl) {
       return url;
     }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
@@ -49,7 +49,12 @@ public class RemoteClientFactory {
 
   public RemoteClient createRemoteClient(String discoverableServiceName, HttpRequestConfig httpRequestConfig,
                                          String basePath) {
+    return createRemoteClient(discoverableServiceName, httpRequestConfig, basePath, false);
+  }
+
+  public RemoteClient createRemoteClient(String discoverableServiceName, HttpRequestConfig httpRequestConfig,
+                                         String basePath, boolean skipRewriterUrl) {
     return new RemoteClient(internalAuthenticator, discoveryClient, discoverableServiceName,
-                            httpRequestConfig, basePath, remoteAuthenticator);
+                            httpRequestConfig, basePath, remoteAuthenticator, skipRewriterUrl);
   }
 }

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/ClientMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/ClientMessagingService.java
@@ -92,14 +92,15 @@ import javax.annotation.Nullable;
  *
  * NOTE: This class shouldn't expose to end user (e.g. cdap-client module).
  */
-public final class ClientMessagingService implements MessagingService {
+public class ClientMessagingService implements MessagingService {
 
-  private static final HttpRequestConfig HTTP_REQUEST_CONFIG = new DefaultHttpRequestConfig(false);
   private static final TransactionCodec TRANSACTION_CODEC = new TransactionCodec();
   private static final Gson GSON = new Gson();
   // These types for only for Gson to use, hence using the gson TypeToken instead of guava one
   private static final Type TOPIC_PROPERTY_TYPE = new TypeToken<Map<String, String>>() { }.getType();
   private static final Type TOPIC_LIST_TYPE = new TypeToken<List<String>>() { }.getType();
+  protected static final HttpRequestConfig HTTP_REQUEST_CONFIG = new DefaultHttpRequestConfig(false);
+  protected static final String NAMESPACE_PATH = "/v1/namespaces/";
 
   private final RemoteClient remoteClient;
   private final boolean compressPayload;
@@ -111,8 +112,13 @@ public final class ClientMessagingService implements MessagingService {
 
   @VisibleForTesting
   public ClientMessagingService(RemoteClientFactory remoteClientFactory, boolean compressPayload) {
-    this.remoteClient = remoteClientFactory.createRemoteClient(
-      Constants.Service.MESSAGING_SERVICE, HTTP_REQUEST_CONFIG, "/v1/namespaces/");
+    this(remoteClientFactory.createRemoteClient(
+      Constants.Service.MESSAGING_SERVICE, HTTP_REQUEST_CONFIG, NAMESPACE_PATH),
+         compressPayload);
+  }
+
+  protected ClientMessagingService(RemoteClient remoteClient, boolean compressPayload) {
+    this.remoteClient = remoteClient;
     this.compressPayload = compressPayload;
   }
 

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/LocalClientMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/LocalClientMessagingService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.client;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.messaging.MessagingService;
+
+/**
+ * The client implementation of {@link MessagingService} that *only* talks to the local messaging service even if
+ * a runtime monitor url is configured.
+ * This client is intended for internal higher level API implementation only.
+ *
+ * NOTE: This class shouldn't expose to end user (e.g. cdap-client module).
+ */
+public final class LocalClientMessagingService extends ClientMessagingService {
+  @Inject
+  LocalClientMessagingService(CConfiguration cConf, RemoteClientFactory remoteClientFactory) {
+    super(remoteClientFactory.createRemoteClient(Constants.Service.MESSAGING_SERVICE,
+                                                 HTTP_REQUEST_CONFIG,
+                                                 NAMESPACE_PATH,
+                                                 true),
+          cConf.getBoolean(Constants.MessagingSystem.HTTP_COMPRESS_PAYLOAD));
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/guice/MessagingClientModule.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/guice/MessagingClientModule.java
@@ -18,17 +18,39 @@ package io.cdap.cdap.messaging.guice;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
+import com.google.inject.name.Names;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.client.ClientMessagingService;
+import io.cdap.cdap.messaging.client.LocalClientMessagingService;
 
 /**
  * The Guice module to provide binding for messaging system client.
  * This module should only be used in containers in distributed mode.
  */
 public class MessagingClientModule extends AbstractModule {
+  public static final String PROGRAM_MESSAGING = "programMessaging";
+  private final boolean tetheringEnabled;
+
+  public MessagingClientModule() {
+    this(false);
+  }
+
+  public MessagingClientModule(boolean tetheringEnabled) {
+    this.tetheringEnabled = tetheringEnabled;
+  }
 
   @Override
   protected void configure() {
     bind(MessagingService.class).to(ClientMessagingService.class).in(Scopes.SINGLETON);
+    if (tetheringEnabled) {
+      // Publish program state messages to local TMS when running in tethered mode
+      bind(MessagingService.class).annotatedWith(Names.named(PROGRAM_MESSAGING))
+        .to(LocalClientMessagingService.class).in(Scopes.SINGLETON);
+    } else {
+      // Use the default messaging service for program state messages if we're not
+      // running in tethered mode
+      bind(MessagingService.class).annotatedWith(Names.named(PROGRAM_MESSAGING))
+        .to(ClientMessagingService.class).in(Scopes.SINGLETON);
+    }
   }
 }

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/guice/MessagingServerRuntimeModule.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/guice/MessagingServerRuntimeModule.java
@@ -84,7 +84,10 @@ public class MessagingServerRuntimeModule extends RuntimeModule {
         bindHandlers(binder(), Constants.MessagingSystem.HANDLER_BINDING_NAME);
 
         bind(MessagingService.class).to(LeaderElectionMessagingService.class).in(Scopes.SINGLETON);
+        bind(MessagingService.class).annotatedWith(Names.named(MessagingClientModule.PROGRAM_MESSAGING))
+          .to(LeaderElectionMessagingService.class).in(Scopes.SINGLETON);
         expose(MessagingService.class);
+        expose(MessagingService.class).annotatedWith(Names.named(MessagingClientModule.PROGRAM_MESSAGING));
       }
     };
   }
@@ -123,7 +126,10 @@ public class MessagingServerRuntimeModule extends RuntimeModule {
 
       bind(TableFactory.class).to(LevelDBTableFactory.class).in(Scopes.SINGLETON);
       bind(MessagingService.class).to(CoreMessagingService.class).in(Scopes.SINGLETON);
+      bind(MessagingService.class).annotatedWith(Names.named(MessagingClientModule.PROGRAM_MESSAGING))
+        .to(CoreMessagingService.class).in(Scopes.SINGLETON);
       expose(MessagingService.class);
+      expose(MessagingService.class).annotatedWith(Names.named(MessagingClientModule.PROGRAM_MESSAGING));
 
       // TODO: Because of CDAP-7688, we need to run MessagingHttpService even in local mode so that we
       // can use a custom http exception handler. When CDAP-7688 is resolved, uncomment the following


### PR DESCRIPTION
…tethered mode

When running a pipeline for a tethered peer, program state updates should be written to local TMS so they can be consumed by the Tethering Agent Service and sent to tethered peer over the control channel. All other messages like metrics, logs etc should be sent directly to the runtime server on the peer.