### PR TITLE
[CDAP-19529] Add dependency class localization for running programs on kubernetes

### DIFF
--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -34,6 +34,7 @@
     <okhttp.version>4.9.1</okhttp.version>
     <!-- Needs to define the gson and guava versions to override the one from dependency management in cdap pom.xml -->
     <gson.version>2.8.6</gson.version>
+    <asm.version>7.1</asm.version>
     <guava.version>25.1-jre</guava.version>
     <testSourceLocation>${project.basedir}/src/test/java/</testSourceLocation>
   </properties>
@@ -49,6 +50,13 @@
       <groupId>io.cdap.twill</groupId>
       <artifactId>twill-api</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <!-- org.ow2.asm needs to be compiled for ApplicationBundler usage -->
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>${asm.version}</version>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.cdap.twill</groupId>

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/DistributedSparkProgramRunner.java
@@ -174,7 +174,7 @@ public final class DistributedSparkProgramRunner extends DistributedProgramRunne
 
     launchConfig
       .addExtraEnv(extraEnv)
-      .addExtraDependencies(SparkProgramRuntimeProvider.class)
+      .addExtraDependencies(SparkProgramRuntimeProvider.class, SparkTwillRunnable.class)
       .addExtraSystemArgument(SparkRuntimeContextConfig.DISTRIBUTED_MODE, Boolean.TRUE.toString())
       .setClassAcceptor(createBundlerClassAcceptor());
   }


### PR DESCRIPTION
This allows us to localize dependency classes and jars via the FileLocalizer which is necessary for classes which are required to run on cdap-kubernetes.