### PR TITLE
[CDAP-18933] Send program state updates between tethered instances

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeProgramStatusSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeProgramStatusSubscriberService.java
@@ -54,6 +54,7 @@ import javax.annotation.Nullable;
  * a running program.
  */
 public class RuntimeProgramStatusSubscriberService extends AbstractNotificationSubscriberService {
+  public static final String SUBSCRIBER = "runtime";
 
   private static final Logger LOG = LoggerFactory.getLogger(RuntimeProgramStatusSubscriberService.class);
   private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder()).create();
@@ -72,12 +73,12 @@ public class RuntimeProgramStatusSubscriberService extends AbstractNotificationS
   @Nullable
   @Override
   protected String loadMessageId(StructuredTableContext context) throws IOException {
-    return getAppMetadataStore(context).retrieveSubscriberState(getTopicId().getTopic(), "runtime");
+    return getAppMetadataStore(context).retrieveSubscriberState(getTopicId().getTopic(), SUBSCRIBER);
   }
 
   @Override
   protected void storeMessageId(StructuredTableContext context, String messageId) throws IOException {
-    getAppMetadataStore(context).persistSubscriberState(getTopicId().getTopic(), "runtime", messageId);
+    getAppMetadataStore(context).persistSubscriberState(getTopicId().getTopic(), SUBSCRIBER, messageId);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringControlChannelRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringControlChannelRequest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import io.cdap.cdap.proto.Notification;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Sent from TetheringAgentService to TetheringServerHandler.
+ * Contains last TetheringControlMessage received and list of program status update notifications.
+ */
+public class TetheringControlChannelRequest {
+  private final String lastControlMessageId;
+  private final List<Notification> notificationList;
+
+  public TetheringControlChannelRequest(@Nullable String lastControlMessageId,
+                                        @Nullable List<Notification> notificationList) {
+    this.lastControlMessageId = lastControlMessageId;
+    if (notificationList == null) {
+      notificationList = new ArrayList<>();
+    }
+    this.notificationList = notificationList;
+  }
+
+  public String getLastControlMessageId() {
+    return lastControlMessageId;
+  }
+
+  public List<Notification> getNotificationList() {
+    return notificationList;
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringClientHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringClientHandlerTest.java
@@ -41,6 +41,8 @@ import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.data.runtime.StorageModule;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.data.runtime.TransactionExecutorModule;
+import io.cdap.cdap.internal.app.store.StoreProgramRunRecordFetcher;
+import io.cdap.cdap.logging.gateway.handlers.ProgramRunRecordFetcher;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
 import io.cdap.cdap.proto.id.InstanceId;
@@ -139,6 +141,8 @@ public class TetheringClientHandlerTest {
           expose(MetricsCollectionService.class);
           bind(ProgramStateWriter.class).to(NoOpProgramStateWriter.class).in(Scopes.SINGLETON);
           expose(ProgramStateWriter.class);
+          bind(ProgramRunRecordFetcher.class).to(StoreProgramRunRecordFetcher.class).in(Scopes.SINGLETON);
+          expose(ProgramRunRecordFetcher.class);
         }
       });
     tetheringStore = new TetheringStore(injector.getInstance(TransactionRunner.class));
@@ -199,6 +203,8 @@ public class TetheringClientHandlerTest {
 
     tetheringAgentService = new TetheringAgentService(cConf, injector.getInstance(TransactionRunner.class),
                                                       tetheringStore, injector.getInstance(ProgramStateWriter.class),
+                                                      messagingService,
+                                                      injector.getInstance(ProgramRunRecordFetcher.class),
                                                       injector.getInstance(RemoteAuthenticator.class));
     Assert.assertEquals(Service.State.RUNNING, tetheringAgentService.startAndWait());
   }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1937,7 +1937,7 @@ public final class Constants {
     /**
      * Interval for connecting to the server.
      */
-    public static final String CONNECTION_INTERVAL = "tethering.connection.interval.secs";
+    public static final String CONNECTION_INTERVAL = "tethering.agent.connection.interval.secs";
 
     /**
      * Tethering connection timeout.

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/TetheringAgentServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/TetheringAgentServiceMain.java
@@ -32,7 +32,9 @@ import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.namespace.guice.NamespaceQueryAdminModule;
 import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
+import io.cdap.cdap.internal.app.store.StoreProgramRunRecordFetcher;
 import io.cdap.cdap.internal.tethering.TetheringAgentService;
+import io.cdap.cdap.logging.gateway.handlers.ProgramRunRecordFetcher;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
@@ -76,6 +78,8 @@ public class TetheringAgentServiceMain extends AbstractServiceMain<EnvironmentOp
         protected void configure() {
           bind(TetheringAgentService.class).in(Scopes.SINGLETON);
           expose(TetheringAgentService.class);
+          bind(ProgramRunRecordFetcher.class).to(StoreProgramRunRecordFetcher.class).in(Scopes.SINGLETON);
+          expose(ProgramRunRecordFetcher.class);
         }
       });
   }


### PR DESCRIPTION
See https://github.com/cdapio/cdap/pull/14081 for PR comment history

- Changed GET control channel method to POST to enable adding request body (see https://stackoverflow.com/questions/8587913/what-exactly-does-urlconnection-setdooutput-affect)
- Updated `TetheringAgentService` to fetch program status updates from TMS. During control channel connection, filter the program status updates if initiated by a tethered peer to include the notifications in the request
- Created `TetheringControlChannelRequest` class as the content sent during POST control channel request
- Added handling of program status notifications in `TetheringServerHandler` through the request content and publish to TMS

JIRA: CDAP-18933