### PR TITLE
CDAP-19536: hide version in MatadataEntity json response

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
@@ -475,7 +475,6 @@ class CapabilityApplier {
 
   private ApplicationId getApplicationId(MetadataEntity metadataEntity) {
     return new ApplicationId(metadataEntity.getValue(MetadataEntity.NAMESPACE),
-                             metadataEntity.getValue(MetadataEntity.APPLICATION),
-                             metadataEntity.getValue(MetadataEntity.VERSION));
+                             metadataEntity.getValue(MetadataEntity.APPLICATION));
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataHttpHandler.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.api.metadata.MetadataScope;
 import io.cdap.cdap.client.MetadataClient;
 import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.metadata.MetadataEntityCodec;
 import io.cdap.cdap.common.security.AuditDetail;
 import io.cdap.cdap.common.security.AuditPolicy;
 import io.cdap.cdap.data2.metadata.MetadataCompatibility;
@@ -95,6 +96,7 @@ public class MetadataHttpHandler extends AbstractHttpHandler {
   private static final Gson GSON = new GsonBuilder()
     .registerTypeAdapter(NamespacedEntityId.class, new NamespacedEntityIdCodec())
     .registerTypeAdapter(Metadata.class, new MetadataCodec())
+    .registerTypeAdapter(MetadataEntity.class, new MetadataEntityCodec())
     .create();
   // for internal calls (create/update/drop/delete) we need to use a different codec for ScopedName and
   // ScopedNameOfKind: they are used as map keys, where JSON only allows plain strings, so we serialize

--- a/cdap-common/src/main/java/io/cdap/cdap/common/metadata/AbstractMetadataClient.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/metadata/AbstractMetadataClient.java
@@ -53,7 +53,8 @@ public abstract class AbstractMetadataClient {
   private static final Type SET_METADATA_RECORD_TYPE = new TypeToken<Set<MetadataRecord>>() { }.getType();
   private static final Type MAP_STRING_STRING_TYPE = new TypeToken<Map<String, String>>() { }.getType();
   private static final Type SET_STRING_TYPE = new TypeToken<Set<String>>() { }.getType();
-  private static final Gson GSON = new GsonBuilder().create();
+  private static final Gson GSON = new GsonBuilder().
+    registerTypeAdapter(MetadataEntity.class, new MetadataEntityCodec()).create();
 
   public static final BiMap<String, String> ENTITY_TYPE_TO_API_PART;
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/metadata/MetadataEntityCodec.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/metadata/MetadataEntityCodec.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.metadata;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.api.metadata.MetadataEntity.KeyValue;
+import io.cdap.cdap.internal.guava.reflect.TypeToken;
+import io.cdap.cdap.proto.id.ApplicationId;
+
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * JSON Type adapter for MetadataEntity. Version for {@link MetadataUtil#isVersionedEntityType(String)}
+ * will be removed during serialization since it is not persisted in storage and will always be the
+ * default value "-SNAPSHOT".
+ */
+public class MetadataEntityCodec implements JsonSerializer<MetadataEntity>, JsonDeserializer<MetadataEntity> {
+
+  private static final Type MAP_DETAILS_TYPE = new TypeToken<LinkedHashMap<String, String>>() { }.getType();
+
+  @Override
+  public MetadataEntity deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+    throws JsonParseException {
+    if (!typeOfT.equals(MetadataEntity.class)) {
+      return context.deserialize(json, typeOfT);
+    }
+    JsonObject object = json.getAsJsonObject();
+    JsonElement detailsJson = object.get("details");
+    JsonElement typeJson = object.get("type");
+    LinkedHashMap<String, String> details = context.deserialize(detailsJson, MAP_DETAILS_TYPE);
+    String type = context.deserialize(typeJson, String.class);
+    MetadataEntity.Builder builder = MetadataEntity.builder();
+    int index = 0;
+    for (Map.Entry<String, String> keyValue : details.entrySet()) {
+      if (keyValue.getKey().equals(type)) {
+        builder.appendAsType(keyValue.getKey(), keyValue.getValue());
+      } else {
+        builder.append(keyValue.getKey(), keyValue.getValue());
+      }
+      index++;
+      // add back default version that's removed during serialization
+      if (index == 2 && MetadataUtil.isVersionedEntityType(type) && !details.containsKey(MetadataEntity.VERSION)) {
+        builder.append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION);
+      }
+    }
+    return builder.build();
+  }
+
+  @Override
+  public JsonElement serialize(MetadataEntity src, Type typeOfSec, JsonSerializationContext context) {
+    JsonObject entityObject = new JsonObject();
+    JsonObject details = new JsonObject();
+    for (KeyValue keyValue : src) {
+      // skip version if serializing a versionless entity
+      if (!(keyValue.getKey().equals(MetadataEntity.VERSION) && MetadataUtil.isVersionedEntityType(src.getType()))) {
+        details.add(keyValue.getKey(), context.serialize(keyValue.getValue()));
+      }
+    }
+    entityObject.add("details", details);
+    entityObject.add("type", context.serialize(src.getType()));
+    return entityObject;
+  }
+}

--- a/cdap-common/src/test/java/io/cdap/cdap/common/metadata/MetadataEntityCodecTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/metadata/MetadataEntityCodecTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.metadata;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.proto.id.ApplicationId;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test class for testing {@link MetadataEntityCodec}
+ */
+public class MetadataEntityCodecTest {
+
+  @Test
+  public void testVersionlessEntitySerialization() {
+
+    Gson gson = new GsonBuilder().registerTypeAdapter(MetadataEntity.class, new MetadataEntityCodec())
+      .create();
+
+    // Test serialization/deserialization for application MetadataEntity
+    MetadataEntity appMetadata = MetadataEntity.builder()
+      .append(MetadataEntity.NAMESPACE, "ns")
+      .appendAsType(MetadataEntity.APPLICATION, "myApp")
+      .append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION)
+      .build();
+    String json = gson.toJson(appMetadata);
+    // make sure version is removed from Application MetadataEntity json
+    Assert.assertFalse(json.contains(MetadataEntity.VERSION));
+    // deserialization should add back the default version
+    Assert.assertEquals(appMetadata, gson.fromJson(json, MetadataEntity.class));
+
+    // Test serialization/deserialization for program MetadataEntity
+    MetadataEntity programMetadata = MetadataEntity.builder()
+      .append(MetadataEntity.NAMESPACE, "ns")
+      .append(MetadataEntity.APPLICATION, "myApp")
+      .append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION)
+      .append(MetadataEntity.TYPE, "Service")
+      .appendAsType(MetadataEntity.PROGRAM, "myProgram")
+      .build();
+    json = gson.toJson(programMetadata);
+    Assert.assertFalse(json.contains(MetadataEntity.VERSION));
+    Assert.assertEquals(programMetadata, gson.fromJson(json, MetadataEntity.class));
+
+    // Test serialization/deserialization for schedule MetadataEntity
+    MetadataEntity scheduleMetadata = MetadataEntity.builder()
+      .append(MetadataEntity.NAMESPACE, "ns")
+      .append(MetadataEntity.APPLICATION, "myApp")
+      .append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION)
+      .append(MetadataEntity.SCHEDULE, "mySchedule")
+      .build();
+    json = gson.toJson(scheduleMetadata);
+    Assert.assertFalse(json.contains(MetadataEntity.VERSION));
+    Assert.assertEquals(scheduleMetadata, gson.fromJson(json, MetadataEntity.class));
+
+    // Test serialization/deserialization for program_run MetadataEntity
+    MetadataEntity programRunMetadata =  MetadataEntity.builder()
+      .append(MetadataEntity.NAMESPACE, "ns")
+      .append(MetadataEntity.APPLICATION, "myApp")
+      .append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION)
+      .append(MetadataEntity.TYPE, "Service")
+      .append(MetadataEntity.PROGRAM, "myProgram")
+      .appendAsType(MetadataEntity.PROGRAM_RUN, "myProgramRun")
+      .build();
+    json = gson.toJson(programRunMetadata);
+    Assert.assertFalse(json.contains(MetadataEntity.VERSION));
+    Assert.assertEquals(programRunMetadata, gson.fromJson(json, MetadataEntity.class));
+  }
+
+  @Test
+  public void testVersionedMetadataEntitySerialization() {
+
+    Gson gson = new GsonBuilder().registerTypeAdapter(MetadataEntity.class, new MetadataEntityCodec())
+      .setPrettyPrinting().create();
+
+    // test serialize artifact
+    MetadataEntity artifactMetadata = MetadataEntity.builder()
+      .append(MetadataEntity.NAMESPACE, "ns")
+      .appendAsType(MetadataEntity.ARTIFACT, "myArtifact")
+      .append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION)
+      .build();
+    String json = gson.toJson(artifactMetadata);
+    Assert.assertTrue(json.contains(MetadataEntity.VERSION));
+    Assert.assertEquals(artifactMetadata, gson.fromJson(json, MetadataEntity.class));
+
+    // test serialize plugin
+    MetadataEntity pluginMetadata = MetadataEntity.builder()
+      .append(MetadataEntity.NAMESPACE, "ns")
+      .append(MetadataEntity.ARTIFACT, "myArtifact")
+      .append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION)
+      .append(MetadataEntity.TYPE, "myType")
+      .appendAsType(MetadataEntity.PLUGIN, "myPlugin")
+      .build();
+    json = gson.toJson(pluginMetadata);
+    Assert.assertTrue(json.contains(MetadataEntity.VERSION));
+    Assert.assertEquals(pluginMetadata, gson.fromJson(json, MetadataEntity.class));
+  }
+}


### PR DESCRIPTION
JIRA [link](https://cdap.atlassian.net/browse/CDAP-19536) 

Currently the search api (namespaces/ns/metadata/search) will return both metadata entity and metadata in json responses. For some metadata entity types (application, program, schedule, program_run), the version attribute is never used and it is not saved to storage either. So it doesn't make sense to have this version field as part of the entity in response. This PR is to add a codec class for MetadataEntity and it hides this version during serialization.  
