### PR TITLE
[CDAP-19408] Add job watchers in non-system k8s namespaces

### DIFF
--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/stepsdesign/KubernetesNamespaceCreation.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/stepsdesign/KubernetesNamespaceCreation.java
@@ -17,7 +17,7 @@
 package io.cdap.cdap.master.environment.k8s.stepsdesign;
 
 import com.google.common.collect.ImmutableMap;
-import io.cdap.cdap.master.environment.k8s.KubeMasterEnvironment;
+import io.cdap.cdap.k8s.runtime.KubeTwillRunnerService;
 import io.cdap.cdap.master.environment.k8s.actions.NamespaceCreationActions;
 import io.cdap.e2e.pages.actions.CdfSysAdminActions;
 import io.cdap.e2e.utils.CdfHelper;
@@ -101,7 +101,7 @@ public class KubernetesNamespaceCreation implements CdfHelper {
     Map<String, Quantity> hardLimitMap = ImmutableMap.of("limits.cpu", new Quantity(cpuLimit), "limits.memory",
                                                          new Quantity(memLimit));
     try {
-      V1ResourceQuota resourceQuota = coreV1Api.readNamespacedResourceQuota(KubeMasterEnvironment.RESOURCE_QUOTA_NAME,
+      V1ResourceQuota resourceQuota = coreV1Api.readNamespacedResourceQuota(KubeTwillRunnerService.RESOURCE_QUOTA_NAME,
                                                                             namespace, null, null, null);
       if (resourceQuota.getSpec() == null) {
         throw new IOException("Resource quota not created");

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -24,9 +24,7 @@ import io.cdap.cdap.k8s.common.AbstractWatcherThread;
 import io.cdap.cdap.k8s.common.DefaultLocalFileProvider;
 import io.cdap.cdap.k8s.common.LocalFileProvider;
 import io.cdap.cdap.k8s.discovery.KubeDiscoveryService;
-import io.cdap.cdap.k8s.identity.GCPWorkloadIdentityCredential;
 import io.cdap.cdap.k8s.runtime.KubeTwillRunnerService;
-import io.cdap.cdap.k8s.util.KubeUtil;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnable;
@@ -36,14 +34,10 @@ import io.cdap.cdap.master.spi.environment.spark.SparkConfig;
 import io.cdap.cdap.master.spi.environment.spark.SparkDriverWatcher;
 import io.cdap.cdap.master.spi.environment.spark.SparkLocalizeResource;
 import io.cdap.cdap.master.spi.environment.spark.SparkSubmitContext;
-import io.cdap.cdap.proto.id.NamespaceId;
-import io.kubernetes.client.custom.Quantity;
+import io.cdap.cdap.master.spi.namespace.NamespaceDetail;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.RbacAuthorizationV1Api;
-import io.kubernetes.client.openapi.models.V1ClusterRoleBinding;
-import io.kubernetes.client.openapi.models.V1ClusterRoleBindingBuilder;
-import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1ConfigMapBuilder;
 import io.kubernetes.client.openapi.models.V1ConfigMapProjection;
 import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSourceBuilder;
@@ -53,7 +47,6 @@ import io.kubernetes.client.openapi.models.V1DownwardAPIVolumeFile;
 import io.kubernetes.client.openapi.models.V1DownwardAPIVolumeSource;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1KeyToPath;
-import io.kubernetes.client.openapi.models.V1Namespace;
 import io.kubernetes.client.openapi.models.V1ObjectFieldSelector;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
@@ -63,16 +56,8 @@ import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodSpecBuilder;
 import io.kubernetes.client.openapi.models.V1ProjectedVolumeSource;
-import io.kubernetes.client.openapi.models.V1ResourceQuota;
-import io.kubernetes.client.openapi.models.V1ResourceQuotaSpec;
-import io.kubernetes.client.openapi.models.V1RoleBinding;
-import io.kubernetes.client.openapi.models.V1RoleBindingBuilder;
-import io.kubernetes.client.openapi.models.V1RoleRefBuilder;
-import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1SecretVolumeSource;
-import io.kubernetes.client.openapi.models.V1ServiceAccount;
 import io.kubernetes.client.openapi.models.V1ServiceAccountTokenProjection;
-import io.kubernetes.client.openapi.models.V1SubjectBuilder;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
 import io.kubernetes.client.openapi.models.V1VolumeProjection;
@@ -92,7 +77,6 @@ import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -122,8 +106,6 @@ import java.util.zip.GZIPOutputStream;
 public class KubeMasterEnvironment implements MasterEnvironment {
   public static final String DISABLE_POD_DELETION = "disablePodDeletion";
   public static final String NAMESPACE_PROPERTY = "k8s.namespace";
-  public static final String NAMESPACE_CPU_LIMIT_PROPERTY = "k8s.namespace.cpu.limits";
-  public static final String NAMESPACE_MEMORY_LIMIT_PROPERTY = "k8s.namespace.memory.limits";
   private static final Logger LOG = LoggerFactory.getLogger(KubeMasterEnvironment.class);
 
   public static final String SECURITY_CONFIG_NAME = "cdap-security";
@@ -165,7 +147,6 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String POD_TEMPLATE_FILE_NAME = "podTemplate-";
   private static final String CDAP_LOCALIZE_FILES_PATH = "/etc/cdap/localizefiles";
   private static final String CDAP_CONFIG_MAP_PREFIX = "cdap-compressed-files-";
-  private static final String CDAP_NAMESPACE_LABEL = "cdap.namespace";
   private static final String SPARK_DRIVER_POD_CPU_REQUEST = "spark.kubernetes.driver.request.cores";
   private static final String SPARK_DRIVER_POD_CPU_LIMIT = "spark.kubernetes.driver.limit.cores";
   private static final String SPARK_EXECUTOR_POD_CPU_REQUEST = "spark.kubernetes.executor.request.cores";
@@ -177,25 +158,17 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   // Workload Identity Constants
   private static final String WORKLOAD_IDENTITY_ENABLED = "master.environment.k8s.workload.identity.enabled";
   private static final String WORKLOAD_IDENTITY_POOL = "master.environment.k8s.workload.identity.pool";
-  @VisibleForTesting
-  static final String WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY =
-    "workload.identity.gcp.service.account.email";
   private static final String WORKLOAD_IDENTITY_PROVIDER = "master.environment.k8s.workload.identity.provider";
   private static final String WORKLOAD_IDENTITY_SERVICE_ACCOUNT_TOKEN_TTL_SECONDS
     = "master.environment.k8s.workload.identity.service.account.token.ttl.seconds";
   private static final long WORKLOAD_IDENTITY_SERVICE_ACCOUNT_TOKEN_TTL_SECONDS_DEFAULT = 172800L;
-  private static final String WORKLOAD_IDENTITY_CONFIGMAP_NAME = "workload-identity-config";
+  public static final String WORKLOAD_IDENTITY_CONFIGMAP_NAME = "workload-identity-config";
   private static final String WORKLOAD_IDENTITY_PROJECTED_VOLUME_NAME = "gcp-ksa";
   private static final String WORKLOAD_IDENTITY_CONFIGMAP_KEY = "config";
   private static final String WORKLOAD_IDENTITY_CONFIGMAP_FILE = "google-application-credentials.json";
-  private static final String WORKLOAD_IDENTITY_DATA_KEY = "config";
-  private static final String WORKLOAD_IDENTITY_AUDIENCE_FORMAT = "identitynamespace:%s:%s";
-  private static final String WORKLOAD_IDENTITY_IMPERSONATION_URL_FORMAT = "https://iamcredentials.googleapis.com/" +
-    "v1/projects/-/serviceAccounts/%s:generateAccessToken";
-  private static final String WORKLOAD_IDENTITY_TOKEN_URL = "https://sts.googleapis.com/v1/token";
   private static final String WORKLOAD_IDENTITY_CREDENTIAL_DIR = "/var/run/secrets/tokens/gcp-ksa";
   private static final String WORKLOAD_IDENTITY_CREDENTIAL_KSA_PATH = "token";
-  private static final String WORKLOAD_IDENTITY_CREDENTIAL_KSA_SOURCE_PATH = WORKLOAD_IDENTITY_CREDENTIAL_DIR + "/" +
+  public static final String WORKLOAD_IDENTITY_CREDENTIAL_KSA_SOURCE_PATH = WORKLOAD_IDENTITY_CREDENTIAL_DIR + "/" +
     WORKLOAD_IDENTITY_CREDENTIAL_KSA_PATH;
   private static final String WORKLOAD_IDENTITY_CREDENTIAL_GSA_SOURCE_PATH = WORKLOAD_IDENTITY_CREDENTIAL_DIR + "/" +
     WORKLOAD_IDENTITY_CONFIGMAP_FILE;
@@ -217,13 +190,6 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     = "master.environment.k8s.workload.launcher.cluster.role.name";
   private static final String DEFAULT_WORKLOAD_LAUNCHER_NAMESPACE_ROLE_NAME = "cdap-workload-launcher";
   private static final String DEFAULT_WORKLOAD_LAUNCHER_CLUSTER_ROLE_NAME = "cdap-cluster-workload-launcher";
-  private static final String WORKLOAD_LAUNCHER_NAMESPACE_ROLE_BINDING_NAME
-    = "cdap-workload-launcher-namespace-role-binding";
-  private static final String WORKLOAD_LAUNCHER_CLUSTER_ROLE_BINDING_FORMAT
-    = "cdap-workload-launcher-cluster-role-binding-%s";
-  private static final String RBAC_V1_API_GROUP = "rbac.authorization.k8s.io";
-  private static final String CLUSTER_ROLE_KIND = "ClusterRole";
-  private static final String SERVICE_ACCOUNT_KIND = "ServiceAccount";
 
   private static final String DEFAULT_NAMESPACE = "default";
   private static final String DEFAULT_INSTANCE_LABEL = "cdap.instance";
@@ -275,10 +241,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private final Gson gson;
   private boolean workloadIdentityEnabled;
   private String workloadIdentityPool;
-  private String workloadIdentityProvider;
   private long workloadIdentityServiceAccountTokenTTLSeconds;
-  private String workloadLauncherRoleNameForNamespace;
-  private String workloadLauncherRoleNameForCluster;
   private String programCpuMultiplier;
   private List<V1SecretVolumeSource> secretVolumes;
 
@@ -299,6 +262,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     podUidFile = new File(podInfoDir, conf.getOrDefault(POD_UID_FILE, DEFAULT_POD_UID_FILE));
     podNamespaceFile = new File(podInfoDir, conf.getOrDefault(POD_NAMESPACE_FILE, DEFAULT_POD_NAMESPACE_FILE));
     workloadIdentityEnabled = Boolean.parseBoolean(conf.get(WORKLOAD_IDENTITY_ENABLED));
+    String workloadIdentityProvider = null;
     if (workloadIdentityEnabled) {
       // Validate all workload identity configurations are set
       String missingConfig = null;
@@ -326,10 +290,10 @@ public class KubeMasterEnvironment implements MasterEnvironment {
       }
     }
 
-    workloadLauncherRoleNameForNamespace = conf.getOrDefault(WORKLOAD_LAUNCHER_NAMESPACE_ROLE_NAME,
-                                                             DEFAULT_WORKLOAD_LAUNCHER_NAMESPACE_ROLE_NAME);
-    workloadLauncherRoleNameForCluster = conf.getOrDefault(WORKLOAD_LAUNCHER_CLUSTER_ROLE_NAME,
-                                                           DEFAULT_WORKLOAD_LAUNCHER_CLUSTER_ROLE_NAME);
+    String workloadLauncherRoleNameForNamespace = conf.getOrDefault(WORKLOAD_LAUNCHER_NAMESPACE_ROLE_NAME,
+                                                                    DEFAULT_WORKLOAD_LAUNCHER_NAMESPACE_ROLE_NAME);
+    String workloadLauncherRoleNameForCluster = conf.getOrDefault(WORKLOAD_LAUNCHER_CLUSTER_ROLE_NAME,
+                                                                  DEFAULT_WORKLOAD_LAUNCHER_CLUSTER_ROLE_NAME);
 
     // We don't support scaling from inside pod. Scaling should be done via CDAP operator.
     // Currently we don't support more than one instance per system service, hence set it to "1".
@@ -404,7 +368,12 @@ public class KubeMasterEnvironment implements MasterEnvironment {
                                              Collections.singletonMap(instanceLabel, instanceName),
                                              Integer.parseInt(conf.getOrDefault(JOB_CLEANUP_INTERVAL, "60")),
                                              Integer.parseInt(conf.getOrDefault(JOB_CLEANUP_BATCH_SIZE, "1000")),
-                                             enableMonitor);
+                                             enableMonitor,
+                                             workloadIdentityEnabled,
+                                             workloadLauncherRoleNameForNamespace,
+                                             workloadLauncherRoleNameForCluster,
+                                             workloadIdentityPool,
+                                             workloadIdentityProvider);
     LOG.info("Kubernetes environment initialized with pod labels {}", podLabels);
   }
 
@@ -505,37 +474,14 @@ public class KubeMasterEnvironment implements MasterEnvironment {
 
   @Override
   public void onNamespaceCreation(String cdapNamespace, Map<String, String> properties) throws Exception {
-    if (NamespaceId.isReserved(cdapNamespace)) {
-      return;
-    }
-
-    String namespace = properties.get(NAMESPACE_PROPERTY);
-    if (namespace == null || namespace.isEmpty()) {
-      throw new IOException(String.format("Cannot create Kubernetes namespace for %s because no name was provided",
-                                          cdapNamespace));
-    }
-    // Kubernetes namespace must be a lowercase RFC 1123 label, consisting of lower case alphanumeric characters or '-'
-    // and must start and end with an alphanumeric character
-    KubeUtil.validateRFC1123LabelName(namespace);
-    findOrCreateKubeNamespace(namespace, cdapNamespace);
-    updateOrCreateResourceQuota(namespace, cdapNamespace, properties);
-    copyVolumes(namespace, cdapNamespace);
-    createWorkloadServiceAccount(namespace, cdapNamespace);
-    if (workloadIdentityEnabled) {
-      String workloadIdentityServiceAccountEmail = properties.get(WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY);
-      if (workloadIdentityServiceAccountEmail != null && !workloadIdentityServiceAccountEmail.isEmpty()) {
-        findOrCreateWorkloadIdentityConfigMap(namespace, workloadIdentityServiceAccountEmail);
-      }
-    }
-    twillRunner.addAndStartJobWatcher(cdapNamespace);
+    NamespaceDetail namespaceDetail = new NamespaceDetail(cdapNamespace, properties);
+    twillRunner.onNamespaceCreation(namespaceDetail);
   }
 
   @Override
   public void onNamespaceDeletion(String cdapNamespace, Map<String, String> properties) throws Exception {
-    String namespace = properties.get(NAMESPACE_PROPERTY);
-    if (namespace != null && !namespace.isEmpty()) {
-      deleteKubeNamespace(namespace, cdapNamespace);
-    }
+    NamespaceDetail namespaceDetail = new NamespaceDetail(cdapNamespace, properties);
+    twillRunner.onNamespaceDeletion(namespaceDetail);
   }
 
   /**
@@ -886,324 +832,6 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   }
 
   /**
-   * Checks if namespace already exists from the same CDAP instance. Otherwise, creates a new Kubernetes namespace.
-   */
-  private void findOrCreateKubeNamespace(String namespace, String cdapNamespace) throws Exception {
-    try {
-      V1Namespace existingNamespace = coreV1Api.readNamespace(namespace, null, null, null);
-      if (existingNamespace.getMetadata() == null) {
-        throw new IOException(String.format("Kubernetes namespace %s exists but was not created by CDAP", namespace));
-      }
-      Map<String, String> labels = existingNamespace.getMetadata().getLabels();
-      if (labels == null || !cdapNamespace.equals(labels.get(CDAP_NAMESPACE_LABEL))) {
-        throw new IOException(String.format("Kubernetes namespace %s exists but was not created by CDAP namespace %s",
-                                            namespace, cdapNamespace));
-      }
-    } catch (ApiException e) {
-      if (e.getCode() != HttpURLConnection.HTTP_NOT_FOUND) {
-        throw new IOException("Error occurred while checking if Kubernetes namespace already exists. Error code = "
-                                + e.getCode() + ", Body = " + e.getResponseBody(), e);
-      }
-      createKubeNamespace(namespace, cdapNamespace);
-    }
-  }
-
-  private void createKubeNamespace(String namespace, String cdapNamespace) throws Exception {
-    V1Namespace namespaceObject = new V1Namespace();
-    namespaceObject.setMetadata(new V1ObjectMeta().name(namespace).putLabelsItem(CDAP_NAMESPACE_LABEL, cdapNamespace));
-    try {
-      coreV1Api.createNamespace(namespaceObject, null, null, null);
-      LOG.debug("Created Kubernetes namespace {} for namespace {}", namespace, cdapNamespace);
-    } catch (ApiException e) {
-      try {
-        deleteKubeNamespace(namespace, cdapNamespace);
-      } catch (IOException deletionException) {
-        e.addSuppressed(deletionException);
-      }
-      throw new IOException("Error occurred while creating Kubernetes namespace. Error code = "
-                              + e.getCode() + ", Body = " + e.getResponseBody(), e);
-    }
-  }
-
-  /**
-   * Updates resource quota if it already exists in the Kubernetes namespace. Otherwise, creates a new resource quota.
-   */
-  private void updateOrCreateResourceQuota(String namespace, String cdapNamespace, Map<String, String> properties)
-    throws Exception {
-
-    String kubeCpuLimit = properties.get(NAMESPACE_CPU_LIMIT_PROPERTY);
-    String kubeMemoryLimit = properties.get(NAMESPACE_MEMORY_LIMIT_PROPERTY);
-    Map<String, Quantity> hardLimitMap = new HashMap<>();
-    if (kubeCpuLimit != null && !kubeCpuLimit.isEmpty()) {
-      hardLimitMap.put("limits.cpu", new Quantity(kubeCpuLimit));
-    }
-    if (kubeMemoryLimit != null && !kubeMemoryLimit.isEmpty()) {
-      hardLimitMap.put("limits.memory", new Quantity(kubeMemoryLimit));
-    }
-    if (hardLimitMap.isEmpty()) {
-      // no resource limits to create
-      return;
-    }
-
-    V1ResourceQuota resourceQuota = new V1ResourceQuota();
-    resourceQuota.setMetadata(new V1ObjectMeta()
-                                .name(RESOURCE_QUOTA_NAME)
-                                .putLabelsItem(CDAP_NAMESPACE_LABEL, cdapNamespace));
-    resourceQuota.setSpec(new V1ResourceQuotaSpec().hard(hardLimitMap));
-    try {
-      V1ResourceQuota existingResourceQuota = coreV1Api.readNamespacedResourceQuota(RESOURCE_QUOTA_NAME, namespace,
-                                                                                    null, null, null);
-      if (existingResourceQuota.getMetadata() == null) {
-        throw new IOException(String.format("%s exists but was not created by CDAP", RESOURCE_QUOTA_NAME));
-      }
-      Map<String, String> labels = existingResourceQuota.getMetadata().getLabels();
-      if (labels == null || !cdapNamespace.equals(labels.get(CDAP_NAMESPACE_LABEL))) {
-        throw new IOException(String.format("%s exists but was not created by CDAP namespace %s",
-                                            RESOURCE_QUOTA_NAME, cdapNamespace));
-      }
-      if (!hardLimitMap.equals(existingResourceQuota.getSpec().getHard())) {
-        coreV1Api.replaceNamespacedResourceQuota(RESOURCE_QUOTA_NAME, namespace, resourceQuota, null, null, null);
-      }
-    } catch (ApiException e) {
-      if (e.getCode() != HttpURLConnection.HTTP_NOT_FOUND) {
-        throw new IOException("Error occurred while checking or updating Kubernetes resource quota. Error code = "
-                                + e.getCode() + ", Body = " + e.getResponseBody(), e);
-      }
-      createKubeResourceQuota(namespace, resourceQuota);
-    }
-  }
-
-  private void createKubeResourceQuota(String namespace, V1ResourceQuota resourceQuota) throws Exception {
-    try {
-      coreV1Api.createNamespacedResourceQuota(namespace, resourceQuota, null, null, null);
-      LOG.debug("Created resource quota for Kubernetes namespace {}", namespace);
-    } catch (ApiException e) {
-      throw new IOException("Error occurred while creating Kubernetes resource quota. Error code = "
-                              + e.getCode() + ", Body = " + e.getResponseBody(), e);
-    }
-  }
-
-  /**
-   * Copy volumes into the new namespace for deployments created via the KubeTwillRunnerService
-   * TODO: (CDAP-18956) improve this logic to be for each pipeline run
-   */
-  private void copyVolumes(String namespace, String cdapNamespace) throws IOException {
-    try {
-      for (V1Volume volume : podInfo.getVolumes()) {
-        if (volume.getConfigMap() != null) {
-          String configMapName = volume.getConfigMap().getName();
-          V1ConfigMap existingMap = coreV1Api.readNamespacedConfigMap(configMapName, podInfo.getNamespace(),
-                                                                      null, null, null);
-          V1ConfigMap configMap = new V1ConfigMap().data(existingMap.getData())
-            .metadata(new V1ObjectMeta().name(configMapName).putLabelsItem(CDAP_NAMESPACE_LABEL, cdapNamespace));
-          try {
-            coreV1Api.createNamespacedConfigMap(namespace, configMap, null, null, null);
-          } catch (ApiException e) {
-            if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
-              throw e;
-            }
-            LOG.warn("The configmap already exists '{}:{}' : {}. Ignoring creation of the configmap.", namespace,
-                     configMapName, e.getResponseBody());
-          }
-          LOG.debug("Created configMap {} in Kubernetes namespace {}", configMapName, namespace);
-        }
-
-        if (volume.getSecret() != null) {
-          String secretName = volume.getSecret().getSecretName();
-          V1Secret existingSecret = coreV1Api.readNamespacedSecret(secretName, podInfo.getNamespace(),
-                                                                   null, null, null);
-          V1Secret secret = new V1Secret().data(existingSecret.getData()).type(existingSecret.getType())
-            .metadata(new V1ObjectMeta().name(secretName).putLabelsItem(CDAP_NAMESPACE_LABEL, cdapNamespace));
-          try {
-            coreV1Api.createNamespacedSecret(namespace, secret, null, null, null);
-          } catch (ApiException e) {
-            if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
-              throw e;
-            }
-            LOG.warn("The secret '{}:{}' already exists : {}. Ignoring creation of the secret.", namespace,
-                     secret.getMetadata().getName(), e.getResponseBody());
-          }
-          LOG.debug("Created secret {} in Kubernetes namespace {}", secretName, namespace);
-        }
-      }
-    } catch (ApiException e) {
-      throw new IOException("Error occurred while copying volumes. Error code = "
-                              + e.getCode() + ", Body = " + e.getResponseBody(), e);
-    }
-  }
-
-  /**
-   * Create service account and role bindings required for workload pod.
-   * TODO: (CDAP-18956) improve this logic to be for each pipeline run
-   */
-  private void createWorkloadServiceAccount(String namespace, String cdapNamespace) throws IOException {
-    try {
-      // Create service account for workload pod
-      // TODO(CDAP-19149): Cleanup strong coupling currently present in CDAP service accounts to avoid copying.
-      String serviceAccountName = podInfo.getServiceAccountName();
-      createServiceAccount(namespace, cdapNamespace, serviceAccountName);
-
-      // Create namespace-specific role-binding for the workload service account
-      createNamespacedRoleBinding(WORKLOAD_LAUNCHER_NAMESPACE_ROLE_BINDING_NAME, CLUSTER_ROLE_KIND,
-                                  workloadLauncherRoleNameForNamespace, namespace, serviceAccountName, cdapNamespace);
-
-      // Create cluster-wide role-binding for the workload service account
-      String workloadLauncherClusterRoleBindingName = String.format(WORKLOAD_LAUNCHER_CLUSTER_ROLE_BINDING_FORMAT,
-                                                                    namespace);
-      createClusterRoleBinding(workloadLauncherClusterRoleBindingName, workloadLauncherRoleNameForCluster, namespace,
-                               serviceAccountName, cdapNamespace);
-
-    } catch (ApiException e) {
-      throw new IOException("Error occurred while creating service account or role binding. Error code = "
-                              + e.getCode() + ", Body = " + e.getResponseBody(), e);
-    }
-  }
-
-  private void createServiceAccount(String namespace, String cdapNamespace, String serviceAccountName)
-    throws ApiException {
-    V1ServiceAccount serviceAccount = new V1ServiceAccount()
-      .metadata(new V1ObjectMeta().name(serviceAccountName)
-                  .putLabelsItem(CDAP_NAMESPACE_LABEL, cdapNamespace));
-    try {
-      coreV1Api.createNamespacedServiceAccount(namespace, serviceAccount, null, null, null);
-    } catch (ApiException e) {
-      if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
-        throw e;
-      }
-      LOG.warn("The service account '{}:{}' already exists : {}. Ignoring creation of the service account.", namespace,
-               serviceAccountName, e.getResponseBody());
-    }
-    LOG.info("Created serviceAccount {} in Kubernetes namespace {}", serviceAccountName, namespace);
-  }
-
-  private void createNamespacedRoleBinding(String bindingName, String roleKind, String roleName, String namespace,
-                                           String serviceAccountName, String cdapNamespace) throws ApiException {
-    KubeUtil.validatePathSegmentName(bindingName);
-    V1RoleBinding namespaceWorkloadLauncherBinding = new V1RoleBindingBuilder()
-      .withMetadata(new V1ObjectMetaBuilder()
-                      .withNamespace(namespace)
-                      .withName(bindingName)
-                      .build().putLabelsItem(CDAP_NAMESPACE_LABEL, cdapNamespace))
-      .withRoleRef(new V1RoleRefBuilder()
-                     .withApiGroup(RBAC_V1_API_GROUP)
-                     .withKind(roleKind)
-                     .withName(roleName).build())
-      .withSubjects(new V1SubjectBuilder()
-                      .withKind(SERVICE_ACCOUNT_KIND)
-                      .withName(serviceAccountName).build())
-      .build();
-    try {
-      rbacV1Api.createNamespacedRoleBinding(namespace, namespaceWorkloadLauncherBinding, null, null, null);
-    } catch (ApiException e) {
-      if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
-        throw e;
-      }
-      LOG.warn("The role binding '{}:{}' already exists : {}. Ignoring creation of the role binding.", namespace,
-               bindingName, e.getResponseBody());
-    }
-
-    LOG.info("Created namespace role binding '{}' in k8s namespace '{}' for service account '{}'",
-             bindingName, serviceAccountName, serviceAccountName);
-  }
-
-  private void createClusterRoleBinding(String bindingName, String roleName, String serviceAccountNamespace,
-                                        String serviceAccountName, String cdapNamespace) throws ApiException {
-    KubeUtil.validatePathSegmentName(bindingName);
-    V1ClusterRoleBinding clusterWorkloadLauncherBinding = new V1ClusterRoleBindingBuilder()
-      .withMetadata(new V1ObjectMetaBuilder()
-                      .withName(bindingName).build().putLabelsItem(CDAP_NAMESPACE_LABEL, cdapNamespace))
-      .withRoleRef(new V1RoleRefBuilder()
-                     .withApiGroup(RBAC_V1_API_GROUP)
-                     .withKind(CLUSTER_ROLE_KIND)
-                     .withName(roleName).build())
-      .withSubjects(new V1SubjectBuilder()
-                      .withKind(SERVICE_ACCOUNT_KIND)
-                      .withNamespace(serviceAccountNamespace)
-                      .withName(serviceAccountName).build())
-      .build();
-    try {
-      rbacV1Api.createClusterRoleBinding(clusterWorkloadLauncherBinding, null, null, null);
-    } catch (ApiException e) {
-      if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
-        throw e;
-      }
-      LOG.warn("The cluster role binding '{}' already exists : {}. Ignoring creation of the cluster role binding.",
-               bindingName, e.getResponseBody());
-    }
-
-    LOG.info("Created cluster role binding '{}' for service account '{}' in k8s namespace '{}'", bindingName,
-             serviceAccountName, serviceAccountNamespace);
-  }
-
-  /**
-   * Deletes Kubernetes namespace created by CDAP and associated resources if they exist.
-   */
-  private void deleteKubeNamespace(String namespace, String cdapNamespace) throws Exception {
-    try {
-      V1Namespace namespaceObject = coreV1Api.readNamespace(namespace, null, null, null);
-      if (namespaceObject.getMetadata() != null) {
-        Map<String, String> namespaceLabels = namespaceObject.getMetadata().getLabels();
-        if (namespaceLabels != null && namespaceLabels.get(CDAP_NAMESPACE_LABEL).equals(cdapNamespace)) {
-          // PropagationPolicy is set to background cascading deletion. Kubernetes deletes the owner object immediately
-          // and the controller cleans up the dependent objects in the background.
-          coreV1Api.deleteNamespace(namespace, null, null, 0, null, "Background", null);
-          LOG.info("Deleted Kubernetes namespace and associated resources for {}", namespace);
-          return;
-        }
-      }
-      LOG.debug("Kubernetes namespace {} was not deleted because it was not created by CDAP namespace {}",
-                namespace, cdapNamespace);
-    } catch (ApiException e) {
-      if (e.getCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-        LOG.debug("Kubernetes namespace {} was not deleted because it was not found", namespace);
-      } else {
-        throw new IOException("Error occurred while deleting Kubernetes namespace. Error code = "
-                                + e.getCode() + ", Body = " + e.getResponseBody(), e);
-      }
-    }
-  }
-
-  /**
-   * Finds or creates the ConfigMap which stores the GCP credentials for Fleet Workload Identity.
-   * For details, see steps 6-7 of
-   * https://cloud.google.com/anthos/multicluster-management/fleets/workload-identity#impersonate_a_service_account
-   */
-  private void findOrCreateWorkloadIdentityConfigMap(String k8sNamespace, String workloadIdentityGCPServiceAccountEmail)
-    throws ApiException, IOException {
-    // Check if workload identity config map already exists
-    try {
-      coreV1Api.readNamespacedConfigMap(k8sNamespace, WORKLOAD_IDENTITY_CONFIGMAP_NAME, null, false, false);
-      // Workload identity config map already exists, so return early
-      LOG.debug("Workload identity config found, returning without creating it...");
-      return;
-    } catch (ApiException e) {
-      if (e.getCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-        LOG.debug("Creating workload identity config map for kubernetes namespace {}", k8sNamespace);
-      } else {
-        throw new IOException("Failed to fetch existing workload identity config map. Error code = " + e.getCode() +
-                                ", Body = " + e.getResponseBody(), e);
-      }
-    }
-
-    String workloadIdentityAudience = String.format(WORKLOAD_IDENTITY_AUDIENCE_FORMAT, workloadIdentityPool,
-                                                    workloadIdentityProvider);
-    String workloadIdentityImpersonationURL = String.format(WORKLOAD_IDENTITY_IMPERSONATION_URL_FORMAT,
-                                                            workloadIdentityGCPServiceAccountEmail);
-    GCPWorkloadIdentityCredential credential =
-      new GCPWorkloadIdentityCredential(GCPWorkloadIdentityCredential.CredentialType.EXTERNAL_ACCOUNT,
-                                        workloadIdentityAudience, workloadIdentityImpersonationURL,
-                                        GCPWorkloadIdentityCredential.TokenType.JWT, WORKLOAD_IDENTITY_TOKEN_URL,
-                                        WORKLOAD_IDENTITY_CREDENTIAL_KSA_SOURCE_PATH);
-    String workloadIdentityCredentialJSON = gson.toJson(credential);
-    Map<String, String> workloadIdentityConfigMapData = new HashMap<>();
-    workloadIdentityConfigMapData.put(WORKLOAD_IDENTITY_DATA_KEY, workloadIdentityCredentialJSON);
-    V1ConfigMap configMap = new V1ConfigMap()
-      .metadata(new V1ObjectMeta().namespace(k8sNamespace).name(WORKLOAD_IDENTITY_CONFIGMAP_NAME))
-      .data(workloadIdentityConfigMapData);
-    coreV1Api.createNamespacedConfigMap(k8sNamespace, configMap, null, null, null);
-  }
-
-  /**
    * Applies workload identity configurations to a given pod specification. For additional details, see steps 6-7 of
    * https://cloud.google.com/anthos/multicluster-management/fleets/workload-identity#impersonate_a_service_account
    *
@@ -1321,11 +949,6 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   }
 
   @VisibleForTesting
-  void setRbacV1Api(RbacAuthorizationV1Api rbacV1Api) {
-    this.rbacV1Api = rbacV1Api;
-  }
-
-  @VisibleForTesting
   void setLocalFileProvider(LocalFileProvider localFileProvider) {
     this.localFileProvider = localFileProvider;
   }
@@ -1338,11 +961,6 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   @VisibleForTesting
   void setWorkloadIdentityPool(String workloadIdentityPool) {
     this.workloadIdentityPool = workloadIdentityPool;
-  }
-
-  @VisibleForTesting
-  void setWorkloadIdentityProvider(String workloadIdentityProvider) {
-    this.workloadIdentityProvider = workloadIdentityProvider;
   }
 
   @VisibleForTesting

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerServiceTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerServiceTest.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.runtime;
+
+import com.google.common.collect.ImmutableSet;
+import io.cdap.cdap.master.environment.k8s.KubeMasterEnvironment;
+import io.cdap.cdap.master.environment.k8s.PodInfo;
+import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
+import io.cdap.cdap.master.spi.namespace.NamespaceDetail;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.apis.RbacAuthorizationV1Api;
+import io.kubernetes.client.openapi.models.V1ClusterRoleBindingList;
+import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1Namespace;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1PodSecurityContext;
+import io.kubernetes.client.openapi.models.V1RoleBindingList;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class KubeTwillRunnerServiceTest {
+  private static final String CDAP_NAMESPACE = "TEST_CDAP_Namespace";
+  private static final String KUBE_NAMESPACE = "test-kube-namespace";
+
+  private CoreV1Api coreV1Api;
+  private RbacAuthorizationV1Api rbacV1Api;
+  private KubeTwillRunnerService twillRunnerService;
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void init() {
+    coreV1Api = mock(CoreV1Api.class);
+    rbacV1Api = mock(RbacAuthorizationV1Api.class);
+    PodInfo podInfo = new PodInfo("test-pod-name", "test-pod-dir", "test-label-file.txt",
+                                  "test-name-file.txt", "test-pod-uid", "test-uid-file.txt", "test-namespace-file.txt",
+                                  "test-pod-namespace", Collections.emptyMap(), Collections.emptyList(),
+                                  "test-pod-service-account", "test-pod-runtime-class",
+                                  Collections.emptyList(), "test-pod-container-label", "test-pod-container-image",
+                                  Collections.emptyList(), Collections.emptyList(), new V1PodSecurityContext(),
+                                  "test-pod-image-pull-policy");
+    MasterEnvironmentContext context = mock(MasterEnvironmentContext.class);
+    DiscoveryServiceClient discoveryServiceClient = mock(DiscoveryServiceClient.class);
+    twillRunnerService = new KubeTwillRunnerService(context, KUBE_NAMESPACE, discoveryServiceClient, podInfo,
+                                                    "", Collections.emptyMap(), 1, 1,
+                                                    true, false,
+                                                    null, null,
+                                                    null, null);
+    twillRunnerService.setCoreV1Api(coreV1Api);
+    twillRunnerService.setRbacV1Api(rbacV1Api);
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithNoNamespace() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    thrown.expect(IOException.class);
+    thrown.expectMessage(String.format("Cannot create Kubernetes namespace for %s because no name was provided",
+                                       CDAP_NAMESPACE));
+    NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
+    twillRunnerService.onNamespaceCreation(namespaceDetail);
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithBootstrapNamespace() {
+    Map<String, String> properties = new HashMap<>();
+    NamespaceDetail namespaceDetail = new NamespaceDetail("default", properties);
+    try {
+      twillRunnerService.onNamespaceCreation(namespaceDetail);
+    } catch (Exception e) {
+      Assert.fail("Kubernetes creation should not error for bootstrap namespace. Exception: " + e);
+    }
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithExistingNamespace() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
+
+    V1Namespace returnedNamespace = new V1Namespace().metadata(new V1ObjectMeta().name(KUBE_NAMESPACE));
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any())).thenReturn(returnedNamespace);
+
+    thrown.expect(IOException.class);
+    thrown.expectMessage(String.format("Kubernetes namespace %s exists but was not created by CDAP", KUBE_NAMESPACE));
+    twillRunnerService.onNamespaceCreation(namespaceDetail);
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithExistingNamespaceAndWrongCdapInstance() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
+
+    V1ObjectMeta returnedMeta = new V1ObjectMeta().name(KUBE_NAMESPACE)
+      .putLabelsItem("cdap.namespace", "wrong namespace");
+    V1Namespace returnedNamespace = new V1Namespace().metadata(returnedMeta);
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any())).thenReturn(returnedNamespace);
+
+    thrown.expect(IOException.class);
+    thrown.expectMessage(String.format("Kubernetes namespace %s exists but was not created by CDAP namespace %s",
+                                       KUBE_NAMESPACE, CDAP_NAMESPACE));
+    twillRunnerService.onNamespaceCreation(namespaceDetail);
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithBadKubeName() throws Exception {
+    Set<String> badKubeNames = ImmutableSet.of(CDAP_NAMESPACE, "UPPERCASE", "special*char", "-badstart", "badend-");
+    Map<String, String> properties = new HashMap<>();
+    NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
+
+    for (String kubeName : badKubeNames) {
+      try {
+        properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, kubeName);
+        twillRunnerService.onNamespaceCreation(namespaceDetail);
+        Assert.fail(String.format("%s does not meet Kubernetes naming standards", kubeName));
+      } catch (IllegalArgumentException e) {
+        // ignore
+      }
+    }
+  }
+
+  @Test
+  public void testOnNamespaceCreationSuccess() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
+
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+    skipRbacSteps();
+    try {
+      twillRunnerService.onNamespaceCreation(namespaceDetail);
+    } catch (Exception e) {
+      Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
+    }
+    verify(coreV1Api, times(0)).createNamespacedConfigMap(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithSuppressedDeletionError() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
+
+    V1ObjectMeta returnedMeta = new V1ObjectMeta().name(KUBE_NAMESPACE)
+      .putLabelsItem("cdap.namespace", CDAP_NAMESPACE);
+    V1Namespace returnedNamespace = new V1Namespace().metadata(returnedMeta);
+
+    // throw ApiException when coreV1Api.readNamespace() is called in findOrCreateKubeNamespace()
+    // return returnedNamespace when coreV1Api.readNamespace() is called in deleteKubeNamespace()
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"))
+      .thenReturn(returnedNamespace);
+    when(coreV1Api.createNamespace(any(), any(), any(), any()))
+      .thenThrow(new ApiException());
+    when(coreV1Api.deleteNamespace(eq(KUBE_NAMESPACE), any(), any(), any(), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_INTERNAL_ERROR, "internal error message"));
+
+    try {
+      twillRunnerService.onNamespaceCreation(namespaceDetail);
+    } catch (IOException e) {
+      Assert.assertThat(e.getMessage(),
+                        CoreMatchers.containsString("Error occurred while creating Kubernetes namespace"));
+      Assert.assertEquals(1, e.getCause().getSuppressed().length);
+      Assert.assertThat(e.getCause().getSuppressed()[0].getMessage(),
+                        CoreMatchers.containsString("Error occurred while deleting Kubernetes namespace."));
+    }
+  }
+
+  @Test
+  public void testOnNamespaceDeletionWithKubernetesNotFoundError() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
+
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+    try {
+      twillRunnerService.onNamespaceDeletion(namespaceDetail);
+    } catch (Exception e) {
+      Assert.fail("Kubernetes deletion should not error if namespace does not exist. Exception: " + e);
+    }
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithWorkloadIdentityEnabled() throws Exception {
+    String workloadIdentityGCPServiceAccount = "test-service-account@test-project-id.iam.gserviceaccount.com";
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    properties.put(KubeTwillRunnerService.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY,
+                   workloadIdentityGCPServiceAccount);
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
+
+    enableWorkloadIdentity();
+
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+    when(coreV1Api.readNamespacedConfigMap(eq(KUBE_NAMESPACE), eq("workload-identity-config"), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "config map not found"));
+    skipRbacSteps();
+    try {
+      twillRunnerService.onNamespaceCreation(namespaceDetail);
+    } catch (Exception e) {
+      Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
+    }
+    verify(coreV1Api, times(1)).createNamespacedConfigMap(any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithWorkloadIdentityEnabledDoesNotCreateExistingConfigMap() throws Exception {
+    String workloadIdentityGCPServiceAccount = "test-service-account@test-project-id.iam.gserviceaccount.com";
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    properties.put(KubeTwillRunnerService.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY,
+                   workloadIdentityGCPServiceAccount);
+    NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
+
+    enableWorkloadIdentity();
+
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+    when(coreV1Api.readNamespacedConfigMap(eq(KUBE_NAMESPACE), eq("workload-identity-config"), any(), any(), any()))
+      .thenReturn(new V1ConfigMap().metadata(new V1ObjectMeta().name("workload-identity-config")
+                                               .namespace(KUBE_NAMESPACE)));
+    skipRbacSteps();
+    try {
+      twillRunnerService.onNamespaceCreation(namespaceDetail);
+    } catch (Exception e) {
+      Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
+    }
+    verify(coreV1Api, times(0)).createNamespacedConfigMap(any(), any(), any(), any(), any());
+  }
+
+  @Test(expected = IOException.class)
+  public void testOnNamespaceCreationWithWorkloadIdentityEnabledReadConfigMapPropagatesException() throws Exception {
+    String workloadIdentityGCPServiceAccount = "test-service-account@test-project-id.iam.gserviceaccount.com";
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    properties.put(KubeTwillRunnerService.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY,
+                   workloadIdentityGCPServiceAccount);
+    NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
+
+    enableWorkloadIdentity();
+
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+    when(coreV1Api.readNamespacedConfigMap(any(), any(), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_INTERNAL_ERROR, "internal error"));
+    when(coreV1Api.createNamespacedConfigMap(any(), any(), any(), any(), any())).thenThrow(new ApiException());
+    skipRbacSteps();
+    twillRunnerService.onNamespaceCreation(namespaceDetail);
+  }
+
+  @Test(expected = ApiException.class)
+  public void testOnNamespaceCreationWithWorkloadIdentityEnabledCreateNamespacePropagatesException() throws Exception {
+    String workloadIdentityGCPServiceAccount = "test-service-account@test-project-id.iam.gserviceaccount.com";
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    properties.put(KubeTwillRunnerService.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY,
+                   workloadIdentityGCPServiceAccount);
+    NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
+
+    enableWorkloadIdentity();
+
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+    when(coreV1Api.readNamespacedConfigMap(eq(KUBE_NAMESPACE), eq("workload-identity-config"), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "config map not found"));
+    when(coreV1Api.createNamespacedConfigMap(any(), any(), any(), any(), any())).thenThrow(new ApiException());
+    skipRbacSteps();
+    twillRunnerService.onNamespaceCreation(namespaceDetail);
+  }
+
+  @Test
+  public void testOnNamespaceCreationWithWorkloadIdentityEnabledNoServiceAccountPropertyCreatesNoVolumes()
+    throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+    NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
+
+    enableWorkloadIdentity();
+
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+      .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
+    skipRbacSteps();
+    try {
+      twillRunnerService.onNamespaceCreation(namespaceDetail);
+    } catch (Exception e) {
+      Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
+    }
+    verify(coreV1Api, times(0)).createNamespacedConfigMap(any(), any(), any(), any(), any());
+    verify(coreV1Api, times(0)).readNamespacedConfigMap(any(), any(), any(), any(), any());
+
+  }
+
+  private void enableWorkloadIdentity() {
+    String workloadIdentityPool = "test-workload-pool";
+    String workloadIdentityProvider = "https://gkehub.googleapis.com/projects/test-project-id/locations/global/" +
+      "memberships/test-cluster";
+    twillRunnerService.setWorkloadIdentityEnabled();
+    twillRunnerService.setWorkloadIdentityPool(workloadIdentityPool);
+    twillRunnerService.setWorkloadIdentityProvider(workloadIdentityProvider);
+  }
+
+  private void skipRbacSteps() throws ApiException {
+    when(rbacV1Api.listNamespacedRoleBinding(eq(KUBE_NAMESPACE), any(), any(), any(), any(), any(), any(), any(),
+                                             any(), any(), any()))
+      .thenReturn(new V1RoleBindingList());
+    when(rbacV1Api.listClusterRoleBinding(any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+      .thenReturn(new V1ClusterRoleBindingList());
+  }
+}

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/MasterEnvironment.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/MasterEnvironment.java
@@ -18,6 +18,8 @@ package io.cdap.cdap.master.spi.environment;
 
 import io.cdap.cdap.master.spi.environment.spark.SparkConfig;
 import io.cdap.cdap.master.spi.environment.spark.SparkSubmitContext;
+import io.cdap.cdap.master.spi.namespace.NamespaceDetail;
+import io.cdap.cdap.master.spi.namespace.NamespaceListener;
 import org.apache.twill.api.TwillRunnerService;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
@@ -100,15 +102,21 @@ public interface MasterEnvironment {
   }
 
   /**
-   * Called during namespace creation
+   * Called during namespace creation.
+   * Namespace creation is rolled back if this method throws an exception.
+   * @deprecated use {@link NamespaceListener#onNamespaceCreation(NamespaceDetail)} instead.
    */
