### PR TITLE
[CDAP-19302] Cherry-pick 6.7

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewConfigModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewConfigModule.java
@@ -93,6 +93,9 @@ public class PreviewConfigModule extends AbstractModule {
     // Set HDFS namespace to use a writable directory by default
     previewCConf.set(Constants.CFG_HDFS_NAMESPACE, previewDir.toString());
 
+    // Never run master environment-specific hooks on namespace creation as all preview runs happen locally.
+    previewCConf.setBoolean(Constants.Namespace.NAMESPACE_CREATION_HOOK_ENABLED, false);
+
     // Setup Hadoop configuration
     previewHConf = new Configuration(hConf);
     previewHConf.set(MRConfig.FRAMEWORK_NAME, MRConfig.LOCAL_FRAMEWORK_NAME);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -154,11 +154,11 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
           CConfiguration cConfCopy = CConfiguration.copy(cConf);
           Path cConfPath = runDir.resolve("cConf.xml");
           if (!cConf.getBoolean(Constants.Twill.Security.WORKER_MOUNT_SECRET)) {
-             // Unset the internal certificate path since certificate is stored cdap-security which
-             // is not going to be exposed to preview runner.
-             // TODO: CDAP-18768 this will break preview when certificate checking is enabled.
-             cConfCopy.unset(Constants.Security.SSL.INTERNAL_CERT_PATH);
-           }
+            // Unset the internal certificate path since certificate is stored cdap-security which
+            // is not going to be exposed to preview runner.
+            // TODO: CDAP-18768 this will break preview when certificate checking is enabled.
+            cConfCopy.unset(Constants.Security.SSL.INTERNAL_CERT_PATH);
+          }
           try (Writer writer = Files.newBufferedWriter(cConfPath, StandardCharsets.UTF_8)) {
             cConfCopy.writeXml(writer);
           }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/namespace/StorageProviderNamespaceAdminTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/namespace/StorageProviderNamespaceAdminTest.java
