### PR TITLE
[CDAP-19409]  Only initialize TokenManager when running on-premise to prevent Guice injection errors

### DIFF
--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -209,7 +209,7 @@ public final class SparkRuntimeContextProvider {
       logAppenderInitializer.initialize();
 
       // For spark running natively on k8s, we may need to initialize the TokenManager for internal identity.
-      if (SecurityUtil.isInternalAuthEnabled(cConf)) {
+      if (clusterMode == ClusterMode.ON_PREMISE && SecurityUtil.isInternalAuthEnabled(cConf)) {
         TokenManager tokenManager = injector.getInstance(TokenManager.class);
         tokenManager.startAndWait();
       }


### PR DESCRIPTION
Only initialize TokenManager when running on-premise to prevent Guice injection errors, and add non-optional debug logging for uncaught exceptions to prevent the 0th stacktrace element's logger from swallowing errors