### PR TITLE
[CDAP-18648] Emit metrics for force terminated programs runs and expected and actual stop times for a program

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -997,10 +997,12 @@ public final class Constants {
       public static final String PROGRAM_FAILED_RUNS = "program.failed.runs";
       public static final String PROGRAM_KILLED_RUNS = "program.killed.runs";
       public static final String PROGRAM_REJECTED_RUNS = "program.rejected.runs";
+      public static final String PROGRAM_FORCE_TERMINATED_RUNS = "program.force.terminated.runs";
       public static final String PROGRAM_NODE_MINUTES = "program.node.minutes";
       public static final String PROGRAM_PROVISIONING_DELAY_SECONDS = "program.provisioning.delay.seconds";
       public static final String PROGRAM_STARTING_DELAY_SECONDS = "program.starting.delay.seconds";
       public static final String RUN_TIME_SECONDS = "program.run.seconds";
+      public static final String PROGRAM_STOPPING_DELAY_SECONDS = "program.stopping.delay.seconds";
       public static final String APPLICATION_COUNT = "application.count";
       public static final String NAMESPACE_COUNT = "namespace.count";
       public static final String APPLICATION_PLUGIN_COUNT = "application.plugin.count";


### PR DESCRIPTION
When a stop command is issued with timeout, app-fabric periodically monitors to see if these runs are terminated on time, and force stops those programs that are still active beyond the timeout. This PR captures metrics to track the number of such force terminated runs and the expected and actual end time for all runs.
Jira: https://cdap.atlassian.net/browse/CDAP-18930

Testing:
`POST` call to `metrics/query` with the payload
```
{
  "query": {
    "tags": {
      "namespace": "default",
      "app": "basic_streaming"
    },
    "metrics": [
      "system.program.force.terminated.runs",
      "system.program.stopping.delay.seconds"
    ],
    "timeRange": {
      "aggregate": false
    }
  }
}
```
gave a 200 response with the below json
```
{
  "query": {
    "startTime": 0,
    "endTime": 1649354350,
    "series": [
      {
        "metricName": "system.program.force.terminated.runs",
        "grouping": {},
        "data": [
          {
            "time": 0,
            "value": 2
          }
        ]
      },
      {
        "metricName": "system.program.stopping.delay.seconds",
        "grouping": {},
        "data": [
          {
            "time": 0,
            "value": 35
          }
        ]
      }
    ],
    "resolution": "2147483647s"
  }
}
```