### PR TITLE
Use remote tethering authenticator in artifact cache

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/ArtifactCacheService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/ArtifactCacheService.java
@@ -36,6 +36,7 @@ import java.nio.file.Paths;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import javax.inject.Named;
 
 /**
  * Launches an HTTP server for fetching and cache artifacts from remote CDAP instances.
@@ -55,7 +56,9 @@ public class ArtifactCacheService extends AbstractIdleService {
 
   @Inject
   public ArtifactCacheService(CConfiguration cConf, ArtifactCache cache, TetheringStore store,
-                              RemoteAuthenticator remoteAuthenticator, DiscoveryService discoveryService) {
+                              @Named(TetheringAgentService.REMOTE_TETHERING_AUTHENTICATOR)
+                                RemoteAuthenticator remoteAuthenticator,
+                              DiscoveryService discoveryService) {
     this.discoveryService = discoveryService;
     httpService = new CommonNettyHttpServiceBuilder(cConf, "artifact.cache")
       .setHttpHandlers(new ArtifactCacheHttpHandlerInternal(cache, store, remoteAuthenticator))


### PR DESCRIPTION
Artifact cache fetches artifacts from a remote CDAP instance, so we need to use the remote authenticator.