### PR TITLE
CDAP-19078 extend format interface for schema detection

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidatingInputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidatingInputFormat.java
@@ -19,6 +19,9 @@ package io.cdap.cdap.etl.api.validation;
 import io.cdap.cdap.api.data.batch.InputFormatProvider;
 import io.cdap.cdap.api.data.schema.Schema;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
@@ -35,10 +38,24 @@ public interface ValidatingInputFormat extends InputFormatProvider {
   void validate(FormatContext context);
 
   /**
-   * Gets validated schema. Also adds
+   * Gets validated schema.
    *
    * @param context format context
    */
   @Nullable
   Schema getSchema(FormatContext context);
+
+  /**
+   * Try to detect the schema from some input data.
+   *
+   * @param context format context
+   * @param dataStream supplier for opening an input stream containing sample data. It is the responsibility of this
+   *                   method to close any InputStreams that it opens.
+   * @return the detected schema, or null if the schema could not be detected.
+   * @throws IOException if there was an issue opening or reading the data.
+   */
+  @Nullable
+  default Schema detectSchema(FormatContext context, Supplier<InputStream> dataStream) throws IOException {
+    return null;
+  }
 }


### PR DESCRIPTION
Adding a method to ValidatingInputFormat so that format plugins
have a way to detect schema given some input data. This removes
the need for format plugins to interact with various filesystems,
allowing them to focus purely on how to read data instead of
also needing to know how to find which data to process.