### PR TITLE
[Cherry-pick][CDAP-19016] Add coarse metrics fact processing

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -788,6 +788,9 @@ public final class Constants {
     public static final String METRICS_TABLE_PREFIX = "metrics.data.table.prefix";
     public static final String TIME_SERIES_TABLE_ROLL_TIME = "metrics.data.table.ts.rollTime";
 
+    public static final String COARSE_LAG_FACTOR = "metrics.data.coarse.lag.factor";
+    public static final String COARSE_ROUND_FACTOR = "metrics.data.coarse.round.factor";
+
     public static final String METRICS_MINIMUM_RESOLUTION_SECONDS = "metrics.minimum.resolution.seconds";
     public static final String MINIMUM_RESOLUTION_RETENTION_SECONDS =
       "metrics.data.table.retention.minimum.resolution.seconds";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2654,6 +2654,29 @@
   </property>
 
   <property>
+    <name>metrics.data.coarse.lag.factor</name>
+    <value>12</value>
+    <description>
+      Resolution-based factor that defines wall clock lag. After incoming metrics processing delay reaches this lag,
+      metrics will be aggregated to bigger inteval based on round factor. E.g. for resolution of 5 seconds and
+      lag factor of 12, coarsing will be done for any metrics that are more than 5*12=60 seconds late.
+    </description>
+  </property>
+
+  <property>
+    <name>metrics.data.coarse.round.factor</name>
+    <value>20</value>
+    <description>
+      Resolution-based factor that defines increased interval at which metrics will be stored after coarsing kicked
+      in based on lag factor. E.g. for resolution of 5 seconds and round factor of 20, metrics will be stored
+      each 5*20=100 seconds instead of each 5 seconds. They will still be stored in the same 5 second table, so
+      table users don't need to be changed, they would just see data at more rare timestamps. The only quirk here
+      is that now data can be attributed to the moment up to 99 seconds earlier and not 5 seconds earlier than it was
+      produced due to a higher rounding involved. This mechanism allows to handle overload more gracefully.
+    </description>
+  </property>
+
+  <property>
     <name>metrics.dataset.hbase.stats.report.interval</name>
     <value>60</value>
     <description>

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/cube/CubeDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/cube/CubeDatasetTest.java
@@ -61,9 +61,24 @@ public class CubeDatasetTest extends AbstractCubeTest {
     return new CubeTxnlWrapper(getCubeInternal(name, resolutions, aggregations));
   }
 
+  @Override
+  protected Cube getCube(String name, int[] resolutions, Map<String, ? extends Aggregation> aggregations,
+                         int coarseLagFactor, int coarseRoundFactor) throws Exception {
+    return new CubeTxnlWrapper(getCubeInternal(name, resolutions, aggregations, coarseLagFactor, coarseRoundFactor));
+  }
+
   private Cube getCubeInternal(String name, int[] resolutions,
-                                  Map<String, ? extends Aggregation> aggregations) throws Exception {
-    DatasetProperties props = configureProperties(resolutions, aggregations);
+                               Map<String, ? extends Aggregation> aggregations
+  ) throws Exception {
+    return getCubeInternal(name, resolutions, aggregations, null, null);
+  }
+
+  private Cube getCubeInternal(String name, int[] resolutions,
+                               Map<String, ? extends Aggregation> aggregations,
+                               Integer coarseLagFactor,
+                               Integer coarseRoundFactor
+                               ) throws Exception {
+    DatasetProperties props = configureProperties(resolutions, aggregations, coarseLagFactor, coarseRoundFactor);
     DatasetId id = DatasetFrameworkTestUtil.NAMESPACE_ID.dataset(name);
     if (dsFrameworkUtil.getInstance(id) == null) {
       dsFrameworkUtil.createInstance(Cube.class.getName(), id, props);
@@ -132,7 +147,8 @@ public class CubeDatasetTest extends AbstractCubeTest {
     }
   }
 
-  private DatasetProperties configureProperties(int[] resolutions, Map<String, ? extends Aggregation> aggregations) {
+  private DatasetProperties configureProperties(int[] resolutions, Map<String, ? extends Aggregation> aggregations,
+                                                Integer coarseLagFactor, Integer coarseRoundFactor) {
     DatasetProperties.Builder builder = DatasetProperties.builder();
 
     // add resolution property
@@ -154,6 +170,14 @@ public class CubeDatasetTest extends AbstractCubeTest {
       if (!defAgg.getRequiredDimensions().isEmpty()) {
         builder.add(aggPropertyPrefix + ".requiredDimensions", Joiner.on(",").join(defAgg.getRequiredDimensions()));
       }
+    }
+
+    if (coarseLagFactor != null) {
+      builder.add(CubeDatasetDefinition.PROPERTY_COARSE_LAG_FACTOR, coarseLagFactor);
+    }
+
+    if (coarseRoundFactor != null) {
+      builder.add(CubeDatasetDefinition.PROPERTY_COARSE_ROUND_FACTOR, coarseRoundFactor);
     }
 
     return builder.build();

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/cube/DefaultCubeTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/cube/DefaultCubeTest.java
@@ -31,7 +31,15 @@ import java.util.Map;
 public class DefaultCubeTest extends AbstractCubeTest {
 
   @Override
-  protected Cube getCube(final String name, int[] resolutions, Map<String, ? extends Aggregation> aggregations) {
+  protected Cube getCube(String name, int[] resolutions, Map<String, ? extends Aggregation> aggregations)
+    throws Exception {
+    return getCube(name, resolutions, aggregations, 10, 1);
+  }
+
+  @Override
+  protected Cube getCube(String name, int[] resolutions, Map<String, ? extends Aggregation> aggregations,
+                         int coarseLagFactor, int coarseRoundFactor) throws Exception {
+
     FactTableSupplier supplier = (resolution, rollTime) -> {
       String entityTableName = "EntityTable-" + name;
       InMemoryTableService.create(entityTableName);
@@ -39,7 +47,7 @@ public class DefaultCubeTest extends AbstractCubeTest {
       InMemoryTableService.create(dataTableName);
       return new FactTable(new InMemoryMetricsTable(dataTableName),
                            new EntityTable(new InMemoryMetricsTable(entityTableName)),
-                           resolution, rollTime);
+                           resolution, rollTime, coarseLagFactor, coarseRoundFactor);
 
     };
 

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/timeseries/FactTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/timeseries/FactTableTest.java
@@ -48,6 +48,9 @@ import java.util.concurrent.TimeUnit;
  */
 public class FactTableTest {
 
+  private int coarseLagFactor = 10;
+  private int coarseRoundFactor = 1;
+
   @Test
   public void testBasics() throws Exception {
     InMemoryTableService.create("EntityTable");
@@ -56,8 +59,8 @@ public class FactTableTest {
     int rollTimebaseInterval = 2;
 
     FactTable table = new FactTable(new InMemoryMetricsTable("DataTable"),
-                                                            new EntityTable(new InMemoryMetricsTable("EntityTable")),
-                                                            resolution, rollTimebaseInterval);
+                                    new EntityTable(new InMemoryMetricsTable("EntityTable")),
+                                    resolution, rollTimebaseInterval, coarseLagFactor, coarseRoundFactor);
 
     // aligned to start of resolution bucket
     // "/1000" because time is expected to be in seconds
@@ -217,7 +220,7 @@ public class FactTableTest {
 
     FactTable table = new FactTable(new InMemoryMetricsTable("SearchDataTable"),
                                     new EntityTable(new InMemoryMetricsTable("SearchEntityTable")),
-                                    resolution, rollTimebaseInterval);
+                                    resolution, rollTimebaseInterval, coarseLagFactor, coarseRoundFactor);
 
     // aligned to start of resolution bucket
     // "/1000" because time is expected to be in seconds
@@ -297,7 +300,7 @@ public class FactTableTest {
 
     FactTable table = new FactTable(new InMemoryMetricsTable("QueryDataTable"),
                                     new EntityTable(new InMemoryMetricsTable("QueryEntityTable")),
-                                    resolution, rollTimebaseInterval);
+                                    resolution, rollTimebaseInterval, coarseLagFactor, coarseRoundFactor);
 
     // aligned to start of resolution bucket
     // "/1000" because time is expected to be in seconds
@@ -488,7 +491,7 @@ public class FactTableTest {
 
     FactTable table = new FactTable(new InMemoryMetricsTable("TotalsDataTable"),
                                     new EntityTable(new InMemoryMetricsTable("TotalsEntityTable")),
-                                    resolution, rollTimebaseInterval);
+                                    resolution, rollTimebaseInterval, coarseLagFactor, coarseRoundFactor);
 
 
     // ts is expected in seconds
@@ -523,7 +526,7 @@ public class FactTableTest {
     InMemoryMetricsTable metricsTable = new InMemoryMetricsTable("presplitDataTable");
     FactTable table = new FactTable(metricsTable,
                                     new EntityTable(new InMemoryMetricsTable("presplitEntityTable")),
-                                    resolution, rollTimebaseInterval);
+                                    resolution, rollTimebaseInterval, coarseLagFactor, coarseRoundFactor);
 
     byte[][] splits = FactTable.getSplits(3);
 
@@ -575,7 +578,9 @@ public class FactTableTest {
 
     InMemoryMetricsTable metricsTable = new InMemoryMetricsTable(tableName);
     FactTable table = new FactTable(metricsTable,
-                                    new EntityTable(new InMemoryMetricsTable(entityTableName)), resolution, 2);
+                                    new EntityTable(new InMemoryMetricsTable(entityTableName)),
+                                    resolution, 2,
+                                    coarseLagFactor, coarseRoundFactor);
 
     // set the metrics collector for the table
     FactTableMetricsCollector metricsCollector = new FactTableMetricsCollector(resolution);

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/metrics/MetricsSuiteTestBase.java
@@ -126,6 +126,9 @@ public abstract class MetricsSuiteTestBase {
     conf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
     conf.setBoolean(Constants.Metrics.CONFIG_AUTHENTICATION_REQUIRED, true);
     conf.set(Constants.Metrics.CLUSTER_NAME, CLUSTER);
+    //Disable coarsing as it will be flacky on integration test level due to variable timing.
+    //It's tested on lower level
+    conf.setInt(Constants.Metrics.COARSE_ROUND_FACTOR, 1);
 
     Injector injector = startMetricsService(conf);
     store = injector.getInstance(Store.class);

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricDatasetFactory.java
@@ -50,6 +50,8 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
   private final DatasetDefinition<MetricsTable, DatasetAdmin> metricsTableDefinition;
   private final Set<DatasetId> existingDatasets;
   private final Supplier<EntityTable> entityTable;
+  private final int coarseLagFactor;
+  private final int coarseRoundFactor;
 
   @Inject
   public DefaultMetricDatasetFactory(CConfiguration cConf,
@@ -62,6 +64,8 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
                                    Constants.Metrics.DEFAULT_ENTITY_TABLE_NAME);
       return new EntityTable(getOrCreateMetricsTable(tableName, DatasetProperties.EMPTY));
     });
+    this.coarseLagFactor = cConf.getInt(Constants.Metrics.COARSE_LAG_FACTOR);
+    this.coarseRoundFactor = cConf.getInt(Constants.Metrics.COARSE_ROUND_FACTOR);
   }
 
   // todo: figure out roll time based on resolution from config? See DefaultMetricsTableFactory for example
@@ -82,7 +86,8 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
     }
 
     MetricsTable table = getOrCreateMetricsTable(tableName, props.build());
-    return new FactTable(table, entityTable.get(), resolution, getRollTime(resolution));
+    return new FactTable(table, entityTable.get(), resolution, getRollTime(resolution),
+                         coarseLagFactor, coarseRoundFactor);
   }
 
   @Override

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/MetricsTestBase.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/MetricsTestBase.java
@@ -76,6 +76,9 @@ public abstract class MetricsTestBase {
     cConf.setInt(Constants.Metrics.QUEUE_SIZE, 1000);
     // Set it to really short delay for faster test
     cConf.setLong(Constants.Metrics.PROCESSOR_MAX_DELAY_MS, 5);
+    //Disable coarsing as it will be flacky on integration test level due to variable timing.
+    //It's tested on lower level
+    cConf.setInt(Constants.Metrics.COARSE_ROUND_FACTOR, 1);
 
     injector = Guice.createInjector(getModules());
     messagingService = injector.getInstance(MessagingService.class);


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/14177

This PR introduces a mechanism to handle metrics overload.
As soon as metrics lag (time between now and when metrics was generated) goes over threshold we start to aggregate metrics to more rare time intervals, thus producing less data to write and serve. Data is still written to all defined resolution tables, so no client changes are needed.
Settings are defined using factors (lag and round factors) and applied independently to each resolution table. Default lag is 12 and factor is 20.
So, for 5 seconds table coarsing will be done for any metrics over 5*12=60 seconds late and metrics time will be rounded to each 5*20=100 second mark instead of 5 second mark.
And for 60 second (1 minute) table coarsing will be done for any metrics over 1*12=12 minutes late and metrics time will be rounded to each 1*20=20 minutes mark instead of 1 minute mark.