### PR TITLE
[Cherry-pick][CDAP-18988] Make metric processing fair under load

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -778,6 +778,7 @@ public final class Constants {
     public static final String SERVICE_DESCRIPTION = "Service to handle metrics requests.";
     public static final String PROCESSOR_MAX_DELAY_MS = "metrics.processor.max.delay.ms";
     public static final String QUEUE_SIZE = "metrics.processor.queue.size";
+    public static final String OFFER_TIMEOUT_MS = "metrics.processor.offer.timeout.ms";
 
     public static final String ENTITY_TABLE_NAME = "metrics.data.entity.tableName";
     public static final String METRICS_TABLE_PREFIX = "metrics.data.table.prefix";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2830,6 +2830,14 @@
   </property>
 
   <property>
+    <name>metrics.processor.offer.timeout.ms</name>
+    <value>10000</value>
+    <description>
+      How long to wait for queue to be able to accept newly-fetched metrics before giving up
+    </description>
+  </property>
+
+  <property>
     <name>metrics.processor.max.delay.ms</name>
     <value>3000</value>
     <description>


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/14127

As soon as number of metrics to be written reaches queue size and a topic can’t write even one message into it, it waits for 60 seconds even if it’s severely lagging behind. This PR makes metric processing do unnecessary pauses and unfair processing between the topics.

It allows each queue to wait up to 10 seconds (configurable with metrics.processor.offer.timeout.ms) to put first message into queue and ensures it does not go into sleep circle even if it could not do it. So, while topic processing is lagging it will be actively trying to put messages into queue without delays