### PR TITLE
CDAP-19153 strip artifact scheme and host for tethering

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactDescriptor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactDescriptor.java
@@ -46,6 +46,13 @@ public final class ArtifactDescriptor implements Comparable<ArtifactDescriptor> 
     this.locationURI = location.toURI();
   }
 
+  public ArtifactDescriptor(String namespace, ArtifactId artifactId, URI locationURI) {
+    this.namespace = namespace;
+    this.artifactId = artifactId;
+    this.location = null;
+    this.locationURI = locationURI;
+  }
+
   public String getNamespace() {
     return namespace;
   }
@@ -63,6 +70,7 @@ public final class ArtifactDescriptor implements Comparable<ArtifactDescriptor> 
    * get location of artifact
    *
    * @return {@link Location} of artifact
+   * @deprecated This will be removed in CDAP-19150
    */
   public Location getLocation() {
     return location;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
@@ -481,7 +481,7 @@ public class AbstractProgramRuntimeServiceTest {
     @Override
     protected Program createProgram(CConfiguration cConf, ProgramRunner programRunner,
                                     ProgramDescriptor programDescriptor,
-                                    ArtifactDetail artifactDetail, File tempDir) {
+                                    ArtifactDetail artifactDetail, File tempDir, boolean isTethered) {
       if (program == null) {
         throw new IllegalArgumentException("No program is available");
       }


### PR DESCRIPTION
This fixes a bug in tethering scenarios when one CDAP instance
has one scheme for location URI (like hdfs://) and the peered
instance has a different scheme (like gs://). In these scenarios,
the LocationFactory cannot convert the URI into a Location
because of the scheme mismatch.

To fix this, the ArtifactCache service used in tethered runs will
strip the scheme and host from the location URI so that the
Location object can be created. This is a hack until the more
complete solution of removing Location from the ArtifactDetail
class can be implemented.