### PR TITLE
CDAP-19078 extend detect schema API

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/DelegatingSeekableInputStream.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/DelegatingSeekableInputStream.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright © 2022 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.cdap.etl.api.validation;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A helper for implementing a {@link SeekableInputStream} where subclasses only need to implement the
+ * methods not present in java's InputStream.
+ */
+public abstract class DelegatingSeekableInputStream extends SeekableInputStream {
+  private final InputStream inputStream;
+
+  public DelegatingSeekableInputStream(InputStream inputStream) {
+    this.inputStream = inputStream;
+  }
+
+  @Override
+  public int read(byte[] b) throws IOException {
+    return inputStream.read(b);
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    return inputStream.read(b, off, len);
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    return inputStream.skip(n);
+  }
+
+  @Override
+  public int available() throws IOException {
+    return inputStream.available();
+  }
+
+  @Override
+  public void close() throws IOException {
+    inputStream.close();
+  }
+
+  @Override
+  public synchronized void mark(int readlimit) {
+    inputStream.mark(readlimit);
+  }
+
+  @Override
+  public synchronized void reset() throws IOException {
+    inputStream.reset();
+  }
+
+  @Override
+  public boolean markSupported() {
+    return inputStream.markSupported();
+  }
+
+  @Override
+  public int read() throws IOException {
+    return inputStream.read();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/InputFile.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/InputFile.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright © 2022 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.cdap.etl.api.validation;
+
+import java.io.IOException;
+
+/**
+ * Represents an input file that can be read
+ */
+public interface InputFile {
+
+  /**
+   * @return the name of the file
+   */
+  String getName();
+
+  /**
+   * @return length of the file in bytes
+   */
+  long getLength();
+
+  /**
+   * @return a SeekableInputStream for reading the file data
+   * @throws IOException if there was an exception opening the file
+   */
+  SeekableInputStream open() throws IOException;
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/InputFiles.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/InputFiles.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright © 2022 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.cdap.etl.api.validation;
+
+/**
+ * A collection of input files to read for schema detection.
+ *
+ * This interface exists in case the API needs to be extended to add more information.
+ */
+public interface InputFiles extends Iterable<InputFile> {
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/SeekableInputStream.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/SeekableInputStream.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright © 2022 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.cdap.etl.api.validation;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * An InputStream that can seek to a specified position.
+ */
+public abstract class SeekableInputStream extends InputStream {
+
+  /**
+   * Seek to the given offset from the start of the file.
+   * The next read() will be from that location. Can't seek past the end of the file.
+   */
+  public abstract void seek(long pos) throws IOException;
+
+  /**
+   * Return the current offset from the start of the file
+   */
+  public abstract long getPos() throws IOException;
+
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidatingInputFormat.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidatingInputFormat.java
@@ -20,8 +20,6 @@ import io.cdap.cdap.api.data.batch.InputFormatProvider;
 import io.cdap.cdap.api.data.schema.Schema;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
@@ -49,13 +47,12 @@ public interface ValidatingInputFormat extends InputFormatProvider {
    * Try to detect the schema from some input data.
    *
    * @param context format context
-   * @param dataStream supplier for opening an input stream containing sample data. It is the responsibility of this
-   *                   method to close any InputStreams that it opens.
+   * @param inputFiles files to sample from in order to detect schema.
    * @return the detected schema, or null if the schema could not be detected.
    * @throws IOException if there was an issue opening or reading the data.
    */
   @Nullable
-  default Schema detectSchema(FormatContext context, Supplier<InputStream> dataStream) throws IOException {
-    return null;
+  default Schema detectSchema(FormatContext context, InputFiles inputFiles) throws IOException {
+    return getSchema(context);
   }
 }


### PR DESCRIPTION
Modify the detect schema API for input formats to provide more
information about the files to sample and to provide a seekable
input stream required by some formats like parquet.

Normally we would not change an existing API, but this one
is unused at the moment.