### PR TITLE
Add Sampling Options for Wrangler

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionUtils.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ConnectionUtils.java
@@ -113,7 +113,7 @@ public final class ConnectionUtils {
     spec.getRelatedPlugins().forEach(pluginSpec -> relatedPlugins.add(
       new PluginDetail(pluginSpec.getName(), pluginSpec.getType(), pluginSpec.getProperties(), artifact,
                        spec.getSchema())));
-    return new ConnectorDetail(relatedPlugins);
+    return new ConnectorDetail(relatedPlugins, spec.getSupportedSampleTypes());
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/ConnectorSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/ConnectorSpec.java
@@ -17,6 +17,7 @@
 
 package io.cdap.cdap.etl.api.connector;
 
+import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.api.data.schema.Schema;
 
 import java.util.HashSet;
@@ -31,10 +32,14 @@ public class ConnectorSpec {
   // schema is null when the connector is unable to retrieve it from the resource
   private final Schema schema;
   private final Set<PluginSpec> relatedPlugins;
+  private final Set<SampleType> supportedSampleTypes;
 
-  private ConnectorSpec(@Nullable Schema schema, Set<PluginSpec> relatedPlugins) {
+  private ConnectorSpec(@Nullable Schema schema,
+                        Set<PluginSpec> relatedPlugins,
+                        Set<SampleType> supportedSampleTypes) {
     this.schema = schema;
     this.relatedPlugins = relatedPlugins;
+    this.supportedSampleTypes = supportedSampleTypes;
   }
 
   @Nullable
@@ -44,6 +49,10 @@ public class ConnectorSpec {
 
   public Set<PluginSpec> getRelatedPlugins() {
     return relatedPlugins;
+  }
+
+  public Set<SampleType> getSupportedSampleTypes() {
+    return supportedSampleTypes;
   }
 
   @Override
@@ -57,13 +66,14 @@ public class ConnectorSpec {
     }
 
     ConnectorSpec that = (ConnectorSpec) o;
-    return Objects.equals(schema, that.schema) &&
-             Objects.equals(relatedPlugins, that.relatedPlugins);
+    return Objects.equals(schema, that.schema)
+            && Objects.equals(relatedPlugins, that.relatedPlugins)
+            && Objects.equals(supportedSampleTypes, that.supportedSampleTypes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(schema, relatedPlugins);
+    return Objects.hash(schema, relatedPlugins, supportedSampleTypes);
   }
 
   /**
@@ -78,10 +88,12 @@ public class ConnectorSpec {
    */
   public static class Builder {
     private Schema schema;
-    private Set<PluginSpec> relatedPlugins;
+    private final Set<PluginSpec> relatedPlugins;
+    private final Set<SampleType> supportedSampleTypes;
 
     public Builder() {
       this.relatedPlugins = new HashSet<>();
+      this.supportedSampleTypes = new HashSet<>();
     }
 
     public Builder setSchema(@Nullable Schema schema) {
@@ -100,8 +112,13 @@ public class ConnectorSpec {
       return this;
     }
 
+    public Builder addSupportedSampleType(SampleType sampleType) {
+      this.supportedSampleTypes.add(sampleType);
+      return this;
+    }
+
     public ConnectorSpec build() {
-      return new ConnectorSpec(schema, relatedPlugins);
+      return new ConnectorSpec(schema, relatedPlugins, ImmutableSet.copyOf(supportedSampleTypes));
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/SampleRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/SampleRequest.java
@@ -30,11 +30,13 @@ public class SampleRequest {
   private final String path;
   private final int limit;
   private final Map<String, String> properties;
+  private final Long timeoutMs;
 
-  private SampleRequest(@Nullable String path, int limit, Map<String, String> properties) {
+  protected SampleRequest(@Nullable String path, int limit, Map<String, String> properties, @Nullable Long timeoutMs) {
     this.path = path;
     this.limit = limit;
     this.properties = properties;
+    this.timeoutMs = timeoutMs;
   }
 
   /**
@@ -48,6 +50,11 @@ public class SampleRequest {
 
   public int getLimit() {
     return limit;
+  }
+
+  @Nullable
+  public Long getTimeoutMs() {
+    return timeoutMs;
   }
 
   public Map<String, String> getProperties() {
@@ -68,12 +75,13 @@ public class SampleRequest {
     SampleRequest that = (SampleRequest) o;
     return limit == that.limit &&
              Objects.equals(path, that.path) &&
-             Objects.equals(properties, that.properties);
+             Objects.equals(properties, that.properties) &&
+             Objects.equals(timeoutMs, that.timeoutMs);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(path, limit, properties);
+    return Objects.hash(path, limit, properties, timeoutMs);
   }
 
   /**
@@ -89,7 +97,8 @@ public class SampleRequest {
   public static class Builder {
     private String path;
     private int limit;
-    private Map<String, String> properties;
+    private final Map<String, String> properties;
+    private Long timeoutMs;
 
     public Builder(int limit) {
       this.limit = limit;
@@ -112,8 +121,13 @@ public class SampleRequest {
       return this;
     }
 
+    public Builder setTimeoutMs(Long timeoutMs) {
+      this.timeoutMs = timeoutMs;
+      return this;
+    }
+
     public SampleRequest build() {
-      return new SampleRequest(path, limit, properties);
+      return new SampleRequest(path, limit, properties, timeoutMs);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/SampleType.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/connector/SampleType.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.connector;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Enum representing type of sampling method
+ */
+public enum SampleType {
+
+  /**
+   * Sample first [x] rows
+   */
+  @SerializedName("first")
+  FIRST("first"),
+
+  /**
+   * Sample random [x] rows
+   */
+  @SerializedName("random")
+  RANDOM("random"),
+
+  /**
+   * Sample [x] rows proportionally based on specified strata column
+   */
+  @SerializedName("stratified")
+  STRATIFIED("stratified"),
+
+  /**
+   * Use default sampling method
+   */
+  DEFAULT("default");
+
+  private final String name;
+
+  SampleType(String name) {
+    this.name = name;
+  }
+
+  public static SampleType fromString(String name) {
+    for (SampleType type : SampleType.values()) {
+      if (type.name.equalsIgnoreCase(name)) {
+        return type;
+      }
+    }
+    return DEFAULT;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/connector/SampleRequestTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/connector/SampleRequestTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package io.cdap.cdap.etl.api.connector;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests for {@link SampleRequest} and related builder.
+ */
+public class SampleRequestTest {
+  private static final String PATH = "/database/table";
+  private static final int LIMIT = 1000;
+  private static final Map<String, String> PROPERTIES = new HashMap<String, String>() {
+    {
+      put("sampleType", "stratified");
+      put("strata", "strata_col");
+    }
+  };
+  private static final Long TIMEOUTMS = 10000L;
+
+  @Test
+  public void testConstructor() {
+    SampleRequest sampleRequest = new SampleRequest(PATH, LIMIT, PROPERTIES, TIMEOUTMS);
+
+    Assert.assertEquals(PATH, sampleRequest.getPath());
+    Assert.assertEquals(LIMIT, sampleRequest.getLimit());
+    Assert.assertEquals(PROPERTIES, sampleRequest.getProperties());
+    Assert.assertEquals(TIMEOUTMS, sampleRequest.getTimeoutMs());
+  }
+
+  @Test
+  public void testConstructorNoTimeout() {
+    SampleRequest sampleRequest = new SampleRequest(PATH, LIMIT, PROPERTIES, null);
+    Assert.assertNull(sampleRequest.getTimeoutMs());
+  }
+
+  @Test
+  public void testConstructorNoProperties() {
+    SampleRequest sampleRequest = new SampleRequest(PATH, LIMIT, null, TIMEOUTMS);
+    Assert.assertEquals(Collections.emptyMap(), sampleRequest.getProperties());
+  }
+
+  @Test
+  public void testBuilder() {
+    SampleRequest sampleRequest = new SampleRequest.Builder(LIMIT)
+      .setPath(PATH)
+      .setLimit(LIMIT)
+      .setProperties(PROPERTIES)
+      .build();
+
+    Assert.assertEquals(PATH, sampleRequest.getPath());
+    Assert.assertEquals(LIMIT, sampleRequest.getLimit());
+    Assert.assertEquals(PROPERTIES, sampleRequest.getProperties());
+    // Timeout is only retrieved from JSON, so there is no need for the builder to set it
+    Assert.assertNull(sampleRequest.getTimeoutMs());
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectorDetail.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/connection/ConnectorDetail.java
@@ -17,8 +17,12 @@
 
 package io.cdap.cdap.etl.proto.connection;
 
+import io.cdap.cdap.etl.api.connector.SampleType;
+
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Response for the spec endpoint. The schema and properties are set on each available plugins.
@@ -27,13 +31,27 @@ import java.util.Set;
  */
 public class ConnectorDetail {
   private final Set<PluginDetail> relatedPlugins;
+  private final Set<SampleType> supportedSampleTypes;
+
+  public ConnectorDetail(Set<PluginDetail> relatedPlugins, @Nullable Set<SampleType> supportedSampleTypes) {
+    this.relatedPlugins = relatedPlugins;
+    if (supportedSampleTypes != null) {
+      this.supportedSampleTypes = supportedSampleTypes;
+    } else {
+      this.supportedSampleTypes = new HashSet<>();
+    }
+  }
 
   public ConnectorDetail(Set<PluginDetail> relatedPlugins) {
-    this.relatedPlugins = relatedPlugins;
+    this(relatedPlugins, null);
   }
 
   public Set<PluginDetail> getRelatedPlugins() {
     return relatedPlugins;
+  }
+
+  public Set<SampleType> getSupportedSampleTypes() {
+    return supportedSampleTypes;
   }
 
   @Override
@@ -47,11 +65,12 @@ public class ConnectorDetail {
     }
 
     ConnectorDetail that = (ConnectorDetail) o;
-    return Objects.equals(relatedPlugins, that.relatedPlugins);
+    return Objects.equals(relatedPlugins, that.relatedPlugins)
+            && Objects.equals(supportedSampleTypes, that.supportedSampleTypes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(relatedPlugins);
+    return Objects.hash(relatedPlugins, supportedSampleTypes);
   }
 }


### PR DESCRIPTION
# Add Sampling Options for Wrangler

## Description
Updated `ConnectorSpec` and `ConnectorDetail` to save supported sampling types to allow for addition of various connector sampling options in Wrangler.

Goes along with several other PRs, linked below.

Related PRs:
- [database-plugins #285](https://github.com/data-integrations/database-plugins/pull/285)
- [google-cloud #1084](https://github.com/data-integrations/google-cloud/pull/1084)
- [wrangler #573](https://github.com/data-integrations/wrangler/pull/573)
- [cdap-ui #603](https://github.com/cdapio/cdap-ui/pull/603)

## PR Type
- [ ] Bug Fix
- [x] Feature
- [ ] Build Fix
- [ ] Testing
- [ ] General Improvement
- [ ] Cherry Pick
