### PR TITLE
[CDAP-19337] Add E2E integration tests for Kube namespace

### DIFF
--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -163,6 +163,90 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>e2e-tests</id>
+      <properties>
+        <testSourceLocation>src/e2e-test/java</testSourceLocation>
+      </properties>
+      <build>
+        <testResources>
+          <testResource>
+            <directory>src/e2e-test/resources</directory>
+          </testResource>
+        </testResources>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>TestRunner.java</include>
+              </includes>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>net.masterthought</groupId>
+            <artifactId>maven-cucumber-reporting</artifactId>
+            <version>5.5.0</version>
+
+            <executions>
+              <execution>
+                <id>execution</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+                <configuration>
+                  <projectName>Cucumber Reports</projectName> <!-- Replace with project name -->
+                  <outputDirectory>target/cucumber-reports/advanced-reports</outputDirectory>
+                  <buildNumber>1</buildNumber>
+                  <skip>false</skip>
+                  <inputDirectory>${project.build.directory}/cucumber-reports</inputDirectory>
+                  <jsonFiles> <!-- supports wildcard or name pattern -->
+                    <param>**/*.json</param>
+                  </jsonFiles> <!-- optional, defaults to outputDirectory if not specified -->
+                  <classificationDirectory>${project.build.directory}/cucumber-reports</classificationDirectory>
+                  <checkBuildResult>true</checkBuildResult>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+        <dependency>
+          <groupId>io.cdap.tests.e2e</groupId>
+          <artifactId>cdap-e2e-framework</artifactId>
+          <version>0.0.1-SNAPSHOT</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+          <version>1.2.8</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+
+    </profile>
   </profiles>
 
 </project>

--- a/cdap-kubernetes/src/e2e-test/features/KubernetesNamespaceCreation.feature
+++ b/cdap-kubernetes/src/e2e-test/features/KubernetesNamespaceCreation.feature
@@ -1,0 +1,53 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@KubernetesNamespace_Creation
+Feature: Kubernetes namespace - Validate Kubernetes namespace creation scenarios
+
+  @KUBE_NAMESPACE_TEST
+  Scenario: Validate successful Kubernetes namespace creation
+    Given Open Datafusion Project to configure pipeline
+    And Get Kubernetes coreV1Api
+    When Open namespace creation wizard
+    Then Enter namespace name "test_cdap_namespace"
+    Then Go to next page in namespace creation wizard
+    Then Enter Kubernetes namespace name "test-kube-namespace"
+    Then Finish namespace creation
+    Then Verify Kubernetes namespace "test-kube-namespace" exists
+
+  @KUBE_NAMESPACE_TEST
+  Scenario: Validate successful Kubernetes namespace creation with resource limits
+    Given Open Datafusion Project to configure pipeline
+    And Get Kubernetes coreV1Api
+    When Open namespace creation wizard
+    Then Enter namespace name "test_cdap_namespace_with_limits"
+    Then Go to next page in namespace creation wizard
+    Then Enter Kubernetes namespace name "test-kube-namespace-with-limits"
+    Then Enter CPU limit "2"
+    Then Enter memory limit "2Gi"
+    Then Finish namespace creation
+    Then Verify Kubernetes namespace "test-kube-namespace-with-limits" exists
+    Then Verify CPU limit "2" and memory limit "2Gi" exists for "test-kube-namespace-with-limits"
+
+  @KUBE_NAMESPACE_TEST
+  Scenario: Validate unsuccessful namespace creation with invalid Kubernetes name
+    Given Open Datafusion Project to configure pipeline
+    When Open namespace creation wizard
+    Then Enter namespace name "test_cdap_namespace_2"
+    Then Go to next page in namespace creation wizard
+    Then Enter Kubernetes namespace name "test_invalid_kube_namespace"
+    Then Finish namespace creation
+    Then Verify namespace creation failure

--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/actions/NamespaceCreationActions.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/actions/NamespaceCreationActions.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s.actions;
+
+import io.cdap.cdap.master.environment.k8s.locators.NamespaceCreationLocators;
+import io.cdap.e2e.utils.ElementHelper;
+import io.cdap.e2e.utils.SeleniumHelper;
+
+/**
+ * Namespace creation related actions
+ */
+public class NamespaceCreationActions {
+
+  static {
+    SeleniumHelper.getPropertiesLocators(NamespaceCreationLocators.class);
+  }
+
+  public static void openNamespaceCreationWizard() {
+    ElementHelper.clickOnElement(NamespaceCreationLocators.createNamespaceWizard);
+  }
+
+  public static void clickNextButton() {
+    ElementHelper.clickOnElement(NamespaceCreationLocators.nextButton);
+  }
+
+  public static void clickFinishButton() {
+    ElementHelper.clickOnElement(NamespaceCreationLocators.finishButton);
+  }
+
+  public static void enterNamespaceName(String name) {
+    ElementHelper.replaceElementValue(NamespaceCreationLocators.namespaceNameInput, name);
+  }
+
+  public static void enterKubernetesNamespace(String name) {
+    ElementHelper.replaceElementValue(NamespaceCreationLocators.kubernetesNamespaceInput, name);
+  }
+
+  public static void enterKubernetesCpu(String limit) {
+    ElementHelper.replaceElementValue(NamespaceCreationLocators.kubernetesCpuInput, limit);
+  }
+
+  public static void enterKubernetesMemory(String limit) {
+    ElementHelper.replaceElementValue(NamespaceCreationLocators.kubernetesMemoryInput, limit);
+  }
+
+  public static boolean isNamespaceCreationFailed() {
+    return ElementHelper.isElementDisplayed(NamespaceCreationLocators.namespaceCreationFailure);
+  }
+}

