### PR TITLE
[CDAP-19353] Return STARTING state if program controller is not set

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/DelayedProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/DelayedProgramController.java
@@ -108,6 +108,11 @@ public final class DelayedProgramController implements ProgramController, Delega
   @Override
   public State getState() {
     try {
+      if (!delegateFuture.isDone()) {
+        // In order to avoid waiting for delegateFuture to complete before returning its state, we can return the
+        // state right away.
+        return State.STARTING;
+      }
       return Uninterruptibles.getUninterruptibly(delegateFuture).getState();
     } catch (ExecutionException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
Why: Flow control counts number of RUNNING programs by counting Programs in RUNNING state. However, DelayedProgramController sets the program controller lazily once the launch is done. This sometimes result in new launch requests to wait for a certain period of time (e.g., 2-3 min) before returning 200/429 and until ProgramController gets set in DelayedProgramController. 

This PR fixes the issue by immediately returning STARTING state if program controller has not been set in DelayedProgramController. 