### PR TITLE
[CDAP-19581] Start deployment watcher thread for non-system namespaces

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeAPIException.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeAPIException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.runtime;
+
+import io.kubernetes.client.openapi.ApiException;
+
+/**
+ * Represents a wrapped {@link io.kubernetes.client.openapi.ApiException} which has the status code and response body
+ * in the message.
+ */
+public class KubeAPIException extends Exception {
+
+  KubeAPIException(String messagePrefix, ApiException cause) {
+    super(String.format("%s\nReceived status code %d with response: %s", messagePrefix, cause.getCode(),
+                        cause.getResponseBody()), cause);
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -700,7 +700,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
    * Deploys a {@link V1Job} to for runnable execution in Kubernetes.
    */
   private V1ObjectMeta createJob(V1ObjectMeta metadata, Map<String, RuntimeSpecification> runtimeSpecs,
-                                 Location runtimeConfigLocation) throws ApiException {
+                                 Location runtimeConfigLocation) throws KubeAPIException {
     int parallelism = getMainRuntimeSpecification(runtimeSpecs).getResourceSpecification().getInstances();
     V1Job job = new V1JobBuilder()
       .withMetadata(metadata)
@@ -722,10 +722,9 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
       LOG.debug("Created Job {} in Kubernetes.", metadata.getName());
     } catch (ApiException e) {
       if (e.getCode() == HttpURLConnection.HTTP_CONFLICT) {
-        LOG.warn("The kubernetes job already exists : {}. Ignoring resubmission of the job." , e.getResponseBody());
+        LOG.warn("The kubernetes job already exists : {}. Ignoring resubmission of the job.", e.getResponseBody());
       } else {
-        LOG.error("Failed to create kubernetes job: {}", e.getResponseBody());
-        throw e;
+        throw new KubeAPIException("Failed to create kubernetes job", e);
       }
     }
     return job.getMetadata();
@@ -736,13 +735,22 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
    */
   private V1ObjectMeta createDeployment(V1ObjectMeta metadata,
                                         Map<String, RuntimeSpecification> runtimeSpecs,
-                                        Location runtimeConfigLocation) throws ApiException {
+                                        Location runtimeConfigLocation) throws KubeAPIException {
     AppsV1Api appsApi = new AppsV1Api(apiClient);
 
     V1Deployment deployment = buildDeployment(metadata, runtimeSpecs, runtimeConfigLocation);
 
-    deployment = appsApi.createNamespacedDeployment(programRuntimeNamespace, deployment, "true", null, null);
-    LOG.info("Created Deployment {} in Kubernetes", metadata.getName());
+    try {
+      deployment = appsApi.createNamespacedDeployment(programRuntimeNamespace, deployment, "true", null, null);
+      LOG.info("Created Deployment {} in Kubernetes", metadata.getName());
+    } catch (ApiException e) {
+      if (e.getCode() == HttpURLConnection.HTTP_CONFLICT) {
+        LOG.warn("The kubernetes deployment already exists : {}. Ignoring resubmission of the deployment.",
+                 e.getResponseBody());
+      } else {
+        throw new KubeAPIException("Failed to create deployment", e);
+      }
+    }
     return deployment.getMetadata();
   }
 
@@ -752,13 +760,22 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
   private V1ObjectMeta createStatefulSet(V1ObjectMeta metadata,
                                          Map<String, RuntimeSpecification> runtimeSpecs,
                                          Location runtimeConfigLocation,
-                                         StatefulRunnable statefulRunnable) throws ApiException {
+                                         StatefulRunnable statefulRunnable) throws KubeAPIException {
     AppsV1Api appsApi = new AppsV1Api(apiClient);
 
     V1StatefulSet statefulSet = buildStatefulSet(metadata, runtimeSpecs, runtimeConfigLocation, statefulRunnable);
 
-    statefulSet = appsApi.createNamespacedStatefulSet(programRuntimeNamespace, statefulSet, "true", null, null);
-    LOG.info("Created StatefulSet {} in Kubernetes", metadata.getName());
+    try {
+      statefulSet = appsApi.createNamespacedStatefulSet(programRuntimeNamespace, statefulSet, "true", null, null);
+      LOG.info("Created StatefulSet {} in Kubernetes", metadata.getName());
+    } catch (ApiException e) {
+      if (e.getCode() == HttpURLConnection.HTTP_CONFLICT) {
+        LOG.warn("The kubernetes statefulset already exists : {}. Ignoring resubmission of the statefulset.",
+                 e.getResponseBody());
+      } else {
+        throw new KubeAPIException("Failed to create kubernetes statefulset", e);
+      }
+    }
     return statefulSet.getMetadata();
   }
 

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -1004,10 +1004,11 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
       return;
     }
     Map<Type, AppResourceWatcherThread<?>> typeMap = new HashMap<>();
+    // Batch jobs are k8s jobs, and streaming pipelines are k8s deployments
     typeMap.put(V1Job.class, AppResourceWatcherThread.createJobWatcher(namespace, selector));
-    // We only create deployments and stateful in the system namespace, so only add watchers for them in that namespace
+    typeMap.put(V1Deployment.class, AppResourceWatcherThread.createDeploymentWatcher(namespace, selector));
+    // We only create statefulsets in the system namespace, so only add watchers for them in that namespace
     if (namespace.equals(kubeNamespace)) {
-      typeMap.put(V1Deployment.class, AppResourceWatcherThread.createDeploymentWatcher(namespace, selector));
       typeMap.put(V1StatefulSet.class, AppResourceWatcherThread.createStatefulSetWatcher(namespace, selector));
     }
     typeMap.values().forEach(watcher -> {


### PR DESCRIPTION
[CDAP-19581] Start deployment watcher thread for non-system namespaces and add logs to CDAP resource creation failure in k8s

Context: this is required for running realtime streaming pipelines in hybrid environments because they are run as deployments.

[CDAP-19581]: https://cdap.atlassian.net/browse/CDAP-19581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