### PR TITLE
[CDAP-18967] Add cdap-authenticator-ext-gcp module dependency

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -355,6 +355,12 @@
         </dependency>
         <dependency>
           <groupId>io.cdap.cdap</groupId>
+          <artifactId>cdap-authenticator-ext-gcp</artifactId>
+          <version>${project.version}</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>io.cdap.cdap</groupId>
           <artifactId>cdap-data-pipeline2_2.11</artifactId>
           <version>${project.version}</version>
           <scope>provided</scope>


### PR DESCRIPTION
Adding the `cdap-authenticator-ext-gcp` module to the `cdap-master` module as a provided dependency guarantees it's built prior to `cdap-master` so that extension copying will happen correctly.