--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/locators/NamespaceCreationLocators.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/locators/NamespaceCreationLocators.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s.locators;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.How;
+
+/**
+ * Namespace creation related locators
+ */
+public class NamespaceCreationLocators {
+
+  @FindBy(how = How.XPATH, using = "//button[contains(text(),'Create New Namespace')]")
+  public static WebElement createNamespaceWizard;
+
+  @FindBy(how = How.XPATH, using = "//button[@data-cy='wizard-next-btn']")
+  public static WebElement nextButton;
+
+  @FindBy(how = How.XPATH, using = "//button[@data-cy='wizard-finish-btn']")
+  public static WebElement finishButton;
+
+  @FindBy(how = How.XPATH, using = "//input[@placeholder='Namespace name']")
+  public static WebElement namespaceNameInput;
+
+  @FindBy(how = How.XPATH, using = "//input[contains(@placeholder, 'Kubernetes namespace')]")
+  public static WebElement kubernetesNamespaceInput;
+
+  @FindBy(how = How.XPATH, using = "//input[contains(@placeholder, 'CPU limit')]")
+  public static WebElement kubernetesCpuInput;
+
+  @FindBy(how = How.XPATH, using = "//input[contains(@placeholder, 'Memory limit')]")
+  public static WebElement kubernetesMemoryInput;
+
+  @FindBy(how = How.XPATH, using = "//*[contains(text(), 'Failed to Add namespace')]")
+  public static WebElement namespaceCreationFailure;
+
+}

--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/runners/TestRunner.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/runners/TestRunner.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s.runners;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+/**
+ * Test Runner to execute namespace creation related test cases.
+ */
+@RunWith(Cucumber.class)
+@CucumberOptions(
+  features = {"src/e2e-test/features"},
+  glue = {"io.cdap.cdap.master.environment.k8s.stepsdesign", "stepsdesign"},
+  tags = {"@KubernetesNamespace_Creation"},
+  plugin = {"pretty", "html:target/cucumber-html-report/kubenamespace-creation",
+    "json:target/cucumber-reports/cucumber-kubenamespace-creation.json",
+    "junit:target/cucumber-reports/cucumber-kubenamespace-creation.xml"}
+)
+public class TestRunner {
+}

