### PR TITLE
CDAP-19351 fix s3 sink on odf

### DIFF
--- a/cdap-spark-core3_2.12/src/k8s/Dockerfile
+++ b/cdap-spark-core3_2.12/src/k8s/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update && \
   apt-get -y install curl && \
   curl -L -o /opt/cdap/cdap-spark-core/lib/gcs-connector-hadoop2-2.2.5.jar https://storage.googleapis.com/hadoop-lib/gcs/gcs-connector-hadoop2-2.2.5.jar && \
   # start aws dependency
-  curl -L -o /opt/cdap/cdap-spark-core/lib/hadoop-aws-2.9.2.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/2.9.2/hadoop-aws-2.9.2.jar && \
+  curl -L -o /opt/cdap/cdap-spark-core/lib/hadoop-aws-3.2.0.jar https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.2.0/hadoop-aws-3.2.0.jar && \
   curl -L -o /opt/cdap/cdap-spark-core/lib/aws-java-sdk-bundle-1.11.199.jar https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.199/aws-java-sdk-bundle-1.11.199.jar && \
   curl -L -o /opt/cdap/cdap-spark-core/lib/jets3t-0.9.4.jar  https://repo1.maven.org/maven2/net/java/dev/jets3t/jets3t/0.9.4/jets3t-0.9.4.jar && \
   curl -L -o /opt/cdap/cdap-spark-core/lib/commons-lang-2.6.jar  https://repo1.maven.org/maven2/commons-lang/commons-lang/2.6/commons-lang-2.6.jar && \


### PR DESCRIPTION
the spark image uses hadoop 3.2.0, which uses `S3ACommiterFactory`, and that is only available after 3.x version of aws, updated the version to be same as hadoop version, verified s3 source -> s3 sink on odf