### PR TITLE
[CDAP-19192] Enable write-ahead logs by default in spark config

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -97,6 +97,17 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
     }
 
     SparkConf sparkConf = new SparkConf();
+    // we do not do checkpointing during preview. Skip enabling write-ahead logs in that case to avoid spark exception
+    boolean isPreviewEnabled =
+      spec.getStages().isEmpty() || context.getDataTracer(spec.getStages().iterator().next().getName()).isEnabled();
+    if (!isPreviewEnabled) {
+      // required spark configs to prevent data loss during real-time pipeline upgrades
+      sparkConf.set("spark.streaming.receiver.writeAheadLog.enable", "true");
+      sparkConf.set("spark.streaming.receiver.writeAheadLog.closeFileAfterWrite", "true");
+      sparkConf.set("spark.streaming.driver.writeAheadLog.closeFileAfterWrite", "true");
+      sparkConf.set("spark.streaming.receiver.writeAheadLog.rollingIntervalSecs", String.valueOf(0));
+      sparkConf.set("spark.streaming.driver.writeAheadLog.rollingIntervalSecs", String.valueOf(0));
+    }
     sparkConf.set("spark.streaming.backpressure.enabled", "true");
     sparkConf.set("spark.spark.streaming.blockInterval", String.valueOf(spec.getBatchIntervalMillis() / 5));
     sparkConf.set("spark.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
@@ -137,6 +148,14 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
             "Number of spark executors was set to invalid value " + property.getValue(), e);
         }
       } else {
+        sparkConf.set(property.getKey(), property.getValue());
+      }
+      if ("spark.streaming.receiver.writeAheadLog.enable".equals(property.getKey())) {
+        boolean isWriteAheadLogEnabled = Boolean.parseBoolean(property.getValue());
+        if (spec.isCheckpointsDisabled() && isWriteAheadLogEnabled) {
+          throw new IllegalArgumentException(
+            "Checkpointing should be enabled when write-ahead logs are enabled for the pipeline.");
+        }
         sparkConf.set(property.getKey(), property.getValue());
       }
     }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/DataStreamsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/DataStreamsTest.java
@@ -533,7 +533,6 @@ public class DataStreamsTest extends HydratorTestBase {
       .addConnection("agg1", "sink1")
       .addConnection("agg2", "sink2")
       .setCheckpointDir(checkpointDir)
-      .disableCheckpoints()
       .build();
 
     AppRequest<DataStreamsConfig> appRequest = new AppRequest<>(APP_ARTIFACT, pipelineConfig);


### PR DESCRIPTION
This is required to avoid data loss.

Jira: https://cdap.atlassian.net/browse/CDAP-19192