### PR TITLE
Updating check style rules

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/common/Bytes.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/common/Bytes.java
@@ -27,6 +27,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -304,20 +305,17 @@ public class Bytes {
    */
   public static String toStringBinary(final byte [] b, int off, int len) {
     StringBuilder result = new StringBuilder();
-    try {
-      String first = new String(b, off, len, "ISO-8859-1");
-      for (int i = 0; i < first.length(); ++i) {
-        int ch = first.charAt(i) & 0xFF;
-        if ((ch >= '0' && ch <= '9')
-            || (ch >= 'A' && ch <= 'Z')
-            || (ch >= 'a' && ch <= 'z')
-            || " `~!@#$%^&*()-_=+[]{}\\|;:'\",.<>/?".indexOf(ch) >= 0) {
-          result.append(first.charAt(i));
-        } else {
-          result.append(String.format("\\x%02X", ch));
-        }
+    String first = new String(b, off, len, StandardCharsets.ISO_8859_1);
+    for (int i = 0; i < first.length(); ++i) {
+      int ch = first.charAt(i) & 0xFF;
+      if ((ch >= '0' && ch <= '9')
+          || (ch >= 'A' && ch <= 'Z')
+          || (ch >= 'a' && ch <= 'z')
+          || " `~!@#$%^&*()-_=+[]{}\\|;:'\",.<>/?".indexOf(ch) >= 0) {
+        result.append(first.charAt(i));
+      } else {
+        result.append(String.format("\\x%02X", ch));
       }
-    } catch (UnsupportedEncodingException e) {
     }
     return result.toString();
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactDetail.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactDetail.java
@@ -51,4 +51,9 @@ public class ArtifactDetail {
     return Objects.equals(descriptor, that.descriptor) &&
       Objects.equals(meta, that.meta);
   }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(descriptor, meta);
+  }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/proto/v1/TetheringLaunchMessage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/proto/v1/TetheringLaunchMessage.java
@@ -60,6 +60,11 @@ public class TetheringLaunchMessage {
       Objects.equals(cConfEntries, that.cConfEntries);
   }
 
+  @Override
+  public int hashCode() {
+    return Objects.hash(localizeFiles, cConfEntries);
+  }
+
   /**
    * Builder for TetheringLaunchMessage
    */

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/AppWithWorker.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/AppWithWorker.java
@@ -71,7 +71,7 @@ public class AppWithWorker extends AbstractApplication {
         try {
           TimeUnit.MILLISECONDS.sleep(100);
         } catch (InterruptedException e) {
-
+          // ignore
         }
       }
     }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/RemoteTaskExecutorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/RemoteTaskExecutorTest.java
@@ -118,7 +118,7 @@ public class RemoteTaskExecutorTest {
     try {
       remoteTaskExecutor.runTask(runnableTaskRequest);
     } catch (Exception e) {
-
+      // expected
     }
     mockMetricsCollector.stopAndWait();
     Assert.assertSame(1, published.size());
@@ -160,7 +160,7 @@ public class RemoteTaskExecutorTest {
     try {
       remoteTaskExecutor.runTask(runnableTaskRequest);
     } catch (Exception e) {
-
+      // expected
     }
     mockMetricsCollector.stopAndWait();
     Assert.assertSame(1, published.size());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityManagementServiceTest.java
@@ -163,7 +163,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       capabilityStatusStore.checkAllEnabled(Collections.singleton("cap1"));
       Assert.fail("expecting exception");
     } catch (CapabilityNotAvailableException ex) {
-
+      // expected
     }
 
     //disable from delete and see if it is applied correctly
@@ -178,7 +178,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       capabilityStatusStore.checkAllEnabled(Collections.singleton("cap1"));
       Assert.fail("expecting exception");
     } catch (CapabilityNotAvailableException ex) {
-
+      // expected
     }
     Assert.assertEquals(disableConfig, capabilityStatusStore.getConfigs(Collections.singleton("cap1")).get("cap1"));
 
@@ -246,7 +246,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       capabilityStatusStore.checkAllEnabled(Collections.singleton(capability));
       Assert.fail("expecting exception");
     } catch (CapabilityNotAvailableException ex) {
-
+      // expected
     }
     appList = getAppList(namespace);
     Assert.assertFalse(appList.isEmpty());
@@ -303,7 +303,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       capabilityStatusStore.checkAllEnabled(Collections.singleton(capability));
       Assert.fail("expecting exception");
     } catch (CapabilityNotAvailableException ex) {
-
+      // expected
     }
     appList = getAppList(namespace);
     Assert.assertFalse(appList.isEmpty());
