### PR TITLE
[CDAP-18937] Fixing wrong last-consumed-message persisted in AbstractMessagingSubscriberService

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewTMSLogSubscriber.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewTMSLogSubscriber.java
@@ -102,8 +102,10 @@ public class PreviewTMSLogSubscriber extends AbstractMessagingSubscriberService<
   }
 
   @Override
-  protected void processMessages(StructuredTableContext structuredTableContext,
-                                 Iterator<ImmutablePair<String, Iterator<byte[]>>> messages) throws Exception {
+  protected ImmutablePair<String, Iterator<byte[]>> processMessages(
+    StructuredTableContext structuredTableContext, Iterator<ImmutablePair<String, Iterator<byte[]>>> messages)
+    throws Exception {
+    ImmutablePair<String, Iterator<byte[]>> lastConsumed = null;
     while (messages.hasNext()) {
       ImmutablePair<String, Iterator<byte[]>> next = messages.next();
       String messageId = next.getFirst();
@@ -116,6 +118,7 @@ public class PreviewTMSLogSubscriber extends AbstractMessagingSubscriberService<
           if (errorCount >= maxRetriesOnError) {
             LOG.warn("Skipping preview message {} after processing it has caused {} consecutive errors: {}",
                      message, errorCount, e.getMessage());
+            lastConsumed = next;
             continue;
           }
         } else {
@@ -124,7 +127,9 @@ public class PreviewTMSLogSubscriber extends AbstractMessagingSubscriberService<
         }
         throw e;
       }
+      lastConsumed = next;
     }
+    return lastConsumed;
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeProgramStatusSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeProgramStatusSubscriberService.java
@@ -82,16 +82,20 @@ public class RuntimeProgramStatusSubscriberService extends AbstractNotificationS
   }
 
   @Override
-  protected void processMessages(StructuredTableContext context,
-                                 Iterator<ImmutablePair<String, Notification>> messages) throws Exception {
+  protected ImmutablePair<String, Notification> processMessages(
+    StructuredTableContext context, Iterator<ImmutablePair<String, Notification>> messages) throws Exception {
+    ImmutablePair<String, Notification> lastConsumed = null;
     while (messages.hasNext()) {
       ImmutablePair<String, Notification> pair = messages.next();
       Notification notification = pair.getSecond();
       if (notification.getNotificationType() != Notification.Type.PROGRAM_STATUS) {
+        lastConsumed = pair;
         continue;
       }
       processNotification(pair.getFirst().getBytes(StandardCharsets.UTF_8), notification, getAppMetadataStore(context));
+      lastConsumed = pair;
     }
+    return lastConsumed;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramStopSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramStopSubscriberService.java
@@ -83,16 +83,20 @@ public class ProgramStopSubscriberService extends AbstractNotificationSubscriber
   }
 
   @Override
-  protected void processMessages(StructuredTableContext context,
-                                 Iterator<ImmutablePair<String, Notification>> messages) throws Exception {
+  protected ImmutablePair<String, Notification> processMessages(
+    StructuredTableContext context, Iterator<ImmutablePair<String, Notification>> messages) throws Exception {
+    ImmutablePair<String, Notification> lastConsumed = null;
     while (messages.hasNext()) {
       ImmutablePair<String, Notification> pair = messages.next();
       Notification notification = pair.getSecond();
       if (notification.getNotificationType() != Notification.Type.PROGRAM_STATUS) {
+        lastConsumed = pair;
         continue;
       }
       processNotification(notification, context);
+      lastConsumed = pair;
     }
+    return lastConsumed;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/ScheduleNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/ScheduleNotificationSubscriberService.java
@@ -138,14 +138,19 @@ public class ScheduleNotificationSubscriberService extends AbstractIdleService {
     }
 
     @Override
-    protected void processMessages(StructuredTableContext structuredTableContext,
-                                   Iterator<ImmutablePair<String, Notification>> messages) throws IOException {
+    protected ImmutablePair<String, Notification> processMessages(
+      StructuredTableContext structuredTableContext, Iterator<ImmutablePair<String, Notification>> messages)
+      throws IOException {
       ProgramScheduleStoreDataset scheduleStore = getScheduleStore(structuredTableContext);
       JobQueueTable jobQueue = getJobQueue(structuredTableContext);
-
+      ImmutablePair<String, Notification> next = null;
+      ImmutablePair<String, Notification> lastConsumed = null;
       while (messages.hasNext()) {
-        processNotification(scheduleStore, jobQueue, messages.next().getSecond());
+        next = messages.next();
+        processNotification(scheduleStore, jobQueue, next.getSecond());
+        lastConsumed = next;
       }
+      return lastConsumed;
     }
 
     @Override


### PR DESCRIPTION
Bug:
MessageTrackingIterator::computeNext is called by either iter.hasNext()
or iter.next(), thus we can NOT tell if an entry is consumed in computeNext.

Fix:
Make abstract processMessages() to return last consumed message
instead of inferring from MessageTrackingIterator passed to it.

Before:
String processMessages(Iterator<ImmutablePair<String, T>> messages) {
  // Create trackingIterator
  processMessages(context, trackingIterator); // trackingIterator records last consumed message <<<< bug
  // persist the last message id recorded in trackingIterator
}

After:
String processMessages(Iterator<ImmutablePair<String, T>> messages) {
  // Create trackingIterator
  lastConsumedMessage = processMessages(context, trackingIterator);  // processMessages returns the last consumed message explicitly
  // persist the last message id recorded in trackingIterator
}