### PR TITLE
CDAP-18984 ensure app class is in manifest for integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1796,7 +1796,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0-M6</version>
           <configuration>
             <argLine>@{argLine}  -Xmx3500m -Djava.awt.headless=true -XX:+UseG1GC -XX:OnOutOfMemoryError="kill -9 %p" -XX:+HeapDumpOnOutOfMemoryError</argLine>
             <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
@@ -1824,7 +1824,7 @@
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
               <artifactId>surefire-junit47</artifactId>
-              <version>3.0.0-M5</version>
+              <version>3.0.0-M6</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -2065,7 +2065,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-surefire-plugin</artifactId>
-              <version>3.0.0-M5</version>
+              <version>3.0.0-M6</version>
               <configuration>
                 <groups>${testcase.groups}</groups>
               </configuration>


### PR DESCRIPTION
Somehow it is possible in some circumstances to find an application
jar with the wrong manifest in IntegrationTestBase. Added some
logic to always ensure that the manifest contains the required
main class attribute.

Also updating surefire-plugin version to fix errors that happen
while running tests in some environments.