### PR TITLE
Adds pipeline runtime argument to prevent cleanup of k8s resources

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/SystemArguments.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/SystemArguments.java
@@ -100,6 +100,10 @@ public final class SystemArguments {
 
   public static final String NAMESPACE_CONFIG_PREFIX = "system.namespace.config.";
 
+  // Runtime argument to disable cleanup after pipeline run. Currently applicable only to jobs running
+  // natively in kubernetes.
+  public static final String RUNTIME_CLEANUP_DISABLED = "system.runtime.cleanup.disabled";
+
   /**
    * Extracts log level settings from the given arguments. It extracts arguments prefixed with key
    * {@link #LOG_LEVEL} + {@code .}, with the remaining part of the key as the logger name, with the argument value
@@ -339,6 +343,11 @@ public final class SystemArguments {
                                            YARN_ATTEMPT_FAILURES_VALIDITY_INTERVAL);
     if (failureValidityInterval != null) {
       result.put(Configs.Keys.YARN_ATTEMPT_FAILURES_VALIDITY_INTERVAL, failureValidityInterval.toString());
+    }
+
+    String cleanupDisabled = args.get(RUNTIME_CLEANUP_DISABLED);
+    if (cleanupDisabled != null) {
+      result.put(RUNTIME_CLEANUP_DISABLED, cleanupDisabled);
     }
 
     return result;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/SystemArgumentsTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/SystemArgumentsTest.java
@@ -124,6 +124,19 @@ public class SystemArgumentsTest {
   }
 
   @Test
+  public void testGetTwillApplicationConfigs() {
+    // disable cleanup config specified
+    Map<String, String> configs = SystemArguments.getTwillApplicationConfigs(
+      ImmutableMap.of(SystemArguments.RUNTIME_CLEANUP_DISABLED, "true"));
+    Assert.assertTrue("unexpected value for config: " + SystemArguments.RUNTIME_CLEANUP_DISABLED,
+                      Boolean.parseBoolean(configs.get(SystemArguments.RUNTIME_CLEANUP_DISABLED)));
+
+    // disable cleanup config not specified
+    configs = SystemArguments.getTwillApplicationConfigs(ImmutableMap.of(SystemArguments.MEMORY_KEY, "10"));
+    Assert.assertTrue(configs.isEmpty());
+  }
+
+  @Test
   public void testRetryStrategies() {
     CConfiguration cConf = CConfiguration.create();
     Map<String, String> args = Collections.emptyMap();

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillController.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillController.java
@@ -250,6 +250,11 @@ class KubeTwillController implements ExtendedTwillController {
       return completion;
     }
 
+    if (meta.getAnnotations() != null && Boolean.parseBoolean(
+        meta.getAnnotations().get(KubeTwillRunnerService.RUNTIME_CLEANUP_DISABLED))) {
+      completion.complete(KubeTwillController.this);
+      return CompletableFuture.completedFuture(KubeTwillController.this);
+    }
     return cleanupResources(gracePeriodSeconds);
   }
 

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -141,6 +141,8 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
   public static final String RESOURCE_QUOTA_NAME = "cdap-resource-quota";
   public static final String WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY =
     "workload.identity.gcp.service.account.email";
+  // Whether to cleanup resources after job completion
+  public static final String RUNTIME_CLEANUP_DISABLED = "system.runtime.cleanup.disabled";
 
   private final MasterEnvironmentContext masterEnvContext;
   private final String kubeNamespace;

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillControllerTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillControllerTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.runtime;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import org.apache.twill.api.ServiceController;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import static org.mockito.Mockito.mock;
+
+public class KubeTwillControllerTest {
+  @Test
+  public void testTerminate() {
+    DiscoveryServiceClient mockDiscoveryServiceClient = mock(DiscoveryServiceClient.class);
+    ApiClient mockApiClient = mock(ApiClient.class);
+    // obj meta with disable cleanup annotation
+    V1ObjectMeta objMetaWithAnnotation = new V1ObjectMeta().name("test-job-name")
+      .putAnnotationsItem(KubeTwillRunnerService.RUNTIME_CLEANUP_DISABLED, "true");
+    CompletableFuture<Void> startupTaskCompletion = new CompletableFuture<>();
+    KubeTwillController controller = new KubeTwillController("default", null, mockDiscoveryServiceClient,
+                                                             mockApiClient, V1Job.class, objMetaWithAnnotation,
+                                                             startupTaskCompletion);
+
+    Future<? extends ServiceController> terminateFuture = controller.terminate();
+    Assert.assertTrue(terminateFuture.isDone());
+  }
+}


### PR DESCRIPTION
This gives a way to keep the pipeline run resources (like pods, Job, StatefulSet etc.) for debugging failures.

The resources will eventually be deleted when the next background cleanup thread executes. The background cleanup job's interval is configurable.

Users will be able to configure individual pipeline run to skip cleanup of the resources using the property - `"system.runtime.cleanup.disabled":"true"`

This runtime argument is only applicable to jobs running natively in kubernetes.

Testing Done:
1. Verified with system worker enabled
   - ensure system worker mode is enabled in cdapmasters CR
   - update cdap image in the cluster and restart all relevant pods
   - setup UI and run sample pipeline
   - verify system worker pod logs show pipeline triggered
   - verify 2 pods in the system after job completes - 
   ```
     cdap-cdap-workflow-default-datafusionquickstart-2-datapipek7j7h   0/1     Completed   0          14m
     phase-1-726a1a8332c95085-driver                                   0/1     Completed   0          12m
   ```
   - verify the Job resource exists in the cluster.
   - wait for background job to execute and verify pods are gone.
   - app fabric pod logs confirm background job removed all resources.

2. Verified with system worker disabled
   - repeat above steps with system worker mode disabled in cdapmasters CR.
   - verify the app-fabric pod triggers the pipeline run from the logs.

3. update cdapmasters CR spec.configs field to add new config -
   program.container.cleaner.interval.mins:                            420
   restart app-fabric pod and re-run the pipeline. check the resources stay
   longer than the default 60 min.