### PR TITLE
[CDAP-19171] Add idempotency to remote task executor

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/RemoteTaskExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/RemoteTaskExecutor.java
@@ -97,6 +97,19 @@ public class RemoteTaskExecutor {
    * @throws Exception returned by remote task if any
    */
   public byte[] runTask(RunnableTaskRequest runnableTaskRequest) throws Exception {
+    return runTask(runnableTaskRequest, false);
+  }
+
+  /**
+   * Sends the {@link RunnableTaskRequest} to a remote worker and returns the result.
+   * Retries sending the request if the workers are busy.
+   *
+   * @param runnableTaskRequest {@link RunnableTaskRequest} with details of task
+   * @param isIdempotent        if true, task will be retried regardless of exception as it is idempotent
+   * @return byte[] response from remote task
+   * @throws Exception returned by remote task if any
+   */
+  public byte[] runTask(RunnableTaskRequest runnableTaskRequest, boolean isIdempotent) throws Exception {
     //initialize start time for collecting latency metric
     long startTime = System.currentTimeMillis();
     ByteBuffer requestBody = encodeTaskRequest(runnableTaskRequest);
@@ -131,6 +144,13 @@ public class RemoteTaskExecutor {
         } catch (NoRouteToHostException e) {
           throw new RetryableException(
             String.format("Received exception %s for %s", e.getMessage(), runnableTaskRequest.getClassName()));
+        } catch (Exception ex) {
+          if (!isIdempotent) {
+            // this is not an idempotent task. We do not try again.
+            throw ex;
+          }
+          throw new RetryableException(
+            String.format("Received exception %s for %s", ex.getMessage(), runnableTaskRequest.getClassName()));
         }
       }, retryStrategy, Retries.DEFAULT_PREDICATE);
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteProgramRunDispatcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteProgramRunDispatcher.java
@@ -103,7 +103,7 @@ public class RemoteProgramRunDispatcher implements ProgramRunDispatcher {
     LOG.debug("Dispatching Program Run operation for Run ID: {}", runId.getId());
     RunnableTaskRequest request = RunnableTaskRequest.getBuilder(ProgramRunDispatcherTask.class.getName())
       .withParam(GSON.toJson(programRunDispatcherInfo)).build();
-    remoteTaskExecutor.runTask(request);
+    remoteTaskExecutor.runTask(request, true);
     ProgramId programId = programRunDispatcherInfo.getProgramDescriptor().getProgramId();
     ProgramRunId programRunId = programId.run(runId);
     ProgramRunner runner =


### PR DESCRIPTION
This PR adds an idempotency flag to remote task executor. The flag is then used for launching pipelines. Therefore, if an exception happens during pipeline launch, the task is retried.

Why: if an exception happens when a launching pipeline using a system worker pod, and given that submitting jobs to Dataproc (and k8s) is idempotent since 6.6, this PR retries to launch a pipeline if an exception occurs during the initial call. 