### PR TITLE
[CDAP-19129] Add ServiceLoader configuration for GCPRemoteAuthenticator

### DIFF
--- a/cdap-authenticator-ext-gcp/src/main/resources/resources/META-INF/services/io.cdap.cdap.security.spi.authenticator.RemoteAuthenticator
+++ b/cdap-authenticator-ext-gcp/src/main/resources/resources/META-INF/services/io.cdap.cdap.security.spi.authenticator.RemoteAuthenticator
@@ -1,0 +1,17 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+io.cdap.cdap.authenticator.gcp.GCPRemoteAuthenticator


### PR DESCRIPTION
At the moment, the extension loader is not finding the GCPRemoteAuthenticator class. This PR adds the ServiceLoader definition for that class in META-INF.

See [CDAP-19129](https://cdap.atlassian.net/browse/CDAP-19129) for details.