### PR TITLE
[Cherry-pick][CDAP-19016] Disable emitting spark metrics by default

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -856,6 +856,9 @@ public final class Constants {
      */
     public static final String WRITER_WRITE_FREQUENCY_SECONDS = "metrics.writer.%s.write.frequency.seconds";
 
+    /** Whether to enable spark metrics collection. */
+    public static final String SPARK_METRICS_ENABLED = "app.program.spark.metrics.enabled";
+
     /**
      * Metric's dataset related constants.
      */

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2881,6 +2881,16 @@
   </property>
 
   <property>
+    <name>app.program.spark.metrics.enabled</name>
+    <value>false</value>
+    <description>
+      Enable or disable emitting spark-specific metrics, by default set to false.
+      Note that spark-specific metrics are very resource consuming and are deprecated. If you need spark metrics
+      it's better to use data from spark history server.
+    </description>
+  </property>
+
+  <property>
     <name>metrics.hbase.max.scan.threads</name>
     <value>96</value>
     <description>

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -234,6 +234,10 @@ public class TestBase {
   @BeforeClass
   public static void initialize() throws Exception {
     if (nestedStartCount++ > 0) {
+      Assert.assertFalse(
+        "Test is loaded that requires custom configuration while other configuration is in place." +
+          "Please check if test is part of the suite and apply configuration on the suite level",
+        hasCustomConfiguration());
       return;
     }
     File localDataDir = TMP_FOLDER.newFolder();
@@ -504,6 +508,11 @@ public class TestBase {
     public MetricsManager get() {
       return new MetricsManager(metricStore);
     }
+  }
+
+  private static boolean hasCustomConfiguration() {
+    return System.getProperties().stringPropertyNames().stream()
+      .anyMatch(key -> key.startsWith(TestConfiguration.PROPERTY_PREFIX));
   }
 
   private static CConfiguration createCConf(File localDataDir) throws IOException {

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -177,6 +177,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.Manifest;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
@@ -198,6 +199,7 @@ public class TestBase {
   public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
 
   static Injector injector;
+  private static Map<String, String> customConfiguration;
   private static CConfiguration cConf;
   private static int nestedStartCount;
   private static boolean firstInit = true;
@@ -234,15 +236,16 @@ public class TestBase {
   @BeforeClass
   public static void initialize() throws Exception {
     if (nestedStartCount++ > 0) {
-      Assert.assertFalse(
-        "Test is loaded that requires custom configuration while other configuration is in place." +
+      Assert.assertEquals(
+        "Test is loaded that requires custom configuration while other configuration is in place. " +
           "Please check if test is part of the suite and apply configuration on the suite level",
-        hasCustomConfiguration());
+        customConfiguration, getCustomConfiguration());
       return;
     }
     File localDataDir = TMP_FOLDER.newFolder();
 
-    cConf = createCConf(localDataDir);
+    customConfiguration = getCustomConfiguration();
+    cConf = createCConf(localDataDir, customConfiguration);
 
     CConfiguration previewCConf = createPreviewConf(cConf);
     LevelDBTableService previewLevelDBTableService = new LevelDBTableService();
@@ -510,12 +513,17 @@ public class TestBase {
     }
   }
 
-  private static boolean hasCustomConfiguration() {
+  private static Map<String, String> getCustomConfiguration() {
     return System.getProperties().stringPropertyNames().stream()
-      .anyMatch(key -> key.startsWith(TestConfiguration.PROPERTY_PREFIX));
+      .filter(key -> key.startsWith(TestConfiguration.PROPERTY_PREFIX))
+      .collect(Collectors.toMap(
+        key -> key.substring(TestConfiguration.PROPERTY_PREFIX.length()),
+        key -> System.getProperty(key)
+      ));
   }
 
-  private static CConfiguration createCConf(File localDataDir) throws IOException {
+  private static CConfiguration createCConf(File localDataDir,
+                                            Map<String, String> customConfiguration) throws IOException {
     CConfiguration cConf = CConfiguration.create();
 
     // Setup defaults that can be overridden by user
@@ -527,12 +535,9 @@ public class TestBase {
 
     // Setup test case specific configurations.
     // The system properties are usually setup by TestConfiguration class using @ClassRule
-    for (String key : System.getProperties().stringPropertyNames()) {
-      if (key.startsWith(TestConfiguration.PROPERTY_PREFIX)) {
-        String value = System.getProperty(key);
-        cConf.set(key.substring(TestConfiguration.PROPERTY_PREFIX.length()), System.getProperty(key));
-        LOG.info("Custom configuration set: {} = {}", key, value);
-      }
+    for (Map.Entry<String, String> e: customConfiguration.entrySet()) {
+      cConf.set(e.getKey(), e.getValue());
+      LOG.info("Custom configuration set: {} = {}", e.getKey(), e.getValue());
     }
 
     // These configurations cannot be overridden by user

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/spark/metrics/SparkMetricsIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/spark/metrics/SparkMetricsIntegrationTestRun.java
@@ -50,7 +50,10 @@ import java.util.concurrent.TimeUnit;
 @Category(XSlowTests.class)
 public class SparkMetricsIntegrationTestRun extends TestFrameworkTestBase {
   @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration("app.program.spark.metrics.enabled", "true");
+  public static final TestConfiguration CONFIG =
+    new TestConfiguration(Constants.Metrics.SPARK_METRICS_ENABLED, true,
+                          Constants.Explore.EXPLORE_ENABLED, false,
+                          Constants.CLUSTER_NAME, "testCluster");
 
   @Test
   public void testSparkMetrics() throws Exception {

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/spark/metrics/SparkMetricsIntegrationTestRun.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/spark/metrics/SparkMetricsIntegrationTestRun.java
@@ -29,9 +29,11 @@ import io.cdap.cdap.proto.RunRecord;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.SparkManager;
+import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.XSlowTests;
 import io.cdap.cdap.test.base.TestFrameworkTestBase;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -47,6 +49,8 @@ import java.util.concurrent.TimeUnit;
  */
 @Category(XSlowTests.class)
 public class SparkMetricsIntegrationTestRun extends TestFrameworkTestBase {
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("app.program.spark.metrics.enabled", "true");
 
   @Test
   public void testSparkMetrics() throws Exception {

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/test/base/TestFrameworkExploreTestSuite.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/test/base/TestFrameworkExploreTestSuite.java
@@ -20,11 +20,13 @@ import io.cdap.cdap.common.test.TestSuite;
 import io.cdap.cdap.partitioned.PartitionConsumingTestRun;
 import io.cdap.cdap.partitioned.PartitionCorrectorTestRun;
 import io.cdap.cdap.partitioned.PartitionRollbackTestRun;
+import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.XSlowTests;
 import io.cdap.cdap.test.app.DummyBaseCloneTestRun;
 import io.cdap.cdap.test.app.DummyBaseTestRun;
 import io.cdap.cdap.test.app.DynamicPartitioningTestRun;
 import io.cdap.cdap.test.app.TestSQLQueryTestRun;
+import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -45,5 +47,8 @@ import org.junit.runners.Suite;
   TestSQLQueryTestRun.class
 })
 public class TestFrameworkExploreTestSuite extends TestFrameworkTestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", true);
 
 }

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/test/base/TestFrameworkTestSuite.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/test/base/TestFrameworkTestSuite.java
@@ -52,7 +52,6 @@ import org.junit.runners.Suite;
   ServiceArtifactTestRun.class,
   ServiceLifeCycleTestRun.class,
   SparkFileSetTestRun.class,
-  SparkMetricsIntegrationTestRun.class,
   SparkServiceIntegrationTestRun.class,
   TestFrameworkTestRun.class,
   SparkStreamingTestRun.class,

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/test/base/TestFrameworkTestSuite.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/test/base/TestFrameworkTestSuite.java
@@ -26,7 +26,6 @@ import io.cdap.cdap.service.ServiceArtifactTestRun;
 import io.cdap.cdap.service.ServiceLifeCycleTestRun;
 import io.cdap.cdap.spark.SparkFileSetTestRun;
 import io.cdap.cdap.spark.SparkStreamingTestRun;
-import io.cdap.cdap.spark.metrics.SparkMetricsIntegrationTestRun;
 import io.cdap.cdap.spark.service.SparkServiceIntegrationTestRun;
 import io.cdap.cdap.test.TestConfiguration;
 import io.cdap.cdap.test.XSlowTests;


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/14156

Spark metrics generate metric name dynamically (it includes app name and executor id) and is very resource-consuming to process. We recommend to use spark history server if needed.