+  @Deprecated
   default void onNamespaceCreation(String namespace, Map<String, String> properties) throws Exception {
     // no-op by default
   }
 
   /**
-   * Called during namespace deletion
+   * Called during namespace deletion.
+   * Namespace deletion is rolled back if this method throws an exception.
+   * @deprecated use {@link NamespaceListener#onNamespaceDeletion(NamespaceDetail)} instead.
    */
+  @Deprecated
   default void onNamespaceDeletion(String namespace, Map<String, String> properties) throws Exception {
     // no-op by default
   }

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/namespace/NamespaceDetail.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/namespace/NamespaceDetail.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.spi.namespace;
+
+import java.util.Map;
+
+/**
+ * CDAP namespace details.
+ */
+public class NamespaceDetail {
+  private final String name;
+  private final Map<String, String> properties;
+
+  public NamespaceDetail(String name, Map<String, String> properties) {
+    this.name = name;
+    this.properties = properties;
+  }
+
+  /**
+   * Returns the name of the CDAP namespace.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Returns namespace properties.
+   */
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+}

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/namespace/NamespaceListener.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/namespace/NamespaceListener.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.spi.namespace;
+
+import java.util.Collection;
+
+/**
+ * A listener that responds to namespace updates.
+ */
+public interface NamespaceListener {
+  /**
+   * Performs initialization actions for all namespaces.
+   * This method will be retried in case of failure, so it must be implemented in an idempotent way.
+   */
+  default void onStart(Collection<NamespaceDetail> namespaceDetails) throws Exception {
+    // no-op by default
+  }
+
+  /**
+   * Called during namespace creation.
+   * This method may be retried in case of failure, so it must be implemented in an idempotent way.
+   */
+  default void onNamespaceCreation(NamespaceDetail namespaceDetail) throws Exception {
+    // no-op by default
+  }
+
+  /**
+   * Called during namespace deletion.
+   * This method may be retried in case of failure, so it must be implemented in an idempotent way.
+   */
+  default void onNamespaceDeletion(NamespaceDetail namespaceDetail) throws Exception {
+    // no-op by default
+  }
+}

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -158,6 +158,8 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
     services.add(new RetryOnStartFailureService(() -> injector.getInstance(DatasetService.class),
                                                 RetryStrategies.exponentialDelay(200, 5000, TimeUnit.MILLISECONDS)));
     services.add(injector.getInstance(AppFabricServer.class));