@@ -338,7 +338,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       capabilityStatusStore.checkAllEnabled(Collections.singleton(capability));
       Assert.fail("expecting exception");
     } catch (CapabilityNotAvailableException ex) {
-
+      // expected
     }
     appList = getAppList(namespace);
     Assert.assertFalse(appList.isEmpty());
@@ -395,7 +395,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       capabilityStatusStore.checkAllEnabled(Collections.singleton(capability));
       Assert.fail("expecting exception");
     } catch (CapabilityNotAvailableException ex) {
-
+      // expected
     }
     appList = getAppList(namespace);
     Assert.assertFalse(appList.isEmpty());
@@ -427,7 +427,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       capabilityStatusStore.checkAllEnabled(Collections.singleton(capability));
       Assert.fail("expecting exception");
     } catch (CapabilityNotAvailableException ex) {
-
+      // expected
     }
     appList = getAppList(namespace);
     Assert.assertFalse(appList.isEmpty());
@@ -455,7 +455,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       capabilityStatusStore.checkAllEnabled(Arrays.asList(declaredAnnotation.capabilities()));
       Assert.fail("expecting exception");
     } catch (CapabilityNotAvailableException ex) {
-
+      // expected
     }
     String appNameWithCapability = appWithWorkflowClass.getSimpleName() + UUID.randomUUID();
     deployTestArtifact(Id.Namespace.DEFAULT.getId(), appNameWithCapability, testVersion, appWithWorkflowClass);
@@ -563,7 +563,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       capabilityStatusStore.checkAllEnabled(Collections.singleton(capability));
       Assert.fail("expecting exception");
     } catch (CapabilityNotAvailableException ex) {
-
+      // expected
     }
 
     //try starting programs
@@ -643,7 +643,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       capabilityStatusStore.checkAllEnabled(Collections.singleton(capability));
       Assert.fail("expecting exception");
     } catch (CapabilityNotAvailableException ex) {
-
+      // expected
     }
 
     //try starting programs
@@ -673,11 +673,13 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
       capabilityStatusStore.checkAllEnabled(Collections.singleton(testCapability2));
       Assert.fail("expecting exception");
     } catch (CapabilityNotAvailableException ex) {
+      // expected
     }
     try {
       capabilityStatusStore.checkAllEnabled(Collections.singleton(testCapability3));
       Assert.fail("expecting exception");
     } catch (CapabilityNotAvailableException ex) {
+      // expected
     }
     try {
       capabilityStatusStore.checkAllEnabled(Collections.singleton(testCapability1));

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringServerHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringServerHandlerTest.java
@@ -306,6 +306,7 @@ public class TetheringServerHandlerTest {
       messagingService.getTopic(topic);
       Assert.fail(String.format("Messaging topic %s was not deleted", topic.getTopic()));
     } catch (TopicNotFoundException ignored) {
+      // expected
     }
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/aggregation/DeduplicateAggregationDefinitionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/aggregation/DeduplicateAggregationDefinitionTest.java
@@ -91,7 +91,7 @@ public class DeduplicateAggregationDefinitionTest {
         .build();
       Assert.fail("Expected IllegalStateException");
     } catch (IllegalStateException ignored) {
-
+      // expected
     }
 
     try {
@@ -101,7 +101,7 @@ public class DeduplicateAggregationDefinitionTest {
         .build();
       Assert.fail("Expected IllegalStateException");
     } catch (IllegalStateException ignored) {
-
+      // expected
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/aggregation/GroupByAggregationDefinitionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/aggregation/GroupByAggregationDefinitionTest.java
@@ -83,7 +83,7 @@ public class GroupByAggregationDefinitionTest {
         .build();
       Assert.fail("Expected IllegalStateException");
     } catch (IllegalStateException ignored) {
-
+      // expected
     }
   }
 }

--- a/cdap-cli/src/main/java/io/cdap/cdap/cli/completer/element/HttpEndpointPrefixCompleter.java
+++ b/cdap-cli/src/main/java/io/cdap/cdap/cli/completer/element/HttpEndpointPrefixCompleter.java
@@ -86,6 +86,7 @@ public class HttpEndpointPrefixCompleter extends PrefixCompleter {
         }
       }
     } catch (IOException | NotFoundException | UnauthenticatedException | UnauthorizedException ignored) {
+      // ignore
     }
     return httpEndpoints;
   }

