### PR TITLE
[CDAP-18224] Replace use of getApps in SupportBundlePipelineInfoTask with scan

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -203,19 +203,6 @@ public class ApplicationLifecycleService extends AbstractIdleService {
   }
 
   /**
-   * Get all applications in the specified namespace
-   *
-   * @param namespace the namespace to get apps from
-   * @return list of all applications in the namespace that satisfy the specified predicate
-   */
-  public List<ApplicationDetail> getApps(NamespaceId namespace) throws Exception {
-
-    List<ApplicationDetail> result = new ArrayList<>();
-    scanApplications(namespace, Collections.emptyList(), d -> result.add(d));
-    return result;
-  }
-
-  /**
    * Scans all applications in the specified namespace, filtered to only include applications with an artifact name
    * in the set of specified names and an artifact version equal to the specified version. If the specified set
    * is empty, no filtering is performed on artifact name. If the specified version is null, no filtering is done

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcher.java
@@ -23,7 +23,7 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Interface for fetching {@code ApplicationDetail}
@@ -40,11 +40,13 @@ public interface ApplicationDetailFetcher {
   ApplicationDetail get(ApplicationId appId) throws IOException, NotFoundException, UnauthorizedException;
 
   /**
-   * Get details of all applications in the given namespace
-   * @param namespace the name of the namespace to get the list of applications
-   * @return a list of {@code ApplicationDetail} in the given namspace
-   * @throws IOException if failed to get the list of {@code ApplicationDetail}
-   * @throws NamespaceNotFoundException if the given namespace doesn't exist
+   * Scans all application details in the given namespace
+   * @param namespace the namespace to scan application details from
+   * @param consumer a {@link Consumer} to consume each ApplicationDetail being scanned
+   * @param batchSize the number of application details to be scanned in each batch
+   * @throws IOException
+   * @throws NamespaceNotFoundException
    */
-  List<ApplicationDetail> list(String namespace) throws IOException, NamespaceNotFoundException, UnauthorizedException;
+  void scan(String namespace, Consumer<ApplicationDetail> consumer, Integer batchSize)
+    throws IOException, NamespaceNotFoundException, UnauthorizedException;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalApplicationDetailFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalApplicationDetailFetcher.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.metadata;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.cdap.cdap.common.NamespaceNotFoundException;
 import io.cdap.cdap.common.NotFoundException;
@@ -27,8 +28,7 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Fetch {@link ApplicationDetail} from local store via {@link ApplicationLifecycleService}
@@ -65,28 +65,22 @@ public class LocalApplicationDetailFetcher implements ApplicationDetailFetcher {
   }
 
   /**
-   * Get a list of {@link ApplicationDetail} for all applications in the given namespace
-   *
-   * @param namespace the name of the namespace to get the list of applications
-   * @return a list of {@link ApplicationDetail} for all applications in the given namespace
-   * @throws IOException if failed to get the list of {@link ApplicationDetail}
-   * @throws NamespaceNotFoundException if the given namespace doesn't exit
+   * Scans all application details in the given namespace
    */
   @Override
-  public List<ApplicationDetail> list(String namespace) throws IOException, NamespaceNotFoundException {
+  public void scan(String namespace, Consumer<ApplicationDetail> consumer, Integer batchSize)
+    throws IOException, NamespaceNotFoundException {
     NamespaceId namespaceId = new NamespaceId(namespace);
-    List<ApplicationDetail> detailList = Collections.emptyList();
     try {
       // Check if the namespace exists before calling ApplicationLifecycleService, since it doesn't check
       // the existence of the namespace. Does a check here to explicitly throw an exception if nonexistent.
       if (!namespaceQueryAdmin.exists(namespaceId)) {
         throw new NamespaceNotFoundException(namespaceId);
       }
-      detailList = applicationLifecycleService.getApps(namespaceId);
+      applicationLifecycleService.scanApplications(namespaceId, ImmutableList.of(), consumer);
     } catch (Exception e) {
       Throwables.propagateIfPossible(e, NamespaceNotFoundException.class, IOException.class);
       throw new IOException(e);
     }
-    return detailList;
   }
 }

--- a/cdap-support-bundle/src/main/java/io/cdap/cdap/support/task/SupportBundlePipelineInfoTask.java
+++ b/cdap-support-bundle/src/main/java/io/cdap/cdap/support/task/SupportBundlePipelineInfoTask.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.support.task;
 
+import com.google.common.base.Throwables;
 import com.google.gson.Gson;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.utils.DirUtils;
