### PR TITLE
Mark StoreRequestWriter fields as volatile as they represent shared mutated state

### DIFF
--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/service/StoreRequestWriter.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/service/StoreRequestWriter.java
@@ -46,9 +46,9 @@ abstract class StoreRequestWriter<T> implements Closeable {
   static final int SEQUENCE_ID_LIMIT = 0x10000;
 
   private final TimeProvider timeProvider;
-  private long writeTimestamp;
-  private long lastWriteTimestamp;
-  private int seqId;
+  private volatile long writeTimestamp;
+  private volatile long lastWriteTimestamp;
+  private volatile int seqId;
 
   private final PayloadTransformIterator payloadTransformIterator;
 


### PR DESCRIPTION
This should prevent TMS message loss and reduce test flackiness