### PR TITLE
Added BigQuery capability for SQL Expressions

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/StandardSQLCapabilities.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/StandardSQLCapabilities.java
@@ -25,5 +25,9 @@ public enum StandardSQLCapabilities implements Capability {
   /**
    * Defines that factory implements SQL92 language
    */
-  SQL92
+  SQL92,
+  /**
+   * Defines that factory implements support for BigQuery specific language
+   */
+  BIGQUERY
 }


### PR DESCRIPTION
Our Group By and Deduplicate plugin currently generate BigQuery SQL specific code.

For example,:

1. `VARP(column)` and `STDEVP(column)` for Group By operations.
2. `CAST(column AS NUMERIC)` for Deduplicate on Double/Float fields.

This makes a clear distinction between ANSI SQL and BigQuery SQL syntax. Plugins will be updated to reflect the new `BIGQUERY_SQL` string factory type.

See https://github.com/cdapio/hydrator-plugins/pull/1575 and https://github.com/data-integrations/google-cloud/pull/967