### PR TITLE
[Cherry-pick][CDAP-19016] Optimize metrics aggregation

### DIFF
--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/timeseries/EntityTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/timeseries/EntityTable.java
@@ -28,6 +28,8 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
@@ -95,10 +97,23 @@ public final class EntityTable implements Closeable {
    * @return Unique ID, it is guaranteed to be smaller than the maxId passed in constructor.
    */
   public long getId(String type, @Nullable String name) {
+    return getId(type, name, (n, cache) -> cache.get());
+  }
+
+  /**
+   * Returns an unique id for the given name.
+   * @param name The {@link EntityName} to lookup. Can be {@code null}, which is treated as a normal value.
+   * @param fastCache additional thread-local cache function that can be consulted before going to concurrent
+   *                  cache or doing database retrieval. May call provided supplier right away if thraed-local cache
+   *                  is not used.
+   * @return Unique ID, it is guaranteed to be smaller than the maxId passed in constructor.
+   */
+  public long getId(String type, @Nullable String name, BiFunction<EntityName, Supplier<Long>, Long> fastCache) {
     if (name == null) {
       return 0;
     }
-    return entityCache.getUnchecked(new EntityName(type, name)) % maxId;
+    EntityName entityName = new EntityName(type, name);
+    return fastCache.apply(entityName, () -> entityCache.getUnchecked(entityName)) % maxId;
   }
 
   /**
@@ -227,7 +242,7 @@ public final class EntityTable implements Closeable {
   /**
    * Package private class to represent an entity name, which compose of type and name.
    */
-  private static final class EntityName {
+  public static final class EntityName {
 
     private final String type;
     private final String name;

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/timeseries/FactCodec.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/timeseries/FactCodec.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
@@ -68,8 +70,23 @@ public class FactCodec {
    * @return row key
    */
   public byte[] createRowKey(List<DimensionValue> dimensionValues, String measureName, long ts, long now) {
+    return createRowKey(dimensionValues, measureName, ts, now, (name, loader) -> loader.get());
+  }
+  /**
+   * Builds row key for write and get operations.
+   * @param dimensionValues dimension values
+   * @param measureName measure name
+   * @param ts timestamp
+   * @param now current time in seconds to calculate processing lag
+   * @param fastCache additional thread-local cache function that can be consulted before going to concurrent
+   *                  cache or doing database retrieval. May call provided supplier right away if thread-local cache
+   *                  is not used.
+   * @return row key
+   */
+  public byte[] createRowKey(List<DimensionValue> dimensionValues, String measureName, long ts, long now,
+                             BiFunction<EntityTable.EntityName, Supplier<Long>, Long> fastCache) {
     // "false" would write null in dimension values as "undefined"
-    return createRowKey(dimensionValues, measureName, ts, false, false, now);
+    return createRowKey(dimensionValues, measureName, ts, false, false, now, fastCache);
   }
 
   /**
@@ -113,6 +130,12 @@ public class FactCodec {
 
   private byte[] createRowKey(List<DimensionValue> dimensionValues, String measureName, long ts, boolean stopKey,
                               boolean anyAggGroup, long now) {
+    return createRowKey(dimensionValues, measureName, ts, stopKey, anyAggGroup, now, (n, cache) -> cache.get());
+  }
+
+  private byte[] createRowKey(List<DimensionValue> dimensionValues, String measureName, long ts, boolean stopKey,
+                              boolean anyAggGroup, long now,
+                              BiFunction<EntityTable.EntityName, Supplier<Long>, Long> fastCache) {
     // Row key format:
     // <version><encoded agg group><time base><encoded dimension1 value>...
     //                                                                 <encoded dimensionN value><encoded measure name>.
@@ -125,7 +148,7 @@ public class FactCodec {
     if (anyAggGroup) {
       offset = writeAnyEncoded(rowKey, offset, stopKey);
     } else {
-      offset = writeEncodedAggGroup(dimensionValues, rowKey, offset);
+      offset = writeEncodedAggGroup(dimensionValues, rowKey, offset, fastCache);
     }
 
     long timestamp = roundToResolution(ts, now);
@@ -135,7 +158,7 @@ public class FactCodec {
     for (DimensionValue dimensionValue : dimensionValues) {
       if (dimensionValue.getValue() != null) {
         // encoded value is unique within values of the dimension name
-        offset = writeEncoded(dimensionValue.getName(), dimensionValue.getValue(), rowKey, offset);
+        offset = writeEncoded(dimensionValue.getName(), dimensionValue.getValue(), rowKey, offset, fastCache);
       } else {
         // todo: this is only applicable for constructing scan, throw smth if constructing key for writing data
         // writing "ANY" as a value
@@ -144,7 +167,7 @@ public class FactCodec {
     }
 
     if (measureName != null) {
-      writeEncoded(TYPE_MEASURE_NAME, measureName, rowKey, offset);
+      writeEncoded(TYPE_MEASURE_NAME, measureName, rowKey, offset, fastCache);
     } else {
       // todo: this is only applicable for constructing scan, throw smth if constructing key for writing data
       // writing "ANY" value
@@ -301,21 +324,23 @@ public class FactCodec {
     return splits;
   }
 
-  private int writeEncodedAggGroup(List<DimensionValue> dimensionValues, byte[] rowKey, int offset) {
+  private int writeEncodedAggGroup(List<DimensionValue> dimensionValues, byte[] rowKey, int offset,
+                                   BiFunction<EntityTable.EntityName, Supplier<Long>, Long> fastCache) {
     // aggregation group is defined by list of dimension names
     StringBuilder sb = new StringBuilder();
     for (DimensionValue dimensionValue : dimensionValues) {
       sb.append(dimensionValue.getName()).append(".");
     }
 
-    return writeEncoded(TYPE_DIMENSIONS_GROUP, sb.toString(), rowKey, offset);
+    return writeEncoded(TYPE_DIMENSIONS_GROUP, sb.toString(), rowKey, offset, fastCache);
   }
 
   /**
    * @return incremented offset
    */
-  private int writeEncoded(String type, String entity, byte[] destination, int offset) {
-    long id = entityTable.getId(type, entity);
+  private int writeEncoded(String type, String entity, byte[] destination, int offset,
+                           BiFunction<EntityTable.EntityName, Supplier<Long>, Long> fastCache) {
+    long id = entityTable.getId(type, entity, fastCache);
     int idSize = entityTable.getIdSize();
     return writeEncoded(destination, offset, id, idSize);
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/timeseries/FactTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/timeseries/FactTable.java
@@ -49,8 +49,10 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /**
@@ -113,53 +115,51 @@ public final class FactTable implements Closeable {
     this.metrics = metrics;
   }
 
-  public void add(List<Fact> facts) {
+  public int add(List<Fact> facts) {
     // Simply collecting all rows/cols/values that need to be put to the underlying table.
-    NavigableMap<byte[], NavigableMap<byte[], Long>> gaugesTable = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
-    NavigableMap<byte[], NavigableMap<byte[], Long>> incrementsTable = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+    Map<FactMeasurementKey, Long> gaugesTable = new HashMap<>();
+    Map<FactMeasurementKey, Long> incrementsTable = new HashMap<>();
     long nowSeconds = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
 
     // this map is used to store metrics which was COUNTER type, but can be considered as GAUGE, which means it is
     // guaranteed to be a new row key in the underlying table.
-    NavigableMap<byte[], NavigableMap<byte[], Long>> incGaugeTable = Maps.newTreeMap(Bytes.BYTES_COMPARATOR);
+    Map<FactMeasurementKey, Long> incGaugeTable = new HashMap<>();
     // this map is used to store the updated timestamp for the cache
     Map<FactCacheKey, Long> cacheUpdates = new HashMap<>();
     for (Fact fact : facts) {
       for (Measurement measurement : fact.getMeasurements()) {
-        byte[] rowKey = codec.createRowKey(fact.getDimensionValues(), measurement.getName(),
-                                           fact.getTimestamp(), nowSeconds);
-        byte[] column = codec.createColumn(fact.getTimestamp(), nowSeconds);
-
+        // round to the resolution timestamp
+        long tsToResolution = codec.roundToResolution(fact.getTimestamp(), nowSeconds);
+        FactMeasurementKey key = new FactMeasurementKey(tsToResolution,
+                                                        fact.getDimensionValues(),
+                                                        measurement.getName());
         if (MeasureType.COUNTER == measurement.getType()) {
           if (factCounterCache != null) {
-            // round to the resolution timestamp
-            long tsToResolution = codec.roundToResolution(fact.getTimestamp(), nowSeconds);
             FactCacheKey cacheKey = new FactCacheKey(fact.getDimensionValues(), measurement.getName());
             Long existingTs = factCounterCache.getIfPresent(cacheKey);
 
             // if there is no existing ts or existing ts is greater than or equal to the current ts, this metric value
             // cannot be considered as a gauge, and we should update the incrementsTable
             if (existingTs == null || existingTs >= tsToResolution) {
-              inc(incrementsTable, rowKey, column, measurement.getValue());
+              inc(incrementsTable, key, measurement.getValue());
               // if the current ts is greater than existing ts, then we can consider this metric as a newly seen metric
               // and perform gauge on this metric
             } else {
-              inc(incGaugeTable, rowKey, column, measurement.getValue());
+              inc(incGaugeTable, key, measurement.getValue());
             }
 
             // if there is no existing value or the current ts is greater than the existing ts, the value in the cache
             // should be updated
             if (existingTs == null || existingTs < tsToResolution) {
               cacheUpdates.compute(
-                cacheKey, (key, oldValue) -> oldValue == null || tsToResolution > oldValue ? tsToResolution : oldValue);
+                cacheKey, (k, oldValue) -> oldValue == null || tsToResolution > oldValue ? tsToResolution : oldValue);
             }
           } else {
-            inc(incrementsTable, rowKey, column, measurement.getValue());
+            inc(incrementsTable, key, measurement.getValue());
           }
         } else {
           gaugesTable
-            .computeIfAbsent(rowKey, k -> Maps.newTreeMap(Bytes.BYTES_COMPARATOR))
-            .put(column, measurement.getValue());
+            .put(key, measurement.getValue());
         }
       }
     }
@@ -168,12 +168,67 @@ public final class FactTable implements Closeable {
       gaugesTable.putAll(incGaugeTable);
       factCounterCache.putAll(cacheUpdates);
     }
+    // We use HashMap as a fast L0 cache that we create and throw out after each batch
+    Map<EntityTable.EntityName, Long> cache = new HashMap<>();
+    BiFunction<EntityTable.EntityName, Supplier<Long>, Long> cacheFunction = (name, loader) ->
+      cache.computeIfAbsent(name, nm -> loader.get());
     // todo: replace with single call, to be able to optimize rpcs in underlying table
-    timeSeriesTable.put(gaugesTable);
-    timeSeriesTable.increment(incrementsTable);
+    timeSeriesTable.put(toColumnarFormat(gaugesTable, nowSeconds, cacheFunction));
+    timeSeriesTable.increment(toColumnarFormat(incrementsTable, nowSeconds, cacheFunction));
     if (metrics != null) {
       metrics.increment(putCountMetric, gaugesTable.size());
       metrics.increment(incrementCountMetric, incrementsTable.size());
+    }
+    return gaugesTable.size() + incrementsTable.size();
+  }
+
+  private NavigableMap<byte[], NavigableMap<byte[], Long>> toColumnarFormat(
+    Map<FactMeasurementKey, Long> data, long nowSeconds,
+    BiFunction<EntityTable.EntityName, Supplier<Long>, Long> fastCache) {
+
+    return data.entrySet().stream().collect(Collectors.groupingBy(
+      entry -> codec.createRowKey(entry.getKey().dimensionValues, entry.getKey().measurementName,
+                                  entry.getKey().timestamp, nowSeconds, fastCache),
+      () -> Maps.newTreeMap(Bytes.BYTES_COMPARATOR),
+      Collectors.toMap(
+        entry -> codec.createColumn(entry.getKey().timestamp, nowSeconds),
+        entry -> entry.getValue(),
+        (u, v) -> {
+          throw new IllegalStateException(String.format("Duplicate key %s", u));
+          },
+        () -> Maps.newTreeMap(Bytes.BYTES_COMPARATOR)
+      )
+    ));
+  }
+
+  private class FactMeasurementKey {
+    private final long timestamp;
+    private final List<DimensionValue> dimensionValues;
+    private final String measurementName;
+
+    private FactMeasurementKey(long timestamp, List<DimensionValue> dimensionValues, String measurementName) {
+      this.timestamp = timestamp;
+      this.dimensionValues = dimensionValues;
+      this.measurementName = measurementName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      FactMeasurementKey that = (FactMeasurementKey) o;
+      return timestamp == that.timestamp
+        && dimensionValues.equals(that.dimensionValues)
+        && measurementName.equals(that.measurementName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(timestamp, dimensionValues, measurementName);
     }
   }
 
@@ -482,19 +537,9 @@ public final class FactTable implements Closeable {
     return new FuzzyRowFilter(ImmutableList.of(new ImmutablePair<>(startRow, fuzzyRowMask)));
   }
 
-  // todo: shouldn't we aggregate "before" writing to FactTable? We could do it really efficient outside
-  //       also: the underlying datasets will do aggregation in memory anyways
-  private static void inc(NavigableMap<byte[], NavigableMap<byte[], Long>> incrementsTable,
-                          byte[] rowKey, byte[] column, long value) {
-    NavigableMap<byte[], Long> values = incrementsTable.computeIfAbsent(rowKey,
-                                                                        k -> new TreeMap<>(Bytes.BYTES_COMPARATOR));
-    Long oldValue = values.get(column);
-    long newValue = value;
-    if (oldValue != null) {
-      newValue += oldValue;
-    }
-
-    values.put(column, newValue);
+  private static void inc(Map<FactMeasurementKey, Long> incrementsTable,
+                          FactMeasurementKey key, long value) {
+    incrementsTable.compute(key, (k, prev) -> value + (prev == null ? 0 : prev));
   }
 
   class FactCacheKey {


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/14191
Last PR for this JIRA with final set of perf optimizations:
* convert to columnar format after deduplication. Working with HashMap and Object keys are much faster than working with trees and byte arrays (and converting into those arrays).
 * add simple HashMap-based per-batch cache for entity name mapping. Takes much load from the second level concurrent LRU cache
 * add some more logging