### PR TITLE
Added small fix to prevent Spark caching for SQL engine collections

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkPipelineRunner.java
@@ -965,8 +965,17 @@ public abstract class SparkPipelineRunner {
    * will be called on stages in topological order, where any parent that is a joiner will be included in the
    * provided shufflers set.
    */
-  private boolean shouldCache(Dag dag, String stageName, Set<String> branchers, Set<String> shufflers) {
+  private boolean shouldCache(Dag dag,
+                              String stageName,
+                              Set<String> branchers,
+                              Set<String> shufflers,
+                              SparkCollection<RecordInfo<Object>> stageData) {
     if (!branchers.contains(stageName) || shufflers.contains(stageName)) {
+      return false;
+    }
+
+    // Skip caching for SQL engine collections
+    if (stageData instanceof SQLBackedCollection) {
       return false;
     }
 
@@ -1004,7 +1013,7 @@ public abstract class SparkPipelineRunner {
                                             boolean hasErrors, boolean hasAlerts) {
     builder.setRawData(stageData);
 
-    if (shouldCache(dag, stageSpec.getName(), branchers, shufflers)) {
+    if (shouldCache(dag, stageSpec.getName(), branchers, shufflers, stageData)) {
       stageData = stageData.cache();
     }
 


### PR DESCRIPTION
We should not cache records in Spark that have been executed in the SQL engine. Doing this forces an unnecessary pull to Spark.