### PR TITLE
CDAP-19465 Replacing kill() functionality by clean()

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillController.java
@@ -133,10 +133,10 @@ class RemoteExecutionTwillController implements TwillController {
         TimeUnit.SECONDS.sleep(1);
       }
     } catch (Exception e) {
-      // If there is exception, use the remote execution controller to try killing the remote process
+      // If there is exception, use the remote execution controller to try cleaning up the remote process
       try {
-        LOG.debug("Force termination of remote process for program run {}", programRunId);
-        remoteProcessController.kill();
+        LOG.debug("Clean up of remote process for program run {}", programRunId);
+        remoteProcessController.clean();
       } catch (Exception ex) {
         LOG.warn("Failed to terminate remote process for program run {}", programRunId, ex);
       }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteProcessController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteProcessController.java
@@ -40,4 +40,10 @@ public interface RemoteProcessController {
    * @throws Exception if not able to kill the remote process
    */
   void kill() throws Exception;
+
+  /**
+   * Cleans up the remote process, functionally similar to kill in some cases whereas a no-op in others
+   * @throws Exception if not able to kill the remote process
+   */
+  void clean() throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RuntimeJobRemoteProcessController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RuntimeJobRemoteProcessController.java
@@ -75,4 +75,12 @@ class RuntimeJobRemoteProcessController implements RemoteProcessController {
       runtimeJobManager.kill(programRunInfo);
     }
   }
+
+  @Override
+  public void clean() throws Exception {
+    LOG.debug("Cleaning up program run {}", programRunId);
+    try (RuntimeJobManager runtimeJobManager = runtimeJobManagerSupplier.get()) {
+      runtimeJobManager.clean(programRunInfo);
+    }
+  }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/SSHRemoteProcessController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/SSHRemoteProcessController.java
@@ -102,6 +102,12 @@ final class SSHRemoteProcessController implements RemoteProcessController {
     killProcess(9);
   }
 
+  @Override
+  public void clean() throws Exception {
+    LOG.debug("Cleaning up program run {}", programRunId);
+    kill();
+  }
+
   private void killProcess(int signal) throws IOException, InterruptedException {
     // SSH and kill the process
     try (SSHSession session = new DefaultSSHSession(sshConfig)) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManager.java
@@ -106,9 +106,13 @@ public class TetheringRuntimeJobManager implements RuntimeJobManager {
     publishToControlChannel(message);
   }
 
+  /**
+   * This method should be used carefully, as currently it is always returning RUNNING
+   */
   @Override
   public Optional<RuntimeJobDetail> getDetail(ProgramRunInfo programRunInfo) {
     // TODO: CDAP-18739 - pull job status instead of always treating it as RUNNING
+
     return Optional.of(new RuntimeJobDetail(programRunInfo, RuntimeJobStatus.RUNNING));
   }
 
@@ -151,6 +155,12 @@ public class TetheringRuntimeJobManager implements RuntimeJobManager {
     TetheringControlMessage message = createProgramTerminatePayload(programRunInfo,
                                                                     TetheringControlMessage.Type.KILL_PROGRAM);
     publishToControlChannel(message);
+  }
+
+  @Override
+  public void clean(ProgramRunInfo programRunInfo) throws Exception {
+    // no-op
+    LOG.debug("No-op cleanup for program {}", programRunInfo);
   }
 
   @Override

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -299,6 +299,12 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
   }
 
   @Override
+  public void clean(ProgramRunInfo programRunInfo) throws Exception {
+    LOG.debug(" Cleaning up program {}", programRunInfo);
+    stop(programRunInfo);
+  }
+
+  @Override
   public void close() {
     JobControllerClient client = this.jobControllerClient;
     if (client != null) {

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobManager.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobManager.java
@@ -70,6 +70,15 @@ public interface RuntimeJobManager extends Closeable {
   void kill(ProgramRunInfo programRunInfo) throws Exception;
 
   /**
+   * Cleans up any resources after a pipeline is complete. For example, signals Dataproc to
+   * clean up dataproc clusters.
+   *
+   * @param programRunInfo program run info
+   * @throws Exception thrown if any exception while killing the job
+   */
+  void clean(ProgramRunInfo programRunInfo) throws Exception;
+
+  /**
    * This method is responsible to perform clean up for runtime manager.
    */
   @Override


### PR DESCRIPTION
Logs when program finishes successfully in tethered mode - 


```


2022-09-16 05:47:27,160 - DEBUG [program-start-1:i.c.c.d.u.h.HBaseVersion@244] - HBase is not available from the environment. Cannot determine HBase version.
2022-09-16 05:47:27,161 - DEBUG [program-start-1:i.c.c.i.a.r.d.DistributedProgramRunner@803] - No HBase dependencies to add.
2022-09-16 05:47:27,263 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@909] - Create and copy service : file:/data/tmp/1663307245430-0/cConf.xml
2022-09-16 05:47:27,444 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@912] - Done service : file:/data/tmp/1663307245430-0/cConf.xml
2022-09-16 05:47:27,496 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@909] - Create and copy service : file:/etc/cdap/conf/logback-container.xml
2022-09-16 05:47:27,657 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@912] - Done service : file:/etc/cdap/conf/logback-container.xml
2022-09-16 05:47:27,691 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@909] - Create and copy service : file:/data/tmp/1663307245430-0/1663307245614-0/artifacts.jar
2022-09-16 05:47:28,438 - DEBUG [program.status:i.c.c.i.a.r.d.r.RemoteExecutionTwillController@138] - Clean up of remote process for program run program_run:default.tether1.-SNAPSHOT.workflow.DataPipelineWorkflow.8a73aa11-3582-11ed-bef6-f2627761eec2
2022-09-16 05:47:28,439 - DEBUG [program.status:i.c.c.i.a.r.d.r.RuntimeJobRemoteProcessController@81] - Cleaning up program run program_run:default.tether1.-SNAPSHOT.workflow.DataPipelineWorkflow.8a73aa11-3582-11ed-bef6-f2627761eec2
2022-09-16 05:47:28,445 - DEBUG [program.status:i.c.c.i.t.r.s.r.TetheringRuntimeJobManager@162] - No-op cleanup for program ProgramRunInfo{namespace='default', application='tether1', version='-SNAPSHOT', programType='WORKFLOW', program='DataPipelineWorkflow', run='8a73aa11-3582-11ed-bef6-f2627761eec2'}
2022-09-16 05:47:28,476 - DEBUG [program.status:i.c.c.i.p.t.ProvisioningTask@86] - Created DEPROVISION task for program run program_run:default.tether1.-SNAPSHOT.workflow.DataPipelineWorkflow.8a73aa11-3582-11ed-bef6-f2627761eec2.
2022-09-16 05:47:28,495 - DEBUG [provisioning-task-1:i.c.c.i.p.t.ProvisioningTask@125] - Executing DEPROVISION subtask REQUESTING_DELETE for program run program_run:default.tether1.-SNAPSHOT.workflow.DataPipelineWorkflow.8a73aa11-3582-11ed-bef6-f2627761eec2.
2022-09-16 05:47:28,496 - DEBUG [provisioning-task-1:i.c.c.i.p.t.ProvisioningTask@129] - Completed DEPROVISION subtask REQUESTING_DELETE for program run program_run:default.tether1.-SNAPSHOT.workflow.DataPipelineWorkflow.8a73aa11-3582-11ed-bef6-f2627761eec2.
2022-09-16 05:47:28,600 - DEBUG [provisioning-task-0:i.c.c.i.p.t.ProvisioningTask@116] - Completed DEPROVISION task for program run program_run:default.tether1.-SNAPSHOT.workflow.DataPipelineWorkflow.8a73aa11-3582-11ed-bef6-f2627761eec2.
2022-09-16 05:47:30,630 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@912] - Done service : file:/data/tmp/1663307245430-0/1663307245614-0/artifacts.jar
2022-09-16 05:47:30,662 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@909] - Create and copy service : file:/data/tmp/1663307245430-0/appSpec244617500569484490.json
2022-09-16 05:47:30,841 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@912] - Done service : file:/data/tmp/1663307245430-0/appSpec244617500569484490.json
2022-09-16 05:47:30,885 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@909] - Create and copy service : file:/data/tmp/service.system.dataprep.service.08c2de92-3583-11ed-8473-f2627761eec2/program.jar
2022-09-16 05:47:33,358 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@912] - Done service : file:/data/tmp/service.system.dataprep.service.08c2de92-3583-11ed-8473-f2627761eec2/program.jar
2022-09-16 05:47:33,405 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@909] - Create and copy service : file:/data/tmp/1663307245430-0/hConf.xml
2022-09-16 05:47:33,614 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@912] - Done service : file:/data/tmp/1663307245430-0/hConf.xml
2022-09-16 05:47:33,661 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@909] - Create and copy service : file:/data/tmp/1663307245430-0/1663307245614-0/artifacts.jar
2022-09-16 05:47:40,181 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@912] - Done service : file:/data/tmp/1663307245430-0/1663307245614-0/artifacts.jar
2022-09-16 05:47:40,240 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@909] - Create and copy service : file:/data/tmp/1663307245430-0/program.options2420381179233932434.json
2022-09-16 05:47:40,423 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@912] - Done service : file:/data/tmp/1663307245430-0/program.options2420381179233932434.json
2022-09-16 05:47:40,461 - DEBUG [program-start-1:i.c.c.k.r.KubeTwillPreparer@835] - Saving twill specification for service.system.dataprep.service to /tmp/runtime.config.jar290541846354934103/twillSpec.json



```