### PR TITLE
Use HDFS when storing resources for tethered runs

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -159,4 +159,10 @@ public final class ProgramOptionConstants {
    * artifact fetching
    */
   public static final String PEER_NAMESPACE = "peerNamespace";
+
+  /**
+   * Option for a URI to a directory containing additional resources needed for the program run. This is needed for
+   * running tethered programs
+   */
+  public static final String PROGRAM_RESOURCE_URI = "programResourceUri";
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedMapReduceProgramRunner.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.mapred.YarnClientProtocolProvider;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -54,7 +55,7 @@ public final class DistributedMapReduceProgramRunner extends DistributedProgramR
                                     Impersonator impersonator, ClusterMode clusterMode,
                                     @Constants.AppFabric.ProgramRunner TwillRunner twillRunner,
                                     Injector injector) {
-    super(cConf, hConf, impersonator, clusterMode, twillRunner);
+    super(cConf, hConf, impersonator, clusterMode, twillRunner, injector.getInstance(LocationFactory.class));
     if (!cConf.getBoolean(Constants.AppFabric.PROGRAM_REMOTE_RUNNER, false)) {
       this.namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedServiceProgramRunner.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.File;
 
@@ -48,7 +49,7 @@ public class DistributedServiceProgramRunner extends DistributedProgramRunner
   DistributedServiceProgramRunner(CConfiguration cConf, YarnConfiguration hConf,
                                   Impersonator impersonator, ClusterMode clusterMode,
                                   @Constants.AppFabric.ProgramRunner TwillRunner twillRunner, Injector injector) {
-    super(cConf, hConf, impersonator, clusterMode, twillRunner);
+    super(cConf, hConf, impersonator, clusterMode, twillRunner, injector.getInstance(LocationFactory.class));
     if (!cConf.getBoolean(Constants.AppFabric.PROGRAM_REMOTE_RUNNER, false)) {
       this.namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkerProgramRunner.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.filesystem.LocationFactory;
 
 import java.io.File;
 
@@ -49,7 +50,7 @@ public class DistributedWorkerProgramRunner extends DistributedProgramRunner
                                  Impersonator impersonator, ClusterMode clusterMode,
                                  @Constants.AppFabric.ProgramRunner TwillRunner twillRunner,
                                  Injector injector) {
-    super(cConf, hConf, impersonator, clusterMode, twillRunner);
+    super(cConf, hConf, impersonator, clusterMode, twillRunner, injector.getInstance(LocationFactory.class));
     if (!cConf.getBoolean(Constants.AppFabric.PROGRAM_REMOTE_RUNNER, false)) {
       this.namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunner.java
@@ -56,6 +56,7 @@ import org.apache.twill.api.ClassAcceptor;
 import org.apache.twill.api.ResourceSpecification;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,7 +86,7 @@ public final class DistributedWorkflowProgramRunner extends DistributedProgramRu
                                    @Constants.AppFabric.ProgramRunner TwillRunner twillRunner,
                                    @Constants.AppFabric.ProgramRunner ProgramRunnerFactory programRunnerFactory,
                                    Injector injector) {
-    super(cConf, hConf, impersonator, clusterMode, twillRunner);
+    super(cConf, hConf, impersonator, clusterMode, twillRunner, injector.getInstance(LocationFactory.class));
     this.programRunnerFactory = programRunnerFactory;
     if (!cConf.getBoolean(Constants.AppFabric.PROGRAM_REMOTE_RUNNER, false)) {
       this.namespaceQueryAdmin = injector.getInstance(NamespaceQueryAdmin.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.internal.tethering;
 
 import com.google.common.base.Preconditions;
-import com.google.common.io.Files;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
@@ -61,13 +60,14 @@ import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpResponse;
 import org.apache.commons.io.IOUtils;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.IOException;
-import java.io.Writer;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -109,6 +109,7 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
   private final MessageFetcher messageFetcher;
   private final ProgramRunRecordFetcher runRecordFetcher;
   private final RemoteAuthenticator remoteAuthenticator;
+  private final LocationFactory locationFactory;
   private final String programUpdateTopic;
   private final int programUpdateFetchSize;
   private String lastProgramUpdateMessageId;
@@ -119,7 +120,8 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
   TetheringAgentService(CConfiguration cConf, TransactionRunner transactionRunner, TetheringStore store,
                         ProgramStateWriter programStateWriter, MessagingService messagingService,
                         ProgramRunRecordFetcher programRunRecordFetcher,
-                        @Named(REMOTE_TETHERING_AUTHENTICATOR) RemoteAuthenticator remoteAuthenticator) {
+                        @Named(REMOTE_TETHERING_AUTHENTICATOR) RemoteAuthenticator remoteAuthenticator,
+                        LocationFactory locationFactory) {
     super(RetryStrategies.fromConfiguration(cConf, "tethering.agent."));
     this.connectionInterval = TimeUnit.SECONDS.toMillis(cConf.getLong(Constants.Tethering.CONNECTION_INTERVAL, 10L));
     this.cConf = cConf;
@@ -131,6 +133,7 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
     this.messageFetcher = new MultiThreadMessagingContext(messagingService).getMessageFetcher();
     this.runRecordFetcher = programRunRecordFetcher;
     this.remoteAuthenticator = remoteAuthenticator;
+    this.locationFactory = locationFactory;
     this.programUpdateTopic = cConf.get(Constants.AppFabric.PROGRAM_STATUS_RECORD_EVENT_TOPIC);
     this.programUpdateFetchSize = cConf.getInt(Constants.AppFabric.STATUS_EVENT_FETCH_SIZE);
   }
@@ -333,25 +336,25 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
                                                ProgramOptions.class);
     ProgramId programId = new ProgramId(message.getRuntimeNamespace(), programOpts.getProgramId().getApplication(),
                                         programOpts.getProgramId().getType(), programOpts.getProgramId().getProgram());
-    Map<String, String> systemArgs = new HashMap<>(programOpts.getArguments().asMap());
-    systemArgs.put(ProgramOptionConstants.PEER_NAME, peerName);
-    systemArgs.put(ProgramOptionConstants.PEER_NAMESPACE, message.getPeerNamespace());
-    ProgramOptions updatedOpts = new SimpleProgramOptions(programId, new BasicArguments(systemArgs),
-                                                          programOpts.getUserArguments());
     ProgramRunId programRunId = programId.run(programOpts.getArguments().getOption(ProgramOptionConstants.RUN_ID));
     ProgramDescriptor programDescriptor = new ProgramDescriptor(programId, appSpec);
 
-    File tmpDir = new File(cConf.get(Constants.CFG_LOCAL_DATA_DIR),
-                           cConf.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
-    File runDir = new File(tmpDir, programRunId.getRun());
-    runDir.mkdirs();
-    Files.write(files.get(DistributedProgramRunner.LOGBACK_FILE_NAME),
-                new File(runDir, DistributedProgramRunner.LOGBACK_FILE_NAME), StandardCharsets.UTF_8);
-    try (Writer writer = Files.newWriter(new File(runDir, DistributedProgramRunner.TETHER_CONF_FILE_NAME),
-                                         StandardCharsets.UTF_8)) {
-      cConfCopy.writeXml(writer);
+    Location programDir = locationFactory.create(String.format("%s/%s", cConf.get(Constants.Tethering.PROGRAM_DIR),
+                                                               programRunId.getRun()));
+    programDir.mkdirs();
+    try (OutputStream os = programDir.append(DistributedProgramRunner.LOGBACK_FILE_NAME).getOutputStream()) {
+      os.write(files.get(DistributedProgramRunner.LOGBACK_FILE_NAME).getBytes(StandardCharsets.UTF_8));
+    }
+    try (OutputStream os = programDir.append(DistributedProgramRunner.TETHER_CONF_FILE_NAME).getOutputStream()) {
+      cConfCopy.writeXml(os);
     }
 
+    Map<String, String> systemArgs = new HashMap<>(programOpts.getArguments().asMap());
+    systemArgs.put(ProgramOptionConstants.PEER_NAME, peerName);
+    systemArgs.put(ProgramOptionConstants.PEER_NAMESPACE, message.getPeerNamespace());
+    systemArgs.put(ProgramOptionConstants.PROGRAM_RESOURCE_URI, programDir.toURI().toString());
+    ProgramOptions updatedOpts = new SimpleProgramOptions(programId, new BasicArguments(systemArgs),
+                                                          programOpts.getUserArguments());
     programStateWriter.start(programRunId, updatedOpts, null, programDescriptor);
     LOG.debug("Published program start message for run {}", programRunId.getRun());
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringClientHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringClientHandlerTest.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.guice.LocalLocationModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
@@ -69,6 +70,7 @@ import io.cdap.http.NettyHttpService;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.tephra.TransactionManager;
 import org.apache.tephra.runtime.TransactionModules;
+import org.apache.twill.filesystem.LocationFactory;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -134,6 +136,7 @@ public class TetheringClientHandlerTest {
       new AuthorizationTestModule(),
       new AuthorizationEnforcementModule().getInMemoryModules(),
       new AuthenticationContextModules().getMasterModule(),
+      new LocalLocationModule(),
       new PrivateModule() {
         @Override
         protected void configure() {
@@ -207,7 +210,8 @@ public class TetheringClientHandlerTest {
                                                       tetheringStore, injector.getInstance(ProgramStateWriter.class),
                                                       messagingService,
                                                       injector.getInstance(ProgramRunRecordFetcher.class),
-                                                      injector.getInstance(RemoteAuthenticator.class));
+                                                      injector.getInstance(RemoteAuthenticator.class),
+                                                      injector.getInstance(LocationFactory.class));
     Assert.assertEquals(Service.State.RUNNING, tetheringAgentService.startAndWait());
   }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1938,6 +1938,7 @@ public final class Constants {
 
   public static final class Tethering {
     public static final String TETHERING_SERVER_ENABLED = "tethering.server.enabled";
+    public static final String PROGRAM_DIR = "tethering.program.dir";
     /**
      * Prefix of per-client TMS topic used on the tethering server.
      */

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5115,6 +5115,14 @@
   </property>
 
   <property>
+    <name>tethering.program.dir</name>
+    <value>program-resources</value>
+    <description>
+      Directory that contains resources needed for tethered program runs.
+    </description>
+  </property>
+
+  <property>
     <name>jmx.metrics.collector.poll.interval.secs</name>
     <value>60</value>
     <description>

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/TetheringAgentServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/TetheringAgentServiceMain.java
@@ -26,6 +26,7 @@ import com.google.inject.Scopes;
 import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
@@ -73,6 +74,7 @@ public class TetheringAgentServiceMain extends AbstractServiceMain<EnvironmentOp
       new DataSetsModules().getStandaloneModules(),
       new AuthorizationEnforcementModule().getDistributedModules(),
       new ProgramRunnerRuntimeModule.ProgramStateWriterModule(),
+      new DFSLocationModule(),
       new PrivateModule() {
         @Override
         protected void configure() {

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -88,7 +88,7 @@ public final class DistributedSparkProgramRunner extends DistributedProgramRunne
                                        ClusterMode clusterMode,
                                        @Constants.AppFabric.ProgramRunner TwillRunner twillRunner,
                                        Injector injector) {
-    super(cConf, hConf, impersonator, clusterMode, twillRunner);
+    super(cConf, hConf, impersonator, clusterMode, twillRunner, locationFactory);
     this.sparkCompat = sparkComat;
     this.locationFactory = locationFactory;
     if (!cConf.getBoolean(Constants.AppFabric.PROGRAM_REMOTE_RUNNER, false)) {


### PR DESCRIPTION
- Update TetheringAgent to write to file system and store the URI in program options
- Update `DistributedProgramRunner` to read from file system for tethered runs and localize the files