### PR TITLE
[CDAP-19268] Cherry-Pick 6.7

### DIFF
--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/SystemMetricsExporterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/SystemMetricsExporterServiceMain.java
@@ -30,6 +30,8 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.metrics.jmx.JMXMetricsCollectorFactory;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.TokenManager;
+import io.cdap.cdap.security.impersonation.SecurityUtil;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -78,6 +80,11 @@ public class SystemMetricsExporterServiceMain extends AbstractServiceMain<Enviro
                              MasterEnvironment masterEnv,
                              MasterEnvironmentContext masterEnvContext,
                              EnvironmentOptions options) {
+    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    if (SecurityUtil.isInternalAuthEnabled(cConf)) {
+      services.add(injector.getInstance(TokenManager.class));
+    }
+
     Map<String, String> conf = masterEnvContext.getConfigurations();
     Map<String, String> metricTags = filterByKeyPrefix(
       conf, MasterEnvironmentContext.ENVIRONMENT_PROPERTY_PREFIX);


### PR DESCRIPTION
Cherry-pick of #14317

[CDAP-19268] Start TokenManager in SystemMetricsExporterServiceMain if internal auth is enabled

[CDAP-19268]: https://cdap.atlassian.net/browse/CDAP-19268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