--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/stepsdesign/KubernetesNamespaceCreation.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/stepsdesign/KubernetesNamespaceCreation.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s.stepsdesign;
+
+import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.master.environment.k8s.KubeMasterEnvironment;
+import io.cdap.cdap.master.environment.k8s.actions.NamespaceCreationActions;
+import io.cdap.e2e.pages.actions.CdfSysAdminActions;
+import io.cdap.e2e.utils.CdfHelper;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.kubernetes.client.custom.Quantity;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1ResourceQuota;
+import io.kubernetes.client.util.Config;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Namespace creation related steps definitions
+ */
+public class KubernetesNamespaceCreation implements CdfHelper {
+
+  private static CoreV1Api coreV1Api;
+
+  @Given("Get Kubernetes coreV1Api")
+  public static void getCoreV1Api() throws IOException {
+    coreV1Api = new CoreV1Api(Config.defaultClient());
+  }
+
+  @When("Open namespace creation wizard")
+  public static void beginNamespaceCreation() {
+    CdfSysAdminActions.clickSystemAdminMenu();
+    CdfSysAdminActions.clickConfigurationMenu();
+    NamespaceCreationActions.openNamespaceCreationWizard();
+  }
+
+  @Then("Enter namespace name {string}")
+  public static void enterNamespaceName(String name) {
+    NamespaceCreationActions.enterNamespaceName(name);
+  }
+
+  @Then("Enter Kubernetes namespace name {string}")
+  public static void enterKubernetesNamespaceName(String name) {
+    NamespaceCreationActions.enterKubernetesNamespace(name);
+  }
+
+  @Then("Enter CPU limit {string}")
+  public static void enterKubernetesCpuLimit(String limit) {
+    NamespaceCreationActions.enterKubernetesCpu(limit);
+  }
+
+  @Then("Enter memory limit {string}")
+  public static void enterKubernetesMemoryLimit(String limit) {
+    NamespaceCreationActions.enterKubernetesMemory(limit);
+  }
+
+  @Then("Go to next page in namespace creation wizard")
+  public static void nextNamespaceCreationPage() {
+    NamespaceCreationActions.clickNextButton();
+  }
+
+  @Then("Finish namespace creation")
+  public static void finishNamespaceCreation() {
+    NamespaceCreationActions.clickFinishButton();
+  }
+
+  @Then("Verify Kubernetes namespace {string} exists")
+  public static void verifyKubeNamespaceExists(String namespace) throws IOException {
+    try {
+      coreV1Api.readNamespace(namespace, null, null, null);
+    } catch (ApiException e) {
+      throw new IOException("Error occurred while checking for Kubernetes namespace. Error code = "
+                              + e.getCode() + ", Body = " + e.getResponseBody(), e);
+    }
+  }
+
+  @Then("Verify CPU limit {string} and memory limit {string} exists for {string}")
+  public static void verifyResourceLimits(String cpuLimit, String memLimit, String namespace) throws IOException {
+    Map<String, Quantity> hardLimitMap = ImmutableMap.of("limits.cpu", new Quantity(cpuLimit), "limits.memory",
+                                                         new Quantity(memLimit));
+    try {
+      V1ResourceQuota resourceQuota = coreV1Api.readNamespacedResourceQuota(KubeMasterEnvironment.RESOURCE_QUOTA_NAME,
+                                                                            namespace, null, null, null);
+      if (resourceQuota.getSpec() == null) {
+        throw new IOException("Resource quota not created");
+      } else if (!hardLimitMap.equals(resourceQuota.getSpec().getHard())) {
+        throw new IOException(String.format("Incorrect resource limits. Expected %s but received %s",
+                                            hardLimitMap, resourceQuota.getSpec().getHard()));
+      }
+    } catch (ApiException e) {
+      throw new IOException("Error occurred while checking for Kubernetes resource quota. Error code = "
+                              + e.getCode() + ", Body = " + e.getResponseBody(), e);
+    }
+  }
+
+  @Then("Verify namespace creation failure")
+  public static void verifyNamespaceCreationFailure() throws IOException {
+    if (!NamespaceCreationActions.isNamespaceCreationFailed()) {
+      throw new IOException("Namespace creation did not fail as expected");
+    }
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -129,6 +129,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final Logger LOG = LoggerFactory.getLogger(KubeMasterEnvironment.class);
 
   public static final String SECURITY_CONFIG_NAME = "cdap-security";
+  public static final String RESOURCE_QUOTA_NAME = "cdap-resource-quota";
   // Contains the list of configuration / secret names coming from the Pod information, which are
   // needed to propagate to deployments created via the KubeTwillRunnerService
   private static final Set<String> CONFIG_NAMES = ImmutableSet.of("cdap-conf", "hadoop-conf", "cdap-security");
@@ -177,7 +178,6 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String DEFAULT_PROGRAM_CPU_MULTIPLIER = "0.5";
 
   // Workload Identity Constants
-  private static final String RESOURCE_QUOTA_NAME = "cdap-resource-quota";
   private static final String WORKLOAD_IDENTITY_ENABLED = "master.environment.k8s.workload.identity.enabled";
   private static final String WORKLOAD_IDENTITY_POOL = "master.environment.k8s.workload.identity.pool";
   @VisibleForTesting


### PR DESCRIPTION
Add E2E integration tests for:
- successful Kubernetes namespace creation
- successful Kubernetes namespace creation with resource limits
- unsuccessful namespace creation due to invalid Kubernetes name

JIRA: CDAP-19337