### PR TITLE
[CDAP-18526] Skip checking for configs for bootstrapped namespaces

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -800,7 +800,7 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
    */
   @VisibleForTesting
   Map<String, String> getNamespaceConfigs(String namespace) throws Exception {
-    if (namespaceQueryAdmin == null) {
+    if (namespaceQueryAdmin == null || NamespaceId.isReserved(namespace)) {
       return new HashMap<>();
     }
     return namespaceQueryAdmin.get(new NamespaceId(namespace)).getConfig().getConfigs();


### PR DESCRIPTION
Fix bug where checking for user-configured configs during program run on bootstrapped namespaces is throwing a `NamespaceNotFoundException`