### PR TITLE
[CDAP-19289] Validate tethering conn for profile creation

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringProvisioner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringProvisioner.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.internal.provision.ProvisionerExtensionLoader;
 import io.cdap.cdap.internal.tethering.PeerInfo;
 import io.cdap.cdap.internal.tethering.PeerNotFoundException;
+import io.cdap.cdap.internal.tethering.TetheringStatus;
 import io.cdap.cdap.internal.tethering.TetheringStore;
 import io.cdap.cdap.internal.tethering.runtime.spi.runtimejob.TetheringRuntimeJobManager;
 import io.cdap.cdap.messaging.MessagingService;
@@ -93,6 +94,9 @@ public class TetheringProvisioner implements Provisioner {
       .noneMatch(n -> n.getNamespace().equals(namespace))) {
       throw new IllegalArgumentException(String.format("Namespace %s is not provided by tethered peer %s",
                                                        namespace, peer));
+    }
+    if (!peerInfo.getTetheringStatus().equals(TetheringStatus.ACCEPTED)) {
+      throw new IllegalArgumentException(String.format("Connection to tethered peer %s must first be accepted", peer));
     }
   }
 


### PR DESCRIPTION
Check that tethering connection is accepted before compute profile creation

JIRA: CDAP-19289

--------------------------
**Testing**
Tried to create a tethering compute profile with a peer that was not yet accepted (in `pending` state)
<img width="882" alt="image" src="https://user-images.githubusercontent.com/8079472/168392632-0227a57e-011b-48c8-9e95-15a49b5b6f45.png">
