### PR TITLE
chore(CDAP-19493): turn on the feature flag for Composite Trigger

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5305,7 +5305,7 @@
 
   <property>
     <name>feature.pipeline.composite.triggers.enabled</name>
-    <value>false</value>
+    <value>true</value>
     <description>
       Enables configuring composite AND/OR triggers for a pipeline schedule.
     </description>


### PR DESCRIPTION
Turn on the composite trigger flag by default. This feature is supposed to be released in 6.8.0. We'd like to bake it in advance  for some time in develop


The sister PR that updates the UI: https://github.com/cdapio/cdap-ui/pull/587