### PR TITLE
feat(CDAP-19426): Add the abbility to add new columns&indexes to StructuredTableAdmin

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/config/UserConfigStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/config/UserConfigStoreTest.java
@@ -41,7 +41,7 @@ public abstract class UserConfigStoreTest {
   @Before
   public void setupTest() throws Exception {
     if (!admin.exists(StoreDefinition.ConfigStore.CONFIGS)) {
-      admin.create(StoreDefinition.ConfigStore.CONFIG_TABLE_SPEC);
+      admin.createOrUpdate(StoreDefinition.ConfigStore.CONFIG_TABLE_SPEC);
     }
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/connection/ConnectionStoreTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/connection/ConnectionStoreTest.java
@@ -47,7 +47,7 @@ public class ConnectionStoreTest extends SystemAppTestBase {
 
   @BeforeClass
   public static void setupTest() throws Exception {
-    getStructuredTableAdmin().create(ConnectionStore.CONNECTION_TABLE_SPEC);
+    getStructuredTableAdmin().createOrUpdate(ConnectionStore.CONNECTION_TABLE_SPEC);
     connectionStore = new ConnectionStore(getTransactionRunner());
   }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -633,13 +633,15 @@ public final class Constants {
     public static final String DATA_STORAGE_SQL_DRIVER_DIRECTORY = "data.storage.sql.jdbc.driver.directory";
     public static final String DATA_STORAGE_SQL_JDBC_DRIVER_NAME = "data.storage.sql.jdbc.driver.name";
 
-    // the jdbc connection related properties should be from cdap-security.xml
+    // the jdbc connection related properties should be from cdap-site.xml
     public static final String DATA_STORAGE_SQL_JDBC_CONNECTION_URL = "data.storage.sql.jdbc.connection.url";
-    public static final String DATA_STORAGE_SQL_USERNAME = "data.storage.sql.jdbc.username";
-    public static final String DATA_STORAGE_SQL_PASSWORD = "data.storage.sql.jdbc.password";
     public static final String DATA_STORAGE_SQL_PROPERTY_PREFIX = "data.storage.sql.jdbc.property.";
     public static final String DATA_STORAGE_SQL_CONNECTION_SIZE = "data.storage.sql.jdbc.connection.pool.size";
     public static final String DATA_STORAGE_SQL_SCAN_FETCH_SIZE_ROWS = "data.storage.sql.scan.size.rows";
+
+    // the db credentials properties should be from cdap-security.xml
+    public static final String DATA_STORAGE_SQL_USERNAME = "data.storage.sql.jdbc.username";
+    public static final String DATA_STORAGE_SQL_PASSWORD = "data.storage.sql.jdbc.password";
 
     // used for Guice named bindings
     public static final String TABLE_TYPE = "table.type";

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/MetricsTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/MetricsTable.java
@@ -49,7 +49,7 @@ public interface MetricsTable extends Dataset {
   void putBytes(SortedMap<byte[], ? extends SortedMap<byte[], byte[]>> updates);
 
   /**
-   * Atomically compare a single column of a row with a expected value, and if it matches, replace it with a new value.
+   * Atomically compare a single column of a row with an expected value, and if it matches, replace it with a new value.
    * @param oldValue the expected value of the column. If null, this means that the column must not exist.
    * @param newValue the new value of the column. If null, the effect to delete the column if the comparison succeeds.
    * @return whether the write happened, that is, whether the existing value of the column matched the expected value.

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/CachedStructuredTableRegistry.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/CachedStructuredTableRegistry.java
@@ -19,7 +19,6 @@ package io.cdap.cdap.spi.data.common;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.table.StructuredTableId;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 import org.slf4j.Logger;
@@ -56,7 +55,7 @@ public class CachedStructuredTableRegistry implements StructuredTableRegistry {
 
   @Override
   public void registerSpecification(StructuredTableSpecification specification)
-    throws IOException, TableAlreadyExistsException {
+    throws IOException {
     delegate.registerSpecification(specification);
     specCache.invalidate(specification.getTableId());
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/StructuredTableRegistry.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/StructuredTableRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2019-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,7 +17,6 @@
 package io.cdap.cdap.spi.data.common;
 
 import io.cdap.cdap.api.annotation.Beta;
-import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.table.StructuredTableId;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 
@@ -35,10 +34,9 @@ public interface StructuredTableRegistry {
    *
    * @param specification table specification to register
    * @throws IOException if not able to write to the underlying storage
-   * @throws TableAlreadyExistsException if the table already exists
    */
   void registerSpecification(StructuredTableSpecification specification)
-    throws IOException, TableAlreadyExistsException;
+    throws IOException;
 
   /**
    * Get the specification of a table if it exists in the registry.

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableAdmin.java
@@ -25,8 +25,8 @@ import io.cdap.cdap.api.dataset.lib.IndexedTable;
 import io.cdap.cdap.api.dataset.lib.IndexedTableDefinition;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.TableNotFoundException;
+import io.cdap.cdap.spi.data.TableSchemaIncompatibleException;
 import io.cdap.cdap.spi.data.common.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.table.StructuredTableId;
 import io.cdap.cdap.spi.data.table.StructuredTableSchema;
@@ -62,9 +62,11 @@ public final class NoSqlStructuredTableAdmin implements StructuredTableAdmin {
   }
 
   @Override
-  public void create(StructuredTableSpecification spec) throws IOException, TableAlreadyExistsException {
+  public void createOrUpdate(StructuredTableSpecification spec)
+    throws IOException, TableSchemaIncompatibleException {
     if (exists(spec.getTableId())) {
-      throw new TableAlreadyExistsException(spec.getTableId());
+      updateTable(spec);
+      return;
     }
     LOG.info("Creating table {} in namespace {}", spec, NamespaceId.SYSTEM);
     DatasetAdmin indexTableAdmin = indexTableDefinition.getAdmin(SYSTEM_CONTEXT, indexTableSpec, null);
@@ -87,6 +89,24 @@ public final class NoSqlStructuredTableAdmin implements StructuredTableAdmin {
       throw new TableNotFoundException(tableId);
     }
     return new StructuredTableSchema(spec);
+  }
+
+  private void updateTable(StructuredTableSpecification spec)
+    throws IOException, TableNotFoundException, TableSchemaIncompatibleException {
+    StructuredTableId tableId = spec.getTableId();
+    StructuredTableSpecification existingSpec = registry.getSpecification(tableId);
+    if (existingSpec == null) {
+      throw new TableNotFoundException(tableId);
+    }
+    if (existingSpec.equals(spec)) {
+      LOG.trace("The table schema is already up to date: {}", tableId);
+      return;
+    }
+    StructuredTableSchema existingSchema = new StructuredTableSchema(existingSpec);
+    if (!existingSchema.isCompatible(spec)) {
+      throw new TableSchemaIncompatibleException(tableId);
+    }
+    registry.registerSpecification(spec);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
@@ -17,7 +17,7 @@
 package io.cdap.cdap.store;
 
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.TableAlreadyExistsException;
+import io.cdap.cdap.spi.data.TableSchemaIncompatibleException;
 import io.cdap.cdap.spi.data.table.StructuredTableId;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 import io.cdap.cdap.spi.data.table.field.Fields;
@@ -79,13 +79,9 @@ public final class StoreDefinition {
 
     StructuredTableId tableId = spec.getTableId();
     try {
-      if (!admin.exists(tableId)) {
-        admin.create(spec);
-      }
-    } catch (TableAlreadyExistsException e) {
-      if (!admin.getSchema(tableId).isCompatible(spec)) {
-        throw new IllegalStateException("Table " + tableId + " already exists with an incompatible schema", e);
-      }
+      admin.createOrUpdate(spec);
+    } catch (TableSchemaIncompatibleException e) {
+      throw new IllegalStateException("Table " + tableId + " already exists with an incompatible schema", e);
     }
   }
 
@@ -356,8 +352,9 @@ public final class StoreDefinition {
       createIfNotExists(tableAdmin, PROVISIONER_STORE_SPEC);
     }
   }
+
   /**
-   *  Defines schema for AppMetadata tables
+   * Defines schema for AppMetadata tables
    */
   public static final class AppMetadataStore {
 
@@ -847,7 +844,7 @@ public final class StoreDefinition {
   }
 
   /**
-   *  Schema for usage table
+   * Schema for usage table
    */
   public static final class UsageStore {
     public static final StructuredTableId USAGES = new StructuredTableId("usages");
@@ -878,10 +875,10 @@ public final class StoreDefinition {
 
   /**
    * Schema for field lineage.
-   *
+   * <p>
    * Endpoint checksum table is used to store endpoints/properties of endpoints to a checksum. Checksum can then be
    * used the query the other tables. Also contains the program run info for that checksum.
-   *
+   * <p>
    * The remaining tables store various endpoint data keyed by checksum.
    */
   public static final class FieldLineageStore {

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/common/StructuredTableRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/common/StructuredTableRegistryTest.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.spi.data.common;
 
-import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.table.StructuredTableId;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 import io.cdap.cdap.spi.data.table.field.FieldType;
@@ -83,14 +82,6 @@ public abstract class StructuredTableRegistryTest {
     registry.registerSpecification(SPEC2);
     Assert.assertEquals(SPEC2, registry.getSpecification(TABLE2));
     Assert.assertFalse(registry.isEmpty());
-
-    // Re-registering table1 should fail
-    try {
-      registry.registerSpecification(SPEC1);
-      Assert.fail("Expected re-registration to fail");
-    } catch (TableAlreadyExistsException e) {
-      // Expected
-    }
 
     // Remove spec for table1, and try again to register
     registry.removeSpecification(TABLE1);

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableAdminTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableAdminTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,8 +20,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.StructuredTableConcurrencyTest;
-import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.StructuredTableAdminTest;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tephra.TransactionManager;
 import org.junit.AfterClass;
@@ -31,25 +30,14 @@ import org.junit.ClassRule;
 import java.io.IOException;
 
 /**
- * Tests concurrent operations on {@link NoSqlStructuredTable}.
+ * Test for NoSQL structured table admin.
  */
-public class NoSqlStructuredTableConcurrencyTest extends StructuredTableConcurrencyTest {
+public class NoSqlStructuredTableAdminTest extends StructuredTableAdminTest {
   @ClassRule
   public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
 
   private static TransactionManager txManager;
   private static StructuredTableAdmin noSqlTableAdmin;
-  private static TransactionRunner transactionRunner;
-
-  @Override
-  protected StructuredTableAdmin getStructuredTableAdmin() {
-    return noSqlTableAdmin;
-  }
-
-  @Override
-  protected TransactionRunner getTransactionRunner() {
-    return transactionRunner;
-  }
 
   @BeforeClass
   public static void beforeClass() throws IOException {
@@ -60,7 +48,11 @@ public class NoSqlStructuredTableConcurrencyTest extends StructuredTableConcurre
     CConfiguration cConf = dsFrameworkUtil.getConfiguration();
     cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
     noSqlTableAdmin = dsFrameworkUtil.getInjector().getInstance(StructuredTableAdmin.class);
-    transactionRunner = dsFrameworkUtil.getInjector().getInstance(TransactionRunner.class);
+  }
+
+  @Override
+  protected StructuredTableAdmin getStructuredTableAdmin() throws Exception {
+    return noSqlTableAdmin;
   }
 
   @AfterClass

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableRegistryTest.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.data2.dataset2.DatasetFrameworkTestUtil;
 import io.cdap.cdap.spi.data.common.StructuredTableRegistry;
 import io.cdap.cdap.spi.data.common.StructuredTableRegistryTest;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.tephra.TransactionManager;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -47,7 +46,7 @@ public class NoSqlStructuredTableRegistryTest extends StructuredTableRegistryTes
 
   @BeforeClass
   public static void beforeClass() {
-    Configuration txConf = HBaseConfiguration.create();
+    Configuration txConf = new Configuration();
     txManager = new TransactionManager(txConf);
     txManager.startAndWait();
   }

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
@@ -29,7 +29,6 @@ import io.cdap.cdap.spi.data.StructuredTableTest;
 import io.cdap.cdap.spi.data.table.StructuredTableSchema;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.tephra.TransactionManager;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -47,7 +46,7 @@ import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 
 /**
- * Unit test for nosql strcutured table.
+ * Unit test for nosql structured table.
  */
 public class NoSqlStructuredTableTest extends StructuredTableTest {
   @ClassRule
@@ -71,7 +70,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
 
   @BeforeClass
   public static void beforeClass() throws IOException {
-    Configuration txConf = HBaseConfiguration.create();
+    Configuration txConf = new Configuration();
     txManager = new TransactionManager(txConf);
     txManager.startAndWait();
 

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableAdminTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableAdminTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data.sql;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.StructuredTableAdminTest;
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+/**
+ * Test for SQL structured table admin.
+ */
+public class SqlStructuredTableAdminTest extends StructuredTableAdminTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+  private static StructuredTableAdmin tableAdmin;
+  private static EmbeddedPostgres pg;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    pg = PostgresInstantiator.createAndStart(cConf, TEMP_FOLDER.newFolder());
+
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new StorageModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class).in(Scopes.SINGLETON);
+        }
+      }
+    );
+
+    tableAdmin = injector.getInstance(StructuredTableAdmin.class);
+
+    Assert.assertEquals(PostgreSqlStructuredTableAdmin.class, tableAdmin.getClass());
+  }
+
+  @AfterClass
+  public static void afterClass() throws IOException {
+    if (pg != null) {
+      pg.close();
+    }
+  }
+
+  @Override
+  protected StructuredTableAdmin getStructuredTableAdmin() throws Exception {
+    return tableAdmin;
+  }
+}

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableAdmin.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableAdmin.java
@@ -32,15 +32,19 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
-import io.cdap.cdap.spi.data.TableAlreadyExistsException;
+import io.cdap.cdap.spi.data.TableDuplicateUpdateException;
 import io.cdap.cdap.spi.data.TableNotFoundException;
+import io.cdap.cdap.spi.data.TableSchemaIncompatibleException;
 import io.cdap.cdap.spi.data.table.StructuredTableId;
 import io.cdap.cdap.spi.data.table.StructuredTableSchema;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 import io.cdap.cdap.spi.data.table.field.FieldType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -51,7 +55,7 @@ import java.util.stream.Collectors;
  * A {@link StructuredTableAdmin} implementation backed by Google Cloud Spanner.
  */
 public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
-
+  private static final Logger LOG = LoggerFactory.getLogger(SpannerStructuredTableAdmin.class);
   private final DatabaseId databaseId;
   private final DatabaseAdminClient adminClient;
   private final DatabaseClient databaseClient;
@@ -75,37 +79,12 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
   }
 
   @Override
-  public void create(StructuredTableSpecification spec) throws IOException, TableAlreadyExistsException {
-    List<String> statements = new ArrayList<>();
-    statements.add(getCreateTableStatement(spec));
-
-    for (String idxColumn : spec.getIndexes()) {
-      String createIndex = String.format("CREATE INDEX %s ON %s (%s)",
-                                         escapeName(getIndexName(spec.getTableId(), idxColumn)),
-                                         escapeName(spec.getTableId().getName()), escapeName(idxColumn));
-
-      // Need to store all the non-primary keys and non index fields so that it can be queried
-      Set<String> storingFields = spec.getFieldTypes().stream().map(FieldType::getName).collect(Collectors.toSet());
-      storingFields.remove(idxColumn);
-      spec.getPrimaryKeys().forEach(storingFields::remove);
-
-      if (!storingFields.isEmpty()) {
-        createIndex += " STORING (" + String.join(",", storingFields) + ")";
-      }
-
-      statements.add(createIndex);
-    }
-
-    try {
-      Uninterruptibles.getUninterruptibly(adminClient.updateDatabaseDdl(databaseId.getInstanceId().getInstance(),
-                                                                        databaseId.getDatabase(), statements, null));
-    } catch (ExecutionException e) {
-      Throwable cause = e.getCause();
-      if (cause instanceof SpannerException
-        && ((SpannerException) cause).getErrorCode() == ErrorCode.FAILED_PRECONDITION) {
-        throw new TableAlreadyExistsException(spec.getTableId());
-      }
-      throw new IOException("Failed to create table in Spanner", cause);
+  public void createOrUpdate(StructuredTableSpecification spec)
+    throws IOException, TableSchemaIncompatibleException {
+    if (exists(spec.getTableId())) {
+      tryUpdatingTable(spec);
+    } else {
+      createTable(spec);
     }
   }
 
@@ -128,6 +107,45 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
         throw (TableNotFoundException) e.getCause();
       }
       throw new RuntimeException("Failed to load table schema for " + tableId, e.getCause());
+    }
+  }
+
+  private void updateTable(StructuredTableSpecification spec)
+    throws IOException, TableNotFoundException, TableSchemaIncompatibleException {
+    StructuredTableId tableId = spec.getTableId();
+    StructuredTableSchema cachedTableSchema = getSchema(tableId);
+    StructuredTableSchema newTableSchema = new StructuredTableSchema(spec);
+
+    if (newTableSchema.equals(cachedTableSchema)) {
+      LOG.trace("The table schema is already up to date: {}", tableId);
+      return;
+    }
+    if (!cachedTableSchema.isCompatible(newTableSchema)) {
+      throw new TableSchemaIncompatibleException(tableId);
+    }
+
+    List<String> statements = new ArrayList<>();
+    statements.addAll(getAddColumnsStatement(newTableSchema, cachedTableSchema));
+    statements.addAll(getAddIndicesStatement(newTableSchema, cachedTableSchema));
+    try {
+      Uninterruptibles.getUninterruptibly(adminClient.updateDatabaseDdl(databaseId.getInstanceId().getInstance(),
+                                                                        databaseId.getDatabase(), statements, null));
+      schemaCache.invalidate(tableId);
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SpannerException) {
+        if (((SpannerException) cause).getErrorCode() == ErrorCode.FAILED_PRECONDITION) {
+          LOG.debug("Concurrent table update error: ", e);
+          throw new TableDuplicateUpdateException(spec.getTableId());
+        }
+
+        if (((SpannerException) cause).getErrorCode() == ErrorCode.NOT_FOUND) {
+          LOG.debug("Concurrent table update error, table not found while updating the table schema: ", e);
+          throw new TableNotFoundException(spec.getTableId());
+        }
+      }
+
+      throw new IOException("Failed to update table schema in Spanner", cause);
     }
   }
 
@@ -168,10 +186,10 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
     // Query the information_schema to reconstruct the StructuredTableSchema
     // See https://cloud.google.com/spanner/docs/information-schema for details
     Statement schemaStatement = Statement.newBuilder(
-      "SELECT C.column_name, C.spanner_type, I.index_type, I.ordinal_position FROM information_schema.columns C " +
-        "LEFT JOIN information_schema.index_columns I " +
-        "ON C.column_name = I.column_name AND C.table_name = I.table_name " +
-        "WHERE C.table_name = @table_name ORDER BY C.ordinal_position")
+        "SELECT C.column_name, C.spanner_type, I.index_type, I.ordinal_position FROM information_schema.columns C " +
+          "LEFT JOIN information_schema.index_columns I " +
+          "ON C.column_name = I.column_name AND C.table_name = I.table_name AND I.ordinal_position is not NULL " +
+          "WHERE C.table_name = @table_name ORDER BY C.ordinal_position")
       .bind("table_name").to(tableId.getName())
       .build();
 
@@ -214,22 +232,9 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
     String statement = spec.getFieldTypes().stream()
       .map(f -> {
         String fieldName = f.getName();
-
-        switch (f.getType()) {
-          case INTEGER:
-          case LONG:
-            return escapeName(fieldName) + " INT64" + (primaryKeys.contains(fieldName) ? " NOT NULL" : "");
-          case FLOAT:
-          case DOUBLE:
-            return escapeName(fieldName) + " FLOAT64" + (primaryKeys.contains(fieldName) ? " NOT NULL" : "");
-          case STRING:
-            return escapeName(fieldName) + " STRING(MAX)" + (primaryKeys.contains(fieldName) ? " NOT NULL" : "");
-          case BYTES:
-            return escapeName(fieldName) + " BYTES(MAX)" + (primaryKeys.contains(fieldName) ? " NOT NULL" : "");
-          default:
-            // This should never happen
-            throw new IllegalArgumentException("Unsupported field type " + f.getType());
-        }
+        return escapeName(fieldName) + " "
+          + getSpannerType(f.getType())
+          + (primaryKeys.contains(fieldName) ? " NOT NULL" : "");
       }).collect(Collectors.joining(", ", "CREATE TABLE " + escapeName(spec.getTableId().getName()) + " (", ")"));
 
     if (primaryKeys.isEmpty()) {
@@ -237,6 +242,40 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
     }
 
     return statement + " PRIMARY KEY (" + String.join(", ", primaryKeys) + ")";
+  }
+
+  private String getCreateIndexStatement(String idxColumn, StructuredTableSchema schema) {
+    String createIndex = String.format("CREATE INDEX %s ON %s (%s)",
+                                       escapeName(getIndexName(schema.getTableId(), idxColumn)),
+                                       escapeName(schema.getTableId().getName()), escapeName(idxColumn));
+
+    // Need to store all the non-primary keys and non index fields so that it can be queried
+    Set<String> storingFields = new HashSet<>(schema.getFieldNames());
+    storingFields.remove(idxColumn);
+    schema.getPrimaryKeys().forEach(storingFields::remove);
+
+    if (!storingFields.isEmpty()) {
+      createIndex += " STORING (" + String.join(",", storingFields) + ")";
+    }
+    return createIndex;
+  }
+
+  private String getSpannerType(FieldType.Type fieldType) {
+    switch (fieldType) {
+      case INTEGER:
+      case LONG:
+        return "INT64";
+      case FLOAT:
+      case DOUBLE:
+        return "FLOAT64";
+      case STRING:
+        return "STRING(MAX)";
+      case BYTES:
+        return "BYTES(MAX)";
+      default:
+        // This should never happen
+        throw new IllegalArgumentException("Unsupported field type " + fieldType);
+    }
   }
 
   private FieldType.Type fromSpannerType(String spannerType) {
@@ -250,11 +289,77 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
       case "bytes(max)":
         return FieldType.Type.BYTES;
       default:
-        throw new IllegalArgumentException("Unsupport spanner type " + spannerType);
+        throw new IllegalArgumentException("Unsupported spanner type " + spannerType);
     }
   }
 
   private String escapeName(String name) {
     return "`" + name + "`";
+  }
+
+  private void createTable(StructuredTableSpecification spec) throws IOException {
+    List<String> statements = new ArrayList<>();
+    statements.add(getCreateTableStatement(spec));
+
+    StructuredTableSchema schema = new StructuredTableSchema(spec);
+    spec.getIndexes()
+      .forEach(idxColumn -> statements.add(getCreateIndexStatement(idxColumn, schema)));
+
+    try {
+      Uninterruptibles.getUninterruptibly(adminClient.updateDatabaseDdl(databaseId.getInstanceId().getInstance(),
+                                                                        databaseId.getDatabase(), statements, null));
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof SpannerException
+        && ((SpannerException) cause).getErrorCode() == ErrorCode.FAILED_PRECONDITION) {
+        LOG.debug("Concurrent table creation error: ", e);
+      } else {
+        throw new IOException("Failed to create table in Spanner", cause);
+      }
+    }
+  }
+
+  private void tryUpdatingTable(StructuredTableSpecification spec)
+    throws IOException, TableSchemaIncompatibleException {
+    try {
+      updateTable(spec);
+    } catch (TableDuplicateUpdateException | TableNotFoundException e) {
+      // Invalidate cached schema and retry
+      schemaCache.invalidate(spec.getTableId());
+      if (e instanceof TableDuplicateUpdateException) {
+        // Exception due to adding existing columns or indexes in Spanner
+        LOG.debug(String.format("Retry updating the table: %s", spec.getTableId()));
+        updateTable(spec);
+      }
+      if (e instanceof TableNotFoundException) {
+        // Exception due to table being deleted while updating the schema
+        // re-create it
+        LOG.debug(String.format("Re-creating the table: %s", spec.getTableId()));
+        createTable(spec);
+      }
+    }
+  }
+
+  private List<String> getAddColumnsStatement(StructuredTableSchema newSpannerSchema,
+                                              StructuredTableSchema cachedTableSchema) {
+    Set<String> existingSchemaFields = cachedTableSchema.getFieldNames();
+    return newSpannerSchema.getFieldNames().stream()
+      .filter(field -> !existingSchemaFields.contains(field))
+      .map(field ->
+             String.format("ALTER TABLE %s ADD COLUMN %s %s",
+                           escapeName(newSpannerSchema.getTableId().getName()),
+                           escapeName(field),
+                           getSpannerType(newSpannerSchema.getType(field))
+             ))
+      .collect(Collectors.toList());
+  }
+
+  private List<String> getAddIndicesStatement(StructuredTableSchema newSchema,
+                                              StructuredTableSchema cachedTableSchema) {
+    Set<String> existingSchemaIndices = cachedTableSchema.getIndexes();
+    return newSchema.getIndexes().stream()
+      .filter(field -> !existingSchemaIndices.contains(field))
+      .map(field -> getCreateIndexStatement(field, newSchema))
+      .collect(Collectors.toList());
   }
 }

