### PR TITLE
Deployment logic for edit flow

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -26,8 +26,10 @@ import io.cdap.cdap.api.workflow.WorkflowToken;
 import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.common.ApplicationNotFoundException;
+import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.ProgramNotFoundException;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.internal.app.store.WorkflowTable;
 import io.cdap.cdap.internal.app.store.state.AppStateKey;
@@ -293,12 +295,12 @@ public interface Store {
 
   /**
    * Creates new application if it doesn't exist. Updates existing one otherwise.
-   *
    * @param id            application id
-   * @param specification application specification to store
+   * @param meta          application metadata to store
+   * @throws ConflictException if the app cannot be deployed when the user provided parent-version doesn't match the
+   * current latest version
    */
-  void addApplication(ApplicationId id, ApplicationSpecification specification);
-
+  void addApplication(ApplicationId id, ApplicationMeta meta) throws ConflictException;
 
   /**
    * Return a list of program specifications that are deleted comparing the specification in the store with the
@@ -319,6 +321,15 @@ public interface Store {
    */
   @Nullable
   ApplicationSpecification getApplication(ApplicationId id);
+
+  /**
+   * Returns application metadata information by id.
+   *
+   * @param id application id
+   * @return application metadata
+   */
+  @Nullable
+  ApplicationMeta getApplicationMetadata(ApplicationId id);
 
   /**
    * Returns a collection of all application specs in the specified namespace
@@ -364,6 +375,16 @@ public interface Store {
    * @return collection of all application specs of all the application versions
    */
   Collection<ApplicationSpecification> getAllAppVersions(ApplicationId id);
+
+  /**
+   * Returns latest version of an application in a namespace
+   *
+   * @param namespace namespace
+   * @param appName application id
+   * @return The metadata information of the latest application version.
+   */
+  @Nullable
+  ApplicationMeta getLatest(NamespaceId namespace, String appName);
 
   /**
    * Returns a list of all versions' ApplicationId's of the application by id

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -69,6 +69,7 @@ import io.cdap.cdap.proto.ApplicationRecord;
 import io.cdap.cdap.proto.ApplicationUpdateDetail;
 import io.cdap.cdap.proto.BatchApplicationDetail;
 import io.cdap.cdap.proto.artifact.AppRequest;
+import io.cdap.cdap.proto.artifact.ChangeSummary;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
@@ -682,11 +683,13 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
           Object config = appRequest.getConfig();
           String configString = config == null ? null :
             config instanceof String ? (String) config : GSON.toJson(config);
+          ChangeSummary changeSummary = appRequest.getChange();
 
           try {
             applicationLifecycleService.deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
-                                                  artifactSummary, configString, createProgramTerminator(),
-                                                  ownerPrincipalId, appRequest.canUpdateSchedules(), false,
+                                                  artifactSummary, configString, changeSummary,
+                                                  createProgramTerminator(), ownerPrincipalId,
+                                                  appRequest.canUpdateSchedules(), false,
                                                   Collections.emptyMap());
           } catch (DatasetManagementException e) {
             if (e.getCause() instanceof UnauthorizedException) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
@@ -20,6 +20,7 @@ import com.google.gson.annotations.SerializedName;
 import io.cdap.cdap.api.app.Application;
 import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.internal.app.deploy.LocalApplicationManager;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
@@ -50,6 +51,8 @@ public class AppDeploymentInfo {
   private final boolean updateSchedules;
   @Nullable
   private final AppDeploymentRuntimeInfo runtimeInfo;
+  @Nullable
+  private final ChangeDetail changeDetail;
 
   /**
    * Creates a new {@link Builder}.
@@ -72,13 +75,15 @@ public class AppDeploymentInfo {
       .setConfigString(other.configString)
       .setOwnerPrincipal(other.ownerPrincipal)
       .setUpdateSchedules(other.updateSchedules)
-      .setRuntimeInfo(other.runtimeInfo);
+      .setRuntimeInfo(other.runtimeInfo)
+      .setChangeDetail(other.changeDetail);
   }
 
   private AppDeploymentInfo(ArtifactId artifactId, Location artifactLocation, NamespaceId namespaceId,
                             ApplicationClass applicationClass, @Nullable String appName, @Nullable String appVersion,
                             @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal,
-                            boolean updateSchedules, @Nullable AppDeploymentRuntimeInfo runtimeInfo) {
+                            boolean updateSchedules, @Nullable AppDeploymentRuntimeInfo runtimeInfo,
+                            @Nullable ChangeDetail changeDetail) {
     this.artifactId = artifactId;
     this.artifactLocation = artifactLocation;
     this.namespaceId = namespaceId;
@@ -89,6 +94,7 @@ public class AppDeploymentInfo {
     this.updateSchedules = updateSchedules;
     this.applicationClass = applicationClass;
     this.runtimeInfo = runtimeInfo;
+    this.changeDetail = changeDetail;
   }
 
   /**
@@ -171,6 +177,14 @@ public class AppDeploymentInfo {
   }
 
   /**
+   * Returns the change detail {@code null} if it is not provided.
+   */
+  @Nullable
+  public ChangeDetail getChangeDetail() {
+    return changeDetail;
+  }
+
+  /**
    * Builder class for the {@link AppDeploymentInfo}.
    */
   public static final class Builder {
@@ -186,6 +200,8 @@ public class AppDeploymentInfo {
     // The default behavior of update schedules is to update schedule on deployment.
     private boolean updateSchedules = true;
     private AppDeploymentRuntimeInfo runtimeInfo;
+    @Nullable
+    private ChangeDetail changeDetail;
 
     private Builder() {
       // Only for the builder() method to use
@@ -248,6 +264,11 @@ public class AppDeploymentInfo {
       return this;
     }
 
+    public Builder setChangeDetail(@Nullable ChangeDetail changeDetail) {
+      this.changeDetail = changeDetail;
+      return this;
+    }
+
     public AppDeploymentInfo build() {
       if (artifactId == null) {
         throw new IllegalStateException("Missing artifact ID");
@@ -262,7 +283,8 @@ public class AppDeploymentInfo {
         throw new IllegalStateException("Missing application class");
       }
       return new AppDeploymentInfo(artifactId, artifactLocation, namespaceId, applicationClass,
-                                   appName, appVersion, configString, ownerPrincipal, updateSchedules, runtimeInfo);
+                                   appName, appVersion, configString, ownerPrincipal, updateSchedules, runtimeInfo,
+                                   changeDetail);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.api.metadata.Metadata;
 import io.cdap.cdap.api.metadata.MetadataScope;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
@@ -50,6 +51,8 @@ public class ApplicationDeployable {
   private final KerberosPrincipalId ownerPrincipal;
   @SerializedName("update-schedules")
   private final boolean updateSchedules;
+  @Nullable
+  private final ChangeDetail changeDetail;
 
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
                                ApplicationId applicationId, ApplicationSpecification specification,
@@ -57,7 +60,8 @@ public class ApplicationDeployable {
                                ApplicationDeployScope applicationDeployScope,
                                ApplicationClass applicationClass) {
     this(artifactId, artifactLocation, applicationId, specification, existingAppSpec, applicationDeployScope,
-         applicationClass, null, true, Collections.emptyList(), Collections.emptyMap());
+         applicationClass, null, true, Collections.emptyList(), Collections.emptyMap(),
+         null);
   }
 
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
@@ -68,7 +72,7 @@ public class ApplicationDeployable {
                                @Nullable KerberosPrincipalId ownerPrincipal,
                                boolean updateSchedules,
                                Collection<StructuredTableSpecification> systemTables,
-                               Map<MetadataScope, Metadata> metadata) {
+                               Map<MetadataScope, Metadata> metadata, @Nullable ChangeDetail changeDetail) {
     this.artifactId = artifactId;
     this.artifactLocation = artifactLocation;
     this.applicationId = applicationId;
@@ -80,6 +84,7 @@ public class ApplicationDeployable {
     this.systemTables = systemTables;
     this.applicationClass = applicationClass;
     this.metadata = metadata;
+    this.changeDetail = changeDetail;
   }
 
   /**
@@ -158,5 +163,13 @@ public class ApplicationDeployable {
    */
   public Map<MetadataScope, Metadata> getMetadata() {
     return metadata;
+  }
+
+  /**
+   * Returns the change details of the application
+   */
+  @Nullable
+  public ChangeDetail getChangeDetail() {
+    return changeDetail;
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.api.spark.SparkSpecification;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.AlreadyExistsException;
 import io.cdap.cdap.data2.registry.UsageRegistry;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
 import io.cdap.cdap.pipeline.AbstractStage;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -55,8 +56,10 @@ public class ApplicationRegistrationStage extends AbstractStage<ApplicationWithP
     ApplicationSpecification applicationSpecification = input.getSpecification();
     Collection<ApplicationId> allAppVersionsAppIds = store.getAllAppVersionsAppIds(input.getApplicationId());
     boolean ownerAdded = addOwnerIfRequired(input, allAppVersionsAppIds);
+    ApplicationMeta appMeta = new ApplicationMeta(applicationSpecification.getName(), input.getSpecification(),
+                                                  input.getChangeDetail());
     try {
-      store.addApplication(input.getApplicationId(), applicationSpecification);
+      store.addApplication(input.getApplicationId(), appMeta);
     } catch (Exception e) {
       // if we failed to store the app spec cleanup the owner if it was added in this call
       if (ownerAdded) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
@@ -35,7 +35,7 @@ public class ApplicationWithPrograms extends ApplicationDeployable {
           applicationDeployable.getExistingAppSpec(), applicationDeployable.getApplicationDeployScope(),
           applicationDeployable.getApplicationClass(), applicationDeployable.getOwnerPrincipal(),
           applicationDeployable.canUpdateSchedules(), applicationDeployable.getSystemTables(),
-          applicationDeployable.getMetadata());
+          applicationDeployable.getMetadata(), applicationDeployable.getChangeDetail());
     this.programDescriptors = ImmutableList.copyOf(programDescriptors);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
@@ -117,6 +117,6 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
                                    applicationId, specification, store.getApplication(applicationId),
                                    ApplicationDeployScope.USER, deploymentInfo.getApplicationClass(),
                                    deploymentInfo.getOwnerPrincipal(), deploymentInfo.canUpdateSchedules(),
-                                   appSpecInfo.getSystemTables(), metadatas));
+                                   appSpecInfo.getSystemTables(), metadatas, deploymentInfo.getChangeDetail()));
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
@@ -188,8 +188,9 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
     try {
       LOG.debug("Deploying preview application for {}", programId);
       applicationLifecycleService.deployApp(preview.getParent(), preview.getApplication(), preview.getVersion(),
-                                            artifactSummary, config, NOOP_PROGRAM_TERMINATOR, null,
-                                            request.canUpdateSchedules(), true, userProps);
+                                            artifactSummary, config, request.getChange(),
+                                            NOOP_PROGRAM_TERMINATOR, null, request.canUpdateSchedules(),
+                                            true, userProps);
     } catch (Exception e) {
       PreviewStatus previewStatus = new PreviewStatus(PreviewStatus.Status.DEPLOY_FAILED, submitTimeMillis,
                                                       new BasicThrowable(e), null, null);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
@@ -350,8 +350,7 @@ public class DefaultRuntimeJob implements RuntimeJob {
     String appClassName = systemArguments.get(ProgramOptionConstants.APPLICATION_CLASS);
     Location programJarLocation = Locations.toLocation(
       new File(systemArguments.get(ProgramOptionConstants.PROGRAM_JAR)));
-
-
+    
     AppDeploymentInfo deploymentInfo = AppDeploymentInfo.builder()
       .setArtifactId(programDescriptor.getArtifactId())
       .setArtifactLocation(programJarLocation)

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/ApplicationMeta.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/ApplicationMeta.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.internal.app.store;
 import com.google.common.base.Objects;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
 
 /**
  * Holds application metadata
@@ -28,10 +29,12 @@ public class ApplicationMeta {
 
   private final String id;
   private final ApplicationSpecification spec;
+  private final ChangeDetail change;
 
-  public ApplicationMeta(String id, ApplicationSpecification spec) {
+  public ApplicationMeta(String id, ApplicationSpecification spec, ChangeDetail change) {
     this.id = id;
     this.spec = spec;
+    this.change = change;
   }
 
   public String getId() {
@@ -42,11 +45,16 @@ public class ApplicationMeta {
     return spec;
   }
 
+  public ChangeDetail getChange() {
+    return change;
+  }
+
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
       .add("id", id)
       .add("spec", ADAPTER.toJson(spec))
+      .add("change", change)
       .toString();
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/executor/AppCreator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/executor/AppCreator.java
@@ -64,8 +64,9 @@ public class AppCreator extends BaseStepExecutor<AppCreator.Arguments> {
 
     try {
       appLifecycleService.deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
-                                    artifactSummary, configString, x -> { },
-                                    ownerPrincipalId, arguments.canUpdateSchedules(), false, Collections.emptyMap());
+                                    artifactSummary, configString, arguments.getChange(), x -> { },
+                                    ownerPrincipalId, arguments.canUpdateSchedules(), false,
+                                    Collections.emptyMap());
     } catch (NotFoundException | UnauthorizedException | InvalidArtifactException e) {
       // these exceptions are for sure not retry-able. It's hard to tell if the others are, so we just try retrying
       // up to the default time limit

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
@@ -309,8 +309,8 @@ class CapabilityApplier {
     String configString = application.getConfig() == null ? null : GSON.toJson(application.getConfig());
     applicationLifecycleService
       .deployApp(applicationId.getParent(), applicationId.getApplication(), applicationId.getVersion(),
-                 application.getArtifact(), configString, NOOP_PROGRAM_TERMINATOR, null, null, false,
-                 Collections.emptyMap());
+                 application.getArtifact(), configString, null, NOOP_PROGRAM_TERMINATOR,
+                 null, null, false, Collections.emptyMap());
   }
 
   @VisibleForTesting

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
@@ -116,7 +116,7 @@ public class SystemAppEnableExecutor {
 
     try {
       return appLifecycleService.deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
-                                           artifactSummary, configString, x -> { },
+                                           artifactSummary, configString, null, x -> { },
                                            ownerPrincipalId, arguments.canUpdateSchedules(), false,
                                            Collections.emptyMap());
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
@@ -43,10 +43,12 @@ import io.cdap.cdap.internal.app.runtime.schedule.TriggeringScheduleInfoAdapter;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.DefaultTimeTriggerInfo;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.TimeTrigger;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
 import io.cdap.cdap.internal.app.store.DefaultStore;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -282,7 +284,7 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
   /**
    * Adds {@link ApplicationSpecification} for APP1_ID and APP2_ID.
    */
-  private void addAppSpecs() {
+  private void addAppSpecs() throws ConflictException {
     WorkflowSpecification scheduledWorfklow1 =
       new WorkflowSpecification("DummyClass", SCHEDULED_PROG1_ID.getProgram(), "scheduled workflow",
                                 Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap(),
@@ -297,8 +299,10 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
                                           Collections.emptyMap(), Collections.emptyMap(),
                                           Collections.emptyMap(), Collections.emptyMap()
       );
-
-    store.addApplication(APP1_ID, dummyAppSpec1);
+    ApplicationMeta meta = new ApplicationMeta(dummyAppSpec1.getName(), dummyAppSpec1,
+                                               new ChangeDetail(null, null, null,
+                                                                System.currentTimeMillis()));
+    store.addApplication(APP1_ID, meta);
     WorkflowSpecification scheduledWorfklow2 =
       new WorkflowSpecification("DummyClass", SCHEDULED_PROG2_ID.getProgram(), "scheduled workflow",
                                 Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap(),
@@ -313,7 +317,10 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
                                           Collections.emptyMap(), Collections.emptyMap(),
                                           Collections.emptyMap(), Collections.emptyMap()
       );
-    store.addApplication(APP2_ID, dummyAppSpec2);
+    meta = new ApplicationMeta(dummyAppSpec2.getName(), dummyAppSpec2,
+                               new ChangeDetail(null, null, null,
+                                                System.currentTimeMillis()));
+    store.addApplication(APP2_ID, meta);
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
@@ -77,6 +77,7 @@ import io.cdap.cdap.messaging.data.MessageId;
 import io.cdap.cdap.metadata.MetadataService;
 import io.cdap.cdap.metadata.MetadataSubscriberService;
 import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
@@ -318,6 +319,7 @@ public class AppFabricTestHelper {
       .setArtifactLocation(deployedJar)
       .setNamespaceId(namespaceId).setApplicationClass(applicationClass)
       .setConfigString(config == null ? null : new Gson().toJson(config))
+      .setChangeDetail(new ChangeDetail(null, null, null, System.currentTimeMillis()))
       .build();
     return getLocalManager().deploy(info).get();
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -111,7 +111,7 @@ public class ConfiguratorTest {
     ArtifactRepository artifactRepo = new AuthorizationArtifactRepository(baseArtifactRepo,
                                                                           authEnforcer, authenticationContext);
     PluginFinder pluginFinder = new LocalPluginFinder(artifactRepo);
-
+    
     AppDeploymentInfo appDeploymentInfo = AppDeploymentInfo.builder()
       .setArtifactId(artifactId.toEntityId())
       .setArtifactLocation(appJar)
@@ -158,7 +158,7 @@ public class ConfiguratorTest {
                                                                           authEnforcer, authenticationContext);
     PluginFinder pluginFinder = new LocalPluginFinder(artifactRepo);
     ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("myTable");
-
+    
     AppDeploymentInfo appDeploymentInfo = AppDeploymentInfo.builder()
       .setArtifactId(artifactId.toEntityId())
       .setArtifactLocation(appJar)

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/LocalApplicationManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/LocalApplicationManagerTest.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import io.cdap.cdap.internal.app.runtime.artifact.Artifacts;
 import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import org.apache.twill.filesystem.LocalLocationFactory;
@@ -132,6 +133,7 @@ public class LocalApplicationManagerTest {
       .setArtifactLocation(jarLoc)
       .setNamespaceId(NamespaceId.DEFAULT)
       .setApplicationClass(applicationClass)
+      .setChangeDetail(new ChangeDetail(null, null, null, System.currentTimeMillis()))
       .build();
     AppFabricTestHelper.getLocalManager().deploy(info).get();
   }
@@ -149,6 +151,7 @@ public class LocalApplicationManagerTest {
       .setArtifactLocation(deployedJar)
       .setNamespaceId(NamespaceId.DEFAULT)
       .setApplicationClass(applicationClass)
+      .setChangeDetail(new ChangeDetail(null, null, null, System.currentTimeMillis()))
       .build();
     ApplicationWithPrograms input = AppFabricTestHelper.getLocalManager().deploy(info).get();
 
@@ -179,6 +182,7 @@ public class LocalApplicationManagerTest {
       .setApplicationClass(applicationClass)
       .setAppName("MyApp")
       .setConfigString(GSON.toJson(config))
+      .setChangeDetail(new ChangeDetail(null, null, null, System.currentTimeMillis()))
       .build();
     AppFabricTestHelper.getLocalManager().deploy(info).get();
   }
@@ -195,6 +199,7 @@ public class LocalApplicationManagerTest {
       .setApplicationClass(applicationClass)
       .setAppName("BadApp")
       .setConfigString(GSON.toJson("invalid"))
+      .setChangeDetail(new ChangeDetail(null, null, null, System.currentTimeMillis()))
       .build();
     AppFabricTestHelper.getLocalManager().deploy(info).get();
   }
@@ -210,6 +215,7 @@ public class LocalApplicationManagerTest {
       .setNamespaceId(NamespaceId.DEFAULT)
       .setApplicationClass(applicationClass)
       .setAppName("CustomDSApp")
+      .setChangeDetail(new ChangeDetail(null, null, null, System.currentTimeMillis()))
       .build();
 
     try {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
@@ -208,7 +208,7 @@ public class RemoteConfiguratorTest {
     ArtifactId artifactId = NamespaceId.DEFAULT.artifact(AllProgramsApp.class.getSimpleName(), "1.0.0");
 
     // Don't update the artifacts map so that the fetching of artifact would fail.
-
+    
     AppDeploymentInfo info = AppDeploymentInfo.builder()
       .setArtifactId(artifactId)
       .setArtifactLocation(appJar)
@@ -231,7 +231,7 @@ public class RemoteConfiguratorTest {
     artifacts.put(artifactId, new ArtifactDetail(new ArtifactDescriptor(artifactId.getNamespace(),
                                                                         artifactId.toApiArtifactId(), appJar),
                                                  new ArtifactMeta(ArtifactClasses.builder().build())));
-
+    
     AppDeploymentInfo info = AppDeploymentInfo.builder()
       .setArtifactId(artifactId)
       .setArtifactLocation(appJar)

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
@@ -121,7 +121,7 @@ public class SystemProgramManagementServiceTest extends AppFabricTestBase {
     artifactRepository.addArtifact(artifactId, appJarFile);
     ArtifactSummary summary = new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(),
                                                   ArtifactScope.SYSTEM);
-    applicationLifecycleService.deployApp(NamespaceId.SYSTEM, APP_NAME, VERSION, summary, null,
+    applicationLifecycleService.deployApp(NamespaceId.SYSTEM, APP_NAME, VERSION, summary, null, null,
                                           programId -> {
                                             // no-op
                                           }, null, false, false, Collections.emptyMap());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerInternalTest.java
@@ -22,10 +22,13 @@ import io.cdap.cdap.AllProgramsApp;
 import io.cdap.cdap.api.app.Application;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.gateway.handlers.PreferencesHttpHandlerInternal;
 import io.cdap.cdap.internal.app.deploy.Specifications;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
 import io.cdap.cdap.proto.PreferencesDetail;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.Assert;
@@ -47,9 +50,12 @@ public class PreferencesHttpHandlerInternalTest extends AppFabricTestBase {
     store = getInjector().getInstance(Store.class);
   }
 
-  private void addApplication(String namespace, Application app) {
+  private void addApplication(String namespace, Application app) throws ConflictException {
     ApplicationSpecification appSpec = Specifications.from(app);
-    store.addApplication(new ApplicationId(namespace, appSpec.getName()), appSpec);
+    ApplicationMeta meta = new ApplicationMeta(appSpec.getName(), appSpec,
+                                               new ChangeDetail(null, null, null,
+                                                                System.currentTimeMillis()));
+    store.addApplication(new ApplicationId(namespace, appSpec.getName()), meta);
   }
 
   @Test

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/PreferencesHttpHandlerTest.java
@@ -22,10 +22,13 @@ import io.cdap.cdap.AllProgramsApp;
 import io.cdap.cdap.api.app.Application;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.gateway.handlers.PreferencesHttpHandler;
 import io.cdap.cdap.internal.app.deploy.Specifications;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.profile.Profile;
@@ -48,9 +51,12 @@ public class PreferencesHttpHandlerTest extends AppFabricTestBase {
     store = getInjector().getInstance(Store.class);
   }
 
-  private void addApplication(String namespace, Application app) {
+  private void addApplication(String namespace, Application app) throws ConflictException {
     ApplicationSpecification appSpec = Specifications.from(app);
-    store.addApplication(new ApplicationId(namespace, appSpec.getName()), appSpec);
+    ApplicationMeta meta = new ApplicationMeta(appSpec.getName(), appSpec,
+                                               new ChangeDetail(null, null, null,
+                                                                System.currentTimeMillis()));
+    store.addApplication(new ApplicationId(namespace, appSpec.getName()), meta);
   }
 
   @Test

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.internal.app.deploy.Specifications;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProfileId;
@@ -77,6 +78,7 @@ public abstract class AppMetadataStoreTest {
 
   private final AtomicInteger sourceId = new AtomicInteger();
   private final AtomicLong runIdTime = new AtomicLong();
+  private final Long creationTimeMillis = System.currentTimeMillis();
 
   @Before
   public void before() {
@@ -923,8 +925,10 @@ public abstract class AppMetadataStoreTest {
       String appName = "test" + i;
       TransactionRunners.run(transactionRunner, context -> {
         AppMetadataStore store = AppMetadataStore.create(context);
-        store.writeApplication(NamespaceId.DEFAULT.getNamespace(), appName, ApplicationId.DEFAULT_VERSION, appSpec);
-        store.writeApplication(NamespaceId.SYSTEM.getNamespace(), appName, ApplicationId.DEFAULT_VERSION, appSpec);
+        store.writeApplication(NamespaceId.DEFAULT.getNamespace(), appName, ApplicationId.DEFAULT_VERSION, appSpec,
+                               new ChangeDetail(null, null, null, creationTimeMillis));
+        store.writeApplication(NamespaceId.SYSTEM.getNamespace(), appName, ApplicationId.DEFAULT_VERSION, appSpec,
+                               new ChangeDetail(null, null, null, creationTimeMillis));
       });
     }
     TransactionRunners.run(transactionRunner, context -> {
@@ -960,7 +964,8 @@ public abstract class AppMetadataStoreTest {
       String appName = "test" + i;
       TransactionRunners.run(transactionRunner, context -> {
         AppMetadataStore store = AppMetadataStore.create(context);
-        store.writeApplication(NamespaceId.DEFAULT.getNamespace(), appName, ApplicationId.DEFAULT_VERSION, appSpec);
+        store.writeApplication(NamespaceId.DEFAULT.getNamespace(), appName, ApplicationId.DEFAULT_VERSION, appSpec,
+                               new ChangeDetail(null, null, null, creationTimeMillis));
       });
     }
 
@@ -989,7 +994,8 @@ public abstract class AppMetadataStoreTest {
       String appName = "test" + i;
       TransactionRunners.run(transactionRunner, context -> {
         AppMetadataStore store = AppMetadataStore.create(context);
-        store.writeApplication(NamespaceId.DEFAULT.getNamespace(), appName, ApplicationId.DEFAULT_VERSION, appSpec);
+        store.writeApplication(NamespaceId.DEFAULT.getNamespace(), appName, ApplicationId.DEFAULT_VERSION, appSpec,
+                               new ChangeDetail(null, null, null, creationTimeMillis));
       });
     }
 
@@ -1111,14 +1117,16 @@ public abstract class AppMetadataStoreTest {
       TransactionRunners.run(transactionRunner, context -> {
         AppMetadataStore store = AppMetadataStore.create(context);
         store.writeApplication(NamespaceId.DEFAULT.getNamespace(),
-                               defaultAppName, ApplicationId.DEFAULT_VERSION, appSpec);
+                               defaultAppName, ApplicationId.DEFAULT_VERSION, appSpec,
+                               new ChangeDetail(null, null, null, creationTimeMillis));
       });
 
       String cdapAppName = "test" + (2 * i + 1);
       TransactionRunners.run(transactionRunner, context -> {
         AppMetadataStore store = AppMetadataStore.create(context);
         store.writeApplication(NamespaceId.CDAP.getNamespace(),
-                               cdapAppName, ApplicationId.DEFAULT_VERSION, appSpec);
+                               cdapAppName, ApplicationId.DEFAULT_VERSION, appSpec,
+                               new ChangeDetail(null, null, null, creationTimeMillis));
       });
     }
 
@@ -1147,14 +1155,16 @@ public abstract class AppMetadataStoreTest {
       TransactionRunners.run(transactionRunner, context -> {
         AppMetadataStore store = AppMetadataStore.create(context);
         store.writeApplication(NamespaceId.DEFAULT.getNamespace(),
-            defaultAppName, ApplicationId.DEFAULT_VERSION, appSpec);
+            defaultAppName, ApplicationId.DEFAULT_VERSION, appSpec,
+                               new ChangeDetail(null, null, null, creationTimeMillis));
       });
 
       String cdapAppName = "test" + (2 * i + 1);
       TransactionRunners.run(transactionRunner, context -> {
         AppMetadataStore store = AppMetadataStore.create(context);
         store.writeApplication(NamespaceId.CDAP.getNamespace(),
-            cdapAppName, ApplicationId.DEFAULT_VERSION, appSpec);
+            cdapAppName, ApplicationId.DEFAULT_VERSION, appSpec,
+                               new ChangeDetail(null, null, null, creationTimeMillis));
       });
     }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/NoSqlDefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/NoSqlDefaultStoreTest.java
@@ -18,10 +18,10 @@ package io.cdap.cdap.internal.app.store;
 
 import com.google.inject.Injector;
 import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.internal.AppFabricTestHelper;
 import io.cdap.cdap.spi.data.SortOrder;
-import io.cdap.cdap.spi.data.transaction.TransactionException;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.store.DefaultNamespaceStore;
 import org.junit.AfterClass;
@@ -41,12 +41,12 @@ public class NoSqlDefaultStoreTest extends DefaultStoreTest {
   }
 
   @Test
-  public void testScanApplicationsWithSmallReorderBatch() throws TransactionException {
+  public void testScanApplicationsWithSmallReorderBatch() throws ConflictException {
     testScanApplications(getDescOrderUnsupportedStore());
   }
 
   @Test
-  public void testScanApplicationsWithNamespaceWithSmallReorderBatch() throws TransactionException {
+  public void testScanApplicationsWithNamespaceWithSmallReorderBatch() throws ConflictException {
     testScanApplicationsWithNamespace(getDescOrderUnsupportedStore());
   }
 
@@ -56,7 +56,7 @@ public class NoSqlDefaultStoreTest extends DefaultStoreTest {
    * {@link UnsupportedOperationException}. Store in this case should fall back to resorting in memory.
    * It will also use a small batch size to test multiple reorder batches
    */
-  private Store getDescOrderUnsupportedStore() throws TransactionException {
+  private Store getDescOrderUnsupportedStore() throws ConflictException {
     TransactionRunner runner = injector.getInstance(TransactionRunner.class);
     Store store = new DefaultStore(runner, 20);
     return store;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/LineageAdminTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/LineageAdminTest.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.api.workflow.WorkflowActionNode;
 import io.cdap.cdap.api.workflow.WorkflowNode;
 import io.cdap.cdap.api.workflow.WorkflowSpecification;
 import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.utils.ProjectInfo;
 import io.cdap.cdap.data2.metadata.lineage.AccessType;
@@ -42,7 +43,9 @@ import io.cdap.cdap.internal.app.DefaultApplicationSpecification;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
 import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -459,7 +462,7 @@ public class LineageAdminTest extends AppFabricTestBase {
 
 
   @Test
-  public void testWorkflowLineage() {
+  public void testWorkflowLineage() throws ConflictException {
 
     TransactionRunner transactionRunner = getInjector().getInstance(TransactionRunner.class);
     LineageStoreReader lineageReader =
@@ -490,7 +493,10 @@ public class LineageAdminTest extends AppFabricTestBase {
       );
 
     Store store = getInjector().getInstance(Store.class);
-    store.addApplication(testApp, appSpec);
+    ApplicationMeta meta = new ApplicationMeta(appSpec.getName(), appSpec,
+                                               new ChangeDetail(null, null, null,
+                                                                System.currentTimeMillis()));
+    store.addApplication(testApp, meta);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageReader, store);
 
     // Add accesses for D3 -> P2 -> D2 -> P1 -> D1 <-> P3
@@ -663,7 +669,10 @@ public class LineageAdminTest extends AppFabricTestBase {
       );
 
     Store store = getInjector().getInstance(Store.class);
-    store.addApplication(testApp, appSpec);
+    ApplicationMeta meta = new ApplicationMeta(appSpec.getName(), appSpec,
+                                               new ChangeDetail(null, null, null,
+                                                                System.currentTimeMillis()));
+    store.addApplication(testApp, meta);
     LineageAdmin lineageAdmin = new LineageAdmin(lineageReader, store);
 
     // Add accesses for D1 -|

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/MetadataSubscriberServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/MetadataSubscriberServiceTest.java
@@ -68,6 +68,7 @@ import io.cdap.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
 import io.cdap.cdap.internal.app.runtime.workflow.MessagingWorkflowStateWriter;
 import io.cdap.cdap.internal.app.runtime.workflow.WorkflowStateWriter;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
 import io.cdap.cdap.internal.app.store.DefaultStore;
 import io.cdap.cdap.internal.profile.AdminEventPublisher;
 import io.cdap.cdap.internal.profile.ProfileService;
@@ -80,6 +81,7 @@ import io.cdap.cdap.messaging.store.TableFactory;
 import io.cdap.cdap.messaging.store.leveldb.LevelDBTableFactory;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.WorkflowNodeStateDetail;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.EntityId;
@@ -443,7 +445,10 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
     // app must exist before assigning the profile for the namespace, otherwise the app's
     // programs will not receive the profile metadata.
     Store store = injector.getInstance(DefaultStore.class);
-    store.addApplication(appId, appSpec);
+    ApplicationMeta meta = new ApplicationMeta(appSpec.getName(), appSpec,
+                                               new ChangeDetail(null, null, null,
+                                                                System.currentTimeMillis()));
+    store.addApplication(appId, meta);
 
     // set default namespace to use the profile, since now MetadataSubscriberService is not started,
     // it should not affect the mds
@@ -584,7 +589,10 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
     Assert.assertEquals(Collections.emptyMap(), mds.read(new Read(workflowId.toMetadataEntity())).getProperties());
 
     Store store = injector.getInstance(DefaultStore.class);
-    store.addApplication(appId, appSpec);
+    ApplicationMeta meta = new ApplicationMeta(appSpec.getName(), appSpec,
+                                               new ChangeDetail(null, null, null,
+                                                                System.currentTimeMillis()));
+    store.addApplication(appId, meta);
 
     // set default namespace to use the profile, since now MetadataSubscriberService is not started,
     // it should not affect the mds

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
@@ -371,6 +371,10 @@ public final class StoreDefinition {
     public static final String APPLICATION_FIELD = "application";
     public static final String VERSION_FIELD = "version";
     public static final String APPLICATION_DATA_FIELD = "application_data";
+    public static final String CREATION_TIME_FIELD = "created";
+    public static final String CHANGE_SUMMARY_FIELD = "change_summary";
+    public static final String AUTHOR_FIELD = "author";
+    public static final String LATEST_FIELD = "latest";
     public static final String PROGRAM_TYPE_FIELD = "program_type";
     public static final String PROGRAM_FIELD = "program";
     public static final String RUN_FIELD = "run";
@@ -393,8 +397,13 @@ public final class StoreDefinition {
         .withFields(Fields.stringType(NAMESPACE_FIELD),
                     Fields.stringType(APPLICATION_FIELD),
                     Fields.stringType(VERSION_FIELD),
-                    Fields.stringType(APPLICATION_DATA_FIELD))
+                    Fields.stringType(APPLICATION_DATA_FIELD),
+                    Fields.longType(CREATION_TIME_FIELD),
+                    Fields.stringType(AUTHOR_FIELD),
+                    Fields.stringType(CHANGE_SUMMARY_FIELD),
+                    Fields.stringType(LATEST_FIELD))
         .withPrimaryKeys(NAMESPACE_FIELD, APPLICATION_FIELD, VERSION_FIELD)
+        .withIndexes(LATEST_FIELD, CREATION_TIME_FIELD)
         .build();
 
     public static final StructuredTableSpecification WORKFLOW_NODE_STATES_SPEC =

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/ApplicationDetail.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/ApplicationDetail.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.plugin.Plugin;
 import io.cdap.cdap.internal.dataset.DatasetCreationSpec;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +36,7 @@ public class ApplicationDetail {
   private final String name;
   private final String appVersion;
   private final String description;
+  private final ChangeDetail change;
   private final String configuration;
   private final List<DatasetDetail> datasets;
   private final List<ProgramRecord> programs;
@@ -52,9 +54,23 @@ public class ApplicationDetail {
                            List<PluginDetail> plugins,
                            ArtifactSummary artifact,
                            @Nullable String ownerPrincipal) {
+    this(name, appVersion, description, null, configuration, datasets, programs, plugins, artifact, ownerPrincipal);
+  }
+
+  public ApplicationDetail(String name,
+                           String appVersion,
+                           String description,
+                           @Nullable ChangeDetail change,
+                           String configuration,
+                           List<DatasetDetail> datasets,
+                           List<ProgramRecord> programs,
+                           List<PluginDetail> plugins,
+                           ArtifactSummary artifact,
+                           @Nullable String ownerPrincipal) {
     this.name = name;
     this.appVersion = appVersion;
     this.description = description;
+    this.change = change;
     this.configuration = configuration;
     this.datasets = datasets;
     this.programs = programs;
@@ -78,6 +94,10 @@ public class ApplicationDetail {
     return configuration;
   }
 
+  public ChangeDetail getChange() {
+    return change;
+  }
+
   public List<DatasetDetail> getDatasets() {
     return datasets;
   }
@@ -99,8 +119,10 @@ public class ApplicationDetail {
     return ownerPrincipal;
   }
 
-  public static ApplicationDetail fromSpec(ApplicationSpecification spec,
-                                           @Nullable String ownerPrincipal) {
+  public static ApplicationDetail fromSpec(ApplicationSpecification spec, @Nullable String ownerPrincipal,
+                                           @Nullable ChangeDetail change) {
+    // Adding owner, creation time and change summary description fields to the app detail
+
     List<ProgramRecord> programs = new ArrayList<>();
     for (ProgramSpecification programSpec : spec.getMapReduce().values()) {
       programs.add(new ProgramRecord(ProgramType.MAPREDUCE, spec.getName(),
@@ -139,7 +161,7 @@ public class ApplicationDetail {
     // in the meantime, we don't want this api call to null pointer exception.
     ArtifactSummary summary = spec.getArtifactId() == null ?
       new ArtifactSummary(spec.getName(), null) : ArtifactSummary.from(spec.getArtifactId());
-    return new ApplicationDetail(spec.getName(), spec.getAppVersion(), spec.getDescription(), spec.getConfiguration(),
-                                 datasets, programs, plugins, summary, ownerPrincipal);
+    return new ApplicationDetail(spec.getName(), spec.getAppVersion(), spec.getDescription(), change,
+                                 spec.getConfiguration(), datasets, programs, plugins, summary, ownerPrincipal);
   }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/artifact/AppRequest.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/artifact/AppRequest.java
@@ -31,12 +31,13 @@ public class AppRequest<T> {
   private final ArtifactSummary artifact;
   private final T config;
   private final T configuration;
+  @Nullable
+  private final ChangeSummary change;
   private final PreviewConfig preview;
   @SerializedName("principal")
   private final String ownerPrincipal;
   @SerializedName("app.deploy.update.schedules")
   private final Boolean updateSchedules;
-
 
   public AppRequest(ArtifactSummary artifact) {
     this(artifact, null);
@@ -61,12 +62,19 @@ public class AppRequest<T> {
 
   public AppRequest(ArtifactSummary artifact, @Nullable T config, @Nullable PreviewConfig preview,
                     @Nullable String ownerPrincipal, @Nullable Boolean updateSchedules, @Nullable T configuration) {
+    this(artifact, config, preview, ownerPrincipal, updateSchedules, configuration, null);
+  }
+
+  public AppRequest(ArtifactSummary artifact, @Nullable T config, @Nullable PreviewConfig preview,
+                    @Nullable String ownerPrincipal, @Nullable Boolean updateSchedules, @Nullable T configuration,
+                    @Nullable ChangeSummary change) {
     this.artifact = artifact;
     this.config = config;
     this.preview = preview;
     this.ownerPrincipal = ownerPrincipal;
     this.updateSchedules = updateSchedules;
     this.configuration = configuration;
+    this.change = change;
   }
 
   public ArtifactSummary getArtifact() {
@@ -76,6 +84,11 @@ public class AppRequest<T> {
   @Nullable
   public T getConfig() {
     return config != null ? config : configuration;
+  }
+
+  @Nullable
+  public ChangeSummary getChange() {
+    return change;
   }
 
   @Nullable

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/artifact/ChangeDetail.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/artifact/ChangeDetail.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.artifact;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Change Summary returned in the app response.
+ */
+public class ChangeDetail extends ChangeSummary {
+  @Nullable
+  private final String author;
+  private final long creationTimeMillis;
+
+  public ChangeDetail(@Nullable String description, @Nullable String parentVersion, @Nullable String author,
+                      long creationTimeMillis) {
+    super(description, parentVersion);
+    this.author = author;
+    this.creationTimeMillis = creationTimeMillis;
+  }
+
+  /**
+   * @return The creation time of the update in millis seconds.
+   */
+  public long getCreationTimeMillis() {
+    return creationTimeMillis;
+  }
+
+  /**
+   * @return Author(user name) of the change.
+   */
+  @Nullable
+  public String getAuthor() {
+    return author;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ChangeDetail that = (ChangeDetail) o;
+
+    return creationTimeMillis == that.creationTimeMillis &&
+      Objects.equals(author, that.author);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(author, creationTimeMillis);
+  }
+
+  @Override
+  public String toString() {
+    return "ChangeDetail{" +
+      "author='" + author + '\'' +
+      ", creationTimeMillis=" + creationTimeMillis +
+      '}';
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/artifact/ChangeSummary.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/artifact/ChangeSummary.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.artifact;
+
+import io.cdap.cdap.api.annotation.Beta;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Represents the change summary for an update of the application
+ */
+@Beta
+public class ChangeSummary {
+  @Nullable
+  protected final String description;
+  @Nullable
+  protected final String parentVersion;
+
+  public ChangeSummary(@Nullable String description, @Nullable String parentVersion) {
+    this.description = description;
+    this.parentVersion = parentVersion;
+  }
+
+  @Nullable
+  public String getDescription() {
+    return description;
+  }
+
+  @Nullable
+  public String getParentVersion() {
+    return parentVersion;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ChangeSummary that = (ChangeSummary) o;
+
+    return Objects.equals(description, that.description) && Objects.equals(parentVersion, that.parentVersion);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(description, parentVersion);
+  }
+
+  @Override
+  public String toString() {
+    return "ChangeSummary{" +
+      "description='" + description + '\'' +
+      ", parentVersion=" + parentVersion +
+      '}';
+  }
+}


### PR DESCRIPTION
The changes to the following deploy endpoints are as follows: 

```
PUT /apps/{app-id}
POST /apps/{app-id}/versions/{version-id}/create
POST /apps/{app-id}/update
POST /apps/{app-id}/upgrade
POST /upgrade
```


1. Additional optional fields to the request body: 
```
"changeSummary": {
      "description": "..."
  },
  "parentVersion": "..."
```
2. If the parent version in the request of the app doesn’t match the current latest version, deployment is rejected.
3. The change-summary, creation time, author and latest is written to the table during deployment
4. [TEMPORARY CHANGE]The latest version of the app is retrieved by scanning the table for all app versions.
5.  New version of the pipeline is created on deploy - version id is UUID. Version is identified by metadata: creation time and owner - both will be written to the table.


NOTE: TODO [These changes are complete and  can be merged only when the following are addressed]:

1. Unit tests to be added.
3. BLOCKING on https://cdap.atlassian.net/browse/CDAP-19427 : Creation time and owner are written to Appmetadata store 
4. BLOCKING on https://cdap.atlassian.net/browse/CDAP-19427 latest field must be written to the table and the current latest value is updated- to make deployment transactional.
5. BLOCKING on https://cdap.atlassian.net/browse/CDAP-19427 fetch the latest version by querying the index (on creation time) instead of scanning the entire table.