### PR TITLE
CDAP-19207 do not expose macro impl detail

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/macro/InvalidMacroException.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/macro/InvalidMacroException.java
@@ -28,4 +28,8 @@ public class InvalidMacroException extends RuntimeException {
     super(message, cause);
   }
 
+  public InvalidMacroException(Throwable cause) {
+    super(cause);
+  }
+
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java
@@ -90,15 +90,14 @@ abstract class AbstractServiceRetryableMacroEvaluator implements MacroEvaluator 
           delay = (long) (delay * (minMultiplier + Math.random() * (maxMultiplier - minMultiplier + 1)));
           delay = Math.min(delay, RETRY_MAX_DELAY_MILLIS);
         } catch (IOException e) {
-          throw new RuntimeException("Failed to evaluate the macro function '" + functionName
-                                       + "' with args " + Arrays.asList(args), e);
+          throw new InvalidMacroException(e);
         }
       }
     } catch (InterruptedException e) {
-      throw new RuntimeException("Thread interrupted while trying to evaluate the macro function '" + functionName
+      throw new RuntimeException("Thread interrupted while trying to evaluate the value for '" + functionName
                                    + "' with args " + Arrays.asList(args), e);
     }
-    throw new IllegalStateException("Timed out when trying to evaluate the macro function '" + functionName
+    throw new IllegalStateException("Timed out when trying to evaluate the value for '" + functionName
                                       + "' with args " + Arrays.asList(args));
   }
 


### PR DESCRIPTION
Fix the error message to not expose macro implementation but preserve the original message the service returns, 
Previously the error message is like 
![image](https://user-images.githubusercontent.com/12615579/167214763-0ea463bd-eb71-4be8-af42-24a8d65781cc.png)
Now it is 
```
Failed to call Connection service with status 404: Connection 'test_gcs_c5aa066b_ea07_483c_8968_56b822388168' in namespace 'default' not found.
```