### PR TITLE
[CDAP-19455] Transition runs throttled by RuntimeJobManager to "rejected" state instead of "failed"

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/MessagingProgramStateWriter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/MessagingProgramStateWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2019 Cask Data, Inc.
+ * Copyright © 2017-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -154,6 +154,7 @@ public final class MessagingProgramStateWriter implements ProgramStateWriter {
       .put(ProgramOptionConstants.PROGRAM_STATUS, ProgramRunStatus.REJECTED.name())
       .put(ProgramOptionConstants.USER_ID, userId)
       .put(ProgramOptionConstants.PROGRAM_DESCRIPTOR, GSON.toJson(programDescriptor))
+      .put(ProgramOptionConstants.END_TIME, String.valueOf(System.currentTimeMillis()))
       .put(ProgramOptionConstants.PROGRAM_ERROR, GSON.toJson(new BasicThrowable(cause)));
     programStatePublisher.publish(Notification.Type.PROGRAM_STATUS, properties.build());
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberServiceTest.java
@@ -403,6 +403,18 @@ public class ProgramNotificationSubscriberServiceTest {
     });
     checkProgramStatus(artifactId, runId3, ProgramRunStatus.STOPPING);
     heartbeatDatasetStatusCheck(stopTime, ProgramRunStatus.KILLED);
+
+    ProgramRunId runId4 = programId.run(RunIds.generate());
+    TransactionRunners.run(transactionRunner, context -> {
+      programStateWriter.start(runId4, programOptions, null, programDescriptor);
+    });
+    checkProgramStatus(artifactId, runId4, ProgramRunStatus.STARTING);
+    TransactionRunners.run(transactionRunner, context -> {
+      programStateWriter.reject(runId4, programOptions, programDescriptor,
+          "internal", new Throwable("program rejected"));
+    });
+    // rejected status check.
+    checkProgramStatus(artifactId, runId4, ProgramRunStatus.REJECTED);
   }
 
   private void checkProgramStatus(ArtifactId artifactId, ProgramRunId runId, ProgramRunStatus expectedStatus)

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/ProgramRunStatus.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/ProgramRunStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2019 Cask Data, Inc.
+ * Copyright © 2014-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -68,8 +68,9 @@ public enum ProgramRunStatus {
         // FAILED happens if the run failed while starting
         // COMPLETED happens somehow? Not sure when we expect this but we test that this transition can happen
         // SUSPENDED happens if you suspend while starting. Not sure why this is allowed, seems wrong (CDAP-13551)
+        // REJECTED happens if the runtime job manager rejects the job due to throttling.
         return status == RUNNING || status == STOPPING || status == SUSPENDED || status == COMPLETED ||
-          status == KILLED || status == FAILED;
+            status == KILLED || status == FAILED || status == REJECTED;
       case RUNNING:
         // SUSPENDED happens if the run was suspended
         // STOPPING happens if the run was manually stopped gracefully(may include a timeout)

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/TooManyRequestsException.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/TooManyRequestsException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner;
+
+/**
+ * Thrown when throttling occurs while starting a job.
+ */
+public class TooManyRequestsException extends Exception {
+  public TooManyRequestsException() {
+    super();
+  }
+
+  public TooManyRequestsException(String message) {
+    super(message);
+  }
+
+  public TooManyRequestsException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
[CDAP 19455](https://cdap.atlassian.net/browse/CDAP-19455)

When Dataproc submit job API is called, it returns a 429 HTTP code or RESOURCE_EXHAUSTED grpc code when their master agent isn't running on Dataproc master node. This transitions the pipeline to a failed state. Rejected state better represents rate limiting errors, so this PR aims to transition such failures to rejected state instead.

A new exception `TooManyRequestsException` is added to the runtime SPI. When runtime job managers throw this exception, pipeline is transitioned to rejected state by `RemoteExecutionTwillRunnerService`.

Added a function call to handle pipeline completion when pipeline transitions to rejected state. Previously transitions to `rejected` happened before reaching the starting state. In such cases call to handle pipeline completion is avoided.

Manually tested to ensure pipelines with unhealthy dataproc master node are rejected: 
<img width="1486" alt="Screenshot 2022-07-29 at 5 43 54 PM" src="https://user-images.githubusercontent.com/46515553/181756191-a6631708-709c-446d-8a76-e3f3341c8071.png">

Manually tested to ensure flow control still works as it used to.
<img width="1502" alt="Screenshot 2022-07-29 at 5 45 34 PM" src="https://user-images.githubusercontent.com/46515553/181756460-8b73d3dd-9665-44e9-858f-67f5eb465ba9.png">

