### PR TITLE
[Cherry-pick][CDAP-18993] Improve metrics cleanup speed by doing removal per-row instead of per-column

### DIFF
--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/MetricsTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/MetricsTable.java
@@ -84,6 +84,19 @@ public interface MetricsTable extends Dataset {
   void delete(byte[] row, byte[][] columns);
 
   /**
+   * Deletes specified columns of the specified row.
+   *
+   * @param row row to delete from
+   * @param columns names of columns to delete
+   * @param fullRow if the whole row is deleted. Note that this parameter is just an optimization and list
+   *                of columns must still be passed in case when this optimization is not implemented
+   * @see #delete(byte[], byte[][]) 
+   */
+  default void delete(byte[] row, byte[][] columns, boolean fullRow) {
+    delete(row, columns);
+  }
+
+  /**
    * Get a scanner for a table.
    * @param start the row key of the first row to scan. If null, the scan begins at the first row of the table.
    * @param stop the row key of the last row to scan. If null, the scan goes to the last row of the table.

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBMetricsTable.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.data2.dataset2.lib.table.MetricsTable;
 import io.cdap.cdap.data2.dataset2.lib.table.inmemory.PrefixedNamespaces;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.SortedMap;
@@ -112,6 +113,19 @@ public class LevelDBMetricsTable implements MetricsTable {
       return core.increment(row, ImmutableMap.of(column, delta)).get(column);
     } catch (IOException e) {
       throw new DataSetException("IncrementAndGet failed on table " + tableName, e);
+    }
+  }
+
+  @Override
+  public void delete(byte[] row, byte[][] columns, boolean fullRow) {
+    if (fullRow) {
+      try {
+        core.deleteRows(Collections.singleton(row));
+      } catch (IOException e) {
+        throw new DataSetException("Delete failed on table " + tableName, e);
+      }
+    } else {
+      delete(row, columns);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/timeseries/FactTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/timeseries/FactTable.java
@@ -251,14 +251,17 @@ public final class FactTable implements Closeable {
         List<byte[]> columns = Lists.newArrayList();
 
         boolean exhausted = false;
+        boolean fullRow = true;
         for (byte[] column : row.getColumns().keySet()) {
           long ts = codec.getTimestamp(row.getRow(), column);
           if (ts < scan.getStartTs()) {
+            fullRow = false;
             continue;
           }
 
           if (ts > scan.getEndTs()) {
             exhausted = true;
+            fullRow = false;
             break;
           }
 
@@ -266,7 +269,7 @@ public final class FactTable implements Closeable {
         }
 
         // todo: do deletes efficiently, in batches, not one-by-one
-        timeSeriesTable.delete(row.getRow(), columns.toArray(new byte[columns.size()][]));
+        timeSeriesTable.delete(row.getRow(), columns.toArray(new byte[columns.size()][]), fullRow);
 
         if (exhausted) {
           break;

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/table/MetricsTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/table/MetricsTableTest.java
@@ -236,7 +236,20 @@ public abstract class MetricsTableTest {
 
   @Test
   public void testDelete() throws Exception {
-    MetricsTable table = getTable("testDelete");
+    testDelete(null);
+  }
+
+  @Test
+  public void testDeleteFullRow() throws Exception {
+    testDelete(true);
+  }
+
+  @Test
+  public void testDeleteNonFullRow() throws Exception {
+    testDelete(false);
+  }
+  public void testDelete(Boolean fullRow) throws Exception {
+    MetricsTable table = getTable("testDelete" + fullRow);
     NavigableMap<byte[], SortedMap<byte[], Long>> writes = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
     for (int i = 0; i < 1024; i++) {
       writes.put(Bytes.toBytes(i << 22), mapOf(A, Bytes.toLong(X)));
@@ -251,7 +264,11 @@ public abstract class MetricsTableTest {
     // verify these three are there, and delete them
     for (byte[] row : toDelete) {
       Assert.assertArrayEquals(X, table.get(row, A));
-      table.delete(row, new byte[][] {A});
+      if (fullRow == null) {
+        table.delete(row, new byte[][]{A});
+      } else {
+        table.delete(row, new byte[][]{A}, fullRow);
+      }
     }
     // verify these three are now gone.
     for (byte[] row : toDelete) {


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/14131
Since we have up to 3600 columns per row, this should give a good performance boost