### PR TITLE
CDAP-19050 remove GCE calls when they are not needed

### DIFF
--- a/cdap-runtime-ext-dataproc/pom.xml
+++ b/cdap-runtime-ext-dataproc/pom.xml
@@ -180,6 +180,61 @@
   </dependencyManagement>
 
   <profiles>
+    <!--
+      this profile is used to build a fat jar to use the DataprocTool utility class,
+      primarily for manual testing purposes
+     -->
+    <profile>
+      <id>tool</id>
+      <!-- add provided scope dependencies as compile scope so that they get bundled in fat jar
+       -->
+      <dependencies>
+        <dependency>
+          <groupId>io.cdap.cdap</groupId>
+          <artifactId>cdap-runtime-spi</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>2.3</version>
+            <executions>
+              <!-- Run shade goal on package phase -->
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <keepDependenciesWithProvidedScope>true</keepDependenciesWithProvidedScope>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
+                  <transformers>
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                  </transformers>
+                  <filters>
+                    <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>dist</id>
       <build>

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/ComputeFactory.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/ComputeFactory.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright © 2022 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner.dataproc;
+
+import com.google.api.services.compute.Compute;
+import com.google.auth.oauth2.GoogleCredentials;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+/**
+ * Creates Compute instances.
+ */
+public interface ComputeFactory {
+
+  /**
+   * Create a Compute client.
+   *
+   * @param credentials credentials to use for the compute calls
+   * @param connectTimeout connect timeout
+   * @param readTimeout read timeout
+   * @return Compute client
+   * @throws GeneralSecurityException if there was a security issue creating the client
+   * @throws IOException if there was an I/O exception creating the client
+   */
+  Compute createCompute(GoogleCredentials credentials, int connectTimeout,
+                        int readTimeout) throws GeneralSecurityException, IOException;
+}

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -16,33 +16,18 @@
 
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.api.client.http.HttpRequestInitializer;
-import com.google.api.client.http.HttpResponseException;
-import com.google.api.client.http.HttpStatusCodes;
-import com.google.api.client.http.HttpTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.api.gax.core.CredentialsProvider;
-import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.rpc.AlreadyExistsException;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.NotFoundException;
 import com.google.api.services.compute.Compute;
-import com.google.api.services.compute.model.AccessConfig;
-import com.google.api.services.compute.model.Firewall;
-import com.google.api.services.compute.model.FirewallList;
-import com.google.api.services.compute.model.Instance;
 import com.google.api.services.compute.model.Network;
 import com.google.api.services.compute.model.NetworkList;
-import com.google.api.services.compute.model.NetworkPeering;
-import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.cloud.dataproc.v1.AutoscalingConfig;
 import com.google.cloud.dataproc.v1.Cluster;
 import com.google.cloud.dataproc.v1.ClusterConfig;
 import com.google.cloud.dataproc.v1.ClusterControllerClient;
-import com.google.cloud.dataproc.v1.ClusterControllerSettings;
 import com.google.cloud.dataproc.v1.ClusterOperationMetadata;
 import com.google.cloud.dataproc.v1.ClusterStatus;
 import com.google.cloud.dataproc.v1.DeleteClusterRequest;
@@ -65,7 +50,6 @@ import com.google.protobuf.Duration;
 import com.google.protobuf.FieldMask;
 import com.google.rpc.Status;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
-import io.cdap.cdap.runtime.spi.common.IPRange;
 import io.cdap.cdap.runtime.spi.provisioner.Node;
 import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
 import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
@@ -75,14 +59,9 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
-import java.security.GeneralSecurityException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,12 +79,9 @@ import javax.annotation.Nullable;
 /**
  * Wrapper around the dataproc client that adheres to our configuration settings.
  */
