### PR TITLE
CDAP-19540: add unit test for overwriting old tags and properties 

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/DefaultMetadataServiceClientTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/DefaultMetadataServiceClientTest.java
@@ -79,6 +79,23 @@ public class DefaultMetadataServiceClientTest extends AppFabricTestBase {
                         getMetadataProperties(createEntity, MetadataScope.USER));
     Assert.assertEquals(testMetadata.getTags(MetadataScope.USER),
                         getMetadataTags(createEntity, MetadataScope.USER));
+
+    // confirm that recreating a metadata will generate brand-new tags and properties
+    final Metadata overwrite = new Metadata(
+      ImmutableSet.of(new ScopedName(MetadataScope.SYSTEM, "tag0"),
+                      new ScopedName(MetadataScope.USER, "c")),
+      ImmutableMap.of(new ScopedName(MetadataScope.SYSTEM, "key0"), "val0",
+                      new ScopedName(MetadataScope.SYSTEM, "key1"), "val1",
+                      new ScopedName(MetadataScope.USER, "z"), "4"));
+    createMetadataMutation(new MetadataMutation.Create(createEntity, overwrite, CREATE_DIRECTIVES));
+    Assert.assertEquals(overwrite.getProperties(MetadataScope.SYSTEM),
+                        getMetadataProperties(createEntity, MetadataScope.SYSTEM));
+    Assert.assertEquals(overwrite.getTags(MetadataScope.SYSTEM),
+                        getMetadataTags(createEntity, MetadataScope.SYSTEM));
+    Assert.assertEquals(overwrite.getProperties(MetadataScope.USER),
+                        getMetadataProperties(createEntity, MetadataScope.USER));
+    Assert.assertEquals(overwrite.getTags(MetadataScope.USER),
+                        getMetadataTags(createEntity, MetadataScope.USER));
   }
 
   @Test


### PR DESCRIPTION
JIRA [link](https://cdap.atlassian.net/browse/CDAP-19540)

Since it is decided to make metadata versionless, we will need to make sure during deploying a newer version application, the old tags and properties in existing metadata is completely overwrite by the new metadata. We will only preserve the original creation-time property in system scope and everything else will be replaced by the new metadata. 
The desired create/replace behavior is already implemented [here](https://github.com/cdapio/cdap/blob/e7d54ac71a2dddbb16333bb3e2f5abd46941e785/cdap-metadata-spi/src/main/java/io/cdap/cdap/spi/metadata/MetadataMutation.java#L67-L81), thus this PR only adds a new unit test to make sure old tags and properties (except ones mark as KEEP & PRESERVE) are removed completely. 