### PR TITLE
Artifact cache fixes

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/discovery/URIScheme.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/discovery/URIScheme.java
@@ -113,4 +113,11 @@ public enum URIScheme {
   public String getScheme() {
     return scheme;
   }
+
+  /**
+   * Returns the default port.
+   */
+  public int getDefaultPort() {
+    return defaultPort;
+  }
 }


### PR DESCRIPTION
- Use system namespace when the artifact scope is SYSTEM
- Fix base path used by the remote client
- Fix scheme, port set in NoOpDiscoveryServiceClient