### PR TITLE
[CDAP-19125]Added additonal metrics for pushdown execution

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLWriteResult.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/request/SQLWriteResult.java
@@ -19,6 +19,8 @@ package io.cdap.cdap.etl.api.engine.sql.request;
 import io.cdap.cdap.api.annotation.Beta;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * A request to perform write operation
@@ -28,25 +30,47 @@ public class SQLWriteResult implements Serializable {
   private final String datasetName;
   private final SQLWriteOperationResult result;
   private final long numRecords;
+  private final Map<String, Long> metrics;
 
   private static final long serialVersionUID = 7843665889511527477L;
 
   /**
    * Creates a new SQLWriteResult instance
-   * @param datasetName The name of the dataset (stage) that is being written
-   * @param result result of this write operation
-   * @param numRecords number of written records (if any)
+   *
+   * @param datasetName The name of the dataset (stage) that is being written.
+   * @param result      result of this write operation.
+   * @param numRecords  number of written records (if any).
    */
   public SQLWriteResult(String datasetName, SQLWriteOperationResult result, long numRecords) {
     this.datasetName = datasetName;
     this.result = result;
     this.numRecords = numRecords;
+    this.metrics = Collections.emptyMap();
+  }
+
+  /**
+   * Creates a new SQLWriteResult instance
+   *
+   * @param datasetName The name of the dataset (stage) that is being written.
+   * @param result      result of this write operation.
+   * @param numRecords  number of written records (if any).
+   * @param metrics  map containing metrics from the write operation.
+   */
+  public SQLWriteResult(String datasetName,
+                        SQLWriteOperationResult result,
+                        long numRecords,
+                        Map<String, Long> metrics) {
+    this.datasetName = datasetName;
+    this.result = result;
+    this.numRecords = numRecords;
+    this.metrics = metrics;
   }
 
   /**
    * Utility method to create an instance with a successful result
+   *
    * @param datasetName dataset name
-   * @param numRecords number of written records
+   * @param numRecords  number of written records
    * @return new instance with a Success result and the number of specified records.
    */
   public static SQLWriteResult success(String datasetName, long numRecords) {
@@ -54,7 +78,20 @@ public class SQLWriteResult implements Serializable {
   }
 
   /**
+   * Utility method to create an instance with a successful result
+   *
+   * @param datasetName dataset name.
+   * @param numRecords  number of written records.
+   * @param metrics  map containing metrics from the write operation.
+   * @return new instance with a Success result and the number of specified records.
+   */
+  public static SQLWriteResult success(String datasetName, long numRecords, Map<String, Long> metrics) {
+    return new SQLWriteResult(datasetName, SQLWriteOperationResult.SUCCESS, numRecords, metrics);
+  }
+
+  /**
    * Utility method to create an instance with an unsupported result
+   *
    * @param datasetName dataset name
    * @return new instance with an unsupported result status and no output records.
    */
@@ -64,11 +101,23 @@ public class SQLWriteResult implements Serializable {
 
   /**
    * Utility method to create an instance with a failed result
+   *
    * @param datasetName dataset name
    * @return new instance with an unsupported failed status and no output records.
    */
   public static SQLWriteResult faiure(String datasetName) {
     return new SQLWriteResult(datasetName, SQLWriteOperationResult.FAILURE, 0);
+  }
+
+  /**
+   * Utility method to create an instance with a failed result
+   *
+   * @param datasetName dataset name.
+   * @param metrics  map containing metrics from the write operation.
+   * @return new instance with an unsupported failed status and no output records.
+   */
+  public static SQLWriteResult faiure(String datasetName, Map<String, Long> metrics) {
+    return new SQLWriteResult(datasetName, SQLWriteOperationResult.FAILURE, 0, metrics);
   }
 
   /**
@@ -94,10 +143,20 @@ public class SQLWriteResult implements Serializable {
 
   /**
    * Used to check if the write operation was successful
+   *
    * @return true if successful, false otherwise.
    */
   public boolean isSuccessful() {
     return result == SQLWriteOperationResult.SUCCESS;
+  }
+
+  /**
+   * Get metrics for the write operation
+   *
+   * @return map containing metrics for the write operation.
+   */
+  public Map<String, Long> getMetrics() {
+    return metrics;
   }
 
   public enum SQLWriteOperationResult {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
@@ -72,9 +72,13 @@ public final class Constants {
     public static final String RECORDS_OUT = "records.out";
     public static final String RECORDS_ERROR = "records.error";
     public static final String RECORDS_ALERT = "records.alert";
+    public static final String RECORDS_PUSH = "records.push";
+    public static final String RECORDS_PULL = "records.pull";
     public static final String AGG_GROUPS = "aggregator.groups";
     public static final String JOIN_KEYS = "joiner.keys";
     public static final String DRAFT_COUNT = "draft.count";
+    public static final String STAGES_COUNT = "stages.count";
+    public static final String STAGES_COUNT_PREFIX = STAGES_COUNT + ".";
 
     public static final class Connection {
       public static final String CONNECTION_COUNT = "connections.count";

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/engine/SQLEngineJobTypeMetric.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/engine/SQLEngineJobTypeMetric.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,26 +14,23 @@
  * the License.
  */
 
-package io.cdap.cdap.etl.api.engine.sql.dataset;
-
-import java.util.Collections;
-import java.util.Map;
+package io.cdap.cdap.etl.engine;
 
 /**
- * Represents a dataset that resides in a SQL engine outside of spark.
+ * Enum used to specify metrics for SQL engine job types
  */
-public interface SQLDataset extends SQLDatasetDescription {
+public enum SQLEngineJobTypeMetric {
+  JOIN("join"),
+  TRANSFORM("transform"),
+  WRITE("join");
 
-  /**
-   * Get the number of rows stored in this dataset.
-   */
-  long getNumRows();
+  private final String type;
 
-  /**
-   * Returns additional metrics that should be logged for this dataset.
-   */
-  default Map<String, Long> getMetrics() {
-    return Collections.emptyMap();
+  SQLEngineJobTypeMetric(String type) {
+    this.type = type;
   }
 
+  public String getType() {
+    return this.type;
+  }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSparkPipelineDriver.java
@@ -217,7 +217,8 @@ public class BatchSparkPipelineDriver extends SparkPipelineRunner implements Jav
                                                                     sec.getNamespace());
           Object instance = pluginInstantiator.newPluginInstance(sqlEngineStage,
                                                                  macroEvaluator);
-          sqlEngineAdapter = new BatchSQLEngineAdapter((SQLEngine<?, ?, ?, ?>) instance,
+          sqlEngineAdapter = new BatchSQLEngineAdapter(phaseSpec.getSQLEngineStageSpec().getPlugin().getName(),
+                                                       (SQLEngine<?, ?, ?, ?>) instance,
                                                        sec,
                                                        jsc,
                                                        collectors);

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSQLEngine.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSQLEngine.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -135,6 +136,11 @@ public class MockSQLEngine extends BatchSQLEngine<Object, Object, Object, Object
       @Override
       public long getNumRows() {
         return 1;
+      }
+
+      @Override
+      public Map<String, Long> getMetrics() {
+        return Collections.singletonMap("additional_metric_join", 123L);
       }
     };
   }

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSQLEngineWithCapabilities.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSQLEngineWithCapabilities.java
@@ -168,6 +168,11 @@ public class MockSQLEngineWithCapabilities extends BatchSQLEngine<Object, Object
       public long getNumRows() {
         return 1;
       }
+
+      @Override
+      public Map<String, Long> getMetrics() {
+        return Collections.singletonMap("additional_metric_join", 123L);
+      }
     };
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSQLEngineWithStageSettings.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/batch/MockSQLEngineWithStageSettings.java
@@ -143,6 +143,11 @@ public class MockSQLEngineWithStageSettings extends BatchSQLEngine<Object, Objec
       public long getNumRows() {
         return 1;
       }
+
+      @Override
+      public Map<String, Long> getMetrics() {
+        return Collections.singletonMap("additional_metric_consume", 123L);
+      }
     };
   }
 


### PR DESCRIPTION
Added ability for SQL Dataset instances to expose additional metrics that we will log.

Metrics are prefixed with `user.pushdown.<the_plugin_name>.<the_metric>`

For example, for BQ, we would have something like: 

```
user.pushdown.BigQueryPushdownEngine.records.push -> Pushed records into the engine
user.pushdown.BigQueryPushdownEngine.records.pull -> Pulled records from the engine
user.pushdown.BigQueryPushdownEngine.records.in -> number of input records into SQL operations
user.pushdown.BigQueryPushdownEngine.records.out -> number of output records from SQL operations
```

