### PR TITLE
Cache artfacts and artifact_archive.jar files in GCS

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java
@@ -22,6 +22,8 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
 import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
@@ -101,6 +103,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -125,6 +129,8 @@ public class InMemoryProgramRunDispatcher implements ProgramRunDispatcher {
   private final RemoteClientFactory remoteClientFactory;
   private final PluginFinder pluginFinder;
   private final ArtifactRepository noAuthArtifactRepository;
+  private final boolean artifactsComputeHash;
+  private final boolean artifactsComputeHashSnapshot;
   private RemoteAuthenticator remoteAuthenticator;
   private ProgramRunnerFactory remoteProgramRunnerFactory;
   private String hostname;
@@ -143,6 +149,9 @@ public class InMemoryProgramRunDispatcher implements ProgramRunDispatcher {
     this.remoteClientFactory = remoteClientFactory;
     this.noAuthArtifactRepository = artifactRepository;
     this.pluginFinder = pluginFinder;
+
+    this.artifactsComputeHash = cConf.getBoolean(Constants.AppFabric.ARTIFACTS_COMPUTE_HASH);
+    this.artifactsComputeHashSnapshot = cConf.getBoolean(Constants.AppFabric.ARTIFACTS_COMPUTE_HASH_SNAPSHOT);
   }
 
   /**
@@ -477,6 +486,12 @@ public class InMemoryProgramRunDispatcher implements ProgramRunDispatcher {
                                     new BasicArguments(userArguments), options.isDebug());
   }
 
+  private static void hashArtifactId(Hasher hasher, ArtifactId artifactId) {
+    hasher.putString(artifactId.getParent().toString());
+    hasher.putString(artifactId.getArtifact());
+    hasher.putString(artifactId.getVersion());
+  }
+
   /**
    * Return the copy of the {@link ProgramOptions} including locations of plugin artifacts in it.
    *
@@ -497,8 +512,22 @@ public class InMemoryProgramRunDispatcher implements ProgramRunDispatcher {
 
     Set<String> files = Sets.newHashSet();
     HashMap<String, String> arguments = new HashMap<>(options.getArguments().asMap());
-    for (Map.Entry<String, Plugin> pluginEntry : appSpec.getPlugins().entrySet()) {
-      Plugin plugin = pluginEntry.getValue();
+    Hasher hasher = Hashing.sha256().newHasher();
+
+    /**
+     * If there is an artifact with SNAPSHOT version, hash should not be computed because artifact with
+     * SNAPSHOT might get changed but hash value remaining the same.
+     * {@link Constants.AppFabric.ARTIFACTS_COMPUTE_HASH_SNAPSHOT} allows to compute hash on snapshots
+     * which should only be used in testings.
+     */
+    boolean computeHash = artifactsComputeHash && !appSpec.getPlugins().isEmpty() &&
+      (artifactsComputeHashSnapshot ||
+        appSpec.getPlugins().values().stream().allMatch(plugin -> !plugin.getArtifactId().getVersion().isSnapshot()));
+
+    // Sort plugins based on keys so generated hashes remain identical
+    SortedMap<String, Plugin> sortedMap = new TreeMap<>(appSpec.getPlugins());
+    for (Map.Entry<String, Plugin> entry : sortedMap.entrySet()) {
+      Plugin plugin = entry.getValue();
       File destFile = new File(tempDir, Artifacts.getFileName(plugin.getArtifactId()));
       // Skip if the file has already been copied.
       if (!files.add(destFile.getName())) {
@@ -507,15 +536,22 @@ public class InMemoryProgramRunDispatcher implements ProgramRunDispatcher {
 
       try {
         ArtifactId artifactId = Artifacts.toProtoArtifactId(programId.getNamespaceId(), plugin.getArtifactId());
+        if (computeHash) {
+          hashArtifactId(hasher, artifactId);
+        }
         String peer = options.getArguments().getOption(ProgramOptionConstants.PEER_NAME);
         ArtifactDetail artifactDetail = getArtifactDetail(artifactId, artifactRepository);
         copyArtifact(artifactId, artifactDetail, destFile, artifactRepository, isDistributed, peer != null);
       } catch (ArtifactNotFoundException e) {
         throw new IllegalArgumentException(String.format("Artifact %s could not be found", plugin.getArtifactId()), e);
       }
+
     }
     LOG.debug("Plugin artifacts of {} copied to {}", programId, tempDir.getAbsolutePath());
     arguments.put(ProgramOptionConstants.PLUGIN_DIR, tempDir.getAbsolutePath());
+    if (computeHash) {
+      arguments.put(ProgramOptionConstants.PLUGIN_DIR_HASH, hasher.hash().toString());
+    }
     return new SimpleProgramOptions(options.getProgramId(), new BasicArguments(ImmutableMap.copyOf(arguments)),
                                     options.getUserArguments(), options.isDebug());
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -110,6 +110,16 @@ public final class ProgramOptionConstants {
   public static final String PLUGIN_DIR = "pluginDir";
 
   /**
+   * Option to hash value of local file path of a directory containing plugins artifacts.
+   */
+  public static final String PLUGIN_DIR_HASH = "pluginDirHash";
+
+  /**
+   * Option to cacheable file names.
+   */
+  public static final String CACHEABLE_FILES = "cacheableFiles";
+
+  /**
    * Option to a local file path of a JAR file containing plugins artifacts.
    */
   public static final String PLUGIN_ARCHIVE = "pluginArchive";

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -237,6 +237,8 @@ public final class Constants {
     public static final String PROGRAM_TERMINATOR_INTERVAL_SECS = "app.program.terminator.interval.secs";
     public static final String PROGRAM_TERMINATE_TIME_BUFFER_SECS = "app.program.terminate.time.buffer.secs";
     public static final String PROGRAM_TERMINATOR_TX_BATCH_SIZE = "app.program.terminator.tx.batch.size";
+    public static final String ARTIFACTS_COMPUTE_HASH = "app.artifact.compute.hash";
+    public static final String ARTIFACTS_COMPUTE_HASH_SNAPSHOT = "app.artifact.compute.hash.snapshot";
     public static final String SYSTEM_ARTIFACTS_DIR = "app.artifact.dir";
     public static final String SYSTEM_ARTIFACTS_MAX_PARALLELISM = "app.artifact.parallelism.max";
     public static final String PROGRAM_EXTRA_CLASSPATH = "app.program.extra.classpath";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -416,6 +416,23 @@
 
 
   <!-- Applications Configuration -->
+  <property>
+    <name>app.artifact.compute.hash</name>
+    <value>false</value>
+    <description>
+      If true, a hash for sharable artifacts will be computed and appended to artifact filename.
+    </description>
+  </property>
+
+  <property>
+    <name>app.artifact.compute.hash.snapshot</name>
+    <value>false</value>
+    <description>
+      If true, a hash for sharable artifacts with SNAPSHOT in their versions will be computed and appended
+      to artifact filename.
+      Should only be enabled for testing purposes. Otherwise, should always remain false.
+    </description>
+  </property>
 
   <property>
     <name>app.artifact.dir</name>

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -50,6 +50,7 @@ import javax.annotation.Nullable;
 public final class DataprocUtils {
 
   public static final String CDAP_GCS_ROOT = "cdap-job";
+  public static final String CDAP_CACHED_ARTIFACTS = "cached-artifacts";
   public static final String WORKER_CPU_PREFIX = "Up to";
 
   /**

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/CacheableLocalFile.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/CacheableLocalFile.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi;
+
+import org.apache.twill.api.LocalFile;
+
+import java.net.URI;
+import javax.annotation.Nullable;
+
+/**
+ * LocalFile implementation that can be cached.
+ */
+public class CacheableLocalFile implements LocalFile {
+  private final LocalFile localFile;
+
+  public CacheableLocalFile(LocalFile localFile) {
+    this.localFile = localFile;
+  }
+
+  @Override
+  public String getName() {
+    return localFile.getName();
+  }
+
+  @Override
+  public URI getURI() {
+    return localFile.getURI();
+  }
+
+  @Override
+  public long getLastModified() {
+    return localFile.getLastModified();
+  }
+
+  @Override
+  public long getSize() {
+    return localFile.getSize();
+  }
+
+  @Override
+  public boolean isArchive() {
+    return localFile.isArchive();
+  }
+
+  @Nullable
+  @Override
+  public String getPattern() {
+    return localFile.getPattern();
+  }
+}


### PR DESCRIPTION
The goal of this PR is reduce pipeline start-time. To this end, it performs the following changes:
1. if enabled through configuration, it computes hash of artifacts (and uses it as the cache for artifacts_archive.jar) based on pipeline plugins. 
2. It uploads artifacts with appended hash to a shared folder in GCS so they can be reused. 

This is the first PR focusing on artifacts and artifact_archive.jar files. Caching other artifact files will be done in separate PRs. 