### PR TITLE
[Cherry-pick][CDAP-19016] Parallel computation / writes to metric tables

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -782,6 +782,7 @@ public final class Constants {
     public static final String OFFER_TIMEOUT_MS = "metrics.processor.offer.timeout.ms";
 
     public static final String ENTITY_TABLE_NAME = "metrics.data.entity.tableName";
+    public static final String METRICS_TABLE_WRITE_PARRALELISM = "metrics.data.table.write.parallelism";
     public static final String METRICS_TABLE_PREFIX = "metrics.data.table.prefix";
     public static final String TIME_SERIES_TABLE_ROLL_TIME = "metrics.data.table.ts.rollTime";
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2662,6 +2662,15 @@
   </property>
 
   <property>
+    <name>metrics.data.table.write.parallelism</name>
+    <value>5</value>
+    <description>
+      Controls parallel computations and writes to each resolution metrics table. While write itself is guarded
+      by a mutex, pre-write computations and aggregations takes time, so it makes sense to do it in parallel.
+    </description>
+  </property>
+
+  <property>
     <name>metrics.exec.threads</name>
     <value>${http.service.exec.threads}</value>
     <description>

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/cube/DefaultCube.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/cube/DefaultCube.java
@@ -65,6 +65,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 /**
@@ -83,20 +84,38 @@ public class DefaultCube implements Cube, MeteredDataset {
   private final Map<String, ? extends Aggregation> aggregations;
   private final Map<String, AggregationAlias> aggregationAliasMap;
   private final ExecutorService executorService;
+  private final int writeParallelism;
 
   @Nullable
   private MetricsCollector metrics;
 
+  /**
+   * Created a cube with no parallel computations / writes to same resultion
+   */
   public DefaultCube(int[] resolutions, FactTableSupplier factTableSupplier,
                      Map<String, ? extends Aggregation> aggregations,
                      Map<String, AggregationAlias> aggregationAliasMap) {
+    this(resolutions, factTableSupplier, aggregations, aggregationAliasMap, 1);
+  }
+
+  /**
+   * Creates a cube that can do up to writePrallelism parallel computations when writing data to each resolution
+   * table
+   */
+  public DefaultCube(int[] resolutions, FactTableSupplier factTableSupplier,
+                     Map<String, ? extends Aggregation> aggregations,
+                     Map<String, AggregationAlias> aggregationAliasMap,
+                     int writeParallelism) {
     this.aggregations = aggregations;
     this.resolutionToFactTable = Maps.newHashMap();
     for (int resolution : resolutions) {
       resolutionToFactTable.put(resolution, factTableSupplier.get(resolution, 3600));
     }
     this.aggregationAliasMap = aggregationAliasMap;
-    ThreadPoolExecutor executor = new ThreadPoolExecutor(resolutions.length, resolutions.length, 30, TimeUnit.SECONDS,
+    this.writeParallelism = writeParallelism;
+    ThreadPoolExecutor executor = new ThreadPoolExecutor(resolutions.length * this.writeParallelism,
+                                                         resolutions.length * this.writeParallelism,
+                                                         30, TimeUnit.SECONDS,
                                                          new LinkedBlockingQueue<>(),
                                                          Threads.createDaemonThreadFactory("metrics-table-%d"));
     executor.allowCoreThreadTimeOut(true);
@@ -110,8 +129,9 @@ public class DefaultCube implements Cube, MeteredDataset {
 
   @Override
   public void add(Collection<? extends CubeFact> facts) {
-    List<Fact> toWrite = Lists.newArrayList();
+    Map<List<DimensionValue>, List<Fact>> toWrite = new HashMap<>();
     int dimValuesCount = 0;
+    long numFacts = 0;
     for (CubeFact fact : facts) {
       for (Map.Entry<String, ? extends Aggregation> aggEntry : aggregations.entrySet()) {
         Aggregation agg = aggEntry.getValue();
@@ -129,28 +149,53 @@ public class DefaultCube implements Cube, MeteredDataset {
             dimensionValues.add(new DimensionValue(dimensionName, fact.getDimensionValues().get(dimensionValueKey)));
             dimValuesCount++;
           }
-          toWrite.add(new Fact(fact.getTimestamp(), dimensionValues, fact.getMeasurements()));
+          toWrite.computeIfAbsent(dimensionValues, v -> new ArrayList<>())
+            .add(new Fact(fact.getTimestamp(), dimensionValues, fact.getMeasurements()));
+          numFacts++;
         }
       }
     }
 
-    Map<Integer, Future<?>> futures = new HashMap<>();
-    for (Map.Entry<Integer, FactTable> table : resolutionToFactTable.entrySet()) {
-      futures.put(table.getKey(), executorService.submit(() -> table.getValue().add(toWrite)));
+    Map<Integer, List<Future<?>>> futures = new HashMap<>();
+    Consumer<List<Fact>> batchWriter = batch -> {
+      for (Map.Entry<Integer, FactTable> table : resolutionToFactTable.entrySet()) {
+        Future<?> future = executorService.submit(() -> table.getValue().add(batch));
+        futures.computeIfAbsent(table.getKey(), k -> new ArrayList<>()).add(future);
+      }
+    };
+
+    List<Fact> writeBatch = new ArrayList<>();
+    int batchSize = (int) Math.min(Integer.MAX_VALUE, numFacts / writeParallelism);
+    for (List<Fact> metricFacts: toWrite.values()) {
+      if (metricFacts.size() > batchSize) {
+        batchWriter.accept(metricFacts);
+      } else if (writeBatch.size() <= batchSize - metricFacts.size()) {
+        writeBatch.addAll(metricFacts);
+      } else {
+        batchWriter.accept(writeBatch);
+        writeBatch = new ArrayList<>();
+        writeBatch.addAll(metricFacts);
+      }
     }
+    if (!writeBatch.isEmpty()) {
+      batchWriter.accept(writeBatch);
+    }
+
 
     boolean failed = false;
     Exception failedException = null;
     StringBuilder failedMessage = new StringBuilder("Failed to add metrics to ");
-    for (Map.Entry<Integer, Future<?>> future : futures.entrySet()) {
+    for (Map.Entry<Integer, List<Future<?>>> futureList: futures.entrySet()) {
       try {
-        Uninterruptibles.getUninterruptibly(future.getValue());
+        for (Future<?> future: futureList.getValue()) {
+          Uninterruptibles.getUninterruptibly(future);
+        }
       } catch (ExecutionException e) {
         if (!failed) {
           failed = true;
-          failedMessage.append(String.format("the %d resolution table", future.getKey()));
+          failedMessage.append(String.format("the %d resolution table", futureList.getKey()));
         } else {
-          failedMessage.append(String.format(", the %d resolution table", future.getKey()));
+          failedMessage.append(String.format(", the %d resolution table", futureList.getKey()));
         }
         if (failedException == null) {
           failedException = e;
@@ -166,9 +211,9 @@ public class DefaultCube implements Cube, MeteredDataset {
 
     incrementMetric("cube.cubeFact.add.request.count", 1);
     incrementMetric("cube.cubeFact.added.count", facts.size());
-    incrementMetric("cube.tsFact.created.count", toWrite.size());
+    incrementMetric("cube.tsFact.created.count", numFacts);
     incrementMetric("cube.tsFact.created.dimValues.count", dimValuesCount);
-    incrementMetric("cube.tsFact.added.count", toWrite.size() * resolutionToFactTable.size());
+    incrementMetric("cube.tsFact.added.count", numFacts * resolutionToFactTable.size());
   }
 
   @Override

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricStore.java
@@ -201,6 +201,7 @@ public class DefaultMetricStore implements MetricStore {
 
   @Inject
   DefaultMetricStore(MetricDatasetFactory dsFactory, CConfiguration cConf) {
+    int writeParallelism = cConf.getInt(Constants.Metrics.METRICS_TABLE_WRITE_PARRALELISM);
     int minimumResolution = cConf.getInt(Constants.Metrics.METRICS_MINIMUM_RESOLUTION_SECONDS);
     int[] resolutions = minimumResolution < 60 ?
       new int[] {minimumResolution, 60, 3600, TOTALS_RESOLUTION} : new int[] {60, 3600, TOTALS_RESOLUTION};
@@ -223,7 +224,8 @@ public class DefaultMetricStore implements MetricStore {
     this.cube = Suppliers.memoize(new Supplier<Cube>() {
       @Override
       public Cube get() {
-        DefaultCube cube = new DefaultCube(resolutions, factTableSupplier, AGGREGATIONS, AGGREGATIONS_ALIAS_DIMENSIONS);
+        DefaultCube cube = new DefaultCube(resolutions, factTableSupplier, AGGREGATIONS, AGGREGATIONS_ALIAS_DIMENSIONS,
+                                           writeParallelism);
         cube.setMetricsCollector(metricsContext);
         return cube;
       }


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/14148

Main change here is to do metric table preaggregation / persisting in parallel. While persisting itself is sequential in LevelDB, there is significant amount of preprocessing done (aggregation and entity id resolution) that would benefit from parallel processing.

Also it enhances logging a bit and ensures we try to write the current metric queue before waiting for space in it.