### PR TITLE
CDAP-19565 fix backwards incompatible change to storage SPI

### DIFF
--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStructuredTableAdmin.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStructuredTableAdmin.java
@@ -20,6 +20,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.TableNotFoundException;
 import io.cdap.cdap.spi.data.TableSchemaIncompatibleException;
 import io.cdap.cdap.spi.data.common.StructuredTableRegistry;
@@ -60,6 +61,14 @@ public class PostgreSqlStructuredTableAdmin implements StructuredTableAdmin {
   PostgreSqlStructuredTableAdmin(StructuredTableRegistry registry, DataSource dataSource) {
     this.registry = registry;
     this.dataSource = dataSource;
+  }
+
+  @Override
+  public void create(StructuredTableSpecification spec) throws IOException, TableAlreadyExistsException {
+    if (registry.getSpecification(spec.getTableId()) != null) {
+      throw new TableAlreadyExistsException(spec.getTableId());
+    }
+    createTable(spec);
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableRegistry.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/SqlStructuredTableRegistry.java
@@ -195,6 +195,11 @@ public class SqlStructuredTableRegistry implements StructuredTableRegistry {
     StructuredTableAdmin specAdmin =
       new StructuredTableAdmin() {
         @Override
+        public void create(StructuredTableSpecification spec) {
+          throw new UnsupportedOperationException("Unexpected DDL operation during registry usage!!");
+        }
+
+        @Override
         public void createOrUpdate(StructuredTableSpecification spec) {
           throw new UnsupportedOperationException("Unexpected DDL operation during registry usage!!");
         }

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableAdmin.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableAdmin.java
@@ -32,6 +32,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.TableDuplicateUpdateException;
 import io.cdap.cdap.spi.data.TableNotFoundException;
 import io.cdap.cdap.spi.data.TableSchemaIncompatibleException;
@@ -76,6 +77,14 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
           return loadSchema(tableId);
         }
       });
+  }
+
+  @Override
+  public void create(StructuredTableSpecification spec) throws IOException, TableAlreadyExistsException {
+    if (exists(spec.getTableId())) {
+      throw new TableAlreadyExistsException(spec.getTableId());
+    }
+    createTable(spec);
   }
 
   @Override

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTableAdmin.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTableAdmin.java
@@ -28,6 +28,16 @@ import java.io.IOException;
  */
 @Beta
 public interface StructuredTableAdmin {
+
+  /**
+   * Create a StructuredTable using the {@link StructuredTableSpecification}.
+   *
+   * @throws TableAlreadyExistsException if the table already exists
+   * @deprecated use {@link #createOrUpdate(StructuredTableSpecification)} instead
+   */
+  @Deprecated
+  void create(StructuredTableSpecification spec) throws IOException, TableAlreadyExistsException;
+
   /**
    * If the table does not exist, create a StructuredTable using the {@link StructuredTableSpecification}.
    * If the table exists, check the columns and update the schema if necessary
@@ -39,7 +49,9 @@ public interface StructuredTableAdmin {
    * @throws IOException if there is an error creating the table
    * @throws TableSchemaIncompatibleException if the new table schema is incompatible with the existing one
    */
-  void createOrUpdate(StructuredTableSpecification spec) throws IOException, TableSchemaIncompatibleException;
+  default void createOrUpdate(StructuredTableSpecification spec) throws IOException, TableSchemaIncompatibleException {
+    throw new UnsupportedOperationException("Storage SPI did not implement createOrUpdate.");
+  }
 
   /**
    * Checks if the given table exists.


### PR DESCRIPTION
Added back the create() method to StructuredTableAdmin and made the new createOrUpdate() method have a default implementation. This ensures that the changes to the interface are backwards compatible.