### PR TITLE
CDAP-18890 stop programs in an async fashion through TMS

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -44,6 +44,7 @@ import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.gateway.handlers.WorkflowHttpHandler;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleStatus;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.store.AppMetadataStore;
 import io.cdap.cdap.proto.DatasetSpecificationSummary;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.ProgramStatus;
@@ -629,7 +630,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
   @Category(XSlowTests.class)
   @Test
   public void testWorkflowScopedArguments() throws Exception {
-    String workflowRunIdProperty = "workflowrunid";
+    String workflowRunIdProperty = AppMetadataStore.WORKFLOW_RUNID;
     deploy(WorkflowAppWithScopedParameters.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE2);
 
     ProgramId programId = Ids.namespace(TEST_NAMESPACE2).app(WorkflowAppWithScopedParameters.APP_NAME)
@@ -676,7 +677,7 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
     verifyProgramRuns(mr1ProgramId, ProgramRunStatus.RUNNING);
     List<RunRecord> oneMRHistoryRuns = getProgramRuns(mr1ProgramId, ProgramRunStatus.ALL);
 
-    String expectedMessage = String.format("Cannot stop the program '%s' started by the Workflow run '%s'. " +
+    String expectedMessage = String.format("Cannot stop the program run '%s' started by the Workflow run '%s'. " +
                                              "Please stop the Workflow.",
                                            mr1ProgramId.run(oneMRHistoryRuns.get(0).getPid()), workflowRunId);
     stopProgram(Id.Program.fromEntityId(mr1ProgramId), oneMRHistoryRuns.get(0).getPid(), 400, expectedMessage);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/DelayedProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/DelayedProgramController.java
@@ -101,6 +101,11 @@ public final class DelayedProgramController implements ProgramController, Delega
   }
 
   @Override
+  public void kill() {
+    getDelegate().kill();
+  }
+
+  @Override
   public State getState() {
     try {
       return Uninterruptibles.getUninterruptibly(delegateFuture).getState();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/ProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/ProgramController.java
@@ -135,7 +135,17 @@ public interface ProgramController {
 
   ListenableFuture<ProgramController> resume();
 
+  /**
+   * Attempt to stop the program gracefully.
+   *
+   * @return A {@link ListenableFuture} that will be completed when the program is actually stopped.
+   */
   ListenableFuture<ProgramController> stop();
+
+  /**
+   * Force kill the program.
+   */
+  void kill();
 
   /**
    * @return The current state of the program at the time when this method is called.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -806,24 +806,21 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   private ProgramTerminator createProgramTerminator() {
-    return new ProgramTerminator() {
-      @Override
-      public void stop(ProgramId programId) throws Exception {
-        switch (programId.getType()) {
-          case SERVICE:
-          case WORKER:
-            stopProgramIfRunning(programId);
-            break;
-        }
+    return programId -> {
+      switch (programId.getType()) {
+        case SERVICE:
+        case WORKER:
+          killProgramIfRunning(programId);
+          break;
       }
     };
   }
 
-  private void stopProgramIfRunning(ProgramId programId) throws InterruptedException, ExecutionException {
+  private void killProgramIfRunning(ProgramId programId) {
     ProgramRuntimeService.RuntimeInfo programRunInfo = findRuntimeInfo(programId, runtimeService);
     if (programRunInfo != null) {
       ProgramController controller = programRunInfo.getController();
-      controller.stop().get();
+      controller.kill();
     }
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -17,13 +17,10 @@
 package io.cdap.cdap.gateway.handlers;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
@@ -44,6 +41,7 @@ import io.cdap.cdap.common.NamespaceNotFoundException;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.NotImplementedException;
 import io.cdap.cdap.common.ServiceUnavailableException;
+import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.discovery.EndpointStrategy;
 import io.cdap.cdap.common.discovery.RandomEndpointStrategy;
@@ -298,11 +296,43 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                   @PathParam("app-id") String appId,
                                   @PathParam("program-type") String type,
                                   @PathParam("program-id") String programId,
-                                  @PathParam("run-id") String runId) throws Exception {
+                                  @PathParam("run-id") String runId,
+                                  @QueryParam("graceful") String gracefulShutdownSecs) throws Exception {
     ProgramType programType = getProgramType(type);
     ProgramId program = new ProgramId(namespaceId, appId, programType, programId);
-    lifecycleService.stop(program, runId);
+    int gracefulShutdownSecsInt;
+    try {
+      gracefulShutdownSecsInt = validateAndGetGracefulShutdownSecsInt(gracefulShutdownSecs);
+    } catch (IllegalArgumentException e) {
+      responder.sendJson(HttpResponseStatus.BAD_REQUEST, e.getMessage());
+      return;
+    }
+    try {
+      RunIds.fromString(runId);
+    } catch (Exception e) {
+      responder.sendJson(HttpResponseStatus.BAD_REQUEST, e.getMessage());
+    }
+    lifecycleService.stop(program, runId, gracefulShutdownSecsInt);
     responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  private int validateAndGetGracefulShutdownSecsInt(String gracefulShutdownSecs) {
+    try {
+      if (gracefulShutdownSecs == null || gracefulShutdownSecs.isEmpty()) {
+        return Integer.parseInt(String.valueOf(Integer.MAX_VALUE));
+      }
+      int gracefulShutdownSecsInt = Integer.parseInt(gracefulShutdownSecs);
+      if (gracefulShutdownSecsInt < 0) {
+        throw new IllegalArgumentException(String.format("Invalid graceful shutdown period %s passed. " +
+                                                           "Please specify a value greater than or equal to 0.",
+                                                         gracefulShutdownSecs));
+      }
+      return gracefulShutdownSecsInt;
+    } catch (NumberFormatException e) {
+      LOG.error("Invalid graceful shutdown period %s passed.");
+      throw new IllegalArgumentException(String.format("Invalid graceful shutdown period %s passed. " +
+                                                         "Please specify a valid number", gracefulShutdownSecs));
+    }
   }
 
   @POST
@@ -1272,46 +1302,34 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/stop")
   @AuditPolicy({AuditDetail.REQUEST_BODY, AuditDetail.RESPONSE_BODY})
   public void stopPrograms(FullHttpRequest request, HttpResponder responder,
-                           @PathParam("namespace-id") String namespaceId) throws Exception {
-
+                           @PathParam("namespace-id") String namespaceId,
+                           @QueryParam("graceful") String gracefulShutdownSecs) throws Exception {
+    int gracefulShutdownSecsInt;
+    try {
+      gracefulShutdownSecsInt = validateAndGetGracefulShutdownSecsInt(gracefulShutdownSecs);
+    } catch (IllegalArgumentException e) {
+      responder.sendJson(HttpResponseStatus.BAD_REQUEST, e.getMessage());
+      return;
+    }
     List<BatchProgram> programs = validateAndGetBatchInput(request, BATCH_PROGRAMS_TYPE);
 
-    List<ListenableFuture<BatchProgramResult>> issuedStops = new ArrayList<>(programs.size());
+    List<BatchProgramResult> issuedStops = new ArrayList<>(programs.size());
     for (final BatchProgram program : programs) {
       ProgramId programId = new ProgramId(namespaceId, program.getAppId(), program.getProgramType(),
                                          program.getProgramId());
       try {
-        List<ListenableFuture<ProgramRunId>> stops = lifecycleService.issueStop(programId, null);
-        for (ListenableFuture<ProgramRunId> stop : stops) {
-          ListenableFuture<BatchProgramResult> issuedStop =
-            Futures.transform(stop, (Function<ProgramRunId, BatchProgramResult>) input ->
-              new BatchProgramResult(program, HttpResponseStatus.OK.code(), null, input.getRun()));
-          issuedStops.add(issuedStop);
+        Collection<ProgramRunId> stoppedRuns = lifecycleService.issueStop(programId, null, gracefulShutdownSecsInt);
+        for (ProgramRunId stoppedRun : stoppedRuns) {
+          issuedStops.add(new BatchProgramResult(program, HttpResponseStatus.OK.code(), null, stoppedRun.getRun()));
         }
       } catch (NotFoundException e) {
-        issuedStops.add(Futures.immediateFuture(
-          new BatchProgramResult(program, HttpResponseStatus.NOT_FOUND.code(), e.getMessage())));
+        issuedStops.add(new BatchProgramResult(program, HttpResponseStatus.NOT_FOUND.code(), e.getMessage()));
       } catch (BadRequestException e) {
-        issuedStops.add(Futures.immediateFuture(
-          new BatchProgramResult(program, HttpResponseStatus.BAD_REQUEST.code(), e.getMessage())));
+        issuedStops.add(new BatchProgramResult(program, HttpResponseStatus.BAD_REQUEST.code(), e.getMessage()));
       }
     }
 
-    List<BatchProgramResult> output = new ArrayList<>(programs.size());
-    // need to keep this index in case there is an exception getting the future, since we won't have the program
-    // information in that scenario
-    int i = 0;
-    for (ListenableFuture<BatchProgramResult> issuedStop : issuedStops) {
-      try {
-        output.add(issuedStop.get());
-      } catch (Throwable t) {
-        LOG.warn(t.getMessage(), t);
-        output.add(new BatchProgramResult(programs.get(i), HttpResponseStatus.INTERNAL_SERVER_ERROR.code(),
-                                          t.getMessage()));
-      }
-      i++;
-    }
-    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(output));
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(issuedStops));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
@@ -48,6 +48,7 @@ import io.cdap.cdap.internal.app.runtime.AbstractListener;
 import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
 import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
 import io.cdap.cdap.internal.app.services.ProgramNotificationSubscriberService;
+import io.cdap.cdap.internal.app.services.ProgramStopSubscriberService;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.metadata.PreferencesFetcher;
@@ -109,6 +110,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
   private final NamespaceAdmin namespaceAdmin;
   private final MetricsCollectionService metricsCollectionService;
   private final ProgramNotificationSubscriberService programNotificationSubscriberService;
+  private final ProgramStopSubscriberService programStopSubscriberService;
   private final LevelDBTableService levelDBTableService;
   private final StructuredTableAdmin structuredTableAdmin;
   private final Path previewIdDirPath;
@@ -127,6 +129,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
                        NamespaceAdmin namespaceAdmin,
                        MetricsCollectionService metricsCollectionService,
                        ProgramNotificationSubscriberService programNotificationSubscriberService,
+                       ProgramStopSubscriberService programStopSubscriberService,
                        LevelDBTableService levelDBTableService,
                        StructuredTableAdmin structuredTableAdmin,
                        CConfiguration cConf,
@@ -143,6 +146,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
     this.namespaceAdmin = namespaceAdmin;
     this.metricsCollectionService = metricsCollectionService;
     this.programNotificationSubscriberService = programNotificationSubscriberService;
+    this.programStopSubscriberService = programStopSubscriberService;
     this.levelDBTableService = levelDBTableService;
     this.structuredTableAdmin = structuredTableAdmin;
     this.previewIdDirPath = Paths.get(cConf.get(Constants.CFG_LOCAL_DATA_DIR), "previewid").toAbsolutePath();
@@ -320,7 +324,8 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
       applicationLifecycleService.start(),
       programRuntimeService.start(),
       metricsCollectionService.start(),
-      programNotificationSubscriberService.start()
+      programNotificationSubscriberService.start(),
+      programStopSubscriberService.start()
     ).get();
 
     Files.createDirectories(previewIdDirPath);
@@ -352,6 +357,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
     logAppenderInitializer.close();
     metricsCollectionService.stopAndWait();
     programNotificationSubscriberService.stopAndWait();
+    programStopSubscriberService.stopAndWait();
     datasetService.stopAndWait();
     dsOpExecService.stopAndWait();
     if (messagingService instanceof Service) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/AbstractProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/AbstractProgramController.java
@@ -159,6 +159,11 @@ public abstract class AbstractProgramController implements ProgramController {
     return result;
   }
 
+  @Override
+  public void kill() {
+    stop();
+  }
+
   /**
    * Children call this method to signal the program is completed.
    */

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AbstractTwillProgramController.java
@@ -141,6 +141,12 @@ public abstract class AbstractTwillProgramController extends AbstractProgramCont
     Futures.getUnchecked(twillController.terminate());
   }
 
+  @Override
+  public void kill() {
+    stopRequested = true;
+    twillController.kill();
+  }
+
   protected final TwillController getTwillController() {
     return twillController;
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
@@ -165,6 +165,7 @@ public class DefaultRuntimeJob implements RuntimeJob {
 
   private final CompletableFuture<ProgramController> controllerFuture = new CompletableFuture<>();
   private final CountDownLatch runCompletedLatch = new CountDownLatch(1);
+  private RuntimeClientService runtimeClientService;
   private volatile boolean stopRequested;
 
   @Override
@@ -256,7 +257,6 @@ public class DefaultRuntimeJob implements RuntimeJob {
     }
 
     ProgramStateWriter programStateWriter = injector.getInstance(ProgramStateWriter.class);
-    RuntimeClientService runtimeClientService = injector.getInstance(RuntimeClientService.class);
     CompletableFuture<ProgramController.State> programCompletion = new CompletableFuture<>();
     try {
       ProgramRunner programRunner = injector.getInstance(ProgramRunnerFactory.class).create(programId.getType());
@@ -521,7 +521,8 @@ public class DefaultRuntimeJob implements RuntimeJob {
     if (injector.getInstance(RuntimeMonitorType.class) == RuntimeMonitorType.SSH) {
       services.add(injector.getInstance(TrafficRelayService.class));
     }
-    services.add(injector.getInstance(RuntimeClientService.class));
+    runtimeClientService = injector.getInstance(RuntimeClientService.class);
+    services.add(runtimeClientService);
 
     // Creates a service to emit profile metrics
     ProgramRunId programRunId = injector.getInstance(ProgramRunId.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -74,6 +74,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final Set<String> servicesNames;
   private final Set<String> handlerHookNames;
   private final ProgramNotificationSubscriberService programNotificationSubscriberService;
+  private final ProgramStopSubscriberService programStopSubscriberService;
   private final RunRecordCorrectorService runRecordCorrectorService;
   private final RunRecordMonitorService runRecordCounterService;
   private final CoreSchedulerService coreSchedulerService;
@@ -103,6 +104,7 @@ public class AppFabricServer extends AbstractIdleService {
                          RunRecordCorrectorService runRecordCorrectorService,
                          ApplicationLifecycleService applicationLifecycleService,
                          ProgramNotificationSubscriberService programNotificationSubscriberService,
+                         ProgramStopSubscriberService programStopSubscriberService,
                          @Named("appfabric.services.names") Set<String> servicesNames,
                          @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
                          CoreSchedulerService coreSchedulerService,
@@ -123,6 +125,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.handlerHookNames = handlerHookNames;
     this.applicationLifecycleService = applicationLifecycleService;
     this.programNotificationSubscriberService = programNotificationSubscriberService;
+    this.programStopSubscriberService = programStopSubscriberService;
     this.runRecordCorrectorService = runRecordCorrectorService;
     this.sslEnabled = cConf.getBoolean(Constants.Security.SSL.INTERNAL_ENABLED);
     this.coreSchedulerService = coreSchedulerService;
@@ -149,6 +152,7 @@ public class AppFabricServer extends AbstractIdleService {
         bootstrapService.start(),
         programRuntimeService.start(),
         programNotificationSubscriberService.start(),
+        programStopSubscriberService.start(),
         runRecordCorrectorService.start(),
         coreSchedulerService.start(),
         eventPublishManager.start(),
@@ -201,6 +205,7 @@ public class AppFabricServer extends AbstractIdleService {
     programRuntimeService.stopAndWait();
     applicationLifecycleService.stopAndWait();
     programNotificationSubscriberService.stopAndWait();
+    programStopSubscriberService.stopAndWait();
     runRecordCorrectorService.stopAndWait();
     provisioningService.stopAndWait();
     eventPublishManager.stopAndWait();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -53,6 +53,7 @@ import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.internal.app.runtime.SimpleProgramOptions;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.store.AppMetadataStore;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.internal.capability.CapabilityReader;
 import io.cdap.cdap.internal.pipeline.PluginRequirement;
@@ -741,7 +742,7 @@ public class ProgramLifecycleService {
     Map<ProgramRunId, RunRecordDetail> activeRunRecords = getActiveRuns(programId, runId);
 
     if (activeRunRecords.isEmpty()) {
-      // Error out if no run information from runtime service and from run record
+      // Error out if no run information from run record
       Store.ensureProgramExists(programId, store.getApplication(programId.getParent()));
       throw new BadRequestException(String.format("Program '%s' is not running.", programId));
     }
@@ -751,10 +752,10 @@ public class ProgramLifecycleService {
       RunRecordDetail runRecord = activeRunRecord.getValue();
 
       // Check if the program is actually started from workflow and the workflow is running
-      if (runRecord != null && runRecord.getProperties().containsKey("workflowrunid")
+      if (runRecord != null && runRecord.getProperties().containsKey(AppMetadataStore.WORKFLOW_RUNID)
         && runRecord.getStatus().equals(ProgramRunStatus.RUNNING)) {
-        String workflowRunId = runRecord.getProperties().get("workflowrunid");
-        throw new BadRequestException(String.format("Cannot stop the program '%s' started by the Workflow " +
+        String workflowRunId = runRecord.getProperties().get(AppMetadataStore.WORKFLOW_RUNID);
+        throw new BadRequestException(String.format("Cannot stop the program run '%s' started by the Workflow " +
                                                       "run '%s'. Please stop the Workflow.", activeRunId,
                                                     workflowRunId));
       }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -17,11 +17,8 @@
 package io.cdap.cdap.internal.app.services;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
@@ -61,9 +58,7 @@ import io.cdap.cdap.internal.capability.CapabilityReader;
 import io.cdap.cdap.internal.pipeline.PluginRequirement;
 import io.cdap.cdap.internal.profile.ProfileService;
 import io.cdap.cdap.internal.provision.ProvisionerNotifier;
-import io.cdap.cdap.internal.provision.ProvisioningOp;
 import io.cdap.cdap.internal.provision.ProvisioningService;
-import io.cdap.cdap.internal.provision.ProvisioningTaskInfo;
 import io.cdap.cdap.proto.ProgramHistory;
 import io.cdap.cdap.proto.ProgramRecord;
 import io.cdap.cdap.proto.ProgramRunClusterStatus;
@@ -102,16 +97,12 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
 /**
@@ -372,7 +363,7 @@ public class ProgramLifecycleService {
 
   /**
    * Returns the program status based on the active run records of a program.
-   * A program is RUNNING if there are any RUNNING or SUSPENDED run records.
+   * A program is RUNNING if there are any RUNNING, STOPPING, or SUSPENDED run records.
    * A program is starting if there are any PENDING or STARTING run records and no RUNNING run records.
    * Otherwise, it is STOPPED.
    *
@@ -384,7 +375,8 @@ public class ProgramLifecycleService {
     boolean hasStarting = false;
     for (RunRecordDetail runRecord : runRecords) {
       ProgramRunStatus runStatus = runRecord.getStatus();
-      if (runStatus == ProgramRunStatus.RUNNING || runStatus == ProgramRunStatus.SUSPENDED) {
+      if (runStatus == ProgramRunStatus.RUNNING || runStatus == ProgramRunStatus.SUSPENDED
+        || runStatus == ProgramRunStatus.STOPPING) {
         return ProgramStatus.RUNNING;
       }
       hasStarting = hasStarting || runStatus == ProgramRunStatus.STARTING || runStatus == ProgramRunStatus.PENDING;
@@ -501,7 +493,7 @@ public class ProgramLifecycleService {
   public void stopAll(ApplicationId applicationId) throws Exception {
     Map<ProgramRunId, RunRecordDetail> runMap = store.getActiveRuns(applicationId);
     for (ProgramRunId programRunId : runMap.keySet()) {
-      stop(programRunId.getParent(), programRunId.getRun());
+      stop(programRunId.getParent(), programRunId.getRun(), 0);
     }
   }
 
@@ -705,7 +697,7 @@ public class ProgramLifecycleService {
    * @throws ExecutionException if there was a problem while waiting for the stop call to complete
    */
   public void stop(ProgramId programId) throws Exception {
-    stop(programId, null);
+    stop(programId, null, 0);
   }
 
   /**
@@ -714,39 +706,15 @@ public class ProgramLifecycleService {
    * @param programId the {@link ProgramId program} to stop
    * @param runId the runId of the program run to stop. If null, all runs of the program as returned by
    *              {@link ProgramRuntimeService} are stopped.
+   * @param gracefulShutdownSecs amount of seconds to wait for graceful shutdown before killing the run
    * @throws NotFoundException if the app, program or run was not found
    * @throws BadRequestException if an attempt is made to stop a program that is either not running or
    *                             was started by a workflow
    * @throws InterruptedException if there was a problem while waiting for the stop call to complete
    * @throws ExecutionException if there was a problem while waiting for the stop call to complete
    */
-  public void stop(ProgramId programId, @Nullable String runId) throws Exception {
-    List<ListenableFuture<ProgramRunId>> futures = issueStop(programId, runId);
-
-    // Block until all stop requests completed. This call never throw ExecutionException
-    Futures.successfulAsList(futures).get();
-
-    Throwable failureCause = null;
-    for (ListenableFuture<ProgramRunId> f : futures) {
-      try {
-        f.get();
-      } catch (ExecutionException e) {
-        // If the program is stopped in between the time listing runs and issuing stops of the program,
-        // an IllegalStateException will be throw, which we can safely ignore
-        if (!(e.getCause() instanceof IllegalStateException)) {
-          if (failureCause == null) {
-            failureCause = e.getCause();
-          } else {
-            failureCause.addSuppressed(e.getCause());
-          }
-        }
-      }
-    }
-    if (failureCause != null) {
-      throw new ExecutionException(String.format("%d out of %d runs of the program %s failed to stop",
-                                                 failureCause.getSuppressed().length + 1, futures.size(), programId),
-                                   failureCause);
-    }
+  public void stop(ProgramId programId, @Nullable String runId, int gracefulShutdownSecs) throws Exception {
+    issueStop(programId, runId, gracefulShutdownSecs);
   }
 
   /**
@@ -755,8 +723,8 @@ public class ProgramLifecycleService {
    * Clients can wait for completion of the {@link ListenableFuture}.
    *
    * @param programId the {@link ProgramId program} to issue a stop for
-   * @param runId the runId of the program run to stop. If null, all runs of the program as returned by
-   *              {@link ProgramRuntimeService} are stopped.
+   * @param runId the runId of the program run to stop. If null, all runs of the program are stopped.
+   * @param gracefulShutdownSecs amount of seconds to wait for graceful shutdown before killing the run
    * @return a list of {@link ListenableFuture} with the {@link ProgramRunId} that clients can wait on for stop
    *         to complete.
    * @throws NotFoundException if the app, program or run was not found
@@ -766,111 +734,35 @@ public class ProgramLifecycleService {
    *                               program, a user requires {@link ApplicationPermission#EXECUTE} permission on
    *                               the program.
    */
-  public List<ListenableFuture<ProgramRunId>> issueStop(ProgramId programId, @Nullable String runId) throws Exception {
+  public Collection<ProgramRunId> issueStop(ProgramId programId, @Nullable String runId,
+                                            int gracefulShutdownSecs) throws Exception {
     accessEnforcer.enforce(programId, authenticationContext.getPrincipal(), ApplicationPermission.EXECUTE);
 
-    // See if the program is running as per the runtime service
-    Map<RunId, RuntimeInfo> runtimeInfos = findRuntimeInfo(programId, runId);
     Map<ProgramRunId, RunRecordDetail> activeRunRecords = getActiveRuns(programId, runId);
 
-    if (runtimeInfos.isEmpty() && activeRunRecords.isEmpty()) {
+    if (activeRunRecords.isEmpty()) {
       // Error out if no run information from runtime service and from run record
       Store.ensureProgramExists(programId, store.getApplication(programId.getParent()));
       throw new BadRequestException(String.format("Program '%s' is not running.", programId));
     }
 
-    // Stop the running program based on a combination of runtime info and run record
-    // It's possible that some of them are not yet available from the runtimeService due to timing
-    // differences between the run record was created vs being added to runtimeService
-    // So we retry in a loop for up to 3 seconds max to cater for those cases
+    for (Map.Entry<ProgramRunId, RunRecordDetail> activeRunRecord : activeRunRecords.entrySet()) {
+      ProgramRunId activeRunId = activeRunRecord.getKey();
+      RunRecordDetail runRecord = activeRunRecord.getValue();
 
-    Set<String> pendingStops = Stream.concat(runtimeInfos.keySet().stream().map(RunId::getId),
-                                             activeRunRecords.keySet().stream().map(ProgramRunId::getRun))
-                                      .collect(Collectors.toSet());
-
-    List<ListenableFuture<ProgramRunId>> futures = new ArrayList<>();
-    Stopwatch stopwatch = new Stopwatch().start();
-
-    Set<ProgramRunId> cancelledProvisionRuns = new HashSet<>();
-    while (!pendingStops.isEmpty() && stopwatch.elapsedTime(TimeUnit.SECONDS) < 3L) {
-      Iterator<String> iterator = pendingStops.iterator();
-      while (iterator.hasNext()) {
-        ProgramRunId activeRunId = programId.run(iterator.next());
-        RunRecordDetail runRecord = activeRunRecords.get(activeRunId);
-        if (runRecord == null) {
-          runRecord = store.getRun(activeRunId);
-        }
-        // Check if the program is actually started from workflow and the workflow is running
-        if (runRecord != null && runRecord.getProperties().containsKey("workflowrunid")
-          && runRecord.getStatus().equals(ProgramRunStatus.RUNNING)) {
-          String workflowRunId = runRecord.getProperties().get("workflowrunid");
-          throw new BadRequestException(String.format("Cannot stop the program '%s' started by the Workflow " +
-                                                        "run '%s'. Please stop the Workflow.", activeRunId,
-                                                      workflowRunId));
-        }
-
-        RuntimeInfo runtimeInfo = runtimeService.lookup(programId, RunIds.fromString(activeRunId.getRun()));
-        // if there is a runtimeInfo, the run is in the 'starting' state or later
-        if (runtimeInfo != null) {
-          ListenableFuture<ProgramController> future = runtimeInfo.getController().stop();
-          futures.add(Futures.transform(future, ProgramController::getProgramRunId));
-          iterator.remove();
-          // if it was in this set, it means we cancelled a task, but it had already sent a PROVISIONED message
-          // by the time we cancelled it. We then waited for it to show up in the runtime service and got here.
-          // We added a future for this run in the lines above, but we don't want to add another duplicate future
-          // at the end of this loop, so remove this run from the cancelled provision runs.
-          cancelledProvisionRuns.remove(activeRunId);
-        } else {
-          // if there is no runtimeInfo, the run could be in the provisioning state.
-          Optional<ProvisioningTaskInfo> cancelledInfo = provisioningService.cancelProvisionTask(activeRunId);
-          cancelledInfo.ifPresent(taskInfo -> {
-            cancelledProvisionRuns.add(activeRunId);
-            // This state check is to handle a race condition where we cancel the provision task, but not in time
-            // to prevent it from sending the PROVISIONED notification.
-
-            // If the notification was sent, but not yet consumed, we are *not* done stopping the run.
-            // We have to wait for the notification to be consumed, which will start the run, and place the controller
-            // in the runtimeService. The next time we loop, we can find it in the runtimeService and tell it to stop.
-            // If the notification was not sent, then we *are* done stopping the run.
-
-            // Therefore, if the state is CREATED, we don't remove it from the iterator so that the run will get
-            // checked again in the next loop, when we may get the controller from the runtimeService to stop it.
-
-            // No other task states have this race condition, as the PROVISIONED notification is only sent
-            // after the state transitions to CREATED. Therefore it is safe to remove the runId from the iterator,
-            // as we know we are done stopping it.
-            ProvisioningOp.Status taskState = taskInfo.getProvisioningOp().getStatus();
-            if (taskState != ProvisioningOp.Status.CREATED) {
-              iterator.remove();
-            }
-          });
-        }
+      // Check if the program is actually started from workflow and the workflow is running
+      if (runRecord != null && runRecord.getProperties().containsKey("workflowrunid")
+        && runRecord.getStatus().equals(ProgramRunStatus.RUNNING)) {
+        String workflowRunId = runRecord.getProperties().get("workflowrunid");
+        throw new BadRequestException(String.format("Cannot stop the program '%s' started by the Workflow " +
+                                                      "run '%s'. Please stop the Workflow.", activeRunId,
+                                                    workflowRunId));
       }
-
-      if (!pendingStops.isEmpty()) {
-        // If not able to stop all of them, it means there were some runs that didn't have a runtime info and
-        // didn't have a provisioning task. This can happen if the run was already finished, or the run transitioned
-        // from the provisioning state to the starting state during this stop operation.
-        // We'll get the active runs again and filter it by the pending stops. Stop will be retried for those.
-        Set<String> finalPendingStops = pendingStops;
-
-        activeRunRecords = getActiveRuns(programId, runId).entrySet().stream()
-          .filter(e -> finalPendingStops.contains(e.getKey().getRun()))
-          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        pendingStops = activeRunRecords.keySet().stream().map(ProgramRunId::getRun).collect(Collectors.toSet());
-
-        if (!pendingStops.isEmpty()) {
-          TimeUnit.MILLISECONDS.sleep(200);
-        }
-      }
+      // send a message to stop the program run
+      programStateWriter.stop(activeRunId, gracefulShutdownSecs);
     }
 
-    for (ProgramRunId cancelledProvisionRun : cancelledProvisionRuns) {
-      SettableFuture<ProgramRunId> future = SettableFuture.create();
-      future.set(cancelledProvisionRun);
-      futures.add(future);
-    }
-    return futures;
+    return activeRunRecords.keySet();
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -654,7 +654,15 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
         return Optional.of(provisioningService.provision(provisionRequest, context));
       case PROVISIONED:
         Cluster cluster = GSON.fromJson(properties.get(ProgramOptionConstants.CLUSTER), Cluster.class);
-        appMetadataStore.recordProgramProvisioned(programRunId, cluster.getNodes().size(), messageIdBytes);
+        RunRecordDetail runRecord =
+          appMetadataStore.recordProgramProvisioned(programRunId, cluster.getNodes().size(), messageIdBytes);
+        // if the run was stopped right before provisioning completes, it is possible for the state
+        // to transition to stopping or killed, but not in time to cancel the provisioning.
+        // In that case, we end up with a provisioned message, but we don't want to start the program.
+        if (runRecord == null || runRecord.getStatus() == ProgramRunStatus.STOPPING
+          || runRecord.getStatus() == ProgramRunStatus.KILLED) {
+          break;
+        }
 
         // Update the ProgramOptions system arguments to include information needed for program execution
         Map<String, String> systemArgs = new HashMap<>(programOptions.getArguments().asMap());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramStopSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramStopSubscriberService.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services;
+
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.app.runtime.ProgramRuntimeService;
+import io.cdap.cdap.app.runtime.ProgramStateWriter;
+import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.utils.ImmutablePair;
+import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.internal.app.runtime.SystemArguments;
+import io.cdap.cdap.internal.app.runtime.monitor.RuntimeProgramStatusSubscriberService;
+import io.cdap.cdap.internal.app.store.AppMetadataStore;
+import io.cdap.cdap.internal.app.store.RunRecordDetail;
+import io.cdap.cdap.internal.tethering.runtime.spi.provisioner.TetheringProvisioner;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.proto.Notification;
+import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.spi.data.StructuredTableContext;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Subscribes to the Constants.AppFabric.PROGRAM_STATUS_RECORD_EVENT_TOPIC topic, which gets published to
+ * after the state store has been updated. Looks for stopping messages and performs the actual program stop.
+ */
+public class ProgramStopSubscriberService extends AbstractNotificationSubscriberService {
+  private static final String SUBSCRIBER = "program.stopper";
+  private static final Logger LOG = LoggerFactory.getLogger(RuntimeProgramStatusSubscriberService.class);
+  private static final Gson GSON = new Gson();
+  private final ProgramRuntimeService programRuntimeService;
+  private final ProgramStateWriter programStateWriter;
+
+  @Inject
+  ProgramStopSubscriberService(CConfiguration cConf, MessagingService messagingService,
+                               MetricsCollectionService metricsCollectionService,
+                               TransactionRunner transactionRunner,
+                               ProgramRuntimeService programRuntimeService,
+                               ProgramStateWriter programStateWriter) {
+    super("program.stop.service", cConf,
+          cConf.get(Constants.AppFabric.PROGRAM_STATUS_RECORD_EVENT_TOPIC),
+          cConf.getInt(Constants.AppFabric.STATUS_EVENT_FETCH_SIZE),
+          cConf.getLong(Constants.AppFabric.STATUS_EVENT_POLL_DELAY_MILLIS),
+          messagingService, metricsCollectionService, transactionRunner);
+    this.programRuntimeService = programRuntimeService;
+    this.programStateWriter = programStateWriter;
+  }
+
+  @Nullable
+  @Override
+  protected String loadMessageId(StructuredTableContext context) throws IOException {
+    return AppMetadataStore.create(context).retrieveSubscriberState(getTopicId().getTopic(), SUBSCRIBER);
+  }
+
+  @Override
+  protected void storeMessageId(StructuredTableContext context, String messageId) throws IOException {
+    AppMetadataStore.create(context).persistSubscriberState(getTopicId().getTopic(), SUBSCRIBER, messageId);
+  }
+
+  @Override
+  protected void processMessages(StructuredTableContext context,
+                                 Iterator<ImmutablePair<String, Notification>> messages) throws Exception {
+    while (messages.hasNext()) {
+      ImmutablePair<String, Notification> pair = messages.next();
+      Notification notification = pair.getSecond();
+      if (notification.getNotificationType() != Notification.Type.PROGRAM_STATUS) {
+        continue;
+      }
+      processNotification(notification, context);
+    }
+  }
+
+  /**
+   * Processes a given {@link Notification} from TMS and updates the {@link AppMetadataStore}.
+   *
+   * @param notification the {@link Notification} to process
+   * @param context the table context for accessing the store
+   * @throws IOException if failed to write to the store
+   */
+  private void processNotification(Notification notification, StructuredTableContext context) throws IOException {
+    Map<String, String> properties = notification.getProperties();
+
+    ProgramRunId programRunId;
+    ProgramRunStatus programRunStatus;
+    try {
+      programRunId = GSON.fromJson(properties.get(ProgramOptionConstants.PROGRAM_RUN_ID),
+                                   ProgramRunId.class);
+      if (programRunId == null) {
+        throw new IllegalArgumentException("Missing program run id from notification");
+      }
+      programRunStatus = ProgramRunStatus.valueOf(properties.get(ProgramOptionConstants.PROGRAM_STATUS));
+    } catch (Exception e) {
+      // This shouldn't happen. If it does, we can only log and ignore the event.
+      LOG.warn("Ignore notification due to unable to get program run id and program run status from notification {}",
+               notification, e);
+      return;
+    }
+
+    if (programRunStatus != ProgramRunStatus.STOPPING) {
+      return;
+    }
+
+    AppMetadataStore store = AppMetadataStore.create(context);
+    RunRecordDetail runRecord = store.getRun(programRunId);
+    if (runRecord == null) {
+      // shouldn't happen, but nothing to do but move on
+      return;
+    }
+    // If this run was initiated by this CDAP instance to run on another instance, it will use the tethering
+    // provisioner. The instance that actually runs it on the other side will have a non-null peer name.
+    String provisionerName = SystemArguments.getProfileProvisioner(runRecord.getSystemArgs());
+    if (runRecord.getPeerName() == null && TetheringProvisioner.TETHERING_NAME.equals(provisionerName)) {
+      return;
+    }
+    ProgramRunStatus programStatus = runRecord.getStatus();
+    if (programStatus.isEndState()) {
+      // if the program run completed already ignore the stop request
+      // can happen in race conditions where a stop is issued, but the program ends on its own before
+      // the stop message here is processed.
+      return;
+    }
+
+    // otherwise, look for the controller in the ProgramRuntimeService
+    ProgramRuntimeService.RuntimeInfo runtimeInfo =
+      programRuntimeService.lookup(programRunId.getParent(), RunIds.fromString(programRunId.getRun()));
+    // once the program reaches the starting state, runtimeInfo will be non-null unless the program completed
+    // already but the run state didn't get updated yet
+    // it can also be null if the stop was issued when the program was in the pending state, in which case it
+    // was never started
+    // in both situations, there isn't any program to actual stop, and the right thing to do is
+    // transition the program to the killed state
+    if (runtimeInfo == null) {
+      programStateWriter.killed(programRunId);
+      return;
+    }
+
+    // otherwise, use the controller and try to stop the program run gracefully
+    LOG.info("Stopping application {} program {} run {}", programRunId.getApplication(), programRunId.getProgram(),
+             programRunId.getRun());
+    runtimeInfo.getController().stop();
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SystemProgramManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SystemProgramManagementService.java
@@ -133,7 +133,7 @@ public class SystemProgramManagementService extends AbstractRetryableScheduledSe
   private void stopProgram(ProgramRunId programRunId) {
     LOG.debug("Stopping program run {} ", programRunId);
     try {
-      programLifecycleService.stop(programRunId.getParent(), programRunId.getRun());
+      programLifecycleService.stop(programRunId.getParent(), programRunId.getRun(), 30);
     } catch (Exception ex) {
       LOG.warn("Could not stop program run {} , will be retried .", programRunId, ex);
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SystemProgramManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SystemProgramManagementService.java
@@ -133,7 +133,7 @@ public class SystemProgramManagementService extends AbstractRetryableScheduledSe
   private void stopProgram(ProgramRunId programRunId) {
     LOG.debug("Stopping program run {} ", programRunId);
     try {
-      programLifecycleService.stop(programRunId.getParent(), programRunId.getRun(), 30);
+      programLifecycleService.stop(programRunId.getParent(), programRunId.getRun(), Integer.MAX_VALUE);
     } catch (Exception ex) {
       LOG.warn("Could not stop program run {} , will be retried .", programRunId, ex);
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -114,6 +114,7 @@ import javax.annotation.Nullable;
  */
 public class AppMetadataStore {
 
+  public static final String WORKFLOW_RUNID = "workflowrunid";
   static final DatasetId APP_META_INSTANCE_ID = NamespaceId.SYSTEM.dataset(Constants.AppMetaStore.TABLE);
 
   private static final Logger LOG = LoggerFactory.getLogger(AppMetadataStore.class);
@@ -605,7 +606,7 @@ public class AppMetadataStore {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
     builder.put("runtimeArgs", GSON.toJson(runtimeArgs, MAP_STRING_STRING_TYPE));
     if (workflowRunId != null) {
-      builder.put("workflowrunid", workflowRunId);
+      builder.put(WORKFLOW_RUNID, workflowRunId);
     }
     return builder.build();
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
@@ -70,6 +70,7 @@ import io.cdap.cdap.internal.app.runtime.SimpleProgramOptions;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.Artifacts;
 import io.cdap.cdap.internal.app.services.ProgramNotificationSubscriberService;
+import io.cdap.cdap.internal.app.services.ProgramStopSubscriberService;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.data.MessageId;
@@ -182,6 +183,7 @@ public class AppFabricTestHelper {
       startService(injector, MetricsCollectionService.class);
       startService(injector, MetadataSubscriberService.class);
       startService(injector, ProgramNotificationSubscriberService.class);
+      startService(injector, ProgramStopSubscriberService.class);
 
       Scheduler programScheduler = startService(injector, Scheduler.class);
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberServiceTest.java
@@ -402,7 +402,7 @@ public class ProgramNotificationSubscriberServiceTest {
       programStateWriter.stop(runId3, 10);
     });
     checkProgramStatus(artifactId, runId3, ProgramRunStatus.STOPPING);
-    heartbeatDatasetStatusCheck(stopTime, ProgramRunStatus.STOPPING);
+    heartbeatDatasetStatusCheck(stopTime, ProgramRunStatus.KILLED);
   }
 
   private void checkProgramStatus(ArtifactId artifactId, ProgramRunId runId, ProgramRunStatus expectedStatus)

--- a/cdap-common/src/main/java/io/cdap/cdap/gateway/handlers/ConfigHandler.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/gateway/handlers/ConfigHandler.java
@@ -28,7 +28,6 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -54,7 +53,6 @@ public class ConfigHandler extends AbstractHttpHandler {
                          @DefaultValue("json") @QueryParam("format") String format) throws IOException {
     if ("json".equals(format)) {
       responder.sendJson(HttpResponseStatus.OK, GSON.toJson(configService.getCConf()));
-      TimeUnit.MINUTES.toMillis(5);
     } else if ("xml".equals(format)) {
       responder.sendString(HttpResponseStatus.OK, configService.getCConfXMLString(),
                            new DefaultHttpHeaders().set(HttpHeaderNames.CONTENT_TYPE, "application/xml"));

--- a/cdap-common/src/main/java/io/cdap/cdap/gateway/handlers/ConfigHandler.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/gateway/handlers/ConfigHandler.java
@@ -28,6 +28,7 @@ import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -53,6 +54,7 @@ public class ConfigHandler extends AbstractHttpHandler {
                          @DefaultValue("json") @QueryParam("format") String format) throws IOException {
     if ("json".equals(format)) {
       responder.sendJson(HttpResponseStatus.OK, GSON.toJson(configService.getCConf()));
+      TimeUnit.MINUTES.toMillis(5);
     } else if ("xml".equals(format)) {
       responder.sendString(HttpResponseStatus.OK, configService.getCConfXMLString(),
                            new DefaultHttpHeaders().set(HttpHeaderNames.CONTENT_TYPE, "application/xml"));

--- a/cdap-test/src/main/java/io/cdap/cdap/test/AbstractApplicationManager.java
+++ b/cdap-test/src/main/java/io/cdap/cdap/test/AbstractApplicationManager.java
@@ -76,6 +76,6 @@ public abstract class AbstractApplicationManager implements ApplicationManager {
   public void waitForStopped(final ProgramId programId) throws Exception {
     // TODO CDAP-12362 This should be exposed to ProgramManager to stop all runs of a program
     // Ensure that there are no pending run records before moving on to the next test.
-    Tasks.waitFor(true, () -> isStopped(programId), 10, TimeUnit.SECONDS);
+    Tasks.waitFor(true, () -> isStopped(programId), 120, TimeUnit.SECONDS);
   }
 }


### PR DESCRIPTION
Refactored program stop so that a stopping message is written out
when a program stop is issued instead of trying to actually stop
the run. After the stopping state is recorded, a new subscriber
will perform the actual program stop.

As part of this, added a kill method to the ProgramController, to
differentiate between a graceful stop and a force kill, and to
better match the TwillController API that already exists.
Changed the RemoteTwillController so that the graceful stop simply
waits for the RuntimeClient to stop the program itself.
Also changed the KubeTwillController so that it specifies a
graceful stop argument accordingly when deleting
jobs/deployments/statefulsets