+    services.add(new RetryOnStartFailureService(() -> injector.getInstance(NamespaceInitializerService.class),
+                                                RetryStrategies.exponentialDelay(200, 5000, TimeUnit.MILLISECONDS)));
 
     if (cConf.getBoolean(Constants.TaskWorker.POOL_ENABLE)) {
       services.add(injector.getInstance(TaskWorkerServiceLauncher.class));

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/NamespaceInitializerService.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/NamespaceInitializerService.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import com.google.common.util.concurrent.AbstractExecutionThreadService;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.master.spi.namespace.NamespaceDetail;
+import io.cdap.cdap.master.spi.namespace.NamespaceListener;
+import org.apache.twill.api.TwillRunnerService;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+
+/**
+ * A service for initializing the {@link TwillRunnerService} with a list of namespaces.
+ */
+public class NamespaceInitializerService extends AbstractExecutionThreadService {
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final TwillRunnerService twillRunnerService;
+
+  @Inject
+  NamespaceInitializerService(NamespaceQueryAdmin namespaceQueryAdmin, TwillRunnerService twillRunnerService) {
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.twillRunnerService = twillRunnerService;
+  }
+
+  @Override
+  protected void run() throws Exception {
+    if (!(twillRunnerService instanceof NamespaceListener)) {
+      return;
+    }
+    List<NamespaceDetail> namespaceDetails = namespaceQueryAdmin.list().stream()
+      .map(meta -> new NamespaceDetail(meta.getName(), meta.getConfig().getConfigs()))
+      .collect(Collectors.toList());
+    NamespaceListener namespaceListener = (NamespaceListener) twillRunnerService;
+    namespaceListener.onStart(namespaceDetails);
+  }
+}


### PR DESCRIPTION
When the KubeTwillRunnerService starts up, it starts a watcher thread in the system namespace to discover running jobs.
We also need to do this in other namespaces.