### PR TITLE
[CDAP-18985] Remove artifact localizer sidecar container from system worker

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/RemoteTaskExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/RemoteTaskExecutor.java
@@ -64,19 +64,19 @@ public class RemoteTaskExecutor {
   private static final Gson GSON = new Gson();
   private static final String TASK_WORKER_URL = "/worker/run";
   private static final String SYSTEM_WORKER_URL = "/system/run";
-
-  private String workerUrl;
   private static final Logger LOG = LoggerFactory.getLogger(RemoteTaskExecutor.class);
-
   private final boolean compression;
   private final RemoteClient remoteClient;
   private final RetryStrategy retryStrategy;
   private final MetricsCollectionService metricsCollectionService;
+  private String workerUrl;
 
   public RemoteTaskExecutor(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
                             RemoteClientFactory remoteClientFactory, Type workerType) {
     this.compression = cConf.getBoolean(Constants.TaskWorker.COMPRESSION_ENABLED);
-    this.remoteClient = remoteClientFactory.createRemoteClient(Constants.Service.TASK_WORKER,
+    String serviceName = workerType == Type.TASK_WORKER ?
+      Constants.Service.TASK_WORKER : Constants.Service.SYSTEM_WORKER;
+    this.remoteClient = remoteClientFactory.createRemoteClient(serviceName,
                                                                new DefaultHttpRequestConfig(false),
                                                                Constants.Gateway.INTERNAL_API_VERSION_3);
     this.retryStrategy = RetryStrategies.fromConfiguration(cConf, Constants.Service.TASK_WORKER + ".");

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceLauncher.java
@@ -23,8 +23,6 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.Constants.Twill.Security;
 import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.utils.DirUtils;
-import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerTwillRunnable;
-import io.cdap.cdap.master.spi.twill.DependentTwillPreparer;
 import io.cdap.cdap.master.spi.twill.SecretDisk;
 import io.cdap.cdap.master.spi.twill.SecureTwillPreparer;
 import io.cdap.cdap.master.spi.twill.SecurityContext;
@@ -43,6 +41,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -59,7 +58,7 @@ public class SystemWorkerServiceLauncher extends AbstractScheduledService {
 
   @Inject
   public SystemWorkerServiceLauncher(CConfiguration cConf, Configuration hConf, SConfiguration sConf,
-      TwillRunner twillRunner) {
+                                     TwillRunner twillRunner) {
     this.cConf = cConf;
     this.hConf = hConf;
     this.sConf = sConf;
@@ -95,7 +94,14 @@ public class SystemWorkerServiceLauncher extends AbstractScheduledService {
   @Override
   protected Scheduler scheduler() {
     return Scheduler.newFixedRateSchedule(0,
-        cConf.getInt(Constants.TaskWorker.POOL_CHECK_INTERVAL), TimeUnit.SECONDS);
+                                          cConf.getInt(Constants.TaskWorker.POOL_CHECK_INTERVAL), TimeUnit.SECONDS);
+  }
+
+  @Override
+  protected final ScheduledExecutorService executor() {
+    executor = Executors.newSingleThreadScheduledExecutor(
+      Threads.createDaemonThreadFactory("system-worker-service-launcher-scheduler"));
+    return executor;
   }
 
   public void run() {
@@ -112,7 +118,7 @@ public class SystemWorkerServiceLauncher extends AbstractScheduledService {
     if (activeController == null) {
       try {
         Path tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
-            cConf.get(Constants.AppFabric.TEMP_DIR)).toPath();
+                               cConf.get(Constants.AppFabric.TEMP_DIR)).toPath();
         Files.createDirectories(tmpDir);
 
         Path runDir = Files.createTempDirectory(tmpDir, "system.worker.launcher");
@@ -132,47 +138,31 @@ public class SystemWorkerServiceLauncher extends AbstractScheduledService {
           }
 
           ResourceSpecification systemResourceSpec = ResourceSpecification.Builder.with()
-              .setVirtualCores(cConf.getInt(Constants.SystemWorker.CONTAINER_CORES))
-              .setMemory(cConf.getInt(Constants.SystemWorker.CONTAINER_MEMORY_MB), ResourceSpecification.SizeUnit.MEGA)
-              .setInstances(cConf.getInt(Constants.SystemWorker.CONTAINER_COUNT))
-              .build();
-
-          ResourceSpecification artifactLocalizerResourceSpec = ResourceSpecification.Builder.with()
-              .setVirtualCores(cConf.getInt(Constants.ArtifactLocalizer.CONTAINER_CORES))
-              .setMemory(cConf.getInt(Constants.ArtifactLocalizer.CONTAINER_MEMORY_MB),
-                  ResourceSpecification.SizeUnit.MEGA)
-              .setInstances(cConf.getInt(Constants.SystemWorker.CONTAINER_COUNT))
-              .build();
+            .setVirtualCores(cConf.getInt(Constants.SystemWorker.CONTAINER_CORES))
+            .setMemory(cConf.getInt(Constants.SystemWorker.CONTAINER_MEMORY_MB), ResourceSpecification.SizeUnit.MEGA)
+            .setInstances(cConf.getInt(Constants.SystemWorker.CONTAINER_COUNT))
+            .build();
 
           LOG.info("Starting SystemWorker pool with {} instances", systemResourceSpec.getInstances());
 
           TwillPreparer twillPreparer = twillRunner.prepare(
             new SystemWorkerTwillApplication(cConfPath.toUri(), hConfPath.toUri(), sConfPath.toUri(),
-                                             systemResourceSpec, artifactLocalizerResourceSpec));
+                                             systemResourceSpec));
 
           String priorityClass = cConf.get(Constants.TaskWorker.CONTAINER_PRIORITY_CLASS_NAME);
           if (priorityClass != null) {
             twillPreparer = twillPreparer.setSchedulerQueue(priorityClass);
           }
 
-          if (twillPreparer instanceof DependentTwillPreparer) {
-            twillPreparer = ((DependentTwillPreparer) twillPreparer)
-                .dependentRunnableNames(SystemWorkerTwillRunnable.class.getSimpleName(),
-                    ArtifactLocalizerTwillRunnable.class.getSimpleName());
-          }
-
           if (twillPreparer instanceof SecureTwillPreparer) {
             SecurityContext securityContext = createSecurityContext();
             twillPreparer = ((SecureTwillPreparer) twillPreparer)
-                .withSecurityContext(SystemWorkerTwillRunnable.class.getSimpleName(), securityContext);
+              .withSecurityContext(SystemWorkerTwillRunnable.class.getSimpleName(), securityContext);
             String secretName = cConf.get(Security.MASTER_SECRET_DISK_NAME);
             String secretPath = cConf.get(Security.MASTER_SECRET_DISK_PATH);
             twillPreparer = ((SecureTwillPreparer) twillPreparer)
-                .withSecretDisk(ArtifactLocalizerTwillRunnable.class.getSimpleName(),
-                    new SecretDisk(secretName, secretPath));
-            twillPreparer = ((SecureTwillPreparer) twillPreparer)
-                .withSecretDisk(SystemWorkerTwillRunnable.class.getSimpleName(), new SecretDisk(secretName,
-                    secretPath));
+              .withSecretDisk(SystemWorkerTwillRunnable.class.getSimpleName(), new SecretDisk(secretName,
+                                                                                              secretPath));
           }
 
           activeController = twillPreparer.start(5, TimeUnit.MINUTES);
@@ -184,7 +174,7 @@ public class SystemWorkerServiceLauncher extends AbstractScheduledService {
         }
       } catch (Exception e) {
         LOG.warn(String.format("Failed to launch SystemWorker pool, retry in %d",
-            cConf.getInt(Constants.TaskWorker.POOL_CHECK_INTERVAL)), e);
+                               cConf.getInt(Constants.TaskWorker.POOL_CHECK_INTERVAL)), e);
       }
     }
     this.twillController = activeController;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerTwillApplication.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.internal.app.worker.system;
 
-import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerTwillRunnable;
 import org.apache.twill.api.ResourceSpecification;
 import org.apache.twill.api.TwillApplication;
 import org.apache.twill.api.TwillSpecification;
@@ -31,36 +30,27 @@ public class SystemWorkerTwillApplication implements TwillApplication {
   private final URI hConfFileURI;
   private final URI sConfFileURI;
   private final ResourceSpecification systemWorkerResourceSpec;
-  private final ResourceSpecification artifactLocalizerResourceSpec;
 
   public SystemWorkerTwillApplication(URI cConfFileURI, URI hConfFileURI, URI sConfFileURI,
-      ResourceSpecification systemWorkerResourceSpec,
-      ResourceSpecification artifactLocalizerResourceSpec) {
+                                      ResourceSpecification systemWorkerResourceSpec) {
     this.cConfFileURI = cConfFileURI;
     this.hConfFileURI = hConfFileURI;
     this.sConfFileURI = sConfFileURI;
     this.systemWorkerResourceSpec = systemWorkerResourceSpec;
-    this.artifactLocalizerResourceSpec = artifactLocalizerResourceSpec;
   }
 
   @Override
   public TwillSpecification configure() {
     return TwillSpecification.Builder.with()
-        .setName(NAME)
-        .withRunnable()
-        .add(new SystemWorkerTwillRunnable("cConf.xml", "hConf.xml", "sConf.xml"), systemWorkerResourceSpec)
-        .withLocalFiles()
-        .add("cConf.xml", cConfFileURI)
-        .add("hConf.xml", hConfFileURI)
-        .add("sConf.xml", sConfFileURI)
-        .apply()
-        .add(new ArtifactLocalizerTwillRunnable("cConf.xml", "hConf.xml"),
-            artifactLocalizerResourceSpec)
-        .withLocalFiles()
-        .add("cConf.xml", cConfFileURI)
-        .add("hConf.xml", hConfFileURI)
-        .apply()
-        .anyOrder()
-        .build();
+      .setName(NAME)
+      .withRunnable()
+      .add(new SystemWorkerTwillRunnable("cConf.xml", "hConf.xml", "sConf.xml"), systemWorkerResourceSpec)
+      .withLocalFiles()
+      .add("cConf.xml", cConfFileURI)
+      .add("hConf.xml", hConfFileURI)
+      .add("sConf.xml", sConfFileURI)
+      .apply()
+      .anyOrder()
+      .build();
   }
 }


### PR DESCRIPTION
This PR removes artifact localizer sidecar container from system worker pods as it's not needed. 

It also fixes a bug in RemoteTaskExecutor in which runTask only sends tasks to worker pods instead of sending tasks correctly to either task worker pod or system worker pod depending on the worker type. 

It also fixes executor in SystemWorkerServiceLauncher.java