### PR TITLE
[CDAP-19134] Set resource version on watch

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/AbstractWatcherThread.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/AbstractWatcherThread.java
@@ -141,7 +141,7 @@ public abstract class AbstractWatcherThread<T> extends Thread implements AutoClo
               break;
             }
             case ERROR: {
-              watchError(response.status);
+              onError(response.status);
               break;
             }
             default:

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/AbstractWatcherThread.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/AbstractWatcherThread.java
@@ -47,6 +47,8 @@ public abstract class AbstractWatcherThread<T> extends Thread implements AutoClo
   private static final String DELETED = "DELETED";
   // The response type from K8s when a resource was modified
   private static final String MODIFIED = "MODIFIED";
+  // The response type from K8s when there is an error on the watch
+  private static final String ERROR = "ERROR";
 
   private final String namespace;
   private final Random random;
@@ -136,6 +138,10 @@ public abstract class AbstractWatcherThread<T> extends Thread implements AutoClo
               break;
             case DELETED: {
               resourceDeleted(response.object);
+              break;
+            }
+            case ERROR: {
+              watchError(response.status);
               break;
             }
             default:

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/ResourceChangeListener.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/ResourceChangeListener.java
@@ -57,7 +57,7 @@ public interface ResourceChangeListener<T> {
    *
    * @param status the error status.
    */
-  default void watchError(V1Status status) {
+  default void onError(V1Status status) {
     // no-op
   }
 }

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/ResourceChangeListener.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/common/ResourceChangeListener.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.k8s.common;
 
+import io.kubernetes.client.openapi.models.V1Status;
+
 /**
  * Listener for listening to changes in K8s resources.
  *
@@ -47,6 +49,15 @@ public interface ResourceChangeListener<T> {
    * @param resource the resource being deleted
    */
   default void resourceDeleted(T resource) {
+    // no-op
+  }
+
+  /**
+   * Invoked when there's an error on the watch. Default is a no-op.
+   *
+   * @param status the error status.
+   */
+  default void watchError(V1Status status) {
     // no-op
   }
 }

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/AppResourceWatcherThread.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/AppResourceWatcherThread.java
@@ -183,12 +183,12 @@ abstract class AppResourceWatcherThread<T> extends AbstractWatcherThread<T> {
   }
 
   @Override
