### PR TITLE
[CDAP-19171] Add http request config for system worker pods

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/RemoteTaskExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/RemoteTaskExecutor.java
@@ -36,6 +36,7 @@ import io.cdap.cdap.internal.io.ExposedByteArrayOutputStream;
 import io.cdap.cdap.proto.BasicThrowable;
 import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpRequestConfig;
 import io.cdap.common.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.slf4j.Logger;
@@ -73,11 +74,17 @@ public class RemoteTaskExecutor {
 
   public RemoteTaskExecutor(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
                             RemoteClientFactory remoteClientFactory, Type workerType) {
+    this(cConf, metricsCollectionService, remoteClientFactory, workerType, new DefaultHttpRequestConfig(false));
+  }
+
+  public RemoteTaskExecutor(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
+                            RemoteClientFactory remoteClientFactory, Type workerType,
+                            HttpRequestConfig httpRequestConfig) {
     this.compression = cConf.getBoolean(Constants.TaskWorker.COMPRESSION_ENABLED);
     String serviceName = workerType == Type.TASK_WORKER ?
       Constants.Service.TASK_WORKER : Constants.Service.SYSTEM_WORKER;
     this.remoteClient = remoteClientFactory.createRemoteClient(serviceName,
-                                                               new DefaultHttpRequestConfig(false),
+                                                               httpRequestConfig,
                                                                Constants.Gateway.INTERNAL_API_VERSION_3);
     this.retryStrategy = RetryStrategies.fromConfiguration(cConf, Constants.Service.TASK_WORKER + ".");
     this.metricsCollectionService = metricsCollectionService;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteProgramRunDispatcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteProgramRunDispatcher.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.app.runtime.ProgramRunnerFactory;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.Constants.AppFabric.RemoteExecution;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
@@ -51,6 +52,7 @@ import io.cdap.cdap.internal.app.worker.ProgramRunDispatcherTask;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.common.http.HttpRequestConfig;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.TwillController;
 import org.apache.twill.api.TwillRunnerService;
@@ -93,8 +95,12 @@ public class RemoteProgramRunDispatcher implements ProgramRunDispatcher {
     this.remoteProgramRunnerFactory = remoteProgramRunnerFactory;
     // TODO(CDAP-18964): Get rid of type casting.
     this.remoteTwillRunnerService = (RemoteExecutionTwillRunnerService) twillRunnerService;
+    int connectTimeout = cConf.getInt(Constants.SystemWorker.HTTP_CLIENT_CONNECTION_TIMEOUT_MS);
+    int readTimeout = cConf.getInt(Constants.SystemWorker.HTTP_CLIENT_READ_TIMEOUT_MS);
+    HttpRequestConfig httpRequestConfig = new HttpRequestConfig(connectTimeout, readTimeout, false);
     this.remoteTaskExecutor = new RemoteTaskExecutor(cConf, metricsCollectionService,
-                                                     remoteClientFactory, RemoteTaskExecutor.Type.SYSTEM_WORKER);
+                                                     remoteClientFactory, RemoteTaskExecutor.Type.SYSTEM_WORKER,
+                                                     httpRequestConfig);
   }
 
   @Override

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -483,6 +483,8 @@ public final class Constants {
     public static final String CLEANUP_EXECUTOR_SERVICE_BINDING = "cleanup.executor.service";
     public static final String CLEANUP_THREADS = "system.worker.cleanup.threads";
     public static final String DISPATCH_PROGRAM_TYPES = "system.worker.dispatch.program.types";
+    public static final String HTTP_CLIENT_READ_TIMEOUT_MS = "system.worker.http.client.read.timeout.ms";
+    public static final String HTTP_CLIENT_CONNECTION_TIMEOUT_MS = "system.worker.http.client.connection.timeout.ms";
 
     /**
      * System worker http handler configuration

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4946,6 +4946,22 @@
   </property>
 
   <property>
+    <name>system.worker.http.client.read.timeout.ms</name>
+    <value>300000</value>
+    <description>
+      Read timeout in milliseconds for system worker HTTP requests.
+    </description>
+  </property>
+
+  <property>
+    <name>system.worker.http.client.connection.timeout.ms</name>
+    <value>60000</value>
+    <description>
+      Connection timeout in milliseconds for system worker HTTP requests.
+    </description>
+  </property>
+
+  <property>
     <name>artifact.localizer.container.num.cores</name>
     <value>1</value>
     <description>


### PR DESCRIPTION
This PR introduces new http request config for (long running) requests sent to system worker pods. 

Why: currently read timeout for http requests for system pods is set to default (i.e., 60 seconds). Since launching a pipeline on a system pod is a synchronous call, and may take more than 60 seconds, the pipeline fails with read timeout if launch takes more than 60 seconds (which is possible under very high load).
