### PR TITLE
CDAP-19577 - Auto detect atleast once processing mode for streaming pipelines

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpec.java
@@ -34,10 +34,13 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
   private final long batchIntervalMillis;
   private final String extraJavaOpts;
   private final boolean stopGracefully;
+  @Deprecated
   private final boolean checkpointsDisabled;
   private final boolean isUnitTest;
+  @Deprecated
   private final String checkpointDirectory;
   private final String pipelineId;
+  private final DataStreamsStateSpec stateSpec;
 
   private DataStreamsPipelineSpec(Set<StageSpec> stages, Set<Connection> connections,
                                   Resources resources, Resources driverResources, Resources clientResources,
@@ -45,7 +48,8 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
                                   String extraJavaOpts, int numOfRecordsPreview,
                                   boolean stopGracefully, Map<String, String> properties,
                                   boolean checkpointsDisabled, boolean isUnitTest, String checkpointDirectory,
-                                  String pipelineId, Set<String> connectionsUsed, Engine engine) {
+                                  String pipelineId, Set<String> connectionsUsed, Engine engine,
+                                  DataStreamsStateSpec stateSpec) {
     super(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled, processTimingEnabled,
           numOfRecordsPreview, properties, connectionsUsed, engine);
     this.batchIntervalMillis = batchIntervalMillis;
@@ -55,6 +59,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
     this.isUnitTest = isUnitTest;
     this.checkpointDirectory = checkpointDirectory;
     this.pipelineId = pipelineId;
+    this.stateSpec = stateSpec;
   }
 
   public long getBatchIntervalMillis() {
@@ -85,6 +90,10 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
     return pipelineId;
   }
 
+  public DataStreamsStateSpec getStateSpec() {
+    return stateSpec;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -104,6 +113,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
       stopGracefully == that.stopGracefully &&
       checkpointsDisabled == that.checkpointsDisabled &&
       isUnitTest == that.isUnitTest &&
+      Objects.equals(stateSpec, that.stateSpec) &&
       Objects.equals(checkpointDirectory, that.checkpointDirectory) &&
       Objects.equals(pipelineId, that.pipelineId);
   }
@@ -111,7 +121,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), batchIntervalMillis, extraJavaOpts,
-                        stopGracefully, checkpointsDisabled, isUnitTest, checkpointDirectory, pipelineId);
+                        stopGracefully, checkpointsDisabled, isUnitTest, checkpointDirectory, pipelineId, stateSpec);
   }
 
   @Override
@@ -124,6 +134,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
       ", isUnitTest=" + isUnitTest +
       ", checkpointDirectory='" + checkpointDirectory + '\'' +
       ", pipelineId='" + pipelineId + '\'' +
+      ", stateSpec='" + stateSpec + '\'' +
       "} " + super.toString();
   }
 
@@ -146,6 +157,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
     private boolean isUnitTest;
     private String checkpointDirectory;
     private String pipelineId;
+    private DataStreamsStateSpec stateSpec;
 
     public Builder(long batchIntervalMillis) {
       this(batchIntervalMillis, UUID.randomUUID().toString());
@@ -158,6 +170,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
       this.isUnitTest = false;
       this.checkpointDirectory = "";
       this.pipelineId = pipelineId;
+      this.stateSpec = null;
     }
 
     public Builder setExtraJavaOpts(String extraJavaOpts) {
@@ -185,13 +198,18 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
       return this;
     }
 
+    public Builder setStateSpec(DataStreamsStateSpec stateSpec) {
+      this.stateSpec = stateSpec;
+      return this;
+    }
+
     @Override
     public DataStreamsPipelineSpec build() {
       return new DataStreamsPipelineSpec(stages, connections, resources, driverResources, clientResources,
                                          stageLoggingEnabled, processTimingEnabled, batchIntervalMillis, extraJavaOpts,
                                          numOfRecordsPreview, stopGracefully, properties,
                                          checkpointsDisabled, isUnitTest, checkpointDirectory, pipelineId,
-                                         connectionsUsed, Engine.SPARK);
+                                         connectionsUsed, Engine.SPARK, stateSpec);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.datastreams;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.api.DatasetConfigurer;
@@ -27,14 +28,20 @@ import io.cdap.cdap.api.spark.SparkSpecification;
 import io.cdap.cdap.etl.api.Engine;
 import io.cdap.cdap.etl.api.FailureCollector;
 import io.cdap.cdap.etl.api.join.JoinCondition;
