### PR TITLE
Added method to execute ad-hoc jobs using the SQL Engine Adapter.

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineCollection.java
@@ -49,7 +49,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Supplier;
@@ -249,8 +248,7 @@ public class SQLEngineCollection<T> implements SQLBackedCollection<T> {
           return null;
         };
         // We submit these in parallel to prevent blocking for each store task to complete in sequence.
-        Future<String> future = CompletableFuture.supplyAsync(task);
-        directStoreFutures.add(future);
+        directStoreFutures.add(adapter.submitTask(task));
       }
     }
 


### PR DESCRIPTION
This is used when attempting direct copy with the MultiSink Jobs,
meaning sink groups.