### PR TITLE
[CDAP-19376] Explicitly Check for Existing Service In KubeDiscoveryService

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/discovery/KubeDiscoveryService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/discovery/KubeDiscoveryService.java
@@ -112,16 +112,12 @@ public class KubeDiscoveryService implements DiscoveryService, DiscoveryServiceC
     try {
       CoreV1Api api = getCoreApi();
       while (true) {
-        // First try to create the service
-        if (createV1Service(api, serviceName, discoverable)) {
-          break;
-        }
-
-        // If creation failed, we update the service.
-        // To update, first need to find the service version.
         Optional<V1Service> currentService = getV1Service(api, serviceName, discoverable.getName());
         if (!currentService.isPresent()) {
-          // Loop and try to create again
+          if (createV1Service(api, serviceName, discoverable)) {
+            break;
+          }
+          // Service create encountered a conflict, loop and check for service again
           continue;
         }
 
@@ -276,6 +272,7 @@ public class KubeDiscoveryService implements DiscoveryService, DiscoveryServiceC
     } catch (ApiException e) {
       // It means the service already exists. In this case we update the port if it is not the same.
       if (e.getCode() == HttpURLConnection.HTTP_CONFLICT) {
+        LOG.debug("Service {} already exists.", serviceName);
         return false;
       }
       throw e;
@@ -292,8 +289,8 @@ public class KubeDiscoveryService implements DiscoveryService, DiscoveryServiceC
    * @param discoverable the {@link Discoverable} for updating the service
    * @return {@code true} if the update was successful
    *         {@code false} if the current service version doesn't match with the server, and there is no
-   *         change to the service
-   * @throws ApiException if the update failed that doesn't due to mismatch of current version
+   *         change to the service; or if the service does not exist
+   * @throws ApiException if the update failed for reasons other than mismatch of current version or service not found
    */
   private boolean updateV1Service(CoreV1Api api, V1Service currentService,
                                   Discoverable discoverable) throws ApiException {
@@ -338,7 +335,7 @@ public class KubeDiscoveryService implements DiscoveryService, DiscoveryServiceC
       LOG.info("Service updated in kubernetes with name {} and port {}",
                currentService.getMetadata().getName(), port.getPort());
     } catch (ApiException e) {
-      if (e.getCode() == HttpURLConnection.HTTP_CONFLICT) {
+      if (e.getCode() == HttpURLConnection.HTTP_CONFLICT || e.getCode() == HttpURLConnection.HTTP_NOT_FOUND) {
         return false;
       }
       throw e;


### PR DESCRIPTION
Trying to create service when all IP addresses are assigned results in
unhandled error. This is possible in RBAC enabled private network environments
 with /27 address space because there we create exactly 31 services.   
After initial startup, if any pod which performs the KubeDiscoveryService restarts, it will keep crashing on this issue. 
The taskworker pods restart quite often and face this issue the most.   

Testing Done - 
1. Create a RBAC enabled private network with /27 address space.
2. After a few hours, observe that ALL taskworker pods are in INIT/terminate loop.
3. Update the image for all those pods with this fix.
4. Observe that taskworker pods now come up successfully. No errors after couple of hours.
5. Deleted other pods such as runtime and appfabric pods. Observed the pods come up successfully.