--- a/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableAdminTest.java
+++ b/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableAdminTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.storage.spanner;
+
+import io.cdap.cdap.api.metrics.MetricsCollector;
+import io.cdap.cdap.spi.data.StorageProviderContext;
+import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.StructuredTableAdminTest;
+import io.cdap.cdap.spi.data.TableNotFoundException;
+import io.cdap.cdap.spi.data.table.StructuredTableSchema;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Unit tests for GCP spanner implementation of the {@link StructuredTableAdmin}. This test needs the following
+ * Java properties to run. If they are not provided, tests will be ignored.
+ *
+ * <ul>
+ *   <li>gcp.project - GCP project name</li>
+ *   <li>gcp.spanner.instance - GCP spanner instance name</li>
+ *   <li>gcp.spanner.database - GCP spanner database name</li>
+ *   <li>(optional) gcp.credentials.path - Local file path to the service account
+ *   json that has the "Cloud Spanner Database User" role</li>
+ * </ul>
+ */
+public class SpannerStructuredTableAdminTest extends StructuredTableAdminTest {
+
+  private static SpannerStorageProvider storageProvider;
+
+  @BeforeClass
+  public static void createSpannerStorageProvider() throws Exception {
+    String project = System.getProperty("gcp.project");
+    String instance = System.getProperty("gcp.spanner.instance");
+    String database = System.getProperty("gcp.spanner.database");
+    String credentialsPath = System.getProperty("gcp.credentials.path");
+
+    // GCP project, instance, and database must be provided
+    Assume.assumeNotNull(project, instance, database);
+
+    Map<String, String> configs = new HashMap<>();
+    configs.put(SpannerStorageProvider.PROJECT, project);
+    configs.put(SpannerStorageProvider.INSTANCE, instance);
+    configs.put(SpannerStorageProvider.DATABASE, database);
+
+    if (credentialsPath != null) {
+      configs.put(SpannerStorageProvider.CREDENTIALS_PATH, credentialsPath);
+    }
+
+    StorageProviderContext context = new MockStorageProviderContext(configs);
+
+    storageProvider = new SpannerStorageProvider();
+    storageProvider.initialize(context);
+  }
+
+  @AfterClass
+  public static void closeSpannerStorageProvider() {
+    Optional.ofNullable(storageProvider).ifPresent(SpannerStorageProvider::close);
+  }
+
+  @Override
+  protected StructuredTableAdmin getStructuredTableAdmin() {
+    return storageProvider.getStructuredTableAdmin();
+  }
+
+  @Test
+  @Override
+  public void testAdmin() throws Exception {
+    StructuredTableAdmin admin = getStructuredTableAdmin();
+
+    // Assert SIMPLE_TABLE Empty
+    Assert.assertFalse(admin.exists(SIMPLE_TABLE));
+
+    // getSchema SIMPLE_TABLE should fail
+    try {
+      admin.getSchema(SIMPLE_TABLE);
+      Assert.fail("Expected getSchema SIMPLE_TABLE to fail");
+    } catch (TableNotFoundException e) {
+      // Expected
+    }
+
+    // Create SIMPLE_TABLE
+    admin.createOrUpdate(SIMPLE_TABLE_SPEC);
+    Assert.assertTrue(admin.exists(SIMPLE_TABLE));
+
+    // Assert SIMPLE_TABLE schema
+    // ONLY checking compatibility because of INT/LONG to INT64 conversion in Spanner
+    StructuredTableSchema simpleTableSchema = admin.getSchema(SIMPLE_TABLE);
+    Assert.assertTrue(simpleTableSchema.isCompatible(SIMPLE_TABLE_SPEC));
+
+    // Update SIMPLE_TABLE spec to UPDATED_SIMPLE_TABLE_SPEC
+    admin.createOrUpdate(UPDATED_SIMPLE_TABLE_SPEC);
+
+    // Assert UPDATED_SIMPLE_TABLE_SPEC schema
+    StructuredTableSchema updateSimpleTableSchema = admin.getSchema(SIMPLE_TABLE);
+    Assert.assertTrue(updateSimpleTableSchema.isCompatible(UPDATED_SIMPLE_TABLE_SPEC));
+  }
+
+  private static final class MockStorageProviderContext implements StorageProviderContext {
+
+    private final Map<String, String> config;
+
+    MockStorageProviderContext(Map<String, String> config) {
+      this.config = config;
+    }
+
+    @Override
+    public MetricsCollector getMetricsCollector() {
+      return new MetricsCollector() {
+        @Override
+        public void increment(String metricName, long value) {
+          // no-op
+        }
+
+        @Override
+        public void gauge(String metricName, long value) {
+          // no-op
+        }
+      };
+    }
+
+    @Override
+    public Map<String, String> getConfiguration() {
+      return config;
+    }
+
+    @Override
+    public Map<String, String> getSecurityConfiguration() {
+      return Collections.emptyMap();
+    }
+  }
+}

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTableAdmin.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTableAdmin.java
@@ -29,13 +29,17 @@ import java.io.IOException;
 @Beta
 public interface StructuredTableAdmin {
   /**
-   * Create a StructuredTable using the {@link StructuredTableSpecification}.
+   * If the table does not exist, create a StructuredTable using the {@link StructuredTableSpecification}.
+   * If the table exists, check the columns and update the schema if necessary
+   * using the {@link StructuredTableSpecification}.
+   * Currently, only non-primary keys are allowed to be added to the existing table schema.
+   * The passed in StructuredTableSpecification has to be backward compatible with the existing table schema.
    *
    * @param spec table specification
    * @throws IOException if there is an error creating the table
-   * @throws TableAlreadyExistsException if the table already exists
+   * @throws TableSchemaIncompatibleException if the new table schema is incompatible with the existing one
    */
-  void create(StructuredTableSpecification spec) throws IOException, TableAlreadyExistsException;
+  void createOrUpdate(StructuredTableSpecification spec) throws IOException, TableSchemaIncompatibleException;
 
   /**
    * Checks if the given table exists.

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/TableDuplicateUpdateException.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/TableDuplicateUpdateException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.spi.data;
+
+import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+
+/**
+ * Thrown when a table duplicate update happens, like duplicate column or index.
+ */
+@Beta
+public class TableDuplicateUpdateException extends RuntimeException {
+  private final StructuredTableId id;
+
+  public TableDuplicateUpdateException(StructuredTableId id) {
+    super(String.format("System table '%s' duplicate update on columns or indexes.", id));
+    this.id = id;
+  }
+
+  public StructuredTableId getId() {
+    return id;
+  }
+}

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/TableSchemaIncompatibleException.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/TableSchemaIncompatibleException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.spi.data;
+
+import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+
+/**
+ * Thrown when a table schema is not backward compatible.
+ */
+@Beta
+public class TableSchemaIncompatibleException extends Exception {
+  private final StructuredTableId id;
+
+  public TableSchemaIncompatibleException(StructuredTableId id) {
+    super(String.format("The new table schema is not backward compatible: %s", id));
+    this.id = id;
+  }
+
+  public StructuredTableId getId() {
+    return id;
+  }
+}

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/StructuredTableSchema.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/StructuredTableSchema.java
@@ -120,13 +120,13 @@ public class StructuredTableSchema {
   public int hashCode() {
     return Objects.hash(tableId, fields, primaryKeys, indexes);
   }
-  
+
   /**
    * Checks if this schema is compatible with the given {@link StructuredTableSpecification}. They are compatible if
    *
    * <ol>
    *   <li>
-   *     This schema contains all the fields in the specification.
+   *     The new specification contains all the fields in the existing schema.
    *   </li>
    *   <li>
    *     Each schema field has data type that can store the corresponding spec field data without losing precision.
@@ -135,7 +135,7 @@ public class StructuredTableSchema {
    *     They have the same set of primary keys.
    *   </li>
    *   <li>
-   *     They have the same set of indexes.
+   *     This new specification contains all the indexes in the existing schema.
    *   </li>
    * </ol>
    *
@@ -143,14 +143,39 @@ public class StructuredTableSchema {
    * @return {@code true} if this schema is compatible with the given specification, otherwise return {@code false}
    */
   public boolean isCompatible(StructuredTableSpecification spec) {
-    for (FieldType field : spec.getFieldTypes()) {
-      FieldType.Type type = getType(field.getName());
-      if (type == null || !type.isCompatible(field.getType())) {
+    return isCompatible(new StructuredTableSchema(spec));
+  }
+
+  /**
+   * Checks if this schema is compatible with the given {@link StructuredTableSchema}. They are compatible if
+   *
+   * <ol>
+   *   <li>
+   *     The new schema contains all the fields in the existing schema.
+   *   </li>
+   *   <li>
+   *     Each schema field has data type that can store the corresponding spec field data without losing precision.
+   *   </li>
+   *   <li>
+   *     They have the same set of primary keys.
+   *   </li>
+   *   <li>
+   *     The new schema contains all the indexes in the existing schema.
+   *   </li>
+   * </ol>
+   *
+   * @param schema the {@link StructuredTableSchema} to check for compatibility
+   * @return {@code true} if this schema is compatible with the given schema, otherwise return {@code false}
+   */
+  public boolean isCompatible(StructuredTableSchema schema) {
+    for (String field : getFieldNames()) {
+      FieldType.Type type = schema.getType(field);
+      if (type == null || !getType(field).isCompatible(type)) {
         return false;
       }
     }
 
-    return getPrimaryKeys().equals(spec.getPrimaryKeys())
-      && getIndexes().equals(new HashSet<>(spec.getIndexes()));
+    return getPrimaryKeys().equals(schema.getPrimaryKeys())
+      && schema.getIndexes().containsAll(getIndexes());
   }
 }

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/StructuredTableSpecification.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/StructuredTableSpecification.java
@@ -151,6 +151,7 @@ public final class StructuredTableSpecification {
 
     /**
      * Set the table id. A table should have an id.
+     *
      * @param id table id
      * @return Builder instance
      */
@@ -161,10 +162,11 @@ public final class StructuredTableSpecification {
 
     /**
      * Set the field types in the table schema. A table should have at least one field.
+     *
      * @param fieldTypes list of field types
      * @return Builder instance
      */
-    public Builder withFields(FieldType ...fieldTypes) {
+    public Builder withFields(FieldType... fieldTypes) {
       this.fieldTypes = Arrays.asList(fieldTypes);
       return this;
     }
@@ -172,10 +174,11 @@ public final class StructuredTableSpecification {
     /**
      * Set the fields that form the primary keys of the table. A table should have at least one primary key.
      * See {@link FieldType#PRIMARY_KEY_TYPES} for valid primary key field types.
+     *
      * @param primaryKeys list of field names forming the primary keys
      * @return Builder instance
      */
-    public Builder withPrimaryKeys(String ...primaryKeys) {
+    public Builder withPrimaryKeys(String... primaryKeys) {
       this.primaryKeys = Arrays.asList(primaryKeys);
       return this;
     }
@@ -183,10 +186,11 @@ public final class StructuredTableSpecification {
     /**
      * Set the fields that need to be indexed in the table. A table need not define any indexes.
      * See {@link FieldType#INDEX_COLUMN_TYPES} for valid index field types.
+     *
      * @param indexes list of field names for the index
      * @return Builder instance
      */
-    public Builder withIndexes(String ...indexes) {
+    public Builder withIndexes(String... indexes) {
       if (indexes != null) {
         this.indexes = Arrays.asList(indexes);
       }
@@ -195,6 +199,7 @@ public final class StructuredTableSpecification {
 
     /**
      * Build the table specification
+     *
      * @return the table specification
      */
     public StructuredTableSpecification build() throws InvalidFieldException {

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableAdminTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableAdminTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data;
+
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+import io.cdap.cdap.spi.data.table.StructuredTableSchema;
+import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
+import io.cdap.cdap.spi.data.table.field.FieldType;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * This is a test base for {@link StructuredTableAdmin}.
+ */
+public abstract class StructuredTableAdminTest {
+  private static final FieldType KEY_FIELD = Fields.intType("i");
+  private static final FieldType STR_FIELD = Fields.stringType("s");
+  private static final FieldType LONG_FIELD = Fields.longType("l");
+  protected static final StructuredTableId SIMPLE_TABLE = new StructuredTableId("simple_table");
+
+  protected static final StructuredTableSpecification SIMPLE_TABLE_SPEC =
+    new StructuredTableSpecification.Builder()
+      .withId(SIMPLE_TABLE)
+      .withFields(KEY_FIELD, STR_FIELD, LONG_FIELD)
+      .withPrimaryKeys(KEY_FIELD.getName())
+      .withIndexes(STR_FIELD.getName())
+      .build();
+
+  protected static final StructuredTableSpecification UPDATED_SIMPLE_TABLE_SPEC =
+    new StructuredTableSpecification.Builder()
+      .withId(SIMPLE_TABLE)
+      .withFields(
+        KEY_FIELD,
+        STR_FIELD,
+        LONG_FIELD,
+        Fields.floatType("updated_field1"),
+        Fields.longType("updated_field2"))
+      .withPrimaryKeys(KEY_FIELD.getName())
+      .withIndexes(STR_FIELD.getName(), LONG_FIELD.getName())
+      .build();
+
+  protected static final StructuredTableSpecification INCOMPATIBLE_TABLE_SPEC =
+    new StructuredTableSpecification.Builder()
+      .withId(SIMPLE_TABLE)
+      .withFields(KEY_FIELD, STR_FIELD, Fields.floatType("updated_field1"))
+      .withPrimaryKeys(KEY_FIELD.getName())
+      .build();
+
+  /**
+   * @return the right implementation of the table admin based on the underlying storage.
+   */
+  protected abstract StructuredTableAdmin getStructuredTableAdmin() throws Exception;
+
+
+  @After
+  public void cleanUp() throws Exception {
+    StructuredTableAdmin admin = getStructuredTableAdmin();
+    if (admin.exists(SIMPLE_TABLE)) {
+      admin.drop(SIMPLE_TABLE);
+    }
+    Assert.assertFalse(admin.exists(SIMPLE_TABLE));
+  }
+
+  @Test
+  public void testAdmin() throws Exception {
+    StructuredTableAdmin admin = getStructuredTableAdmin();
+
+    // Assert SIMPLE_TABLE Empty
+    Assert.assertFalse(admin.exists(SIMPLE_TABLE));
+
+    // getSchema SIMPLE_TABLE should fail
+    try {
+      admin.getSchema(SIMPLE_TABLE);
+      Assert.fail("Expected getSchema SIMPLE_TABLE to fail");
+    } catch (TableNotFoundException e) {
+      // Expected
+    }
+
+    // Create SIMPLE_TABLE
+    admin.createOrUpdate(SIMPLE_TABLE_SPEC);
+    Assert.assertTrue(admin.exists(SIMPLE_TABLE));
+
+    // Assert SIMPLE_TABLE schema
+    StructuredTableSchema simpleTableSchema = admin.getSchema(SIMPLE_TABLE);
+    Assert.assertEquals(simpleTableSchema, new StructuredTableSchema(SIMPLE_TABLE_SPEC));
+
+    // Update SIMPLE_TABLE spec to UPDATED_SIMPLE_TABLE_SPEC
+    admin.createOrUpdate(UPDATED_SIMPLE_TABLE_SPEC);
+
+    // Assert UPDATED_SIMPLE_TABLE_SPEC schema
+    StructuredTableSchema updateSimpleTableSchema = admin.getSchema(SIMPLE_TABLE);
+    Assert.assertEquals(updateSimpleTableSchema, new StructuredTableSchema(UPDATED_SIMPLE_TABLE_SPEC));
+  }
+
+  @Test
+  public void testBackwardCompatible() throws Exception {
+    StructuredTableAdmin admin = getStructuredTableAdmin();
+
+    // Assert SIMPLE_TABLE Empty
+    Assert.assertFalse(admin.exists(SIMPLE_TABLE));
+
+    // Create SIMPLE_TABLE
+    admin.createOrUpdate(SIMPLE_TABLE_SPEC);
+    Assert.assertTrue(admin.exists(SIMPLE_TABLE));
+
+    // getSchema SIMPLE_TABLE should fail
+    try {
+      admin.createOrUpdate(INCOMPATIBLE_TABLE_SPEC);
+      Assert.fail("Expected createOrUpdate INCOMPATIBLE_TABLE_SPEC to fail");
+    } catch (TableSchemaIncompatibleException e) {
+      // Expected
+    }
+  }
+}

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableConcurrencyTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableConcurrencyTest.java
@@ -81,7 +81,7 @@ public abstract class StructuredTableConcurrencyTest {
 
   @Before
   public void init() throws Exception {
-    getStructuredTableAdmin().create(TEST_SPEC);
+    getStructuredTableAdmin().createOrUpdate(TEST_SPEC);
   }
 
   @After

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
@@ -70,19 +70,20 @@ public abstract class StructuredTableTest {
   private static final String FLOAT_COL = "col3";
   private static final String BYTES_COL = "col4";
   private static final String LONG_COL = "col5";
+  private static final String IDX_COL = "col6";
   private static final String VAL = "val";
   private static final StructuredTableSchema SIMPLE_SCHEMA;
 
   static {
     try {
       SIMPLE_SPEC = new StructuredTableSpecification.Builder()
-       .withId(SIMPLE_TABLE)
-       .withFields(Fields.intType(KEY), Fields.stringType(STRING_COL), Fields.longType(KEY2),
-                   Fields.doubleType(DOUBLE_COL), Fields.floatType(FLOAT_COL), Fields.bytesType(BYTES_COL),
-                   Fields.longType(LONG_COL))
-       .withPrimaryKeys(KEY, KEY2)
-       .withIndexes(STRING_COL)
-       .build();
+        .withId(SIMPLE_TABLE)
+        .withFields(Fields.intType(KEY), Fields.stringType(STRING_COL), Fields.longType(KEY2),
+                    Fields.doubleType(DOUBLE_COL), Fields.floatType(FLOAT_COL), Fields.bytesType(BYTES_COL),
+                    Fields.longType(LONG_COL), Fields.longType(IDX_COL))
+        .withPrimaryKeys(KEY, KEY2)
+        .withIndexes(STRING_COL, IDX_COL)
+        .build();
       SIMPLE_SCHEMA = new StructuredTableSchema(SIMPLE_SPEC);
     } catch (InvalidFieldException e) {
       throw new RuntimeException(e);
@@ -90,11 +91,12 @@ public abstract class StructuredTableTest {
   }
 
   protected abstract StructuredTableAdmin getStructuredTableAdmin() throws Exception;
+
   protected abstract TransactionRunner getTransactionRunner() throws Exception;
 
   @Before
   public void init() throws Exception {
-    getStructuredTableAdmin().create(SIMPLE_SPEC);
+    getStructuredTableAdmin().createOrUpdate(SIMPLE_SPEC);
   }
 
   @After
@@ -595,11 +597,11 @@ public abstract class StructuredTableTest {
   @Test
   public void testUpdate() throws Exception {
     List<Field<?>> fields = Arrays.asList(Fields.intField(KEY, 1),
-                                            Fields.longField(KEY2, 2L),
-                                            Fields.stringField(STRING_COL, "str1"),
-                                            Fields.doubleField(DOUBLE_COL, (double) 1.0),
-                                            Fields.floatField(FLOAT_COL, (float) 1.0),
-                                            Fields.bytesField(BYTES_COL, Bytes.toBytes("bytes")));
+                                          Fields.longField(KEY2, 2L),
+                                          Fields.stringField(STRING_COL, "str1"),
+                                          Fields.doubleField(DOUBLE_COL, (double) 1.0),
+                                          Fields.floatField(FLOAT_COL, (float) 1.0),
+                                          Fields.bytesField(BYTES_COL, Bytes.toBytes("bytes")));
     getTransactionRunner().run(context -> {
       StructuredTable table = context.getTable(SIMPLE_TABLE);
       table.upsert(fields);

--- a/cdap-system-app-unit-test/src/test/java/io/cdap/cdap/test/SystemAppTestBaseTest.java
+++ b/cdap-system-app-unit-test/src/test/java/io/cdap/cdap/test/SystemAppTestBaseTest.java
@@ -56,12 +56,12 @@ public class SystemAppTestBaseTest extends SystemAppTestBase {
 
     String keyCol = "key";
     String valCol = "val";
-    tableAdmin.create(new StructuredTableSpecification.Builder()
-                        .withId(id)
-                        .withFields(new FieldType(keyCol, FieldType.Type.STRING),
-                                    new FieldType(valCol, FieldType.Type.STRING))
-                        .withPrimaryKeys(keyCol)
-                        .build());
+    tableAdmin.createOrUpdate(new StructuredTableSpecification.Builder()
+                                .withId(id)
+                                .withFields(new FieldType(keyCol, FieldType.Type.STRING),
+                                            new FieldType(valCol, FieldType.Type.STRING))
+                                .withPrimaryKeys(keyCol)
+                                .build());
 
     try {
       TransactionRunner transactionRunner = getTransactionRunner();


### PR DESCRIPTION
This PR adds the ability to add non-primaryKey columns and indexes to the StructuredTables. 

Added the in respect implementation in Postgresql admin, nosql admin and Spanner admin. Basically the flow is like: when the StructuredTableAdmin checks table existence, we also check if there's updated schema, if so, we proceed to add the new columns and update table schema in registry


Verification: manually verified, the new table columns are added successfully added in platform tables and system tables