### PR TITLE
[6.7][CDAP-19063]Added checks to ensure dataproc cluster version is greater than 1.5 before running

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocImageVersion.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocImageVersion.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.common;
+
+import com.google.common.base.Strings;
+import io.cdap.cdap.runtime.spi.VersionInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * Class used to compare versions from Dataproc cluster images
+ */
+public class DataprocImageVersion implements VersionInfo {
+  private static final Pattern IS_NUMBER_PATTERN = Pattern.compile("^\\d+$");
+  private final List<Integer> versionSegments;
+
+  public DataprocImageVersion(@Nullable String imageVersion) {
+    // For null versions, we assume zero.
+    if (Strings.isNullOrEmpty(imageVersion)) {
+      throw new IllegalArgumentException("Invalid image version: " + imageVersion);
+    }
+
+    versionSegments = new ArrayList<>();
+
+    // If the version contains a hyphen, only take the first portion (e.g. 1.2.3-debian4)
+    if (imageVersion.contains("-")) {
+      imageVersion = imageVersion.split("-")[0];
+    }
+
+    for (String component : imageVersion.split("\\.")) {
+      // Check if each portion of the version is not empty and contains only numbers
+      if (!IS_NUMBER_PATTERN.matcher(component).matches()) {
+        throw new IllegalArgumentException("Invalid image version: " + imageVersion);
+      }
+
+      Integer part = Strings.isNullOrEmpty(component) ? 0 : Integer.parseInt(component);
+      versionSegments.add(part);
+    }
+  }
+
+  @Override
+  public int compareTo(Object o) {
+    DataprocImageVersion other;
+    if (o == null) {
+      return 1;
+    } else if (o instanceof DataprocImageVersion) {
+      other = (DataprocImageVersion) o;
+    } else {
+      other = new DataprocImageVersion(o.toString());
+    }
+
+    // Go over each element of the version and compare.
+    // if elements have different lengths, 0 is taken as the value for each of the missing segments
+    for (int i = 0; i < Math.max(this.versionSegments.size(), other.versionSegments.size()); i++) {
+      int thisSegment = this.versionSegments.size() > i ? this.versionSegments.get(i) : 0;
+      int otherSegment = other.versionSegments.size() > i ? other.versionSegments.get(i) : 0;
+
+      if (thisSegment < otherSegment) {
+        return -1;
+      } else if (thisSegment > otherSegment) {
+        return 1;
+      }
+    }
+
+    return 0;
+  }
+
+  @Override
+  public String toString() {
+    String output = this.versionSegments.stream().map(Object::toString).collect(Collectors.joining("."));
+
+    if (output.isEmpty()) {
+      return "0";
+    }
+
+    return output;
+  }
+}

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -780,6 +780,26 @@ class DataprocClient implements AutoCloseable {
   }
 
   /**
+   * Get image version for the specified cluster. This information will not be present if the cluster could not be
+   * found, or the cluster specification doesn't contain this information
+   *
+   * @param name the cluster name
+   * @return the cluster image version if available.
+   * @throws RetryableProvisionException if there was a non 4xx error code returned
+   */
+  Optional<String> getClusterImageVersion(String name)
+    throws RetryableProvisionException {
+    Optional<Cluster> clusterOptional = getDataprocCluster(name);
+    if (!clusterOptional.isPresent()) {
+      return Optional.empty();
+    }
+
+    Cluster cluster = clusterOptional.get();
+    SoftwareConfig softwareConfig = cluster.getConfig().getSoftwareConfig();
+    return Optional.ofNullable(softwareConfig.getImageVersion());
+  }
+
+  /**
    * Converts dataproc cluster object into provisioner one. This version does not throw checked exceptions and
    * can be used as a {@link java.util.function.Function}.
    * @param cluster dataproc cluster object

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/ExistingDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/ExistingDataprocProvisioner.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
 import com.google.common.base.Strings;
 import io.cdap.cdap.runtime.spi.RuntimeMonitorType;
+import io.cdap.cdap.runtime.spi.VersionInfo;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
 import io.cdap.cdap.runtime.spi.provisioner.PollingStrategies;
@@ -101,10 +102,23 @@ public class ExistingDataprocProvisioner extends AbstractDataprocProvisioner {
           LOG.debug("Cannot update cluster labels due to {}", e.getMessage());
         }
       }
-      return client.getCluster(clusterName)
+      Cluster cluster = client.getCluster(clusterName)
         .filter(c -> c.getStatus() == ClusterStatus.RUNNING)
         .orElseThrow(() -> new DataprocRuntimeException("Dataproc cluster " + clusterName +
                                                           " does not exist or not in running state."));
+
+      // Determine cluster version and fail if version is smaller than 1.5
+      Optional<String> optImageVer = client.getClusterImageVersion(clusterName);
+      Optional<VersionInfo> optComparableImageVer = optImageVer.map(this::extractVersion);
+      if (!optImageVer.isPresent()) {
+        LOG.warn("Unable to determine Dataproc version.");
+      } else if (!optComparableImageVer.isPresent()) {
+        LOG.warn("Unable to extract Dataproc version from string '{}'.", optImageVer.get());
+      } else if (DATAPROC_1_5_VERSION.compareTo(optComparableImageVer.get()) > 0) {
+        throw new DataprocRuntimeException("Dataproc cluster must be version 1.5 or greater for pipeline execution.");
+      }
+
+      return cluster;
     }
   }
 


### PR DESCRIPTION
Cherry pick of https://github.com/cdapio/cdap/pull/14272/ into 6.7