### PR TITLE
CDAP-19347 - Enforce correct configurations for monitoring

### DIFF
--- a/cdap-common/merge-config-transform.xsl
+++ b/cdap-common/merge-config-transform.xsl
@@ -1,0 +1,56 @@
+<?xml version="1.0" ?>
+<xsl:transform
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        version="1.0">
+  <!--
+      Copyright © 2014-2022 Cask Data, Inc.
+
+      Licensed under the Apache License, Version 2.0 (the "License"); you may not
+      use this file except in compliance with the License. You may obtain a copy of
+      the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+      WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+      License for the specific language governing permissions and limitations under
+      the License.
+    -->
+  <!-- output should be in xml format -->
+  <xsl:output method="xml" indent="yes"/>
+  <!-- config-path parameter with file path for additional properties -->
+  <xsl:param name="config-path"/>
+  <xsl:template match="*">
+    <!-- New line after xml header -->
+    <xsl:text>&#x0A;</xsl:text>
+    <!-- Specify the processing instruction and point to configuration.xsl-->
+    <xsl:processing-instruction name="xml-stylesheet">type="text/xsl" href="configuration.xsl"</xsl:processing-instruction>
+    <!-- Add a new line -->
+    <xsl:text>&#x0A;</xsl:text>
+    <!-- Add comment with copyright -->
+    <xsl:comment>
+      Copyright © 2014-2022 Cask Data, Inc.
+
+      Licensed under the Apache License, Version 2.0 (the "License"); you may not
+      use this file except in compliance with the License. You may obtain a copy of
+      the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+      WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+      License for the specific language governing permissions and limitations under
+      the License.
+    </xsl:comment>
+    <!-- Add a new line -->
+    <xsl:text>&#x0A;</xsl:text>
+    <xsl:copy>
+      <!-- Copy all the configurations from existing cdap-default.xml -->
+      <xsl:copy-of select="document('src/main/resources/cdap-default.xml')/configuration/*"/>
+      <!-- Copy all the additional configurations -->
+      <xsl:copy-of select="document($config-path)/configuration/*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:transform>

--- a/cdap-common/pom.xml
+++ b/cdap-common/pom.xml
@@ -275,4 +275,52 @@
     </plugins>
   </build>
 
+  <profiles>
+    <profile>
+      <!-- Use when the default configs need to be extended -->
+      <id>extend-default-configs</id>
+      <activation>
+        <property>
+          <name>extend-default-configs</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>xml-maven-plugin</artifactId>
+            <version>1.0.2</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>transform</goal>
+                </goals>
+                <configuration>
+                  <transformationSets>
+                    <transformationSet>
+                      <dir>src/main/resources</dir>
+                      <includes>
+                        <include>cdap-default.xml</include>
+                      </includes>
+                      <!--  <stylesheet>configuration-transform.xsl</stylesheet> -->
+                      <parameters>
+                        <parameter>
+                          <name>config-path</name>
+                          <value>${config-path}</value>
+                        </parameter>
+                      </parameters>
+                      <stylesheet>merge-config-transform.xsl</stylesheet>
+                      <outputDir>src/main/resources</outputDir>
+                    </transformationSet>
+                  </transformationSets>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorService.java
@@ -70,7 +70,7 @@ import java.util.stream.Collectors;
  */
 public class MessagingMetricsProcessorService extends AbstractExecutionThreadService {
 
-  private static final Logger LOG = LoggerFactory.getLogger(MessagingMetricsProcessorManagerService.class);
+  private static final Logger LOG = LoggerFactory.getLogger(MessagingMetricsProcessorService.class);
   // Log the metrics processing progress no more than once per minute.
   private static final Logger PROGRESS_LOG = Loggers.sampling(LOG, LogSamplers.limitRate(60000));
 


### PR DESCRIPTION
- Enable adding additional configurations to cdap-default. Use the args -Dextend-default-configs=true -Dconfig-path=<file-path> .
- Enforce configuration for first metric writer initialization