+import io.cdap.cdap.etl.api.streaming.StreamingStateHandler;
+import io.cdap.cdap.etl.api.streaming.Windower;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.common.DefaultStageConfigurer;
 import io.cdap.cdap.etl.common.macro.TimeParser;
 import io.cdap.cdap.etl.proto.v2.DataStreamsConfig;
+import io.cdap.cdap.etl.proto.v2.ETLStage;
 import io.cdap.cdap.etl.spec.PipelineSpecGenerator;
+import io.cdap.cdap.features.Feature;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import org.apache.hadoop.fs.Path;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
@@ -48,6 +55,9 @@ public class DataStreamsPipelineSpecGenerator
                                      .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
                                      .create();
   private final RuntimeConfigurer runtimeConfigurer;
+  //Set of sources in this pipeline that supports @link{StreamingStateHandler}
+  private Set<String> stateHandlingSources;
+  private Set<String> sourcePluginTypes;
 
   <T extends PluginConfigurer & DatasetConfigurer> DataStreamsPipelineSpecGenerator(
     String namespace, T configurer, @Nullable RuntimeConfigurer runtimeConfigurer, Set<String> sourcePluginTypes,
@@ -55,6 +65,8 @@ public class DataStreamsPipelineSpecGenerator
     super(namespace, configurer, runtimeConfigurer, sourcePluginTypes, sinkPluginTypes,
           Engine.SPARK, featureFlagsProvider);
     this.runtimeConfigurer = runtimeConfigurer;
+    this.sourcePluginTypes = sourcePluginTypes;
+    this.stateHandlingSources = new HashSet<>();
   }
 
   @Override
@@ -79,20 +91,76 @@ public class DataStreamsPipelineSpecGenerator
     DataStreamsPipelineSpec.Builder specBuilder = DataStreamsPipelineSpec.builder(batchIntervalMillis, pipelineId)
       .setExtraJavaOpts(config.getExtraJavaOpts())
       .setStopGracefully(config.getStopGracefully())
-      .setIsUnitTest(config.isUnitTest())
-      .setCheckpointsDisabled(config.checkpointsDisabled());
-    String checkpointDir = config.getCheckpointDir();
-    if (!config.checkpointsDisabled() && checkpointDir != null) {
-      try {
-        new Path(checkpointDir);
-      } catch (Exception e) {
-        throw new IllegalArgumentException(
-          String.format("Checkpoint directory '%s' is not a valid Path: %s", checkpointDir, e.getMessage()), e);
-      }
-      specBuilder.setCheckpointDirectory(checkpointDir);
-    }
+      .setIsUnitTest(config.isUnitTest());
+
     configureStages(config, specBuilder);
+    //Configure the at least once processing mode for this pipeline
+    configureAtleastOnceMode(config, specBuilder);
     return specBuilder.build();
