### PR TITLE
Add Sampling Options for Wrangler

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionUtils.java
@@ -113,7 +113,7 @@ public final class ConnectionUtils {
     spec.getRelatedPlugins().forEach(pluginSpec -> relatedPlugins.add(
       new PluginDetail(pluginSpec.getName(), pluginSpec.getType(), pluginSpec.getProperties(), artifact,
                        spec.getSchema())));
-    return new ConnectorDetail(relatedPlugins);
+    return new ConnectorDetail(relatedPlugins, spec.getSupportedSampleTypes());
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/ConnectorSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/ConnectorSpec.java
@@ -31,17 +31,17 @@ public class ConnectorSpec {
   // schema is null when the connector is unable to retrieve it from the resource
   private final Schema schema;
   private final Set<PluginSpec> relatedPlugins;
-  private final Set<String> availableSampleTypes;
+  private final Set<String> supportedSampleTypes;
 
   private ConnectorSpec(@Nullable Schema schema,
                         Set<PluginSpec> relatedPlugins,
-                        Set<String> availableSampleTypes) {
+                        Set<String> supportedSampleTypes) {
     this.schema = schema;
     this.relatedPlugins = relatedPlugins;
-    if (availableSampleTypes != null) {
-      this.availableSampleTypes = availableSampleTypes;
+    if (supportedSampleTypes != null) {
+      this.supportedSampleTypes = supportedSampleTypes;
     } else {
-      this.availableSampleTypes = new HashSet<String>();
+      this.supportedSampleTypes = new HashSet<String>();
     }
   }
 
@@ -58,8 +58,8 @@ public class ConnectorSpec {
     return relatedPlugins;
   }
 
-  public Set<String> getAvailableSampleTypes() {
-    return availableSampleTypes;
+  public Set<String> getSupportedSampleTypes() {
+    return supportedSampleTypes;
   }
 
   @Override
@@ -75,12 +75,12 @@ public class ConnectorSpec {
     ConnectorSpec that = (ConnectorSpec) o;
     return Objects.equals(schema, that.schema)
             && Objects.equals(relatedPlugins, that.relatedPlugins)
-            && Objects.equals(availableSampleTypes, that.availableSampleTypes);
+            && Objects.equals(supportedSampleTypes, that.supportedSampleTypes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(schema, relatedPlugins, availableSampleTypes);
+    return Objects.hash(schema, relatedPlugins, supportedSampleTypes);
   }
 
   /**
@@ -96,11 +96,11 @@ public class ConnectorSpec {
   public static class Builder {
     private Schema schema;
     private Set<PluginSpec> relatedPlugins;
-    private final Set<String> availableSampleTypes;
+    private final Set<String> supportedSampleTypes;
 
     public Builder() {
       this.relatedPlugins = new HashSet<>();
-      this.availableSampleTypes = new HashSet<>();
+      this.supportedSampleTypes = new HashSet<>();
     }
 
     public Builder setSchema(@Nullable Schema schema) {
@@ -119,19 +119,19 @@ public class ConnectorSpec {
       return this;
     }
 
-    public Builder setAvailableSampleTypes(Set<String> availableSampleTypes) {
-      this.availableSampleTypes.clear();
-      this.availableSampleTypes.addAll(availableSampleTypes);
+    public Builder setSupportedSampleTypes(Set<String> supportedSampleTypes) {
+      this.supportedSampleTypes.clear();
+      this.supportedSampleTypes.addAll(supportedSampleTypes);
       return this;
     }
 
-    public Builder addAvailableSampleType(String sampleType) {
-      this.availableSampleTypes.add(sampleType);
+    public Builder addSupportedSampleType(String sampleType) {
+      this.supportedSampleTypes.add(sampleType);
       return this;
     }
 
     public ConnectorSpec build() {
-      return new ConnectorSpec(schema, relatedPlugins, availableSampleTypes);
+      return new ConnectorSpec(schema, relatedPlugins, supportedSampleTypes);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/ConnectorSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/ConnectorSpec.java
@@ -31,10 +31,14 @@ public class ConnectorSpec {
   // schema is null when the connector is unable to retrieve it from the resource
   private final Schema schema;
   private final Set<PluginSpec> relatedPlugins;
+  private final Set<String> availableSampleTypes;
 
-  private ConnectorSpec(@Nullable Schema schema, Set<PluginSpec> relatedPlugins) {
+  private ConnectorSpec(@Nullable Schema schema,
+                        Set<PluginSpec> relatedPlugins,
+                        @Nullable Set<String> availableSampleTypes) {
     this.schema = schema;
     this.relatedPlugins = relatedPlugins;
+    this.availableSampleTypes = availableSampleTypes;
   }
 
   @Nullable
@@ -44,6 +48,11 @@ public class ConnectorSpec {
 
   public Set<PluginSpec> getRelatedPlugins() {
     return relatedPlugins;
+  }
+
+  @Nullable
+  public Set<String> getAvailableSampleTypes() {
+    return availableSampleTypes;
   }
 
   @Override
@@ -57,13 +66,14 @@ public class ConnectorSpec {
     }
 
     ConnectorSpec that = (ConnectorSpec) o;
-    return Objects.equals(schema, that.schema) &&
-             Objects.equals(relatedPlugins, that.relatedPlugins);
+    return Objects.equals(schema, that.schema)
+            && Objects.equals(relatedPlugins, that.relatedPlugins)
+            && Objects.equals(availableSampleTypes, that.availableSampleTypes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(schema, relatedPlugins);
+    return Objects.hash(schema, relatedPlugins, availableSampleTypes);
   }
 
   /**
@@ -79,9 +89,11 @@ public class ConnectorSpec {
   public static class Builder {
     private Schema schema;
     private Set<PluginSpec> relatedPlugins;
+    private final Set<String> availableSampleTypes;
 
     public Builder() {
       this.relatedPlugins = new HashSet<>();
+      this.availableSampleTypes = new HashSet<>();
     }
 
     public Builder setSchema(@Nullable Schema schema) {
@@ -100,8 +112,19 @@ public class ConnectorSpec {
       return this;
     }
 
+    public Builder setAvailableSampleTypes(@Nullable Set<String> availableSampleTypes) {
+      this.availableSampleTypes.clear();
+      this.availableSampleTypes.addAll(availableSampleTypes);
+      return this;
+    }
+
+    public Builder addAvailableSampleType(String sampleType) {
+      this.availableSampleTypes.add(sampleType);
+      return this;
+    }
+
     public ConnectorSpec build() {
-      return new ConnectorSpec(schema, relatedPlugins);
+      return new ConnectorSpec(schema, relatedPlugins, availableSampleTypes);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/ConnectorSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/ConnectorSpec.java
@@ -41,7 +41,7 @@ public class ConnectorSpec {
     if (supportedSampleTypes != null) {
       this.supportedSampleTypes = supportedSampleTypes;
     } else {
-      this.supportedSampleTypes = new HashSet<String>();
+      this.supportedSampleTypes = new HashSet<>();
     }
   }
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/ConnectorSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/ConnectorSpec.java
@@ -35,10 +35,18 @@ public class ConnectorSpec {
 
   private ConnectorSpec(@Nullable Schema schema,
                         Set<PluginSpec> relatedPlugins,
-                        @Nullable Set<String> availableSampleTypes) {
+                        Set<String> availableSampleTypes) {
     this.schema = schema;
     this.relatedPlugins = relatedPlugins;
-    this.availableSampleTypes = availableSampleTypes;
+    if (availableSampleTypes != null) {
+      this.availableSampleTypes = availableSampleTypes;
+    } else {
+      this.availableSampleTypes = new HashSet<String>();
+    }
+  }
+
+  private ConnectorSpec(@Nullable Schema schema, Set<PluginSpec> relatedPlugins) {
+    this(schema, relatedPlugins, null);
   }
 
   @Nullable
@@ -50,7 +58,6 @@ public class ConnectorSpec {
     return relatedPlugins;
   }
 
-  @Nullable
   public Set<String> getAvailableSampleTypes() {
     return availableSampleTypes;
   }
@@ -112,7 +119,7 @@ public class ConnectorSpec {
       return this;
     }
 
-    public Builder setAvailableSampleTypes(@Nullable Set<String> availableSampleTypes) {
+    public Builder setAvailableSampleTypes(Set<String> availableSampleTypes) {
       this.availableSampleTypes.clear();
       this.availableSampleTypes.addAll(availableSampleTypes);
       return this;

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectorDetail.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectorDetail.java
@@ -27,13 +27,27 @@ import java.util.Set;
  */
 public class ConnectorDetail {
   private final Set<PluginDetail> relatedPlugins;
+  private final Set<String> availableSampleTypes;
+
+  public ConnectorDetail(Set<PluginDetail> relatedPlugins, Set<String> availableSampleTypes) {
+    this.relatedPlugins = relatedPlugins;
+    if (availableSampleTypes != null) {
+      this.availableSampleTypes = availableSampleTypes;
+    } else {
+      this.availableSampleTypes = new HashSet<String>();
+    }
+  }
 
   public ConnectorDetail(Set<PluginDetail> relatedPlugins) {
-    this.relatedPlugins = relatedPlugins;
+    this(relatedPlugins, null);
   }
 
   public Set<PluginDetail> getRelatedPlugins() {
     return relatedPlugins;
+  }
+
+  public Set<String> getAvailableSampleTypes() {
+    return availableSampleTypes;
   }
 
   @Override
@@ -47,11 +61,12 @@ public class ConnectorDetail {
     }
 
     ConnectorDetail that = (ConnectorDetail) o;
-    return Objects.equals(relatedPlugins, that.relatedPlugins);
+    return Objects.equals(relatedPlugins, that.relatedPlugins)
+            && Objects.equals(availableSampleTypes, that.availableSampleTypes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(relatedPlugins);
+    return Objects.hash(relatedPlugins, availableSampleTypes);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectorDetail.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectorDetail.java
@@ -27,14 +27,14 @@ import java.util.Set;
  */
 public class ConnectorDetail {
   private final Set<PluginDetail> relatedPlugins;
-  private final Set<String> availableSampleTypes;
+  private final Set<String> supportedSampleTypes;
 
-  public ConnectorDetail(Set<PluginDetail> relatedPlugins, Set<String> availableSampleTypes) {
+  public ConnectorDetail(Set<PluginDetail> relatedPlugins, Set<String> supportedSampleTypes) {
     this.relatedPlugins = relatedPlugins;
-    if (availableSampleTypes != null) {
-      this.availableSampleTypes = availableSampleTypes;
+    if (supportedSampleTypes != null) {
+      this.supportedSampleTypes = supportedSampleTypes;
     } else {
-      this.availableSampleTypes = new HashSet<String>();
+      this.supportedSampleTypes = new HashSet<String>();
     }
   }
 
@@ -46,8 +46,8 @@ public class ConnectorDetail {
     return relatedPlugins;
   }
 
-  public Set<String> getAvailableSampleTypes() {
-    return availableSampleTypes;
+  public Set<String> getSupportedSampleTypes() {
+    return supportedSampleTypes;
   }
 
   @Override
@@ -62,11 +62,11 @@ public class ConnectorDetail {
 
     ConnectorDetail that = (ConnectorDetail) o;
     return Objects.equals(relatedPlugins, that.relatedPlugins)
-            && Objects.equals(availableSampleTypes, that.availableSampleTypes);
+            && Objects.equals(supportedSampleTypes, that.supportedSampleTypes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(relatedPlugins, availableSampleTypes);
+    return Objects.hash(relatedPlugins, supportedSampleTypes);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectorDetail.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectorDetail.java
@@ -17,6 +17,7 @@
 
 package io.cdap.cdap.etl.proto.connection;
 
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectorDetail.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectorDetail.java
@@ -35,7 +35,7 @@ public class ConnectorDetail {
     if (supportedSampleTypes != null) {
       this.supportedSampleTypes = supportedSampleTypes;
     } else {
-      this.supportedSampleTypes = new HashSet<String>();
+      this.supportedSampleTypes = new HashSet<>();
     }
   }
 


### PR DESCRIPTION
# Add Sampling Options for Wrangler

## Description
Updated `ConnectorSpec` and `ConnectorDetail` to save supported sampling types to allow for addition of various connector sampling options in Wrangler.

Related PRs:
- [wrangler #573](https://github.com/data-integrations/wrangler/pull/573)
- [google-cloud #1084](https://github.com/data-integrations/google-cloud/pull/1084)
- [database-plugins #285](https://github.com/data-integrations/database-plugins/pull/285)

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick

## Links
Jira: none