### PR TITLE
[CDAP-18841] Move peerName to RunRecord metadata

### DIFF
--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
@@ -381,7 +381,6 @@ public final class StoreDefinition {
     public static final String RUN_STATUS = "run_status";
     public static final String RUN_START_TIME = "run_start_time";
     public static final String RUN_RECORD_DATA = "run_record_data";
-    public static final String PEER_NAME = "peer_name";
     public static final String WORKFLOW_DATA = "workflow_data";
     public static final String COUNT_TYPE = "count_type";
     public static final String COUNTS = "counts";
@@ -426,8 +425,7 @@ public final class StoreDefinition {
                     Fields.stringType(PROGRAM_FIELD),
                     Fields.longType(RUN_START_TIME),
                     Fields.stringType(RUN_FIELD),
-                    Fields.stringType(RUN_RECORD_DATA),
-                    Fields.stringType(PEER_NAME))
+                    Fields.stringType(RUN_RECORD_DATA))
         .withPrimaryKeys(RUN_STATUS, NAMESPACE_FIELD, APPLICATION_FIELD, VERSION_FIELD, PROGRAM_TYPE_FIELD,
                          PROGRAM_FIELD, RUN_START_TIME, RUN_FIELD)
         .build();


### PR DESCRIPTION
Modify changes made in https://github.com/cdapio/cdap/pull/14029 to be backwards compatible by storing `peer_name` in `run_record_data` (our use case no longer requires a separate column because we are okay with post-filtering on RunRecords) 

JIRA: CDAP-18841