### PR TITLE
Tethering fixes

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java
@@ -69,6 +69,7 @@ import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.security.impersonation.Impersonator;
+import io.cdap.common.http.HttpRequestConfig;
 import org.apache.twill.api.RunId;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
@@ -168,8 +169,13 @@ public class InMemoryProgramRunDispatcher implements ProgramRunDispatcher {
     if (peer != null) {
       // For tethered pipeline runs, fetch artifacts from ArtifactCacheService
       String basePath = String.format("%s/peers/%s", Constants.Gateway.INTERNAL_API_VERSION_3, peer);
+      // Set longer timeouts because we fetch from remote appfabric the first time we get an artifact. Subsequent
+      // reads are served by the cache.
+      HttpRequestConfig requestConfig = new HttpRequestConfig(600000,
+                                                              600000,
+                                                              false);
       RemoteClient client = remoteClientFactory.createRemoteClient(Constants.Service.ARTIFACT_CACHE_SERVICE,
-                                                                   RemoteClientFactory.NO_VERIFY_HTTP_REQUEST_CONFIG,
+                                                                   requestConfig,
                                                                    basePath);
       RemoteArtifactRepositoryReader artifactRepositoryReader = new RemoteArtifactRepositoryReader(locationFactory,
                                                                                                    client);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringConf.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringConf.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.internal.tethering.runtime.spi.provisioner;
 
+import io.cdap.cdap.proto.id.EntityId;
+
 import java.util.Map;
 
 /**
@@ -39,6 +41,7 @@ public class TetheringConf {
   public static TetheringConf fromProperties(Map<String, String> properties) {
     String tetheredInstanceName = getString(properties, TETHERED_INSTANCE_PROPERTY);
     String tetheredNamespace = getString(properties, TETHERED_NAMESPACE_PROPERTY);
+    EntityId.ensureValidNamespace(tetheredNamespace);
     return new TetheringConf(tetheredInstanceName, tetheredNamespace);
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManagerTest.java
@@ -69,7 +69,7 @@ public class TetheringRuntimeJobManagerTest {
 
   private static final Gson GSON = new GsonBuilder().create();
   private static final String TETHERED_INSTANCE_NAME = "other-instance";
-  private static final String TETHERED_NAMESPACE_NAME = "other-namespace";
+  private static final String TETHERED_NAMESPACE_NAME = "other_namespace";
   private static final Map<String, String> PROPERTIES = ImmutableMap.of(TetheringConf.TETHERED_INSTANCE_PROPERTY,
                                                                         TETHERED_INSTANCE_NAME,
                                                                         TetheringConf.TETHERED_NAMESPACE_PROPERTY,
@@ -150,5 +150,15 @@ public class TetheringRuntimeJobManagerTest {
       uncompressedContents = IOUtils.toString(inputStream);
     }
     Assert.assertEquals(fileContents, uncompressedContents);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testConfValidation() {
+    Map<String, String> properties = ImmutableMap.of(TetheringConf.TETHERED_INSTANCE_PROPERTY,
+                                                     "my-instance",
+                                                     TetheringConf.TETHERED_NAMESPACE_PROPERTY,
+                                                     "invalid-ns");
+    // Validation should fail as namespace can only contain alphanumeric characters or _
+    TetheringConf.fromProperties(properties);
   }
 }

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -700,6 +700,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
       if (e.getCode() == HttpURLConnection.HTTP_CONFLICT) {
         LOG.warn("The kubernetes job already exists : {}. Ignoring resubmission of the job." , e.getResponseBody());
       } else {
+        LOG.error("Failed to create kubernetes job: {}", e.getResponseBody());
         throw e;
       }
     }


### PR DESCRIPTION
- CDAP-19128: increase timeout for remote artifact fetching
- Log error when k8s job creation fails
- Validate namespace in tethering provisioner