@@ -42,6 +42,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Arrays;
 
 /**
@@ -176,6 +177,57 @@ public class StorageProviderNamespaceAdminTest {
     // but custom namespace location should still exists
     Assert.assertTrue(custom.exists());
     Assert.assertTrue(custom.delete());
+  }
+
+  @Test
+  public void testLocalNamespaceWithExistingDirectory() throws Exception {
+    // Ensure a namespace creation with an existing folder completes successfully
+    NamespaceId existingFolderNamespace = new NamespaceId("exists");
+    File existingNamespaceFolder = TEMP_FOLDER.newFolder(existingFolderNamespace.getNamespace());
+    existingNamespaceFolder.mkdirs();
+    NamespaceMeta existingFolderNamespaceMeta = new NamespaceMeta.Builder()
+      .setName(existingFolderNamespace.getNamespace()).build();
+
+    namespaceStore.create(existingFolderNamespaceMeta);
+    storageProviderNamespaceAdmin.create(existingFolderNamespaceMeta);
+    storageProviderNamespaceAdmin.delete(existingFolderNamespace);
+    namespaceStore.delete(existingFolderNamespace);
+  }
+
+  @Test
+  public void testLocalStorageProviderNamespaceAdminWithExistingDataDirectory() throws Exception {
+    // Ensure a namespace creation with an existing folder and data subdirectory completes successfully
+    NamespaceId existingFolderNamespace = new NamespaceId("existsdata");
+    File existingNamespaceFolder = TEMP_FOLDER.newFolder(existingFolderNamespace.getNamespace());
+    existingNamespaceFolder.mkdirs();
+    File existingNamespaceDataFolder = Paths.get(existingNamespaceFolder.getPath(), "data").toFile();
+    existingNamespaceDataFolder.mkdirs();
+
+    NamespaceMeta existingFolderNamespaceMeta = new NamespaceMeta.Builder()
+      .setName(existingFolderNamespace.getNamespace()).build();
+
+    namespaceStore.create(existingFolderNamespaceMeta);
+    storageProviderNamespaceAdmin.create(existingFolderNamespaceMeta);
+    storageProviderNamespaceAdmin.delete(existingFolderNamespace);
+    namespaceStore.delete(existingFolderNamespace);
+  }
+
+  @Test
+  public void testLocalStorageProviderNamespaceAdminWithExistingTempDirectory() throws Exception {
+    // Ensure a namespace creation with an existing folder and temp subdirectory completes successfully
+    NamespaceId existingFolderNamespace = new NamespaceId("existstemp");
+    File existingNamespaceFolder = TEMP_FOLDER.newFolder(existingFolderNamespace.getNamespace());
+    existingNamespaceFolder.mkdirs();
+    File existingNamespaceTempFolder = Paths.get(existingNamespaceFolder.getPath(), "temp").toFile();
+    existingNamespaceTempFolder.mkdirs();
+
+    NamespaceMeta existingFolderNamespaceMeta = new NamespaceMeta.Builder()
+      .setName(existingFolderNamespace.getNamespace()).build();
+
+    namespaceStore.create(existingFolderNamespaceMeta);
+    storageProviderNamespaceAdmin.create(existingFolderNamespaceMeta);
+    storageProviderNamespaceAdmin.delete(existingFolderNamespace);
+    namespaceStore.delete(existingFolderNamespace);
   }
 
   @AfterClass

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1660,6 +1660,7 @@ public final class Constants {
    */
   public static final class Namespace {
     public static final String NAMESPACES_DIR = "namespaces.dir";
+    public static final String NAMESPACE_CREATION_HOOK_ENABLED = "namespaces.creation.hook.enabled";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -178,6 +178,14 @@
   </property>
 
   <property>
+    <name>namespaces.creation.hook.enabled</name>
+    <value>true</value>
+    <description>
+      Whether to invoke a master environment-specific method hook upon namespace creation.
+    </description>
+  </property>
+
+  <property>
     <name>root.namespace</name>
     <value>cdap</value>
     <description>

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
@@ -88,7 +88,6 @@ public class KubeMasterEnvironmentTest {
     kubeMasterEnvironment = new KubeMasterEnvironment();
     kubeMasterEnvironment.setCoreV1Api(coreV1Api);
     kubeMasterEnvironment.setRbacV1Api(rbacV1Api);
-    kubeMasterEnvironment.setNamespaceCreationEnabled();
     kubeMasterEnvironment.setLocalFileProvider(new TemporaryLocalFileProvider(temporaryFolder));
     KubeMasterPathProvider mockKubeMasterPathProvider = mock(KubeMasterPathProvider.class);
     when(mockKubeMasterPathProvider.getMasterPath()).thenReturn("https://127.0.0.1:443");
@@ -243,7 +242,6 @@ public class KubeMasterEnvironmentTest {
     properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
     properties.put(KubeMasterEnvironment.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY,
                    workloadIdentityGCPServiceAccount);
-    kubeMasterEnvironment.setNamespaceCreationEnabled();
     kubeMasterEnvironment.setWorkloadIdentityEnabled();
     kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
     kubeMasterEnvironment.setWorkloadIdentityProvider(workloadIdentityProvider);
@@ -270,7 +268,6 @@ public class KubeMasterEnvironmentTest {
     properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
     properties.put(KubeMasterEnvironment.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY,
                    workloadIdentityGCPServiceAccount);
-    kubeMasterEnvironment.setNamespaceCreationEnabled();
     kubeMasterEnvironment.setWorkloadIdentityEnabled();
     kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
     kubeMasterEnvironment.setWorkloadIdentityProvider(workloadIdentityProvider);
@@ -299,7 +296,6 @@ public class KubeMasterEnvironmentTest {
     properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
     properties.put(KubeMasterEnvironment.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY,
                    workloadIdentityGCPServiceAccount);
-    kubeMasterEnvironment.setNamespaceCreationEnabled();
     kubeMasterEnvironment.setWorkloadIdentityEnabled();
     kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
     kubeMasterEnvironment.setWorkloadIdentityProvider(workloadIdentityProvider);
@@ -322,7 +318,6 @@ public class KubeMasterEnvironmentTest {
     properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
     properties.put(KubeMasterEnvironment.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY,
                    workloadIdentityGCPServiceAccount);
-    kubeMasterEnvironment.setNamespaceCreationEnabled();
     kubeMasterEnvironment.setWorkloadIdentityEnabled();
     kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
     kubeMasterEnvironment.setWorkloadIdentityProvider(workloadIdentityProvider);
@@ -343,7 +338,6 @@ public class KubeMasterEnvironmentTest {
       "memberships/test-cluster";
     Map<String, String> properties = new HashMap<>();
     properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
-    kubeMasterEnvironment.setNamespaceCreationEnabled();
     kubeMasterEnvironment.setWorkloadIdentityEnabled();
     kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
     kubeMasterEnvironment.setWorkloadIdentityProvider(workloadIdentityProvider);


### PR DESCRIPTION
Cherry-pick of #14397 

[CDAP-19302] Disable namespace creation for preview runners for k8s

[CDAP-19302] Don't fail if namespace subdirectories exist when creating a namespace via AbstractStorageProviderNamespaceAdmin

[CDAP-19302] Remove original namespace creation flag from KubeMasterEnvironment in favor of new system-wide flag

[CDAP-19302]: https://cdap.atlassian.net/browse/CDAP-19302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-19302]: https://cdap.atlassian.net/browse/CDAP-19302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-19302]: https://cdap.atlassian.net/browse/CDAP-19302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