--- a/cdap-cli/src/main/java/io/cdap/cdap/cli/completer/element/HttpMethodPrefixCompleter.java
+++ b/cdap-cli/src/main/java/io/cdap/cdap/cli/completer/element/HttpMethodPrefixCompleter.java
@@ -85,6 +85,7 @@ public class HttpMethodPrefixCompleter extends PrefixCompleter {
         }
       }
     } catch (IOException | UnauthenticatedException | NotFoundException | UnauthorizedException ignored) {
+      // ignore
     }
     return httpMethods;
   }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/db/DBConnectionPoolManager.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/db/DBConnectionPoolManager.java
@@ -313,7 +313,7 @@ public class DBConnectionPoolManager {
         return conn;
       }
     } catch (SQLException e) {
-
+      // Ignore the exception since we are going to cleanup the invalid connection.
     }
     // This Exception should never occur. If it nevertheless occurs,
     // it's because of an error in the JDBC driver which we ignore and assume

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/guava/ClassPath.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/guava/ClassPath.java
@@ -463,7 +463,9 @@ public final class ClassPath {
       } finally {
         try {
           jarFile.close();
-        } catch (IOException ignored) { }
+        } catch (IOException ignored) {
+          // Ignore failure on closing jar.
+        }
       }
     }
 

--- a/cdap-common/src/test/java/io/cdap/cdap/common/conf/CConfigurationUtilTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/conf/CConfigurationUtilTest.java
@@ -58,6 +58,7 @@ public class CConfigurationUtilTest {
       CConfigurationUtil.verify(cConf);
       Assert.fail("Expected cConf to be invalid");
     } catch (IllegalArgumentException expected) {
+      // Expected
     }
   }
 

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/api/dataset/lib/KeyValueTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/api/dataset/lib/KeyValueTableTest.java
@@ -307,6 +307,7 @@ public class KeyValueTableTest {
           keyValueIterator.next();
           Assert.fail("Reading after closing Scanner returned result.");
         } catch (NoSuchElementException e) {
+          // expected
         }
       }
     });

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/TestObject.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/TestObject.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.data2.dataset2;
 
-import com.google.common.base.Objects;
+import java.util.Objects;
 
 public final class TestObject {
   private final String a;
@@ -57,6 +57,11 @@ public final class TestObject {
     TestObject that = (TestObject) o;
 
     return b == that.b
-      && Objects.equal(a, that.a);
+      && Objects.equals(a, that.a);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(a, b);
   }
 }

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/partitioned/PartitionConsumerTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/partitioned/PartitionConsumerTest.java
@@ -740,6 +740,7 @@ public class PartitionConsumerTest {
           partitionConsumer.onFinish(partitionDetails, false);
           Assert.fail("Expected not to be able to abort a partition that is not IN_PROGRESS");
         } catch (IllegalStateException expected) {
+          // expected
         }
 
         // try to process the partition again, this time marking it as complete (by passing in true)
