### PR TITLE
(CDAP-19355) (CDAP-19356) (CDAP-19361) Implements timeout based graceful stop

### DIFF
--- a/cdap-api-spark-base/src/main/java/io/cdap/cdap/api/spark/JavaSparkExecutionContextBase.java
+++ b/cdap-api-spark-base/src/main/java/io/cdap/cdap/api/spark/JavaSparkExecutionContextBase.java
@@ -68,6 +68,16 @@ public abstract class JavaSparkExecutionContextBase implements SchedulableProgra
   public abstract long getLogicalStartTime();
 
   /**
+   * Returns the termination time of this Spark job as timestamp in milliseconds.
+   * The termination time is the time where this Spark job will be forced to termination
+   * The value is only available when stop was requested on this Spark job.
+   *
+   * @return Time in milliseconds since epoch time (00:00:00 January 1, 1970 UTC).
+   * @throws IllegalStateException if stop was not requested
+   */
+  public abstract long getTerminationTime();
+
+  /**
    * Returns a {@link Serializable} {@link ServiceDiscoverer} for Service Discovery in Spark Program which can be
    * passed in Spark program's closures.
    *

--- a/cdap-api-spark-base/src/main/scala/io/cdap/cdap/api/spark/SparkExecutionContextBase.scala
+++ b/cdap-api-spark-base/src/main/scala/io/cdap/cdap/api/spark/SparkExecutionContextBase.scala
@@ -16,24 +16,29 @@
 
 package io.cdap.cdap.api.spark
 
-import java.io.IOException
-
+import io.cdap.cdap.api.RuntimeContext
+import io.cdap.cdap.api.ServiceDiscoverer
+import io.cdap.cdap.api.TaskLocalizationContext
+import io.cdap.cdap.api.Transactional
+import io.cdap.cdap.api.TxRunnable
 import io.cdap.cdap.api.annotation.Beta
 import io.cdap.cdap.api.data.batch.Split
 import io.cdap.cdap.api.lineage.field.LineageRecorder
 import io.cdap.cdap.api.messaging.MessagingContext
-import io.cdap.cdap.api.metadata.{MetadataReader, MetadataWriter}
+import io.cdap.cdap.api.metadata.MetadataReader
+import io.cdap.cdap.api.metadata.MetadataWriter
 import io.cdap.cdap.api.metrics.Metrics
 import io.cdap.cdap.api.plugin.PluginContext
 import io.cdap.cdap.api.schedule.TriggeringScheduleInfo
 import io.cdap.cdap.api.security.store.SecureStore
 import io.cdap.cdap.api.spark.dynamic.SparkInterpreter
-import io.cdap.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
-import io.cdap.cdap.api.{RuntimeContext, ServiceDiscoverer, TaskLocalizationContext, Transactional, TxRunnable}
+import io.cdap.cdap.api.workflow.WorkflowInfo
+import io.cdap.cdap.api.workflow.WorkflowToken
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.tephra.TransactionFailureException
 
+import java.io.IOException
 import scala.reflect.ClassTag
 /**
   * Spark program execution context. User Spark program can interact with CDAP through this context.
@@ -55,6 +60,16 @@ trait SparkExecutionContextBase extends RuntimeContext
     * @return Time in milliseconds since epoch time (00:00:00 January 1, 1970 UTC).
     */
   def getLogicalStartTime: Long
+
+  /**
+   * Returns the termination time of this Spark job as timestamp in milliseconds.
+   * The termination time is the time where this Spark job will be forced to termination
+   * The value is only available when stop was requested on this Spark job.
+   *
+   * @return Time in milliseconds since epoch time (00:00:00 January 1, 1970 UTC).
+   * @throws IllegalStateException if stop was not requested
+   */
+  def getTerminationTime: Long
 
   /**
     * Returns a [[scala.Serializable]] [[io.cdap.cdap.api.ServiceDiscoverer]] for Service Discovery

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/DelayedProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/DelayedProgramController.java
@@ -31,6 +31,7 @@ import org.apache.twill.common.Cancellable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 /**
@@ -101,8 +102,20 @@ public final class DelayedProgramController implements ProgramController, Delega
   }
 
   @Override
+  public ListenableFuture<ProgramController> stop(long timeout, TimeUnit timeoutUnit) {
+    return callDelegate(controller -> controller.stop(timeout, timeoutUnit));
+  }
+
+  @Override
   public void kill() {
-    getDelegate().kill();
+    Futures.getUnchecked(callDelegate(controller -> {
+      try {
+        controller.kill();
+        return Futures.immediateFuture(controller);
+      } catch (Throwable t) {
+        return Futures.immediateFailedFuture(t);
+      }
+    }));
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/ProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/ProgramController.java
@@ -23,6 +23,7 @@ import org.apache.twill.api.RunId;
 import org.apache.twill.common.Cancellable;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
 /**
@@ -141,6 +142,16 @@ public interface ProgramController {
    * @return A {@link ListenableFuture} that will be completed when the program is actually stopped.
    */
   ListenableFuture<ProgramController> stop();
