### PR TITLE
[CDAP-19316] Fix security vulnerability in commons-fileupload dependency

### DIFF
--- a/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
@@ -92,6 +92,12 @@
     <groupId>org.apache.hbase</groupId>
     <artifactId>hbase-server</artifactId>
     <version>${hbase12cdh570.version}</version>
+    <exclusions>
+      <exclusion>
+        <groupId>commons-fileupload</groupId>
+        <artifactId>commons-fileupload</artifactId>
+      </exclusion>
+    </exclusions>
   </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
### Change Description

Fixed security vulnerabilities for dependencies:
* commons-fileupload

Changes:
* Excluded transitive dependencies from maven packages in pom.xml.

### Verification
* Verified dependency exclusion and version upgrade using `mvn dependency:tree`
* Sanity testing of CDAP sandbox image