### PR TITLE
[CDAP-13926] ResourceCoordinator should not log resource requirements at INFO level

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/zookeeper/coordination/ResourceCoordinator.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/zookeeper/coordination/ResourceCoordinator.java
@@ -230,7 +230,7 @@ public final class ResourceCoordinator extends AbstractService {
 
         try {
           ResourceRequirement requirement = CoordinationConstants.RESOURCE_REQUIREMENT_CODEC.decode(nodeData);
-          LOG.info("Get requirement {}", requirement);
+          LOG.debug("Get requirement {}", requirement);
 
           // See if the requirement changed.
           ResourceRequirement oldRequirement = requirements.get(requirement.getName());


### PR DESCRIPTION
### [CDAP-13926] ResourceCoordinator should not log resource requirements at INFO level

Description: Updated log level from info to debug.

JIRA: https://cdap.atlassian.net/browse/CDAP-13926

[CDAP-13926]: https://cdap.atlassian.net/browse/CDAP-13926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