### PR TITLE
[CDAP-19512] Fix security vulnerability in log4j

### DIFF
--- a/cdap-data-fabric-tests/pom.xml
+++ b/cdap-data-fabric-tests/pom.xml
@@ -62,6 +62,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>log4j-over-slf4j</artifactId>
+    <scope>test</scope>
+  </dependency>
+    <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-security</artifactId>
       <version>${project.version}</version>

--- a/cdap-security/pom.xml
+++ b/cdap-security/pom.xml
@@ -144,6 +144,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-testing-util</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
     <!-- Please keep consistent with the one in Spark 3 -->
     <scala2.12.version>2.12.10</scala2.12.version>
     <servlet.api.version>3.0.1</servlet.api.version>
-    <slf4j.version>1.7.5</slf4j.version>
+    <slf4j.version>1.7.6</slf4j.version>
     <snappy.version>1.1.1.7</snappy.version>
     <spark2.artifacts.dir>spark2_2.11</spark2.artifacts.dir>
     <spark3.artifacts.dir>spark3_2.12</spark3.artifacts.dir>
@@ -761,6 +761,10 @@
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>jetty-util</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -804,6 +808,10 @@
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-servlet</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -811,6 +819,10 @@
         <artifactId>hadoop-hdfs</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
@@ -950,6 +962,10 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -957,6 +973,10 @@
         <artifactId>hbase-client</artifactId>
         <version>${hbase10.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
@@ -985,6 +1005,10 @@
         <version>${hbase10.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
           </exclusion>
@@ -999,6 +1023,10 @@
         <artifactId>hbase-server</artifactId>
         <version>${hbase10.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
@@ -1375,6 +1403,10 @@
         <scope>test</scope>
         <exclusions>
           <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>asm</groupId>
             <artifactId>asm</artifactId>
           </exclusion>
@@ -1402,6 +1434,10 @@
         <version>${hadoop.version}</version>
         <scope>test</scope>
         <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
@@ -1431,6 +1467,10 @@
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
Excluding `log4j:1.2.17` from
- `org.apache.hadoop:hadoop-yarn-client:2.6.0`
- `org.apache.hadoop:hadoop-yarn-common:2.6.0`
- `org.apache.hadoop:hadoop-hdfs:2.6.0`
- `org.apache.hadoop:hadoop-minicluster:2.6.0`
- `org.apache.hadoop:hadoop-minikdc:2.6.0`
- `org.apache.hbase:hbase-common:1.0.1.1`
- `org.apache.hbase:hbase-client:1.0.1.1`
- `org.apache.hbase:hbase-protocol:1.0.1.1`
- `org.apache.hbase:hbase-testing-util:1.0.1.1`

Upgraded `log4j-over-slf4j` to `1.7.6` because of some unit test failures in `cdap-security` depending on `AppendorSkeleton` class added in https://github.com/qos-ch/slf4j/commit/b26727a6b2e4f52190d06584eab87eef64f1b323

Fixes vulnerability
- [CVE-2019-17571](https://nvd.nist.gov/vuln/detail/CVE-2019-17571)

Verified using `mvn dependency:tree` and sanity check on `cdap-sandbox`.

Still present as a transitive test dependency in test scopes
- `org.apache.hadoop:hadoop-common:test-jar:tests:2.6.0:test`
- `org.apache.hbase:hbase-server:test-jar:tests:1.0.0-cdh5.4.4:test`
- `org.apache.hbase:hbase-server:test-jar:tests:1.0.0-cdh5.5.0:test`
- `org.apache.hbase:hbase-server:test-jar:tests:1.1.1:test`
- `org.apache.hbase:hbase-server:test-jar:tests:1.0.1.1:test`
- `org.apache.hadoop:hadoop-hdfs:test-jar:tests:2.6.0:test`