### PR TITLE
[CDAP-19462] Enforce at least once correct initialization for SystemMetricsExporter

### DIFF
--- a/cdap-master/src/test/java/io/cdap/cdap/metrics/publisher/MetricsWritersMetricsPublisherTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/metrics/publisher/MetricsWritersMetricsPublisherTest.java
@@ -20,13 +20,19 @@ import io.cdap.cdap.api.metrics.MetricType;
 import io.cdap.cdap.api.metrics.MetricValue;
 import io.cdap.cdap.api.metrics.MetricValues;
 import io.cdap.cdap.api.metrics.MetricsWriter;
+import io.cdap.cdap.api.metrics.MetricsWriterContext;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.metrics.process.loader.MetricsWriterProvider;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -47,6 +53,9 @@ import static org.mockito.Mockito.when;
 public class MetricsWritersMetricsPublisherTest {
   @Mock
   private MetricsWriterProvider provider;
+
+  @ClassRule
+  public static TemporaryFolder tmpFolder = new TemporaryFolder();
 
   @Before
   public void beforeEach() {
@@ -104,6 +113,57 @@ public class MetricsWritersMetricsPublisherTest {
     CConfiguration cConf = CConfiguration.create();
     MetricsWritersMetricsPublisher publisher = new MetricsWritersMetricsPublisher(provider, cConf);
     publisher.publish(getMockMetricArray(2), new TreeMap<>());
+  }
+
+  @Test
+  public void testWriterInititlaization() throws IOException {
+    CConfiguration cConf = CConfiguration.create();
+    String filePath = tmpFolder.newFolder().getAbsolutePath();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR, filePath);
+    MetricsWritersMetricsPublisher publisher = new MetricsWritersMetricsPublisher(provider, cConf);
+
+    //create test metricWriter that throws exception
+    MetricsWriter mockWriter = new MetricsWriter() {
+
+      @Override
+      public void close() throws IOException {
+
+      }
+
+      @Override
+      public void write(Collection<MetricValues> metricValues) {
+
+      }
+
+      @Override
+      public void initialize(MetricsWriterContext metricsWriterContext) {
+        throw new IllegalArgumentException("Not configured correctly");
+      }
+
+      @Override
+      public String getID() {
+        return "test_writer_exception";
+      }
+    };
+    Map<String, MetricsWriter> writers = new TreeMap<>();
+    writers.put(mockWriter.getID(), mockWriter);
+    when(provider.loadMetricsWriters()).thenReturn(writers);
+    try {
+      publisher.initialize();
+      Assert.fail("Expected exception, but method succeeded");
+    } catch (Exception e) {
+      //expected
+    }
+
+    //create the init file
+    File base = new File(filePath, "metricswriters");
+    base.mkdirs();
+    new File(base, mockWriter.getID()).createNewFile();
+    try {
+      publisher.initialize();
+    } catch (Exception e) {
+      Assert.fail("Not expecting exception, but received one");
+    }
   }
 
   private Map<String, MetricsWriter> getMockWriters(int count) {


### PR DESCRIPTION
https://cdap.atlassian.net/browse/CDAP-19462