### PR TITLE
Add metricswriter extension to CDAP image - part 2

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -791,6 +791,7 @@ public final class Constants {
 
     public static final String METRICS_WRITER_EXTENSIONS_DIR = "metrics.writer.extensions.dir";
     public static final String METRICS_WRITER_PREFIX = "metrics.writer.";
+    public static final String METRICS_WRITER_EXTENSIONS_ENABLED_LIST = "metrics.writer.extensions.enabled.list";
 
     public static final Map<String, String> METRICS_PROCESSOR_CONTEXT =
       ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace(),

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2865,6 +2865,15 @@
     </description>
   </property>
 
+  <property>
+    <name>metrics.writer.extensions.enabled.list</name>
+    <value></value>
+    <description>
+      Comma separated list of metric writer extension names that are enabled.
+      Extensions that are not present in this list will be ignored.
+    </description>
+  </property>
+
   <!-- Provisioner Configuration -->
   <property>
     <name>provisioner.executor.threads</name>

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -279,6 +279,7 @@
         <stage.securestores.ext.dir>${stage.opt.dir}/ext/securestores</stage.securestores.ext.dir>
         <stage.storage.ext.dir>${stage.opt.dir}/ext/storageproviders</stage.storage.ext.dir>
         <stage.authenticators.ext.dir>${stage.opt.dir}/ext/authenticators</stage.authenticators.ext.dir>
+        <stage.metricswriters.ext.dir>${stage.opt.dir}/ext/metricswriters/metrics-writer-extension</stage.metricswriters.ext.dir>
         <stage.bootstrap.dir>${stage.opt.dir}/bootstrap</stage.bootstrap.dir>
         <stage.capability.dir>${stage.opt.dir}/capability-config</stage.capability.dir>
         <additional.artifacts.jar.pattern>**/target/*.jar</additional.artifacts.jar.pattern>
@@ -287,6 +288,9 @@
         <security.ext.jar.pattern>**/target/*.jar</security.ext.jar.pattern>
         <security.ext.config.pattern>**/target/*.json</security.ext.config.pattern>
         <security.ext.exclude.pattern>**/target/*-tests.jar</security.ext.exclude.pattern>
+        <metricswriters.ext.jar.pattern>**/target/libexec/*.jar</metricswriters.ext.jar.pattern>
+        <metricswriters.ext.config.pattern>**/target/libexec/*.json</metricswriters.ext.config.pattern>
+        <metricswriters.ext.exclude.pattern>**/target/libexec/*-tests.jar</metricswriters.ext.exclude.pattern>
         <!-- contains hydrator upgrade tool. Should be moved out when Hydrator is moved out of CDAP -->
         <stage.libexec.dir>${stage.opt.dir}/libexec</stage.libexec.dir>
       </properties>
@@ -842,6 +846,26 @@
                         <include name="${security.ext.jar.pattern}"/>
                         <include name="${security.ext.config.pattern}"/>
                         <exclude name="${security.ext.exclude.pattern}"/>
+                        <exclude name="**/target/*-sources.jar"/>
+                        <exclude name="**/target/*-javadoc.jar"/>
+                      </fileset>
+                    </copy>
+                  </target>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>copy-metricswriters-extensions-artifacts</id>
+                <phase>process-resources</phase>
+                <configuration>
+                  <target if="metricswriters.extensions.dir">
+                    <copy todir="${stage.metricswriters.ext.dir}" flatten="true">
+                      <fileset dir="${metricswriters.extensions.dir}">
+                        <include name="${metricswriters.ext.jar.pattern}"/>
+                        <include name="${metricswriters.ext.config.pattern}"/>
+                        <exclude name="${metricswriters.ext.exclude.pattern}"/>
                         <exclude name="**/target/*-sources.jar"/>
                         <exclude name="**/target/*-javadoc.jar"/>
                       </fileset>

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/loader/MetricsWriterExtensionLoaderTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/loader/MetricsWriterExtensionLoaderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metrics.process.loader;
+
+import io.cdap.cdap.api.metrics.MetricsWriter;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Set;
+
+/**
+ * Tests for {@link MetricsWriterExtensionLoader}
+ */
+public class MetricsWriterExtensionLoaderTest {
+
+  @Test
+  public void testEnabledMetricsWriterFilter() {
+    //Test default value
+    String mockWriterName = "mock-writer";
+    CConfiguration cConf = CConfiguration.create();
+    MetricsWriter mockWriter = new MockMetricsWriter(mockWriterName);
+    MetricsWriterExtensionLoader writerExtensionLoader1 = new MetricsWriterExtensionLoader(cConf);
+    Set<String> test1 = writerExtensionLoader1.getSupportedTypesForProvider(mockWriter);
+    Assert.assertTrue(test1.isEmpty());
+
+    //Test with writer ID enabled
+    cConf.setStrings(Constants.Metrics.METRICS_WRITER_EXTENSIONS_ENABLED_LIST, mockWriterName);
+    MetricsWriterExtensionLoader writerExtensionLoader2 = new MetricsWriterExtensionLoader(cConf);
+    Set<String> test2 = writerExtensionLoader2.getSupportedTypesForProvider(mockWriter);
+    Assert.assertTrue(test2.contains(mockWriterName));
+
+    //Test comma separated writer IDs
+    cConf.setStrings(Constants.Metrics.METRICS_WRITER_EXTENSIONS_ENABLED_LIST, mockWriterName + ",writer2");
+    MetricsWriterExtensionLoader writerExtensionLoader3 = new MetricsWriterExtensionLoader(cConf);
+    Set<String> test3 = writerExtensionLoader3.getSupportedTypesForProvider(mockWriter);
+    Assert.assertTrue(test3.contains(mockWriterName));
+    Assert.assertFalse(test3.contains("writer2"));
+
+    cConf.setStrings(Constants.Metrics.METRICS_WRITER_EXTENSIONS_ENABLED_LIST, mockWriterName + ",writer2");
+    MetricsWriterExtensionLoader writerExtensionLoader4 = new MetricsWriterExtensionLoader(cConf);
+    Set<String> test4 = writerExtensionLoader4.getSupportedTypesForProvider(new MockMetricsWriter("writer2"));
+    Assert.assertFalse(test4.contains(mockWriterName));
+    Assert.assertTrue(test4.contains("writer2"));
+  }
+}

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/loader/MockMetricsWriter.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/loader/MockMetricsWriter.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.metrics.process.loader;
+
+import io.cdap.cdap.api.metrics.MetricValues;
+import io.cdap.cdap.api.metrics.MetricsWriter;
+import io.cdap.cdap.api.metrics.MetricsWriterContext;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * Mock implementation for {@link MetricsWriter} that does no-op
+ */
+public class MockMetricsWriter implements MetricsWriter {
+
+  private final String id;
+
+  MockMetricsWriter(String id) {
+    this.id = id;
+  }
+
+  @Override
+  public void write(Collection<MetricValues> metricValues) {
+    //no-op
+  }
+
+  @Override
+  public void initialize(MetricsWriterContext metricsWriterContext) {
+    //no-op
+  }
+
+  @Override
+  public String getID() {
+    return id;
+  }
+
+  @Override
+  public void close() throws IOException {
+    //no-op
+  }
+}


### PR DESCRIPTION
- Add option for copying metrics writer extension in distribution. 

- Add ability to selectively enable metricwriters.