### PR TITLE
CDAP-19023: add support for configuring composite trigger

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/PipelineTriggers.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/PipelineTriggers.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.schedule.ProgramStatusTriggerInfo;
+import io.cdap.cdap.etl.api.lineage.field.FieldOperation;
+import io.cdap.cdap.etl.common.BasicArguments;
+import io.cdap.cdap.etl.common.FieldOperationTypeAdapter;
+import io.cdap.cdap.etl.proto.v2.ArgumentMapping;
+import io.cdap.cdap.etl.proto.v2.PluginPropertyMapping;
+import io.cdap.cdap.etl.proto.v2.TriggeringPipelineId;
+import io.cdap.cdap.etl.proto.v2.TriggeringPropertyMapping;
+import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Handles parsing of pipeline runtime arguments mapping.
+ */
+public final class PipelineTriggers {
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
+    .registerTypeAdapter(FieldOperation.class, new FieldOperationTypeAdapter()).create();
+  private static final String RESOLVED_PLUGIN_PROPERTIES_MAP = "resolved.plugin.properties.map";
+  private static final Type STAGE_PROPERTIES_MAP = new TypeToken<Map<String, Map<String, String>>>() { }.getType();
+  private static final Logger LOG = LoggerFactory.getLogger(PipelineTriggers.class);
+
+  private PipelineTriggers() {
+  }
+
+  /**
+   * Parse the arguments mapping from the pipeline schedule and add to mappings.
+   * If compositeTriggerEnabled is true, the code will iterate through all the argument mappings and only adds
+   * those which match pipeline IDs.
+   * Example: for given TriggeringPropertyMapping as "{"arguments":[{"source":"source1","target":"target1","pipelineId"
+   * :{"namespace":"default","pipelineName":"Pipeline1"}}，{"source":"source2","target":"target2","pipelineId":
+   * {"namespace":"default","pipelineName":"Pipeline2"}}]}" and a trigger {"namespace":"default","pipelineName":
+   * "Pipeline1"} which has runtime arguments "{"source1": "value1","source2":"value2"}". When composite pipeline
+   * trigger is enabled, only {"target1": "value1"} is added. Otherwise, the code will ignore the ID check and
+   * {"target1": "value1", "target2": "value2"} is added.
+   *
+   * @param triggerInfo {@link ProgramStatusTriggerInfo} with plugin properties
+   * @param propertiesMapping  {@link TriggeringPropertyMapping} for using the plugin
+   * @param compositeTriggerEnabled  whether the composite trigger is enabled
+   */
+  public static void addSchedulePropertiesMapping(Map<String, String> mappings,
+                                                  ProgramStatusTriggerInfo triggerInfo,
+                                                  TriggeringPropertyMapping propertiesMapping,
+                                                  boolean compositeTriggerEnabled) {
+    TriggeringPipelineId pipelineId = new TriggeringPipelineId(
+      triggerInfo.getNamespace(),
+      triggerInfo.getApplicationName());
+
+    BasicArguments triggeringArguments = new BasicArguments(
+      triggerInfo.getWorkflowToken(),
+      triggerInfo.getRuntimeArguments());
+
+    // Get the value of every triggering pipeline arguments specified in the propertiesMapping and update newRuntimeArgs
+    List<ArgumentMapping> argumentMappings = propertiesMapping.getArguments();
+    for (ArgumentMapping mapping : argumentMappings) {
+      if (compositeTriggerEnabled && !pipelineId.equals(mapping.getTriggeringPipelineId())) {
+        continue;
+      }
+      String sourceKey = mapping.getSource();
+      if (sourceKey == null) {
+        LOG.warn("The name of argument from the triggering pipeline cannot be null, " +
+          "skip this argument mapping: '{}'.", mapping);
+        continue;
+      }
+      String value = triggeringArguments.get(sourceKey);
+      if (value == null) {
+        LOG.warn("Runtime argument '{}' is not found in run '{}' of the triggering "
+            + "pipeline '{}' in namespace '{}' ",
+            sourceKey, triggerInfo.getRunId(), triggerInfo.getApplicationName(),
+          triggerInfo.getNamespace());
+        continue;
+      }
+      // Use the argument name in the triggering pipeline if target is not specified
+      String targetKey = mapping.getTarget() == null ? sourceKey : mapping.getTarget();
+      mappings.put(targetKey, value);
+    }
+    // Get the resolved plugin properties map from triggering pipeline's workflow token in triggeringArguments
+    Map<String, Map<String, String>> resolvedProperties =
+      GSON.fromJson(triggeringArguments.get(RESOLVED_PLUGIN_PROPERTIES_MAP), STAGE_PROPERTIES_MAP);
+    for (PluginPropertyMapping mapping : propertiesMapping.getPluginProperties()) {
+      if (compositeTriggerEnabled && !pipelineId.equals(mapping.getTriggeringPipelineId())) {
+        continue;
+      }
+      String stageName = mapping.getStageName();
+      if (stageName == null) {
+        LOG.warn("The name of the stage cannot be null in plugin property mapping, "
+          + "skip this mapping: '{}'.", mapping);
+        continue;
+      }
+      Map<String, String> pluginProperties = resolvedProperties.get(stageName);
+      if (pluginProperties == null) {
+        LOG.warn("No plugin properties can be found with stage name '{}' in triggering "
+            + "pipeline '{}' in namespace '{}' ", mapping.getStageName(), triggerInfo.getApplicationName(),
+          triggerInfo.getNamespace());
+        continue;
+      }
+      String sourceKey = mapping.getSource();
+      if (sourceKey == null) {
+        LOG.warn("The name of argument from the triggering pipeline cannot be null, " +
+            "skip this argument mapping: '{}'.", mapping);
+        continue;
+      }
+      String value = pluginProperties.get(sourceKey);
+      if (value == null) {
+        LOG.warn("No property with name '{}' can be found in plugin "
+            + "'{}' of the triggering pipeline '{}' "
+            + "in namespace '{}' ", sourceKey, stageName, triggerInfo.getApplicationName(),
+          triggerInfo.getNamespace());
+        continue;
+      }
+      // Use the argument name in the triggering pipeline if target is not specified
+      String targetKey = mapping.getTarget() == null ? sourceKey : mapping.getTarget();
+      mappings.put(targetKey, value);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
@@ -105,6 +105,7 @@ import io.cdap.cdap.etl.proto.v2.ETLBatchConfig;
 import io.cdap.cdap.etl.proto.v2.ETLPlugin;
 import io.cdap.cdap.etl.proto.v2.ETLStage;
 import io.cdap.cdap.etl.proto.v2.PluginPropertyMapping;
+import io.cdap.cdap.etl.proto.v2.TriggeringPipelineId;
 import io.cdap.cdap.etl.proto.v2.TriggeringPropertyMapping;
 import io.cdap.cdap.etl.spark.Compat;
 import io.cdap.cdap.internal.app.runtime.schedule.store.Schedulers;
@@ -625,8 +626,17 @@ public class DataPipelineTest extends HydratorTestBase {
 
     String defaultNamespace = NamespaceId.DEFAULT.getNamespace();
     // Use properties from the triggering pipeline as values for runtime argument key1, key2
+    ArgumentMapping key1MappingWithId = new ArgumentMapping(
+      key1Mapping.getSource(),
+      key1Mapping.getTarget(),
+      new TriggeringPipelineId(defaultNamespace, triggeringPipelineName));
+    PluginPropertyMapping key2MappingWithId = new PluginPropertyMapping(
+      key2Mapping.getStageName(),
+      key2Mapping.getSource(),
+      key2Mapping.getTarget(),
+      new TriggeringPipelineId(defaultNamespace, triggeringPipelineName));
     TriggeringPropertyMapping propertyMapping =
-      new TriggeringPropertyMapping(ImmutableList.of(key1Mapping), ImmutableList.of(key2Mapping));
+      new TriggeringPropertyMapping(ImmutableList.of(key1MappingWithId), ImmutableList.of(key2MappingWithId));
     ProgramStatusTrigger completeTrigger =
       new ProgramStatusTrigger(new WorkflowId(defaultNamespace, triggeringPipelineName, SmartWorkflow.NAME),
                                ImmutableSet.of(ProgramStatus.COMPLETED));

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/service/PipelineTriggersTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/service/PipelineTriggersTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline.service;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import io.cdap.cdap.WorkflowAppWithFork;
+import io.cdap.cdap.api.ProgramStatus;
+import io.cdap.cdap.api.app.ProgramType;
+import io.cdap.cdap.api.schedule.ProgramStatusTriggerInfo;
+import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.etl.proto.v2.ArgumentMapping;
+import io.cdap.cdap.etl.proto.v2.PluginPropertyMapping;
+import io.cdap.cdap.etl.proto.v2.TriggeringPipelineId;
+import io.cdap.cdap.etl.proto.v2.TriggeringPropertyMapping;
+import io.cdap.cdap.internal.app.runtime.schedule.trigger.DefaultProgramStatusTriggerInfo;
+import io.cdap.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
+import io.cdap.cdap.proto.id.NamespaceId;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PipelineTriggersTest {
+  private static final Gson GSON = new Gson();
+
+  private static final String expectedValue1 = "headArgValue";
+  private static final String expectedValue2 = "headPluginValue";
+  private static final String defaultNamespace = NamespaceId.DEFAULT.getNamespace();
+  private ProgramStatusTriggerInfo triggerInfo;
+  private TriggeringPropertyMapping triggeringPropertyMapping;
+
+  @Before
+  public void init() {
+    TriggeringPipelineId pipelineIdHead = new TriggeringPipelineId(defaultNamespace, "head");
+    TriggeringPipelineId pipelineIdMiddle = new TriggeringPipelineId(defaultNamespace, "middle");
+    ArgumentMapping argHead = new ArgumentMapping("head-arg", "middle-arg", pipelineIdHead);
+    ArgumentMapping argMiddle = new ArgumentMapping("middle-arg", "tail-arg", pipelineIdMiddle);
+    PluginPropertyMapping pluginHead = new PluginPropertyMapping("action1",
+      "value", "middle-plugin", pipelineIdHead);
+    PluginPropertyMapping pluginMiddle = new PluginPropertyMapping("action2",
+      "value", "tail-plugin", pipelineIdMiddle);
+    triggeringPropertyMapping =
+      new TriggeringPropertyMapping(ImmutableList.of(argHead, argMiddle), ImmutableList.of(pluginHead, pluginMiddle));
+
+    Map<String, Map<String, String>> pluginProperties = new HashMap<String, Map<String, String>>() {{
+      put("action1", new HashMap<String, String>() {{
+        put("value", expectedValue2);
+      }});
+      put("action2", new HashMap<String, String>() {{
+        put("value", "pipelineIdMiddleValue");
+      }});
+    }};
+    String pluginPropertiesJson = GSON.toJson(pluginProperties,
+      new TypeToken<Map<String, Map<String, String>>>() { }.getType());
+    Map<String, String> runtimeArguments =  new HashMap<String, String>() {{
+      put("head-arg", expectedValue1);
+      put("middle-arg", "pipelineIdMiddleValue");
+      put("resolved.plugin.properties.map", pluginPropertiesJson);
+    }};
+
+    triggerInfo = new DefaultProgramStatusTriggerInfo(
+      defaultNamespace, pipelineIdHead.getName(),
+      ProgramType.WORKFLOW,
+      WorkflowAppWithFork.WorkflowWithFork.class.getSimpleName(),
+      RunIds.generate(), ProgramStatus.COMPLETED,
+      new BasicWorkflowToken(1), runtimeArguments);
+  }
+
+  @Test
+  public void testGetCompositeSchedulePropertiesMapping() {
+    Map<String, String> propertyMappingResult = new HashMap<>();
+    PipelineTriggers.addSchedulePropertiesMapping(propertyMappingResult, triggerInfo,
+      triggeringPropertyMapping, true);
+
+    Assert.assertEquals(propertyMappingResult.size(), 2);
+    Assert.assertEquals(propertyMappingResult.get("middle-arg"), expectedValue1);
+    Assert.assertEquals(propertyMappingResult.get("middle-plugin"), expectedValue2);
+  }
+
+  @Test
+  public void testGetSingleSchedulePropertiesMapping() {
+    Map<String, String> propertyMappingResult = new HashMap<>();
+    PipelineTriggers.addSchedulePropertiesMapping(propertyMappingResult, triggerInfo,
+      triggeringPropertyMapping, false);
+
+    Assert.assertEquals(propertyMappingResult.size(), 4);
+    Assert.assertEquals(propertyMappingResult.get("middle-arg"), expectedValue1);
+    Assert.assertEquals(propertyMappingResult.get("middle-plugin"), expectedValue2);
+    Assert.assertEquals(propertyMappingResult.get("tail-arg"), "pipelineIdMiddleValue");
+    Assert.assertEquals(propertyMappingResult.get("tail-plugin"), "pipelineIdMiddleValue");
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline2_2.11/pom.xml
@@ -145,6 +145,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-features</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline3_2.12/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline3_2.12/pom.xml
@@ -160,6 +160,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-features</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ArgumentMapping.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ArgumentMapping.java
@@ -26,10 +26,19 @@ public class ArgumentMapping {
   private final String source;
   @Nullable
   private final String target;
+  @Nullable
+  private final TriggeringPipelineId pipeline;
 
   public ArgumentMapping(@Nullable String source, @Nullable String target) {
+    this(source, target, null);
+  }
+
+  public ArgumentMapping(@Nullable String source,
+                         @Nullable String target,
+                         @Nullable TriggeringPipelineId pipeline) {
     this.source = source;
     this.target = target;
+    this.pipeline = pipeline;
   }
 
   /**
@@ -48,11 +57,20 @@ public class ArgumentMapping {
     return target;
   }
 
+  /**
+   * @return The identifiers of properties from the triggering pipeline.
+   */
+  @Nullable
+  public TriggeringPipelineId getTriggeringPipelineId() {
+    return pipeline;
+  }
+
   @Override
   public String toString() {
     return "ArgumentMapping{" +
       "source='" + getSource() + '\'' +
       ", target='" + getTarget() + '\'' +
+      ", triggeringPipelineId='" + getTriggeringPipelineId() + '\'' +
       '}';
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/PluginPropertyMapping.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/PluginPropertyMapping.java
@@ -26,7 +26,14 @@ public class PluginPropertyMapping extends ArgumentMapping {
   private final String stageName;
 
   public PluginPropertyMapping(@Nullable String stageName, @Nullable String source, @Nullable String target) {
-    super(source, target);
+    this(stageName, source, target, null);
+  }
+
+  public PluginPropertyMapping(@Nullable String stageName,
+                               @Nullable String source,
+                               @Nullable String target,
+                               @Nullable TriggeringPipelineId pipelineId) {
+    super(source, target, pipelineId);
     this.stageName = stageName;
   }
 
@@ -43,7 +50,8 @@ public class PluginPropertyMapping extends ArgumentMapping {
     return "PluginPropertyMapping{" +
       "source='" + getSource() + '\'' +
       ", target='" + getTarget() + '\'' +
-      "stageName='" + getStageName() + '\'' +
+      ", stageName='" + getStageName() + '\'' +
+      ", triggeringPipelineId='" + getTriggeringPipelineId() + '\'' +
       '}';
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/TriggeringPipelineId.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/TriggeringPipelineId.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.proto.v2;
+
+/**
+ * Class for identifiers of properties from the triggering pipeline.
+ */
+public class TriggeringPipelineId {
+  private final String namespace;
+  private final String name;
+
+  public TriggeringPipelineId(String namespace, String name) {
+    this.namespace = namespace;
+    this.name = name;
+  }
+
+  /**
+   * @return Namespace of the triggering pipeline.
+   */
+  public String getNamespace() {
+    return namespace;
+  }
+
+  /**
+   * @return Names of the triggering pipeline.
+   */
+  public String getName() {
+    return name;
+  }
+
+  public boolean equals(TriggeringPipelineId otherPipelineId) {
+    if (otherPipelineId == null) {
+      return false;
+    }
+    return namespace.equals(otherPipelineId.getNamespace())
+      && name.equals(otherPipelineId.getName());
+  }
+
+  @Override
+  public String toString() {
+    return "TriggeringPipelineId{" +
+      "namespace='" + getNamespace() + '\'' +
+      ", pipelineName='" + getName() + '\'' +
+      '}';
+  }
+}

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5224,10 +5224,10 @@
   </property>
 
   <property>
-    <name>feature.pipeline.triggers.conditional.and.enabled</name>
+    <name>feature.pipeline.composite.triggers.enabled</name>
     <value>false</value>
     <description>
-      Enables configuring AND or OR trigger groups for a pipeline.
+      Enables configuring composite AND/OR triggers for a pipeline schedule.
     </description>
   </property>
 

--- a/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
+++ b/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
@@ -27,7 +27,7 @@ import io.cdap.cdap.api.feature.FeatureFlagsProvider;
  */
 public enum Feature {
   REPLICATION_TRANSFORMATIONS("6.6.0"),
-  PIPELINE_TRIGGERS_CONDITIONAL_AND("6.8.0");
+  PIPELINE_COMPOSITE_TRIGGERS("6.8.0");
 
   private final PlatformInfo.Version versionIntroduced;
   private final boolean defaultAfterIntroduction;


### PR DESCRIPTION
This PR adds support for configuring composite trigger, more specifically it adds the id information for the respective composite trigger. Originally schedule trigger was default to the PROGRAM_STATUS type when parsing runtime arguments. The sister UI pr is here: https://github.com/cdapio/cdap-ui/pull/414