### PR TITLE
[CDAP-19058] Do not inherit Java Opts from Parent Launching Pod

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -244,6 +244,12 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
             }
           }
 
+          // Set JVM options for preview runner and artifact localizer
+          twillPreparer.setJVMOptions(PreviewRunnerTwillRunnable.class.getSimpleName(),
+                                      cConf.get(Constants.Preview.CONTAINER_JVM_OPTS));
+          twillPreparer.setJVMOptions(ArtifactLocalizerTwillRunnable.class.getSimpleName(),
+                                      cConf.get(Constants.ArtifactLocalizer.CONTAINER_JVM_OPTS));
+
           activeController = twillPreparer.start(5, TimeUnit.MINUTES);
           activeController.onRunning(() -> deleteDir(runDir), Threads.SAME_THREAD_EXECUTOR);
           activeController.onTerminated(() -> deleteDir(runDir), Threads.SAME_THREAD_EXECUTOR);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/LauncherUtils.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/LauncherUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.program;
+
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import org.apache.twill.api.TwillPreparer;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Utility class for launching twill runnables.
+ */
+public class LauncherUtils {
+  /**
+   * Sets the JVM options overrides for all twill runnables with an override config set.
+   * @param cConf The configuration to use
+   * @param twillPreparer The twill preparer to use
+   * @param runnables The set of runnables to override
+   */
+  public static void overrideJVMOpts(CConfiguration cConf, TwillPreparer twillPreparer, Set<String> runnables) {
+    Map<String, String> jvmOverrideConfig = cConf.getPropsWithPrefix(Constants.AppFabric.PROGRAM_JVM_OPTS_PREFIX);
+    for (Map.Entry<String, String> jvmOverrideEntry : jvmOverrideConfig.entrySet()) {
+      String jvmOverrideKey = jvmOverrideEntry.getKey();
+      if (runnables.contains(jvmOverrideKey)) {
+        twillPreparer.setJVMOptions(jvmOverrideKey, jvmOverrideEntry.getValue());
+      }
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -47,6 +47,7 @@ import io.cdap.cdap.common.twill.TwillAppLifecycleEventHandler;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.data2.util.hbase.HBaseTableUtilFactory;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
+import io.cdap.cdap.internal.app.program.LauncherUtils;
 import io.cdap.cdap.internal.app.runtime.BasicArguments;
 import io.cdap.cdap.internal.app.runtime.LocalizationUtils;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
@@ -279,8 +280,10 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
         twillPreparer.withConfiguration(twillConfigs);
 
         // Setup per runnable configurations
+        Set<String> runnables = new HashSet<>();
         for (Map.Entry<String, RunnableDefinition> entry : launchConfig.getRunnables().entrySet()) {
           String runnable = entry.getKey();
+          runnables.add(runnable);
           RunnableDefinition runnableDefinition = entry.getValue();
           if (runnableDefinition.getMaxRetries() != null) {
             twillPreparer.withMaxRetries(runnable, runnableDefinition.getMaxRetries());
@@ -321,6 +324,9 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
         if (!Strings.isNullOrEmpty(jvmOpts)) {
           twillPreparer.addJVMOptions(jvmOpts);
         }
+
+        // Overwrite JVM options if specified
+        LauncherUtils.overrideJVMOpts(cConf, twillPreparer, runnables);
 
         if (logbackURI != null) {
           twillPreparer.addJVMOptions("-Dlogback.configurationFile=" + LOGBACK_FILE_NAME);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
@@ -203,6 +203,12 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
             }
           }
 
+          // Set JVM options for task worker and artifact localizer
+          twillPreparer.setJVMOptions(TaskWorkerTwillRunnable.class.getSimpleName(),
+                                      cConf.get(Constants.TaskWorker.CONTAINER_JVM_OPTS));
+          twillPreparer.setJVMOptions(ArtifactLocalizerTwillRunnable.class.getSimpleName(),
+                                      cConf.get(Constants.ArtifactLocalizer.CONTAINER_JVM_OPTS));
+
           activeController = twillPreparer.start(5, TimeUnit.MINUTES);
           activeController.onRunning(() -> deleteDir(runDir), Threads.SAME_THREAD_EXECUTOR);
           activeController.onTerminated(() -> deleteDir(runDir), Threads.SAME_THREAD_EXECUTOR);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceLauncher.java
@@ -165,6 +165,10 @@ public class SystemWorkerServiceLauncher extends AbstractScheduledService {
                                                                                               secretPath));
           }
 
+          // Set JVM options for system worker
+          twillPreparer.setJVMOptions(SystemWorkerTwillRunnable.class.getSimpleName(),
+                                      cConf.get(Constants.SystemWorker.CONTAINER_JVM_OPTS));
+
           activeController = twillPreparer.start(5, TimeUnit.MINUTES);
           activeController.onRunning(() -> deleteDir(runDir), Threads.SAME_THREAD_EXECUTOR);
           activeController.onTerminated(() -> deleteDir(runDir), Threads.SAME_THREAD_EXECUTOR);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/program/LauncherUtilsTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/program/LauncherUtilsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.program;
+
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import org.apache.twill.api.TwillPreparer;
+import org.junit.Test;
+import org.mockito.Matchers;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link LauncherUtils}.
+ */
+public class LauncherUtilsTest {
+  @Test
+  public void testOverrideJVMOpts() {
+    String testRunnableName = "test-runnable";
+    String testJVMOpts = "-DtestOptions";
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.AppFabric.PROGRAM_JVM_OPTS + "." + testRunnableName, testJVMOpts);
+    TwillPreparer mockTwillPreparer = mock(TwillPreparer.class);
+    Set<String> testRunnables = Collections.singleton(testRunnableName);
+    LauncherUtils.overrideJVMOpts(cConf, mockTwillPreparer, testRunnables);
+    verify(mockTwillPreparer, times(1)).setJVMOptions(testRunnableName, testJVMOpts);
+  }
+
+  @Test
+  public void testOverrideJVMOptsDifferentRunnable() {
+    String testRunnableName = "test-runnable";
+    String testJVMOpts = "-DtestOptions";
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.AppFabric.PROGRAM_JVM_OPTS + "." + testRunnableName, testJVMOpts);
+    TwillPreparer mockTwillPreparer = mock(TwillPreparer.class);
+    Set<String> testRunnables = Collections.singleton("other-test-runnable");
+    LauncherUtils.overrideJVMOpts(cConf, mockTwillPreparer, testRunnables);
+    verify(mockTwillPreparer, never()).setJVMOptions(Matchers.any(), Matchers.any());
+  }
+
+  @Test
+  public void testOverrideJVMOptsNoConfig() {
+    String testRunnableName = "test-runnable-2";
+    String testJVMOpts = "-DtestOptions";
+    CConfiguration cConf = CConfiguration.create();
+    TwillPreparer mockTwillPreparer = mock(TwillPreparer.class);
+    Set<String> testRunnables = Collections.singleton(testRunnableName);
+    LauncherUtils.overrideJVMOpts(cConf, mockTwillPreparer, testRunnables);
+    verify(mockTwillPreparer, never()).setJVMOptions(Matchers.any(), Matchers.any());
+  }
+
+  @Test
+  public void testOverrideJVMOptsMultiplerunnables() {
+    String testRunnableName1 = "test-runnable-1";
+    String testJVMOpts1 = "-DtestOptions";
+    String testRunnableName2 = "test-runnable-2";
+    String testJVMOpts2 = "-DtestOptions -DsomeOtherTestOptions";
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.AppFabric.PROGRAM_JVM_OPTS + "." + testRunnableName1, testJVMOpts1);
+    cConf.set(Constants.AppFabric.PROGRAM_JVM_OPTS + "." + testRunnableName2, testJVMOpts2);
+    TwillPreparer mockTwillPreparer = mock(TwillPreparer.class);
+    Set<String> testRunnables = new HashSet<>();
+    testRunnables.add(testRunnableName1);
+    testRunnables.add(testRunnableName2);
+    LauncherUtils.overrideJVMOpts(cConf, mockTwillPreparer, testRunnables);
+    verify(mockTwillPreparer, times(1)).setJVMOptions(testRunnableName1, testJVMOpts1);
+    verify(mockTwillPreparer, times(1)).setJVMOptions(testRunnableName2, testJVMOpts2);
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -217,6 +217,7 @@ public final class Constants {
     public static final String TEMP_DIR = "app.temp.dir";
     public static final String REST_PORT = "app.rest.port";
     public static final String PROGRAM_JVM_OPTS = "app.program.jvm.opts";
+    public static final String PROGRAM_JVM_OPTS_PREFIX = "app.program.jvm.opts.";
     public static final String BACKLOG_CONNECTIONS = "app.connection.backlog";
     public static final String STREAMING_BATCH_SIZE = "app.streaming.batch.size";
     public static final String EXEC_THREADS = "app.exec.threads";
@@ -407,6 +408,7 @@ public final class Constants {
     public static final String CONTAINER_MEMORY_MULTIPLIER = "preview.runner.container.memory.multiplier";
     public static final String CONTAINER_HEAP_RESERVED_RATIO = "preview.runner.container.java.heap.memory.ratio";
     public static final String CONTAINER_PRIORITY_CLASS_NAME = "preview.runner.container.priority.class.name";
+    public static final String CONTAINER_JVM_OPTS = "preview.runner.container.jvm.opts";
 
     public static final String ARTIFACT_LOCALIZER_ENABLED = "preview.runner.artifact.localizer.enabled";
   }
@@ -453,6 +455,7 @@ public final class Constants {
     public static final String CONTAINER_RUN_AS_USER = "task.worker.container.run.as.user";
     public static final String CONTAINER_RUN_AS_GROUP = "task.worker.container.run.as.group";
     public static final String CONTAINER_DISK_READONLY = "task.worker.container.disk.readonly";
+    public static final String CONTAINER_JVM_OPTS = "task.worker.container.jvm.opts";
 
     /**
      * Task worker http handler configuration
@@ -475,6 +478,7 @@ public final class Constants {
     public static final String CONTAINER_MEMORY_MB = "system.worker.container.memory.mb";
     public static final String CONTAINER_CORES = "system.worker.container.num.cores";
     public static final String CONTAINER_COUNT = "system.worker.container.count";
+    public static final String CONTAINER_JVM_OPTS = "system.worker.container.jvm.opts";
     public static final String LOCAL_DATA_DIR = "task.worker.local.data.dir";
     public static final String CLEANUP_EXECUTOR_SERVICE_BINDING = "cleanup.executor.service";
     public static final String CLEANUP_THREADS = "system.worker.cleanup.threads";
@@ -504,6 +508,7 @@ public final class Constants {
      */
     public static final String CONTAINER_MEMORY_MB = "artifact.localizer.container.memory.mb";
     public static final String CONTAINER_CORES = "artifact.localizer.container.num.cores";
+    public static final String CONTAINER_JVM_OPTS = "artifact.localizer.container.jvm.opts";
 
     /**
      * Artifact localizer http handler configuration

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3470,6 +3470,14 @@
   </property>
 
   <property>
+    <name>preview.runner.container.jvm.opts</name>
+    <value>-XX:+UseG1GC -XX:+ExitOnOutOfMemoryError</value>
+    <description>
+      JVM opts for preview runner containers.
+    </description>
+  </property>
+
+  <property>
     <name>preview.runner.artifact.localizer.enabled</name>
     <value>false</value>
     <description>
@@ -4848,6 +4856,14 @@
     </description>
   </property>
 
+  <property>
+    <name>task.worker.container.jvm.opts</name>
+    <value>-XX:+UseG1GC -XX:+ExitOnOutOfMemoryError</value>
+    <description>
+      JVM opts for task worker containers.
+    </description>
+  </property>
+
   <!-- System pods Configuration  -->
   <property>
     <name>system.worker.pool.enable</name>
@@ -4958,6 +4974,22 @@
     <value>1</value>
     <description>
       The number of boss threads for the artifact localizer.
+    </description>
+  </property>
+
+  <property>
+    <name>artifact.localizer.container.jvm.opts</name>
+    <value>-XX:+UseG1GC -XX:+ExitOnOutOfMemoryError</value>
+    <description>
+      JVM opts for artifact localizer containers.
+    </description>
+  </property>
+
+  <property>
+    <name>file.localizer.container.jvm.opts</name>
+    <value>-XX:+UseG1GC -XX:+ExitOnOutOfMemoryError</value>
+    <description>
+      JVM opts for file localizer containers.
     </description>
   </property>
 

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.k8s.runtime;
 
+import io.cdap.cdap.master.environment.k8s.PodInfo;
+import io.kubernetes.client.openapi.models.V1PodSecurityContext;
 import org.apache.twill.api.AbstractTwillRunnable;
 import org.apache.twill.api.ResourceSpecification;
 import org.apache.twill.api.TwillSpecification;
@@ -25,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.URI;
+import java.util.Collections;
 
 /**
  * Tests for {@link KubeTwillPreparer}.
@@ -57,8 +60,15 @@ public class KubeTwillPreparerTest {
       .anyOrder()
       .build();
 
+    PodInfo podInfo = new PodInfo("test-pod-name", "test-pod-dir", "test-label-file.txt",
+                                  "test-name-file.txt", "test-pod-uid", "test-uid-file.txt",
+                                  "test-pod-namespace", Collections.emptyMap(), Collections.emptyList(),
+                                  "test-pod-service-account", "test-pod-runtime-class",
+                                  Collections.emptyList(), "test-pod-container-label", "test-pod-container-image",
+                                  Collections.emptyList(), Collections.emptyList(), new V1PodSecurityContext(),
+                                  "test-pod-image-pull-policy");
     KubeTwillPreparer preparer = new KubeTwillPreparer(null, null, "default",
-                                                       null, twillSpecification, null, null,
+                                                       podInfo, twillSpecification, null, null,
                                                        null, null, null);
 
     // test catching main runnable depends on itself


### PR DESCRIPTION
Support overriding Java opts from CConf instead of directly inheriting Java opts from parent pod.