### PR TITLE
[CDAP-19048] Add new twill runner service for launching programs inside system pods

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/FireAndForgetTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/FireAndForgetTwillRunnerService.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.distributed.remote;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.app.runtime.ProgramStateWriter;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.internal.provision.ProvisioningService;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.security.auth.AccessTokenCodec;
+import io.cdap.cdap.security.auth.TokenManager;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.api.RunId;
+import org.apache.twill.api.TwillApplication;
+import org.apache.twill.api.TwillController;
+import org.apache.twill.api.TwillRunnerService;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.filesystem.LocationFactory;
+
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
+
+/**
+ * A {@link TwillRunnerService} implementations that only launches (i.e., fire and forget) {@link TwillApplication}
+ * without monitoring.
+ */
+public class FireAndForgetTwillRunnerService extends RemoteExecutionTwillRunnerService {
+
+  @Inject
+  FireAndForgetTwillRunnerService(CConfiguration cConf, Configuration hConf,
+                                  DiscoveryServiceClient discoveryServiceClient, LocationFactory locationFactory,
+                                  ProvisioningService provisioningService, ProgramStateWriter programStateWriter,
+                                  TransactionRunner transactionRunner, AccessTokenCodec accessTokenCodec,
+                                  TokenManager tokenManager) {
+    super(cConf, hConf, discoveryServiceClient, locationFactory, provisioningService, programStateWriter,
+          transactionRunner, accessTokenCodec, tokenManager);
+  }
+
+  @Override
+  public void start() {
+    //  no need to initialize controllers as this is a fire and forget twill runner service.
+    doInitialize();
+  }
+
+  @Nullable
+  @Override
+  public TwillController lookup(String applicationName, RunId runId) {
+    throw new UnsupportedOperationException("The lookup method is not supported in FireAndForgetTwillRunnerService.");
+  }
+
+  @Override
+  public Iterable<TwillController> lookup(String applicationName) {
+    throw new UnsupportedOperationException("The lookup method is not supported in FireAndForgetTwillRunnerService.");
+  }
+
+  @Override
+  public Iterable<LiveInfo> lookupLive() {
+    throw new UnsupportedOperationException("The lookupLive method is not supported in " +
+                                              "FireAndForgetTwillRunnerService.");
+  }
+
+  @Override
+  protected RemoteExecutionTwillController getController(ProgramRunId programRunId) {
+    //no op as this is a fire and forget twill runner service
+    return null;
+  }
+
+  @Override
+  protected void addController(ProgramRunId programRunId, RemoteExecutionTwillController controller) {
+    //no op as this is a fire and forget twill runner service
+  }
+
+  @Override
+  protected void monitorController(ProgramRunId programRunId, CompletableFuture<Void> startupTaskCompletion,
+                                   RemoteExecutionTwillController controller,
+                                   RemoteExecutionService remoteExecutionService) {
+
+    //no need to monitor the controller as this is a fire and forget twill runner service.
+    controller.release();
+  }
+
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerTwillRunnable.java
@@ -26,6 +26,7 @@ import com.google.inject.Binder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
+import com.google.inject.Scopes;
 import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
@@ -61,6 +62,8 @@ import io.cdap.cdap.data2.transaction.TransactionSystemClientService;
 import io.cdap.cdap.explore.guice.ExploreClientModule;
 import io.cdap.cdap.internal.app.namespace.LocalStorageProviderNamespaceAdmin;
 import io.cdap.cdap.internal.app.namespace.StorageProviderNamespaceAdmin;
+import io.cdap.cdap.internal.app.runtime.distributed.remote.FireAndForgetTwillRunnerService;
+import io.cdap.cdap.internal.app.runtime.distributed.remote.RemoteExecutionTwillRunnerService;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
 import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
@@ -160,7 +163,15 @@ public class SystemWorkerTwillRunnable extends AbstractTwillRunnable {
             bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
           }
         }, new DistributedArtifactManagerModule()),
-      new ProgramRunnerRuntimeModule().getDistributedModules(true),
+      Modules.override(new ProgramRunnerRuntimeModule().getDistributedModules(true))
+        .with(new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(RemoteExecutionTwillRunnerService.class)
+              .to(FireAndForgetTwillRunnerService.class)
+              .in(Scopes.SINGLETON);
+          }
+        }),
       new SecureStoreClientModule(),
       new AbstractModule() {
         @Override


### PR DESCRIPTION
Current state: when a program (i.e., workflow) is launched from system pods, it uses RemoteExecutionTwillRunnerService to launch the program. This result in multiple issues:

1. Upon twill controller terminating (e.g., program finishes), RemoteExecutionService running inside system pod will notices it, and sends a FAILED message to TMS. This results in appfabric receiving a FAILED message when a program finishes and has transitioned into COMPLETED. Thus, this transition is shown as a WARN in the logs (see JIRA ticket for details).
2. twill controllers are added to an in-memory map inside RemoteExecutionTwillRunnerService, but are never removed as system pod does not get notified when a program has finished its execution.
3. When RemoteExecutionTwillRunnerService is initialized inside system pods, it tries to initialize controllers for existing programs.

This PR addresses the above issues by introducing a new class that extends RemoteExecutionTwillRunnerService and overrides specific methods change the logic in order to resolve the above issues. 