### PR TITLE
[CDAP-19316] Fix security vulnerabilities in commons-collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,7 @@
     <cdap.common.version>0.13.0</cdap.common.version>
     <cdap.client.version>1.4.0</cdap.client.version>
     <commons.cli.version>1.2</commons.cli.version>
+    <commons.collections.version>3.2.2</commons.collections.version>
     <commons.compress.version>1.18</commons.compress.version>
     <commons.lang3.version>3.5</commons.lang3.version>
     <dropwizard.version>3.1.2</dropwizard.version>
@@ -1753,6 +1754,11 @@
             <artifactId>gson</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>${commons.collections.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
### Change Description

Fixed security vulnerability [CVE-2015-4852](https://nvd.nist.gov/vuln/detail/CVE-2015-4852) for dependencies:
* commons-collections

Changes:
* Update the commons-collections dependency version to `3.2.2`. Hadoop common and other dependencies use `3.2.1` transitively. The newer version is backward compatible.

### Verification
* Verified version override using `mvn dependency:tree`
* Sanity testing of CDAP sandbox image