### PR TITLE
[CDAP-19215] Fix remote program run dispatcher breaking standalone

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -37,6 +37,7 @@ import com.google.inject.util.Modules;
 import io.cdap.cdap.app.deploy.Configurator;
 import io.cdap.cdap.app.deploy.Manager;
 import io.cdap.cdap.app.deploy.ManagerFactory;
+import io.cdap.cdap.app.deploy.ProgramRunDispatcher;
 import io.cdap.cdap.app.mapreduce.DistributedMRJobInfoFetcher;
 import io.cdap.cdap.app.mapreduce.LocalMRJobInfoFetcher;
 import io.cdap.cdap.app.mapreduce.MRJobInfoFetcher;
@@ -281,7 +282,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                                  .to(DistributedStorageProviderNamespaceAdmin.class);
                                bind(UGIProvider.class).toProvider(UGIProviderProvider.class);
 
-                               bind(RemoteProgramRunDispatcher.class).in(Scopes.SINGLETON);
+                               bind(ProgramRunDispatcher.class).to(RemoteProgramRunDispatcher.class)
+                                 .in(Scopes.SINGLETON);
 
                                Multibinder<String> servicesNamesBinder =
                                  Multibinder.newSetBinder(binder(), String.class,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/ProgramRunDispatcherFactory.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/ProgramRunDispatcherFactory.java
@@ -34,7 +34,7 @@ public class ProgramRunDispatcherFactory {
   private final InMemoryProgramRunDispatcher inMemoryProgramRunDispatcher;
   private final boolean workerPoolEnabled;
   private final Set<ProgramType> remoteDispatchProgramTypes;
-  private RemoteProgramRunDispatcher remoteProgramRunDispatcher;
+  private ProgramRunDispatcher remoteProgramRunDispatcher;
 
   @Inject
   public ProgramRunDispatcherFactory(CConfiguration cConf, InMemoryProgramRunDispatcher inMemoryProgramRunDispatcher) {
@@ -57,8 +57,8 @@ public class ProgramRunDispatcherFactory {
    * For unit tests, RemoteProgramRunDispatcher would not be set.
    */
   @Inject(optional = true)
-  public void setRemoteProgramRunDispatcher(RemoteProgramRunDispatcher remoteProgramRunDispatcher) {
-    this.remoteProgramRunDispatcher = remoteProgramRunDispatcher;
+  public void setRemoteProgramRunDispatcher(ProgramRunDispatcher programRunDispatcher) {
+    this.remoteProgramRunDispatcher = programRunDispatcher;
   }
 
   public ProgramRunDispatcher getProgramRunDispatcher(ProgramType type) {


### PR DESCRIPTION
Why: RemoteProgramRunDispatcher should optionally set in ProgramRunDispatcherFactory as it's only needed in appfabric when running in distributed mode. 
This PR changes the method parameter type to ProgramRunDispatcher interface instead of its implementation (i.e., RemoteProgramRunDispatcher). Using RemoteProgramRunDispatcher as a method parameter for `setRemoteProgramRunDispatcher` results in guice to inject it even though method injection is optional. 