### PR TITLE
[CDAP-19068] Add pod requests and limits while launching pipelines on…

### DIFF
--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
@@ -399,7 +399,7 @@ public class KubeMasterEnvironmentTest {
     kubeMasterEnvironment.setWorkloadIdentityProvider(workloadIdentityProvider);
     kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTTLSeconds(172800L);
 
-    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap());
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap(), 1, 1);
 
     SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
 

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/spark/SparkSubmitContext.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/spark/SparkSubmitContext.java
@@ -24,12 +24,25 @@ import java.util.Map;
  */
 public class SparkSubmitContext {
   private final Map<String, SparkLocalizeResource> localizeResources;
+  private final int driverVirtualCores;
+  private final int executorVirtualCores;
 
-  public SparkSubmitContext(Map<String, SparkLocalizeResource> localizeResources) {
+  public SparkSubmitContext(Map<String, SparkLocalizeResource> localizeResources,
+                            int driverVirtualCores, int executorVirtualCores) {
     this.localizeResources = Collections.unmodifiableMap(new HashMap<>(localizeResources));
+    this.driverVirtualCores = driverVirtualCores;
+    this.executorVirtualCores = executorVirtualCores;
   }
 
   public Map<String, SparkLocalizeResource> getLocalizeResources() {
     return localizeResources;
+  }
+
+  public int getDriverVirtualCores() {
+    return driverVirtualCores;
+  }
+
+  public int getExecutorVirtualCores() {
+    return executorVirtualCores;
   }
 }

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.app.runtime.spark.submit;
 
 import com.google.common.collect.ImmutableList;
+import io.cdap.cdap.api.spark.SparkSpecification;
 import io.cdap.cdap.app.runtime.spark.SparkRuntimeContext;
 import io.cdap.cdap.app.runtime.spark.SparkRuntimeEnv;
 import io.cdap.cdap.app.runtime.spark.SparkRuntimeUtils;
@@ -47,6 +48,7 @@ import java.util.Map;
  */
 public class MasterEnvironmentSparkSubmitter extends AbstractSparkSubmitter {
   private final SparkExecutionService sparkExecutionService;
+  private final SparkRuntimeContext runtimeContext;
   private final MasterEnvironment masterEnv;
   private SparkConfig sparkConfig;
   private List<LocalizeResource> resources;
@@ -61,6 +63,7 @@ public class MasterEnvironmentSparkSubmitter extends AbstractSparkSubmitter {
     WorkflowProgramInfo workflowInfo = runtimeContext.getWorkflowInfo();
     BasicWorkflowToken workflowToken = workflowInfo == null ? null : workflowInfo.getWorkflowToken();
     this.sparkExecutionService = new SparkExecutionService(locationFactory, hostname, programRunId, workflowToken);
+    this.runtimeContext = runtimeContext;
     this.masterEnv = masterEnv;
     this.cConf = cConf;
   }
@@ -137,7 +140,10 @@ public class MasterEnvironmentSparkSubmitter extends AbstractSparkSubmitter {
 
   private SparkConfig generateOrGetSparkConfig() throws Exception {
     if (sparkConfig == null) {
-      sparkConfig = masterEnv.generateSparkSubmitConfig(new SparkSubmitContext(getLocalizeResources(resources)));
+      SparkSpecification spec = runtimeContext.getSparkSpecification();
+      sparkConfig = masterEnv.generateSparkSubmitConfig(
+        new SparkSubmitContext(getLocalizeResources(resources), spec.getDriverResources().getVirtualCores(),
+                               spec.getExecutorResources().getVirtualCores()));
     }
     return sparkConfig;
   }


### PR DESCRIPTION
… kubernetes

Memory limits from spark is not allowed. 
https://spark.apache.org/docs/latest/running-on-kubernetes.html

Adding cpu and memory limits for workflow and worker pods. But for spark pods only adding cpu limits.

