### PR TITLE
CDAP-19573 increase default resources for test pipelines

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/spec/PipelineSpecGeneratorTest.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.etl.spec;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import io.cdap.cdap.api.Resources;
 import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactVersion;
@@ -304,8 +303,8 @@ public class PipelineSpecGeneratorTest {
           .build())
       .addConnections(etlConfig.getConnections())
       .setResources(etlConfig.getResources())
-      .setDriverResources(new Resources(1024, 1))
-      .setClientResources(new Resources(1024, 1))
+      .setDriverResources(ETLConfig.Builder.DEFAULT_TEST_RESOURCES)
+      .setClientResources(ETLConfig.Builder.DEFAULT_TEST_RESOURCES)
       .setStageLoggingEnabled(etlConfig.isStageLoggingEnabled())
       .setNumOfRecordsPreview(etlConfig.getNumOfRecordsPreview())
       .setEngine(Engine.MAPREDUCE)
@@ -341,8 +340,8 @@ public class PipelineSpecGeneratorTest {
           .build())
       .addConnections(etlConfig.getConnections())
       .setResources(etlConfig.getResources())
-      .setDriverResources(new Resources(1024, 1))
-      .setClientResources(new Resources(1024, 1))
+      .setDriverResources(ETLConfig.Builder.DEFAULT_TEST_RESOURCES)
+      .setClientResources(ETLConfig.Builder.DEFAULT_TEST_RESOURCES)
       .setStageLoggingEnabled(etlConfig.isStageLoggingEnabled())
       .setNumOfRecordsPreview(etlConfig.getNumOfRecordsPreview())
       .setEngine(Engine.MAPREDUCE)
@@ -921,9 +920,9 @@ public class PipelineSpecGeneratorTest {
       .addStage(StageSpec.builder("a2", new PluginSpec(Action.PLUGIN_TYPE, "action2", empty, ARTIFACT_ID))
                   .addInputSchema("a1", null)
                   .build())
-      .setResources(new Resources(1024))
-      .setDriverResources(new Resources(1024))
-      .setClientResources(new Resources(1024))
+      .setResources(ETLConfig.Builder.DEFAULT_TEST_RESOURCES)
+      .setDriverResources(ETLConfig.Builder.DEFAULT_TEST_RESOURCES)
+      .setClientResources(ETLConfig.Builder.DEFAULT_TEST_RESOURCES)
       .setNumOfRecordsPreview(config.getNumOfRecordsPreview())
       .setEngine(Engine.MAPREDUCE)
       .build();

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLConfig.java
@@ -246,6 +246,7 @@ public class ETLConfig extends Config implements UpgradeableConfig {
    */
   @SuppressWarnings("unchecked")
   public abstract static class Builder<T extends Builder> {
+    public static final Resources DEFAULT_TEST_RESOURCES = new Resources(2048, 1);
     protected Set<ETLStage> stages;
     protected Set<Connection> connections;
     protected Resources resources;
@@ -259,9 +260,9 @@ public class ETLConfig extends Config implements UpgradeableConfig {
     protected Builder() {
       this.stages = new HashSet<>();
       this.connections = new HashSet<>();
-      this.resources = new Resources(1024, 1);
-      this.driverResources = new Resources(1024, 1);
-      this.clientResources = new Resources(1024, 1);
+      this.resources = DEFAULT_TEST_RESOURCES;
+      this.driverResources = DEFAULT_TEST_RESOURCES;
+      this.clientResources = DEFAULT_TEST_RESOURCES;
       this.stageLoggingEnabled = true;
       this.processTimingEnabled = true;
       this.properties = new HashMap<>();


### PR DESCRIPTION
Increased the default memory for pipeline configs created programmatically through the ETLConfig.Builder class. This will not affect the default value for pipelines created through the REST API, only the default value for pipelines created programmatically for tests. This also has no impact on unit tests, only on integration tests.