### PR TITLE
[CDAP-19311] Do not unpack artifacts beforehand when running in preview runners

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java
@@ -48,6 +48,7 @@ import io.cdap.cdap.internal.app.namespace.StorageProviderNamespaceAdmin;
 import io.cdap.cdap.internal.app.preview.DefaultDataTracerFactory;
 import io.cdap.cdap.internal.app.preview.DefaultPreviewRunner;
 import io.cdap.cdap.internal.app.preview.MessagingPreviewDataPublisher;
+import io.cdap.cdap.internal.app.preview.PreviewPluginFinder;
 import io.cdap.cdap.internal.app.runtime.ProgramRuntimeProviderLoader;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
@@ -57,7 +58,6 @@ import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepositoryWithLo
 import io.cdap.cdap.internal.app.runtime.workflow.BasicWorkflowStateWriter;
 import io.cdap.cdap.internal.app.runtime.workflow.WorkflowStateWriter;
 import io.cdap.cdap.internal.app.store.DefaultStore;
-import io.cdap.cdap.internal.app.worker.RemoteWorkerPluginFinder;
 import io.cdap.cdap.internal.capability.CapabilityReader;
 import io.cdap.cdap.internal.capability.CapabilityStatusStore;
 import io.cdap.cdap.internal.pipeline.SynchronousPipelineFactory;
@@ -117,9 +117,9 @@ public class PreviewRunnerModule extends PrivateModule {
     expose(ArtifactRepository.class).annotatedWith(Names.named(AppFabricServiceRuntimeModule.NOAUTH_ARTIFACT_REPO));
 
 
-    // Use remote implementation to fetch plugin metadata from AppFab.
-    // Remote implementation internally uses artifact localizer to fetch and cache artifacts locally.
-    bind(PluginFinder.class).to(RemoteWorkerPluginFinder.class);
+    // Use preview implementation to fetch plugin metadata from AppFab.
+    // Preview implementation internally uses artifact localizer to fetch and cache artifacts locally.
+    bind(PluginFinder.class).to(PreviewPluginFinder.class);
     expose(PluginFinder.class);
 
     // Read artifact locations from disk when using artifact localizer due to shared mounted read-only PD.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewPluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewPluginFinder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.preview;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.ArtifactNotFoundException;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.common.io.Locations;
+import io.cdap.cdap.internal.app.runtime.artifact.RemotePluginFinder;
+import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
+import io.cdap.cdap.proto.id.ArtifactId;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import org.apache.twill.filesystem.Location;
+import org.apache.twill.filesystem.LocationFactory;
+
+import java.io.IOException;
+
+/**
+ * PreviewPluginFinder is an extension of {@link RemotePluginFinder} that is meant to be used exclusively in tasks
+ * running in the {@link PreviewRunnerTwillRunnable}. This implementation uses the {@link ArtifactLocalizerClient} to
+ * download and cache the given artifact on the local file system; however, it does not unpack the artifact as the
+ * SparkCompiler may require it packed to function properly. See CDAP-19311 for details.
+ */
+public class PreviewPluginFinder extends RemotePluginFinder {
+  private final ArtifactLocalizerClient artifactLocalizerClient;
+
+  @Inject
+  PreviewPluginFinder(LocationFactory locationFactory,
+                      RemoteClientFactory remoteClientFactory,
+                      ArtifactLocalizerClient artifactLocalizerClient) {
+    super(locationFactory, remoteClientFactory);
+    this.artifactLocalizerClient = artifactLocalizerClient;
+  }
+
+  @Override
+  protected Location getArtifactLocation(ArtifactId artifactId)
+    throws IOException, ArtifactNotFoundException, UnauthorizedException {
+    return Locations.toLocation(artifactLocalizerClient.getArtifactLocation(artifactId));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -66,7 +66,6 @@ import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepositoryReader;
 import io.cdap.cdap.internal.app.runtime.k8s.PreviewRequestPollerInfo;
-import io.cdap.cdap.internal.app.worker.RemoteWorkerPluginFinder;
 import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
@@ -265,8 +264,8 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
         //  preview runners do not have to talk directly to app-fabric for artifacts to prevent hot-spotting.
         bind(ArtifactRepositoryReader.class).to(RemoteArtifactRepositoryReader.class).in(Scopes.SINGLETON);
         bind(ArtifactRepository.class).to(RemoteArtifactRepository.class);
-        // Use artifact localizer client
-        bind(PluginFinder.class).to(RemoteWorkerPluginFinder.class);
+        // Use artifact localizer client for preview.
+        bind(PluginFinder.class).to(PreviewPluginFinder.class);
         bind(ArtifactLocalizerClient.class).in(Scopes.SINGLETON);
         // Preview runner pods should not have any elevated privileges, so use the current UGI.
         bind(UGIProvider.class).to(CurrentUGIProvider.class);


### PR DESCRIPTION
Context: unpacking the artifact causes the AbstractSparkCompiler to fail compilation for the dynamic spark plugin with the following error:
```
java.io.FileNotFoundException: /data/preview/tmp/1652917883643-0/USER-dynamic-spark-2.2.3.jar (Is a directory)
```