### PR TITLE
[CDAP-19283] Throw exception from SparkProgramStatusMetricsProvider when metrics cannot be retrieved successfully

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/events/MetricsProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/events/MetricsProvider.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.internal.events;
 
+import io.cdap.cdap.common.MetricRetrievalException;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.spi.events.ExecutionMetrics;
 
@@ -30,5 +31,5 @@ public interface MetricsProvider {
    *
    * @param runId The {@link ProgramRunId} which references this execution.
    */
-  ExecutionMetrics[] retrieveMetrics(ProgramRunId runId);
+  ExecutionMetrics[] retrieveMetrics(ProgramRunId runId) throws MetricRetrievalException;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/events/SparkProgramStatusMetricsProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/events/SparkProgramStatusMetricsProvider.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.api.retry.RetryableException;
+import io.cdap.cdap.common.MetricRetrievalException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.service.Retries;
@@ -78,7 +79,7 @@ public class SparkProgramStatusMetricsProvider implements MetricsProvider {
   }
 
   @Override
-  public ExecutionMetrics[] retrieveMetrics(ProgramRunId runId) {
+  public ExecutionMetrics[] retrieveMetrics(ProgramRunId runId) throws MetricRetrievalException {
     if (!runId.getType().equals(ProgramType.SPARK)) {
       return new ExecutionMetrics[]{ExecutionMetrics.emptyMetrics()};
     }
@@ -120,8 +121,7 @@ public class SparkProgramStatusMetricsProvider implements MetricsProvider {
         t -> t instanceof RetryableException);
     } catch (Exception e) {
       emitMetrics(runId, startTime, false);
-      logger.error("Retries failed for extracting metrics. ", e);
-      return new ExecutionMetrics[]{};
+      throw new MetricRetrievalException(e);
     }
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/events/SparkProgramStatusMetricsProviderTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/events/SparkProgramStatusMetricsProviderTest.java
@@ -16,8 +16,11 @@
 
 package io.cdap.cdap.internal.events;
 
+import io.cdap.cdap.common.MetricRetrievalException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.spi.events.ExecutionMetrics;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -40,6 +43,8 @@ public class SparkProgramStatusMetricsProviderTest {
   private final String mockedApplicationJson = "mocked_spark_applications_response.json";
   private final String mockedStagesJson = "mocked_spark_stages_response.json";
   private final String mockedStagesSeveralStagesJson = "mocked_spark_stages_response_several_stages.json";
+  private final ProgramRunId mockProgramRunId =
+    new ProgramRunId("ns", "app", ProgramType.SPARK, "test", mockedRunId);
 
   @BeforeClass
   public static void setupClass() throws IOException {
@@ -66,6 +71,16 @@ public class SparkProgramStatusMetricsProviderTest {
     String responseStr = loadMockedResponseAsString(mockedStagesSeveralStagesJson);
     ExecutionMetrics[] metrics = metricsProvider.extractMetrics(responseStr);
     Assert.assertArrayEquals(metrics, getMockedMetricsSeveralStages());
+  }
+
+  @Test
+  public void testRetriveMetricsFail() throws MetricRetrievalException {
+    try {
+      ExecutionMetrics[] metrics = metricsProvider.retrieveMetrics(mockProgramRunId);
+      Assert.fail("Expected an Exception");
+    } catch (MetricRetrievalException e) {
+      //expected
+    }
   }
 
   private String loadMockedResponseAsString(String mockedFile) {

--- a/cdap-common/src/main/java/io/cdap/cdap/common/MetricRetrievalException.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/MetricRetrievalException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common;
+
+/**
+ * Thrown when metrics can not be retrieved successfully.
+ */
+
+public class MetricRetrievalException extends Exception {
+
+  public MetricRetrievalException(String message) {
+    super(message);
+  }
+
+  public MetricRetrievalException(Throwable cause) {
+    super(cause);
+  }
+
+  public MetricRetrievalException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
Jira: https://cdap.atlassian.net/browse/CDAP-19283

Throw Exception in SparkProgramStatusMetricsProvider.java, update ProgramStatusEventPublisher.java file to catch the exception.
Add Test for retrieved metric failed. 