### PR TITLE
[CDAP-19032] Refactor PreviewRunnerTwillRunnable and DefaultPreviewRunnerManager to remove unused Guice modules

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
@@ -168,7 +168,7 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
    * Create injector for the given application id.
    */
   @VisibleForTesting
-  Injector createPreviewInjector() {
+  public Injector createPreviewInjector() {
     return Guice.createInjector(
       new ConfigModule(previewCConf, previewHConf, previewSConf),
       new IOModule(),
@@ -193,7 +193,7 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements 
           bind(LogAppender.class).to(PreviewTMSLogAppender.class).in(Scopes.SINGLETON);
         }
       },
-    new MessagingServerRuntimeModule().getInMemoryModules(),
+      new MessagingServerRuntimeModule().getInMemoryModules(),
       Modules.override(new MetadataReaderWriterModules().getInMemoryModules()).with(new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java
@@ -32,7 +32,6 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
-import io.cdap.cdap.config.PreferencesService;
 import io.cdap.cdap.data.security.DefaultSecretStore;
 import io.cdap.cdap.explore.client.ExploreClient;
 import io.cdap.cdap.explore.client.MockExploreClient;
@@ -53,7 +52,6 @@ import io.cdap.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReaderProvider;
-import io.cdap.cdap.internal.app.runtime.artifact.ArtifactStore;
 import io.cdap.cdap.internal.app.runtime.artifact.DefaultArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinderProvider;
@@ -76,7 +74,6 @@ import io.cdap.cdap.pipeline.PipelineFactory;
 import io.cdap.cdap.scheduler.NoOpScheduler;
 import io.cdap.cdap.scheduler.Scheduler;
 import io.cdap.cdap.securestore.spi.SecretStore;
-import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
 import io.cdap.cdap.security.impersonation.DefaultOwnerAdmin;
 import io.cdap.cdap.security.impersonation.DefaultUGIProvider;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
@@ -84,7 +81,6 @@ import io.cdap.cdap.security.impersonation.OwnerStore;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
-import io.cdap.cdap.security.spi.authorization.PermissionManager;
 import io.cdap.cdap.store.DefaultOwnerStore;
 
 /**
@@ -92,12 +88,8 @@ import io.cdap.cdap.store.DefaultOwnerStore;
  */
 public class PreviewRunnerModule extends PrivateModule {
   private final CConfiguration cConf;
-  private final ArtifactStore artifactStore;
-  private final AccessControllerInstantiator accessControllerInstantiator;
   private final AccessEnforcer accessEnforcer;
   private final ContextAccessEnforcer contextAccessEnforcer;
-  private final PermissionManager permissionManager;
-  private final PreferencesService preferencesService;
   private final ProgramRuntimeProviderLoader programRuntimeProviderLoader;
   private final ArtifactRepositoryReaderProvider artifactRepositoryReaderProvider;
   private final PluginFinderProvider pluginFinderProvider;
@@ -106,23 +98,17 @@ public class PreviewRunnerModule extends PrivateModule {
 
   @Inject
   PreviewRunnerModule(CConfiguration cConf,
-                      ArtifactRepositoryReaderProvider readerProvider, ArtifactStore artifactStore,
-                      AccessControllerInstantiator accessControllerInstantiator,
+                      ArtifactRepositoryReaderProvider readerProvider,
                       AccessEnforcer accessEnforcer,
                       ContextAccessEnforcer contextAccessEnforcer,
-                      PermissionManager permissionManager, PreferencesService preferencesService,
                       ProgramRuntimeProviderLoader programRuntimeProviderLoader,
                       PluginFinderProvider pluginFinderProvider,
                       PreferencesFetcherProvider preferencesFetcherProvider,
                       MessagingService messagingService) {
     this.cConf = cConf;
     this.artifactRepositoryReaderProvider = readerProvider;
-    this.artifactStore = artifactStore;
-    this.accessControllerInstantiator = accessControllerInstantiator;
     this.accessEnforcer = accessEnforcer;
     this.contextAccessEnforcer = contextAccessEnforcer;
-    this.permissionManager = permissionManager;
-    this.preferencesService = preferencesService;
     this.programRuntimeProviderLoader = programRuntimeProviderLoader;
     this.pluginFinderProvider = pluginFinderProvider;
     this.preferencesFetcherProvider = preferencesFetcherProvider;
@@ -173,9 +159,6 @@ public class PreviewRunnerModule extends PrivateModule {
       expose(PreferencesFetcher.class);
     }
 
-    bind(ArtifactStore.class).toInstance(artifactStore);
-    expose(ArtifactStore.class);
-
     bind(MessagingService.class)
       .annotatedWith(Names.named(PreviewConfigModule.GLOBAL_TMS))
       .toInstance(messagingService);
@@ -185,11 +168,6 @@ public class PreviewRunnerModule extends PrivateModule {
     expose(AccessEnforcer.class);
     bind(ContextAccessEnforcer.class).toInstance(contextAccessEnforcer);
     expose(ContextAccessEnforcer.class);
-    bind(AccessControllerInstantiator.class).toInstance(accessControllerInstantiator);
-    expose(AccessControllerInstantiator.class);
-    bind(PermissionManager.class).toInstance(permissionManager);
-    expose(PermissionManager.class);
-    bind(PreferencesService.class).toInstance(preferencesService);
     // bind explore client to mock.
     bind(ExploreClient.class).to(MockExploreClient.class);
     expose(ExploreClient.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -28,16 +28,20 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
-import com.google.inject.util.Modules;
+import com.google.inject.Scopes;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.multibindings.MapBinder;
 import io.cdap.cdap.api.common.Bytes;
-import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule;
-import io.cdap.cdap.app.guice.AuthorizationModule;
-import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
-import io.cdap.cdap.app.guice.UnsupportedExploreClient;
+import io.cdap.cdap.app.deploy.Configurator;
+import io.cdap.cdap.app.guice.DefaultProgramRunnerFactory;
 import io.cdap.cdap.app.preview.PreviewConfigModule;
 import io.cdap.cdap.app.preview.PreviewRunner;
 import io.cdap.cdap.app.preview.PreviewRunnerManager;
 import io.cdap.cdap.app.preview.PreviewRunnerManagerModule;
+import io.cdap.cdap.app.runtime.ProgramRunner;
+import io.cdap.cdap.app.runtime.ProgramRunnerFactory;
+import io.cdap.cdap.app.runtime.ProgramRuntimeProvider;
+import io.cdap.cdap.app.runtime.ProgramStateWriter;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.SConfiguration;
@@ -53,14 +57,18 @@ import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.LoggingContextAccessor;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.data.runtime.ConstantTransactionSystemClient;
-import io.cdap.cdap.data.runtime.DataFabricModules;
-import io.cdap.cdap.data.runtime.DataSetServiceModules;
-import io.cdap.cdap.data.runtime.DataSetsModules;
-import io.cdap.cdap.data2.audit.AuditModule;
-import io.cdap.cdap.data2.transaction.DelegatingTransactionSystemClientService;
-import io.cdap.cdap.data2.transaction.TransactionSystemClientService;
-import io.cdap.cdap.explore.client.ExploreClient;
+import io.cdap.cdap.internal.app.deploy.ConfiguratorFactory;
+import io.cdap.cdap.internal.app.deploy.InMemoryConfigurator;
+import io.cdap.cdap.internal.app.program.MessagingProgramStateWriter;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
+import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
+import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepositoryReader;
+import io.cdap.cdap.internal.app.runtime.artifact.RemotePluginFinder;
 import io.cdap.cdap.internal.app.runtime.k8s.PreviewRequestPollerInfo;
+import io.cdap.cdap.internal.app.worker.RemoteWorkerPluginFinder;
+import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
 import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
@@ -68,15 +76,13 @@ import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.twill.ExtendedTwillContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
-import io.cdap.cdap.metadata.MetadataReaderWriterModules;
-import io.cdap.cdap.metadata.MetadataServiceModule;
-import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
-import io.cdap.cdap.metrics.guice.MetricsStoreModule;
+import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.SecureStoreClientModule;
+import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
+import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.spi.data.StorageProvider;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionSystemClient;
@@ -214,7 +220,6 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     modules.add(RemoteAuthenticatorModules.getDefaultModule());
     modules.add(new PreviewConfigModule(cConf, hConf, sConf));
     modules.add(new IOModule());
-    modules.add(new MetricsClientRuntimeModule().getDistributedModules());
 
     // If MasterEnvironment is not available, assuming it is the old hadoop stack with ZK, Kafka
     MasterEnvironment masterEnv = MasterEnvironments.getMasterEnvironment();
@@ -238,36 +243,45 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     }
 
     modules.add(new PreviewRunnerManagerModule().getDistributedModules());
-    modules.add(new DataSetServiceModules().getStandaloneModules());
-    modules.add(new DataSetsModules().getStandaloneModules());
-    modules.add(new AppFabricServiceRuntimeModule(cConf).getStandaloneModules());
-    modules.add(new ProgramRunnerRuntimeModule().getStandaloneModules());
-    modules.add(new MetricsStoreModule());
     modules.add(new MessagingClientModule());
-    modules.add(new AuditModule());
     modules.add(new SecureStoreClientModule());
-    modules.add(new MetadataReaderWriterModules().getStandaloneModules());
+    // Needed for InMemoryProgramRunnerModule. We use local metadata reader/publisher to avoid conflicting with
+    // metadata stored in AppFabric.
     modules.add(new DFSLocationModule());
-    modules.add(new MetadataServiceModule());
-    modules.add(new CoreSecurityRuntimeModule().getInMemoryModules());
+    // Configurator tasks should be executed in-memory since it is in the preview runner pod.
+    modules.add(new FactoryModuleBuilder().implement(Configurator.class, InMemoryConfigurator.class)
+                  .build(ConfiguratorFactory.class));
+
     modules.add(new AuthenticationContextModules().getMasterWorkerModule());
-    modules.add(new AuthorizationModule());
     modules.add(new AuthorizationEnforcementModule().getNoOpModules());
-    modules.add(Modules.override(
-      new DataFabricModules("master").getDistributedModules()).with(new AbstractModule() {
+    modules.add(new AbstractModule() {
       @Override
       protected void configure() {
-        // Bind transaction system to a constant one, basically no transaction, with every write become
-        // visible immediately.
-        // TODO: Ideally we shouldn't need this at all. However, it is needed now to satisfy dependencies
-        bind(TransactionSystemClientService.class).to(DelegatingTransactionSystemClientService.class);
         bind(TransactionSystemClient.class).to(ConstantTransactionSystemClient.class);
 
-        bind(ExploreClient.class).to(UnsupportedExploreClient.class);
         bind(PreviewRequestPollerInfoProvider.class).toInstance(() -> pollerInfoBytes);
-      }
-    }));
 
+        // Artifact Repository should use RemoteArtifactRepository.
+        // TODO(CDAP-19041): Consider adding a remote artifact respository handler to the preview manager so that
+        //  preview runners do not have to talk directly to app-fabric for artifacts to prevent hot-spotting.
+        bind(ArtifactRepositoryReader.class).to(RemoteArtifactRepositoryReader.class).in(Scopes.SINGLETON);
+        bind(ArtifactRepository.class).to(RemoteArtifactRepository.class);
+        // Use artifact localizer client if it is enabled, otherwise use regular RemotePluginFinder
+        if (cConf.getBoolean(Constants.Preview.ARTIFACT_LOCALIZER_ENABLED)) {
+          bind(PluginFinder.class).to(RemoteWorkerPluginFinder.class);
+          bind(ArtifactLocalizerClient.class).in(Scopes.SINGLETON);
+        } else {
+          bind(PluginFinder.class).to(RemotePluginFinder.class);
+        }
+        // Preview runner pods should not have any elevated privileges, so use the current UGI.
+        bind(UGIProvider.class).to(CurrentUGIProvider.class);
+        // Need ProgramRunnerFactory for the RemoteArtifactRepository
+        bind(ProgramRunnerFactory.class).to(DefaultProgramRunnerFactory.class).in(Scopes.SINGLETON);
+        MapBinder.newMapBinder(binder(), ProgramType.class, ProgramRunner.class);
+        bind(ProgramStateWriter.class).to(MessagingProgramStateWriter.class);
+        bind(ProgramRuntimeProvider.Mode.class).toInstance(ProgramRuntimeProvider.Mode.LOCAL);
+      }
+    });
 
     return Guice.createInjector(modules);
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnableTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnableTest.java
@@ -17,6 +17,8 @@
 package io.cdap.cdap.internal.app.preview;
 
 import com.google.inject.Injector;
+import io.cdap.cdap.app.preview.DefaultPreviewRunnerManager;
+import io.cdap.cdap.app.preview.PreviewRunner;
 import io.cdap.cdap.app.preview.PreviewRunnerManager;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.internal.app.runtime.k8s.PreviewRequestPollerInfo;
@@ -32,6 +34,9 @@ public class PreviewRunnerTwillRunnableTest {
   public void testInjector() {
     Injector injector = PreviewRunnerTwillRunnable.createInjector(CConfiguration.create(), new Configuration(),
                                                                   new PreviewRequestPollerInfo(0, "testuid"));
-    injector.getInstance(PreviewRunnerManager.class);
+    DefaultPreviewRunnerManager defaultPreviewRunnerManager = (DefaultPreviewRunnerManager) injector
+      .getInstance(PreviewRunnerManager.class);
+    Injector previewInjector = defaultPreviewRunnerManager.createPreviewInjector();
+    previewInjector.getInstance(PreviewRunner.class);
   }
 }


### PR DESCRIPTION
This refactor removes Guice modules which are unused by the preview runner to avoid performing unnecessary initialization.

For additional details, see [CDAP-19032](https://cdap.atlassian.net/browse/CDAP-19032).