### PR TITLE
[CDAP-19448] Cherrypick 6.7

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/RemoteWorkerPluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/RemoteWorkerPluginFinder.java
@@ -46,6 +46,6 @@ public class RemoteWorkerPluginFinder extends RemotePluginFinder {
   @Override
   protected Location getArtifactLocation(ArtifactId artifactId)
     throws IOException, ArtifactNotFoundException, UnauthorizedException {
-    return Locations.toLocation(artifactLocalizerClient.getUnpackedArtifactLocation(artifactId));
+    return Locations.toLocation(artifactLocalizerClient.getArtifactLocation(artifactId));
   }
 }


### PR DESCRIPTION
Cherry-pick of #14458 

[CDAP-19448] Don't unpack artifacts in task workers due to spark compilation failure

[CDAP-19448]: https://cdap.atlassian.net/browse/CDAP-19448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