@@ -754,6 +755,7 @@ public class PartitionConsumerTest {
           partitionConsumer.onFinish(partitionDetails, true);
           Assert.fail("Expected not to be able to call onFinish on a partition is not IN_PROGRESS");
         } catch (IllegalArgumentException expected) {
+          // expected
         }
       }
     });

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetArgumentsTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetArgumentsTest.java
@@ -164,11 +164,13 @@ public class PartitionedFileSetArgumentsTest {
       PartitionedFileSetArguments.isDynamicPartitionerConcurrencyAllowed(arguments);
       Assert.fail();
     } catch (IllegalArgumentException expected) {
+      // expected
     }
     try {
       PartitionedFileSetArguments.setDynamicPartitionerConcurrency(arguments, false);
       Assert.fail();
     } catch (IllegalArgumentException expected) {
+      // expected
     }
 
     // set a DynamicPartitioner

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetTest.java
@@ -619,6 +619,7 @@ public class PartitionedFileSetTest {
           dataset.addMetadata(PARTITION_KEY, "key2", "value3");
           Assert.fail("Expected not to be able to update an existing metadata entry");
         } catch (DataSetException expected) {
+          // expected
         }
 
         // possible to remove multiple metadata entries; if a key doesn't exist, no error is thrown
@@ -639,6 +640,7 @@ public class PartitionedFileSetTest {
           dataset.addMetadata(nonexistentPartitionKey, "key2", "value3");
           Assert.fail("Expected not to be able to add metadata for a nonexistent partition");
         } catch (DataSetException expected) {
+          // expected
         }
       }
     });
@@ -740,6 +742,7 @@ public class PartitionedFileSetTest {
       createPartition(pfs, PARTITION_KEY, "file2");
       Assert.fail("Expected PartitionAlreadyExistsException");
     } catch (PartitionAlreadyExistsException expected) {
+      // expected
     }
     // because of the above failure, we want to abort and rollback the transaction
     txContext.abort();

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/partitioned/TimePartitionedFileSetTest.java
@@ -121,6 +121,7 @@ public class TimePartitionedFileSetTest {
           tpfs.addMetadata(time, "key3", "value5");
           Assert.fail("Expected not to be able to update an existing metadata entry");
         } catch (DataSetException expected) {
+          // expected
         }
 
         partitionByTime = tpfs.getPartitionByTime(time);

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/table/MDSKeyTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/table/MDSKeyTest.java
@@ -125,12 +125,14 @@ public class MDSKeyTest {
       splitter.getBytes();
       Assert.fail();
     } catch (BufferUnderflowException expected) {
+      // expected
     }
 
     try {
       splitter.getString();
       Assert.fail();
     } catch (BufferUnderflowException expected) {
+      // expected
     }
   }
 

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/table/ObjectStoreDatasetTest.java
@@ -502,6 +502,7 @@ public class ObjectStoreDatasetTest {
           objectsIterator.next();
           Assert.fail("Reading after closing Scanner returned result.");
         } catch (NoSuchElementException e) {
+          // expected
         }
       }
     });

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/metrics/MetricsHandlerTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/metrics/MetricsHandlerTest.java
@@ -139,7 +139,7 @@ public class MetricsHandlerTest extends MetricsSuiteTestBase {
       replicatorMetrics.child(ImmutableMap.of("ns", "anothernamespace"));
       Assert.fail("Creating child Metrics with duplicate tag name 'ns' should have failed.");
     } catch (IllegalArgumentException ignored) {
-
+      // ignore
     }
     // need a better way to do this
     TimeUnit.SECONDS.sleep(2);

--- a/cdap-security/src/main/java/io/cdap/cdap/security/zookeeper/SharedResourceCache.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/zookeeper/SharedResourceCache.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -249,8 +250,13 @@ public class SharedResourceCache<T> extends AbstractLoadingCache<String, T> {
     }
 
     SharedResourceCache other = (SharedResourceCache) object;
-    return this.parentZnode.equals(other.parentZnode) &&
-      this.resources.equals(other.resources);
+    return Objects.equals(this.parentZnode, other.parentZnode) &&
+      Objects.equals(this.resources, other.resources);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(parentZnode, resources);
   }
 
   private String joinZNode(String parent, String name) {

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/TestTokenManager.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/TestTokenManager.java
@@ -64,7 +64,9 @@ public abstract class TestTokenManager {
       tokenManager.validateSecret(expiredToken);
       fail("Token should have been expired but passed validation: " +
              Bytes.toStringBinary(tokenCodec.encode(expiredToken)));
-    } catch (InvalidTokenException expected) { }
+    } catch (InvalidTokenException expected) {
+      // expected
+    }
 
     // test token with invalid signature
     Random random = new Random();