+  }
+
+  @VisibleForTesting
+  void configureAtleastOnceMode(DataStreamsConfig config, DataStreamsPipelineSpec.Builder specBuilder) {
+    //If runtime arg sets atleast once processing to false, disable both
+    if (runtimeConfigurer != null && runtimeConfigurer.getRuntimeArguments() != null) {
+      boolean atleastOnceProcessingEnabled = Boolean.parseBoolean(
+        runtimeConfigurer.getRuntimeArguments().getOrDefault(Constants.CDAP_STREAMING_ATLEASTONCE_ENABLED, "true"));
+      if (!atleastOnceProcessingEnabled) {
+        DataStreamsStateSpec stateSpec = DataStreamsStateSpec.getBuilder(DataStreamsStateSpec.Mode.NONE).build();
+        specBuilder.setStateSpec(stateSpec);
+        return;
+      }
+    }
+    //Check if native state tracking is possible
+    if (nativeStateTrackingSupported(config, sourcePluginTypes, stateHandlingSources)) {
+      // Native state tracking and spark checkpointing is mutually exclusive
+      // This is because Spark recreates context from checkpoint data
+      DataStreamsStateSpec stateSpec = DataStreamsStateSpec.getBuilder(DataStreamsStateSpec.Mode.NATIVE_STATE_STORE)
+        .build();
+      specBuilder.setStateSpec(stateSpec);
+    } else {
+      String checkpointDir = config.getCheckpointDir();
+      if (checkpointDir != null) {
+        try {
+          new Path(checkpointDir);
+        } catch (Exception e) {
+          throw new IllegalArgumentException(
+            String.format("Checkpoint directory '%s' is not a valid Path: %s", checkpointDir, e.getMessage()), e);
+        }
+      }
+      DataStreamsStateSpec.Builder builder = DataStreamsStateSpec.getBuilder(
+        DataStreamsStateSpec.Mode.SPARK_CHECKPOINTING).setCheckPointDir(checkpointDir);
+      specBuilder.setStateSpec(builder.build());
+    }
+  }
+
+  private boolean nativeStateTrackingSupported(DataStreamsConfig config, Set<String> sourcePluginTypes,
+                                               Set<String> stateHandlingSources) {
+    if (!Feature.STREAMING_PIPELINE_NATIVE_STATE_TRACKING.isEnabled(getFeatureFlagsProvider())) {
+      return false;
+    }
+
+    // Should have a source plugin that supports native state tracking
+    if (stateHandlingSources.isEmpty()) {
+      return false;
+    }
+
+    // Additional validations.
+    // Pipelines with multiple sources and Windower plugin does not work with native state handling.
+    int sourceCount = 0;
+    for (ETLStage stage : config.getStages()) {
+      if (sourcePluginTypes.contains(stage.getPlugin().getType())) {
+        sourceCount++;
+        if (sourceCount > 1) {
+          return false;
+        }
+      }
+      if (stage.getPlugin().getType() == Windower.PLUGIN_TYPE) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   @Override
@@ -102,6 +170,15 @@ public class DataStreamsPipelineSpecGenerator
         String.format("Join stage '%s' uses a %s condition, which is not supported in streaming pipelines.",
                       stageName, condition.getOp()),
         "Only basic joins on key equality are supported.");
+    }
+  }
+
+  @Override
+  protected void configureSourcePlugin(String stageName, Object plugin, DefaultStageConfigurer stageConfigurer,
+                                       FailureCollector collector) {
+    super.configureSourcePlugin(stageName, plugin, stageConfigurer, collector);
+    if (plugin instanceof StreamingStateHandler) {
+      stateHandlingSources.add(stageName);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsStateSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsStateSpec.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datastreams;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Spec for state management for atleast once processing
+ */
+public class DataStreamsStateSpec {
+
+  public enum Mode {
+    NONE, SPARK_CHECKPOINTING, NATIVE_STATE_STORE
+  }
+
+  private final Mode mode;
+  @Nullable
+  private final String checkpointDir;
+
+  public Mode getMode() {
+    return mode;
+  }
+
+  @Nullable
+  public String getCheckpointDir() {
+    return checkpointDir;
+  }
+
+  private DataStreamsStateSpec(Mode mode, @Nullable String checkpointDir) {
+    this.mode = mode;
+    this.checkpointDir = checkpointDir;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DataStreamsStateSpec)) {
+      return false;
+    }
+    DataStreamsStateSpec stateSpec = (DataStreamsStateSpec) o;
+    return mode == stateSpec.mode && Objects.equals(checkpointDir, stateSpec.checkpointDir);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mode, checkpointDir);
+  }
+
+  @Override
+  public String toString() {
+    return "DataStreamsStateSpec{" +
+      "mode=" + mode +
+      ", checkpointDir='" + checkpointDir + '\'' +
+      '}';
+  }
+
+  public static Builder getBuilder(Mode mode) {
+    return new Builder(mode);
+  }
+
+  public static class Builder {
+    private Mode mode;
+    private String checkpointDir;
+
+    private Builder(Mode mode) {
+      this.mode = mode;
+    }
+
+    public Builder setCheckPointDir(String checkpointDir) {
+      this.checkpointDir = checkpointDir;
+      return this;
+    }
+
+    public DataStreamsStateSpec build() {
+      return new DataStreamsStateSpec(mode, checkpointDir);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGeneratorTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datastreams;
+
+import com.google.common.collect.ImmutableSet;
+import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.app.RuntimeConfigurer;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.feature.FeatureFlagsProvider;
+import io.cdap.cdap.etl.api.AlertPublisher;
+import io.cdap.cdap.etl.api.batch.BatchSink;
+import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.api.streaming.StreamingSource;
+import io.cdap.cdap.etl.api.streaming.Windower;
+import io.cdap.cdap.etl.mock.spark.streaming.MockSink;
+import io.cdap.cdap.etl.mock.spark.streaming.MockSource;
+import io.cdap.cdap.etl.proto.v2.DataStreamsConfig;
+import io.cdap.cdap.etl.proto.v2.ETLPlugin;
+import io.cdap.cdap.etl.proto.v2.ETLStage;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Tests for @link{DataStreamsPipelineSpecGenerator}
+ */
+public class DataStreamsPipelineSpecGeneratorTest {
+
+  private static final ImmutableSet<String> SOURCE_PLUGIN_TYPES = ImmutableSet.of(StreamingSource.PLUGIN_TYPE);
+  private static final ImmutableSet<String> SINK_PLUGIN_TYPES = ImmutableSet.of(BatchSink.PLUGIN_TYPE,
+                                                                                SparkSink.PLUGIN_TYPE,
+                                                                                AlertPublisher.PLUGIN_TYPE);
+  private static Schema schema = Schema.recordOf("test", Schema.Field.of("key", Schema.of(Schema.Type.STRING)),
+                                                 Schema.Field.of("value", Schema.of(Schema.Type.STRING)));
+
+  @Test
+  public void testConfigureAtleastOnceModeSuccess() throws IOException {
+    DataStreamsConfig etlConfig = getDataStreamsConfig(MockStateHandlerSource.getPlugin(schema, new ArrayList<>()));
+    DataStreamsPipelineSpec.Builder builder = DataStreamsPipelineSpec.builder(System.currentTimeMillis(), "test-id");
+    FeatureFlagsProvider featureFlagsProvider = new FeatureFlagsProvider() {
+
+      @Override
+      public boolean isFeatureEnabled(String name) {
+        return true;
+      }
+    };
+    DataStreamsPipelineSpecGenerator specGenerator = new DataStreamsPipelineSpecGenerator("test", null, null,
+                                                                                          SOURCE_PLUGIN_TYPES,
+                                                                                          SINK_PLUGIN_TYPES,
+                                                                                          featureFlagsProvider);
+    specGenerator.configureSourcePlugin("source", new MockStateHandlerSource(new MockSource.Conf()), null, null);
+    specGenerator.configureAtleastOnceMode(etlConfig, builder);
+
+    DataStreamsPipelineSpec pipelineSpec = builder.build();
+    Assert.assertTrue(pipelineSpec.getStateSpec().getMode() == DataStreamsStateSpec.Mode.NATIVE_STATE_STORE);
+  }
+
+  @Test
+  public void testConfigureAtleastOnceModeRuntimeArg() throws IOException {
+    DataStreamsConfig etlConfig = getDataStreamsConfig(MockStateHandlerSource.getPlugin(schema, new ArrayList<>()));
+    DataStreamsPipelineSpec.Builder builder = DataStreamsPipelineSpec.builder(System.currentTimeMillis(), "test-id");
+    FeatureFlagsProvider featureFlagsProvider = new FeatureFlagsProvider() {
+
+      @Override
+      public boolean isFeatureEnabled(String name) {
+        return true;
+      }
+    };
+    RuntimeConfigurer runtimeConfigurer = new RuntimeConfigurer() {
+
+      @Override
+      public Map<String, String> getRuntimeArguments() {
+        return Collections.singletonMap("cdap.streaming.atleastonce.enabled", "false");
+      }
+
+      @Nullable
+      @Override
+      public ApplicationSpecification getDeployedApplicationSpec() {
+        return null;
+      }
+
+      @Nullable
+      @Override
+      public URL getServiceURL(String applicationId, String serviceId) {
+        return null;
+      }
+
+      @Nullable
+      @Override
+      public URL getServiceURL(String serviceId) {
+        return null;
+      }
+    };
+    DataStreamsPipelineSpecGenerator specGenerator = new DataStreamsPipelineSpecGenerator("test", null,
+                                                                                          runtimeConfigurer,
+                                                                                          SOURCE_PLUGIN_TYPES,
+                                                                                          SINK_PLUGIN_TYPES,
+                                                                                          featureFlagsProvider);
+    specGenerator.configureSourcePlugin("source", new MockStateHandlerSource(new MockSource.Conf()), null, null);
+    specGenerator.configureAtleastOnceMode(etlConfig, builder);
+
+    DataStreamsPipelineSpec pipelineSpec = builder.build();
+    Assert.assertTrue(pipelineSpec.getStateSpec().getMode() == DataStreamsStateSpec.Mode.NONE);
+  }
+
+  @Test
+  public void testConfigureAtleastOnceModeFeatureDisabled() throws IOException {
+    DataStreamsConfig etlConfig = getDataStreamsConfig(MockStateHandlerSource.getPlugin(schema, new ArrayList<>()));
+    DataStreamsPipelineSpec.Builder builder = DataStreamsPipelineSpec.builder(System.currentTimeMillis(), "test-id");
+    FeatureFlagsProvider featureFlagsProvider = new FeatureFlagsProvider() {
+
+      @Override
+      public boolean isFeatureEnabled(String name) {
+        return false;
+      }
+    };
+    DataStreamsPipelineSpecGenerator specGenerator = new DataStreamsPipelineSpecGenerator("test", null, null,
+                                                                                          SOURCE_PLUGIN_TYPES,
+                                                                                          SINK_PLUGIN_TYPES,
+                                                                                          featureFlagsProvider);
+    specGenerator.configureSourcePlugin("source", new MockStateHandlerSource(new MockSource.Conf()), null, null);
+    specGenerator.configureAtleastOnceMode(etlConfig, builder);
+
+    DataStreamsPipelineSpec pipelineSpec = builder.build();
+    Assert.assertTrue(pipelineSpec.getStateSpec().getMode() == DataStreamsStateSpec.Mode.SPARK_CHECKPOINTING);
+  }
+
+  @Test
+  public void testConfigureAtleastOnceModeUnsupportedSource() throws IOException {
+    DataStreamsConfig etlConfig = getDataStreamsConfig(MockSource.getPlugin(schema, new ArrayList<>()));
+    DataStreamsPipelineSpec.Builder builder = DataStreamsPipelineSpec.builder(System.currentTimeMillis(), "test-id");
+    FeatureFlagsProvider featureFlagsProvider = new FeatureFlagsProvider() {
+
+      @Override
+      public boolean isFeatureEnabled(String name) {
+        return true;
+      }
+    };
+    DataStreamsPipelineSpecGenerator specGenerator = new DataStreamsPipelineSpecGenerator("test", null, null,
+                                                                                          SOURCE_PLUGIN_TYPES,
+                                                                                          SINK_PLUGIN_TYPES,
+                                                                                          featureFlagsProvider);
+    specGenerator.configureSourcePlugin("source", new MockSource(new MockSource.Conf()), null, null);
+    specGenerator.configureAtleastOnceMode(etlConfig, builder);
+
+    DataStreamsPipelineSpec pipelineSpec = builder.build();
+    Assert.assertTrue(pipelineSpec.getStateSpec().getMode() == DataStreamsStateSpec.Mode.SPARK_CHECKPOINTING);
+  }
+
+  @Test
+  public void testConfigureAtleastOnceModeWindower() throws IOException {
+    DataStreamsConfig etlConfig = DataStreamsConfig.builder()
+      .addStage(new ETLStage("source", MockStateHandlerSource.getPlugin(schema, new ArrayList<>())))
+      .addStage(new ETLStage("sink", MockSink.getPlugin("${tablename}")))
+      .addStage(new ETLStage("windower", new ETLPlugin("MockWindower", Windower.PLUGIN_TYPE, new HashMap<>(), null)))
+      .addConnection("source", "windower").addConnection("windower", "sink").setCheckpointDir(null)
+      .setBatchInterval("1s").build();
+    DataStreamsPipelineSpec.Builder builder = DataStreamsPipelineSpec.builder(System.currentTimeMillis(), "test-id");
+    FeatureFlagsProvider featureFlagsProvider = new FeatureFlagsProvider() {
+
+      @Override
+      public boolean isFeatureEnabled(String name) {
+        return true;
+      }
+    };
+    DataStreamsPipelineSpecGenerator specGenerator = new DataStreamsPipelineSpecGenerator("test", null, null,
+                                                                                          SOURCE_PLUGIN_TYPES,
+                                                                                          SINK_PLUGIN_TYPES,
+                                                                                          featureFlagsProvider);
+    specGenerator.configureSourcePlugin("source", new MockStateHandlerSource(new MockSource.Conf()), null, null);
+    specGenerator.configureAtleastOnceMode(etlConfig, builder);
+
+    DataStreamsPipelineSpec pipelineSpec = builder.build();
+    Assert.assertTrue(pipelineSpec.getStateSpec().getMode() == DataStreamsStateSpec.Mode.SPARK_CHECKPOINTING);
+  }
+
+  private DataStreamsConfig getDataStreamsConfig(ETLPlugin plugin) throws IOException {
+    return DataStreamsConfig.builder().addStage(new ETLStage("source", plugin))
+      .addStage(new ETLStage("sink", MockSink.getPlugin("${tablename}"))).addConnection("source", "sink")
+      .setCheckpointDir(null).setBatchInterval("1s").build();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/MockStateHandlerSource.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/MockStateHandlerSource.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datastreams;
+
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.etl.api.streaming.StreamingSource;
+import io.cdap.cdap.etl.api.streaming.StreamingStateHandler;
+import io.cdap.cdap.etl.mock.spark.streaming.MockSource;
+
+@Plugin(type = StreamingSource.PLUGIN_TYPE)
+@Name("MockStateHandler")
+/**
+ * Mock streaming source implemeneting @link{StreamingStateHandler}
+ */
+public class MockStateHandlerSource extends MockSource implements StreamingStateHandler {
+
+  public MockStateHandlerSource(MockSource.Conf conf) {
+    super(conf);
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingStateHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingStateHandler.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.streaming;
+
+/**
+ * Marker interface for indicating that a @link{StreamingSource} plugin allows native state handling for at least once
+ * processing
+ */
+public interface StreamingStateHandler {
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
@@ -42,6 +42,8 @@ public final class Constants {
   public static final String DATASET_AGGREGATE_IGNORE_PARTITIONS =
     "spark.cdap.pipeline.aggregate.dataset.partitions.ignore";
   public static final String DEFAULT_CACHING_STORAGE_LEVEL = "DISK_ONLY";
+  // Can be used as a runtime argument for streaming pipeline to disable at least once processing.
+  public static final String CDAP_STREAMING_ATLEASTONCE_ENABLED = "cdap.streaming.atleastonce.enabled";
 
   private Constants() {
     throw new AssertionError("Suppress default constructor for noninstantiability");

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
@@ -339,6 +339,10 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
       } else if (!type.equals(Constants.SPARK_PROGRAM_PLUGIN_TYPE)) {
         PipelineConfigurable singlePlugin = (PipelineConfigurable) plugin;
         singlePlugin.configurePipeline(pipelineConfigurer);
+        // Any source specific settings
+        if (sourcePluginTypes.contains(type)) {
+          configureSourcePlugin(stageName, plugin, stageConfigurer, collector);
+        }
         // we don't have StreamingSource dependency so use source plugin types to check type
         // evaluate macros and find out if there is connection used
         if ((sourcePluginTypes.contains(type) || BatchSink.PLUGIN_TYPE.equals(type)) && runtimeEvaluator == null) {
@@ -398,6 +402,11 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
       specBuilder.setOutputSchema(stageConfigurer.getOutputSchema());
     }
     return specBuilder;
+  }
+
+  protected void configureSourcePlugin(String stageName, Object plugin, DefaultStageConfigurer stageConfigurer,
+                                       FailureCollector collector) {
+    //no-op
   }
 
   protected void validateJoinCondition(String stageName, JoinCondition condition, FailureCollector collector) {

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5378,6 +5378,14 @@
   </property>
 
   <property>
+    <name>feature.streaming.pipeline.native.state.tracking.enabled</name>
+    <value>false</value>
+    <description>
+      Enable native state tracking for streaming pipelines for Atleast Once guarantee
+    </description>
+  </property>
+
+  <property>
     <name>artifact.cache.bind.address</name>
     <value>0.0.0.0</value>
     <description>

--- a/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
+++ b/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
@@ -32,7 +32,8 @@ public enum Feature {
   PUSHDOWN_TRANSFORMATION_GROUPBY("6.7.0"),
   PUSHDOWN_TRANSFORMATION_DEDUPLICATE("6.7.0"),
   STREAMING_PIPELINE_CHECKPOINT_DELETION("6.7.1"),
-  LIFECYCLE_MANAGEMENT_EDIT("6.8.0");
+  LIFECYCLE_MANAGEMENT_EDIT("6.8.0"),
+  STREAMING_PIPELINE_NATIVE_STATE_TRACKING("6.8.0", false);
 
   private final PlatformInfo.Version versionIntroduced;
   private final boolean defaultAfterIntroduction;


### PR DESCRIPTION
- The option for enabling checkpointing by user is deprecated and the system will autodetect state tracking mode.
- Assumption is that atleast once processing is always desired and so is enabled by default. This can be overridden for individual pipelines with runtime arg `cdap.streaming.atleastonce.enabled`
- Native state tracking is enabled if following are true
  
  - Feature flag enabled for native state tracking
  - There should be a single source that supports native state tracking
  - There should be no Windower plugin in the pipeline.
- Checkpointing is enabled when native state tracking is not possible
- The use of native state tracking variable will be implemented in subsequent PRs. Feature flag default set to false till implementation is complete
- Moved the state in the pipelinespec to a different class. Deprecated the existing fields.
