### PR TITLE
[CDAP-19286] Only validate role when namespace creation is enabled

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -342,9 +342,11 @@ public class KubeMasterEnvironment implements MasterEnvironment {
                                                              DEFAULT_WORKLOAD_LAUNCHER_NAMESPACE_ROLE_NAME);
     workloadLauncherRoleNameForCluster = conf.getOrDefault(WORKLOAD_LAUNCHER_CLUSTER_ROLE_NAME,
                                                            DEFAULT_WORKLOAD_LAUNCHER_CLUSTER_ROLE_NAME);
-    // Validate cluster roles exist.
-    validateClusterRole(workloadLauncherRoleNameForNamespace);
-    validateClusterRole(workloadLauncherRoleNameForCluster);
+    // Validate cluster roles exist if namespace creation is enabled.
+    if (namespaceCreationEnabled) {
+      validateClusterRole(workloadLauncherRoleNameForNamespace);
+      validateClusterRole(workloadLauncherRoleNameForCluster);
+    }
 
     // Load the pod labels from the configured path. It should be setup by the CDAP operator
     podInfo = createPodInfo(conf);


### PR DESCRIPTION
Resolves a bug in which validation causes full crashloop when namespace creation is disabled.