### PR TITLE
Fixes to build for Kubernetes E2E test

### DIFF
--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -35,6 +35,7 @@
     <!-- Needs to define the gson and guava versions to override the one from dependency management in cdap pom.xml -->
     <gson.version>2.8.6</gson.version>
     <guava.version>25.1-jre</guava.version>
+    <testSourceLocation>${project.basedir}/src/test/java/</testSourceLocation>
   </properties>
 
   <dependencies>
@@ -114,6 +115,10 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <testSourceDirectory>${testSourceLocation}</testSourceDirectory>
+  </build>
+
   <profiles>
     <profile>
       <id>dist</id>
@@ -170,11 +175,6 @@
         <testSourceLocation>src/e2e-test/java</testSourceLocation>
       </properties>
       <build>
-        <testResources>
-          <testResource>
-            <directory>src/e2e-test/resources</directory>
-          </testResource>
-        </testResources>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -237,6 +237,12 @@
           <artifactId>cdap-e2e-framework</artifactId>
           <version>0.0.1-SNAPSHOT</version>
           <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+          <version>1.2.8</version>
+          <scope>runtime</scope>
         </dependency>
         <dependency>
           <groupId>ch.qos.logback</groupId>

--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/actions/NamespaceCreationActions.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/actions/NamespaceCreationActions.java
@@ -21,7 +21,7 @@ import io.cdap.e2e.utils.ElementHelper;
 import io.cdap.e2e.utils.SeleniumHelper;
 
 /**
- * Namespace creation related actions
+ * Namespace creation related actions.
  */
 public class NamespaceCreationActions {
 

--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/actions/package-info.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/actions/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the actions for the Kubernetes namespace creation feature.
+ */
+package io.cdap.cdap.master.environment.k8s.actions;

--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/locators/NamespaceCreationLocators.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/locators/NamespaceCreationLocators.java
@@ -21,7 +21,7 @@ import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.How;
 
 /**
- * Namespace creation related locators
+ * Namespace creation related locators.
  */
 public class NamespaceCreationLocators {
 

--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/locators/package-info.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/locators/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the locators for the Kubernetes namespace creation feature.
+ */
+package io.cdap.cdap.master.environment.k8s.locators;

--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/runners/package-info.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/runners/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the runners for the Kubernetes namespace creation feature.
+ */
+package io.cdap.cdap.master.environment.k8s.runners;

--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/stepsdesign/KubernetesNamespaceCreation.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/stepsdesign/KubernetesNamespaceCreation.java
@@ -34,9 +34,11 @@ import java.io.IOException;
 import java.util.Map;
 
 /**
- * Namespace creation related steps definitions
+ * Namespace creation related steps definitions.
  */
 public class KubernetesNamespaceCreation implements CdfHelper {
+
+  private static final int WAIT_TIME_MS = 3000;
 
   private static CoreV1Api coreV1Api;
 
@@ -78,8 +80,10 @@ public class KubernetesNamespaceCreation implements CdfHelper {
   }
 
   @Then("Finish namespace creation")
-  public static void finishNamespaceCreation() {
+  public static void finishNamespaceCreation() throws InterruptedException {
     NamespaceCreationActions.clickFinishButton();
+    // add delay to wait for Kubernetes actions to complete
+    Thread.sleep(WAIT_TIME_MS);
   }
 
   @Then("Verify Kubernetes namespace {string} exists")

--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/stepsdesign/package-info.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/stepsdesign/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the steps for the Kubernetes namespace creation feature.
+ */
+package io.cdap.cdap.master.environment.k8s.stepsdesign;


### PR DESCRIPTION
- Update class Javadocs and include package-info files for checkstyle step
- Add 3 sec wait after namespace creation to avoid race condition where tests check Kubernetes namespace before it's ready
- Update pom to use correct testSourceDirectory during integration tests in order to generate Cucumber report files during `mvn verify`