### PR TITLE
Support using tethered peer namespace for artifact caching

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -153,4 +153,10 @@ public final class ProgramOptionConstants {
    * Option for name of tethered peer, if any, that has initiated the program run
    */
   public static final String PEER_NAME = "peer";
+
+  /**
+   * Option for name of tethered peer namespace, if any, that has initiated the program run. This is needed for
+   * artifact fetching
+   */
+  public static final String PEER_NAMESPACE = "peerNamespace";
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
@@ -331,10 +331,11 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
                                                      ApplicationSpecification.class);
     ProgramOptions programOpts = GSON.fromJson(files.get(DistributedProgramRunner.PROGRAM_OPTIONS_FILE_NAME),
                                                ProgramOptions.class);
-    ProgramId programId = new ProgramId(message.getNamespace(), programOpts.getProgramId().getApplication(),
+    ProgramId programId = new ProgramId(message.getRuntimeNamespace(), programOpts.getProgramId().getApplication(),
                                         programOpts.getProgramId().getType(), programOpts.getProgramId().getProgram());
     Map<String, String> systemArgs = new HashMap<>(programOpts.getArguments().asMap());
     systemArgs.put(ProgramOptionConstants.PEER_NAME, peerName);
+    systemArgs.put(ProgramOptionConstants.PEER_NAMESPACE, message.getPeerNamespace());
     ProgramOptions updatedOpts = new SimpleProgramOptions(programId, new BasicArguments(systemArgs),
                                                           programOpts.getUserArguments());
     ProgramRunId programRunId = programId.run(programOpts.getArguments().getOption(ProgramOptionConstants.RUN_ID));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/proto/v1/TetheringLaunchMessage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/proto/v1/TetheringLaunchMessage.java
@@ -33,13 +33,16 @@ public class TetheringLaunchMessage {
   // Select cConf entries
   private final Map<String, String> cConfEntries;
   // Namespace to run program on
-  private final String namespace;
+  private final String runtimeNamespace;
+  // Namespace of the peer that initiated the program run
+  private final String peerNamespace;
 
   private TetheringLaunchMessage(Map<String, byte[]> localizeFiles, Map<String, String> cConfEntries,
-                                 String namespace) {
+                                 String runtimeNamespace, String peerNamespace) {
     this.localizeFiles = localizeFiles;
     this.cConfEntries = cConfEntries;
-    this.namespace = namespace;
+    this.runtimeNamespace = runtimeNamespace;
+    this.peerNamespace = peerNamespace;
   }
 
   public Map<String, byte[]> getFiles() {
@@ -50,8 +53,12 @@ public class TetheringLaunchMessage {
     return cConfEntries;
   }
 
-  public String getNamespace() {
-    return namespace;
+  public String getRuntimeNamespace() {
+    return runtimeNamespace;
+  }
+
+  public String getPeerNamespace() {
+    return peerNamespace;
   }
 
   @Override
@@ -59,7 +66,8 @@ public class TetheringLaunchMessage {
     return "TetheringLaunchMessage{" +
       "localizeFiles='" + localizeFiles + '\'' +
       ", cConfEntries=" + cConfEntries +
-      ", namespace=" + namespace +
+      ", runtimeNamespace=" + runtimeNamespace +
+      ", peerNamespace=" + peerNamespace +
       '}';
   }
 
@@ -75,7 +83,8 @@ public class TetheringLaunchMessage {
     TetheringLaunchMessage that = (TetheringLaunchMessage) o;
     return Objects.equals(localizeFiles, that.localizeFiles) &&
       Objects.equals(cConfEntries, that.cConfEntries) &&
-      Objects.equals(namespace, that.namespace);
+      Objects.equals(runtimeNamespace, that.runtimeNamespace) &&
+      Objects.equals(peerNamespace, that.peerNamespace);
   }
 
   @Override
@@ -90,7 +99,8 @@ public class TetheringLaunchMessage {
     private final Set<String> fileNames = new HashSet<>();
     private final Map<String, byte[]> localizeFiles = new HashMap<>();
     private final Map<String, String> cConfEntries = new HashMap<>();
-    private String namespace;
+    private String runtimeNamespace;
+    private String peerNamespace;
 
     public Builder addFileNames(String fileName) {
       this.fileNames.add(fileName);
@@ -105,8 +115,12 @@ public class TetheringLaunchMessage {
       this.cConfEntries.putAll(entries);
     }
 
-    public void addNamespace(String namespace) {
-      this.namespace = namespace;
+    public void addRuntimeNamespace(String runtimeNamespace) {
+      this.runtimeNamespace = runtimeNamespace;
+    }
+
+    public void addPeerNamespace(String peerNamespace) {
+      this.peerNamespace = peerNamespace;
     }
 
     public Set<String> getFileNames() {
@@ -114,7 +128,7 @@ public class TetheringLaunchMessage {
     }
 
     public TetheringLaunchMessage build() {
-      return new TetheringLaunchMessage(localizeFiles, cConfEntries, namespace);
+      return new TetheringLaunchMessage(localizeFiles, cConfEntries, runtimeNamespace, peerNamespace);
     }
   }
 }


### PR DESCRIPTION
- Fix typo in `TetheringRuntimeJobManager` in order to send the namespace that program will run on (on the receiving instance)
- Include initiating instance's namespace in the launch message built in `TetheringRuntimeJobManager` and store as a program option in `TetheringAgentService`. Use the initiating instance's namespace during plugin artifact fetching