### PR TITLE
[CDAP-19337] Add tethering e2e tests

### DIFF
--- a/cdap-e2e-tests/pom.xml
+++ b/cdap-e2e-tests/pom.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2022 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>cdap</artifactId>
+    <groupId>io.cdap.cdap</groupId>
+    <version>6.8.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>cdap-e2e-tests</artifactId>
+  <name>CDAP E2E Tests</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <guava.version>25.1-jre</guava.version>
+  </properties>
+
+  <build>
+    <testSourceDirectory>${testSourceLocation}</testSourceDirectory>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>e2e-tests</id>
+      <properties>
+        <testSourceLocation>src/e2e-test/java</testSourceLocation>
+      </properties>
+      <build>
+        <testResources>
+          <testResource>
+            <directory>src/e2e-test/resources</directory>
+          </testResource>
+        </testResources>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>TestRunner.java</include>
+              </includes>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>net.masterthought</groupId>
+            <artifactId>maven-cucumber-reporting</artifactId>
+            <version>5.5.0</version>
+
+            <executions>
+              <execution>
+                <id>execution</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+                <configuration>
+                  <projectName>Cucumber Reports</projectName> <!-- Replace with project name -->
+                  <outputDirectory>target/cucumber-reports/advanced-reports</outputDirectory>
+                  <buildNumber>1</buildNumber>
+                  <skip>false</skip>
+                  <inputDirectory>${project.build.directory}/cucumber-reports</inputDirectory>
+                  <jsonFiles> <!-- supports wildcard or name pattern -->
+                    <param>**/*.json</param>
+                  </jsonFiles> <!-- optional, defaults to outputDirectory if not specified -->
+                  <classificationDirectory>${project.build.directory}/cucumber-reports</classificationDirectory>
+                  <checkBuildResult>true</checkBuildResult>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+        <dependency>
+          <groupId>io.cdap.tests.e2e</groupId>
+          <artifactId>cdap-e2e-framework</artifactId>
+          <version>0.0.1-SNAPSHOT</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+          <version>1.2.8</version>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-core</artifactId>
+          <version>1.2.8</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+
+    </profile>
+  </profiles>
+
+</project>

--- a/cdap-e2e-tests/src/e2e-test/features/tethering/ManageRequestsServer.feature
+++ b/cdap-e2e-tests/src/e2e-test/features/tethering/ManageRequestsServer.feature
@@ -1,0 +1,48 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@Tethering_Manage_Requests_Server
+# Ignore these tests until more auth options are enabled in order to run these steps through UI - see CDAP-19412
+Feature: Tethering - Manage Tethering Requests on Server
+
+  @TETHERING_MANAGE_REQUESTS_SERVER_TEST
+  Scenario: Validate successful acceptance of a tethering request
+    Given Open Datafusion Project to configure pipeline
+    When Navigate to tethering page
+    Then Count number of pending requests on server
+    Then Count number of established connections on server
+    Then Click on accept button
+    Then Verify the request has been accepted
+
+  @TETHERING_MANAGE_REQUESTS_SERVER_TEST
+  Scenario: Validate successful rejection of a tethering request
+    Given Open Datafusion Project to configure pipeline
+    When Navigate to tethering page
+    Then Count number of pending requests on server
+    Then Count number of established connections on server
+    Then Click on reject button
+    Then Confirm the reject action
+    Then Verify the request has been rejected
+
+  @TETHERING_MANAGE_REQUESTS_SERVER_TEST
+  Scenario: Validate successful deletion of an established connection
+    Given Open Datafusion Project to configure pipeline
+    When Navigate to tethering page
+    Then Count number of established connections on server
+    Then Click on the more menu of a established connection
+    Then Click on Delete option for established connection
+    Then Confirm the delete action
+    Then Verify the established connection has been deleted on server

--- a/cdap-e2e-tests/src/e2e-test/features/tethering/TetheringRegistration.feature
+++ b/cdap-e2e-tests/src/e2e-test/features/tethering/TetheringRegistration.feature
@@ -1,0 +1,124 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@Tethering_Registration
+Feature: Tethering registration and management
+
+  @TETHERING_CREATION_TEST @TETHERING_CONNECTION_MANAGEMENT
+  Scenario: Validate successful creation of new tethering connection requests
+    Given Open tethering client Datafusion project
+    When Navigate to tethering page
+    Then Open create new request page
+    Then Click to select a namespace
+    Then Enter project name "test-project"
+    Then Enter region "us-west-1b"
+    Then Enter instance name "test"
+    Then Enter instance url for tethering server
+    Then Enter description "test description"
+    Then Finish creating new tethering request
+    Then Verify the request was created successfully
+
+  @TETHERING_CREATION_TEST
+  Scenario: Validate unsuccessful creation of a new request with the same instance name
+    Given Open tethering client Datafusion project
+    When Navigate to tethering page
+    Then Open create new request page
+    Then Click to select a namespace
+    Then Enter project name "test-project"
+    Then Enter region "us-west-1b"
+    Then Enter instance name "test"
+    Then Enter instance url for tethering server
+    Then Enter description "test description"
+    Then Finish creating new tethering request
+    Then Verify the request failed to be created
+
+  @TETHERING_CREATION_TEST
+  Scenario: Validate unsuccessful creation of a new request with no namespaces
+    Given Open tethering client Datafusion project
+    When Navigate to tethering page
+    Then Open create new request page
+    Then Enter project name "test-project"
+    Then Enter region "us-west-1b"
+    Then Enter instance name "test-no-namespace"
+    Then Enter instance url for tethering server
+    Then Enter description "test description"
+    Then Finish creating new tethering request
+    Then Verify the request failed to be created with no selected namespaces
+
+  @TETHERING_CREATION_TEST
+  Scenario: Validate unsuccessful creation of a new request with a missing required field
+    Given Open tethering client Datafusion project
+    When Navigate to tethering page
+    Then Open create new request page
+    Then Click to select a namespace
+    Then Enter region "us-west-1b"
+    Then Enter instance name "test-missing-field"
+    Then Enter instance url for tethering server
+    Then Enter description "test description"
+    Then Finish creating new tethering request
+    Then Verify the request failed to be created with a missing required field
+
+  @TETHERING_CONNECTION_MANAGEMENT
+  Scenario: Validate successful deletion of a pending request
+    Given Open tethering client Datafusion project
+    When Navigate to tethering page
+    Then Count number of pending requests on client
+    Then Click on the more menu of a pending request
+    Then Click on Delete option for pending request
+    Then Confirm the delete action
+    Then Verify the pending request has been deleted
+
+  @TETHERING_CONNECTION_MANAGEMENT
+  Scenario: Validate successful rejection of a tethering request
+    Given Connect to tethering server Datafusion project
+    Then Reject request on server from client
+    Then Verify no pending tethering requests on server
+    Then Delete rejected request on server from client
+
+  @TETHERING_CONNECTION_MANAGEMENT
+  Scenario: Validate successful connection between client and server
+    Given Open tethering client Datafusion project
+    When Navigate to tethering page
+    Then Open create new request page
+    Then Click to select a namespace
+    Then Enter project name "test-project"
+    Then Enter region "us-west-1b"
+    Then Enter instance name "test"
+    Then Enter instance url for tethering server
+    Then Enter description "test description"
+    Then Finish creating new tethering request
+    Then Verify the request was created successfully
+    When Navigate to tethering page
+    Then Count number of pending requests on client
+    Then Count number of established connections on server
+    Given Connect to tethering server Datafusion project
+    Then Accept request on server from client
+    Then Verify no pending tethering requests on server
+    Given Open tethering client Datafusion project
+    When Navigate to tethering page
+    Then Verify the connection is established
+
+  @TETHERING_CONNECTION_MANAGEMENT
+  Scenario: Validate successful deletion of an established connection
+    Given Open tethering client Datafusion project
+    When Navigate to tethering page
+    Then Count number of established connections on client
+    Then Click on the more menu of a established connection
+    Then Click on Delete option for established connection
+    Then Confirm the delete action
+    Then Verify the established connection has been deleted on client
+    Given Connect to tethering server Datafusion project
+    Then Delete rejected request on server from client

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/actions/TetheringActions.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/actions/TetheringActions.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.tethering.actions;
+
+import io.cdap.cdap.tethering.locators.TetheringLocators;
+import io.cdap.e2e.utils.ElementHelper;
+import io.cdap.e2e.utils.SeleniumHelper;
+
+/**
+ * Tethering related actions.
+ */
+public class TetheringActions {
+
+  static {
+    SeleniumHelper.getPropertiesLocators(TetheringLocators.class);
+  }
+
+  public static void openTetheringPage() {
+    ElementHelper.clickOnElement(TetheringLocators.tetheringPage);
+  }
+
+  public static void clickMoreMenuPendingReq() {
+    ElementHelper.clickOnElement(TetheringLocators.pendingReqMoreMenu);
+  }
+
+  public static void clickOnDeleteOptionPendingReq() {
+    ElementHelper.clickOnElement(TetheringLocators.pendingReqDeleteOption);
+  }
+
+  public static void clickOnConfirmDelete() {
+    ElementHelper.clickOnElement(TetheringLocators.deleteConfirmation);
+  }
+
+  public static int countNumberOfPendingClientReqs() {
+    return ElementHelper.countNumberOfElements(TetheringLocators.pendingRequestLocatorClient);
+  }
+
+  public static int countNumberOfPendingServerReqs() {
+    return ElementHelper.countNumberOfElements(TetheringLocators.pendingRequestLocatorServer);
+  }
+
+  public static void clickMoreMenuEstablishedConn() {
+    ElementHelper.clickOnElement(TetheringLocators.establishedConnMoreMenu);
+  }
+
+  public static void clickOnDeleteOptionEstablishedConn() {
+    ElementHelper.clickOnElement(TetheringLocators.establishedConnDeleteOption);
+  }
+
+  public static int countNumberOfEstablishedConns() {
+    return ElementHelper.countNumberOfElements(TetheringLocators.establishedConnLocator);
+  }
+
+  public static void clickOnAcceptConnReq() {
+    ElementHelper.clickOnElement(TetheringLocators.acceptConnReqButton);
+  }
+
+  public static void clickOnRejectConnReq() {
+    ElementHelper.clickOnElement(TetheringLocators.rejectConnReqButton);
+  }
+
+  public static void clickOnConfirmReject() {
+    ElementHelper.clickOnElement(TetheringLocators.rejectConfirmation);
+  }
+}

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/actions/TetheringRegistrationActions.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/actions/TetheringRegistrationActions.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.tethering.actions;
+
+import io.cdap.cdap.tethering.locators.TetheringRegistrationLocators;
+import io.cdap.e2e.utils.ElementHelper;
+import io.cdap.e2e.utils.SeleniumHelper;
+
+/**
+ * Tethering registration related actions.
+ */
+public class TetheringRegistrationActions {
+
+  static {
+    SeleniumHelper.getPropertiesLocators(TetheringRegistrationLocators.class);
+  }
+
+  public static void openTetheringRegistrationPage() {
+    ElementHelper.clickOnElement(TetheringRegistrationLocators.createNewReqButton);
+  }
+
+  public static void clickSendReqButton() {
+    ElementHelper.clickOnElement(TetheringRegistrationLocators.sendReqButton);
+  }
+
+  public static void clickNamespaceCheckbox() {
+    ElementHelper.clickOnElement(TetheringRegistrationLocators.namespaceCheckBox);
+  }
+
+  public static void enterProjectName(String projName) {
+    ElementHelper.replaceElementValue(TetheringRegistrationLocators.projectNameInput, projName);
+  }
+
+  public static void enterRegion(String region) {
+    ElementHelper.replaceElementValue(TetheringRegistrationLocators.regionInput, region);
+  }
+
+  public static void enterInstanceName(String instanceName) {
+    ElementHelper.replaceElementValue(TetheringRegistrationLocators.instanceNameInput, instanceName);
+  }
+
+  public static void enterInstanceUrl(String instanceUrl) {
+    ElementHelper.replaceElementValue(TetheringRegistrationLocators.instanceUrlInput, instanceUrl);
+  }
+
+  public static void enterDescription(String description) {
+    ElementHelper.replaceElementValue(TetheringRegistrationLocators.descriptionInput, description);
+  }
+
+  public static boolean isReqCreationSucceeded() {
+    return ElementHelper.isElementDisplayed(TetheringRegistrationLocators.reqSuccessMessage);
+  }
+
+  public static boolean isReqCreationFailed() {
+    return ElementHelper.isElementDisplayed(TetheringRegistrationLocators.reqErrorMessage);
+  }
+
+  public static boolean isReqCreationFailedWithNoNs() {
+    return ElementHelper.isElementDisplayed(TetheringRegistrationLocators.noNsErrorMessage);
+  }
+
+  public static boolean isReqCreationFailedWithMissingRequiredField() {
+    return ElementHelper.isElementDisplayed(TetheringRegistrationLocators.missingReqFieldMessage);
+  }
+
+}

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/actions/package-info.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/actions/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the actions for tethering features.
+ */
+package io.cdap.cdap.tethering.actions;

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/locators/TetheringLocators.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/locators/TetheringLocators.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.tethering.locators;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.How;
+
+/**
+ * Tethering related locators.
+ */
+public class TetheringLocators {
+
+  @FindBy(how = How.XPATH, using = "//a[@href='/cdap/administration/tethering']")
+  public static WebElement tetheringPage;
+
+  @FindBy(how = How.CSS, using = "[data-testid='pending-request']")
+  public static WebElement pendingReqMoreMenu;
+
+  @FindBy(how = How.CSS, using = "[data-testid='delete-pending-request']")
+  public static WebElement pendingReqDeleteOption;
+
+  @FindBy(how = How.CSS, using = "[data-testid='Delete']")
+  public static WebElement deleteConfirmation;
+
+  public static By pendingRequestLocatorClient = By.cssSelector("[data-testid='pending-request']");
+
+  public static By pendingRequestLocatorServer = By.cssSelector("[data-testid='accept-connection']");
+
+  @FindBy(how = How.CSS, using = "[data-testid='established-connection']")
+  public static WebElement establishedConnMoreMenu;
+
+  @FindBy(how = How.CSS, using = "[data-testid='delete-connection']")
+  public static WebElement establishedConnDeleteOption;
+
+  public static By establishedConnLocator = By.cssSelector("[data-testid='established-connection']");
+
+  @FindBy(how = How.CSS, using = "[data-testid='accept-connection']")
+  public static WebElement acceptConnReqButton;
+
+  @FindBy(how = How.CSS, using = "[data-testid='reject-connection']")
+  public static WebElement rejectConnReqButton;
+
+  @FindBy(how = How.CSS, using = "[data-testid='Reject']")
+  public static WebElement rejectConfirmation;
+}

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/locators/TetheringRegistrationLocators.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/locators/TetheringRegistrationLocators.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.tethering.locators;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.How;
+
+/**
+ * Tethering registration related locators.
+ */
+public class TetheringRegistrationLocators {
+
+  @FindBy(how = How.CSS, using = "[data-testid='create-tethering-req-btn']")
+  public static WebElement createNewReqButton;
+
+  @FindBy(how = How.CSS, using = "[data-testid='projectName']")
+  public static WebElement projectNameInput;
+
+  @FindBy(how = How.CSS, using = "[data-testid='region']")
+  public static WebElement regionInput;
+
+  @FindBy(how = How.CSS, using = "[data-testid='instanceName']")
+  public static WebElement instanceNameInput;
+
+  @FindBy(how = How.CSS, using = "[data-testid='instanceUrl']")
+  public static WebElement instanceUrlInput;
+
+  @FindBy(how = How.CSS, using = "[data-testid='description']")
+  public static WebElement descriptionInput;
+
+  @FindBy(how = How.CSS, using = "[data-testid='tethering-req-accept-btn']")
+  public static WebElement sendReqButton;
+
+  @FindBy(how = How.CSS, using = "[data-testid='tethering-ns-chk-box']")
+  public static WebElement namespaceCheckBox;
+
+  @FindBy(how = How.CSS, using = "[data-testid='error']")
+  public static WebElement reqErrorMessage;
+
+  @FindBy(how = How.CSS, using = "[data-testid='no-ns-selected']")
+  public static WebElement noNsErrorMessage;
+
+  @FindBy(how = How.CSS, using = "[data-testid='missing-required-field']")
+  public static WebElement missingReqFieldMessage;
+
+  @FindBy(how = How.CSS, using = "[data-testid='success']")
+  public static WebElement reqSuccessMessage;
+
+}

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/locators/package-info.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/locators/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the locators for tethering features.
+ */
+package io.cdap.cdap.tethering.locators;

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/runners/TestRunner.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/runners/TestRunner.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.tethering.runners;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+/**
+ * Test Runner to execute tethering registration related test cases.
+ */
+@RunWith(Cucumber.class)
+@CucumberOptions(
+  features = {"src/e2e-test/features"},
+  glue = {"io.cdap.cdap.tethering.stepsdesign", "stepsdesign"},
+  tags = {"@Tethering_Registration"},
+  plugin = {"pretty", "html:target/cucumber-html-report/tethering",
+    "json:target/cucumber-reports/cucumber-tethering.json",
+    "junit:target/cucumber-reports/cucumber-tethering.xml"}
+)
+public class TestRunner {
+}

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/runners/package-info.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/runners/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the runners for tethering features.
+ */
+package io.cdap.cdap.tethering.runners;

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/stepsdesign/TetheringClient.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/stepsdesign/TetheringClient.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.tethering.stepsdesign;
+
+import io.cdap.cdap.tethering.actions.TetheringActions;
+import io.cdap.e2e.pages.actions.CdfSysAdminActions;
+import io.cdap.e2e.pages.actions.HdfSignInActions;
+import io.cdap.e2e.utils.CdfHelper;
+import io.cdap.e2e.utils.PageHelper;
+import io.cdap.e2e.utils.PluginPropertyUtils;
+import io.cdap.e2e.utils.SeleniumDriver;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+import java.io.IOException;
+
+/**
+ * Tethering client management related steps definitions.
+ */
+public class TetheringClient implements CdfHelper {
+
+  private static final int WAIT_TIME_MS = 3000;
+  private static int pendingReqCount;
+  private static int establishedConnCount;
+
+  @Given("Open tethering client Datafusion project")
+  public static void openTetheringClientProject() throws IOException, InterruptedException {
+    SeleniumDriver.openPage(PluginPropertyUtils.pluginProp("clientUrl"));
+    PageHelper.acceptAlertIfPresent();
+    if (!HdfSignInActions.logged()) {
+      HdfSignInActions.login();
+      PageHelper.acceptAlertIfPresent();
+    }
+  }
+
+  @When("Navigate to tethering page")
+  public static void navigateToTetheringPage() throws InterruptedException {
+    CdfSysAdminActions.clickSystemAdminMenu();
+    TetheringActions.openTetheringPage();
+    Thread.sleep(WAIT_TIME_MS);
+  }
+
+  @Then("Count number of pending requests on client")
+  public static void countNumberOfPendingReqs() {
+    pendingReqCount = TetheringActions.countNumberOfPendingClientReqs();
+  }
+
+  @Then("Click on the more menu of a pending request")
+  public static void clickOnMoreMenuPendingReq() {
+    TetheringActions.clickMoreMenuPendingReq();
+  }
+
+  @Then("Click on Delete option for pending request")
+  public static void clickDeleteOptionPendingReq() {
+    TetheringActions.clickOnDeleteOptionPendingReq();
+  }
+
+  @Then("Confirm the delete action")
+  public static void confirmDeleteAction() {
+    TetheringActions.clickOnConfirmDelete();
+  }
+
+  @Then("Verify the pending request has been deleted")
+  public static void verifyDeletionOfPendingRequest() throws Exception {
+    Thread.sleep(WAIT_TIME_MS);
+    int updatedPendingReqCount = TetheringActions.countNumberOfPendingClientReqs();
+    if (updatedPendingReqCount != pendingReqCount - 1) {
+      throw new Exception("Failure in pending request deletion.");
+    }
+    pendingReqCount = updatedPendingReqCount;
+  }
+
+  @Then("Count number of established connections on client")
+  public static void countNumberOfEstablishedConns() {
+    establishedConnCount = TetheringActions.countNumberOfEstablishedConns();
+  }
+
+  @Then("Verify the connection is established")
+  public static void verifyEstablishedConnection() throws Exception {
+    Thread.sleep(WAIT_TIME_MS);
+    PageHelper.refreshCurrentPage();
+    int updatedPendingReqCount = TetheringActions.countNumberOfPendingClientReqs();
+    int updatedEstablishedConnCount = TetheringActions.countNumberOfEstablishedConns();
+    if (updatedPendingReqCount != pendingReqCount - 1 && updatedEstablishedConnCount != establishedConnCount + 1) {
+      throw new Exception("Failure in creating an established connection.");
+    }
+    pendingReqCount = updatedPendingReqCount;
+    establishedConnCount = updatedEstablishedConnCount;
+  }
+
+  @Then("Click on the more menu of a established connection")
+  public static void clickOnMoreMenuEstablishedConn() {
+    TetheringActions.clickMoreMenuEstablishedConn();
+  }
+
+  @Then("Click on Delete option for established connection")
+  public static void clickDeleteOptionEstablishedConn() {
+    TetheringActions.clickOnDeleteOptionEstablishedConn();
+  }
+
+  @Then("Verify the established connection has been deleted on client")
+  public static void verifyDeletionOfEstablishedConn() throws Exception {
+    Thread.sleep(WAIT_TIME_MS);
+    int updatedEstablishedConnCount = TetheringActions.countNumberOfEstablishedConns();
+    if (updatedEstablishedConnCount != establishedConnCount - 1) {
+      throw new Exception("Failure in established connection deletion.");
+    }
+    establishedConnCount = updatedEstablishedConnCount;
+  }
+}

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/stepsdesign/TetheringRegistration.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/stepsdesign/TetheringRegistration.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.tethering.stepsdesign;
+
+import io.cdap.cdap.tethering.actions.TetheringRegistrationActions;
+import io.cdap.e2e.utils.CdfHelper;
+import io.cdap.e2e.utils.PluginPropertyUtils;
+import io.cucumber.java.en.Then;
+
+import java.io.IOException;
+
+/**
+ * Tethering Registration related steps definitions.
+ */
+public class TetheringRegistration implements CdfHelper {
+
+  @Then("Open create new request page")
+  public static void clickCreateReqButton() {
+    TetheringRegistrationActions.openTetheringRegistrationPage();
+  }
+
+  @Then("Click to select a namespace")
+  public static void selectANamespace() {
+    TetheringRegistrationActions.clickNamespaceCheckbox();
+  }
+
+  @Then("Enter project name {string}")
+  public static void enterProjectName(String projName) {
+    TetheringRegistrationActions.enterProjectName(projName);
+  }
+
+  @Then("Enter region {string}")
+  public static void enterRegion(String region) {
+    TetheringRegistrationActions.enterRegion(region);
+  }
+
+  @Then("Enter instance name {string}")
+  public static void enterInstanceName(String instanceName) {
+    TetheringRegistrationActions.enterInstanceName(instanceName);
+  }
+
+  @Then("Enter instance url for tethering server")
+  public static void enterInstanceUrl() {
+    TetheringRegistrationActions.enterInstanceUrl(PluginPropertyUtils.pluginProp("serverUrl"));
+  }
+
+  @Then("Enter description {string}")
+  public static void enterDescription(String description) {
+    TetheringRegistrationActions.enterDescription(description);
+  }
+
+  @Then("Finish creating new tethering request")
+  public static void finishCreatingNewRequest() {
+    TetheringRegistrationActions.clickSendReqButton();
+  }
+
+  @Then("Verify the request was created successfully")
+  public static void verifyRequestCreatedSuccessfully() throws IOException {
+    if (!TetheringRegistrationActions.isReqCreationSucceeded()) {
+      throw new IOException("Failure because request was not successfully created");
+    }
+  }
+
+  @Then("Verify the request failed to be created")
+  public static void verifyRequestCreationFailure() throws IOException {
+    if (!TetheringRegistrationActions.isReqCreationFailed()) {
+      throw new IOException("Failure because request was not successfully failed");
+    }
+  }
+
+  @Then("Verify the request failed to be created with no selected namespaces")
+  public static void verifyRequestCreationFailureWithNoNamespaces() throws IOException {
+    if (!TetheringRegistrationActions.isReqCreationFailedWithNoNs()) {
+      throw new IOException("Failure because request was not successfully failed");
+    }
+  }
+
+  @Then("Verify the request failed to be created with a missing required field")
+  public static void verifyRequestCreationFailureWithMissingRequiredField() throws IOException {
+    if (!TetheringRegistrationActions.isReqCreationFailedWithMissingRequiredField()) {
+      throw new IOException("Failure because request was not successfully failed");
+    }
+  }
+}

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/stepsdesign/TetheringServer.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/stepsdesign/TetheringServer.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.tethering.stepsdesign;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.ByteStreams;
+import com.google.gson.Gson;
+import io.cdap.cdap.tethering.actions.TetheringActions;
+import io.cdap.e2e.utils.CdfHelper;
+import io.cdap.e2e.utils.PluginPropertyUtils;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Tethering server management related steps definitions.
+ */
+public class TetheringServer implements CdfHelper {
+  private static final Gson GSON = new Gson();
+
+  private static final int WAIT_TIME_MS = 3000;
+  private static int pendingReqCount;
+  private static int establishedConnCount;
+
+  @Given("Connect to tethering server Datafusion project")
+  public static void openTetheringServerProject() throws IOException {
+    HttpURLConnection connection = createConnection("tethering/connections", "GET");
+    try {
+      verifyConnection(connection);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  @Then("Reject request on server from client")
+  public static void rejectRequest() throws IOException {
+    String clientName = PluginPropertyUtils.pluginProp("clientName");
+    HttpURLConnection connection = createConnection("tethering/connections/" + clientName, "POST");
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+    try {
+      connection.getOutputStream().write("{\"action\":\"reject\"}".getBytes(StandardCharsets.UTF_8));
+      verifyConnection(connection);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  @Then("Accept request on server from client")
+  public static void acceptRequest() throws IOException {
+    String clientName = PluginPropertyUtils.pluginProp("clientName");
+    HttpURLConnection connection = createConnection("tethering/connections/" + clientName, "POST");
+    connection.setRequestProperty("Content-Type", "application/json");
+    connection.setDoOutput(true);
+    try {
+      connection.getOutputStream().write("{\"action\":\"accept\"}".getBytes(StandardCharsets.UTF_8));
+      verifyConnection(connection);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  @Then("Verify no pending tethering requests on server")
+  public static void verifyNoRequests() throws IOException {
+    HttpURLConnection connection = createConnection("tethering/connections/", "GET");
+    try {
+      verifyConnection(connection);
+      String responseOutput = new String(ByteStreams.toByteArray(connection.getInputStream()), Charsets.UTF_8);
+      if (GSON.toJson(responseOutput).contains("PENDING")) {
+        throw new IOException(String.format("Expected no pending requests remaining but received %s", responseOutput));
+      }
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  @Then("Delete rejected request on server from client")
+  public static void deleteRejectedRequest() throws IOException {
+    String clientName = PluginPropertyUtils.pluginProp("clientName");
+    HttpURLConnection connection = createConnection("tethering/connections/" + clientName, "DELETE");
+    try {
+      verifyConnection(connection);
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  @Then("Count number of pending requests on server")
+  public static void countNumberOfPendingReqsServer() {
+    pendingReqCount = TetheringActions.countNumberOfPendingServerReqs();
+  }
+
+  @Then("Count number of established connections on server")
+  public static void countNumberOfEstablishedConnsServer() {
+    establishedConnCount = TetheringActions.countNumberOfEstablishedConns();
+  }
+
+  @Then("Click on accept button")
+  public static void clickAcceptButton() throws InterruptedException {
+    TetheringActions.clickOnAcceptConnReq();
+    Thread.sleep(WAIT_TIME_MS);
+  }
+
+  @Then("Click on reject button")
+  public static void clickRejectButton() {
+    TetheringActions.clickOnRejectConnReq();
+  }
+
+  @Then("Confirm the reject action")
+  public static void confirmRejectAction() {
+    TetheringActions.clickOnConfirmReject();
+  }
+
+  @Then("Verify the request has been accepted")
+  public static void verifyAcceptanceOfConnRequest() throws Exception {
+    int updatedPendingReqCount = TetheringActions.countNumberOfPendingServerReqs();
+    int updatedEstablishedConnCount = TetheringActions.countNumberOfEstablishedConns();
+    if (updatedPendingReqCount != pendingReqCount - 1 && updatedEstablishedConnCount != establishedConnCount + 1) {
+      throw new Exception("Failure in accepting connection request.");
+    }
+    pendingReqCount = updatedPendingReqCount;
+    establishedConnCount = updatedEstablishedConnCount;
+  }
+
+  @Then("Verify the request has been rejected")
+  public static void verifyRejectionOfConnRequest() throws Exception {
+    int updatedPendingReqCount = TetheringActions.countNumberOfPendingServerReqs();
+    if (updatedPendingReqCount != pendingReqCount - 1) {
+      throw new Exception("Failure in rejecting connection request.");
+    }
+  }
+
+  @Then("Verify the established connection has been deleted on server")
+  public static void verifyDeletionOfEstablishedConn() throws Exception {
+    int updatedEstablishedConnCount = TetheringActions.countNumberOfEstablishedConns();
+    if (updatedEstablishedConnCount != establishedConnCount - 1) {
+      throw new Exception("Failure in pending request deletion.");
+    }
+  }
+
+  private static HttpURLConnection createConnection(String path, String method) throws IOException {
+    String serverUrl = PluginPropertyUtils.pluginProp("serverUrl");
+    String accessToken = PluginPropertyUtils.pluginProp("serverAccessToken");
+    URL url = new URL(serverUrl + "/v3/" + path);
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setRequestProperty("Authorization", "Bearer " + accessToken);
+    connection.setRequestMethod(method);
+    return connection;
+  }
+
+  private static void verifyConnection(HttpURLConnection connection) throws IOException {
+    if (connection.getResponseCode() != 200) {
+      String msg = String.format("Received response code %s and error: %s", connection.getResponseCode(),
+                                 new String(ByteStreams.toByteArray(connection.getErrorStream()), Charsets.UTF_8));
+      throw new IOException(msg);
+    }
+  }
+}
+
+

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/stepsdesign/package-info.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/stepsdesign/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the steps for tethering features.
+ */
+package io.cdap.cdap.tethering.stepsdesign;

--- a/cdap-e2e-tests/src/e2e-test/resources/pluginParameters.properties
+++ b/cdap-e2e-tests/src/e2e-test/resources/pluginParameters.properties
@@ -1,0 +1,5 @@
+clientName=cdap
+clientUrl=http://localhost:11011
+serverUrl=https://placeholder.com/api
+# command to generate token: gcloud auth print-access-token
+serverAccessToken=placeholder

--- a/pom.xml
+++ b/pom.xml
@@ -2832,6 +2832,7 @@
         <module>cdap-cli-tests</module>
         <module>cdap-client-tests</module>
         <module>cdap-app-fabric-tests</module>
+        <module>cdap-e2e-tests</module>
       </modules>
     </profile>
 


### PR DESCRIPTION
**Description** 

Add tethering related e2e tests:
- Create a new e2e test module to avoid guava dependency issues
- Add integration tests for creating registration requests from the client, interacting with registration requests from both the client and the server, and creating an established connection between the client and the server
- Server UI integration tests are ignored for now until e2e test framework can support additional auth options

**Testing**
Update `pluginParameters.properties` to point to correct client/server and run `mvn verify -P e2e-tests`