### PR TITLE
[CDAP-19016] Allow configuring LevelDB max open files to prevent OOMs.

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1563,6 +1563,7 @@ public final class Constants {
   public static final String CFG_DATA_LEVELDB_COMPRESSION_ENABLED = "data.local.storage.compression.enabled";
   public static final String CFG_DATA_LEVELDB_BLOCKSIZE = "data.local.storage.blocksize";
   public static final String CFG_DATA_LEVELDB_CACHESIZE = "data.local.storage.cachesize";
+  public static final String CFG_DATA_LEVELDB_CACHESIZE_FILES = "data.local.storage.cachesize.files";
   public static final String CFG_DATA_LEVELDB_FSYNC = "data.local.storage.fsync";
   public static final String CFG_DATA_LEVELDB_COMPACTION_INTERVAL_SECONDS =
     "data.local.storage.compaction.interval.seconds";
@@ -1581,6 +1582,13 @@ public final class Constants {
   public static final long DEFAULT_DATA_LEVELDB_COMPACTION_INTERVAL_SECONDS = 3600 * 24 * 7L;
   public static final int DEFAULT_DATA_LEVELDB_COMPACTION_LEVEL_MIN = 0;
   public static final int DEFAULT_DATA_LEVELDB_COMPACTION_LEVEL_MAX = 4;
+
+  /**
+   * LevelDB substracts 10 from maxOpenFiles configuration to calculate table cache size.
+   * This constant allows us to convert it back
+   * @see org.iq80.leveldb.impl.DbImpl#DbImpl
+   */
+  public static final int DATA_LEVELDB_CACHESIZE_MAXFILES_OFFSET = 10;
 
   /**
    * Used for upgrade and backwards compatability

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -913,7 +913,19 @@
     <name>data.local.storage.cachesize</name>
     <value>104857600</value>
     <description>
-      Cache size in bytes for data fabric when in CDAP Local Sandbox
+      Cache size in bytes for data fabric when in CDAP Local Sandbox.
+      Note that this value is only used by LevelDB in the JNI mode, in java mode please use
+      data.local.storage.cachesize.files to control LevelDB cache
+    </description>
+  </property>
+
+  <property>
+    <name>data.local.storage.cachesize.files</name>
+    <value>200</value>
+    <description>
+      Cache size in number of open files when in CDAP Local Sandbox.
+      Note that this value is only used by LevelDB in java mode, in JNI mode please use
+      data.local.storage.cachesize to control LevelDB cache
     </description>
   </property>
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
@@ -69,6 +69,7 @@ public class LevelDBTableService implements AutoCloseable {
   private boolean compressionEnabled;
   private int blockSize;
   private long cacheSize;
+  private int cacheSizeFiles;
   private Duration compactionInterval;
   private int compactionLevelMin;
   private int compactionLevelMax;
@@ -109,6 +110,7 @@ public class LevelDBTableService implements AutoCloseable {
     compressionEnabled = config.getBoolean(Constants.CFG_DATA_LEVELDB_COMPRESSION_ENABLED);
     blockSize = config.getInt(Constants.CFG_DATA_LEVELDB_BLOCKSIZE, Constants.DEFAULT_DATA_LEVELDB_BLOCKSIZE);
     cacheSize = config.getLong(Constants.CFG_DATA_LEVELDB_CACHESIZE, Constants.DEFAULT_DATA_LEVELDB_CACHESIZE);
+    cacheSizeFiles = config.getInt(Constants.CFG_DATA_LEVELDB_CACHESIZE_FILES);
     writeOptions = new WriteOptions().sync(config.getBoolean(Constants.CFG_DATA_LEVELDB_FSYNC,
                                                              Constants.DEFAULT_DATA_LEVELDB_FSYNC));
     compactionInterval = Duration.ofSeconds(config.getLong(Constants.CFG_DATA_LEVELDB_COMPACTION_INTERVAL_SECONDS,
@@ -317,6 +319,7 @@ public class LevelDBTableService implements AutoCloseable {
     options.compressionType(compressionEnabled ? CompressionType.SNAPPY : CompressionType.NONE);
     options.blockSize(blockSize);
     options.cacheSize(cacheSize);
+    options.maxOpenFiles(cacheSizeFiles + Constants.DATA_LEVELDB_CACHESIZE_MAXFILES_OFFSET);
 
     // unfortunately, with the java version of leveldb, with createIfMissing set to false, factory.open will
     // see that there is no table and throw an exception, but it wont clean up after itself and will leave a
@@ -341,6 +344,7 @@ public class LevelDBTableService implements AutoCloseable {
     options.compressionType(compressionEnabled ? CompressionType.SNAPPY : CompressionType.NONE);
     options.blockSize(blockSize);
     options.cacheSize(cacheSize);
+    options.maxOpenFiles(cacheSizeFiles + Constants.DATA_LEVELDB_CACHESIZE_MAXFILES_OFFSET);
 
     DB db = factory.open(new File(dbPath), options);
     tables.put(name, db);

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTableFactory.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTableFactory.java
@@ -82,6 +82,8 @@ public final class LevelDBTableFactory implements TableFactory {
     this.dbOptions = new Options()
       .blockSize(cConf.getInt(Constants.CFG_DATA_LEVELDB_BLOCKSIZE, Constants.DEFAULT_DATA_LEVELDB_BLOCKSIZE))
       .cacheSize(cConf.getLong(Constants.CFG_DATA_LEVELDB_CACHESIZE, Constants.DEFAULT_DATA_LEVELDB_CACHESIZE))
+      .maxOpenFiles(cConf.getInt(Constants.CFG_DATA_LEVELDB_CACHESIZE_FILES)
+                      + Constants.DATA_LEVELDB_CACHESIZE_MAXFILES_OFFSET)
       .errorIfExists(false)
       .createIfMissing(true);
     ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(


### PR DESCRIPTION
Currently we have only cache size (in bytes) option, but this option is not used for Java LevelDB implementation, only JNI one. Java uses "max open files" setting to initialize file cache. Default value of 1000 is way too high as a single file can easily cache ~0.5MB of information, this produces up to 500MB caches on larger databases and we can have multiple LevelDB databases open at once