### PR TITLE
[CDAP-19379] Log service leaves empty folders behind

### DIFF
--- a/cdap-common/src/test/java/io/cdap/cdap/common/io/LocationsTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/io/LocationsTest.java
@@ -108,6 +108,25 @@ public class LocationsTest {
     location2 = Locations.getLocationFromAbsolutePath(locationFactory, location1.toURI().getPath());
     Assert.assertEquals(location1.toURI(), location2.toURI());
   }
+
+  @Test
+  public void testLocationComparator() {
+    LocationFactory locationFactory = new LocalLocationFactory(new File(File.separator));
+    Object[][] testCases = new Object[][] {
+        {"/parent1/child1", "/parent1/child1", 0},
+        {"/parent1/child1/", "/parent1/child1/", 0},
+        {"/parent1/child1", "/parent1/child1/", 0},
+        {"/parent1/child1/", "/parent1/child1", 0},
+        {"/parent1/child", "/parent1/child1", -1},
+        {"/parent1/child1", "/parent1/child", 1}};
+
+    for (Object[] testCase : testCases) {
+      Location location1 = locationFactory.create((String) testCase[0]);
+      Location location2 = locationFactory.create((String) testCase[1]);
+      int expected = (int) testCase[2];
+      Assert.assertEquals(expected, Locations.LOCATION_COMPARATOR.compare(location1, location2));
+    }
+  }
 }
 
 

--- a/cdap-watchdog/pom.xml
+++ b/cdap-watchdog/pom.xml
@@ -137,6 +137,11 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-data-fabric</artifactId>
       <version>${project.version}</version>

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/system/LogFileManager.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/system/LogFileManager.java
@@ -43,8 +43,9 @@ import javax.annotation.Nullable;
 /**
  * Class including logic for getting log file to write to. Used by {@link CDAPLogAppender}
  */
