### PR TITLE
[CDAP-19381] Add overrides for hashcode and equals in CacheKey

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/io/DefaultCachingPathProvider.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/io/DefaultCachingPathProvider.java
@@ -33,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -149,6 +150,24 @@ public class DefaultCachingPathProvider implements CachingPathProvider {
     private CacheKey(String fileName, long lastModified) {
       this.fileName = fileName;
       this.lastModified = lastModified;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(fileName, lastModified);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      CacheKey that = (CacheKey) o;
+      return this.lastModified == that.lastModified &&
+          this.fileName.equals(that.fileName);
     }
 
     String getFileName() {

--- a/cdap-common/src/test/java/io/cdap/cdap/common/io/CachingLocationTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/io/CachingLocationTest.java
@@ -162,10 +162,57 @@ public class CachingLocationTest {
       Assert.assertEquals(message, new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8));
     }
 
-    // Create a new preview cache provider from the same directory, it should populate the cache.
+    // Create a new preview cache provider from the same directory, it should
+    // populate the cache.
     Collection<Path> cacheEntries = new DefaultCachingPathProvider(cachePath, 1, TimeUnit.HOURS).getCacheEntries();
     Assert.assertTrue(cacheEntries.contains(cacheProvider.getCachePath(cacheProvider.getCacheName(location),
-                                                                       location.lastModified())));
+        location.lastModified())));
+  }
+
+  @Test
+  public void testNoDuplicateCacheEntries() throws IOException, InterruptedException {
+    Path cachePath = TEMP_FOLDER.newFolder().toPath();
+    String message = "Testing message";
+
+    // Create a new cache provider from the same directory, it should
+    // populate the cache.
+    DefaultCachingPathProvider cachingPathProvider = new DefaultCachingPathProvider(cachePath, 1, TimeUnit.HOURS);
+    LocationFactory lf = new CachingLocationFactory(
+      new LocalLocationFactory(TEMP_FOLDER.newFolder()), cachingPathProvider);
+
+    // Write out a location
+    Location location = lf.create("test1");
+    try (OutputStream os = location.getOutputStream()) {
+      os.write(message.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Add the location to cache, a new entry should be added to the cache map.
+    cachingPathProvider.apply(location);
+    Assert.assertEquals(1, cachingPathProvider.getCacheEntries().size());
+
+    // Re-add the location to cache, cache size should remain the same.
+    cachingPathProvider.apply(location);
+    Assert.assertEquals(1, cachingPathProvider.getCacheEntries().size());
+
+    // Modify the file, last modified should change, adding a new entry in the cache map.
+    // Sleep for a while to ensure at least 1 millis has passed.
+    Thread.sleep(1);
+    try (OutputStream os = location.getOutputStream()) {
+      os.write((message + message).getBytes(StandardCharsets.UTF_8));
+    }
+
+    cachingPathProvider.apply(location);
+    Assert.assertEquals(2, cachingPathProvider.getCacheEntries().size());
+
+    // Add another location to the cache map, a new entry should get added
+    // to the cache map.
+    Location anotherLocation = lf.create("test2");
+    try (OutputStream os = anotherLocation.getOutputStream()) {
+      os.write(message.getBytes(StandardCharsets.UTF_8));
+    }
+
+    cachingPathProvider.apply(anotherLocation);
+    Assert.assertEquals(3, cachingPathProvider.getCacheEntries().size());
   }
 
   @Test (expected = IOException.class)
@@ -186,7 +233,8 @@ public class CachingLocationTest {
       Assert.assertEquals(message, new String(ByteStreams.toByteArray(is), StandardCharsets.UTF_8));
     }
 
-    // Delete the location and try to read. Exception should be throw instead of reading from the cache.
+    // Delete the location and try to read. Exception should be thrown instead of
+    // reading from the cache.
     location.delete();
     location.getInputStream();
   }

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <tez.version>0.8.4</tez.version>
     <tink.version>1.6.0</tink.version>
     <thrift.version>0.9.3</thrift.version>
-    <twill.version>1.1.0</twill.version>
+    <twill.version>1.1.1</twill.version>
     <unboundid.version>2.3.6</unboundid.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <embedded-postgres.version>1.3.1</embedded-postgres.version>


### PR DESCRIPTION
[CDAP-19381](https://cdap.atlassian.net/browse/CDAP-19381)
When the default hashcode function was used for CacheKey, we kept inserting duplicate keys into the cache map because every time a new CacheKey object was created, it had a different memory address, therefore a different hashcode.

Added unit tests that ensure we no longer have duplicate keys in the cache map.