-class DataprocClient implements AutoCloseable {
+abstract class DataprocClient implements AutoCloseable {
 
   private static final Logger LOG = LoggerFactory.getLogger(DataprocClient.class);
-  private static final List<IPRange> PRIVATE_IP_RANGES = DataprocUtils.parseIPRanges(Arrays.asList("10.0.0.0/8",
-                                                                                                   "172.16.0.0/12",
-                                                                                                   "192.168.0.0/16"));
   private static final int MIN_DEFAULT_CONCURRENCY = 32;
   private static final int PARTITION_NUM_FACTOR = 32;
   private static final int MIN_INITIAL_PARTITIONS_DEFAULT = 128;
@@ -113,174 +89,17 @@ class DataprocClient implements AutoCloseable {
   private static final Set<String> ERROR_INFO_REASONS = ImmutableSet.of(
     "rateLimitExceeded",
     "resourceQuotaExceeded");
-  private final DataprocConf conf;
-  private final ClusterControllerClient client;
-  private final Compute compute;
-  private final Network network;
+  protected final DataprocConf conf;
+  protected final ClusterControllerClient client;
+  protected final Compute compute;
 
-  private enum PeeringState {
-    ACTIVE,
-    INACTIVE,
-    NONE
+  protected DataprocClient(DataprocConf conf, ClusterControllerClient client, Compute compute) {
+    this.conf = conf;
+    this.client = client;
+    this.compute = compute;
   }
 
-  /**
-   * Creates a {@link DataprocClient} from the given {@link DataprocConf}.
-   *
-   * @param conf the configuration for the client
-   * @return a {@link DataprocClient} instance for using Dataproc API
-   * @throws IOException if failed to connect to GCP api during the client creation
-   * @throws GeneralSecurityException if the client is failed to authenticate
-   */
-  static DataprocClient fromConf(DataprocConf conf) throws IOException, GeneralSecurityException,
-    RetryableProvisionException {
-    return fromConf(conf, true);
-  }
-
-  /**
-   * Creates a {@link DataprocClient} from the given {@link DataprocConf}.
-   *
-   * @param conf the configuration for the client
-   * @param requireNetwork if {@code true}, network information will be extracted from the given {@link DataprocConf}
-   *                       or will be derived from the environment.
-   *                       If {@code false}, the {@link DataprocClient} created won't be able to perform any operation
-   *                       that requires network information, such as cluster creation.
-   * @return a {@link DataprocClient} instance for using Dataproc API
-   * @throws IOException if failed to connect to GCP api during the client creation
-   * @throws GeneralSecurityException if the client is failed to authenticate
-   */
-  static DataprocClient fromConf(DataprocConf conf,
-                                 boolean requireNetwork) throws IOException, GeneralSecurityException,
-    RetryableProvisionException {
-    try {
-      return getDataprocClient(conf, requireNetwork);
-    } catch (HttpResponseException e) {
-      if (e.getStatusCode() == HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE) {
-        throw new RetryableProvisionException(e);
-      }
-      throw e;
-    }
-  }
-
-  private static DataprocClient getDataprocClient(DataprocConf conf, boolean requireNetwork)
-    throws IOException, GeneralSecurityException, RetryableProvisionException {
-    ClusterControllerClient client = getClusterControllerClient(conf);
-    Compute compute = getCompute(conf);
-
-    if (!requireNetwork) {
-      return new DataprocClient(conf, client, compute, null);
-    }
-
-    String network = conf.getNetwork();
-    String systemNetwork = null;
-    try {
-      systemNetwork = DataprocUtils.getSystemNetwork();
-    } catch (IllegalArgumentException e) {
-      // expected when not running on GCP, ignore
-    }
-
-    String projectId = conf.getProjectId();
-    String networkHostProjectId = conf.getNetworkHostProjectID();
-    String systemProjectId = null;
-    try {
-      systemProjectId = DataprocUtils.getSystemProjectId();
-    } catch (IllegalArgumentException e) {
-      // expected when not running on GCP, ignore
-    }
-    if (network == null && projectId.equals(systemProjectId)) {
-      // If the CDAP instance is running on a GCE/GKE VM from a project that matches the provisioner project,
-      // use the network of that VM.
-      network = systemNetwork;
-    } else if (network == null) {
-      // Otherwise, pick a network from the configured project using the Compute API
-
-      network = findNetwork(networkHostProjectId, compute);
-    }
-    if (network == null) {
-      throw new IllegalArgumentException("Unable to automatically detect a network, please explicitly set a network.");
-    }
-
-    String subnet = conf.getSubnet();
-    Network networkInfo = getNetworkInfo(networkHostProjectId, network, compute);
-
-    List<String> subnets = networkInfo.getSubnetworks();
-    if (subnet != null && !subnetExists(subnets, subnet)) {
-      throw new IllegalArgumentException(String.format("Subnet '%s' does not exist in network '%s' in project '%s'. "
-                                                         + "Please use a different subnet.",
-                                                       subnet, network, networkHostProjectId));
-    }
-
-    // if the network uses custom subnets, a subnet must be provided to the dataproc api
-    boolean autoCreateSubnet = networkInfo.getAutoCreateSubnetworks() == null ?
-      false : networkInfo.getAutoCreateSubnetworks();
-    if (!autoCreateSubnet) {
-      // if the network uses custom subnets but none exist, error out
-      if (subnets == null || subnets.isEmpty()) {
-        throw new IllegalArgumentException(String.format("Network '%s' in project '%s' does not contain any subnets. "
-                                                           + "Please create a subnet or use a different network.",
-                                                         network, networkHostProjectId));
-      }
-    }
-
-    subnet = chooseSubnet(network, subnets, subnet, conf.getRegion());
-
-    return new DataprocClient(new DataprocConf(conf, network, subnet), client, compute, networkInfo);
-  }
-
-  private static PeeringState getPeeringState(String systemProjectId, String systemNetwork, Network networkInfo) {
-    // note: vpc network is a global resource.
-    // https://cloud.google.com/compute/docs/regions-zones/global-regional-zonal-resources#globalresources
-    String systemNetworkPath = String.format("https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s",
-                                             systemProjectId, systemNetwork);
-
-    LOG.trace(String.format("Self link for the system network is %s", systemNetworkPath));
-    List<NetworkPeering> peerings = networkInfo.getPeerings();
-    // if the customer does not has a peering established at all the peering list is null
-    if (peerings == null) {
-      return PeeringState.NONE;
-    }
-    for (NetworkPeering peering : peerings) {
-      if (!systemNetworkPath.equals(peering.getNetwork())) {
-        continue;
-      }
-      return peering.getState().equals("ACTIVE") ? PeeringState.ACTIVE : PeeringState.INACTIVE;
-    }
-    return PeeringState.NONE;
-  }
-
-  private static boolean subnetExists(List<String> subnets, String subnet) {
-    // subnets are of the form
-    // "https://www.googleapis.com/compute/v1/projects/<project>/regions/<region>/subnetworks/<name>"
-    // the provided subnet can be the full URI but is most often just the name
-    for (String networkSubnet : subnets) {
-      if (networkSubnet.equals(subnet) || networkSubnet.endsWith("subnetworks/" + subnet)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  // subnets are identified as
-  // "https://www.googleapis.com/compute/v1/projects/<project>/regions/<region>/subnetworks/<name>"
-  // a subnet in the same region as the dataproc cluster must be chosen. If a subnet name is provided then the subnet
-  // will be choosen and the region will be picked on basis of the given zone. If a subnet name is not provided then
-  // any subnetwork in the region of the given zone will be picked.
-  private static String chooseSubnet(String network, List<String> subnets, @Nullable String subnet, String region) {
-    for (String currentSubnet : subnets) {
-      // if a subnet name is given then get the region of that subnet based on the zone
-      if (subnet != null && !currentSubnet.endsWith("subnetworks/" + subnet)) {
-        continue;
-      }
-      if (currentSubnet.contains(region + "/subnetworks")) {
-        return currentSubnet;
-      }
-    }
-    throw new IllegalArgumentException(
-      String.format("Could not find %s in network '%s' that are for region '%s'", subnet == null ? "any subnet" :
-        String.format("a subnet named '%s", subnet), network, region));
-  }
-
-  private static String findNetwork(String project, Compute compute) throws IOException, RetryableProvisionException {
+  private String findNetwork(String project) throws IOException, RetryableProvisionException {
     List<Network> networks;
     try {
       NetworkList networkList = compute.networks().list(project).execute();
@@ -304,23 +123,6 @@ class DataprocClient implements AutoCloseable {
     return networks.iterator().next().getName();
   }
 
-  private static Network getNetworkInfo(String project, String network, Compute compute)
-    throws IOException, RetryableProvisionException {
-    Network networkObj;
-    try {
-      networkObj = compute.networks().get(project, network).execute();
-    } catch (Exception e) {
-      handleRetryableExceptions(e);
-      throw e;
-    }
-
-    if (networkObj == null) {
-      throw new IllegalArgumentException(String.format("Unable to find network '%s' in project '%s'. "
-                                                         + "Please specify another network.", network, project));
-    }
-    return networkObj;
-  }
-
   /**
    * Extracts and returns the zone name from the given full zone URI.
    */
@@ -330,50 +132,6 @@ class DataprocClient implements AutoCloseable {
       throw new IllegalArgumentException("Invalid zone uri " + zoneUri);
     }
     return zoneUri.substring(idx + 1);
-  }
-
-  /*
-   * Using the input Google Credentials retrieve the Dataproc Cluster controller client
-   */
-  private static ClusterControllerClient getClusterControllerClient(DataprocConf conf) throws IOException {
-    CredentialsProvider credentialsProvider = FixedCredentialsProvider.create(conf.getDataprocCredentials());
-
-    String rootUrl = Optional.ofNullable(conf.getRootUrl()).orElse(ClusterControllerSettings.getDefaultEndpoint());
-    String regionalEndpoint = conf.getRegion() + "-" + rootUrl;
-
-    ClusterControllerSettings controllerSettings = ClusterControllerSettings.newBuilder()
-      .setCredentialsProvider(credentialsProvider)
-      .setEndpoint(regionalEndpoint)
-      .build();
-    return ClusterControllerClient.create(controllerSettings);
-  }
-
-  /*
-   * Retrieve Google Compute Instance using Credentials
-   */
-  private static Compute getCompute(DataprocConf conf) throws GeneralSecurityException, IOException {
-    HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-    return new Compute.Builder(httpTransport, JacksonFactory.getDefaultInstance(),
-        getHttpRequestInitializerWithTimeouts(new HttpCredentialsAdapter(conf.getComputeCredential()), conf))
-      .setApplicationName("cdap")
-      .build();
-  }
-
-  private static HttpRequestInitializer getHttpRequestInitializerWithTimeouts(
-      HttpRequestInitializer requestInitializer, DataprocConf conf) {
-    return httpRequest -> {
-      requestInitializer.initialize(httpRequest);
-      httpRequest.setConnectTimeout(conf.getComputeConnectionTimeout());
-      httpRequest.setReadTimeout(conf.getComputeReadTimeout());
-    };
-  }
-
-  private DataprocClient(DataprocConf conf, ClusterControllerClient client, Compute compute,
-                         @Nullable Network network) {
-    this.conf = conf;
-    this.client = client;
-    this.compute = compute;
-    this.network = network;
   }
 
   /**
@@ -391,19 +149,11 @@ class DataprocClient implements AutoCloseable {
    * @throws RetryableProvisionException if there was a non 4xx error code returned
    */
   ClusterOperationMetadata createCluster(String name, String imageVersion, Map<String, String> labels,
-                                         boolean privateInstance)
+                                         boolean privateInstance, @Nullable SSHPublicKey publicKey)
     throws RetryableProvisionException, InterruptedException, IOException {
-
-    if (network == null) {
-      // This shouldn't happen as the fromConf method should already check.
-      // This is to guard against programmatic bug that this client was created without network information and
-      // yet being used to create cluster.
-      throw new IllegalArgumentException("Missing network information");
-    }
 
     try {
       Map<String, String> metadata = new HashMap<>();
-      SSHPublicKey publicKey = conf.getPublicKey();
       if (publicKey != null) {
         // Don't fail if there is no public key. It is for tooling case that the key might be generated differently.
         metadata.put("ssh-keys", publicKey.getUser() + ":" + publicKey.getKey());
@@ -432,29 +182,7 @@ class DataprocClient implements AutoCloseable {
         clusterConfig.setZoneUri(conf.getZone());
       }
 
-      // subnets are unique within a location, not within a network, which is why these configs are mutually exclusive.
-      if (conf.getSubnet() != null) {
-        clusterConfig.setSubnetworkUri(conf.getSubnet());
-      } else {
-        clusterConfig.setNetworkUri(network.getSelfLink());
-      }
-
-      //Add any defined Network Tags
-      clusterConfig.addAllTags(conf.getNetworkTags());
-      boolean internalIPOnly = isInternalIPOnly(network, privateInstance, publicKey != null);
-
-      // if public key is not null that means ssh is used to launch / monitor job on dataproc
-      if (publicKey != null) {
-        int maxTags = Math.max(0, DataprocConf.MAX_NETWORK_TAGS - clusterConfig.getTagsCount());
-        List<String> tags = getFirewallTargetTags(network, internalIPOnly);
-        if (tags.size() > maxTags) {
-          LOG.warn("No more than 64 tags can be added. Firewall tags ignored: {}", tags.subList(maxTags, tags.size()));
-        }
-        tags.stream().limit(maxTags).forEach(clusterConfig::addTags);
-      }
-
-      // if internal ip is preferred then create dataproc cluster without external ip for better security
-      clusterConfig.setInternalIpOnly(internalIPOnly);
+      setNetworkConfigs(clusterConfig, privateInstance);
 
       Map<String, String> clusterProperties = new HashMap<>(conf.getClusterProperties());
       // Enable/Disable stackdriver
@@ -582,6 +310,45 @@ class DataprocClient implements AutoCloseable {
       throw new DataprocRuntimeException(cause);
     }
   }
+
+  private void setNetworkConfigs(GceClusterConfig.Builder clusterConfig,
+                                 boolean privateInstance) throws RetryableProvisionException, IOException {
+    String network = conf.getNetwork();
+    String systemNetwork = null;
+    try {
+      systemNetwork = DataprocUtils.getSystemNetwork();
+    } catch (IllegalArgumentException e) {
+      // expected when not running on GCP, ignore
+    }
+
+    String projectId = conf.getProjectId();
+    String networkHostProjectId = conf.getNetworkHostProjectID();
+    String systemProjectId = null;
+    try {
+      systemProjectId = DataprocUtils.getSystemProjectId();
+    } catch (IllegalArgumentException e) {
+      // expected when not running on GCP, ignore
+    }
+
+    if (network == null && projectId.equals(systemProjectId)) {
+      // If the CDAP instance is running on a GCE/GKE VM from a project that matches the provisioner project,
+      // use the network of that VM.
+      network = systemNetwork;
+    } else if (network == null) {
+      // Otherwise, pick a network from the configured project using the Compute API
+      network = findNetwork(networkHostProjectId);
+    }
+    if (network == null) {
+      throw new IllegalArgumentException("Unable to automatically detect a network, please explicitly set a network.");
+    }
+    setNetworkConfigs(clusterConfig, network, privateInstance);
+  }
+
+  protected abstract void setNetworkConfigs(GceClusterConfig.Builder clusterConfig, String network,
+                                            boolean privateInstance)
+    throws RetryableProvisionException, IOException;
+
+  protected abstract Node getNode(Node.Type type, String zone, String nodeName) throws IOException;
 
   private void cleanUpClusterAfterCreationFailure(String name) {
     if (conf.isSkipDelete()) {
@@ -825,10 +592,10 @@ class DataprocClient implements AutoCloseable {
 
     List<Node> nodes = new ArrayList<>();
     for (String masterName : cluster.getConfig().getMasterConfig().getInstanceNamesList()) {
-      nodes.add(getNode(compute, Node.Type.MASTER, zone, masterName));
+      nodes.add(getNode(Node.Type.MASTER, zone, masterName));
     }
     for (String workerName : cluster.getConfig().getWorkerConfig().getInstanceNamesList()) {
-      nodes.add(getNode(compute, Node.Type.WORKER, zone, workerName));
+      nodes.add(getNode(Node.Type.WORKER, zone, workerName));
     }
     io.cdap.cdap.runtime.spi.provisioner.Cluster c = new io.cdap.cdap.runtime.spi.provisioner.Cluster(
       cluster.getClusterName(), convertStatus(cluster.getStatus()), nodes, Collections.emptyMap());
@@ -897,214 +664,6 @@ class DataprocClient implements AutoCloseable {
   }
 
   /**
-   * Determines if the Dataproc cluster is private IP only.
-   *
-   * @param privateInstance a system config to force using private instance
-   * @param sshRuntimeMonitor {@code true} if SSH is used for runtime monitoring
-   * @return {@code true} for pribvate IP only Dataproc cluster
-   */
-  private boolean isInternalIPOnly(Network network, boolean privateInstance, boolean sshRuntimeMonitor) {
-    String systemProjectId = null;
-    String systemNetwork = null;
-    try {
-      systemProjectId = DataprocUtils.getSystemProjectId();
-      systemNetwork = DataprocUtils.getSystemNetwork();
-    } catch (IllegalArgumentException e) {
-      // expected when not running on GCP, ignore
-    }
-
-    // Use private IP only cluster if privateInstance is true or if the compute profile required
-    if (!privateInstance && conf.isPreferExternalIP()) {
-      return false;
-    }
-
-    // If it is forced to be private instance or
-    // if CDAP runs in GCP project and runtime job manager is used and monitoring is not done through SSH,
-    // then we don't need to validate network connectivity
-    if (privateInstance || (systemProjectId != null && conf.isRuntimeJobManagerEnabled() && !sshRuntimeMonitor)) {
-      return true;
-    }
-
-    // If the CDAP is not running on GCP VM, then we just honor the prefer external IP config
-    if (systemProjectId == null || systemNetwork == null) {
-      return true;
-    }
-
-    // SSH will be used for job launching and/or monitoring, we need to validate network connectivity
-    // CDAP and Dataproc are in the same network, should be able to use private IP only cluster
-    if (systemProjectId.equals(conf.getNetworkHostProjectID()) && systemNetwork.equals(network.getName())) {
-      return true;
-    }
-
-    // Check network is peering, we can use private ip only cluster
-    PeeringState state = getPeeringState(systemProjectId, systemNetwork, network);
-    if (state == PeeringState.ACTIVE) {
-      return true;
-    }
-
-    // If there is no network connectivity and yet private ip only cluster is requested, raise an exception
-    throw new DataprocRuntimeException(
-      String.format("Direct network connectivity is needed for private Dataproc cluster between VPC %s/%s and %s/%s",
-                    systemProjectId, systemNetwork, conf.getNetworkHostProjectID(), network.getName())
-    );
-  }
-
-  /**
-   * Finds ingress firewall rules for the configured network that matches the required firewall port as
-   * defined in {@link FirewallPort}.
-   *
-   * @return a {@link Collection} of tags that need to be added to the VM to have those firewall rules applies
-   * @throws IOException If failed to discover those firewall rules
-   */
-  private List<String> getFirewallTargetTags(Network network, boolean useInternalIP)
-    throws IOException, RetryableProvisionException {
-    FirewallList firewalls;
-    try {
-      firewalls = compute.firewalls().list(conf.getNetworkHostProjectID()).execute();
-    } catch (Exception e) {
-      handleRetryableExceptions(e);
-      throw e;
-    }
-
-    List<String> tags = new ArrayList<>();
-    Set<FirewallPort> requiredPorts = EnumSet.allOf(FirewallPort.class);
-    // Iterate all firewall rules and see if it has ingress rules for all required firewall port.
-    for (Firewall firewall : Optional.ofNullable(firewalls.getItems()).orElse(Collections.emptyList())) {
-      // network is a url like https://www.googleapis.com/compute/v1/projects/<project>/<region>/networks/<name>
-      // we want to get the last section of the path and compare to the configured network name
-      int idx = firewall.getNetwork().lastIndexOf('/');
-      String networkName = idx >= 0 ? firewall.getNetwork().substring(idx + 1) : firewall.getNetwork();
-      if (!networkName.equals(network.getName())) {
-        continue;
-      }
-
-      String direction = firewall.getDirection();
-      if (!"INGRESS".equals(direction) || firewall.getAllowed() == null) {
-        continue;
-      }
-
-      if (useInternalIP) {
-        // If the Dataproc cluster is using internal IP only, we are only interested in firewall rule that has source
-        // IP range overlap with one of the private IP block or doesn't have source IP at all.
-        // This is because if Dataproc cluster is using internal IP, the CDAP itself must be running inside one of the
-        // private IP blocks in order to be able to communicate with Dataproc.
-        try {
-          List<IPRange> sourceRanges = Optional.ofNullable(firewall.getSourceRanges())
-            .map(DataprocUtils::parseIPRanges)
-            .orElse(Collections.emptyList());
-
-          if (!sourceRanges.isEmpty()) {
-            boolean isPrivate = PRIVATE_IP_RANGES.stream()
-              .anyMatch(privateRange -> sourceRanges.stream().anyMatch(privateRange::isOverlap));
-            if (!isPrivate) {
-              continue;
-            }
-          }
-        } catch (Exception e) {
-          LOG.warn("Failed to parse source ranges from firewall rule {}", firewall.getName(), e);
-        }
-      }
-
-      for (Firewall.Allowed allowed : firewall.getAllowed()) {
-        String protocol = allowed.getIPProtocol();
-        boolean addTag = false;
-        if ("all".equalsIgnoreCase(protocol)) {
-          requiredPorts.clear();
-          addTag = true;
-        } else if ("tcp".equalsIgnoreCase(protocol) && isPortAllowed(allowed.getPorts(), FirewallPort.SSH.port)) {
-          requiredPorts.remove(FirewallPort.SSH);
-          addTag = true;
-        }
-        if (addTag && firewall.getTargetTags() != null && !firewall.getTargetTags().isEmpty()) {
-          tags.add(firewall.getTargetTags().iterator().next());
-        }
-      }
-    }
-
-    if (!requiredPorts.isEmpty()) {
-      String portList = requiredPorts.stream().map(p -> String.valueOf(p.port)).collect(Collectors.joining(","));
-      throw new IllegalArgumentException(String.format(
-        "Could not find an ingress firewall rule for network '%s' in project '%s' for ports '%s'. " +
-          "Please create a rule to allow incoming traffic on those ports for your IP range.",
-        network.getName(), conf.getNetworkHostProjectID(), portList));
-    }
-    return tags;
-  }
-
-  /**
-   * Returns if the given port is allowed by the list of allowed ports. The allowed ports is in format as allowed by
-   * GCP firewall rule.
-   */
-  private boolean isPortAllowed(@Nullable List<String> allowedPorts, int port) {
-    if (allowedPorts == null) {
-      return true;
-    }
-    for (String allowedPort : allowedPorts) {
-      int idx = allowedPort.lastIndexOf('-');
-      try {
-        // This is a port range specification in format of "startPort-endPort" (e.g. 0-65535)
-        if (idx > 0) {
-          int fromPort = Integer.parseInt(allowedPort.substring(0, idx));
-          int toPort = Integer.parseInt(allowedPort.substring(idx + 1));
-          if (port >= fromPort && port <= toPort) {
-            return true;
-          }
-        } else if (port == Integer.parseInt(allowedPort)) {
-          return true;
-        }
-      } catch (NumberFormatException e) {
-        LOG.warn("Ignoring firewall allowed port value '{}' due to parse error.", allowedPort, e);
-      }
-    }
-    return false;
-  }
-
-  private Node getNode(Compute compute, Node.Type type, String zone, String nodeName) throws IOException {
-    Instance instance;
-    try {
-      instance = compute.instances().get(conf.getProjectId(), zone, nodeName).execute();
-    } catch (GoogleJsonResponseException e) {
-      // this can happen right after a cluster is created
-      if (e.getStatusCode() == 404) {
-        return new Node(nodeName, Node.Type.UNKNOWN, "", -1L, Collections.emptyMap());
-      }
-      throw e;
-    }
-    Map<String, String> properties = new HashMap<>();
-
-    // Dataproc cluster node should only have exactly one network
-    instance.getNetworkInterfaces().stream().findFirst().ifPresent(networkInterface -> {
-      // if the cluster does not have an external ip then then access config is null
-      if (networkInterface.getAccessConfigs() != null) {
-        for (AccessConfig accessConfig : networkInterface.getAccessConfigs()) {
-          if (accessConfig.getNatIP() != null) {
-            properties.put("ip.external", accessConfig.getNatIP());
-            break;
-          }
-        }
-      }
-      properties.put("ip.internal", networkInterface.getNetworkIP());
-    });
-
-    long ts;
-    try {
-      // something like 2018-04-16T12:09:03.943-07:00
-      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSSX");
-      ts = sdf.parse(instance.getCreationTimestamp()).getTime();
-    } catch (ParseException | NumberFormatException e) {
-      LOG.debug("Fail to parse creation ts {}", instance.getCreationTimestamp(), e);
-      ts = -1L;
-    }
-
-    // For internal IP only cluster, nodes only have ip.internal.
-    String ip = properties.get("ip.external");
-    if (ip == null) {
-      ip = properties.get("ip.internal");
-    }
-    return new Node(nodeName, type, ip, ts, properties);
-  }
-
-  /**
    * Converts Google Dataproc cluster status to CDAP Cluster Status
    */
   private io.cdap.cdap.runtime.spi.provisioner.ClusterStatus convertStatus(ClusterStatus status) {
@@ -1140,7 +699,7 @@ class DataprocClient implements AutoCloseable {
   }
 
   //Throws retryable Exception for the cases that are transient in nature
-  private static void handleRetryableExceptions(Exception e) throws RetryableProvisionException {
+  protected void handleRetryableExceptions(Exception e) throws RetryableProvisionException {
     // if there was an SocketTimeoutException ( read time out ) , we can just try again
     if (e instanceof SocketTimeoutException) {
       throw new RetryableProvisionException(e);
@@ -1162,20 +721,6 @@ class DataprocClient implements AutoCloseable {
           throw new RetryableProvisionException(e);
         }
       }
-    }
-  }
-
-
-  /**
-   * Firewall ports that we're concerned about.
-   */
-  private enum FirewallPort {
-    SSH(22);
-
-    private final int port;
-
-    FirewallPort(int port) {
-      this.port = port;
     }
   }
 }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClientFactory.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClientFactory.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright © 2022 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner.dataproc;
+
+import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import javax.annotation.Nullable;
+
+/**
+ * Creates DataprocClients.
+ */
+public interface DataprocClientFactory {
+
+  default DataprocClient create(DataprocConf conf) throws GeneralSecurityException, IOException {
+    return create(conf, false, null);
+  }
+
+  DataprocClient create(DataprocConf conf, boolean requireSSH,
+                        @Nullable SSHPublicKey sshPublicKey) throws IOException, GeneralSecurityException;
+}

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -19,7 +19,6 @@ package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Strings;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
-import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -134,7 +133,6 @@ final class DataprocConf {
   private final boolean stackdriverMonitoringEnabled;
   private final boolean componentGatewayEnabled;
   private final boolean skipDelete;
-  private final SSHPublicKey publicKey;
   private final Map<String, String> clusterProperties;
 
   private final Map<String, String> clusterMetaData;
@@ -160,22 +158,6 @@ final class DataprocConf {
   private final int computeReadTimeout;
   private final int computeConnectionTimeout;
 
-  DataprocConf(DataprocConf conf, String network, String subnet) {
-    this(conf.accountKey, conf.region, conf.zone, conf.projectId, conf.networkHostProjectID, network, subnet,
-         conf.masterNumNodes, conf.masterCPUs, conf.masterMemoryMB, conf.masterDiskGB, conf.masterDiskType,
-         conf.masterMachineType, conf.workerNumNodes, conf.secondaryWorkerNumNodes, conf.workerCPUs,
-         conf.workerMemoryMB, conf.workerDiskGB, conf.workerDiskType, conf.workerMachineType,
-         conf.pollCreateDelay, conf.pollCreateJitter, conf.pollDeleteDelay, conf.pollInterval,
-         conf.encryptionKeyName, conf.gcsBucket, conf.serviceAccount,
-         conf.preferExternalIP, conf.stackdriverLoggingEnabled, conf.stackdriverMonitoringEnabled,
-         conf.componentGatewayEnabled, conf.skipDelete, conf.publicKey, conf.imageVersion, conf.customImageUri,
-         conf.clusterMetaData, conf.clusterLabels, conf.networkTags, conf.initActions, conf.runtimeJobManagerEnabled,
-         conf.clusterProperties, conf.autoScalingPolicy, conf.idleTTLMinutes, conf.tokenEndpoint,
-         conf.secureBootEnabled, conf.vTpmEnabled, conf.integrityMonitoringEnabled, conf.clusterReuseEnabled,
-         conf.clusterReuseThresholdMinutes, conf.clusterReuseKey, conf.enablePredefinedAutoScaling,
-         conf.computeReadTimeout, conf.computeConnectionTimeout, conf.rootUrl);
-  }
-
   private DataprocConf(@Nullable String accountKey, String region, String zone, String projectId,
                        @Nullable String networkHostProjectId, @Nullable String network, @Nullable String subnet,
                        int masterNumNodes, int masterCPUs, int masterMemoryMB,
@@ -186,7 +168,7 @@ final class DataprocConf {
                        @Nullable String encryptionKeyName, @Nullable String gcsBucket,
                        @Nullable String serviceAccount, boolean preferExternalIP, boolean stackdriverLoggingEnabled,
                        boolean stackdriverMonitoringEnabled, boolean componentGatewayEnable, boolean skipDelete,
-                       @Nullable SSHPublicKey publicKey, @Nullable String imageVersion,
+                       @Nullable String imageVersion,
                        @Nullable String customImageUri,
                        @Nullable Map<String, String> clusterMetaData,
                        @Nullable Map<String, String> clusterLabels, List<String> networkTags,
@@ -232,7 +214,6 @@ final class DataprocConf {
     this.stackdriverMonitoringEnabled = stackdriverMonitoringEnabled;
     this.componentGatewayEnabled = componentGatewayEnable;
     this.skipDelete = skipDelete;
-    this.publicKey = publicKey;
     this.imageVersion = imageVersion;
     this.customImageUri = customImageUri;
     this.clusterMetaData = clusterMetaData;
@@ -390,11 +371,6 @@ final class DataprocConf {
     return skipDelete;
   }
 
-  @Nullable
-  SSHPublicKey getPublicKey() {
-    return publicKey;
-  }
-
   Map<String, String> getClusterMetaData() {
     return clusterMetaData;
   }
@@ -524,16 +500,6 @@ final class DataprocConf {
    * @throws IllegalArgumentException if it is an invalid config
    */
   static DataprocConf create(Map<String, String> properties) {
-    return create(properties, null);
-  }
-
-  /**
-   * Create the conf from a property map while also performing validation.
-   *
-   * @param publicKey an optional {@link SSHPublicKey} for the configuration
-   * @throws IllegalArgumentException if it is an invalid config
-   */
-  static DataprocConf create(Map<String, String> properties, @Nullable SSHPublicKey publicKey) {
     String accountKey = getString(properties, "accountKey");
     if (accountKey == null || AUTO_DETECT.equals(accountKey)) {
       String endPoint = getString(properties, TOKEN_ENDPOINT_KEY);
@@ -717,7 +683,7 @@ final class DataprocConf {
                             gcpCmekKeyName, gcpCmekBucket, serviceAccount, preferExternalIP,
                             stackdriverLoggingEnabled, stackdriverMonitoringEnabled,
                             componentGatewayEnabled, skipDelete,
-                            publicKey, imageVersion, customImageUri, clusterMetaData, clusterLabels, networkTags,
+                            imageVersion, customImageUri, clusterMetaData, clusterLabels, networkTags,
                             initActions, runtimeJobManagerEnabled, clusterProps, autoScalingPolicy, idleTTL,
                             tokenEndpoint, secureBootEnabled, vTpmEnabled, integrityMonitoringEnabled,
                             clusterReuseEnabled, clusterReuseThresholdMinutes, clusterReuseKey,

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -32,11 +32,10 @@ import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSpecification;
 import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
 import io.cdap.cdap.runtime.spi.ssh.SSHContext;
 import io.cdap.cdap.runtime.spi.ssh.SSHKeyPair;
+import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -64,15 +63,20 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
 
   private static final Pattern NETWORK_TAGS_PATTERN = Pattern.compile(("^[a-z][a-z0-9-]{0,62}$"));
 
-  //First version spark 3 is default one
-  private static final String SPARK3_CDAP_DEFAULT = "6.5";
-
   //A lock to use for cluster reuse
   private static final String REUSE_LOCK = "reuse";
 
+  private final DataprocClientFactory clientFactory;
+
   @SuppressWarnings("WeakerAccess")
   public DataprocProvisioner() {
+    this(new DefaultDataprocClientFactory(new GoogleComputeFactory()));
+  }
+
+  @VisibleForTesting
+  DataprocProvisioner(DataprocClientFactory clientFactory) {
     super(SPEC);
+    this.clientFactory = clientFactory;
   }
 
   @Override
@@ -135,7 +139,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
                DataprocConf.PREDEFINED_AUTOSCALE_ENABLED);
     }
 
-    if (context.getRuntimeMonitorType() == RuntimeMonitorType.SSH || !conf.isRuntimeJobManagerEnabled()) {
+    SSHPublicKey sshPublicKey = null;
+    if (shouldUseSSH(context, conf)) {
       // Generates and set the ssh key if it does not have one.
       // Since invocation of this method can come from a retry, we don't need to keep regenerating the keys
       SSHContext sshContext = context.getSSHContext();
@@ -145,11 +150,11 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
           sshKeyPair = sshContext.generate("cdap");
           sshContext.setSSHKeyPair(sshKeyPair);
         }
-        conf = DataprocConf.create(createContextProperties(context), sshKeyPair.getPublicKey());
+        sshPublicKey = sshKeyPair.getPublicKey();
       }
     }
 
-    try (DataprocClient client = getClient(conf)) {
+    try (DataprocClient client = clientFactory.create(conf, sshPublicKey != null, sshPublicKey)) {
       Cluster reused = tryReuseCluster(client, context, conf);
       if (reused != null) {
         DataprocUtils.emitMetric(context, conf.getRegion(),
@@ -193,7 +198,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
 
       boolean privateInstance = Boolean.parseBoolean(getSystemContext().getProperties().get(PRIVATE_INSTANCE));
       ClusterOperationMetadata createOperationMeta = client.createCluster(clusterName, imageVersion,
-                                                                          labels, privateInstance);
+                                                                          labels, privateInstance, sshPublicKey);
       int numWarnings = createOperationMeta.getWarningsCount();
       if (numWarnings > 0) {
         LOG.warn("Encountered {} warning{} while creating Dataproc cluster:\n{}",
@@ -233,7 +238,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
    */
   @Nullable
   private Cluster tryReuseCluster(DataprocClient client, ProvisionerContext context, DataprocConf conf)
-    throws RetryableProvisionException, IOException {
+    throws RetryableProvisionException {
     if (!isReuseSupported(conf)) {
       LOG.debug("Not checking cluster reuse, enabled: {}, skip delete: {}, idle ttl: {}, reuse threshold: {}",
                 conf.isClusterReuseEnabled(), conf.isSkipDelete(), conf.getIdleTTLMinutes(),
@@ -252,7 +257,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
         LOG.debug("Found allocated cluster {}", cluster.getName());
         return cluster;
       } else {
-        LOG.debug("Preallocated cluster {} has expired, will find a new one");
+        LOG.debug("Preallocated cluster {} has expired, will find a new one", cluster.getName());
         //Let's remove the reuse label to ensure new cluster will be picked up by findCluster
         try {
           client.updateClusterLabels(cluster.getName(), Collections.emptyMap(), Collections.singleton(LABEL_RUN_KEY));
@@ -279,7 +284,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
 
       Optional<Cluster> cluster = client.getClusters(ClusterStatus.RUNNING, filter, clientCluster -> {
         //Verify reuse label
-        long reuseUntil = Long.valueOf(clientCluster.getLabelsOrDefault(LABEL_REUSE_UNTIL, "0"));
+        long reuseUntil = Long.parseLong(clientCluster.getLabelsOrDefault(LABEL_REUSE_UNTIL, "0"));
         long now = System.currentTimeMillis();
         if (reuseUntil < now) {
           LOG.debug("Skipping expired cluster {}, reuse until {} is before now {}",
@@ -345,7 +350,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       return ClusterStatus.NOT_EXISTS;
     }
 
-    try (DataprocClient client = getClient(conf)) {
+    try (DataprocClient client = clientFactory.create(conf)) {
       status = client.getClusterStatus(clusterName);
       DataprocUtils.emitMetric(context, conf.getRegion(),
                                "provisioner.clusterStatus.response.count");
@@ -361,7 +366,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
   public Cluster getClusterDetail(ProvisionerContext context, Cluster cluster) throws Exception {
     DataprocConf conf = DataprocConf.create(createContextProperties(context));
     String clusterName = cluster.getName();
-    try (DataprocClient client = getClient(conf)) {
+    try (DataprocClient client = clientFactory.create(conf, shouldUseSSH(context, conf), null)) {
       Optional<Cluster> existing = client.getCluster(clusterName);
       DataprocUtils.emitMetric(context, conf.getRegion(),
                                "provisioner.clusterDetail.response.count");
@@ -379,7 +384,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       return;
     }
     String clusterName = cluster.getName();
-    try (DataprocClient client = getClient(conf)) {
+    try (DataprocClient client = clientFactory.create(conf)) {
       if (isReuseSupported(conf)) {
         long reuseUntil = System.currentTimeMillis() +
           TimeUnit.MINUTES.toMillis(conf.getIdleTTLMinutes() - conf.getClusterReuseThresholdMinutes());
@@ -408,18 +413,12 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
     DataprocConf conf = DataprocConf.create(createContextProperties(context));
     String clusterKey = getRunKey(context);
     if (isReuseSupported(conf)) {
-      try (DataprocClient client = getClient(conf)) {
+      try (DataprocClient client = clientFactory.create(conf)) {
         Optional<Cluster> allocatedCluster = findCluster(clusterKey, client);
         return allocatedCluster.map(Cluster::getName).orElse(clusterKey);
       }
     }
     return clusterKey;
-  }
-
-  @VisibleForTesting
-  protected DataprocClient getClient(DataprocConf conf) throws IOException, GeneralSecurityException,
-    RetryableProvisionException {
-    return DataprocClient.fromConf(conf);
   }
 
   private Optional<Cluster> findCluster(String clusterKey, DataprocClient client)
@@ -505,6 +504,10 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       cleanedAppName = cleanedAppName.substring(0, maxAppLength);
     }
     return CLUSTER_PREFIX + cleanedAppName + "-" + programRunInfo.getRun();
+  }
+
+  private boolean shouldUseSSH(ProvisionerContext context, DataprocConf conf) {
+    return context.getRuntimeMonitorType() == RuntimeMonitorType.SSH || !conf.isRuntimeJobManagerEnabled();
   }
 
   private boolean isAutoscalingFieldsValid(DataprocConf conf, Map<String, String> properties) {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocTool.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocTool.java
@@ -56,7 +56,8 @@ public class DataprocTool {
       .addOption(new Option("k", "serviceAccountKey", true, "Google cloud service account key (json format)."))
       .addOption(new Option("p", "project", true, "Google cloud project id."))
       .addOption(new Option("c", "configFile", true, "File all provisioner settings as a json object."))
-      .addOption(new Option("i", "imageVersion", true, "The image version for the cluster. Defaults to 1.2."))
+      .addOption(new Option("i", "imageVersion", true, "The image version for the cluster. Defaults to 2.0."))
+      .addOption(new Option("l", "lookupNetwork", false, "Whether to lookup network information about the cluster."))
       .addOption(new Option("n", "name", true, "Name of the cluster."));
 
     CommandLineParser parser = new BasicParser();
@@ -105,12 +106,14 @@ public class DataprocTool {
       conf = DataprocConf.create(properties);
     }
 
-    String imageVersion = commandLine.hasOption('i') ? commandLine.getOptionValue('i') : "1.2";
+    String imageVersion = commandLine.hasOption('i') ? commandLine.getOptionValue('i') : "2.0";
 
     String name = commandLine.getOptionValue('n');
-    try (DataprocClient client = DataprocClient.fromConf(conf)) {
+    DataprocClientFactory clientFactory = new DefaultDataprocClientFactory(new GoogleComputeFactory());
+    try (DataprocClient client = clientFactory.create(conf, commandLine.hasOption('l'), null)) {
       if (PROVISION.equalsIgnoreCase(command)) {
-        ClusterOperationMetadata createOp = client.createCluster(name, imageVersion, Collections.emptyMap(), false);
+        ClusterOperationMetadata createOp = client.createCluster(name, imageVersion, Collections.emptyMap(), false,
+                                                                 null);
         System.out.println(GSON.toJson(createOp));
       } else if (DETAILS.equalsIgnoreCase(command)) {
         Optional<Cluster> cluster = client.getCluster(name);

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DefaultDataprocClientFactory.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DefaultDataprocClientFactory.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright © 2022 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner.dataproc;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.services.compute.Compute;
+import com.google.cloud.dataproc.v1.ClusterControllerClient;
+import com.google.cloud.dataproc.v1.ClusterControllerSettings;
+import io.cdap.cdap.runtime.spi.ssh.SSHPublicKey;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * Creates DataprocClients.
+ */
+public class DefaultDataprocClientFactory implements DataprocClientFactory {
+  private final ComputeFactory computeFactory;
+
+  public DefaultDataprocClientFactory() {
+    this(new GoogleComputeFactory());
+  }
+
+  public DefaultDataprocClientFactory(ComputeFactory computeFactory) {
+    this.computeFactory = computeFactory;
+  }
+
+  @Override
+  public DataprocClient create(DataprocConf conf, boolean requireSSH,
+                               @Nullable SSHPublicKey sshPublicKey) throws IOException, GeneralSecurityException {
+    ClusterControllerClient clusterControllerClient = getClusterControllerClient(conf);
+    Compute compute = computeFactory.createCompute(conf.getComputeCredential(), conf.getComputeConnectionTimeout(),
+                                                   conf.getComputeReadTimeout());
+    return requireSSH ? new SSHDataprocClient(conf, clusterControllerClient, compute) :
+      new RuntimeMonitorDataprocClient(conf, clusterControllerClient, compute);
+  }
+
+  private static ClusterControllerClient getClusterControllerClient(DataprocConf conf) throws IOException {
+    CredentialsProvider credentialsProvider = FixedCredentialsProvider.create(conf.getDataprocCredentials());
+
+    String rootUrl = Optional.ofNullable(conf.getRootUrl()).orElse(ClusterControllerSettings.getDefaultEndpoint());
+    String regionalEndpoint = conf.getRegion() + "-" + rootUrl;
+
+    ClusterControllerSettings controllerSettings = ClusterControllerSettings.newBuilder()
+      .setCredentialsProvider(credentialsProvider)
+      .setEndpoint(regionalEndpoint)
+      .build();
+    return ClusterControllerClient.create(controllerSettings);
+  }
+}

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/ExistingDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/ExistingDataprocProvisioner.java
@@ -50,6 +50,7 @@ public class ExistingDataprocProvisioner extends AbstractDataprocProvisioner {
   private static final String CLUSTER_NAME = "clusterName";
   private static final String SSH_USER = "sshUser";
   private static final String SSH_KEY = "sshKey";
+  private static final DataprocClientFactory CLIENT_FACTORY = new DefaultDataprocClientFactory();
 
   public ExistingDataprocProvisioner() {
     super(SPEC);
@@ -90,7 +91,7 @@ public class ExistingDataprocProvisioner extends AbstractDataprocProvisioner {
     }
 
     String clusterName = contextProperties.get(CLUSTER_NAME);
-    try (DataprocClient client = DataprocClient.fromConf(conf, false)) {
+    try (DataprocClient client = CLIENT_FACTORY.create(conf)) {
       try {
         client.updateClusterLabels(clusterName, getSystemLabels());
       } catch (DataprocRuntimeException e) {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/GoogleComputeFactory.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/GoogleComputeFactory.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright © 2022 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner.dataproc;
+
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.compute.Compute;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+public class GoogleComputeFactory implements ComputeFactory {
+
+  @Override
+  public Compute createCompute(GoogleCredentials credentials, int connectTimeout,
+                               int readTimeout) throws GeneralSecurityException, IOException {
+    HttpRequestInitializer requestInitializer = new HttpCredentialsAdapter(credentials);
+    HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+    HttpRequestInitializer timeoutRequestInitializer = httpRequest -> {
+      requestInitializer.initialize(httpRequest);
+      httpRequest.setConnectTimeout(connectTimeout);
+      httpRequest.setReadTimeout(readTimeout);
+    };
+    return new Compute.Builder(httpTransport, JacksonFactory.getDefaultInstance(), timeoutRequestInitializer)
+      .setApplicationName("cdap")
+      .build();
+  }
+}

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/RuntimeMonitorDataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/RuntimeMonitorDataprocClient.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner.dataproc;
+
+import com.google.api.services.compute.Compute;
+import com.google.cloud.dataproc.v1.ClusterControllerClient;
+import com.google.cloud.dataproc.v1.GceClusterConfig;
+import io.cdap.cdap.runtime.spi.provisioner.Node;
+
+import java.util.Collections;
+
+/**
+ * Wrapper around the dataproc client that adheres to our configuration settings.
+ */
+class RuntimeMonitorDataprocClient extends DataprocClient {
+
+  RuntimeMonitorDataprocClient(DataprocConf conf, ClusterControllerClient client, Compute compute) {
+    super(conf, client, compute);
+  }
+
+  @Override
+  protected Node getNode(Node.Type type, String zone, String nodeName) {
+    return new Node(nodeName, type, null, 0, Collections.emptyMap());
+  }
+
+  @Override
+  protected void setNetworkConfigs(GceClusterConfig.Builder clusterConfig, String network, boolean privateInstance) {
+    String subnet = conf.getSubnet();
+    // subnets are unique within a location, not within a network, which is why these configs are mutually exclusive.
+    if (subnet != null) {
+      clusterConfig.setSubnetworkUri(subnet);
+    } else {
+      clusterConfig.setNetworkUri(network);
+    }
+
+    //Add any defined Network Tags
+    clusterConfig.addAllTags(conf.getNetworkTags());
+
+    // if internal ip is preferred then create dataproc cluster without external ip for better security
+    clusterConfig.setInternalIpOnly(privateInstance || !conf.isPreferExternalIP());
+  }
+}

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/SSHDataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/SSHDataprocClient.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner.dataproc;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.compute.Compute;
+import com.google.api.services.compute.model.AccessConfig;
+import com.google.api.services.compute.model.Firewall;
+import com.google.api.services.compute.model.FirewallList;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.Network;
+import com.google.api.services.compute.model.NetworkPeering;
+import com.google.cloud.dataproc.v1.ClusterControllerClient;
+import com.google.cloud.dataproc.v1.GceClusterConfig;
+import io.cdap.cdap.runtime.spi.common.DataprocUtils;
+import io.cdap.cdap.runtime.spi.common.IPRange;
+import io.cdap.cdap.runtime.spi.provisioner.Node;
+import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * Wrapper around the dataproc client that adheres to our configuration settings. Creates Dataproc clusters that
+ * are accessible through SSH.
+ */
+class SSHDataprocClient extends DataprocClient {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SSHDataprocClient.class);
+  private static final List<IPRange> PRIVATE_IP_RANGES = DataprocUtils.parseIPRanges(Arrays.asList("10.0.0.0/8",
+                                                                                                   "172.16.0.0/12",
+                                                                                                   "192.168.0.0/16"));
+
+  SSHDataprocClient(DataprocConf conf, ClusterControllerClient client, Compute compute) {
+    super(conf, client, compute);
+  }
+
+  @Override
+  protected void setNetworkConfigs(GceClusterConfig.Builder clusterConfig, String network,
+                                   boolean privateInstance) throws RetryableProvisionException, IOException {
+    String networkHostProjectId = conf.getNetworkHostProjectID();
+    String subnet = conf.getSubnet();
+    Network networkInfo = getNetworkInfo(networkHostProjectId, network, compute);
+
+    List<String> subnets = networkInfo.getSubnetworks();
+    if (subnet != null && !subnetExists(subnets, subnet)) {
+      throw new IllegalArgumentException(String.format("Subnet '%s' does not exist in network '%s' in project '%s'. "
+                                                         + "Please use a different subnet.",
+                                                       subnet, network, networkHostProjectId));
+    }
+
+    // if the network uses custom subnets, a subnet must be provided to the dataproc api
+    boolean autoCreateSubnet = networkInfo.getAutoCreateSubnetworks() != null && networkInfo.getAutoCreateSubnetworks();
+    if (!autoCreateSubnet) {
+      // if the network uses custom subnets but none exist, error out
+      if (subnets == null || subnets.isEmpty()) {
+        throw new IllegalArgumentException(String.format("Network '%s' in project '%s' does not contain any subnets. "
+                                                           + "Please create a subnet or use a different network.",
+                                                         network, networkHostProjectId));
+      }
+    }
+
+    subnet = chooseSubnet(network, subnets, subnet, conf.getRegion());
+
+    // subnets are unique within a location, not within a network, which is why these configs are mutually exclusive.
+    clusterConfig.setSubnetworkUri(subnet);
+
+    //Add any defined Network Tags
+    clusterConfig.addAllTags(conf.getNetworkTags());
+    boolean internalIPOnly = isInternalIPOnly(networkInfo, privateInstance);
+
+    // if public key is not null that means ssh is used to launch / monitor job on dataproc
+    int maxTags = Math.max(0, DataprocConf.MAX_NETWORK_TAGS - clusterConfig.getTagsCount());
+    List<String> tags = getFirewallTargetTags(networkInfo, internalIPOnly);
+    if (tags.size() > maxTags) {
+      LOG.warn("No more than 64 tags can be added. Firewall tags ignored: {}", tags.subList(maxTags, tags.size()));
+    }
+    tags.stream().limit(maxTags).forEach(clusterConfig::addTags);
+
+    // if internal ip is preferred then create dataproc cluster without external ip for better security
+    clusterConfig.setInternalIpOnly(internalIPOnly);
+  }
+
+  @Override
+  protected Node getNode(Node.Type type, String zone, String nodeName) throws IOException {
+    Instance instance;
+    try {
+      instance = compute.instances().get(conf.getProjectId(), zone, nodeName).execute();
+    } catch (GoogleJsonResponseException e) {
+      // this can happen right after a cluster is created
+      if (e.getStatusCode() == 404) {
+        return new Node(nodeName, Node.Type.UNKNOWN, "", -1L, Collections.emptyMap());
+      }
+      throw e;
+    }
+    Map<String, String> properties = new HashMap<>();
+
+    // Dataproc cluster node should only have exactly one network
+    instance.getNetworkInterfaces().stream().findFirst().ifPresent(networkInterface -> {
+      // if the cluster does not have an external ip then then access config is null
+      if (networkInterface.getAccessConfigs() != null) {
+        for (AccessConfig accessConfig : networkInterface.getAccessConfigs()) {
+          if (accessConfig.getNatIP() != null) {
+            properties.put("ip.external", accessConfig.getNatIP());
+            break;
+          }
+        }
+      }
+      properties.put("ip.internal", networkInterface.getNetworkIP());
+    });
+
+    long ts;
+    try {
+      // something like 2018-04-16T12:09:03.943-07:00
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSSX");
+      ts = sdf.parse(instance.getCreationTimestamp()).getTime();
+    } catch (ParseException | NumberFormatException e) {
+      LOG.debug("Fail to parse creation ts {}", instance.getCreationTimestamp(), e);
+      ts = -1L;
+    }
+
+    // For internal IP only cluster, nodes only have ip.internal.
+    String ip = properties.get("ip.external");
+    if (ip == null) {
+      ip = properties.get("ip.internal");
+    }
+    return new Node(nodeName, type, ip, ts, properties);
+  }
+
+  private static PeeringState getPeeringState(String systemProjectId, String systemNetwork, Network networkInfo) {
+    // note: vpc network is a global resource.
+    // https://cloud.google.com/compute/docs/regions-zones/global-regional-zonal-resources#globalresources
+    String systemNetworkPath = String.format("https://www.googleapis.com/compute/v1/projects/%s/global/networks/%s",
+                                             systemProjectId, systemNetwork);
+
+    LOG.trace(String.format("Self link for the system network is %s", systemNetworkPath));
+    List<NetworkPeering> peerings = networkInfo.getPeerings();
+    // if the customer does not has a peering established at all the peering list is null
+    if (peerings == null) {
+      return PeeringState.NONE;
+    }
+    for (NetworkPeering peering : peerings) {
+      if (!systemNetworkPath.equals(peering.getNetwork())) {
+        continue;
+      }
+      return peering.getState().equals("ACTIVE") ? PeeringState.ACTIVE : PeeringState.INACTIVE;
+    }
+    return PeeringState.NONE;
+  }
+
+  private static boolean subnetExists(List<String> subnets, String subnet) {
+    // subnets are of the form
+    // "https://www.googleapis.com/compute/v1/projects/<project>/regions/<region>/subnetworks/<name>"
+    // the provided subnet can be the full URI but is most often just the name
+    for (String networkSubnet : subnets) {
+      if (networkSubnet.equals(subnet) || networkSubnet.endsWith("subnetworks/" + subnet)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // subnets are identified as
+  // "https://www.googleapis.com/compute/v1/projects/<project>/regions/<region>/subnetworks/<name>"
+  // a subnet in the same region as the dataproc cluster must be chosen. If a subnet name is provided then the subnet
+  // will be choosen and the region will be picked on basis of the given zone. If a subnet name is not provided then
+  // any subnetwork in the region of the given zone will be picked.
+  private static String chooseSubnet(String network, List<String> subnets, @Nullable String subnet, String region) {
+    for (String currentSubnet : subnets) {
+      // if a subnet name is given then get the region of that subnet based on the zone
+      if (subnet != null && !currentSubnet.endsWith("subnetworks/" + subnet)) {
+        continue;
+      }
+      if (currentSubnet.contains(region + "/subnetworks")) {
+        return currentSubnet;
+      }
+    }
+    throw new IllegalArgumentException(
+      String.format("Could not find %s in network '%s' that are for region '%s'", subnet == null ? "any subnet" :
+        String.format("a subnet named '%s", subnet), network, region));
+  }
+
+  private Network getNetworkInfo(String project, String network, Compute compute)
+    throws IOException, RetryableProvisionException {
+    Network networkObj;
+    try {
+      networkObj = compute.networks().get(project, network).execute();
+    } catch (Exception e) {
+      handleRetryableExceptions(e);
+      throw e;
+    }
+
+    if (networkObj == null) {
+      throw new IllegalArgumentException(String.format("Unable to find network '%s' in project '%s'. "
+                                                         + "Please specify another network.", network, project));
+    }
+    return networkObj;
+  }
+
+  /**
+   * Determines if the Dataproc cluster is private IP only.
+   *
+   * @param privateInstance a system config to force using private instance
+   * @return {@code true} for pribvate IP only Dataproc cluster
+   */
+  private boolean isInternalIPOnly(Network network, boolean privateInstance) {
+    String systemProjectId = null;
+    String systemNetwork = null;
+    try {
+      systemProjectId = DataprocUtils.getSystemProjectId();
+      systemNetwork = DataprocUtils.getSystemNetwork();
+    } catch (IllegalArgumentException e) {
+      // expected when not running on GCP, ignore
+    }
+
+    // Use private IP only cluster if privateInstance is true or if the compute profile required
+    if (!privateInstance && conf.isPreferExternalIP()) {
+      return false;
+    }
+
+    // If it is forced to be private instance or
+    // if CDAP runs in GCP project and runtime job manager is used and monitoring is not done through SSH,
+    // then we don't need to validate network connectivity
+    if (privateInstance) {
+      return true;
+    }
+
+    // If the CDAP is not running on GCP VM, then we just honor the prefer external IP config
+    if (systemProjectId == null || systemNetwork == null) {
+      return true;
+    }
+
+    // SSH will be used for job launching and/or monitoring, we need to validate network connectivity
+    // CDAP and Dataproc are in the same network, should be able to use private IP only cluster
+    if (systemProjectId.equals(conf.getNetworkHostProjectID()) && systemNetwork.equals(network.getName())) {
+      return true;
+    }
+
+    // Check network is peering, we can use private ip only cluster
+    PeeringState state = getPeeringState(systemProjectId, systemNetwork, network);
+    if (state == PeeringState.ACTIVE) {
+      return true;
+    }
+
+    // If there is no network connectivity and yet private ip only cluster is requested, raise an exception
+    throw new DataprocRuntimeException(
+      String.format("Direct network connectivity is needed for private Dataproc cluster between VPC %s/%s and %s/%s",
+                    systemProjectId, systemNetwork, conf.getNetworkHostProjectID(), network.getName())
+    );
+  }
+
+  /**
+   * Finds ingress firewall rules for the configured network that matches the required firewall port as
+   * defined in {@link FirewallPort}.
+   *
+   * @return a {@link Collection} of tags that need to be added to the VM to have those firewall rules applies
+   * @throws IOException If failed to discover those firewall rules
+   */
+  private List<String> getFirewallTargetTags(Network network, boolean useInternalIP)
+    throws IOException, RetryableProvisionException {
+    FirewallList firewalls;
+    try {
+      firewalls = compute.firewalls().list(conf.getNetworkHostProjectID()).execute();
+    } catch (Exception e) {
+      handleRetryableExceptions(e);
+      throw e;
+    }
+
+    List<String> tags = new ArrayList<>();
+    Set<FirewallPort> requiredPorts = EnumSet.allOf(FirewallPort.class);
+    // Iterate all firewall rules and see if it has ingress rules for all required firewall port.
+    for (Firewall firewall : Optional.ofNullable(firewalls.getItems()).orElse(Collections.emptyList())) {
+      // network is a url like https://www.googleapis.com/compute/v1/projects/<project>/<region>/networks/<name>
+      // we want to get the last section of the path and compare to the configured network name
+      int idx = firewall.getNetwork().lastIndexOf('/');
+      String networkName = idx >= 0 ? firewall.getNetwork().substring(idx + 1) : firewall.getNetwork();
+      if (!networkName.equals(network.getName())) {
+        continue;
+      }
+
+      String direction = firewall.getDirection();
+      if (!"INGRESS".equals(direction) || firewall.getAllowed() == null) {
+        continue;
+      }
+
+      if (useInternalIP) {
+        // If the Dataproc cluster is using internal IP only, we are only interested in firewall rule that has source
+        // IP range overlap with one of the private IP block or doesn't have source IP at all.
+        // This is because if Dataproc cluster is using internal IP, the CDAP itself must be running inside one of the
+        // private IP blocks in order to be able to communicate with Dataproc.
+        try {
+          List<IPRange> sourceRanges = Optional.ofNullable(firewall.getSourceRanges())
+            .map(DataprocUtils::parseIPRanges)
+            .orElse(Collections.emptyList());
+
+          if (!sourceRanges.isEmpty()) {
+            boolean isPrivate = PRIVATE_IP_RANGES.stream()
+              .anyMatch(privateRange -> sourceRanges.stream().anyMatch(privateRange::isOverlap));
+            if (!isPrivate) {
+              continue;
+            }
+          }
+        } catch (Exception e) {
+          LOG.warn("Failed to parse source ranges from firewall rule {}", firewall.getName(), e);
+        }
+      }
+
+      for (Firewall.Allowed allowed : firewall.getAllowed()) {
+        String protocol = allowed.getIPProtocol();
+        boolean addTag = false;
+        if ("all".equalsIgnoreCase(protocol)) {
+          requiredPorts.clear();
+          addTag = true;
+        } else if ("tcp".equalsIgnoreCase(protocol) && isPortAllowed(allowed.getPorts(), FirewallPort.SSH.port)) {
+          requiredPorts.remove(FirewallPort.SSH);
+          addTag = true;
+        }
+        if (addTag && firewall.getTargetTags() != null && !firewall.getTargetTags().isEmpty()) {
+          tags.add(firewall.getTargetTags().iterator().next());
+        }
+      }
+    }
+
+    if (!requiredPorts.isEmpty()) {
+      String portList = requiredPorts.stream().map(p -> String.valueOf(p.port)).collect(Collectors.joining(","));
+      throw new IllegalArgumentException(String.format(
+        "Could not find an ingress firewall rule for network '%s' in project '%s' for ports '%s'. " +
+          "Please create a rule to allow incoming traffic on those ports for your IP range.",
+        network.getName(), conf.getNetworkHostProjectID(), portList));
+    }
+    return tags;
+  }
+
+  /**
+   * Returns if the given port is allowed by the list of allowed ports. The allowed ports is in format as allowed by
+   * GCP firewall rule.
+   */
+  private boolean isPortAllowed(@Nullable List<String> allowedPorts, int port) {
+    if (allowedPorts == null) {
+      return true;
+    }
+    for (String allowedPort : allowedPorts) {
+      int idx = allowedPort.lastIndexOf('-');
+      try {
+        // This is a port range specification in format of "startPort-endPort" (e.g. 0-65535)
+        if (idx > 0) {
+          int fromPort = Integer.parseInt(allowedPort.substring(0, idx));
+          int toPort = Integer.parseInt(allowedPort.substring(idx + 1));
+          if (port >= fromPort && port <= toPort) {
+            return true;
+          }
+        } else if (port == Integer.parseInt(allowedPort)) {
+          return true;
+        }
+      } catch (NumberFormatException e) {
+        LOG.warn("Ignoring firewall allowed port value '{}' due to parse error.", allowedPort, e);
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public void close() {
+    client.close();
+  }
+
+  private enum PeeringState {
+    ACTIVE,
+    INACTIVE,
+    NONE
+  }
+
+  /**
+   * Firewall ports that we're concerned about.
+   */
+  private enum FirewallPort {
+    SSH(22);
+
+    private final int port;
+
+    FirewallPort(int port) {
+      this.port = port;
+    }
+  }
+}

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/PredefinedAutoScalingTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/PredefinedAutoScalingTest.java
@@ -49,7 +49,7 @@ public class PredefinedAutoScalingTest {
     properties.put("accountKey", "{ \"type\": \"test\"}");
     properties.put(DataprocConf.PROJECT_ID_KEY, PROJECT);
     properties.put("zone", REGION);
-    dataprocConf = DataprocConf.create(properties, null);
+    dataprocConf = DataprocConf.create(properties);
   }
 
   @Test

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/Node.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/Node.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.runtime.spi.provisioner;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Information about a cluster node.
@@ -30,7 +31,7 @@ public class Node {
   private final long createTime;
   private final Map<String, String> properties;
 
-  public Node(String id, Type type, String ipAddress, long createTime, Map<String, String> properties) {
+  public Node(String id, Type type, @Nullable String ipAddress, long createTime, Map<String, String> properties) {
     this.id = id;
     this.type = type;
     this.ipAddress = ipAddress;
@@ -46,6 +47,7 @@ public class Node {
     return type;
   }
 
+  @Nullable
   public String getIpAddress() {
     return ipAddress;
   }


### PR DESCRIPTION
Refactored DataprocClient to use a new NetworkClient interface
to perform all operations that used to require a call to the
GCE APIs. A ComputeNetworkClient implementation contains all the
existing logic, while a NoOpNetworkClient implementation performs
all operations without making any external calls. When SSH is
required to monitor the program run, the ComputeNetworkClient is
used. When runtime monitoring is used, the NoOpNetworkClient is
used.