@@ -75,7 +77,9 @@ public abstract class TestTokenManager {
       tokenManager.validateSecret(invalidToken);
       fail("Token should have been rejected for invalid digest but passed: " +
              Bytes.toStringBinary(tokenCodec.encode(invalidToken)));
-    } catch (InvalidTokenException expected) { }
+    } catch (InvalidTokenException expected) {
+      // expected
+    }
 
     // test token with bad key ID
     AccessToken invalidKeyToken = new AccessToken(token1.getIdentifier(), token1.getKeyId() + 1,
@@ -84,7 +88,9 @@ public abstract class TestTokenManager {
       tokenManager.validateSecret(invalidKeyToken);
       fail("Token should have been rejected for invalid key ID but passed: " +
              Bytes.toStringBinary(tokenCodec.encode(invalidToken)));
-    } catch (InvalidTokenException expected) { }
+    } catch (InvalidTokenException expected) {
+      // expected
+    }
 
     tokenManager.stopAndWait();
   }

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
@@ -293,7 +293,7 @@ public final class SparkContainerLauncher {
     try {
       logger.getClass().getMethod(level, String.class, Object[].class).invoke(logger, message, args);
     } catch (Exception e) {
-
+      // ignore
     }
   }
 

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/partitioned/PartitionRollbackTestRun.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/partitioned/PartitionRollbackTestRun.java
@@ -276,7 +276,7 @@ public class PartitionRollbackTestRun extends TestFrameworkTestBase {
       pfs.getPartitionOutput(KEY_1);
       Assert.fail("Expected getPartitionOutput to fail, because the partition already exists.");
     } catch (DataSetException expected) {
-
+      // expected
     }
     pfsValidator.validate();
 

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/test/app/AppWithWorker.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/test/app/AppWithWorker.java
@@ -69,6 +69,7 @@ public class AppWithWorker extends AbstractApplication {
           try {
             TimeUnit.MILLISECONDS.sleep(100);
           } catch (InterruptedException e) {
+            // ignore
           }
         }
       } catch (TransactionFailureException e) {

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/TopicProcessMeta.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/TopicProcessMeta.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.metrics.process;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -119,6 +120,21 @@ public final class TopicProcessMeta {
 
   @Override
   public int hashCode() {
-    return Objects.hash(messageId, oldestMetricsTimestamp, latestMetricsTimestamp, messagesProcessed);
+    return Objects.hash(Arrays.hashCode(messageId), oldestMetricsTimestamp, latestMetricsTimestamp, messagesProcessed);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TopicProcessMeta that = (TopicProcessMeta) o;
+    return oldestMetricsTimestamp == that.oldestMetricsTimestamp
+      && latestMetricsTimestamp == that.latestMetricsTimestamp
+      && messagesProcessed == that.messagesProcessed
+      && Arrays.equals(messageId, that.messageId);
   }
 }

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/collect/DistributionTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/collect/DistributionTest.java
@@ -94,6 +94,7 @@ public class DistributionTest {
         try {
           Thread.sleep(1000);
         } catch (InterruptedException e) {
+          // ignore
         }
         MetricValue metricValue = emitter.emit();
         totalEmitCount.add(Arrays.stream(metricValue.getBucketCounts()).sum());

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -281,6 +281,12 @@ page at http://checkstyle.sourceforge.net/config.html -->
     </module>
 
 
+    <!-- Requires overriding equals and hashCode at the same time -->
+    <module name="EqualsHashCode"/>
+
+    <!-- Empty catch block is not allowed -->
+    <module name="EmptyCatchBlock"/>
+
     <!--
 
     MODIFIERS CHECKS


### PR DESCRIPTION
- Added EqualsHashCode
  - The equals() and hashCode() method must both be implemented
- Added EmptyCatchBlock
  - Disallow empty catch block