### PR TITLE
[CDAP-19340] Allow Running Pipelines In Namespaces Without Workload Identity

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/util/WorkloadIdentityUtil.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/util/WorkloadIdentityUtil.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.util;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.k8s.identity.GCPWorkloadIdentityCredential;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1ConfigMap;
+import io.kubernetes.client.openapi.models.V1ConfigMapProjection;
+import io.kubernetes.client.openapi.models.V1EnvVar;
+import io.kubernetes.client.openapi.models.V1KeyToPath;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1ProjectedVolumeSource;
+import io.kubernetes.client.openapi.models.V1ServiceAccountTokenProjection;
+import io.kubernetes.client.openapi.models.V1Volume;
+import io.kubernetes.client.openapi.models.V1VolumeMount;
+import io.kubernetes.client.openapi.models.V1VolumeProjection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Utility methods for workload identity.
+ */
+public class WorkloadIdentityUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(WorkloadIdentityUtil.class);
+
+  /**
+   * Needs to be public to allow for filtering these environment variables from parent pods.
+   */
+  public static final String WORKLOAD_IDENTITY_ENV_VAR_KEY = "GOOGLE_APPLICATION_CREDENTIALS";
+  public static final String WORKLOAD_IDENTITY_PROJECTED_VOLUME_NAME = "gcp-ksa";
+
+  private static final String WORKLOAD_IDENTITY_CONFIGMAP_NAME = "workload-identity-config";
+  private static final String WORKLOAD_IDENTITY_CREDENTIAL_DIR = "/var/run/secrets/tokens/gcp-ksa";
+  private static final String WORKLOAD_IDENTITY_CONFIGMAP_KEY = "config";
+  private static final String WORKLOAD_IDENTITY_CONFIGMAP_FILE = "google-application-credentials.json";
+  private static final String WORKLOAD_IDENTITY_DATA_KEY = "config";
+  private static final String WORKLOAD_IDENTITY_AUDIENCE_FORMAT = "identitynamespace:%s:%s";
+  private static final String WORKLOAD_IDENTITY_IMPERSONATION_URL_FORMAT = "https://iamcredentials.googleapis.com/" +
+    "v1/projects/-/serviceAccounts/%s:generateAccessToken";
+  private static final String WORKLOAD_IDENTITY_TOKEN_URL = "https://sts.googleapis.com/v1/token";
+  private static final String WORKLOAD_IDENTITY_CREDENTIAL_KSA_PATH = "token";
+  private static final String WORKLOAD_IDENTITY_CREDENTIAL_KSA_SOURCE_PATH
+    = WorkloadIdentityUtil.WORKLOAD_IDENTITY_CREDENTIAL_DIR + "/" + WORKLOAD_IDENTITY_CREDENTIAL_KSA_PATH;
+  private static final String WORKLOAD_IDENTITY_CREDENTIAL_GSA_SOURCE_PATH
+    = WorkloadIdentityUtil.WORKLOAD_IDENTITY_CREDENTIAL_DIR + "/" + WORKLOAD_IDENTITY_CONFIGMAP_FILE;
+  private static final long WORKLOAD_IDENTITY_SERVICE_ACCOUNT_TOKEN_TTL_SECONDS_DEFAULT = 172800L;
+
+  /**
+   * Helper method for testing whether to mount a workload identity config map.
+   * Workload identity should be mounted in the following two scenarios:
+   *  - A program is running in the CDAP installation namespace
+   *  - A program has a workload identity email set
+   * This helper method helps keep the mounting logic consistent between KubeTwillPreparer and KubeMasterEnvironment.
+   *
+   * @param installK8sNamespace The k8s namespace CDAP is installed in
+   * @param programRuntimeNamespace The namespace the program is running in
+   * @param workloadIdentityServiceAccountEmail The email value for the namespace
+   */
+  public static boolean shouldMountWorkloadIdentity(String installK8sNamespace, String programRuntimeNamespace,
+                                                 String workloadIdentityServiceAccountEmail) {
+    return installK8sNamespace.equals(programRuntimeNamespace)
+      || (workloadIdentityServiceAccountEmail != null && !workloadIdentityServiceAccountEmail.isEmpty());
+  }
+
+  /**
+   * Finds or creates the ConfigMap which stores the GCP credentials for Fleet Workload Identity.
+   * For details, see steps 6-7 of
+   * https://cloud.google.com/anthos/multicluster-management/fleets/workload-identity#impersonate_a_service_account
+   */
+  public static void findOrCreateWorkloadIdentityConfigMap(CoreV1Api coreV1Api, String k8sNamespace,
+                                                           String workloadIdentityGCPServiceAccountEmail,
+                                                           String workloadIdentityPool,
+                                                           String workloadIdentityProvider)
+    throws ApiException, IOException {
+    // Check if workload identity config map already exists
+    try {
+      coreV1Api.readNamespacedConfigMap(k8sNamespace, WORKLOAD_IDENTITY_CONFIGMAP_NAME, null, false, false);
+      // Workload identity config map already exists, so return early
+      LOG.debug("Workload identity config found, returning without creating it...");
+      return;
+    } catch (ApiException e) {
+      if (e.getCode() == HttpURLConnection.HTTP_NOT_FOUND) {
+        LOG.debug("Creating workload identity config map for kubernetes namespace {}", k8sNamespace);
+      } else {
+        throw new IOException("Failed to fetch existing workload identity config map. Error code = " + e.getCode() +
+                                ", Body = " + e.getResponseBody(), e);
+      }
+    }
+
+    String workloadIdentityAudience = String.format(WORKLOAD_IDENTITY_AUDIENCE_FORMAT, workloadIdentityPool,
+                                                    workloadIdentityProvider);
+    String workloadIdentityImpersonationURL = String.format(WORKLOAD_IDENTITY_IMPERSONATION_URL_FORMAT,
+                                                            workloadIdentityGCPServiceAccountEmail);
+    GCPWorkloadIdentityCredential credential =
+      new GCPWorkloadIdentityCredential(GCPWorkloadIdentityCredential.CredentialType.EXTERNAL_ACCOUNT,
+                                        workloadIdentityAudience, workloadIdentityImpersonationURL,
+                                        GCPWorkloadIdentityCredential.TokenType.JWT, WORKLOAD_IDENTITY_TOKEN_URL,
+                                        WORKLOAD_IDENTITY_CREDENTIAL_KSA_SOURCE_PATH);
+    String workloadIdentityCredentialJSON = new Gson().toJson(credential);
+    Map<String, String> workloadIdentityConfigMapData = new HashMap<>();
+    workloadIdentityConfigMapData.put(WORKLOAD_IDENTITY_DATA_KEY, workloadIdentityCredentialJSON);
+    V1ConfigMap configMap = new V1ConfigMap()
+      .metadata(new V1ObjectMeta().namespace(k8sNamespace).name(WorkloadIdentityUtil.WORKLOAD_IDENTITY_CONFIGMAP_NAME))
+      .data(workloadIdentityConfigMapData);
+    coreV1Api.createNamespacedConfigMap(k8sNamespace, configMap, null, null, null);
+  }
+
+  /**
+   * Creates a workload identity volume. For details, see steps 6-7 of
+   * https://cloud.google.com/anthos/multicluster-management/fleets/workload-identity#impersonate_a_service_account
+   *
+   * @param workloadIdentityServiceAccountTokenTTLSeconds TTL for the KSA token.
+   * @param workloadIdentityPool The workload identity pool to use.
+   * @return a projected V1Volume containing workload identity credentials.
+   */
+  public static V1Volume generateWorkloadIdentityVolume(long workloadIdentityServiceAccountTokenTTLSeconds,
+                                                        String workloadIdentityPool) {
+    V1ServiceAccountTokenProjection serviceAccountTokenProjection = new V1ServiceAccountTokenProjection()
+      .path(WORKLOAD_IDENTITY_CREDENTIAL_KSA_PATH)
+      .expirationSeconds(workloadIdentityServiceAccountTokenTTLSeconds)
+      .audience(workloadIdentityPool);
+    V1ConfigMapProjection configMapProjection = new V1ConfigMapProjection()
+      .name(WORKLOAD_IDENTITY_CONFIGMAP_NAME)
+      .optional(false)
+      .addItemsItem(new V1KeyToPath().key(WORKLOAD_IDENTITY_CONFIGMAP_KEY)
+                      .path(WORKLOAD_IDENTITY_CONFIGMAP_FILE));
+    return new V1Volume().name(WORKLOAD_IDENTITY_PROJECTED_VOLUME_NAME)
+      .projected(new V1ProjectedVolumeSource().defaultMode(420)
+                   .addSourcesItem(new V1VolumeProjection().serviceAccountToken(serviceAccountTokenProjection))
+                   .addSourcesItem(new V1VolumeProjection().configMap(configMapProjection)));
+  }
+
+  /**
+   * @return a V1VolumeMount for mounting workload identity credentials.
+   */
+  public static V1VolumeMount generateWorkloadIdentityVolumeMount() {
+    return new V1VolumeMount()
+      .name(WorkloadIdentityUtil.WORKLOAD_IDENTITY_PROJECTED_VOLUME_NAME)
+      .mountPath(WORKLOAD_IDENTITY_CREDENTIAL_DIR).readOnly(true);
+  }
+
+  /**
+   * @return the V1EnvVar for setting workload identity credentials.
+   */
+  public static V1EnvVar generateWorkloadIdentityEnvVar() {
+    return new V1EnvVar().name(WORKLOAD_IDENTITY_ENV_VAR_KEY).value(WORKLOAD_IDENTITY_CREDENTIAL_GSA_SOURCE_PATH);
+  }
+
+  /**
+   * Converts a string form of a the workload identity TTL to a long.
+   * @param ttlStr The workload identity KSA TTL string. If null, defaults to 172800L.
+   * @return The long form of the TTL.
+   * @throws IllegalArgumentException if the TTL is less than or equal to 0.
+   */
+  public static long convertWorkloadIdentityTTLFromString(@Nullable String ttlStr) throws IllegalArgumentException {
+    long ttl = WORKLOAD_IDENTITY_SERVICE_ACCOUNT_TOKEN_TTL_SECONDS_DEFAULT;
+    if (ttlStr != null) {
+      ttl = Long.parseLong(ttlStr);
+    }
+    if (ttl <= 0) {
+      throw new IllegalArgumentException(String.format("Workload identity k8s service account token TTL '%d' " +
+                                                         "cannot be less than zero", ttl));
+    }
+    return ttl;
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.k8s.common.DefaultLocalFileProvider;
 import io.cdap.cdap.k8s.common.LocalFileProvider;
 import io.cdap.cdap.k8s.discovery.KubeDiscoveryService;
 import io.cdap.cdap.k8s.runtime.KubeTwillRunnerService;
+import io.cdap.cdap.k8s.util.WorkloadIdentityUtil;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnable;
@@ -39,14 +40,12 @@ import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.RbacAuthorizationV1Api;
 import io.kubernetes.client.openapi.models.V1ConfigMapBuilder;
-import io.kubernetes.client.openapi.models.V1ConfigMapProjection;
 import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSourceBuilder;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1ContainerBuilder;
 import io.kubernetes.client.openapi.models.V1DownwardAPIVolumeFile;
 import io.kubernetes.client.openapi.models.V1DownwardAPIVolumeSource;
 import io.kubernetes.client.openapi.models.V1EnvVar;
-import io.kubernetes.client.openapi.models.V1KeyToPath;
 import io.kubernetes.client.openapi.models.V1ObjectFieldSelector;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1ObjectMetaBuilder;
@@ -55,12 +54,8 @@ import io.kubernetes.client.openapi.models.V1OwnerReferenceBuilder;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1PodSpecBuilder;
-import io.kubernetes.client.openapi.models.V1ProjectedVolumeSource;
-import io.kubernetes.client.openapi.models.V1SecretVolumeSource;
-import io.kubernetes.client.openapi.models.V1ServiceAccountTokenProjection;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
-import io.kubernetes.client.openapi.models.V1VolumeProjection;
 import io.kubernetes.client.util.Config;
 import io.kubernetes.client.util.Yaml;
 import io.kubernetes.client.util.generic.options.ListOptions;
@@ -109,7 +104,6 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final Logger LOG = LoggerFactory.getLogger(KubeMasterEnvironment.class);
 
   public static final String SECURITY_CONFIG_NAME = "cdap-security";
-  public static final String RESOURCE_QUOTA_NAME = "cdap-resource-quota";
   // Contains the list of configuration / secret names coming from the Pod information, which are
   // needed to propagate to deployments created via the KubeTwillRunnerService
   private static final Set<String> CONFIG_NAMES = ImmutableSet.of("cdap-conf", "hadoop-conf", "cdap-security");
@@ -120,7 +114,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String JOB_CLEANUP_INTERVAL = "program.container.cleaner.interval.mins";
   private static final String JOB_CLEANUP_BATCH_SIZE = "program.container.cleaner.batch.size";
 
-  private static final String NAMESPACE_KEY = "master.environment.k8s.namespace";
+  public static final String NAMESPACE_KEY = "master.environment.k8s.namespace";
   private static final String INSTANCE_LABEL = "master.environment.k8s.instance.label";
   // Label for the container name
   private static final String CONTAINER_LABEL = "master.environment.k8s.container.label";
@@ -156,22 +150,12 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String DEFAULT_PROGRAM_CPU_MULTIPLIER = "0.5";
 
   // Workload Identity Constants
-  private static final String WORKLOAD_IDENTITY_ENABLED = "master.environment.k8s.workload.identity.enabled";
-  private static final String WORKLOAD_IDENTITY_POOL = "master.environment.k8s.workload.identity.pool";
-  private static final String WORKLOAD_IDENTITY_PROVIDER = "master.environment.k8s.workload.identity.provider";
-  private static final String WORKLOAD_IDENTITY_SERVICE_ACCOUNT_TOKEN_TTL_SECONDS
+  // Needed to be read from KubeTwillPreparer.
+  public static final String WORKLOAD_IDENTITY_ENABLED = "master.environment.k8s.workload.identity.enabled";
+  public static final String WORKLOAD_IDENTITY_POOL = "master.environment.k8s.workload.identity.pool";
+  public static final String WORKLOAD_IDENTITY_PROVIDER = "master.environment.k8s.workload.identity.provider";
+  public static final String WORKLOAD_IDENTITY_SERVICE_ACCOUNT_TOKEN_TTL_SECONDS
     = "master.environment.k8s.workload.identity.service.account.token.ttl.seconds";
-  private static final long WORKLOAD_IDENTITY_SERVICE_ACCOUNT_TOKEN_TTL_SECONDS_DEFAULT = 172800L;
-  public static final String WORKLOAD_IDENTITY_CONFIGMAP_NAME = "workload-identity-config";
-  private static final String WORKLOAD_IDENTITY_PROJECTED_VOLUME_NAME = "gcp-ksa";
-  private static final String WORKLOAD_IDENTITY_CONFIGMAP_KEY = "config";
-  private static final String WORKLOAD_IDENTITY_CONFIGMAP_FILE = "google-application-credentials.json";
-  private static final String WORKLOAD_IDENTITY_CREDENTIAL_DIR = "/var/run/secrets/tokens/gcp-ksa";
-  private static final String WORKLOAD_IDENTITY_CREDENTIAL_KSA_PATH = "token";
-  public static final String WORKLOAD_IDENTITY_CREDENTIAL_KSA_SOURCE_PATH = WORKLOAD_IDENTITY_CREDENTIAL_DIR + "/" +
-    WORKLOAD_IDENTITY_CREDENTIAL_KSA_PATH;
-  private static final String WORKLOAD_IDENTITY_CREDENTIAL_GSA_SOURCE_PATH = WORKLOAD_IDENTITY_CREDENTIAL_DIR + "/" +
-    WORKLOAD_IDENTITY_CONFIGMAP_FILE;
 
   // Workload Launcher Constants
   /**
@@ -191,7 +175,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String DEFAULT_WORKLOAD_LAUNCHER_NAMESPACE_ROLE_NAME = "cdap-workload-launcher";
   private static final String DEFAULT_WORKLOAD_LAUNCHER_CLUSTER_ROLE_NAME = "cdap-cluster-workload-launcher";
 
-  private static final String DEFAULT_NAMESPACE = "default";
+  public static final String DEFAULT_NAMESPACE = "default";
   private static final String DEFAULT_INSTANCE_LABEL = "cdap.instance";
   private static final String DEFAULT_CONTAINER_LABEL = "cdap.container";
   private static final String DEFAULT_POD_INFO_DIR = "/etc/podinfo";
@@ -243,7 +227,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private String workloadIdentityPool;
   private long workloadIdentityServiceAccountTokenTTLSeconds;
   private String programCpuMultiplier;
-  private List<V1SecretVolumeSource> secretVolumes;
+  private String cdapInstallNamespace;
 
   public KubeMasterEnvironment() {
     gson = new Gson();
@@ -274,16 +258,8 @@ public class KubeMasterEnvironment implements MasterEnvironment {
       if (workloadIdentityProvider == null) {
         missingConfig = WORKLOAD_IDENTITY_PROVIDER;
       }
-      workloadIdentityServiceAccountTokenTTLSeconds = WORKLOAD_IDENTITY_SERVICE_ACCOUNT_TOKEN_TTL_SECONDS_DEFAULT;
-      String confWorkloadIdentityTokenTTL = conf.get(WORKLOAD_IDENTITY_SERVICE_ACCOUNT_TOKEN_TTL_SECONDS);
-      if (confWorkloadIdentityTokenTTL != null) {
-        workloadIdentityServiceAccountTokenTTLSeconds = Long.parseLong(confWorkloadIdentityTokenTTL);
-      }
-      if (workloadIdentityServiceAccountTokenTTLSeconds <= 0) {
-        throw new IllegalArgumentException(String.format("Workload identity k8s service account token TTL '%d' " +
-                                                           "cannot be less than zero",
-                                                         workloadIdentityServiceAccountTokenTTLSeconds));
-      }
+      workloadIdentityServiceAccountTokenTTLSeconds = WorkloadIdentityUtil
+        .convertWorkloadIdentityTTLFromString(conf.get(WORKLOAD_IDENTITY_SERVICE_ACCOUNT_TOKEN_TTL_SECONDS));
       if (missingConfig != null) {
         throw new IllegalArgumentException(String.format("Missing expected workload identity config '%s'",
                                                          missingConfig));
@@ -308,7 +284,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     Map<String, String> podLabels = podInfo.getLabels();
 
     String namespace = podInfo.getNamespace();
-    String cdapNamespace = conf.getOrDefault(NAMESPACE_KEY, DEFAULT_NAMESPACE);
+    cdapInstallNamespace = conf.getOrDefault(NAMESPACE_KEY, DEFAULT_NAMESPACE);
     additionalSparkConfs = getSparkConfigurations(conf);
     programCpuMultiplier = conf.getOrDefault(PROGRAM_CPU_MULTIPLIER, DEFAULT_PROGRAM_CPU_MULTIPLIER);
 
@@ -326,7 +302,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
 
     // Services are publish to K8s with a prefix
     String resourcePrefix = "cdap-" + instanceName + "-";
-    discoveryService = new KubeDiscoveryService(cdapNamespace, "cdap-" + instanceName + "-", podLabels,
+    discoveryService = new KubeDiscoveryService(cdapInstallNamespace, "cdap-" + instanceName + "-", podLabels,
                                                 podInfo.getOwnerReferences());
 
     // Optionally creates the pod killer task
@@ -432,7 +408,8 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     // Create pod template with config maps and add to spark conf.
     sparkConfMap.put(SPARK_KUBERNETES_DRIVER_POD_TEMPLATE,
                      getDriverPodTemplate(podInfo, sparkSubmitContext).getAbsolutePath());
-    sparkConfMap.put(SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE, getExecutorPodTemplateFile().getAbsolutePath());
+    sparkConfMap.put(SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE,
+                     getExecutorPodTemplateFile(sparkSubmitContext).getAbsolutePath());
     sparkConfMap.put(SPARK_KUBERNETES_METRICS_PROPERTIES_CONF, "/opt/spark/work-dir/metrics.properties");
 
     Map<String, String> submitConfigs = sparkSubmitContext.getConfig();
@@ -681,8 +658,8 @@ public class KubeMasterEnvironment implements MasterEnvironment {
       mountHostSecretVolumes(podInfo, driverPodSpec);
 
       if (workloadIdentityEnabled) {
-        setupWorkloadIdentityForPodSpec(driverPodSpec, workloadIdentityPool,
-                                        workloadIdentityServiceAccountTokenTTLSeconds);
+        setupWorkloadIdentityForPodSpecIfExists(sparkSubmitContext, driverPodSpec, workloadIdentityPool,
+                                                workloadIdentityServiceAccountTokenTTLSeconds);
       }
     } catch (ApiException e) {
       throw new IOException("Error occurred while creating pod spec. Error code = "
@@ -694,7 +671,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     return serializePodTemplate(driverPod);
   }
 
-  private File getExecutorPodTemplateFile() throws Exception {
+  private File getExecutorPodTemplateFile(SparkSubmitContext sparkSubmitContext) throws Exception {
     V1Pod executorPod = new V1Pod();
     V1PodSpec executorPodSpec = createBasePodSpec();
     executorPod.setSpec(executorPodSpec);
@@ -712,8 +689,8 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     mountHostSecretVolumes(podInfo, executorPodSpec);
 
     if (workloadIdentityEnabled) {
-      setupWorkloadIdentityForPodSpec(executorPodSpec, workloadIdentityPool,
-                                      workloadIdentityServiceAccountTokenTTLSeconds);
+      setupWorkloadIdentityForPodSpecIfExists(sparkSubmitContext, executorPodSpec, workloadIdentityPool,
+                                              workloadIdentityServiceAccountTokenTTLSeconds);
     }
 
     // Create spark template file. We do not delete it because pod will get deleted at the end of job completion.
@@ -837,32 +814,30 @@ public class KubeMasterEnvironment implements MasterEnvironment {
    *
    * @param podSpec The pod spec to setup workload identity for.
    */
-  private static void setupWorkloadIdentityForPodSpec(V1PodSpec podSpec, String workloadIdentityPool,
-                                                      long workloadIdentityServiceAccountTokenTTLSeconds) {
+  private void setupWorkloadIdentityForPodSpecIfExists(SparkSubmitContext sparkSubmitContext, V1PodSpec podSpec,
+                                                              String workloadIdentityPool,
+                                                              long workloadIdentityServiceAccountTokenTTLSeconds) {
+    // If the namespace service account does not exist, do not attempt to mount the ConfigMap.
+    // If the program is executing in the install namespace, always mount the ConfigMap.
+    String executionNamespace = sparkSubmitContext.getConfig().getOrDefault(NAMESPACE_PROPERTY,
+                                                                            podInfo.getNamespace());
+    String workloadIdentityServiceAccount = sparkSubmitContext.getConfig()
+      .get(KubeTwillRunnerService.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY);
+    if (!WorkloadIdentityUtil.shouldMountWorkloadIdentity(cdapInstallNamespace, executionNamespace,
+                                                         workloadIdentityServiceAccount)) {
+      return;
+    }
+
     // Mount volume to expected directory
-    V1ServiceAccountTokenProjection serviceAccountTokenProjection = new V1ServiceAccountTokenProjection()
-      .path(WORKLOAD_IDENTITY_CREDENTIAL_KSA_PATH)
-      .expirationSeconds(workloadIdentityServiceAccountTokenTTLSeconds)
-      .audience(workloadIdentityPool);
-    V1ConfigMapProjection configMapProjection = new V1ConfigMapProjection()
-      .name(WORKLOAD_IDENTITY_CONFIGMAP_NAME)
-      .optional(false)
-      .addItemsItem(new V1KeyToPath().key(WORKLOAD_IDENTITY_CONFIGMAP_KEY)
-                      .path(WORKLOAD_IDENTITY_CONFIGMAP_FILE));
-    podSpec.addVolumesItem(new V1Volume().name(WORKLOAD_IDENTITY_PROJECTED_VOLUME_NAME)
-                             .projected(new V1ProjectedVolumeSource()
-                                          .defaultMode(420)
-                                          .addSourcesItem(new V1VolumeProjection()
-                                                            .serviceAccountToken(serviceAccountTokenProjection))
-                                          .addSourcesItem(new V1VolumeProjection()
-                                                            .configMap(configMapProjection))));
+    V1Volume workloadIdentityVolume = WorkloadIdentityUtil
+      .generateWorkloadIdentityVolume(workloadIdentityServiceAccountTokenTTLSeconds, workloadIdentityPool);
+
+    podSpec.addVolumesItem(workloadIdentityVolume);
     for (V1Container container : podSpec.getContainers()) {
       // Mount projected volume
-      container.addVolumeMountsItem(new V1VolumeMount().name(WORKLOAD_IDENTITY_PROJECTED_VOLUME_NAME)
-                                      .mountPath(WORKLOAD_IDENTITY_CREDENTIAL_DIR).readOnly(true));
+      container.addVolumeMountsItem(WorkloadIdentityUtil.generateWorkloadIdentityVolumeMount());
       // Setup environment variables
-      container.addEnvItem(new V1EnvVar().name("GOOGLE_APPLICATION_CREDENTIALS")
-                             .value(WORKLOAD_IDENTITY_CREDENTIAL_GSA_SOURCE_PATH));
+      container.addEnvItem(WorkloadIdentityUtil.generateWorkloadIdentityEnvVar());
     }
   }
 
@@ -1016,5 +991,10 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   @VisibleForTesting
   void setProgramCpuMultiplier(String programCpuMultiplier) {
     this.programCpuMultiplier = programCpuMultiplier;
+  }
+
+  @VisibleForTesting
+  void setCDAPInstallNamespace(String cdapInstallNamespace) {
+    this.cdapInstallNamespace = cdapInstallNamespace;
   }
 }

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
@@ -17,10 +17,13 @@
 package io.cdap.cdap.k8s.runtime;
 
 import io.cdap.cdap.master.environment.k8s.PodInfo;
+import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
+import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnable;
 import io.kubernetes.client.openapi.models.V1PodSecurityContext;
 import org.apache.twill.api.AbstractTwillRunnable;
 import org.apache.twill.api.ResourceSpecification;
 import org.apache.twill.api.TwillSpecification;
+import org.apache.twill.filesystem.LocationFactory;
 import org.apache.twill.internal.DefaultResourceSpecification;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -28,6 +31,7 @@ import org.junit.Test;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.Map;
 
 /**
  * Tests for {@link KubeTwillPreparer}.
@@ -67,7 +71,23 @@ public class KubeTwillPreparerTest {
                                   Collections.emptyList(), "test-pod-container-label", "test-pod-container-image",
                                   Collections.emptyList(), Collections.emptyList(), new V1PodSecurityContext(),
                                   "test-pod-image-pull-policy");
-    KubeTwillPreparer preparer = new KubeTwillPreparer(null, null, "default",
+    KubeTwillPreparer preparer = new KubeTwillPreparer(new MasterEnvironmentContext() {
+      @Override
+      public LocationFactory getLocationFactory() {
+        return null;
+      }
+
+      @Override
+      public Map<String, String> getConfigurations() {
+        return Collections.emptyMap();
+      }
+
+      @Override
+      public String[] getRunnableArguments(Class<? extends MasterEnvironmentRunnable> runnableClass,
+                                           String... runnableArgs) {
+        return new String[0];
+      }
+    }, null, "default",
                                                        podInfo, twillSpecification, null, null,
                                                        null, null, null);
 

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.master.environment.k8s;
 
 import io.cdap.cdap.k8s.common.TemporaryLocalFileProvider;
 import io.cdap.cdap.k8s.runtime.KubeTwillRunnerService;
+import io.cdap.cdap.k8s.util.WorkloadIdentityUtil;
 import io.cdap.cdap.master.spi.environment.spark.SparkConfig;
 import io.cdap.cdap.master.spi.environment.spark.SparkSubmitContext;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
@@ -26,6 +27,7 @@ import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1EnvVar;
 import io.kubernetes.client.openapi.models.V1KeyToPath;
 import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1ProjectedVolumeSource;
 import io.kubernetes.client.openapi.models.V1ServiceAccountTokenProjection;
 import io.kubernetes.client.openapi.models.V1Volume;
@@ -40,8 +42,10 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -54,6 +58,7 @@ import static org.mockito.Mockito.when;
 public class KubeMasterEnvironmentTest {
 
   private static final String KUBE_NAMESPACE = "test-kube-namespace";
+  private static final String KUBE_INSTALL_NAMESPACE = "kube-install-namespace";
 
   private CoreV1Api coreV1Api;
   private KubeMasterEnvironment kubeMasterEnvironment;
@@ -90,6 +95,211 @@ public class KubeMasterEnvironmentTest {
                                                  Collections.emptyList(), Collections.emptyList(), null,
                                                  "image-pull-policy"));
     kubeMasterEnvironment.setProgramCpuMultiplier("1");
+  }
+
+  @Test
+  public void testGenerateSparkConfigWithNamespace() throws Exception {
+    Map<String, String> config = new HashMap<>();
+    String ns = "some-ns";
+    config.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, ns);
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap(), config, 1, 1);
+    SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
+    Assert.assertEquals(ns, sparkConfig.getConfigs().get("spark.kubernetes.namespace"));
+  }
+
+  @Test
+  public void testGenerateSparkConfigWithWorkloadIdentityEnabledInNonInstallNamespaceMountsConfigMap()
+    throws Exception {
+    String workloadIdentityPool = "test-workload-pool";
+    String workloadIdentityProvider = "https://gkehub.googleapis.com/projects/test-project-id/locations/global/" +
+      "memberships/test-cluster";
+    kubeMasterEnvironment.setWorkloadIdentityEnabled();
+    kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
+    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTTLSeconds(172800L);
+    kubeMasterEnvironment.setCDAPInstallNamespace(KUBE_INSTALL_NAMESPACE);
+
+    Map<String, String> conf = new HashMap<>();
+    conf.put(KubeTwillRunnerService.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY, "test-email@gmail.com");
+    conf.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap(), conf, 1, 1);
+
+    SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
+
+    // Verify volume, volume mount, and environment variables are set for workload identity
+    Map<String, String> configs = sparkConfig.getConfigs();
+    File sparkDriverPodFile = new File(configs.get(KubeMasterEnvironment.SPARK_KUBERNETES_DRIVER_POD_TEMPLATE));
+    File sparkExecutorPodFile = new File(configs.get(KubeMasterEnvironment.SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE));
+    V1Pod driverPod = Yaml.loadAs(sparkDriverPodFile, V1Pod.class);
+    V1Pod executorPod = Yaml.loadAs(sparkExecutorPodFile, V1Pod.class);
+
+    assertMountsWorkloadIdentityVolume(workloadIdentityPool, driverPod, executorPod);
+  }
+
+  @Test
+  public void testGenerateSparkConfigWithWorkloadIdentityEnabledInInstallNamespaceWithNoEmailMountsConfigMap()
+    throws Exception {
+    String workloadIdentityPool = "test-workload-pool";
+    String workloadIdentityProvider = "https://gkehub.googleapis.com/projects/test-project-id/locations/global/" +
+      "memberships/test-cluster";
+    kubeMasterEnvironment.setWorkloadIdentityEnabled();
+    kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
+    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTTLSeconds(172800L);
+    kubeMasterEnvironment.setCDAPInstallNamespace(KUBE_INSTALL_NAMESPACE);
+
+    Map<String, String> conf = new HashMap<>();
+    conf.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_INSTALL_NAMESPACE);
+
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap(), conf, 1, 1);
+
+    SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
+
+    // Verify volume, volume mount, and environment variables are set for workload identity
+    Map<String, String> configs = sparkConfig.getConfigs();
+    File sparkDriverPodFile = new File(configs.get(KubeMasterEnvironment.SPARK_KUBERNETES_DRIVER_POD_TEMPLATE));
+    File sparkExecutorPodFile = new File(configs.get(KubeMasterEnvironment.SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE));
+    V1Pod driverPod = Yaml.loadAs(sparkDriverPodFile, V1Pod.class);
+    V1Pod executorPod = Yaml.loadAs(sparkExecutorPodFile, V1Pod.class);
+
+    assertMountsWorkloadIdentityVolume(workloadIdentityPool, driverPod, executorPod);
+  }
+
+  @Test
+  public void testGenerateSparkConfigWithWorkloadIdentityDisabledDoesNotMountConfigMap()
+    throws Exception {
+    String workloadIdentityPool = "test-workload-pool";
+    String workloadIdentityProvider = "https://gkehub.googleapis.com/projects/test-project-id/locations/global/" +
+      "memberships/test-cluster";
+    kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
+    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTTLSeconds(172800L);
+    kubeMasterEnvironment.setCDAPInstallNamespace(KUBE_INSTALL_NAMESPACE);
+
+    Map<String, String> conf = new HashMap<>();
+    conf.put(KubeTwillRunnerService.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY, "test-email@gmail.com");
+    conf.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap(), conf, 1, 1);
+
+    SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
+
+    // Verify volume, volume mount, and environment variables are set for workload identity
+    Map<String, String> configs = sparkConfig.getConfigs();
+    File sparkDriverPodFile = new File(configs.get(KubeMasterEnvironment.SPARK_KUBERNETES_DRIVER_POD_TEMPLATE));
+    File sparkExecutorPodFile = new File(configs.get(KubeMasterEnvironment.SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE));
+    V1Pod driverPod = Yaml.loadAs(sparkDriverPodFile, V1Pod.class);
+    V1Pod executorPod = Yaml.loadAs(sparkExecutorPodFile, V1Pod.class);
+
+    assertDoesNotMountWorkloadIdentityVolume(driverPod, executorPod);
+  }
+
+  @Test
+  public void testGenerateSparkConfigWithWorkloadIdentityEnabledInDifferentNamespaceWithNoEmailDoesNotMountConfigMap()
+    throws Exception {
+    String workloadIdentityPool = "test-workload-pool";
+    String workloadIdentityProvider = "https://gkehub.googleapis.com/projects/test-project-id/locations/global/" +
+      "memberships/test-cluster";
+    kubeMasterEnvironment.setWorkloadIdentityEnabled();
+    kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
+    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTTLSeconds(172800L);
+    kubeMasterEnvironment.setCDAPInstallNamespace(KUBE_INSTALL_NAMESPACE);
+
+    Map<String, String> conf = new HashMap<>();
+    conf.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
+
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap(), conf, 1, 1);
+
+    SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
+
+    // Verify volume, volume mount, and environment variables are set for workload identity
+    Map<String, String> configs = sparkConfig.getConfigs();
+    File sparkDriverPodFile = new File(configs.get(KubeMasterEnvironment.SPARK_KUBERNETES_DRIVER_POD_TEMPLATE));
+    File sparkExecutorPodFile = new File(configs.get(KubeMasterEnvironment.SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE));
+    V1Pod driverPod = Yaml.loadAs(sparkDriverPodFile, V1Pod.class);
+    V1Pod executorPod = Yaml.loadAs(sparkExecutorPodFile, V1Pod.class);
+
+    assertDoesNotMountWorkloadIdentityVolume(driverPod, executorPod);
+  }
+
+  @Test
+  public void testGetComponentName() {
+    // Ensure valid pod names are parsed correctly
+    String gotName = KubeMasterEnvironment.getComponentName(
+      "instance-abc", "cdap-instance-abc-appfabric-0");
+    Assert.assertEquals("appfabric-0", gotName);
+
+    gotName = KubeMasterEnvironment.getComponentName(
+      "123", "cdap-123-appfabric-23");
+    Assert.assertEquals("appfabric-23", gotName);
+
+    gotName = KubeMasterEnvironment.getComponentName(
+      "cdap", "cdap-cdap-appfabric-0");
+    Assert.assertEquals("appfabric-0", gotName);
+
+    gotName = KubeMasterEnvironment.getComponentName(
+      "", "cdap-test-metrics-0");
+    Assert.assertEquals("test-metrics-0", gotName);
+
+    gotName = KubeMasterEnvironment.getComponentName(
+      "test-cdap", "cdap-test-cdap-preview-runner-b5786a15-e8f4-47-0cebad7d67-0");
+    Assert.assertEquals("preview-runner-b5786a15-e8f4-47-0cebad7d67-0", gotName);
+
+    gotName = KubeMasterEnvironment.getComponentName(
+      "dap", "cdap-dap-preview-runner-b5786a15-e8f4-47-0cebad7d67-0");
+    Assert.assertEquals("preview-runner-b5786a15-e8f4-47-0cebad7d67-0", gotName);
+  }
+
+  private void assertDoesNotMountWorkloadIdentityVolume(V1Pod driverPod, V1Pod executorPod) {
+    List<V1Pod> pods = Arrays.asList(driverPod, executorPod);
+    for (V1Pod pod : pods) {
+      V1PodSpec podSpec = pod.getSpec();
+      for (V1Volume volume : podSpec.getVolumes()) {
+        if (volume.getName().equals(WorkloadIdentityUtil.WORKLOAD_IDENTITY_PROJECTED_VOLUME_NAME)) {
+          Assert.fail(String.format("Found unexpected volume '%s' in pod spec '%s'",
+                                    WorkloadIdentityUtil.WORKLOAD_IDENTITY_PROJECTED_VOLUME_NAME,
+                                    pod.getMetadata().getName()));
+        }
+      }
+      for (V1Container container : podSpec.getContainers()) {
+        for (V1VolumeMount volumeMount : container.getVolumeMounts()) {
+          if (volumeMount.getName().equals(WorkloadIdentityUtil.WORKLOAD_IDENTITY_PROJECTED_VOLUME_NAME)) {
+            Assert.fail(String.format("Found unexpected volume mount '%s' in container '%s' in pod '%s'",
+                                      WorkloadIdentityUtil.WORKLOAD_IDENTITY_PROJECTED_VOLUME_NAME,
+                                      container.getName(),
+                                      pod.getMetadata().getName()));
+          }
+        }
+      }
+    }
+  }
+
+  private void assertMountsWorkloadIdentityVolume(String workloadIdentityPool, V1Pod driverPod,
+                                                  V1Pod executorPod) {
+    // NOTE: Several of these values are hard-coded to ensure that it is not changed by accident as it can cause other
+    // pieces to fail. If one of the values changed, the other constants must be validated!
+    V1ServiceAccountTokenProjection workloadIdentityKSATokenProjection = new V1ServiceAccountTokenProjection()
+      .path("token")
+      .expirationSeconds(172800L)
+      .audience(workloadIdentityPool);
+    V1ConfigMapProjection workloadIdentityGSAConfigMapProjection = new V1ConfigMapProjection()
+      .name("workload-identity-config")
+      .optional(false)
+      .addItemsItem(new V1KeyToPath().key("config").path("google-application-credentials.json"));
+    V1Volume expectedWorkloadIdentityProjectedVolume = new V1Volume().name("gcp-ksa")
+      .projected(new V1ProjectedVolumeSource()
+                   .defaultMode(420)
+                   .addSourcesItem(new V1VolumeProjection().serviceAccountToken(workloadIdentityKSATokenProjection))
+                   .addSourcesItem(new V1VolumeProjection().configMap(workloadIdentityGSAConfigMapProjection)));
+    V1VolumeMount expectedWorkloadIdentityProjectedVolumeMount = new V1VolumeMount().name("gcp-ksa")
+      .mountPath("/var/run/secrets/tokens/gcp-ksa").readOnly(true);
+    V1EnvVar expectedGoogleApplicationCredentialsEnvVar = new V1EnvVar().name("GOOGLE_APPLICATION_CREDENTIALS")
+      .value("/var/run/secrets/tokens/gcp-ksa/google-application-credentials.json");
+    // Verify pod specs
+    assertContainsVolume(driverPod, expectedWorkloadIdentityProjectedVolume);
+    assertContainersContainVolumeMount(driverPod, expectedWorkloadIdentityProjectedVolumeMount);
+    assertContainersContainEnvVar(driverPod, expectedGoogleApplicationCredentialsEnvVar);
+    assertContainsVolume(executorPod, expectedWorkloadIdentityProjectedVolume);
+    assertContainersContainVolumeMount(executorPod, expectedWorkloadIdentityProjectedVolumeMount);
+    assertContainersContainEnvVar(executorPod, expectedGoogleApplicationCredentialsEnvVar);
   }
 
   private void assertContainsVolume(V1Pod pod, V1Volume expectedVolume) {
@@ -131,92 +341,5 @@ public class KubeMasterEnvironmentTest {
                                 container.getName(),
                                 pod.getMetadata().getName()));
     }
-  }
-
-  @Test
-  public void testGenerateSparkConfigWithNamespace() throws Exception {
-    Map<String, String> config = new HashMap<>();
-    String ns = "some-ns";
-    config.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, ns);
-    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap(), config, 1, 1);
-    SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
-    Assert.assertEquals(ns, sparkConfig.getConfigs().get("spark.kubernetes.namespace"));
-  }
-
-  @Test
-  public void testGenerateSparkConfigWithWorkloadIdentityEnabled() throws Exception {
-    String workloadIdentityPool = "test-workload-pool";
-    String workloadIdentityProvider = "https://gkehub.googleapis.com/projects/test-project-id/locations/global/" +
-      "memberships/test-cluster";
-    kubeMasterEnvironment.setWorkloadIdentityEnabled();
-    kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
-    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTTLSeconds(172800L);
-
-    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap(),
-                                                                   Collections.emptyMap(), 1, 1);
-
-    SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
-
-    // Verify volume, volume mount, and environment variables are set for workload identity
-    Map<String, String> configs = sparkConfig.getConfigs();
-    File sparkDriverPodFile = new File(configs.get(KubeMasterEnvironment.SPARK_KUBERNETES_DRIVER_POD_TEMPLATE));
-    File sparkExecutorPodFile = new File(configs.get(KubeMasterEnvironment.SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE));
-    V1Pod driverPod = Yaml.loadAs(sparkDriverPodFile, V1Pod.class);
-    V1Pod executorPod = Yaml.loadAs(sparkExecutorPodFile, V1Pod.class);
-
-    // NOTE: Several of these values are hard-coded to ensure that it is not changed by accident as it can cause other
-    // pieces to fail. If one of the values changed, the other constants must be validated!
-    V1ServiceAccountTokenProjection workloadIdentityKSATokenProjection = new V1ServiceAccountTokenProjection()
-      .path("token")
-      .expirationSeconds(172800L)
-      .audience(workloadIdentityPool);
-    V1ConfigMapProjection workloadIdentityGSAConfigMapProjection = new V1ConfigMapProjection()
-      .name("workload-identity-config")
-      .optional(false)
-      .addItemsItem(new V1KeyToPath().key("config").path("google-application-credentials.json"));
-    V1Volume expectedWorkloadIdentityProjectedVolume = new V1Volume().name("gcp-ksa")
-      .projected(new V1ProjectedVolumeSource()
-                   .defaultMode(420)
-                   .addSourcesItem(new V1VolumeProjection().serviceAccountToken(workloadIdentityKSATokenProjection))
-                   .addSourcesItem(new V1VolumeProjection().configMap(workloadIdentityGSAConfigMapProjection)));
-    V1VolumeMount expectedWorkloadIdentityProjectedVolumeMount = new V1VolumeMount().name("gcp-ksa")
-      .mountPath("/var/run/secrets/tokens/gcp-ksa").readOnly(true);
-    V1EnvVar expectedGoogleApplicationCredentialsEnvVar = new V1EnvVar().name("GOOGLE_APPLICATION_CREDENTIALS")
-      .value("/var/run/secrets/tokens/gcp-ksa/google-application-credentials.json");
-    // Verify pod specs
-    assertContainsVolume(driverPod, expectedWorkloadIdentityProjectedVolume);
-    assertContainersContainVolumeMount(driverPod, expectedWorkloadIdentityProjectedVolumeMount);
-    assertContainersContainEnvVar(driverPod, expectedGoogleApplicationCredentialsEnvVar);
-    assertContainsVolume(executorPod, expectedWorkloadIdentityProjectedVolume);
-    assertContainersContainVolumeMount(executorPod, expectedWorkloadIdentityProjectedVolumeMount);
-    assertContainersContainEnvVar(executorPod, expectedGoogleApplicationCredentialsEnvVar);
-  }
-
-  @Test
-  public void testGetComponentName() {
-    // Ensure valid pod names are parsed correctly
-    String gotName = KubeMasterEnvironment.getComponentName(
-      "instance-abc", "cdap-instance-abc-appfabric-0");
-    Assert.assertEquals("appfabric-0", gotName);
-
-    gotName = KubeMasterEnvironment.getComponentName(
-      "123", "cdap-123-appfabric-23");
-    Assert.assertEquals("appfabric-23", gotName);
-
-    gotName = KubeMasterEnvironment.getComponentName(
-      "cdap", "cdap-cdap-appfabric-0");
-    Assert.assertEquals("appfabric-0", gotName);
-
-    gotName = KubeMasterEnvironment.getComponentName(
-      "", "cdap-test-metrics-0");
-    Assert.assertEquals("test-metrics-0", gotName);
-
-    gotName = KubeMasterEnvironment.getComponentName(
-      "test-cdap", "cdap-test-cdap-preview-runner-b5786a15-e8f4-47-0cebad7d67-0");
-    Assert.assertEquals("preview-runner-b5786a15-e8f4-47-0cebad7d67-0", gotName);
-
-    gotName = KubeMasterEnvironment.getComponentName(
-      "dap", "cdap-dap-preview-runner-b5786a15-e8f4-47-0cebad7d67-0");
-    Assert.assertEquals("preview-runner-b5786a15-e8f4-47-0cebad7d67-0", gotName);
   }
 }


### PR DESCRIPTION
Previously, we relied on CDAP copying over the workload identity volume from the default namespace during namespace creation. However, we should not be copying and only create/mount a workload identity configmap to a workload pod if the namespace is workload identity enabled.

[CDAP-19340] Filter workload identity environment variables from parent pod

[CDAP-19340] Only mount workload identity configuration if namespace has a service account sepcified, and refactor workload identity functionality into utility class

[CDAP-19340] Only mount workload identity configmap if namespace has an associated service account

[CDAP-19340]: https://cdap.atlassian.net/browse/CDAP-19340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-19340]: https://cdap.atlassian.net/browse/CDAP-19340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-19340]: https://cdap.atlassian.net/browse/CDAP-19340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