### PR TITLE
[CDAP-19330] Cherry-pick 6.7

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
@@ -363,6 +363,12 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
     try (OutputStream os = programDir.append(DistributedProgramRunner.TETHER_CONF_FILE_NAME).getOutputStream()) {
       cConfCopy.writeXml(os);
     }
+    if (files.containsKey(Constants.Security.Authentication.RUNTIME_TOKEN_FILE)) {
+      try (OutputStream os = programDir
+        .append(Constants.Security.Authentication.RUNTIME_TOKEN_FILE).getOutputStream()) {
+        os.write(files.get(Constants.Security.Authentication.RUNTIME_TOKEN_FILE).getBytes(StandardCharsets.UTF_8));
+      }
+    }
 
     Map<String, String> systemArgs = new HashMap<>(programOpts.getArguments().asMap());
     // Remove the plugin artifact archive argument from options and let the program runner recreate it

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringProvisioner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringProvisioner.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.runtime.spi.provisioner.Provisioner;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSpecification;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobManager;
+import org.apache.twill.filesystem.LocationFactory;
 
 import java.util.Collections;
 import java.util.Map;
@@ -50,6 +51,7 @@ public class TetheringProvisioner implements Provisioner {
 
   private MessagingService messagingService;
   private TetheringStore tetheringStore;
+  private LocationFactory locationFactory;
 
   /**
    * Using method injection instead of constructor injection because {@link ServiceLoader} (used by
@@ -65,6 +67,12 @@ public class TetheringProvisioner implements Provisioner {
   @SuppressWarnings("unused")
   void setTetheringStore(TetheringStore tetheringStore) {
     this.tetheringStore = tetheringStore;
+  }
+
+  @Inject
+  @SuppressWarnings("unused")
+  void setLocationFactory(LocationFactory locationFactory) {
+    this.locationFactory = locationFactory;
   }
 
   @Override
@@ -118,6 +126,6 @@ public class TetheringProvisioner implements Provisioner {
   public Optional<RuntimeJobManager> getRuntimeJobManager(ProvisionerContext context) {
     TetheringConf conf = TetheringConf.fromProperties(context.getProperties());
     CConfiguration cConf = CConfiguration.create();
-    return Optional.of(new TetheringRuntimeJobManager(conf, cConf, messagingService, tetheringStore));
+    return Optional.of(new TetheringRuntimeJobManager(conf, cConf, messagingService, tetheringStore, locationFactory));
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunnerResourceCopyTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRunnerResourceCopyTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.distributed;
+
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.internal.app.runtime.BasicArguments;
+import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import org.apache.twill.filesystem.LocalLocationFactory;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DistributedProgramRunnerResourceCopyTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testCopyRuntimeTokenWithoutTokenFileDoesNotCopy() throws Exception {
+    File tempDirCopyTo = temporaryFolder.newFolder();
+    File tempDirCopyFrom = temporaryFolder.newFolder();
+
+    Map<String, String> arguments = new HashMap<>();
+    arguments.put(ProgramOptionConstants.PEER_NAME, "test-peer");
+    arguments.put(ProgramOptionConstants.PROGRAM_RESOURCE_URI, tempDirCopyFrom.toURI().toString());
+
+    LocationFactory locationFactory = new LocalLocationFactory();
+    Map<String, LocalizeResource> localizeResourceMap = new HashMap<>();
+    DistributedProgramRunner.copyRuntimeToken(locationFactory, new BasicArguments(arguments), tempDirCopyTo,
+                                              localizeResourceMap);
+    Assert.assertFalse(localizeResourceMap.containsKey(Constants.Security.Authentication.RUNTIME_TOKEN_FILE));
+  }
+
+  @Test
+  public void testCopyRuntimeTokenWithTokenFileSuccess() throws Exception {
+    File tempDirCopyTo = temporaryFolder.newFolder();
+    File tempDirCopyFrom = temporaryFolder.newFolder();
+    File runtimeTokenFile = new File(tempDirCopyFrom, Constants.Security.Authentication.RUNTIME_TOKEN_FILE);
+    byte[] runtimeTokenBytes = new byte[64];
+    SecureRandom.getInstanceStrong().nextBytes(runtimeTokenBytes);
+    Files.write(runtimeTokenFile.toPath(), runtimeTokenBytes);
+
+    Map<String, String> arguments = new HashMap<>();
+    arguments.put(ProgramOptionConstants.PEER_NAME, "test-peer");
+    arguments.put(ProgramOptionConstants.PROGRAM_RESOURCE_URI, tempDirCopyFrom.toURI().toString());
+
+    LocationFactory locationFactory = new LocalLocationFactory(temporaryFolder.getRoot());
+    Map<String, LocalizeResource> localizeResourceMap = new HashMap<>();
+    DistributedProgramRunner.copyRuntimeToken(locationFactory, new BasicArguments(arguments), tempDirCopyTo,
+                                              localizeResourceMap);
+    Assert.assertTrue(localizeResourceMap.containsKey(Constants.Security.Authentication.RUNTIME_TOKEN_FILE));
+    File copiedRuntimeTokenFile = new File(localizeResourceMap
+                                             .get(Constants.Security.Authentication.RUNTIME_TOKEN_FILE).getURI());
+    Assert.assertArrayEquals(Files.readAllBytes(copiedRuntimeTokenFile.toPath()), runtimeTokenBytes);
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManagerTest.java
@@ -60,6 +60,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.tephra.TransactionManager;
 import org.apache.tephra.runtime.TransactionModules;
 import org.apache.twill.api.LocalFile;
+import org.apache.twill.filesystem.LocationFactory;
 import org.apache.twill.internal.DefaultLocalFile;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -141,7 +142,8 @@ public class TetheringRuntimeJobManagerTest {
                           cConf.get(Constants.Tethering.TOPIC_PREFIX) + TETHERED_INSTANCE_NAME);
     messagingService.createTopic(new TopicMetadata(topicId, Collections.emptyMap()));
     messageFetcher = new MultiThreadMessagingContext(messagingService).getMessageFetcher();
-    runtimeJobManager = new TetheringRuntimeJobManager(conf, cConf, messagingService, tetheringStore);
+    runtimeJobManager = new TetheringRuntimeJobManager(conf, cConf, messagingService, tetheringStore,
+                                                       injector.getInstance(LocationFactory.class));
     tetheringProvisioner = injector.getInstance(TetheringProvisioner.class);
   }
 

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -250,6 +250,17 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
           localizeResources.add(new LocalizeResource(logbackJar, true));
         }
 
+        // Localize the runtime token if there is one. This happens only in tethered mode.
+        File runtimeToken = new File(Constants.Security.Authentication.RUNTIME_TOKEN_FILE);
+        if (runtimeToken.exists() && !runtimeToken.isDirectory()) {
+          LOG.debug("Localizing runtime token...");
+          localizeResources.add(new LocalizeResource(runtimeToken));
+        } else if (runtimeToken.isDirectory()) {
+          LOG.error("Expected runtime token to be a file, instead found a directory");
+        } else {
+          LOG.debug("No runtime token file found, skipping runtime token localization...");
+        }
+
         // Localize all the files from user resources
         List<File> files = copyUserResources(context.getLocalizeResources(), tempDir);
         for (File file : files) {


### PR DESCRIPTION
Cherry-pick of #14382 

[CDAP-19330] Add internal identity remote runtime token to tethered pipeline runs

[CDAP-19330] Close input stream during tethering runtime job manager resource copying, cleaned up logic for checking URI scheme, and cleaned up code structure

[CDAP-19330] Propagate runtime token copy exception upwards

[CDAP-19330]: https://cdap.atlassian.net/browse/CDAP-19330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-19330]: https://cdap.atlassian.net/browse/CDAP-19330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-19330]: https://cdap.atlassian.net/browse/CDAP-19330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