-final class LogFileManager implements Flushable, Syncable {
+public final class LogFileManager implements Flushable, Syncable {
   private static final Logger LOG = LoggerFactory.getLogger(LogFileManager.class);
+  private static final String LOG_DIRECTORY_DATE_FORMAT = "yyyy-MM-dd";
 
   private final String dirPermissions;
   private final String filePermissions;
@@ -66,6 +67,10 @@ final class LogFileManager implements Flushable, Syncable {
     this.fileMetaDataWriter = fileMetaDataWriter;
     this.logsDirectoryLocation = locationFactory.create("logs");
     this.outputStreamMap = new HashMap<>();
+  }
+
+  public Location getLogsDirectoryLocation() {
+    return logsDirectoryLocation;
   }
 
   /**
@@ -216,7 +221,7 @@ final class LogFileManager implements Flushable, Syncable {
   private TimeStampLocation getLocation(LogPathIdentifier logPathIdentifier) throws IOException {
     ensureDirectoryCheck(logsDirectoryLocation);
     long currentTime = System.currentTimeMillis();
-    String date = new SimpleDateFormat("yyyy-MM-dd").format(new Date(currentTime));
+    String date = formatLogDirectoryName(currentTime);
     Location contextLocation =
       logsDirectoryLocation.append(logPathIdentifier.getNamespaceId())
         .append(date)
@@ -252,5 +257,9 @@ final class LogFileManager implements Flushable, Syncable {
         ", timeStamp=" + timeStamp +
         '}';
     }
+  }
+
+  public static String formatLogDirectoryName(long timestamp) {
+    return new SimpleDateFormat(LogFileManager.LOG_DIRECTORY_DATE_FORMAT).format(new Date(timestamp));
   }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/system/LogPathIdentifier.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/system/LogPathIdentifier.java
@@ -53,7 +53,7 @@ public class LogPathIdentifier {
    * first part of path id
    * @return first path id of logging context in a namespace
    */
-  String getPathId1() {
+  public String getPathId1() {
     return pathId1;
   }
 
@@ -61,7 +61,7 @@ public class LogPathIdentifier {
    * second part of path id - used by {@link LogFileManager} to create directory
    * @return second path id of logging context in a namespace
    */
-  String getPathId2() {
+  public String getPathId2() {
     return pathId2;
   }
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/clean/LogCleaner.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/clean/LogCleaner.java
@@ -17,40 +17,60 @@
 package io.cdap.cdap.logging.clean;
 
 import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.logging.appender.system.LogFileManager;
+import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 
 /**
  * cleanup expired log files
  */
-public class LogCleaner implements Runnable {
+public class LogCleaner {
+  public static final int FOLDER_CLEANUP_BATCH_SIZE = 100000;
+
   private static final Logger LOG = LoggerFactory.getLogger(LogCleaner.class);
+  private static final long MILLISECONDS_IN_DAY = TimeUnit.DAYS.toMillis(1);
+  private static final long DEFAULT_DELAY_IN_MILLIS = -1L;
+  private static final long FOLDER_CLEANUP_DELAY_IN_MILLIS = TimeUnit.HOURS.toMillis(1);
+  private static final int EXCLUDE_FOLDER_CLEANUP_DAYS = 2;
 
   private final FileMetadataCleaner fileMetadataCleaner;
   private final LocationFactory locationFactory;
+  private final Location logsDirectoryLocation;
   private final long retentionDurationMs;
+  private final int folderCleanupBatchSize;
   private final int fileCleanupBatchSize;
 
+  private int folderCleanupCount;
+
   public LogCleaner(FileMetadataCleaner fileMetadataCleaner, LocationFactory locationFactory,
-                    long retentionDurationMs, int fileCleanupBatchSize) {
+      Location logsDirectoryLocation, long retentionDurationMs, int folderCleanupBatchSize,
+      int fileCleanupBatchSize) {
     this.fileMetadataCleaner = fileMetadataCleaner;
     this.locationFactory = locationFactory;
+    this.logsDirectoryLocation = logsDirectoryLocation;
     this.retentionDurationMs = retentionDurationMs;
+    this.folderCleanupBatchSize = folderCleanupBatchSize;
     this.fileCleanupBatchSize = fileCleanupBatchSize;
     LOG.debug("Log retention duration = {}ms", retentionDurationMs);
   }
 
-  @Override
-  public void run() {
+  public long run() {
+    cleanupLogFolders();
+
     LOG.info("Starting log cleanup");
     long startTime = System.currentTimeMillis();
     long tillTime = startTime - retentionDurationMs;
     List<FileMetadataCleaner.DeletedEntry> deleteEntries =
-      fileMetadataCleaner.scanAndGetFilesToDelete(tillTime, fileCleanupBatchSize);
+        fileMetadataCleaner.scanAndGetFilesToDelete(tillTime, fileCleanupBatchSize);
     int deleteCount = 0;
     int failureCount = 0;
     for (FileMetadataCleaner.DeletedEntry deletedEntry : deleteEntries) {
@@ -62,6 +82,7 @@ public class LogCleaner implements Runnable {
         } else {
           deleteCount++;
           LOG.trace("File {} deleted by log cleanup", deletedEntry.getPath());
+          deleteDirectoryIfEmpty(deletedEntry.getPath());
         }
       } catch (IOException e) {
         LOG.warn("Exception while deleting file {}", deletedEntry.getPath(), e);
@@ -69,6 +90,95 @@ public class LogCleaner implements Runnable {
     }
     long completionTime = System.currentTimeMillis();
     LOG.info("File cleanup completed, Successful file deletes - {}. Failed file deletes - {}. Log Cleanup took {} ms",
-             deleteCount, failureCount, (completionTime - startTime));
+        deleteCount, failureCount, (completionTime - startTime));
+
+    return folderCleanupCount < folderCleanupBatchSize ? DEFAULT_DELAY_IN_MILLIS : FOLDER_CLEANUP_DELAY_IN_MILLIS;
+  }
+
+  private void cleanupLogFolders() {
+    LOG.info("Starting log folder cleanup");
+    try {
+      long startTime = System.currentTimeMillis();
+      LOG.debug("Starting log folder cleanup");
+      folderCleanupCount = 0;
+
+      // TODO: (CDAP-19437): Exclude recent log folders during cleanups in LogCleaner service.
+      // For now exclude folders for current date and current date - 1.
+      long currentTime = System.currentTimeMillis();
+      Set<String> excludeFolders = new HashSet<String>();
+      for (int day = 0; day < EXCLUDE_FOLDER_CLEANUP_DAYS; day++) {
+        long time = currentTime - day * MILLISECONDS_IN_DAY;
+        String date = LogFileManager.formatLogDirectoryName(time);
+        excludeFolders.add(date);
+      }
+
+      // Clean up empty folders
+      cleanupEmptyFolders(logsDirectoryLocation, excludeFolders);
+      LOG.debug("Completed cleaning up {} log folders in {} ms", folderCleanupCount,
+          System.currentTimeMillis() - startTime);
+    } catch (IOException ex) {
+      LOG.warn("Exception while deleting log folders", ex);
+    }
+  }
+
+  /**
+   * Traverses folders in Depth-First manner and recursively deletes the folder in bottom-up manner
+   * if it is empty or sub folders are empty.
+   *
+   * @param location Root folder to start the traversal.
+   * @return Returns false if the folder cannot be cleaned up if it has files or maximum number of
+   *         folders are cleaned up, true otherwise.
+   * @throws IOException
+   */
+  private boolean cleanupEmptyFolders(@Nullable Location location, Set<String> excludeFolders) throws IOException {
+    if (location == null) {
+      return true;
+    }
+    if (!location.isDirectory()) {
+      // Parent directory has files.
+      return false;
+    }
+    if (excludeFolders.contains(location.getName())) {
+      // No need to traverse excluded folders
+      return false;
+    }
+    if (folderCleanupCount >= folderCleanupBatchSize) {
+      return false;
+    }
+
+    boolean isEmpty = true;
+    List<Location> children = location.list();
+    for (Location child : children) {
+      if (!cleanupEmptyFolders(child, excludeFolders)) {
+        isEmpty = false;
+        if (folderCleanupCount >= folderCleanupBatchSize) {
+          break;
+        }
+      }
+    }
+
+    // If the sub folders were empty, delete the current folder.
+    if (isEmpty) {
+      if (location.delete()) {
+        folderCleanupCount++;
+      } else {
+        isEmpty = false;
+      }
+    }
+
+    return isEmpty;
+  }
+
+  private void deleteDirectoryIfEmpty(String logFilePath) throws IOException {
+    Location logFileLocation = Locations.getLocationFromAbsolutePath(locationFactory, logFilePath);
+    Location folderLocation = Locations.getParent(logFileLocation);
+    while (Locations.LOCATION_COMPARATOR.compare(logsDirectoryLocation, folderLocation) != 0) {
+      if (!folderLocation.delete()) {
+        // Deletion will fail if folder is empty. Stop the bottom-up deletion.
+        break;
+      }
+
+      folderLocation = Locations.getParent(folderLocation);
+    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
     <jetty8.version>8.1.15.v20140411</jetty8.version>
     <jline.version>2.12</jline.version>
     <junit.version>4.11</junit.version>
+    <pragmatists.version>1.0.5</pragmatists.version>
     <kafka.version>0.8.2.2</kafka.version>
     <leveldb.version>0.12</leveldb.version>
     <logback.version>1.0.9</logback.version>
@@ -1334,6 +1335,12 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>pl.pragmatists</groupId>
+        <artifactId>JUnitParams</artifactId>
+        <version>${pragmatists.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### Background
* Log service creates a new directory for each pipeline run and system service. The format of the log file is: `/data/logs/default/<YYYY-MM-DD>/<pathId1>/<pathId2>/<timestamp>.avro `
* The default retention period for the log files is 7 days. Clean up is performed by the LogCleaner service, which is scheduled to run every 24 hours. Only the log files are deleted, not their parent folders.
* When a new log file is created, the metadata for this file is stored in the ‘logfile_meta’ table. LogCleaner service scans the table to fetch the list of file metadata. The maximum batch size is 10000. First, the metadata is deleted from the table. Then the log files are deleted without deleting the empty parent folders causing folder leak.

### Issue Details
* Log service fails to start in a timely manner: Large number of folders make mounting of Persistent Disk slow.
* Pipelines take a long time to launch or get stuck: This is linked to I/O throttling happening on the underlying Persistent Disk. 

### Root Cause
* Accumulated empty folders impact disk performance.

### Fix
* Clean up log folders when deleting log files.
  * When the logs files older than the retention period are scanned and deleted, even the parents folders can be deleted recursively if they are empty. 
  * It is easy to clean up the folders during log file deletion as the log file metadata can be fetched from the ‘logfile_meta’ table.
  * The metadata can also be deleted when the log files and folders are deleted.
  * Folders already accumulated will be cleaned up as part of this fix.
    * Perform folder scans at every LogCleaner run to delete empty folders in batches of 100k.
    * Exclude folders for current date and previous date from traversal.
    * While there are more empty folders to be cleaned up, reschedule the next run at every hour. Otherwise schedule the next run at 24 hours.

### Verification
* Verified the code changes by adding Unit Tests.
* Verified the log cleanup in the sandbox environment.