### PR TITLE
CDAP-18945 add more logging to help debug flaky tests

### DIFF
--- a/cdap-common/src/test/resources/logback-test.xml
+++ b/cdap-common/src/test/resources/logback-test.xml
@@ -34,6 +34,7 @@
 
     <!-- log levels for CDAP classes -->
     <logger name="io.cdap.cdap" level="DEBUG" />
+    <logger name="io.cdap.cdap.internal.app.services.ProgramNotificationSubscriberService" level="TRACE" />
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
Setting the log level to trace for processing program
status messages. This is to help with debugging flaky tests.