### PR TITLE
CDAP-19042 fix flaky program kill test

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorService.java
@@ -119,6 +119,7 @@ public class ProgramRunStatusMonitorService extends AbstractRetryableScheduledSe
    *
    * @return a set of programRunIds for which program termination was attempted
    */
+  @VisibleForTesting
   Set<ProgramRunId> terminatePrograms() {
     // fetch all runs that are in stopping state that started at most a minute before current time.
     // Specifying the entire time range should not be worse in performance

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorServiceTest.java
@@ -73,7 +73,7 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
   }
 
   @Test
-  public void testStoppingProgramsBeyondTerminateTimeAreKilled() {
+  public void testStoppingProgramsBeyondTerminateTimeAreKilled() throws InterruptedException {
     AtomicInteger sourceId = new AtomicInteger(0);
     ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
     // set up a workflow for a program in Stopping state
@@ -102,7 +102,7 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
     programRunStatusMonitorService.startAndWait();
     Assert.assertEquals(1, latch.getCount());
     programRunStatusMonitorService.terminatePrograms();
-    Assert.assertEquals(0, latch.getCount());
+    latch.await(10, TimeUnit.SECONDS);
   }
 
   @Test
@@ -135,8 +135,7 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
     ProgramRunStatusMonitorService programRunStatusMonitorService
       = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3, 2);
     Assert.assertEquals(1, latch.getCount());
-    programRunStatusMonitorService.terminatePrograms();
-    Assert.assertEquals(1, latch.getCount());
+    Assert.assertTrue(programRunStatusMonitorService.terminatePrograms().isEmpty());
   }
 
   @Test
@@ -166,8 +165,7 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
     ProgramRunStatusMonitorService programRunStatusMonitorService
       = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3, 2);
     Assert.assertEquals(1, latch.getCount());
-    programRunStatusMonitorService.terminatePrograms();
-    Assert.assertEquals(1, latch.getCount());
+    Assert.assertTrue(programRunStatusMonitorService.terminatePrograms().isEmpty());
   }
 
   @Test
@@ -198,8 +196,7 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
     ProgramRunStatusMonitorService programRunStatusMonitorService
       = new ProgramRunStatusMonitorService(cConf, store, testService, 5, 3, 2);
     Assert.assertEquals(1, latch.getCount());
-    programRunStatusMonitorService.terminatePrograms();
-    Assert.assertEquals(1, latch.getCount());
+    Assert.assertTrue(programRunStatusMonitorService.terminatePrograms().isEmpty());
   }
 
   private ProgramRuntimeService.RuntimeInfo getRuntimeInfo(ProgramId programId, CountDownLatch latch) {


### PR DESCRIPTION
The change to kill programs asynchronously made the test flaky.
Fixed the test to properly test that no programs are killed, or
to wait until the kill completes.