+
+  /**
+   * Attempt to stop the program gracefully within the given timeout. Depending on the implementation,
+   * if the timeout reached, the running program can be killed.
+   *
+   * @param timeout the maximum time that it allows the service to terminate gracefully
+   * @param timeoutUnit the {@link TimeUnit} for the {@code timeout}
+   * @return A {@link ListenableFuture} that will be completed when the program is actually stopped.
+   */
+  ListenableFuture<ProgramController> stop(long timeout, TimeUnit timeoutUnit);
 
   /**
    * Force kill the program.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -323,7 +323,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
         return null;
       }
       if (gracefulShutdownSecs.isEmpty()) {
-        return Integer.parseInt(String.valueOf(Integer.MAX_VALUE));
+        return Integer.MAX_VALUE;
       }
       int gracefulShutdownSecsInt = Integer.parseInt(gracefulShutdownSecs);
       if (gracefulShutdownSecsInt < 0) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/AbstractInMemoryProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/AbstractInMemoryProgramRunner.java
@@ -212,8 +212,8 @@ public abstract class AbstractInMemoryProgramRunner implements ProgramRunner {
       lock.lock();
       try {
         changeInstances(command.get("runnable"),
-                        Integer.valueOf(command.get("newInstances")),
-                        Integer.valueOf(command.get("oldInstances")));
+                        Integer.parseInt(command.get("newInstances")),
+                        Integer.parseInt(command.get("oldInstances")));
       } catch (Throwable t) {
         LOG.error(String.format("Fail to change instances: %s", command), t);
         throw t;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramControllerServiceAdapter.java
@@ -27,9 +27,6 @@ import org.apache.twill.internal.ServiceListenerAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 /**
  * A {@link ProgramController} implementation that control a guava Service.
  * The Service must execute Listeners in the order they were added to the Service, otherwise
@@ -39,44 +36,52 @@ import java.util.concurrent.TimeUnit;
 public class ProgramControllerServiceAdapter extends AbstractProgramController {
 
   private static final Logger LOG = LoggerFactory.getLogger(ProgramControllerServiceAdapter.class);
-  private static final Logger USERLOG = Loggers.mdcWrapper(LOG, Constants.Logging.EVENT_TYPE_TAG,
-                                                           Constants.Logging.USER_LOG_TAG_VALUE);
+  private static final Logger USER_LOG = Loggers.mdcWrapper(LOG, Constants.Logging.EVENT_TYPE_TAG,
+                                                            Constants.Logging.USER_LOG_TAG_VALUE);
 
   private final Service service;
-  private final CountDownLatch serviceStoppedLatch;
+  private volatile boolean stopRequested;
 
   public ProgramControllerServiceAdapter(Service service, ProgramRunId programRunId) {
     super(programRunId);
     this.service = service;
-    this.serviceStoppedLatch = new CountDownLatch(1);
     listenToRuntimeState(service);
   }
 
   @Override
-  protected void doSuspend() throws Exception {
-
+  protected void doSuspend() {
+    // no-op
   }
 
   @Override
-  protected void doResume() throws Exception {
-
+  protected void doResume() {
+    // no-op
   }
 
   @Override
   protected void doStop() throws Exception {
-    if (service.state() != Service.State.TERMINATED && service.state() != Service.State.FAILED) {
-      LOG.debug("stopping controller service for program {}.", getProgramRunId());
+    LOG.debug("Stopping controller service for program {}.", getProgramRunId());
+    stopRequested = true;
+    long gracefulTimeoutMillis = getGracefulTimeoutMillis();
+    if (gracefulTimeoutMillis < 0) {
       service.stopAndWait();
-      LOG.debug("stopped controller service for program {}, waiting for it to finish running listener hooks.",
-                getProgramRunId());
-      serviceStoppedLatch.await(30, TimeUnit.SECONDS);
-      LOG.debug("controller service for program {} finished running listener hooks.", getProgramRunId());
+    } else {
+      gracefulStop(gracefulTimeoutMillis);
     }
+    LOG.debug("Controller service for program {} finished running listener hooks.", getProgramRunId());
+  }
+
+  /**
+   * Requests a graceful shutdown of the service with a timeout. Subclass can override this if it supports
+   * graceful termination with timeout.
+   */
+  protected void gracefulStop(long gracefulTimeoutMillis) {
+    service.stopAndWait();
   }
 
   @Override
   protected void doCommand(String name, Object value) throws Exception {
-
+    // no-op
   }
 
   private void listenToRuntimeState(Service service) {
@@ -90,20 +95,19 @@ public class ProgramControllerServiceAdapter extends AbstractProgramController {
       public void failed(Service.State from, Throwable failure) {
         Throwable rootCause = Throwables.getRootCause(failure);
         LOG.error("{} Program '{}' failed.", getProgramRunId().getType(), getProgramRunId().getProgram(), failure);
-        USERLOG.error("{} program '{}' failed with error: {}. Please check the system logs for more details.",
-                      getProgramRunId().getType(), getProgramRunId().getProgram(), rootCause.getMessage(), rootCause);
-        serviceStoppedLatch.countDown();
+        USER_LOG.error("{} program '{}' failed with error: {}. Please check the system logs for more details.",
+                       getProgramRunId().getType(), getProgramRunId().getProgram(), rootCause.getMessage(), rootCause);
         error(failure);
       }
 
       @Override
       public void terminated(Service.State from) {
-        serviceStoppedLatch.countDown();
         if (from != Service.State.STOPPING) {
           // Service completed by itself. Simply signal the state change of this controller.
           complete();
-        } else {
-          // Service was killed
+        } else if (!stopRequested) {
+          // Otherwise, if the Service was stopped not through this ProgramController.doStop() method,
+          // call stop() to transit this controller state to KILLED.
           stop();
         }
       }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/ServiceTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/ServiceTwillProgramController.java
@@ -45,8 +45,8 @@ final class ServiceTwillProgramController extends AbstractTwillProgramController
     Map<String, String> command = (Map<String, String>) value;
     try {
       changeInstances(command.get("runnable"),
-                      Integer.valueOf(command.get("newInstances")),
-                      Integer.valueOf(command.get("oldInstances")));
+                      Integer.parseInt(command.get("newInstances")),
+                      Integer.parseInt(command.get("oldInstances")));
     } catch (Throwable t) {
       LOG.error(String.format("Failed to change instances: %s", command), t);
       throw t;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/WorkerTwillProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/WorkerTwillProgramController.java
@@ -45,8 +45,8 @@ public class WorkerTwillProgramController extends AbstractTwillProgramController
     Map<String, String> command = (Map<String, String>) value;
     try {
       changeInstances(command.get("runnable"),
-                      Integer.valueOf(command.get("newInstances")),
-                      Integer.valueOf(command.get("oldInstances")));
+                      Integer.parseInt(command.get("newInstances")),
+                      Integer.parseInt(command.get("oldInstances")));
     } catch (Throwable t) {
       LOG.error(String.format("Failed to change instances: %s", command), t);
       throw t;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java
@@ -57,6 +57,7 @@ import java.util.Map;
 import java.util.Spliterators;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -146,9 +147,9 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
 
   /**
    * Accepts a Runnable and passes it to RuntimeClient
-   * @param stopper a Runnable
+   * @param stopper a {@link LongConsumer} with the termination timestamp in seconds as the argument
    */
-  public void onProgramStopRequested(Runnable stopper) {
+  public void onProgramStopRequested(LongConsumer stopper) {
     runtimeClient.onProgramStopRequested(stopper);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -149,7 +149,7 @@ public class ProgramLifecycleService {
                           RunRecordMonitorService runRecordMonitorService) {
     this.maxConcurrentRuns = cConf.getInt(Constants.AppFabric.MAX_CONCURRENT_RUNS);
     this.maxConcurrentLaunching = cConf.getInt(Constants.AppFabric.MAX_CONCURRENT_LAUNCHING);
-    this.defaultStopTimeoutSecs = cConf.getInt(Constants.AppFabric.DEFAULT_STOP_TIMEOUT_SECS);
+    this.defaultStopTimeoutSecs = cConf.getInt(Constants.AppFabric.PROGRAM_MAX_STOP_SECONDS);
     this.userProgramLaunchDisabled = cConf.getBoolean(Constants.AppFabric.USER_PROGRAM_LAUNCH_DISABLED, false);
     this.store = store;
     this.profileService = profileService;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -744,7 +744,7 @@ public class ProgramNotificationSubscriberService extends AbstractNotificationSu
    */
   private long getTimeSeconds(Map<String, String> properties, String option) {
     String timeString = properties.get(option);
-    return (timeString == null) ? -1 : TimeUnit.MILLISECONDS.toSeconds(Long.parseLong(timeString));
+    return (timeString == null) ? -1L : TimeUnit.MILLISECONDS.toSeconds(Long.parseLong(timeString));
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServerTest.java
@@ -39,7 +39,6 @@ import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.TopicMetadata;
 import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
 import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
-import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.TopicId;
@@ -123,7 +122,7 @@ public class RuntimeClientServerTest {
         @Override
         protected void bindRequestValidator() {
           bind(RuntimeRequestValidator.class).toInstance(
-            (programRunId, request) -> new ProgramRunInfo(ProgramRunStatus.STOPPING, null));
+            (programRunId, request) -> new ProgramRunInfo(Long.MAX_VALUE));
         }
 
         @Override
@@ -224,7 +223,7 @@ public class RuntimeClientServerTest {
   @Test
   public void testFutureIsNotBlockingWhenValueIsSet() throws Exception {
     CountDownLatch countDownLatch = new CountDownLatch(1);
-    runtimeClient.onProgramStopRequested(() -> countDownLatch.countDown());
+    runtimeClient.onProgramStopRequested(terminateTs -> countDownLatch.countDown());
     // Now call sendMessages which will set the future
     ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").workflow("workflow").run(RunIds.generate());
     TopicId topicId = NamespaceId.SYSTEM.topic("topic");

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
@@ -125,7 +125,7 @@ public class RuntimeClientServiceTest {
         @Override
         protected void bindRequestValidator() {
           bind(RuntimeRequestValidator.class).toInstance(
-            (programRunId, request) -> new ProgramRunInfo(ProgramRunStatus.COMPLETED, null));
+            (programRunId, request) -> new ProgramRunInfo(ProgramRunStatus.COMPLETED));
         }
 
         @Override

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingTest.java
@@ -130,7 +130,7 @@ public class RuntimeServiceRoutingTest {
             if (!expected.equals(authHeader)) {
               throw new UnauthenticatedException("Program run " + programRunId + " is not authorized");
             }
-            return new ProgramRunInfo(ProgramRunStatus.COMPLETED, null);
+            return new ProgramRunInfo(ProgramRunStatus.COMPLETED);
           });
         }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorServiceTest.java
@@ -294,6 +294,11 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
       }
 
       @Override
+      public ListenableFuture<ProgramController> stop(long timeout, TimeUnit timeoutUnit) {
+        return null;
+      }
+
+      @Override
       public void kill() {
         latch.countDown();
       }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.datastreams;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.api.ProgramStatus;
@@ -32,6 +33,7 @@ import io.cdap.cdap.etl.common.plugin.PipelinePluginContext;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
 import io.cdap.cdap.etl.spark.plugin.SparkPipelinePluginContext;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.spark.SparkConf;
 import org.slf4j.Logger;
@@ -98,14 +100,23 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
 
     SparkConf sparkConf = new SparkConf();
     // we do not do checkpointing during preview. Skip enabling write-ahead logs in that case to avoid spark exception
-    boolean isPreviewEnabled = spec.isPreviewEnabled(context);
-    if (!isPreviewEnabled) {
+    if (!spec.isPreviewEnabled(context) && !spec.isCheckpointsDisabled()) {
       // required spark configs to prevent data loss during real-time pipeline upgrades
       sparkConf.set("spark.streaming.receiver.writeAheadLog.enable", "true");
-      sparkConf.set("spark.streaming.receiver.writeAheadLog.closeFileAfterWrite", "true");
-      sparkConf.set("spark.streaming.driver.writeAheadLog.closeFileAfterWrite", "true");
-      sparkConf.set("spark.streaming.receiver.writeAheadLog.rollingIntervalSecs", String.valueOf(0));
-      sparkConf.set("spark.streaming.driver.writeAheadLog.rollingIntervalSecs", String.valueOf(0));
+
+      String checkpointDir = spec.getCheckpointDirectory();
+      String checkpointScheme = null;
+
+      if (!Strings.isNullOrEmpty(checkpointDir)) {
+        checkpointScheme = new Path(checkpointDir).toUri().getScheme();
+      }
+
+      // For non-local file or HDFS, assuming the FS doesn't support flush (e.g. GCS or S3), hence set
+      // the following configurations
+      if (!"file".equals(checkpointScheme) && !"hdfs".equals(checkpointScheme)) {
+        sparkConf.set("spark.streaming.receiver.writeAheadLog.closeFileAfterWrite", "true");
+        sparkConf.set("spark.streaming.driver.writeAheadLog.closeFileAfterWrite", "true");
+      }
     }
     sparkConf.set("spark.streaming.backpressure.enabled", "true");
     sparkConf.set("spark.spark.streaming.blockInterval", String.valueOf(spec.getBatchIntervalMillis() / 5));

--- a/cdap-app-templates/cdap-etl/cdap-data-streams2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams2_2.11/pom.xml
@@ -57,6 +57,11 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-features</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-app-templates/cdap-etl/cdap-data-streams3_2.12/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams3_2.12/pom.xml
@@ -57,6 +57,11 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-features</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-etl-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -253,7 +253,6 @@ public final class Constants {
     public static final String PROGRAM_TRANSACTION_CONTROL = "app.program.transaction.control";
     public static final String MAX_CONCURRENT_RUNS = "app.max.concurrent.runs";
     public static final String MAX_CONCURRENT_LAUNCHING = "app.max.concurrent.launching";
-    public static final String DEFAULT_STOP_TIMEOUT_SECS = "app.program.stop.timeout.secs";
     public static final String MONITOR_RECORD_AGE_THRESHOLD_SECONDS =
       "run.record.monitor.record.age.threshold.seconds";
     public static final String MONITOR_CLEANUP_INTERVAL_SECONDS =

--- a/cdap-common/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/ProgramRunInfo.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/ProgramRunInfo.java
@@ -25,22 +25,55 @@ import javax.annotation.Nullable;
  * Used to send information about program status from RuntimeHandler to RuntimeClient.
  */
 public class ProgramRunInfo {
-  private final ProgramRunStatus programRunStatus;
-  @Nullable
-  private final String payload;
 
-  ProgramRunInfo(ProgramRunStatus programRunStatus, @Nullable String payload) {
+  private final ProgramRunStatus programRunStatus;
+
+  @Nullable
+  private final Long terminateTs;
+
+  /**
+   * Creates a {@link ProgramRunInfo} in {@link ProgramRunStatus#STOPPING} state with the given
+   * termination timestamp.
+   *
+   * @param terminateTs timestamp in seconds
+   */
+  ProgramRunInfo(long terminateTs) {
+    this.programRunStatus = ProgramRunStatus.STOPPING;
+    this.terminateTs = terminateTs;
+  }
+
+  /**
+   * Creates a {@link ProgramRunInfo} with the given state except for {@link ProgramRunStatus#STOPPING}, which should
+   * use {@link #ProgramRunInfo(long)} instead.
+   *
+   * @param programRunStatus the program run status
+   */
+  ProgramRunInfo(ProgramRunStatus programRunStatus) {
+    if (programRunStatus == ProgramRunStatus.STOPPING) {
+      throw new IllegalArgumentException("The STOPPING state must associate with a termination timestamp.");
+    }
     this.programRunStatus = programRunStatus;
-    this.payload = payload;
+    this.terminateTs = null;
   }
 
   public ProgramRunStatus getProgramRunStatus() {
     return programRunStatus;
   }
 
-  @Nullable
-  public String getPayload() {
-    return payload;
+  /**
+   * Returns the termination timestamp in seconds if the program run status is in {@link ProgramRunStatus#STOPPING}
+   * state.
+   */
+  public long getTerminateTimestamp() {
+    if (programRunStatus != ProgramRunStatus.STOPPING) {
+      throw new IllegalStateException("Only the STOPPING state has termination timestamp");
+    }
+    // This shouldn't happen
+    if (terminateTs == null) {
+      throw new IllegalStateException("Missing termination timestamp");
+    }
+
+    return terminateTs;
   }
 
   @Override
@@ -54,19 +87,19 @@ public class ProgramRunInfo {
 
     ProgramRunInfo that = (ProgramRunInfo) o;
     return Objects.equals(this.getProgramRunStatus(), that.getProgramRunStatus()) &&
-    Objects.equals(this.getPayload(), that.getPayload());
+    Objects.equals(this.getTerminateTimestamp(), that.getTerminateTimestamp());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getProgramRunStatus(), getPayload());
+    return Objects.hash(getProgramRunStatus(), getTerminateTimestamp());
   }
 
   @Override
   public String toString() {
     return "ProgramRunInfo" +
       "{programRunStatus=" + programRunStatus +
-      ", payload='" + payload +
+      ", terminateTs='" + terminateTs +
       '}';
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -481,15 +481,6 @@
   </property>
 
   <property>
-    <name>app.program.stop.timeout.secs</name>
-    <value>180</value>
-    <description>
-      Time in seconds for which we will wait for a program to stop on its own
-      before force terminating it.
-    </description>
-  </property>
-
-  <property>
     <name>user.program.launch.disabled</name>
     <value>false</value>
     <description>Allows users to disable program launches on CDAP cluster.
@@ -5309,6 +5300,14 @@
     <value>true</value>
     <description>
       Enables deduplicate transformation in pushdown execution.
+    </description>
+  </property>
+
+  <property>
+    <name>feature.streaming.pipeline.checkpoint.deletion.enabled</name>
+    <value>false</value>
+    <description>
+      Enables auto deletion of streaming pipeline checkpoint on successful graceful shutdown
     </description>
   </property>
 

--- a/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
+++ b/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
@@ -30,7 +30,8 @@ public enum Feature {
   EVENT_PUBLISH("6.7.0", false),
   PIPELINE_COMPOSITE_TRIGGERS("6.8.0"),
   PUSHDOWN_TRANSFORMATION_GROUPBY("6.7.0"),
-  PUSHDOWN_TRANSFORMATION_DEDUPLICATE("6.7.0");
+  PUSHDOWN_TRANSFORMATION_DEDUPLICATE("6.7.0"),
+  STREAMING_PIPELINE_CHECKPOINT_DELETION("6.7.1");
 
   private final PlatformInfo.Version versionIntroduced;
   private final boolean defaultAfterIntroduction;

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramController.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramController.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.app.runtime.spark;
 
-import com.google.common.util.concurrent.Service;
 import io.cdap.cdap.api.lineage.field.Operation;
 import io.cdap.cdap.api.spark.Spark;
 import io.cdap.cdap.api.workflow.WorkflowToken;
@@ -26,6 +25,7 @@ import io.cdap.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
 import io.cdap.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link ProgramController} for {@link Spark} jobs. This class acts as an adapter for reflecting state changes
@@ -34,10 +34,17 @@ import java.util.Set;
 final class SparkProgramController extends ProgramControllerServiceAdapter implements WorkflowDataProvider {
 
   private final SparkRuntimeContext context;
+  private final SparkRuntimeService sparkRuntimeService;
 
-  SparkProgramController(Service sparkRuntimeService, SparkRuntimeContext context) {
+  SparkProgramController(SparkRuntimeService sparkRuntimeService, SparkRuntimeContext context) {
     super(sparkRuntimeService, context.getProgramRunId());
     this.context = context;
+    this.sparkRuntimeService = sparkRuntimeService;
+  }
+
+  @Override
+  protected void gracefulStop(long gracefulTimeoutMillis) {
+    sparkRuntimeService.stop(gracefulTimeoutMillis, TimeUnit.MILLISECONDS);
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -21,7 +21,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.io.Closeables;
 import com.google.common.reflect.TypeToken;
-import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.app.ApplicationSpecification;
@@ -224,10 +223,10 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
                                           options.getArguments().getOption(Constants.AppFabric.APP_SCHEDULER_QUEUE));
       }
 
-      Service sparkRuntimeService = new SparkRuntimeService(cConf, spark, getPluginArchive(options),
-                                                            runtimeContext, submitter, locationFactory, isLocal,
-                                                            fieldLineageWriter, masterEnv,
-                                                            commonNettyHttpServiceFactory);
+      SparkRuntimeService sparkRuntimeService = new SparkRuntimeService(cConf, spark, getPluginArchive(options),
+                                                                        runtimeContext, submitter, locationFactory,
+                                                                        isLocal, fieldLineageWriter, masterEnv,
+                                                                        commonNettyHttpServiceFactory);
 
       sparkRuntimeService.addListener(createRuntimeServiceListener(closeables), Threads.SAME_THREAD_EXECUTOR);
       ProgramController controller = new SparkProgramController(sparkRuntimeService, runtimeContext);

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -75,6 +75,7 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
   // since outside of this class, the spark classloader is wrapped with a WeakReferenceDelegatorClassLoader
   @SuppressWarnings("unused")
   private SparkClassLoader sparkClassLoader;
+  private volatile Long terminationTime;
 
   SparkRuntimeContext(Configuration hConf, Program program, ProgramOptions programOptions,
                       CConfiguration cConf, String hostname, TransactionSystemClient txClient,
@@ -152,6 +153,33 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
    */
   public String getHostname() {
     return hostname;
+  }
+
+  /**
+   * Sets the timestamp for termination. The value must be {@code >= 0}.
+   *
+   * @param timestamp timestamp in milliseconds
+   */
+  public void setTerminationTime(long timestamp) {
+    if (timestamp < 0) {
+      throw new IllegalArgumentException("Graceful termination timeout must be >= 0");
+    }
+    this.terminationTime = timestamp;
+  }
+
+  /**
+   * Gets the graceful termination time.
+   *
+   * @return the timeout in milliseconds
+   * @throws IllegalStateException if the timeout was not set by the {@link #setGracefulTerminationTimeout(long)}
+   * before calling this method
+   */
+  public long getTerminationTime() {
+    Long timestamp = terminationTime;
+    if (timestamp == null) {
+      throw new IllegalStateException("Termination time is not available");
+    }
+    return timestamp;
   }
 
   private static SparkSpecification getSparkSpecification(Program program) {

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -29,7 +29,6 @@ import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import io.cdap.cdap.api.ProgramLifecycle;
 import io.cdap.cdap.api.ProgramState;
 import io.cdap.cdap.api.ProgramStatus;
@@ -40,6 +39,7 @@ import io.cdap.cdap.api.spark.SparkClientContext;
 import io.cdap.cdap.app.runtime.spark.distributed.SparkContainerLauncher;
 import io.cdap.cdap.app.runtime.spark.python.PySparkUtil;
 import io.cdap.cdap.app.runtime.spark.service.ArtifactFetcherService;
+import io.cdap.cdap.app.runtime.spark.submit.SparkJobFuture;
 import io.cdap.cdap.app.runtime.spark.submit.SparkSubmitter;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.CConfigurationUtil;
@@ -108,7 +108,9 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -128,12 +130,6 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
   private static final String CDAP_LAUNCHER_JAR = "cdap-spark-launcher.jar";
   private static final String CDAP_SPARK_JAR = "cdap-spark.jar";
   private static final String CDAP_METRICS_PROPERTIES = "metrics.properties";
-  private static final Function<File, URI> FILE_TO_URI = new Function<File, URI>() {
-    @Override
-    public URI apply(File input) {
-      return input.toURI();
-    }
-  };
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkRuntimeService.class);
 
@@ -143,18 +139,18 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
   private final File pluginArchive;
   private final SparkSubmitter sparkSubmitter;
   private final LocationFactory locationFactory;
-  private final AtomicReference<ListenableFuture<RunId>> completion;
+  private final AtomicReference<SparkJobFuture<RunId>> completion;
   private final BasicSparkClientContext context;
   private final boolean isLocal;
   private final ProgramLifecycle<SparkRuntimeContext> programLifecycle;
   private final FieldLineageWriter fieldLineageWriter;
   private final CommonNettyHttpServiceFactory commonNettyHttpServiceFactory;
-
-
-  private Callable<ListenableFuture<RunId>> submitSpark;
-  private Runnable cleanupTask;
   private final MasterEnvironment masterEnv;
+
+  private Callable<SparkJobFuture<RunId>> submitSpark;
+  private Runnable cleanupTask;
   private ArtifactFetcherService artifactFetcherService;
+  private volatile long gracefulTimeoutMillis;
 
   SparkRuntimeService(CConfiguration cConf, final Spark spark, @Nullable File pluginArchive,
                       SparkRuntimeContext runtimeContext, SparkSubmitter sparkSubmitter,
@@ -170,6 +166,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     this.context = new BasicSparkClientContext(runtimeContext);
     this.isLocal = isLocal;
     this.commonNettyHttpServiceFactory = commonNettyHttpServiceFactory;
+    this.gracefulTimeoutMillis = -1L;
     this.programLifecycle = new ProgramLifecycle<SparkRuntimeContext>() {
       @Override
       public void initialize(SparkRuntimeContext runtimeContext) throws Exception {
@@ -198,7 +195,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
   @Override
   protected void startUp() throws Exception {
     // additional spark job initialization at run-time
-    // This context is for calling initialize and onFinish on the Spark program
+    // This context is for calling initialize and destroy on the Spark program
 
     // Fields injection for the Spark program
     // It has to be done in here instead of in SparkProgramRunner for the @UseDataset injection
@@ -317,12 +314,8 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
 
         // Localize the spark.jar archive, which contains all CDAP and dependency jars
         File sparkJar = new File(tempDir, CDAP_SPARK_JAR);
-        classpath = joiner.join(Iterables.transform(buildDependencyJar(sparkJar), new Function<String, String>() {
-          @Override
-          public String apply(String name) {
-            return Paths.get("$PWD", CDAP_SPARK_JAR, name).toString();
-          }
-        }));
+        classpath = joiner.join(Iterables.transform(buildDependencyJar(sparkJar),
+                                                    name -> Paths.get("$PWD", CDAP_SPARK_JAR, name).toString()));
         localizeResources.add(new LocalizeResource(sparkJar, true));
 
         // Localize logback if there is one. It is placed at the beginning of the classpath
@@ -344,23 +337,20 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
       Iterable<URI> pyFiles = Collections.emptyList();
       if (context.isPySpark()) {
         extraPySparkFiles.add(PySparkUtil.createPySparkLib(tempDir));
-        pyFiles = Iterables.concat(Iterables.transform(extraPySparkFiles, FILE_TO_URI),
+        pyFiles = Iterables.concat(Iterables.transform(extraPySparkFiles, File::toURI),
                                    context.getAdditionalPythonLocations());
       }
 
       final Map<String, String> configs = createSubmitConfigs(tempDir, metricsConfPath, classpath,
                                                               context.getLocalizeResources(), isLocal, pyFiles);
-      submitSpark = new Callable<ListenableFuture<RunId>>() {
-        @Override
-        public ListenableFuture<RunId> call() throws Exception {
-          // If stop already requested on this service, don't submit the spark.
-          // This happen when stop() was called whiling starting
-          if (!isRunning()) {
-            return immediateCancelledFuture();
-          }
-          return sparkSubmitter.submit(runtimeContext, configs, localizeResources, jobFile,
-                                       runtimeContext.getRunId());
+      submitSpark = () -> {
+        // If stop already requested on this service, don't submit the spark.
+        // This happen when stop() was called whiling starting
+        if (!isRunning()) {
+          return SparkJobFuture.immeidateCancelled();
         }
+        return sparkSubmitter.submit(runtimeContext, configs, localizeResources, jobFile,
+                                     runtimeContext.getRunId());
       };
     } catch (Throwable t) {
       cleanupTask.run();
@@ -378,11 +368,11 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
    * Creates a jar bundle of all required artifacts.
    * @param artifactsPath the local path where artifacts are located.
    * @return Location of the created jar bundle of artifacts.
-   * @throws IOException
+   * @throws IOException if failed to create the bundle jar
    */
   private static Location createBundle(java.nio.file.Path artifactsPath) throws IOException {
     File tmpDir = Files.createTempDir();
-    for (File file : new File(artifactsPath.toFile().toString()).listFiles()) {
+    for (File file : DirUtils.listFiles(artifactsPath.toFile())) {
       if (file.getName().startsWith("unpacked")) {
         // unpacked directory is skipped.
         continue;
@@ -409,7 +399,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
 
   @Override
   protected void run() throws Exception {
-    ListenableFuture<RunId> jobCompletion = completion.getAndSet(submitSpark.call());
+    SparkJobFuture<RunId> jobCompletion = completion.getAndSet(submitSpark.call());
     // If the jobCompletion is not null, meaning the stop() was called before the atomic reference "completion" has been
     // updated. This mean the job is cancelled. We also need to cancel the future returned by submitSpark.call().
     if (jobCompletion != null) {
@@ -437,7 +427,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
   @Override
   protected void shutDown() throws Exception {
     // Try to get from the submission future to see if the job completed successfully.
-    ListenableFuture<RunId> jobCompletion = completion.get();
+    SparkJobFuture<RunId> jobCompletion = completion.get();
     ProgramState state = new ProgramState(ProgramStatus.COMPLETED, null);
     try {
       jobCompletion.get();
@@ -452,7 +442,13 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     try {
       destroy(state);
     } finally {
-      cleanupTask.run();
+      try {
+        if (artifactFetcherService != null) {
+          artifactFetcherService.stopAndWait();
+        }
+      } finally {
+        cleanupTask.run();
+      }
       LOG.debug("Spark program completed: {}", runtimeContext);
     }
   }
@@ -462,40 +458,52 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     LOG.debug("Stop requested for Spark Program {}", runtimeContext);
     // Replace the completion future with a cancelled one.
     // Also, try to cancel the current completion future if it exists.
-    ListenableFuture<RunId> future = completion.getAndSet(this.<RunId>immediateCancelledFuture());
+    SparkJobFuture<RunId> future = completion.getAndSet(SparkJobFuture.immeidateCancelled());
     if (future != null) {
-      future.cancel(true);
+      if (gracefulTimeoutMillis >= 0L) {
+        future.cancel(gracefulTimeoutMillis, TimeUnit.MILLISECONDS);
+      } else {
+        future.cancel(true);
+      }
     }
+  }
+
+  /**
+   * Stops the Spark job controlled by this service with the given timeout for the Spark job to stop before
+   * forcing it to terminate.
+   *
+   * @param timeout the timeout for force termination of the spark job
+   * @param timeoutUnit the unit for the timeout
+   * @return a future for the shutdown result, regardless of whether this call initiated shutdown.
+   *         Calling {@link ListenableFuture#get} will block until the service has finished shutting
+   *         down, and either returns {@link State#TERMINATED} or throws an
+   *         {@link ExecutionException}. If it has already finished stopping,
+   *         {@link ListenableFuture#get} returns immediately. Cancelling this future has no effect
+   *         on the service.
+   */
+  public ListenableFuture<State> stop(long timeout, TimeUnit timeoutUnit) {
+    gracefulTimeoutMillis = timeoutUnit.toMillis(timeout);
+    return stop();
   }
 
   @Override
   protected Executor executor() {
     // Always execute in new daemon thread.
-    //noinspection NullableProblems
-    return new Executor() {
-      @Override
-      public void execute(final Runnable runnable) {
-        final Thread t = new Thread(new Runnable() {
-
-          @Override
-          public void run() {
-            // note: this sets logging context on the thread level
-            LoggingContextAccessor.setLoggingContext(runtimeContext.getLoggingContext());
-            runnable.run();
-          }
-        });
-        t.setDaemon(true);
-        t.setName("SparkRunner" + runtimeContext.getProgramName());
-        t.start();
-      }
+    return runnable -> {
+      final Thread t = new Thread(() -> {
+        // note: this sets logging context on the thread level
+        LoggingContextAccessor.setLoggingContext(runtimeContext.getLoggingContext());
+        runnable.run();
+      });
+      t.setDaemon(true);
+      t.setName("SparkRunner-" + runtimeContext.getProgramName());
+      t.start();
     };
   }
 
   /**
-   * Calls the {@link Spark#beforeSubmit(SparkClientContext)} for the pre 3.5 Spark programs, calls
-   * the {@link ProgramLifecycle#initialize} otherwise.
+   * Calls the {@link ProgramLifecycle#initialize} of the {@link Spark} program.
    */
-  @SuppressWarnings("unchecked")
   private void initialize() throws Exception {
     context.setState(new ProgramState(ProgramStatus.INITIALIZING, null));
 
@@ -514,7 +522,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
   }
 
   /**
-   * Calls the destroy or onFinish method of {@link ProgramLifecycle}.
+   * Calls the {@link ProgramLifecycle#destroy()} of the {@link Spark} program.
    */
   private void destroy(final ProgramState state) {
     context.setState(state);
@@ -574,7 +582,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
   private Map<String, String> createSubmitConfigs(File localDir, @Nullable String metricsConfPath, String classpath,
                                                   Map<String, LocalizeResource> localizedResources,
                                                   boolean localMode,
-                                                  Iterable<URI> pyFiles) throws Exception {
+                                                  Iterable<URI> pyFiles) {
 
     // Setup configs from the default spark conf
     Map<String, String> configs = new HashMap<>(Maps.fromProperties(SparkPackageUtils.getSparkDefaultConf()));
@@ -684,12 +692,7 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
    * prepended to the existing value.
    */
   private void prependConfig(Map<String, String> configs, String key, String prepend, String separator) {
-    String existing = configs.get(key);
-    if (existing == null) {
-      configs.put(key, prepend);
-    } else {
-      configs.put(key, prepend + separator + existing);
-    }
+    configs.merge(key, prepend, (a, b) -> b + separator + a);
   }
 
   /**
@@ -1055,15 +1058,6 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     } catch (Exception e) {
       LOG.warn("Failed to cleanup BeanIntrospector cache, may lead to memory leak in SDK.", e);
     }
-  }
-
-  /**
-   * Creates a {@link ListenableFuture} that is cancelled.
-   */
-  private <V> ListenableFuture<V> immediateCancelledFuture() {
-    SettableFuture<V> future = SettableFuture.create();
-    future.cancel(true);
-    return future;
   }
 
   /**

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/classloader/SparkClassRewriter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/classloader/SparkClassRewriter.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.common.logging.RedirectedPrintStream;
 import io.cdap.cdap.internal.asm.Classes;
 import io.cdap.cdap.internal.asm.Methods;
 import io.cdap.cdap.internal.asm.Signatures;
+import org.apache.spark.deploy.SparkSubmit;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
@@ -99,13 +100,14 @@ public class SparkClassRewriter implements ClassRewriter {
     Type.getObjectType("org/apache/spark/api/python/PythonWorkerFactory");
   private static final Type SPARK_PYTHON_WORKER_MONITOR_THREAD_TYPE =
     Type.getObjectType("org/apache/spark/api/python/PythonWorkerFactory$MonitorThread");
-  private static final Type SPARK_REDIRECT_THREAD = Type.getObjectType("org/apache/spark/util/RedirectThread");
   private static final Type SPARK_YARN_CLIENT_TYPE = Type.getObjectType("org/apache/spark/deploy/yarn/Client");
   private static final Type CHECKPOINT_WRITE_HANDLER_TYPE =
     Type.getObjectType("org/apache/spark/streaming/CheckpointWriter$CheckpointWriteHandler");
   private static final Type SPARK_DSTREAM_GRAPH_TYPE = Type.getObjectType("org/apache/spark/streaming/DStreamGraph");
   private static final Type SPARK_BATCHED_WRITE_AHEAD_LOG_TYPE =
     Type.getObjectType("org/apache/spark/streaming/util/BatchedWriteAheadLog");
+  private static final Type SPARK_WRITER_AHEAD_LOG_BASED_BLOCK_HANDLER_TYPE =
+    Type.getObjectType("org/apache/spark/streaming/receiver/WriteAheadLogBasedBlockHandler");
   private static final Type RATE_CONTROLLER_TYPE =
     Type.getObjectType("org/apache/spark/streaming/scheduler/RateController");
   private static final Type SPARK_STREAMING_TIME_TYPE =
@@ -204,8 +206,14 @@ public class SparkClassRewriter implements ClassRewriter {
     }
     if (className.equals(SPARK_BATCHED_WRITE_AHEAD_LOG_TYPE.getClassName())) {
       // Rewrite BatchedWriteAheadLog to register it in SparkRuntimeEnv so that we can free up the batch writer thread
-      // even there is no Receiver based DStream (it's a thread leak from Spark) (CDAP-11577) (SPARK-20935)
+      // even there is no Receiver based DStream (it's a thread leak from Spark) (CDAP-11577) (SPARK-20935).
+      // See method for details.
       return rewriteBatchedWriteAheadLog(input);
+    }
+    if (className.equals(SPARK_WRITER_AHEAD_LOG_BASED_BLOCK_HANDLER_TYPE.getClassName())) {
+      // Rewrite WriteAheadLogBasedBlockHandler to keep the ExecutorContext running even after stop().
+      // See method for details.
+      return rewriteWritAheadLogHandler(input);
     }
     if (className.equals(RATE_CONTROLLER_TYPE.getClassName())) {
       // Rewrite the RateController class to avoid leaking a "stream-rate-update"
@@ -377,9 +385,16 @@ public class SparkClassRewriter implements ClassRewriter {
   /**
    * Rewrites the BatchedWriteAheadLog class to register itself to SparkRuntimeEnv so that the write ahead log thread
    * can be shutdown when the Spark program finished.
+   *
+   * Also, rewrite the close() method on the writer to a no-op and
+   * add a new realClose() method to perform the closing operation. This is needed for the graceful shutdown.
+   * During graceful shutdown, the JobGenerator would first close the ReceiverTracker to signal all receivers to stop,
+   * which will also close the WAL inside the ReceiverTracker. This causes the JobGenerator failureto update the WAL
+   * while processing the remaining jobs as part of the graceful shutdown logic.
    */
   private byte[] rewriteBatchedWriteAheadLog(InputStream byteCodeStream) throws IOException {
-    return rewriteConstructor(SPARK_BATCHED_WRITE_AHEAD_LOG_TYPE, byteCodeStream, new ConstructorRewriter() {
+    // First rewrite the constructor
+    byte[] bytecode = rewriteConstructor(SPARK_BATCHED_WRITE_AHEAD_LOG_TYPE, byteCodeStream, new ConstructorRewriter() {
       @Override
       public void onMethodExit(String name, String desc, GeneratorAdapter generatorAdapter) {
         generatorAdapter.loadThis();
@@ -388,6 +403,76 @@ public class SparkClassRewriter implements ClassRewriter {
                                                  new Type[] { Type.getType(Object.class) }));
       }
     });
+
+    // Second pass to copy the close() method to the realClose() method, and turn close() to no-op
+    ClassReader cr = new ClassReader(bytecode);
+    ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+    Method closeMethod = new Method("close", Type.VOID_TYPE, new Type[0]);
+    cr.accept(new ClassVisitor(Opcodes.ASM7, cw) {
+      @Override
+      public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                       String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+
+        if (!(closeMethod.getName().equals(name) && closeMethod.getDescriptor().equals(descriptor))) {
+          return mv;
+        }
+        // Make the close() method no-op and simply return
+        GeneratorAdapter adapter = new GeneratorAdapter(mv, access, name, descriptor);
+        adapter.returnValue();
+        adapter.endMethod();
+
+        // Rename the close() to realClose()
+        return super.visitMethod(access, "realClose", descriptor, signature, exceptions);
+      }
+    }, 0);
+
+    return cw.toByteArray();
+  }
+
+  /**
+   * Rewrites the WriteAheadLogBasedBlockHandler.stop() method to skip shutting down of the ExecutorContext.
+   * The executor is needed for writing out the last received block after stop() was called since persisting
+   * received blocks into WAL is a async operation.
+   * The ExecutorContext runs in daemon thread, hence it won't block the process termination.
+   */
+  private byte[] rewriteWritAheadLogHandler(InputStream byteCodeStream) throws IOException {
+    ClassReader cr = new ClassReader(byteCodeStream);
+    ClassWriter cw = new ClassWriter(0);
+    Method stopMethod = new Method("stop", Type.VOID_TYPE, new Type[0]);
+    Method shutdownMethod = new Method("shutdown", Type.VOID_TYPE, new Type[0]);
+    String executorClass = "scala/concurrent/ExecutionContextExecutorService";
+
+    cr.accept(new ClassVisitor(Opcodes.ASM5, cw) {
+
+      @Override
+      public MethodVisitor visitMethod(int access, String name, String descriptor,
+                                       String signature, String[] exceptions) {
+        MethodVisitor mv = super.visitMethod(access, name, descriptor, signature, exceptions);
+
+        if (!stopMethod.getDescriptor().equals(descriptor)) {
+          return mv;
+        }
+
+        return new MethodVisitor(Opcodes.ASM7, mv) {
+          @Override
+          public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
+            if (Opcodes.INVOKEINTERFACE == opcode
+                && executorClass.equals(owner)
+                && shutdownMethod.getDescriptor().equals(descriptor)) {
+              // Inside the stop() method, skip the call the ExecutionContextExecutorService.shutdown() method.
+              // We need to pop the ExecutionContextExecutorService instance from the stack since
+              // it is not used to call any method.
+              super.visitInsn(Opcodes.POP);
+            } else {
+              super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+            }
+          }
+        };
+      }
+    }, ClassReader.EXPAND_FRAMES);
+
+    return cw.toByteArray();
   }
 
   /**

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkCommand.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkCommand.java
@@ -28,17 +28,41 @@ import java.util.Objects;
  */
 public class SparkCommand implements Command {
 
+  private static final String STOP = "stop";
+  private static final String TERMINATE_TS = "terminateTs";
+
   /**
-   * Command for stopping the spark execution.
+   * Creates a SparkCommand for stopping the spark execution.
+   *
+   * @param terminateTs the termination timestamp in seconds
    */
-  public static final SparkCommand STOP = new SparkCommand("stop");
+  public static SparkCommand createStop(long terminateTs) {
+    if (terminateTs < 0L) {
+      throw new IllegalArgumentException("Timeout seconds must be >= 0");
+    }
+    return new SparkCommand(STOP, Collections.singletonMap(TERMINATE_TS, Long.toString(terminateTs)));
+  }
+
+  /**
+   * Returns {@code true} if the given command is a stop command.
+   */
+  public static boolean isStop(SparkCommand command) {
+    return STOP.equals(command.getCommand());
+  }
+
+  /**
+   * Gets the termination timestamp in seconds from the STOP command.
+   */
+  public static long getTerminateTs(SparkCommand command) {
+    String timeoutSeconds = command.getOptions().get(TERMINATE_TS);
+    if (timeoutSeconds == null) {
+      throw new IllegalStateException("The SparkCommand doesn't have the '" + TERMINATE_TS + "' option");
+    }
+    return Long.parseLong(timeoutSeconds);
+  }
 
   private final String command;
   private final Map<String, String> options;
-
-  public SparkCommand(String command) {
-    this(command, Collections.<String, String>emptyMap());
-  }
 
   public SparkCommand(String command, Map<String, String> options) {
     this.command = command;
@@ -71,5 +95,13 @@ public class SparkCommand implements Command {
   @Override
   public int hashCode() {
     return Objects.hash(command, options);
+  }
+
+  @Override
+  public String toString() {
+    return "SparkCommand{" +
+      "command='" + command + '\'' +
+      ", options=" + options +
+      '}';
   }
 }

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkExecutionService.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkExecutionService.java
@@ -36,7 +36,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.twill.api.Command;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
@@ -59,7 +58,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -85,8 +84,9 @@ public final class SparkExecutionService extends AbstractIdleService {
   private final ProgramRunId programRunId;
   @Nullable
   private final WorkflowToken workflowToken;
-  private final AtomicBoolean stopping;
+  private final AtomicLong shutdownWaitSeconds;
   private final CountDownLatch stopLatch;
+  private volatile SparkCommand stopCommand;
 
   public SparkExecutionService(LocationFactory locationFactory, String host,
                                ProgramRunId programRunId, @Nullable WorkflowToken workflowToken) {
@@ -96,10 +96,10 @@ public final class SparkExecutionService extends AbstractIdleService {
       .setHost(host)
       .setExceptionHandler(new HttpExceptionHandler())
       .build();
-    this.stopping = new AtomicBoolean();
     this.stopLatch = new CountDownLatch(1);
     this.programRunId = programRunId;
     this.workflowToken = workflowToken;
+    this.shutdownWaitSeconds = new AtomicLong(SHUTDOWN_WAIT_SECONDS);
   }
 
   /**
@@ -121,6 +121,16 @@ public final class SparkExecutionService extends AbstractIdleService {
     return bindAddress;
   }
 
+  /**
+   * Sets the number of seconds to wait for the Spark job to complete during shutdown.
+   */
+  public void setShutdownWaitSeconds(long seconds) {
+    if (seconds < 0L) {
+      throw new IllegalStateException("Shutdown wait seconds must be >= 0");
+    }
+    shutdownWaitSeconds.set(seconds);
+  }
+
   @Override
   protected void startUp() throws Exception {
     httpServer.start();
@@ -128,10 +138,17 @@ public final class SparkExecutionService extends AbstractIdleService {
 
   @Override
   protected void shutDown() throws Exception {
-    stopping.set(true);
-    if (!stopLatch.await(SHUTDOWN_WAIT_SECONDS, TimeUnit.SECONDS)) {
+    LOG.info("Shutting down SparkExecutionService");
+    long waitSeconds = shutdownWaitSeconds.get();
+    long currentTs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    long terminateTs = (Long.MAX_VALUE - currentTs < waitSeconds) ? Long.MAX_VALUE : currentTs + waitSeconds;
+
+    stopCommand = SparkCommand.createStop(terminateTs);
+
+    if (!stopLatch.await(waitSeconds, TimeUnit.SECONDS)) {
       LOG.warn("Timeout in waiting for Spark program to stop: {}", programRunId);
     }
+    LOG.info("Shutting down HTTP server");
     httpServer.stop();
   }
 
@@ -166,10 +183,9 @@ public final class SparkExecutionService extends AbstractIdleService {
       validateRequest(programName, runId);
       updateWorkflowToken(request.content());
 
-      // If the stop was requested, send the "stop" command
-      if (stopping.get()) {
-        Command.Builder.of("stop");
-        responder.sendJson(HttpResponseStatus.OK, GSON.toJson(SparkCommand.STOP));
+      // If the stop command is present, send the stop command to request the spark job to stop
+      if (stopCommand != null) {
+        responder.sendJson(HttpResponseStatus.OK, GSON.toJson(stopCommand));
       } else {
         responder.sendStatus(HttpResponseStatus.OK);
       }
@@ -183,6 +199,7 @@ public final class SparkExecutionService extends AbstractIdleService {
     public synchronized void completed(FullHttpRequest request, HttpResponder responder,
                                        @PathParam("programName") String programName,
                                        @PathParam("runId") String runId) throws Exception {
+      LOG.info("Spark program completed {} {}", programName, runId);
       validateRequest(programName, runId);
       try {
         updateWorkflowToken(request.content());
@@ -240,7 +257,7 @@ public final class SparkExecutionService extends AbstractIdleService {
                         programName, programRunId.getProgram())
         );
       }
-      if (runId == null || !programRunId.getRun().equals(runId)) {
+      if (!programRunId.getRun().equals(runId)) {
         throw new BadRequestException(
           String.format("Request runId '%s' is not the same as the context runId '%s'", runId, programRunId.getRun())
         );

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/AbstractSparkJobFuture.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/AbstractSparkJobFuture.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.runtime.spark.submit;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * An abstract base implementation of {@link SparkJobFuture}. When the job execution is completed,
+ * the {@link #complete(Object)}} should be called for a successful execution,
+ * or call the {@link #completeExceptionally(Throwable)} for failure. To terminate the
+ * job execution while it is running, call one of the {@link #cancel(boolean)} or
+ * {@link #cancel(long, TimeUnit)} methods. Sub-classes should override the
+ * {@link #onCancel(long, TimeUnit)} method for cancelling the execution.
+ *
+ * @param <V> the type of the result object
+ */
+public abstract class AbstractSparkJobFuture<V> implements SparkJobFuture<V> {
+
+  private final long defaultCancelTimeoutMillis;
+  private final AtomicReference<Timeout> timeout;
+
+  // The internalFuture is for the internal state change. Any state change happens on this internalFuture, and the
+  // result will be relayed to the delegateFuture
+  private final CompletableFuture<V> internalFuture;
+  // The delegateFuture is the future to provide the final state of this future externally.
+  private final CompletableFuture<V> delegateFuture;
+
+  /**
+   * Creates an instance with the given cancel timeout as default for the {@link #cancel(boolean)} method.
+   *
+   * @param defaultCancelTimeoutMillis timeout in milliseconds
+   */
+  AbstractSparkJobFuture(long defaultCancelTimeoutMillis) {
+    this.defaultCancelTimeoutMillis = defaultCancelTimeoutMillis;
+    this.timeout = new AtomicReference<>();
+    this.delegateFuture = new CompletableFuture<>();
+
+    CompletableFuture<V> completion = new CompletableFuture<>();
+    completion.whenComplete((result, ex) -> {
+      if (ex != null) {
+        if (ex instanceof CancellationException) {
+          Timeout timeout = this.timeout.get();
+          if (timeout == null) {
+            // This shouldn't happen as the timeout is always set before completion is being cancelled
+            // in the cancel(long, TimeUnit) method.
+            throw new IllegalStateException("Missing graceful timeout");
+          }
+          onCancel(timeout.timeout, timeout.timeUnit);
+          delegateFuture.cancel(true);
+        } else {
+          delegateFuture.completeExceptionally(ex);
+        }
+      } else {
+        delegateFuture.complete(result);
+      }
+    });
+    this.internalFuture = completion;
+  }
+
+  /**
+   * The callback method to invoke when this future is being cancelled. This method should block until the spark
+   * job was successfully cancelled (stopped).
+   *
+   * @param timeout the timeout allowed to cancel the spark job
+   * @param timeoutTimeUnit the unit of the timeout
+   */
+  protected abstract void onCancel(long timeout, TimeUnit timeoutTimeUnit);
+
+  void complete(V result) {
+    internalFuture.complete(result);
+  }
+
+  void completeExceptionally(Throwable t) {
+    internalFuture.completeExceptionally(t);
+  }
+
+  @Override
+  public boolean cancel(long gracefulTimeout, TimeUnit gracefulTimeoutUnit) {
+    this.timeout.compareAndSet(null, new Timeout(gracefulTimeout, gracefulTimeoutUnit));
+    return internalFuture.cancel(true);
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    return cancel(defaultCancelTimeoutMillis, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return delegateFuture.isCancelled();
+  }
+
+  @Override
+  public boolean isDone() {
+    return delegateFuture.isDone();
+  }
+
+  @Override
+  public V get() throws InterruptedException, ExecutionException {
+    return delegateFuture.get();
+  }
+
+  @Override
+  public V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    return delegateFuture.get(timeout, unit);
+  }
+
+  private static final class Timeout {
+    private final long timeout;
+    private final TimeUnit timeUnit;
+
+    private Timeout(long timeout, TimeUnit timeUnit) {
+      this.timeout = timeout;
+      this.timeUnit = timeUnit;
+    }
+  }
+}

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/LocalSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/LocalSparkSubmitter.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import io.cdap.cdap.app.runtime.spark.SparkMainWrapper;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -31,7 +32,7 @@ public class LocalSparkSubmitter extends AbstractSparkSubmitter {
   private static final Pattern LOCAL_MASTER_PATTERN = Pattern.compile("local\\[([0-9]+|\\*)\\]");
 
   @Override
-  protected void addMaster(Map<String, String> configs, ImmutableList.Builder<String> argBuilder) throws Exception {
+  protected void addMaster(Map<String, String> configs, ImmutableList.Builder<String> argBuilder) {
     // Use at least two threads for Spark Streaming
     String masterArg = "local[2]";
 
@@ -47,7 +48,7 @@ public class LocalSparkSubmitter extends AbstractSparkSubmitter {
   }
 
   @Override
-  protected void triggerShutdown() {
+  protected void triggerShutdown(long timeout, TimeUnit timeoutTimeUnit) {
     // We just stop the SparkMainWrapper directly. Through the SparkClassLoader, we make sure that Spark
     // sees the same SparkMainWrapper class as this one
     SparkMainWrapper.stop();

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
@@ -138,9 +138,10 @@ public class MasterEnvironmentSparkSubmitter extends AbstractSparkSubmitter {
   }
 
   @Override
-  protected void triggerShutdown() {
+  protected void triggerShutdown(long timeout, TimeUnit timeoutTimeUnit) {
     // Just stop the execution service and block on that.
     // It will wait until the "completed" call from the Spark driver.
+    sparkExecutionService.setShutdownWaitSeconds(timeoutTimeUnit.toSeconds(timeout));
     sparkExecutionService.stopAndWait();
   }
 

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/SparkJobFuture.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/SparkJobFuture.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.runtime.spark.submit;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link Future} implementation for representing a Spark job execution, which allows cancelling the job through
+ * the {@link #cancel(boolean)} method or the {@link #cancel(long, TimeUnit)} method for termination with a graceful
+ * timeout. This future will complete when the job finished either normally or due to failure or cancellation.
+ *
+ * @param <V> type of object returned by the {@link #get()} method.
+ */
+public interface SparkJobFuture<V> extends Future<V> {
+
+  /**
+   * Creates a {@link SparkJobFuture} that is already cancelled.
+   * @param <V>
+   * @return
+   */
+  static <V> SparkJobFuture<V> immeidateCancelled() {
+    SparkJobFuture<V> future = new AbstractSparkJobFuture<V>(0L) {
+
+      @Override
+      protected void onCancel(long timeout, TimeUnit timeoutTimeUnit) {
+        // no-op
+      }
+    };
+
+    future.cancel(true);
+    return future;
+  }
+
+  @Override
+  boolean cancel(boolean mayInterruptIfRunning);
+
+  boolean cancel(long gracefulTimeout, TimeUnit gracefulTimeoutUnit);
+}

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/SparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/SparkSubmitter.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Interface to provide abstraction for submitting a Spark program to
@@ -40,12 +41,13 @@ public interface SparkSubmitter {
    * @param jobFile location of the job file required by the framework
    * @param result object instance to be available through the returned {@link ListenableFuture} when it completes
    * @param <V> Type of the result object
-   * @return An {@link ListenableFuture} that will be completed when the job finished. If the job execution failed,
+   * @return An {@link SparkJobFuture} that will be completed when the job finished. If the job execution failed,
    *         the future will also be failed with the cause wrapped inside an {@link ExecutionException}
-   *         when {@link ListenableFuture#get} is called. If {@link ListenableFuture#cancel(boolean)} is called,
-   *         the running job will be terminated immediately.
+   *         when {@link SparkJobFuture#get} is called. If {@link SparkJobFuture#cancel(boolean)} is called,
+   *         the running job will be terminated immediately. To terminate the job gracefully with a timeout, use
+   *         {@link SparkJobFuture#cancel(long, TimeUnit)}
    * @throws Exception if there is error while submitting the spark job
    */
-  <V> ListenableFuture<V> submit(SparkRuntimeContext runtimeContext, Map<String, String> configs,
+  <V> SparkJobFuture<V> submit(SparkRuntimeContext runtimeContext, Map<String, String> configs,
                                  List<LocalizeResource> resources, URI jobFile, V result) throws Exception;
 }

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/AbstractSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/AbstractSparkExecutionContext.scala
@@ -208,6 +208,8 @@ abstract class AbstractSparkExecutionContext(sparkClassLoader: SparkClassLoader,
 
   override def getLogicalStartTime: Long = runtimeContext.getLogicalStartTime
 
+  override def getTerminationTime: Long = runtimeContext.getTerminationTime
+
   override def getServiceDiscoverer: ServiceDiscoverer = new SparkServiceDiscoverer(runtimeContext)
 
   override def getMetrics: Metrics = new SparkUserMetrics(runtimeContext)

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -16,10 +16,6 @@
 
 package io.cdap.cdap.app.runtime.spark
 
-import java.io.IOException
-import java.lang
-import java.util
-
 import io.cdap.cdap.api.Admin
 import io.cdap.cdap.api.ServiceDiscoverer
 import io.cdap.cdap.api.TxRunnable
@@ -34,7 +30,9 @@ import io.cdap.cdap.api.metrics.Metrics
 import io.cdap.cdap.api.plugin.PluginContext
 import io.cdap.cdap.api.preview.DataTracer
 import io.cdap.cdap.api.schedule.TriggeringScheduleInfo
-import io.cdap.cdap.api.security.store.{SecureStore, SecureStoreData, SecureStoreMetadata}
+import io.cdap.cdap.api.security.store.SecureStore
+import io.cdap.cdap.api.security.store.SecureStoreData
+import io.cdap.cdap.api.security.store.SecureStoreMetadata
 import io.cdap.cdap.api.spark.JavaSparkExecutionContext
 import io.cdap.cdap.api.spark.SparkExecutionContext
 import io.cdap.cdap.api.spark.SparkSpecification
@@ -44,6 +42,9 @@ import io.cdap.cdap.api.workflow.WorkflowToken
 import org.apache.spark.api.java.JavaPairRDD
 import org.apache.twill.api.RunId
 
+import java.io.IOException
+import java.lang
+import java.util
 import scala.collection.JavaConversions._
 import scala.reflect.ClassTag
 
@@ -63,6 +64,8 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
   override def getServiceDiscoverer: ServiceDiscoverer = sec.getServiceDiscoverer
 
   override def getLogicalStartTime: Long = sec.getLogicalStartTime
+
+  override def getTerminationTime: Long = sec.getTerminationTime
 
   override def getPluginContext: PluginContext = sec.getPluginContext
 

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
@@ -102,6 +102,8 @@ class SerializableSparkExecutionContext(val delegate: SparkExecutionContext) ext
 
   override def getLogicalStartTime = delegate.getLogicalStartTime
 
+  override def getTerminationTime = delegate.getTerminationTime
+
   override def getSpecification = delegate.getSpecification
 
   override def readExternal(in: ObjectInput) = {

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SparkMainWrapper.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SparkMainWrapper.scala
@@ -91,6 +91,8 @@ object SparkMainWrapper {
         case cls =>
           getMainMethod(cls).invoke(null, RuntimeArguments.toPosixArray(runtimeContext.getRuntimeArguments))
       }
+
+      LOG.info("Spark main returned {}", userSparkClass)
       executionContext.waitForSparkHttpService()
 
       completion.completed()

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SparkRuntimeEnv.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SparkRuntimeEnv.scala
@@ -367,8 +367,9 @@ object SparkRuntimeEnv {
         TimeUnit.MILLISECONDS.sleep(100)
       }
 
-      // Now call BatchedWriteAheadLog.close()
-      batchedWAL.callMethod("close")
+      // Now call BatchedWriteAheadLog.realClose()
+      // This method is created by the SparkClassRewriter
+      batchedWAL.callMethod("realClose")
     })
   }
 

--- a/cdap-spark-core-base/src/test/java/io/cdap/cdap/app/runtime/spark/distributed/SparkExecutionServiceTest.java
+++ b/cdap-spark-core-base/src/test/java/io/cdap/cdap/app/runtime/spark/distributed/SparkExecutionServiceTest.java
@@ -125,10 +125,11 @@ public class SparkExecutionServiceTest {
       ListenableFuture<Service.State> stopFuture = service.stop();
 
       // Expect some future heartbeats will receive the STOP command
-      Tasks.waitFor(SparkCommand.STOP, new Callable<SparkCommand>() {
+      Tasks.waitFor(true, new Callable<Boolean>() {
         @Override
-        public SparkCommand call() throws Exception {
-          return client.heartbeat(null);
+        public Boolean call() throws Exception {
+          SparkCommand command = client.heartbeat(null);
+          return command != null && SparkCommand.isStop(client.heartbeat(null));
         }
       }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <tez.version>0.8.4</tez.version>
     <tink.version>1.6.0</tink.version>
     <thrift.version>0.9.3</thrift.version>
-    <twill.version>1.0.0</twill.version>
+    <twill.version>1.1.0</twill.version>
     <unboundid.version>2.3.6</unboundid.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <embedded-postgres.version>1.3.1</embedded-postgres.version>
@@ -286,11 +286,7 @@
           </exclusion>
           <exclusion>
             <groupId>org.apache.twill</groupId>
-            <artifactId>twill-common</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.twill</groupId>
-            <artifactId>twill-core</artifactId>
+            <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
- Introduce a new ProgramController.stop(timeout) method to allow timeout
  being pass to stop request.
- Upgrade to twill-1.1.0 to have TwillController.terminate(timeout) support
- Propagate ProgramController.stop(timeout) to TwillController.terminate(timeout)
  for the generic case.
- For Spark execution, propagate the timeout from the Spark client container
  to the Spark driver container.
- Exposes the stop timeout to Spark programs via the SparkExecutionContext
- Enhance SparkStreamingPipelineDriver to use the stop timeout to perform
  graceful job termination.
- Added checkpoint cleanup logic in SparkStreamingPipelineDriver if all received
  data has been processed after the graceful job termination. This is guarded
  by a feature flag.