### PR TITLE
[CDAP-19579] Fix Security Vulnerability in Logback

### DIFF
--- a/cdap-common/src/test/java/io/cdap/cdap/common/service/RetryOnStartFailureServiceTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/service/RetryOnStartFailureServiceTest.java
@@ -24,10 +24,7 @@ import org.apache.twill.common.Threads;
 import org.apache.twill.internal.ServiceListenerAdapter;
 import org.junit.Assert;
 import org.junit.Test;
-import org.slf4j.MDC;
 
-import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -108,33 +105,6 @@ public class RetryOnStartFailureServiceTest {
     } catch (Exception e) {
       Assert.assertEquals("Intentional failure to shutdown", Throwables.getRootCause(e).getMessage());
     }
-  }
-
-  @Test
-  public void testLoggingContext() {
-    // This test logging context set before the service started is propagated into the service
-    final Map<String, String> context = Collections.singletonMap("key", "value");
-
-    // Create the service before setting the context.
-    Service service = new RetryOnStartFailureService(() -> new AbstractIdleService() {
-
-      @Override
-      protected void startUp() throws Exception {
-        Assert.assertEquals(context, MDC.getCopyOfContextMap());
-      }
-
-      @Override
-      protected void shutDown() throws Exception {
-        Assert.assertEquals(context, MDC.getCopyOfContextMap());
-      }
-    }, RetryStrategies.noRetry());
-
-    // Set the MDC context
-    MDC.setContextMap(context);
-
-    // Start and stop shouldn't throw
-    service.startAndWait();
-    service.stopAndWait();
   }
 
   /**

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/framework/LogPipelineLoader.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/framework/LogPipelineLoader.java
@@ -21,7 +21,7 @@ import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.status.Status;
-import ch.qos.logback.core.status.StatusChecker;
+import ch.qos.logback.core.status.StatusUtil;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provider;
@@ -196,7 +196,7 @@ public class LogPipelineLoader {
     configurator.doConfigure(configURL);
 
     // Check if the configuration has any error in it.
-    if (!new StatusChecker(context).isErrorFree(Status.ERROR)) {
+    if (!new StatusUtil(context).isErrorFree(Status.ERROR)) {
       Throwable failureCause = null;
       List<Status> errors = new ArrayList<>();
       for (Status status : context.getStatusManager().getCopyOfStatusList()) {
@@ -251,7 +251,7 @@ public class LogPipelineLoader {
     // defined in the logback xml.
     for (String key : keys) {
       context.putProperty(key, cConf.get(key));
-      cConf.set(key, configurator.getExecutionContext().subst("${" + key + "}"));
+      cConf.set(key, configurator.getInterpretationContext().subst("${" + key + "}"));
     }
 
     return cConf;

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/pipeline/LogPipelineConfigurator.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/pipeline/LogPipelineConfigurator.java
@@ -25,8 +25,8 @@ import ch.qos.logback.core.LogbackException;
 import ch.qos.logback.core.joran.action.Action;
 import ch.qos.logback.core.joran.action.ActionConst;
 import ch.qos.logback.core.joran.spi.ActionException;
+import ch.qos.logback.core.joran.spi.ElementSelector;
 import ch.qos.logback.core.joran.spi.InterpretationContext;
-import ch.qos.logback.core.joran.spi.Pattern;
 import ch.qos.logback.core.joran.spi.RuleStore;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.io.Syncable;
@@ -53,8 +53,8 @@ public class LogPipelineConfigurator extends JoranConfigurator {
   protected void buildInterpreter() {
     super.buildInterpreter();
     RuleStore ruleStore = interpreter.getRuleStore();
-    ruleStore.addRule(new Pattern("configuration/contextName"), new ContextConfigAction(cConf));
-    ruleStore.addRule(new Pattern("configuration/appender"), new WrapAppenderAction<ILoggingEvent>());
+    ruleStore.addRule(new ElementSelector("configuration/contextName"), new ContextConfigAction(cConf));
+    ruleStore.addRule(new ElementSelector("configuration/appender"), new WrapAppenderAction<ILoggingEvent>());
   }
 
   /**

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/plugins/LocationManager.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/plugins/LocationManager.java
@@ -170,12 +170,13 @@ public class LocationManager implements Flushable, Closeable, Syncable {
   @Override
   public void close() {
     Collection<LocationOutputStream> locations = activeLocations.values();
-    activeLocations.clear();
 
     for (LocationOutputStream locationOutputStream : locations) {
       // we do not want to throw any exception rather close all the open output streams. so close quietly
       Closeables.closeQuietly(locationOutputStream);
     }
+
+    activeLocations.clear();
   }
 
   /**

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/serialize/DelegatingLoggingEvent.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/serialize/DelegatingLoggingEvent.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.logging.serialize;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import org.slf4j.Marker;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class DelegatingLoggingEvent implements ILoggingEvent {
+
+  private final ILoggingEvent loggingEvent;
+  private final Map<String, String> mdc;
+
+  public DelegatingLoggingEvent(ILoggingEvent event, Map<String, String> mdc) {
+    this.loggingEvent = event;
+    this.mdc = Collections.unmodifiableMap(new HashMap<>(mdc));
+  }
+
+  @Override
+  public String getThreadName() {
+    return loggingEvent.getThreadName();
+  }
+
+  @Override
+  public Level getLevel() {
+    return loggingEvent.getLevel();
+  }
+
+  @Override
+  public String getMessage() {
+    return loggingEvent.getMessage();
+  }
+
+  @Override
+  public Object[] getArgumentArray() {
+    return loggingEvent.getArgumentArray();
+  }
+
+  @Override
+  public String getFormattedMessage() {
+    return loggingEvent.getFormattedMessage();
+  }
+
+  @Override
+  public String getLoggerName() {
+    return loggingEvent.getLoggerName();
+  }
+
+  @Override
+  public LoggerContextVO getLoggerContextVO() {
+    return loggingEvent.getLoggerContextVO();
+  }
+
+  @Override
+  public IThrowableProxy getThrowableProxy() {
+    return loggingEvent.getThrowableProxy();
+  }
+
+  @Override
+  public StackTraceElement[] getCallerData() {
+    return loggingEvent.getCallerData();
+  }
+
+  @Override
+  public boolean hasCallerData() {
+    return loggingEvent.hasCallerData();
+  }
+
+  @Override
+  public Marker getMarker() {
+    return loggingEvent.getMarker();
+  }
+
+  @Override
+  public Map<String, String> getMDCPropertyMap() {
+    return this.mdc;
+  }
+
+  @Override
+  public Map<String, String> getMdc() {
+    return this.getMDCPropertyMap();
+  }
+
+  @Override
+  public long getTimeStamp() {
+    return loggingEvent.getTimeStamp();
+  }
+
+  @Override
+  public void prepareForDeferredProcessing() {
+    loggingEvent.prepareForDeferredProcessing();
+  }
+}

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/plugins/RollingLocationLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/plugins/RollingLocationLogAppenderTest.java
@@ -161,6 +161,7 @@ public class RollingLocationLogAppenderTest {
     activeFiles = rollingAppender.getLocationManager().getActiveLocations();
     Assert.assertEquals(3, activeFiles.size());
     verifyFileOutput(activeFiles, 5);
+    rollingAppender.stop();
   }
 
   @Test
@@ -210,6 +211,7 @@ public class RollingLocationLogAppenderTest {
     locationOutputStream = activeFiles.get(new LocationIdentifier("testNs1", "testApp1"));
     parentDir = Locations.getParent(locationOutputStream.getLocation());
     Assert.assertEquals(10, parentDir.list().size());
+    rollingAppender.stop();
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <pragmatists.version>1.0.5</pragmatists.version>
     <kafka.version>0.8.2.2</kafka.version>
     <leveldb.version>0.12</leveldb.version>
-    <logback.version>1.0.9</logback.version>
+    <logback.version>1.2.11</logback.version>
     <mockftp.version>2.6</mockftp.version>
     <mockito.version>1.10.19</mockito.version>
     <mysql.version>5.1.21</mysql.version>


### PR DESCRIPTION
**[CDAP-19579: Upgrade Logback Dependencies to Remediate Security Vulnerabiility](https://cdap.atlassian.net/browse/CDAP-19579)**

**Description:**
- [ch.qos.logback:logback-classic](https://mvnrepository.com/artifact/ch.qos.logback/logback-classic) is a reliable, generic, fast and flexible logging library for Java
- [ch.qos.logback:logback-classic](https://mvnrepository.com/artifact/ch.qos.logback/logback-classic) in turn brings up the dependency of [ch.qos.logback:logback-core](https://mvnrepository.com/artifact/ch.qos.logback/logback-core) which is handled by maven’s internal dependency resolution. These dependencies are used extensively in CDAP for logging metrics and are exposed to a security vulnerability.

Related CVE(s):

- [CVE-2017-5929](https://nvd.nist.gov/vuln/detail/CVE-2017-5929)

**Challenges:**
- In the `RollingLocationLogAppender.java` file, overriding setOutputStream was no longer possible due to private access of outputStream object in `OutputStreamAppender.java` class defined in the logback version `1.2.0` and higher
- Many methods have been deleted in the newer versions of logback that need to replaced retaining the functionality
- MDC Values are no longer inherited from logback version 1.1.5 onwards and MDCPropertyMap is initialized to an empty unmodifiable map making it not possible to use put methods

**Solution:**
- Upgrade the version of logback-classic and logback-core from `1.0.9` to `1.2.11`
- Replace the deleted methods in `cdap-watchdog` module with their newer counterparts wherever possible or else modify the logic minimally while retaining the functionality
- Create a new delegating class in the `RollingLocationLogAppender.java` that manages handling switches between streams for write operations using the private outputStream object defined in the `OutputStreamAppender.java`
- Modify the logic of adding tags to MDC in `Log-Appender.java` by creating `DelegatingLoggingEvent` class that implements `ILoggingEvent` but with a modifiable copy of MDC that enables us to add tags

**Verifications:**
- Verified version override using `mvn dependency:tree`
- Verified that all the tests in the `cdap-watchdog` and `cdap-cli-tests` module pass successfully

Upon running the batch pipeline after deploying the cdap image in Kubernetes with changes made in this PR, here is the screenshot of the HTTP response for the pipeline logs & app-fabric logs:
<img width="965" alt="image" src="https://user-images.githubusercontent.com/44469092/194302333-654483ab-a7e8-43eb-8fd3-97c4d9a1b95f.png">
![image](https://user-images.githubusercontent.com/88528384/194617245-cb655b14-1d99-42f0-b6d2-d18e0cd7f4db.png)
