### PR TITLE
[CDAP-19329] Recreate TwillController in AppFabric post program launch

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramTwillApplication.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.twill.TwillAppNames;
+import io.cdap.cdap.master.spi.twill.ExtendedTwillApplication;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.twill.api.EventHandler;
 import org.apache.twill.api.TwillApplication;
@@ -36,7 +37,7 @@ import javax.annotation.Nullable;
 /**
  * The {@link TwillApplication} for running programs in distributed mode.
  */
-public final class ProgramTwillApplication implements TwillApplication {
+public final class ProgramTwillApplication implements ExtendedTwillApplication {
 
   private static final Logger LOG = LoggerFactory.getLogger(ProgramTwillApplication.class);
 
@@ -131,4 +132,8 @@ public final class ProgramTwillApplication implements TwillApplication {
     return moreFile == null ? builder.noLocalFiles() : moreFile.apply();
   }
 
+  @Override
+  public String getRunId() {
+    return programRunId.getRun();
+  }
 }

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -527,6 +527,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
         findOrCreateWorkloadIdentityConfigMap(namespace, workloadIdentityServiceAccountEmail);
       }
     }
+    twillRunner.addAndStartJobWatcher(cdapNamespace);
   }
 
   @Override
@@ -1347,6 +1348,11 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   @VisibleForTesting
   void setWorkloadIdentityServiceAccountTokenTTLSeconds(long workloadIdentityServiceAccountTokenTTLSeconds) {
     this.workloadIdentityServiceAccountTokenTTLSeconds = workloadIdentityServiceAccountTokenTTLSeconds;
+  }
+
+  @VisibleForTesting
+  public void setTwillRunner(KubeTwillRunnerService twillRunner) {
+    this.twillRunner = twillRunner;
   }
 
   @VisibleForTesting

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.master.environment.k8s;
 
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.k8s.common.TemporaryLocalFileProvider;
+import io.cdap.cdap.k8s.runtime.KubeTwillRunnerService;
 import io.cdap.cdap.master.spi.environment.spark.SparkConfig;
 import io.cdap.cdap.master.spi.environment.spark.SparkSubmitContext;
 import io.kubernetes.client.openapi.ApiException;
@@ -74,6 +75,7 @@ public class KubeMasterEnvironmentTest {
   private CoreV1Api coreV1Api;
   private RbacAuthorizationV1Api rbacV1Api;
   private KubeMasterEnvironment kubeMasterEnvironment;
+  private KubeTwillRunnerService twillRunnerService;
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -85,9 +87,11 @@ public class KubeMasterEnvironmentTest {
   public void init() throws IOException {
     coreV1Api = mock(CoreV1Api.class);
     rbacV1Api = mock(RbacAuthorizationV1Api.class);
+    twillRunnerService = mock(KubeTwillRunnerService.class);
     kubeMasterEnvironment = new KubeMasterEnvironment();
     kubeMasterEnvironment.setCoreV1Api(coreV1Api);
     kubeMasterEnvironment.setRbacV1Api(rbacV1Api);
+    kubeMasterEnvironment.setTwillRunner(twillRunnerService);
     kubeMasterEnvironment.setLocalFileProvider(new TemporaryLocalFileProvider(temporaryFolder));
     KubeMasterPathProvider mockKubeMasterPathProvider = mock(KubeMasterPathProvider.class);
     when(mockKubeMasterPathProvider.getMasterPath()).thenReturn("https://127.0.0.1:443");

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillApplication.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillApplication.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.spi.twill;
+
+import org.apache.twill.api.TwillApplication;
+
+/**
+ * An extension of {@link TwillApplication} used to add extra functionalities for CDAP.
+ */
+public interface ExtendedTwillApplication extends TwillApplication {
+
+  String getRunId();
+
+}


### PR DESCRIPTION
This PR recreates twill controller in appfabric when program launch is performed in system pod for on-premise cluster modes. 
co-author: @adityagupta94 