### PR TITLE
Add a log statement to let the user know the timeout value for the program stop request

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -774,6 +774,7 @@ public class ProgramLifecycleService {
                                                     workflowRunId));
       }
       // send a message to stop the program run
+      LOG.info("Issuing a program stop request with a timeout value of {} secs", gracefulShutdownSecs);
       programStateWriter.stop(activeRunId, gracefulShutdownSecs);
     }
 


### PR DESCRIPTION
Context:
The stop button in the UI will now have a default timeout value of 6 hours. When a user triggers a stop this way, they need a way to know this information. 
Additionally we default the timeout to max int for a fully graceful stop and to 3 minutes if we make a non-graceful stop. Adding a log statement indicating this timeout value in seconds in the ProgramLifecycleService just before we send the stop message to the TMS so that it takes care of logging the timeout value for both stop programs and stop specific run of a program APIs.

Jira: https://cdap.atlassian.net/browse/CDAP-18991