### PR TITLE
CDAP-19123 set batch interval for flaky test

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/DataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/DataStreamsTest.java
@@ -1367,6 +1367,7 @@ public class DataStreamsTest extends HydratorTestBase {
       .addConnection("filter2", "sink5")
       .setProperties(Collections.singletonMap(io.cdap.cdap.etl.common.Constants.SPARK_PIPELINE_AUTOCACHE_ENABLE_FLAG,
                                               "false"))
+      .setBatchInterval("5s")
       .build();
 
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, config);


### PR DESCRIPTION
Set batch interval to 5s for flaky stage consolidation test
instead of the default 1m. This allows the pipeline to stop much
faster and avoid the program stop timeout that was causing the
flakiness.