### PR TITLE
[CDAP-19051] Add dataproc operation ID to failure log messages

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocRetryableException.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocRetryableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,34 +17,16 @@
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
 import com.google.common.base.Throwables;
+import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
 
 import javax.annotation.Nullable;
 
 /**
- * A {@link RuntimeException} that wraps exceptions from Dataproc operation and provide a {@link #toString()}
- * implementation that doesn't include this exception class name and with the root cause error message.
+ * An exception thrown while performing a Dataproc operation that may succeed after a retry.
  */
-public class DataprocRuntimeException extends RuntimeException {
-
-  public DataprocRuntimeException(String message) {
-    super(message);
-  }
-
-  public DataprocRuntimeException(Throwable cause) {
-    super(createMessage(cause), cause);
-  }
-
-  public DataprocRuntimeException(@Nullable String operationId, Throwable cause) {
+public class DataprocRetryableException extends RetryableProvisionException  {
+  public DataprocRetryableException(@Nullable String operationId, Throwable cause) {
     super(createMessage(operationId, cause), cause);
-  }
-
-  @Override
-  public String toString() {
-    return getMessage();
-  }
-
-  private static String createMessage(Throwable cause) {
-    return createMessage(null, cause);
   }
 
   private static String createMessage(@Nullable String operationId, Throwable cause) {

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClientTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClientTest.java
@@ -20,27 +20,40 @@ import com.google.api.client.googleapis.json.GoogleJsonError;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
+import com.google.api.core.ApiFuture;
 import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.httpjson.HttpJsonStatusCode;
+import com.google.api.gax.longrunning.OperationFuture;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.services.compute.Compute;
+import com.google.cloud.dataproc.v1.Cluster;
 import com.google.cloud.dataproc.v1.ClusterControllerClient;
+import com.google.cloud.dataproc.v1.ClusterOperationMetadata;
+import com.google.cloud.dataproc.v1.DeleteClusterRequest;
+import com.google.protobuf.Empty;
 import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
 import io.grpc.Status;
+import org.hamcrest.core.IsInstanceOf;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 @PrepareForTest({DataprocClient.class, ClusterControllerClient.class})
 @RunWith(PowerMockRunner.class)
@@ -52,7 +65,12 @@ public class DataprocClientTest {
   @Mock
   private ClusterControllerClient clusterControllerClientMock;
 
-  private DataprocClientFactory clientFactory;
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  private DataprocClientFactory sshDataprocClientFactory;
+  private DataprocClientFactory mockDataprocClientFactory;
+
   private Compute.Networks.List listMock;
   private DataprocConf dataprocConf;
 
@@ -65,24 +83,29 @@ public class DataprocClientTest {
     properties.put("zone", "us-test1-c");
     dataprocConf = DataprocConf.create(properties);
 
-    clientFactory = (conf, requireSSH) ->
+    sshDataprocClientFactory = (conf, requireSSH) ->
       new SSHDataprocClient(dataprocConf, clusterControllerClientMock, dconf -> computeMock);
+    mockDataprocClientFactory = (conf, requireSSH) ->
+      new MockDataprocClient(dataprocConf, clusterControllerClientMock, dconf -> computeMock);
 
     Compute.Networks networksMock = Mockito.mock(Compute.Networks.class);
     listMock = Mockito.mock(Compute.Networks.List.class);
     Mockito.when(computeMock.networks()).thenReturn(networksMock);
     Mockito.when(networksMock.list(Mockito.any())).thenReturn(listMock);
+    Mockito.when(clusterControllerClientMock.getCluster(Mockito.any())).thenReturn(Cluster.newBuilder().build());
 
   }
 
-  @Test(expected = RetryableProvisionException.class)
+  @Test
   public void testReadTimeOutThrowsRetryableException() throws Exception {
     Mockito.when(listMock.execute()).thenThrow(SocketTimeoutException.class);
-    DataprocClient client = clientFactory.create(dataprocConf);
+    DataprocClient client = sshDataprocClientFactory.create(dataprocConf);
+    thrown.expect(RetryableProvisionException.class);
+    thrown.expectCause(IsInstanceOf.instanceOf(SocketTimeoutException.class));
     client.createCluster("name", "2.0", Collections.emptyMap(), true, null);
   }
 
-  @Test(expected = RetryableProvisionException.class)
+  @Test
   public void rateLimitThrowsRetryableException() throws Exception {
 
     List<GoogleJsonError.ErrorInfo> errorList = new ArrayList<>();
@@ -100,11 +123,13 @@ public class DataprocClientTest {
     GoogleJsonResponseException gError = new GoogleJsonResponseException(builder, googleJsonError);
 
     Mockito.when(listMock.execute()).thenThrow(gError);
-    DataprocClient client = clientFactory.create(dataprocConf);
+    DataprocClient client = sshDataprocClientFactory.create(dataprocConf);
+    thrown.expect(RetryableProvisionException.class);
+    thrown.expectCause(IsInstanceOf.instanceOf(GoogleJsonResponseException.class));
     client.createCluster("name", "2.0", Collections.emptyMap(), true, null);
   }
 
-  @Test(expected = GoogleJsonResponseException.class)
+  @Test
   public void nonRateLimitDoesNotThrowsRetryableException() throws Exception {
 
     List<GoogleJsonError.ErrorInfo> errorList = new ArrayList<>();
@@ -122,13 +147,14 @@ public class DataprocClientTest {
     GoogleJsonResponseException gError = new GoogleJsonResponseException(builder, googleJsonError);
 
     Mockito.when(listMock.execute()).thenThrow(gError);
-    DataprocClient client = clientFactory.create(dataprocConf);
+    DataprocClient client = sshDataprocClientFactory.create(dataprocConf);
+    thrown.expect(GoogleJsonResponseException.class);
     client.createCluster("name", "2.0", Collections.emptyMap(), true, null);
   }
 
 
 
-  @Test(expected = RetryableProvisionException.class)
+  @Test
   public void apiExceptionWithNon4XXThrowsRetryableException() throws Exception {
     //500
     ApiException e = new ApiException(new Throwable(), GrpcStatusCode.of(Status.Code.UNKNOWN), true);
@@ -136,12 +162,12 @@ public class DataprocClientTest {
     PowerMockito.when(clusterControllerClientMock.listClusters(Mockito.anyString(), Mockito.anyString(),
                                                                Mockito.anyString()))
       .thenThrow(e);
-
-    clientFactory.create(dataprocConf).getClusters(null, new HashMap<>());
+    thrown.expect(RetryableProvisionException.class);
+    thrown.expectCause(IsInstanceOf.instanceOf(ApiException.class));
+    sshDataprocClientFactory.create(dataprocConf).getClusters(null, new HashMap<>());
   }
 
-
-  @Test(expected = DataprocRuntimeException.class)
+  @Test
   public void apiExceptionWith4XXNotThrowRetryableException() throws Exception {
     //500
     ApiException e = new ApiException(new Throwable(), GrpcStatusCode.of(Status.Code.UNAUTHENTICATED), true);
@@ -149,7 +175,78 @@ public class DataprocClientTest {
     PowerMockito.when(clusterControllerClientMock.listClusters(Mockito.anyString(), Mockito.anyString(),
                                                                Mockito.anyString()))
       .thenThrow(e);
+    thrown.expect(DataprocRuntimeException.class);
+    thrown.expectMessage("Dataproc operation failure");
+    thrown.expectCause(IsInstanceOf.instanceOf(ApiException.class));
+    sshDataprocClientFactory.create(dataprocConf).getClusters(null, new HashMap<>());
+  }
 
-    clientFactory.create(dataprocConf).getClusters(null, new HashMap<>());
+  @Test
+  public void testCreateClusterThrowsDataprocRetryableException() throws Exception {
+    OperationFuture<Cluster, ClusterOperationMetadata> operationFuture = Mockito.mock(OperationFuture.class);
+    Mockito.when(clusterControllerClientMock.createClusterAsync(Matchers.eq(dataprocConf.getProjectId()),
+                                                                Matchers.eq(dataprocConf.getRegion()),
+                                                                Mockito.any(Cluster.class)))
+      .thenReturn(operationFuture);
+    ApiFuture<ClusterOperationMetadata> apiFuture = Mockito.mock(ApiFuture.class);
+    String errorMessage = "Connection reset by peer";
+    ApiException apiException = new ApiException(new IOException(errorMessage),
+                                                 HttpJsonStatusCode.of(503),
+                                                 true);
+    Mockito.when(apiFuture.get()).thenThrow(new ExecutionException(apiException));
+    Mockito.when(operationFuture.getMetadata()).thenReturn(apiFuture);
+    String operationId = "projects/proj/regions/us-east1/operations/myop";
+    Mockito.when(operationFuture.getName()).thenReturn(operationId);
+    thrown.expect(DataprocRetryableException.class);
+    thrown.expectMessage(String.format("Dataproc operation %s failure: %s", operationId, errorMessage));
+    thrown.expectCause(IsInstanceOf.instanceOf(ApiException.class));
+    mockDataprocClientFactory.create(dataprocConf).createCluster("name", "2.0",
+                                                                 Collections.emptyMap(), true, null);
+  }
+
+  @Test
+  public void testCreateClusterThrowsDataprocRuntimeException() throws Exception {
+    OperationFuture<Cluster, ClusterOperationMetadata> operationFuture = Mockito.mock(OperationFuture.class);
+    Mockito.when(clusterControllerClientMock.createClusterAsync(Matchers.eq(dataprocConf.getProjectId()),
+                                                                Matchers.eq(dataprocConf.getRegion()),
+                                                                Mockito.any(Cluster.class)))
+      .thenReturn(operationFuture);
+    ApiFuture<ClusterOperationMetadata> apiFuture = Mockito.mock(ApiFuture.class);
+    String errorMessage = "Operation not found";
+    ApiException apiException = new ApiException(new IOException(errorMessage),
+                                                 HttpJsonStatusCode.of(404),
+                                                 false);
+    Mockito.when(apiFuture.get()).thenThrow(new ExecutionException(apiException));
+    Mockito.when(operationFuture.getMetadata()).thenReturn(apiFuture);
+    String operationId = "projects/proj/regions/us-east1/operations/myop";
+    Mockito.when(operationFuture.getName()).thenReturn(operationId);
+    thrown.expect(DataprocRuntimeException.class);
+    thrown.expectMessage(String.format("Dataproc operation %s failure: %s", operationId, errorMessage));
+    thrown.expectCause(IsInstanceOf.instanceOf(ApiException.class));
+    mockDataprocClientFactory.create(dataprocConf).createCluster("name", "2.0",
+                                                                 Collections.emptyMap(), true, null);
+  }
+
+  @Test
+  public void testDeleteClusterThrowsException() throws Exception {
+    OperationFuture<Empty, ClusterOperationMetadata> operationFuture = Mockito.mock(OperationFuture.class);
+    String clusterName = "mycluster";
+    DeleteClusterRequest request = DeleteClusterRequest.newBuilder()
+      .setClusterName(clusterName)
+      .setProjectId(dataprocConf.getProjectId())
+      .setRegion(dataprocConf.getRegion())
+      .build();
+    Mockito.when(clusterControllerClientMock.deleteClusterAsync(request))
+      .thenReturn(operationFuture);
+    ApiFuture<ClusterOperationMetadata> apiFuture = Mockito.mock(ApiFuture.class);
+    String errorMessage = "Connection reset by peer";
+    Mockito.when(apiFuture.get()).thenThrow(new ExecutionException(new IOException(errorMessage)));
+    Mockito.when(operationFuture.getMetadata()).thenReturn(apiFuture);
+    String operationId = "projects/proj/regions/us-east1/operations/myop";
+    Mockito.when(operationFuture.getName()).thenReturn(operationId);
+    thrown.expect(DataprocRuntimeException.class);
+    thrown.expectMessage(String.format("Dataproc operation %s failure: %s", operationId, errorMessage));
+    thrown.expectCause(IsInstanceOf.instanceOf(IOException.class));
+    mockDataprocClientFactory.create(dataprocConf).deleteCluster(clusterName);
   }
 }

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockDataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockDataprocClient.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.provisioner.dataproc;
+
+import com.google.api.services.compute.Compute;
+import com.google.cloud.dataproc.v1.ClusterControllerClient;
+import com.google.cloud.dataproc.v1.GceClusterConfig;
+import io.cdap.cdap.runtime.spi.provisioner.Node;
+
+import java.util.Collections;
+
+public class MockDataprocClient extends DataprocClient {
+  public MockDataprocClient(DataprocConf conf, ClusterControllerClient client, ComputeFactory computeFactory) {
+    super(conf, client, computeFactory);
+  }
+
+  @Override
+  protected void setNetworkConfigs(Compute compute, GceClusterConfig.Builder clusterConfig,
+                                   boolean privateInstance) {
+    // no-op
+  }
+
+  @Override
+  protected Node getNode(Node.Type type, String zone, String nodeName) {
+    return new Node("", type, null, 0, Collections.emptyMap());
+  }
+}


### PR DESCRIPTION
Log operation id when cluster create/delete cluster operations fail, to help with debugging on the dataproc side.