-  public void watchError(V1Status status) {
+  public void onError(V1Status status) {
     LOG.trace("Got an error on watch for plural {}, status: {}", plural, status);
     // This happens when the specified resource version is too old, so we reset the resource version and restart
     // the watch.
     resourceVersion = null;
-    listeners.forEach(l -> l.watchError(status));
+    listeners.forEach(l -> l.onError(status));
   }
 
   private ApiClient getApiClient() throws IOException {
@@ -231,8 +231,8 @@ abstract class AppResourceWatcherThread<T> extends AbstractWatcherThread<T> {
       }
 
       @Override
-      public void watchError(V1Status status) {
-        listener.watchError(status);
+      public void onError(V1Status status) {
+        listener.onError(status);
       }
     };
   }

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/AppResourceWatcherThread.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/AppResourceWatcherThread.java
@@ -21,15 +21,23 @@ import io.cdap.cdap.k8s.common.AbstractWatcherThread;
 import io.cdap.cdap.k8s.common.ResourceChangeListener;
 import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.AppsV1Api;
+import io.kubernetes.client.openapi.apis.BatchV1Api;
 import io.kubernetes.client.openapi.apis.CustomObjectsApi;
 import io.kubernetes.client.openapi.models.V1Deployment;
+import io.kubernetes.client.openapi.models.V1DeploymentList;
 import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1JobList;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
+import io.kubernetes.client.openapi.models.V1StatefulSetList;
+import io.kubernetes.client.openapi.models.V1Status;
 import io.kubernetes.client.util.Config;
 import io.kubernetes.client.util.Watch;
 import io.kubernetes.client.util.Watchable;
 import okhttp3.Call;
 import org.apache.twill.common.Cancellable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -44,6 +52,7 @@ import javax.annotation.Nullable;
  * @param <T> type of Kubernetes resource for which state changes to be monitored
  */
 abstract class AppResourceWatcherThread<T> extends AbstractWatcherThread<T> {
+  private static final Logger LOG = LoggerFactory.getLogger(AppResourceWatcherThread.class);
 
   /**
    * Creates a {@link AppResourceWatcherThread} for watching {@link V1Deployment} events.
@@ -72,6 +81,7 @@ abstract class AppResourceWatcherThread<T> extends AbstractWatcherThread<T> {
   private final String selector;
   private final Queue<ResourceChangeListener<T>> listeners;
   private volatile ApiClient apiClient;
+  private String resourceVersion;
 
   private AppResourceWatcherThread(String group, String version, String plural, String namespace, String selector) {
     super("kube-" + plural + "-watch", namespace);
@@ -95,11 +105,60 @@ abstract class AppResourceWatcherThread<T> extends AbstractWatcherThread<T> {
   protected Watchable<T> createWatchable(Type resourceType, String namespace,
                                          @Nullable String labelSelector) throws IOException, ApiException {
     ApiClient apiClient = getApiClient();
-    CustomObjectsApi api = new CustomObjectsApi(apiClient);
-    Call call = api.listNamespacedCustomObjectCall(group, version, namespace, plural, null, null, null,
-                                                   labelSelector, null, null, null, true, null);
+    Call call;
+    if (resourceType.equals(V1Job.class)) {
+      call = getCallForJobList(namespace, labelSelector);
+    } else if (resourceType.equals(V1StatefulSet.class)) {
+      call = getCallForStatefulSetList(namespace, labelSelector);
+    } else if (resourceType.equals(V1Deployment.class)) {
+      call = getCallForDeploymentList(namespace, labelSelector);
+    } else {
+      CustomObjectsApi api = new CustomObjectsApi(apiClient);
+      call = api.listNamespacedCustomObjectCall(group, version, namespace, plural, null, null, null,
+                                                labelSelector, null, null, null, true, null);
+    }
     return Watch.createWatch(apiClient, call, TypeToken.getParameterized(Watch.Response.class,
                                                                          resourceType).getType());
+  }
+
+  private Call getCallForJobList(String namespace, @Nullable String labelSelector) throws IOException, ApiException {
+    ApiClient apiClient = getApiClient();
+    BatchV1Api api = new BatchV1Api(apiClient);
+    if (resourceVersion == null) {
+      V1JobList jobList = api.listNamespacedJob(namespace, null, null, null, null, labelSelector,
+                                                       null, null, null, null, null);
+      resourceVersion = jobList.getMetadata().getResourceVersion();
+    }
+    return api.listNamespacedJobCall(namespace, null, null, null, null, labelSelector,
+                                            null, resourceVersion, null, null, true, null);
+  }
+
+  private Call getCallForStatefulSetList(String namespace, @Nullable String labelSelector)
+    throws IOException, ApiException {
+    ApiClient apiClient = getApiClient();
+    AppsV1Api api = new AppsV1Api(apiClient);
+    if (resourceVersion == null) {
+      V1StatefulSetList stateFulSetList =  api.listNamespacedStatefulSet(namespace, null, null, null,
+                                                                         null, labelSelector, null, null,
+                                                                         null, null, null);
+      resourceVersion = stateFulSetList.getMetadata().getResourceVersion();
+    }
+    return api.listNamespacedStatefulSetCall(namespace, null, null, null, null, labelSelector,
+                                             null, resourceVersion, null, null, true, null);
+  }
+
+  private Call getCallForDeploymentList(String namespace, @Nullable String labelSelector)
+    throws IOException, ApiException {
+    ApiClient apiClient = getApiClient();
+    AppsV1Api api = new AppsV1Api(apiClient);
+    if (resourceVersion == null) {
+      V1DeploymentList stateFulSetList =  api.listNamespacedDeployment(namespace, null, null, null,
+                                                                       null, labelSelector, null, null,
+                                                                       null, null, null);
+      resourceVersion = stateFulSetList.getMetadata().getResourceVersion();
+    }
+    return api.listNamespacedDeploymentCall(namespace, null, null, null, null, labelSelector,
+                                            null, resourceVersion, null, null, true, null);
   }
 
   @Nullable
@@ -121,6 +180,15 @@ abstract class AppResourceWatcherThread<T> extends AbstractWatcherThread<T> {
   @Override
   public void resourceDeleted(T resource) {
     listeners.forEach(l -> l.resourceDeleted(resource));
+  }
+
+  @Override
+  public void watchError(V1Status status) {
+    LOG.trace("Got an error on watch for plural {}, status: {}", plural, status);
+    // This happens when the specified resource version is too old, so we reset the resource version and restart
+    // the watch.
+    resourceVersion = null;
+    listeners.forEach(l -> l.watchError(status));
   }
 
   private ApiClient getApiClient() throws IOException {
@@ -160,6 +228,11 @@ abstract class AppResourceWatcherThread<T> extends AbstractWatcherThread<T> {
       @Override
       public void resourceDeleted(T resource) {
         listener.resourceDeleted(resource);
+      }
+
+      @Override
+      public void watchError(V1Status status) {
+        listener.watchError(status);
       }
     };
   }


### PR DESCRIPTION
Set resource version when we create watches for jobs, deployments and statefulsets to ensure that we don't lose events.