### PR TITLE
[CDAP-19164] Check if program is authorized to run on the tethered namespace

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManager.java
@@ -85,8 +85,9 @@ public class TetheringRuntimeJobManager implements RuntimeJobManager {
   @Override
   public void launch(RuntimeJobInfo runtimeJobInfo) throws Exception {
     ProgramRunInfo runInfo = runtimeJobInfo.getProgramRunInfo();
-    LOG.debug("Launching run {} with following configurations: tethered instance name {}, tethered namespace {}.",
-              runInfo.getRun(), tetheredInstanceName, tetheredNamespace);
+    LOG.debug("Launching program run {} with following configurations: " +
+                "tethered instance name {}, tethered namespace {}.",
+              runInfo, tetheredInstanceName, tetheredNamespace);
     byte[] payload = Bytes.toBytes(GSON.toJson(createLaunchPayload(runtimeJobInfo)));
     TetheringControlMessage message = new TetheringControlMessage(TetheringControlMessage.Type.START_PROGRAM, payload);
     publishToControlChannel(message);
@@ -114,8 +115,9 @@ public class TetheringRuntimeJobManager implements RuntimeJobManager {
     if (status.isTerminated()) {
       return;
     }
-    LOG.debug("Stopping run {} with following configurations: tethered instance name {}, tethered namespace {}.",
-              programRunInfo.getRun(), tetheredInstanceName, tetheredNamespace);
+    LOG.debug("Stopping program run {} with following configurations: " +
+                "tethered instance name {}, tethered namespace {}.",
+              programRunInfo, tetheredInstanceName, tetheredNamespace);
     TetheringControlMessage message = createProgramTerminatePayload(programRunInfo,
                                                                     TetheringControlMessage.Type.STOP_PROGRAM);
     publishToControlChannel(message);
@@ -131,8 +133,8 @@ public class TetheringRuntimeJobManager implements RuntimeJobManager {
     if (status.isTerminated()) {
       return;
     }
-    LOG.debug("Killing run {} with following configurations: tethered instance name {}, tethered namespace {}.",
-              programRunInfo.getRun(), tetheredInstanceName, tetheredNamespace);
+    LOG.debug("Killing program run {} with following configurations: tethered instance name {}, tethered namespace {}.",
+              programRunInfo, tetheredInstanceName, tetheredNamespace);
     TetheringControlMessage message = createProgramTerminatePayload(programRunInfo,
                                                                     TetheringControlMessage.Type.KILL_PROGRAM);
     publishToControlChannel(message);
@@ -200,15 +202,7 @@ public class TetheringRuntimeJobManager implements RuntimeJobManager {
    */
   private TetheringControlMessage createProgramTerminatePayload(ProgramRunInfo programRunInfo,
                                                                 TetheringControlMessage.Type messageType) {
-    ProgramRunInfo stopPayload = new ProgramRunInfo.Builder()
-      .setNamespace(tetheredNamespace)
-      .setApplication(programRunInfo.getApplication())
-      .setVersion(programRunInfo.getVersion())
-      .setProgramType(programRunInfo.getProgramType())
-      .setProgram(programRunInfo.getProgram())
-      .setRun(programRunInfo.getRun())
-      .build();
-    byte[] payload = Bytes.toBytes(GSON.toJson(stopPayload));
+    byte[] payload = Bytes.toBytes(GSON.toJson(programRunInfo));
     return new TetheringControlMessage(messageType, payload);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/SqlDefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/SqlDefaultStoreTest.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.internal.AppFabricTestHelper;
 import io.cdap.cdap.internal.app.namespace.DefaultNamespaceAdmin;
 import io.cdap.cdap.internal.app.namespace.NamespaceResourceDeleter;
 import io.cdap.cdap.internal.app.namespace.StorageProviderNamespaceAdmin;
+import io.cdap.cdap.internal.tethering.TetheringStore;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
@@ -65,7 +66,7 @@ public class SqlDefaultStoreTest extends DefaultStoreTest {
       injector.getInstance(MetricsCollectionService.class), injector.getProvider(NamespaceResourceDeleter.class),
       injector.getProvider(StorageProviderNamespaceAdmin.class), injector.getInstance(CConfiguration.class),
       injector.getInstance(Impersonator.class), injector.getInstance(AccessEnforcer.class),
-      injector.getInstance(AuthenticationContext.class));
+      injector.getInstance(AuthenticationContext.class), injector.getInstance(TetheringStore.class));
   }
 
   @AfterClass

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringProvisionerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringProvisionerTest.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.internal.provision.ProvisionerConfig;
 import io.cdap.cdap.internal.provision.ProvisionerConfigProvider;
 import io.cdap.cdap.internal.provision.ProvisionerModule;
@@ -38,6 +39,7 @@ import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
 import io.cdap.cdap.runtime.spi.provisioner.Provisioner;
 import io.cdap.cdap.security.FakeSecureStore;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import org.apache.tephra.runtime.TransactionModules;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -60,6 +62,8 @@ public class TetheringProvisionerTest {
       new LocalLocationModule(),
       new InMemoryDiscoveryModule(),
       new StorageModule(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new TransactionModules().getInMemoryModules(),
       new ProvisionerModule(),
       new AuthorizationEnforcementModule().getNoOpModules(),
       new MessagingServerRuntimeModule().getInMemoryModules(),


### PR DESCRIPTION
- Fail tethering profile creation if peer name or namespace are incorrect
- TetheringClientHandler: fail tethering request if namespace doesn't exist
- Tethering agent: check if peer is allowed to launch program run on the specified namespace
- Fail namespace deletion if the namespace is used in a tethering connection
- TetheringRuntimeJobManager: set the correct namespace when we stop/kill a program. Also enhanced logging.