### PR TITLE
[CDAP-19062] Changes to run tethered programs on different namespaces

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
@@ -325,7 +325,7 @@ public class DistributedProgramContainerModule extends AbstractModule {
     protected void configure() {
       MasterEnvironment masterEnv = MasterEnvironments.getMasterEnvironment();
 
-      if (clusterMode == ClusterMode.ON_PREMISE && tethered && masterEnv != null) {
+      if (clusterMode == ClusterMode.ISOLATED && tethered && masterEnv != null) {
         bind(MasterEnvironment.class).toInstance(masterEnv);
         bind(ProgramStateWriter.class).toProvider(ProgramStateWriterProvider.class);
       } else {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java
@@ -66,7 +66,6 @@ import io.cdap.cdap.internal.app.runtime.artifact.Artifacts;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepositoryReader;
 import io.cdap.cdap.proto.id.ArtifactId;
-import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import io.cdap.common.http.HttpRequestConfig;
@@ -422,10 +421,6 @@ public class InMemoryProgramRunDispatcher implements ProgramRunDispatcher {
       try {
         ArtifactId artifactId = Artifacts.toProtoArtifactId(programId.getNamespaceId(), plugin.getArtifactId());
         String peer = options.getArguments().getOption(ProgramOptionConstants.PEER_NAME);
-        if (peer != null) {
-          String peerNamespace = options.getArguments().getOption(ProgramOptionConstants.PEER_NAMESPACE);
-          artifactId = Artifacts.toProtoArtifactId(new NamespaceId(peerNamespace), plugin.getArtifactId());
-        }
         ArtifactDetail artifactDetail = getArtifactDetail(artifactId);
         copyArtifact(artifactId, artifactDetail, destFile, isDistributed, peer != null);
       } catch (ArtifactNotFoundException e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -155,10 +155,9 @@ public final class ProgramOptionConstants {
   public static final String PEER_NAME = "peer";
 
   /**
-   * Option for name of tethered peer namespace, if any, that has initiated the program run. This is needed for
-   * artifact fetching
+   * Option for name of the runtime namespace for the tethered program run.
    */
-  public static final String PEER_NAMESPACE = "peerNamespace";
+  public static final String RUNTIME_NAMESPACE = "runtimeNamespace";
 
   /**
    * Option for a URI to a directory containing additional resources needed for the program run. This is needed for

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunner.java
@@ -364,7 +364,12 @@ public abstract class DistributedProgramRunner implements ProgramRunner, Program
           .setClassLoader(MainClassLoader.class.getName());
 
         // Add namespace details
-        twillPreparer.withConfiguration(getNamespaceConfigs(program.getNamespaceId()));
+        if (options.getArguments().hasOption(ProgramOptionConstants.RUNTIME_NAMESPACE)) {
+          String runtimeNamespace = options.getArguments().getOption(ProgramOptionConstants.RUNTIME_NAMESPACE);
+          twillPreparer.withConfiguration(getNamespaceConfigs(runtimeNamespace));
+        } else {
+          twillPreparer.withConfiguration(getNamespaceConfigs(program.getNamespaceId()));
+        }
 
         TwillController twillController;
         // Change the context classloader to the combine classloader of this ProgramRunner and

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
@@ -345,8 +345,7 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
                                                      ApplicationSpecification.class);
     ProgramOptions programOpts = GSON.fromJson(files.get(DistributedProgramRunner.PROGRAM_OPTIONS_FILE_NAME),
                                                ProgramOptions.class);
-    ProgramId programId = new ProgramId(message.getRuntimeNamespace(), programOpts.getProgramId().getApplication(),
-                                        programOpts.getProgramId().getType(), programOpts.getProgramId().getProgram());
+    ProgramId programId = programOpts.getProgramId();
     ProgramRunId programRunId = programId.run(programOpts.getArguments().getOption(ProgramOptionConstants.RUN_ID));
     ProgramDescriptor programDescriptor = new ProgramDescriptor(programId, appSpec);
 
@@ -364,7 +363,7 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
     // Remove the plugin artifact archive argument from options and let the program runner recreate it
     systemArgs.remove(ProgramOptionConstants.PLUGIN_ARCHIVE);
     systemArgs.put(ProgramOptionConstants.PEER_NAME, peerName);
-    systemArgs.put(ProgramOptionConstants.PEER_NAMESPACE, message.getPeerNamespace());
+    systemArgs.put(ProgramOptionConstants.RUNTIME_NAMESPACE, message.getRuntimeNamespace());
     systemArgs.put(ProgramOptionConstants.PROGRAM_RESOURCE_URI, programDir.toURI().toString());
     systemArgs.put(ProgramOptionConstants.CLUSTER_MODE, ClusterMode.ISOLATED.name());
     SystemArguments.addProfileArgs(systemArgs, Profile.NATIVE);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/proto/v1/TetheringLaunchMessage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/proto/v1/TetheringLaunchMessage.java
@@ -34,15 +34,12 @@ public class TetheringLaunchMessage {
   private final Map<String, String> cConfEntries;
   // Namespace to run program on
   private final String runtimeNamespace;
-  // Namespace of the peer that initiated the program run
-  private final String peerNamespace;
 
   private TetheringLaunchMessage(Map<String, byte[]> localizeFiles, Map<String, String> cConfEntries,
-                                 String runtimeNamespace, String peerNamespace) {
+                                 String runtimeNamespace) {
     this.localizeFiles = localizeFiles;
     this.cConfEntries = cConfEntries;
     this.runtimeNamespace = runtimeNamespace;
-    this.peerNamespace = peerNamespace;
   }
 
   public Map<String, byte[]> getFiles() {
@@ -57,17 +54,12 @@ public class TetheringLaunchMessage {
     return runtimeNamespace;
   }
 
-  public String getPeerNamespace() {
-    return peerNamespace;
-  }
-
   @Override
   public String toString() {
     return "TetheringLaunchMessage{" +
       "localizeFiles='" + localizeFiles + '\'' +
       ", cConfEntries=" + cConfEntries +
       ", runtimeNamespace=" + runtimeNamespace +
-      ", peerNamespace=" + peerNamespace +
       '}';
   }
 
@@ -83,8 +75,7 @@ public class TetheringLaunchMessage {
     TetheringLaunchMessage that = (TetheringLaunchMessage) o;
     return Objects.equals(localizeFiles, that.localizeFiles) &&
       Objects.equals(cConfEntries, that.cConfEntries) &&
-      Objects.equals(runtimeNamespace, that.runtimeNamespace) &&
-      Objects.equals(peerNamespace, that.peerNamespace);
+      Objects.equals(runtimeNamespace, that.runtimeNamespace);
   }
 
   @Override
@@ -100,7 +91,6 @@ public class TetheringLaunchMessage {
     private final Map<String, byte[]> localizeFiles = new HashMap<>();
     private final Map<String, String> cConfEntries = new HashMap<>();
     private String runtimeNamespace;
-    private String peerNamespace;
 
     public Builder addFileNames(String fileName) {
       this.fileNames.add(fileName);
@@ -119,16 +109,12 @@ public class TetheringLaunchMessage {
       this.runtimeNamespace = runtimeNamespace;
     }
 
-    public void addPeerNamespace(String peerNamespace) {
-      this.peerNamespace = peerNamespace;
-    }
-
     public Set<String> getFileNames() {
       return fileNames;
     }
 
     public TetheringLaunchMessage build() {
-      return new TetheringLaunchMessage(localizeFiles, cConfEntries, runtimeNamespace, peerNamespace);
+      return new TetheringLaunchMessage(localizeFiles, cConfEntries, runtimeNamespace);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManager.java
@@ -192,7 +192,6 @@ public class TetheringRuntimeJobManager implements RuntimeJobManager {
     }
 
     builder.addRuntimeNamespace(tetheredNamespace);
-    builder.addPeerNamespace(runtimeJobInfo.getProgramRunInfo().getNamespace());
     return builder.build();
   }
 

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -141,6 +141,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String SPARK_CONFIGS_PREFIX = "spark.kubernetes";
   private static final String SPARK_KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label.";
   private static final String SPARK_KUBERNETES_EXECUTOR_LABEL_PREFIX = "spark.kubernetes.executor.label.";
+  private static final String SPARK_KUBERNETES_NAMESPACE_LABEL = "spark.kubernetes.namespace";
   @VisibleForTesting
   static final String SPARK_KUBERNETES_DRIVER_POD_TEMPLATE = "spark.kubernetes.driver.podTemplateFile";
   @VisibleForTesting
@@ -391,6 +392,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
                      getDriverPodTemplate(podInfo, sparkSubmitContext).getAbsolutePath());
     sparkConfMap.put(SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE, getExecutorPodTemplateFile().getAbsolutePath());
     sparkConfMap.put(SPARK_KUBERNETES_METRICS_PROPERTIES_CONF, "/opt/spark/work-dir/metrics.properties");
+    sparkConfMap.put(SPARK_KUBERNETES_NAMESPACE_LABEL, podInfo.getNamespace());
 
     // Add spark pod labels. This will be same as job labels
     populateLabels(sparkConfMap);
@@ -489,6 +491,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
         Matcher namespaceMatcher = NAMESPACE_LABEL_PATTERN.matcher(line);
         if (namespaceMatcher.matches()) {
           namespace = namespaceMatcher.group(2);
+          podLabels.put(namespaceMatcher.group(1), namespaceMatcher.group(2));
         }
         line = reader.readLine();
       }


### PR DESCRIPTION
- Use the same program namespace across tethered instances and only reference the runtime Kubernetes namespace during actual program run. This is to allow logs/metrics to be correctly sent back to the tethering server
- Update Spark pods to use runtime Kubernetes namespace
- Remove storing the initiating tethered namespace for artifact fetching use