### PR TITLE
[cherry-pick] [CDAP-19031] Handle IOException as a retryable exception for idempotent operations.

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/retry/Idempotency.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/retry/Idempotency.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.retry;
+
+/**
+ * Enum for different types of idempotency.
+ */
+public enum Idempotency {
+  NONE, IDEMPOTENT, AUTO
+}

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/DatasetServiceClient.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/DatasetServiceClient.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.dataset.DatasetManagementException;
 import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.InstanceConflictException;
 import io.cdap.cdap.api.dataset.InstanceNotFoundException;
+import io.cdap.cdap.api.retry.Idempotency;
 import io.cdap.cdap.common.ServiceUnavailableException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
@@ -306,7 +307,7 @@ public class DatasetServiceClient {
     HttpRequest request = addUserIdHeader(requestBuilder).build();
     try {
       LOG.trace("Executing {} {}", request.getMethod(), request.getURL().getPath());
-      HttpResponse response = remoteClient.execute(request);
+      HttpResponse response = remoteClient.execute(request, Idempotency.AUTO);
       LOG.trace("Executed {} {}", request.getMethod(), request.getURL().getPath());
       return response;
     } catch (ServiceUnavailableException e) { // thrown by RemoteClient in case of ConnectException

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkRetryTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkRetryTest.java
@@ -24,9 +24,10 @@ import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
 import org.mockito.Mockito;
 
+import java.io.IOException;
 import java.net.URL;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RemoteDatasetFrameworkRetryTest extends RemoteDatasetFrameworkTest {
 
@@ -34,18 +35,23 @@ public class RemoteDatasetFrameworkRetryTest extends RemoteDatasetFrameworkTest 
   protected RemoteDatasetFramework createFramework(AuthenticationContext authenticationContext,
                                                    RemoteClientFactory remoteClientFactory) {
     cConf.set("system.dataset.remote.retry.policy.base.delay.ms", "0");
-    cConf.set("system.dataset.remote.retry.policy.max.retries", "1");
+    cConf.set("system.dataset.remote.retry.policy.max.retries", "2");
     RemoteClientFactory mockedFactory = Mockito.spy(remoteClientFactory);
-    Set<URL> failedURIs = new HashSet<>();
+    Map<URL, Integer> failedURIs = new HashMap<>();
     Mockito.doAnswer(i -> {
       RemoteClient realClient = (RemoteClient) i.callRealMethod();
       RemoteClient mocked = Mockito.spy(realClient);
       Mockito.doAnswer(i2 -> {
         HttpRequest request = i2.getArgumentAt(0, HttpRequest.class);
-        //Fail the first GET, allow the second
-        if (request.getMethod() == HttpMethod.GET && failedURIs.add(request.getURL())) {
+        //Fail the first GET with ServiceUnavailableException, second GET with IOException, allow third.
+        if (request.getMethod() == HttpMethod.GET && !failedURIs.containsKey(request.getURL())) {
+          failedURIs.put(request.getURL(), 1);
           throw new ServiceUnavailableException("service");
+        } else if (request.getMethod() == HttpMethod.GET && failedURIs.get(request.getURL()) == 1) {
+          failedURIs.put(request.getURL(), 2);
+          throw new IOException();
         }
+        failedURIs.clear();
         return i2.callRealMethod();
       }).when(mocked).execute(Mockito.any());
       return mocked;


### PR DESCRIPTION
cherry-pick #14374 