### PR TITLE
CDAP-12977 fix app deletion when trigger not found

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/AbstractTimeSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/AbstractTimeSchedulerService.java
@@ -80,7 +80,7 @@ public abstract class AbstractTimeSchedulerService extends AbstractIdleService i
   }
 
   @Override
-  public void deleteProgramSchedule(ProgramSchedule schedule) throws NotFoundException, SchedulerException {
+  public void deleteProgramSchedule(ProgramSchedule schedule) throws SchedulerException {
     if (containsTimeTrigger(schedule)) {
       timeScheduler.deleteProgramSchedule(schedule);
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/TimeSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/TimeSchedulerService.java
@@ -40,12 +40,12 @@ public interface TimeSchedulerService extends Service {
 
   /**
    * Deletes the schedule with the same schedule name and {@link ProgramId} as the given {@link ProgramSchedule}.
+   * If the schedule does not exist, this is a no-op.
    *
    * @param schedule the {@link ProgramSchedule} with schedule name and {@link ProgramId} of the schedule to delete
-   * @throws NotFoundException if the schedule could not be found
    * @throws SchedulerException on unforeseen error
    */
-  void deleteProgramSchedule(ProgramSchedule schedule) throws NotFoundException, SchedulerException;
+  void deleteProgramSchedule(ProgramSchedule schedule) throws SchedulerException;
 
   /**
    * Suspends the schedule with the same schedule name and {@link ProgramId} as the given {@link ProgramSchedule}.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/CoreSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/CoreSchedulerService.java
@@ -351,7 +351,7 @@ public class CoreSchedulerService extends AbstractIdleService implements Schedul
       try {
         // TODO: [CDAP-11576] need to clean up the inconsistent state if this operation fails
         timeSchedulerService.deleteProgramSchedule(schedule);
-      } catch (Exception e) {
+      } catch (SchedulerException e) {
         // TODO: [CDAP-11574] temporarily catch the SchedulerException and throw RuntimeException.
         // Need better error handling
         LOG.error("Exception occurs when deleting schedule {}", schedule, e);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/TimeSchedulerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/TimeSchedulerTest.java
@@ -70,4 +70,15 @@ public class TimeSchedulerTest extends AppFabricTestBase {
     // and from 2:05 pm to 2:55pm will have 11 schedules as end time is exclusive. in total we expect 24 schedules.
     Assert.assertEquals(24, nextRuntimes.size());
   }
+
+  @Test
+  public void testDeleteNonExisting() throws Exception {
+    ProgramSchedule sched = new ProgramSchedule("name", "description", PROG1_ID,
+                                                Collections.emptyMap(),
+                                                new TimeTrigger("*/5 * * * *"), Collections.emptyList());
+    timeScheduler.addProgramSchedule(sched);
+    timeScheduler.deleteProgramSchedule(sched);
+    // check deleting non-existing doesn't throw an exception
+    timeScheduler.deleteProgramSchedule(sched);
+  }
 }


### PR DESCRIPTION
Fixed a bug where app deletion can fail when it tries to delete
the app schedules and a trigger cannot be found. In this scenario,
it is already in the desired state, so just move on.