### PR TITLE
[Cherry-pick][CDAP-19016] Optimize deserialization 

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/lang/FieldCollector.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/lang/FieldCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,25 +13,43 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package io.cdap.cdap.common.lang;
 
 import com.google.common.base.Defaults;
+import com.google.common.reflect.TypeToken;
 import io.cdap.cdap.internal.lang.FieldVisitor;
+import io.cdap.cdap.internal.lang.Reflections;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
- * Package private class for {@link InstantiatorFactory} to initialize fields for instances created using Unsafe.
+ * Helper class to collect all non-static fields with defaults to set while creating an instance
+ * for deserialization
  */
-final class FieldInitializer extends FieldVisitor {
+class FieldCollector extends FieldVisitor {
+  private final Map<Field, Object> fieldsWithDefaults = new LinkedHashMap<>();
 
   @Override
   public void visit(Object instance, Type inspectType, Type declareType, Field field) throws Exception {
     if (Modifier.isStatic(field.getModifiers())) {
       return;
     }
-    field.set(instance, Defaults.defaultValue(field.getType()));
+    fieldsWithDefaults.put(field, Defaults.defaultValue(field.getType()));
+  }
+
+  /**
+   *
+   * @return map of field name to default field value as defined by JLS for given type
+   * @see Defaults#defaultValue(java.lang.Class)
+   */
+  static <T> Map<Field, Object> getFieldsWithDefaults(TypeToken<T> type) {
+    FieldCollector fieldCollector = new FieldCollector();
+    Reflections.visit(null, type.getType(), fieldCollector);
+    return fieldCollector.fieldsWithDefaults;
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/internal/io/ReflectionDatumReader.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/internal/io/ReflectionDatumReader.java
@@ -87,7 +87,7 @@ public final class ReflectionDatumReader<T> extends ReflectionReader<Decoder, T>
     String enumValue = sourceSchema.getEnumValue(decoder.readInt());
     check(targetSchema.getEnumValues().contains(enumValue), "Enum value '%s' missing in target.", enumValue);
     try {
-      return targetTypeToken.getRawType().getMethod("valueOf", String.class).invoke(null, enumValue);
+      return Enum.valueOf((Class) targetTypeToken.getRawType(), enumValue);
     } catch (Exception e) {
       throw new IOException(e);
     }

--- a/cdap-common/src/test/java/io/cdap/cdap/common/lang/FieldCollectorTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/lang/FieldCollectorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.lang;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class FieldCollectorTest {
+
+  @Test
+  public void testFieldsCollected() {
+    Map<Field, Object> actual = FieldCollector.getFieldsWithDefaults(new TypeToken<TestClass>() {
+    });
+    Assert.assertEquals(
+      ImmutableList.of(
+        new AbstractMap.SimpleEntry<>("stringField", null),
+        new AbstractMap.SimpleEntry<>("intField", 0),
+        new AbstractMap.SimpleEntry<>("arrayField", null)
+      ),
+      actual.entrySet().stream()
+        .map(e -> new AbstractMap.SimpleEntry<>(e.getKey().getName(), e.getValue())).collect(Collectors.toList())
+    );
+  }
+
+  private class TestClass {
+    private String stringField;
+    private int intField;
+    private long[] arrayField;
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/14145

- Reusing introspection results for unsafe object creation
- Removing reflection for enum access