### PR TITLE
[cherry-pick] Make terminate time grace period configurable

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorServiceTest.java
@@ -98,7 +98,7 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
       }
     };
     ProgramRunStatusMonitorService programRunStatusMonitorService
-      = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3);
+      = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3, 2);
     Assert.assertEquals(1, latch.getCount());
     programRunStatusMonitorService.terminatePrograms();
     Assert.assertEquals(0, latch.getCount());
@@ -132,7 +132,7 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
       }
     };
     ProgramRunStatusMonitorService programRunStatusMonitorService
-      = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3);
+      = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3, 2);
     Assert.assertEquals(1, latch.getCount());
     programRunStatusMonitorService.terminatePrograms();
     Assert.assertEquals(1, latch.getCount());
@@ -163,7 +163,7 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
       }
     };
     ProgramRunStatusMonitorService programRunStatusMonitorService
-      = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3);
+      = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3, 2);
     Assert.assertEquals(1, latch.getCount());
     programRunStatusMonitorService.terminatePrograms();
     Assert.assertEquals(1, latch.getCount());
@@ -195,7 +195,7 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
       }
     };
     ProgramRunStatusMonitorService programRunStatusMonitorService
-      = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3);
+      = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3, 2);
     Assert.assertEquals(1, latch.getCount());
     programRunStatusMonitorService.terminatePrograms();
     Assert.assertEquals(1, latch.getCount());

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -234,6 +234,7 @@ public final class Constants {
     public static final String LOCAL_DATASET_DELETER_INITIAL_DELAY_SECONDS
       = "app.program.local.dataset.deleter.initial.delay";
     public static final String PROGRAM_TERMINATOR_INTERVAL_SECS = "app.program.terminator.interval.secs";
+    public static final String PROGRAM_TERMINATE_TIME_BUFFER_SECS = "app.program.terminate.time.buffer.secs";
     public static final String PROGRAM_TERMINATOR_TX_BATCH_SIZE = "app.program.terminator.tx.batch.size";
     public static final String SYSTEM_ARTIFACTS_DIR = "app.artifact.dir";
     public static final String SYSTEM_ARTIFACTS_MAX_PARALLELISM = "app.artifact.parallelism.max";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -588,6 +588,15 @@
   </property>
 
   <property>
+    <name>app.program.terminate.time.buffer.secs</name>
+    <value>60</value>
+    <description>
+      Interval in seconds of how much buffer time is given to programs to allow them
+      to stop on their own before issuing a hard kill
+    </description>
+  </property>
+
+  <property>
     <name>app.program.terminator.tx.batch.size</name>
     <value>1000</value>
     <description>


### PR DESCRIPTION
ProgramRunStatusMonitorService is a periodic service that scans for programs in stopping status and issues a hard kill if such programs are running beyond their specified timeout. However, programs are given a grace period of 1 minute before issuing the kill. This PR makes that grace period configurable.

Jira: https://cdap.atlassian.net/browse/CDAP-18979