### PR TITLE
[CDAP-19183] Switch Placeholder Credential to External Credential Type

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/AuthenticationChannelHandler.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/AuthenticationChannelHandler.java
@@ -38,7 +38,7 @@ public class AuthenticationChannelHandler extends ChannelInboundHandlerAdapter {
 
   private static final String EMPTY_USER_ID = "CDAP-empty-user-id";
   private static final Credential EMPTY_USER_CREDENTIAL = new Credential("CDAP-empty-user-credential",
-                                                                         Credential.CredentialType.INTERNAL);
+                                                                         Credential.CredentialType.EXTERNAL);
   private static final String EMPTY_USER_IP = "CDAP-empty-user-ip";
 
   private final boolean internalAuthEnabled;

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/AuthenticationHandler.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/handlers/AuthenticationHandler.java
@@ -121,9 +121,7 @@ public class AuthenticationHandler extends ChannelInboundHandlerAdapter {
 
       Credential credential = getUserCredential(userIdentityPair);
 
-      // For backwards compatibility, we continue propagating credentials by default. This may change in the future.
-      if (cConf.getBoolean(Constants.Security.Authentication.PROPAGATE_USER_CREDENTIAL, true) &&
-        credential != null) {
+      if (cConf.getBoolean(Constants.Security.Authentication.PROPAGATE_USER_CREDENTIAL) && credential != null) {
         request.headers().set(Constants.Security.Headers.RUNTIME_TOKEN,
                               String.format("%s %s", credential.getType().getQualifiedName(), credential.getValue()));
       }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Credential.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Credential.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.proto.security;
 
+import java.util.Objects;
+
 /**
  * Encapsulating class for credentials passing through CDAP.
  */
@@ -101,5 +103,19 @@ public class Credential {
       "type=" + type +
       ", length=" + value.length() +
       "}";
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof Credential)) {
+      return false;
+    }
+    Credential credentialObj = (Credential) obj;
+    return type == credentialObj.type && value.equals(credentialObj.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, value);
   }
 }


### PR DESCRIPTION
This is necessary because if internal auth is enabled and credential propagation is disabled, a default placeholder credential is used for propagation. This causes internal auth to break because it assumes that the credentials passed to it are proper base64-encoded access tokens.

Update: instead of always enabling credential propagation (which is brittle and would not work for non-credential-propagating architectures), we go ahead and assign an external placeholder credential instead of an internal placeholder credential so that the access enforcer extension can still perform enforcement based on user ID.