@@ -51,6 +52,7 @@ public class SupportBundlePipelineInfoTask implements SupportBundleTask {
 
   private static final Logger LOG = LoggerFactory.getLogger(SupportBundlePipelineInfoTask.class);
   private static final Gson GSON = new Gson();
+  private static final Integer BATCH_SIZE = 20;
 
   private final File basePath;
   private final RemoteApplicationDetailFetcher remoteApplicationDetailFetcher;
@@ -94,58 +96,69 @@ public class SupportBundlePipelineInfoTask implements SupportBundleTask {
   @Override
   public void collect() throws IOException, NotFoundException {
     for (NamespaceId namespaceId : namespaces) {
-      Iterable<ApplicationDetail> appDetails;
       if (requestApplication == null) {
-        appDetails = remoteApplicationDetailFetcher.list(namespaceId.getNamespace());
+        remoteApplicationDetailFetcher.scan(namespaceId.getNamespace(),
+              d -> {
+                try {
+                  processApplicationDetail(namespaceId, d);
+                } catch (Exception e) {
+                  throw Throwables.propagate(e);
+                }
+              },
+            BATCH_SIZE
+            );
       } else {
         try {
-          appDetails = Collections.singletonList(
-            remoteApplicationDetailFetcher.get(new ApplicationId(namespaceId.getNamespace(), requestApplication)));
+          processApplicationDetail(namespaceId,
+              remoteApplicationDetailFetcher.get(
+                  new ApplicationId(namespaceId.getNamespace(), requestApplication)));
         } catch (NotFoundException e) {
           LOG.debug("Failed to find application {} ", requestApplication, e);
           continue;
         }
       }
-
-      for (ApplicationDetail appDetail : appDetails) {
-        String application = appDetail.getName();
-        ApplicationId applicationId = new ApplicationId(namespaceId.getNamespace(), application);
-
-        File appFolderPath = new File(basePath, appDetail.getName());
-        DirUtils.mkdirs(appFolderPath);
-        try (FileWriter file = new FileWriter(new File(appFolderPath, appDetail.getName() + ".json"))) {
-          GSON.toJson(appDetail, file);
-        }
-        ProgramId programId = new ProgramId(namespaceId.getNamespace(), appDetail.getName(), programType, programName);
-        Iterable<RunRecord> runRecordList;
-        if (runId != null) {
-          ProgramRunId programRunId =
-            new ProgramRunId(namespaceId.getNamespace(), appDetail.getName(), programType, programName, runId);
-          RunRecordDetail runRecordDetail = remoteProgramRunRecordFetcher.getRunRecordMeta(programRunId);
-          runRecordList = Collections.singletonList(runRecordDetail);
-        } else {
-          runRecordList = getRunRecords(programId);
-        }
-
-        SupportBundleRuntimeInfoTask supportBundleRuntimeInfoTask =
-          new SupportBundleRuntimeInfoTask(appFolderPath, namespaceId, applicationId, programType, programId,
-                                           remoteMetricsSystemClient, runRecordList);
-        SupportBundlePipelineRunLogTask supportBundlePipelineRunLogTask =
-          new SupportBundlePipelineRunLogTask(appFolderPath, programId, remoteLogsFetcher, runRecordList);
-
-        String runtimeInfoClassName = supportBundleRuntimeInfoTask.getClass().getName();
-        String runtimeInfoTaskName =
-          uuid.concat(": ").concat(runtimeInfoClassName).concat(": ").concat(appDetail.getName());
-        supportBundleJob.executeTask(supportBundleRuntimeInfoTask, basePath.getPath(), runtimeInfoTaskName,
-                                     runtimeInfoTaskName);
-
-        String runtimeLogClassName = supportBundlePipelineRunLogTask.getClass().getName();
-        String runtimeLogTaskName =
-          uuid.concat(": ").concat(runtimeLogClassName).concat(": ").concat(appDetail.getName());
-        supportBundleJob.executeTask(supportBundlePipelineRunLogTask, basePath.getPath(), runtimeLogTaskName,
-                                     runtimeLogClassName);
-      }
     }
+  }
+
+  private void processApplicationDetail (NamespaceId namespaceId, ApplicationDetail appDetail)
+    throws IOException, NotFoundException {
+    String application = appDetail.getName();
+    ApplicationId applicationId = new ApplicationId(namespaceId.getNamespace(), application);
+
+    File appFolderPath = new File(basePath, appDetail.getName());
+    DirUtils.mkdirs(appFolderPath);
+    try (FileWriter file = new FileWriter(new File(appFolderPath, appDetail.getName() + ".json"))) {
+      GSON.toJson(appDetail, file);
+    }
+    ProgramId programId = new ProgramId(namespaceId.getNamespace(), appDetail.getName(), programType, programName);
+    Iterable<RunRecord> runRecordList;
+    if (runId != null) {
+      ProgramRunId programRunId =
+          new ProgramRunId(namespaceId.getNamespace(), appDetail.getName(), programType, programName, runId);
+      RunRecordDetail runRecordDetail = remoteProgramRunRecordFetcher.getRunRecordMeta(programRunId);
+      runRecordList = Collections.singletonList(runRecordDetail);
+    } else {
+      runRecordList = getRunRecords(programId);
+    }
+
+    SupportBundleRuntimeInfoTask supportBundleRuntimeInfoTask =
+        new SupportBundleRuntimeInfoTask(appFolderPath, namespaceId, applicationId, programType, programId,
+            remoteMetricsSystemClient, runRecordList);
+    SupportBundlePipelineRunLogTask supportBundlePipelineRunLogTask =
+        new SupportBundlePipelineRunLogTask(appFolderPath, programId, remoteLogsFetcher, runRecordList);
+
+    String runtimeInfoClassName = supportBundleRuntimeInfoTask.getClass().getName();
+    String runtimeInfoTaskName =
+        uuid.concat(": ").concat(runtimeInfoClassName).concat(": ").concat(appDetail.getName());
+    supportBundleJob.executeTask(supportBundleRuntimeInfoTask, basePath.getPath(), runtimeInfoTaskName,
+        runtimeInfoTaskName);
+
+    String runtimeLogClassName = supportBundlePipelineRunLogTask.getClass().getName();
+    String runtimeLogTaskName =
+        uuid.concat(": ").concat(runtimeLogClassName).concat(": ").concat(appDetail.getName());
+    supportBundleJob.executeTask(supportBundlePipelineRunLogTask, basePath.getPath(), runtimeLogTaskName,
+        runtimeLogClassName);
+
   }
 
   private Iterable<RunRecord> getRunRecords(ProgramId programId) throws NotFoundException, IOException {


### PR DESCRIPTION


- Added scan() method to ApplicationDetailFetcher.
- Instead of copying entire list of ApplicationDetails, using the scan() functionality in SupportBundlePipelineInfoTask