### PR TITLE
Streaming pipeline runner changes for state handling

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
@@ -115,7 +115,7 @@ public class DataStreamsPipelineSpecGenerator
     if (nativeStateTrackingSupported(config, sourcePluginTypes, stateHandlingSources)) {
       // Native state tracking and spark checkpointing is mutually exclusive
       // This is because Spark recreates context from checkpoint data
-      DataStreamsStateSpec stateSpec = DataStreamsStateSpec.getBuilder(DataStreamsStateSpec.Mode.NATIVE_STATE_STORE)
+      DataStreamsStateSpec stateSpec = DataStreamsStateSpec.getBuilder(DataStreamsStateSpec.Mode.STATE_STORE)
         .build();
       specBuilder.setStateSpec(stateSpec);
     } else {

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsStateSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsStateSpec.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 public class DataStreamsStateSpec {
 
   public enum Mode {
-    NONE, SPARK_CHECKPOINTING, NATIVE_STATE_STORE
+    NONE, SPARK_CHECKPOINTING, STATE_STORE
   }
 
   private final Mode mode;

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineDriver.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineDriver.java
@@ -278,10 +278,7 @@ public class SparkStreamingPipelineDriver implements JavaSparkMain {
       JavaSparkContext javaSparkContext = context == null ? new JavaSparkContext() : context;
       JavaStreamingContext jssc = new JavaStreamingContext(
         javaSparkContext, Durations.milliseconds(pipelineSpec.getBatchIntervalMillis()));
-      boolean checkpointsDisabled = pipelineSpec.getStateSpec()
-        .getMode() != DataStreamsStateSpec.Mode.SPARK_CHECKPOINTING;
-      SparkStreamingPipelineRunner runner = new SparkStreamingPipelineRunner(sec, jssc, pipelineSpec,
-                                                                             checkpointsDisabled);
+      SparkStreamingPipelineRunner runner = new SparkStreamingPipelineRunner(sec, jssc, pipelineSpec);
 
       // TODO: figure out how to get partitions to use for aggregators and joiners.
       // Seems like they should be set at configure time instead of runtime? but that requires an API change.

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineRunner.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/SparkStreamingPipelineRunner.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.datastreams;
 
+import io.cdap.cdap.api.Transactionals;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.macro.MacroEvaluator;
 import io.cdap.cdap.api.plugin.PluginContext;
@@ -26,19 +27,27 @@ import io.cdap.cdap.etl.api.JoinElement;
 import io.cdap.cdap.etl.api.batch.BatchAutoJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoiner;
 import io.cdap.cdap.etl.api.batch.BatchJoinerRuntimeContext;
+import io.cdap.cdap.etl.api.batch.SparkSink;
 import io.cdap.cdap.etl.api.join.AutoJoinerContext;
 import io.cdap.cdap.etl.api.join.JoinDefinition;
 import io.cdap.cdap.etl.api.streaming.StreamingContext;
+import io.cdap.cdap.etl.api.streaming.StreamingEventHandler;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
 import io.cdap.cdap.etl.common.DefaultAutoJoinerContext;
+import io.cdap.cdap.etl.common.NoopStageStatisticsCollector;
+import io.cdap.cdap.etl.common.PhaseSpec;
 import io.cdap.cdap.etl.common.PipelinePhase;
 import io.cdap.cdap.etl.common.RecordInfo;
 import io.cdap.cdap.etl.common.StageStatisticsCollector;
 import io.cdap.cdap.etl.common.plugin.JoinerBridge;
+import io.cdap.cdap.etl.planner.CombinerDag;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.EmittedRecords;
 import io.cdap.cdap.etl.spark.SparkCollection;
 import io.cdap.cdap.etl.spark.SparkPairCollection;
 import io.cdap.cdap.etl.spark.SparkPipelineRunner;
+import io.cdap.cdap.etl.spark.batch.RDDCollection;
+import io.cdap.cdap.etl.spark.batch.SparkBatchSinkFactory;
 import io.cdap.cdap.etl.spark.function.FunctionCache;
 import io.cdap.cdap.etl.spark.function.PluginFunctionContext;
 import io.cdap.cdap.etl.spark.plugin.SparkPipelinePluginContext;
@@ -49,13 +58,23 @@ import io.cdap.cdap.etl.spark.streaming.PairDStreamCollection;
 import io.cdap.cdap.etl.spark.streaming.function.CountingTransformFunction;
 import io.cdap.cdap.etl.spark.streaming.function.DynamicJoinMerge;
 import io.cdap.cdap.etl.spark.streaming.function.DynamicJoinOn;
+import io.cdap.cdap.etl.spark.streaming.function.StreamingBatchSinkFunction;
+import io.cdap.cdap.etl.spark.streaming.function.StreamingMultiSinkFunction;
+import io.cdap.cdap.etl.spark.streaming.function.StreamingSparkSinkFunction;
 import io.cdap.cdap.etl.spark.streaming.function.WrapOutputTransformFunction;
 import io.cdap.cdap.etl.spark.streaming.function.preview.LimitingFunction;
 import io.cdap.cdap.etl.validation.LoggingFailureCollector;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.streaming.Time;
 import org.apache.spark.streaming.api.java.JavaDStream;
 import org.apache.spark.streaming.api.java.JavaPairDStream;
 import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,25 +85,42 @@ import java.util.Set;
  */
 public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
 
-  private final JavaSparkExecutionContext sec;
-  private final JavaStreamingContext streamingContext;
-  private final DataStreamsPipelineSpec spec;
-  private final boolean checkpointsDisabled;
+  private static final Logger LOG = LoggerFactory.getLogger(SparkStreamingPipelineRunner.class);
 
-  public SparkStreamingPipelineRunner(JavaSparkExecutionContext sec, JavaStreamingContext streamingContext,
-                                      DataStreamsPipelineSpec spec, boolean checkpointsDisabled) {
+  private final JavaSparkExecutionContext sec;
+  private final JavaStreamingContext javaStreamingContext;
+  private final DataStreamsPipelineSpec spec;
+  private final boolean stateStoreEnabled;
+
+  public SparkStreamingPipelineRunner(JavaSparkExecutionContext sec, JavaStreamingContext javaStreamingContext,
+                                      DataStreamsPipelineSpec spec) {
     this.sec = sec;
-    this.streamingContext = streamingContext;
-    this.checkpointsDisabled = checkpointsDisabled;
+    this.javaStreamingContext = javaStreamingContext;
     this.spec = spec;
+    this.stateStoreEnabled = spec.getStateSpec().getMode() == DataStreamsStateSpec.Mode.STATE_STORE
+      && !spec.isPreviewEnabled(sec);
+    LOG.debug("State handling mode is : {}", spec.getStateSpec().getMode());
   }
 
   @Override
   protected SparkCollection<RecordInfo<Object>> getSource(StageSpec stageSpec,
                                                           FunctionCache.Factory functionCacheFactory,
                                                           StageStatisticsCollector collector) throws Exception {
+    JavaDStream<Object> javaDStream = getDStream(stageSpec, collector);
+    DataTracer dataTracer = sec.getDataTracer(stageSpec.getName());
+    if (dataTracer.isEnabled()) {
+      // it will create a new function for each RDD, which would limit each RDD but not the entire DStream.
+      javaDStream = javaDStream.transform(new LimitingFunction<>(spec.getNumOfRecordsPreview()));
+    }
+    JavaDStream<RecordInfo<Object>> outputDStream = javaDStream
+      .transform(new CountingTransformFunction<>(stageSpec.getName(), sec.getMetrics(), "records.out", dataTracer))
+      .map(new WrapOutputTransformFunction<>(stageSpec.getName()));
+    return new DStreamCollection<>(sec, functionCacheFactory, outputDStream);
+  }
+
+  private JavaDStream<Object> getDStream(StageSpec stageSpec, StageStatisticsCollector collector) throws Exception {
     StreamingSource<Object> source;
-    if (checkpointsDisabled) {
+    if (spec.getStateSpec().getMode() != DataStreamsStateSpec.Mode.SPARK_CHECKPOINTING) {
       PluginFunctionContext pluginFunctionContext = new PluginFunctionContext(stageSpec, sec, collector);
       source = pluginFunctionContext.createPlugin();
     } else {
@@ -105,17 +141,8 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
       source = pluginContext.newPluginInstance(stageSpec.getName(), macroEvaluator);
     }
 
-    DataTracer dataTracer = sec.getDataTracer(stageSpec.getName());
-    StreamingContext sourceContext = new DefaultStreamingContext(stageSpec, sec, streamingContext);
-    JavaDStream<Object> javaDStream = source.getStream(sourceContext);
-    if (dataTracer.isEnabled()) {
-      // it will create a new function for each RDD, which would limit each RDD but not the entire DStream.
-      javaDStream = javaDStream.transform(new LimitingFunction<>(spec.getNumOfRecordsPreview()));
-    }
-    JavaDStream<RecordInfo<Object>> outputDStream = javaDStream
-      .transform(new CountingTransformFunction<>(stageSpec.getName(), sec.getMetrics(), "records.out", dataTracer))
-      .map(new WrapOutputTransformFunction<>(stageSpec.getName()));
-    return new DStreamCollection<>(sec, functionCacheFactory, outputDStream);
+    StreamingContext sourceContext = new DefaultStreamingContext(stageSpec, sec, javaStreamingContext);
+    return source.getStream(sourceContext);
   }
 
   @Override
@@ -184,5 +211,121 @@ public class SparkStreamingPipelineRunner extends SparkPipelineRunner {
     joiner.initialize(joinerRuntimeContext);
     shufflers.add(stageName);
     return handleJoin(joiner, inputDataCollections, stageSpec, functionCacheFactory, numPartitions, collector);
+  }
+
+  @Override
+  protected void processDag(PhaseSpec phaseSpec, String sourcePluginType, JavaSparkExecutionContext sec,
+                            Map<String, Integer> stagePartitions, PluginContext pluginContext,
+                            Map<String, StageStatisticsCollector> collectors, PipelinePhase pipelinePhase,
+                            FunctionCache.Factory functionCacheFactory,
+                            MacroEvaluator macroEvaluator, CombinerDag groupedDag,
+                            Map<String, Set<String>> groups, Set<String> branchers,
+                            Set<String> shufflers) throws Exception {
+    if (!stateStoreEnabled) {
+      super.processDag(phaseSpec, sourcePluginType, sec, stagePartitions, pluginContext, collectors, pipelinePhase,
+                       functionCacheFactory, macroEvaluator, groupedDag, groups, branchers, shufflers);
+      return;
+    }
+
+    //Process source separately
+    List<String> topologicalOrder = groupedDag.getTopologicalOrder();
+    String source = topologicalOrder.get(0);
+    StageSpec stageSpec = pipelinePhase.getStage(source);
+    StageStatisticsCollector collector = collectors.getOrDefault(source, new NoopStageStatisticsCollector());
+    JavaDStream<Object> dStream = getDStream(stageSpec, collector);
+    DataTracer dataTracer = sec.getDataTracer(stageSpec.getName());
+    dStream.foreachRDD((javaRDD, time) -> {
+      Collection<Runnable> sinkRunnables = new ArrayList<>();
+      Transactionals.execute(sec, context -> {
+
+        JavaRDD<Object> batchRDD = javaRDD;
+        if (dataTracer.isEnabled()) {
+          // it will create a new function for each RDD, which would limit each RDD but not the entire DStream.
+          batchRDD = new LimitingFunction<>(spec.getNumOfRecordsPreview()).call(batchRDD);
+        }
+        batchRDD = new CountingTransformFunction<>(stageSpec.getName(), sec.getMetrics(), "records.out", dataTracer)
+          .call(batchRDD);
+        JavaRDD<RecordInfo<Object>> wrapped = batchRDD.map(new WrapOutputTransformFunction<>(stageSpec.getName()));
+        RDDCollection<RecordInfo<Object>> rddCollection =
+          new RDDCollection<RecordInfo<Object>>(sec, functionCacheFactory, javaStreamingContext.sparkContext(),
+                                                new SQLContext(javaStreamingContext.sparkContext()),
+                                                context, new SparkBatchSinkFactory(), wrapped);
+        EmittedRecords records = getEmittedRecords(pipelinePhase, stageSpec, rddCollection, groupedDag,
+                                                   branchers, shufflers, false, false);
+        Map<String, EmittedRecords> emittedRecords = new HashMap<>();
+        emittedRecords.put(source, records);
+
+        //process the remaining stages
+        for (int i = 1; i < topologicalOrder.size(); i++) {
+          String stageName = topologicalOrder.get(i);
+          processStage(phaseSpec, sourcePluginType, sec, stagePartitions, pluginContext, collectors, pipelinePhase,
+                       functionCacheFactory, macroEvaluator, emittedRecords, groupedDag, groups, branchers, shufflers,
+                       sinkRunnables, stageName, time.milliseconds(), context);
+        }
+      }, Exception.class);
+
+      //We should have all the sink runnables at this point, execute them
+      executeSinkRunnables(sec, sinkRunnables);
+
+      StreamingContext streamingContext = new DefaultStreamingContext(stageSpec, sec, javaStreamingContext);
+      if (dStream instanceof StreamingEventHandler) {
+        ((StreamingEventHandler) dStream).onBatchCompleted(streamingContext);
+      } else if (dStream.dstream() instanceof StreamingEventHandler) {
+        ((StreamingEventHandler) (dStream.dstream())).onBatchCompleted(streamingContext);
+      }
+    });
+  }
+
+  @Override
+  protected Runnable getSparkSinkRunnable(StageSpec stageSpec, SparkCollection<Object> stageData,
+                                          SparkSink<Object> sparkSink, long time) throws Exception {
+    if (!stateStoreEnabled) {
+      return super.getSparkSinkRunnable(stageSpec, stageData, sparkSink, time);
+    }
+
+    return () -> {
+      try {
+        new StreamingSparkSinkFunction<>(sec, stageSpec).call(stageData.getUnderlying(), Time.apply(time));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+
+  @Override
+  protected Runnable getBatchSinkRunnable(FunctionCache.Factory functionCacheFactory, StageSpec stageSpec,
+                                          SparkCollection<Object> stageData,
+                                          PluginFunctionContext pluginFunctionContext, long time) {
+    if (!stateStoreEnabled) {
+      return super.getBatchSinkRunnable(functionCacheFactory, stageSpec, stageData, pluginFunctionContext, time);
+    }
+
+    return () -> {
+      try {
+        new StreamingBatchSinkFunction<>(sec, stageSpec, functionCacheFactory.newCache()).call(
+          stageData.getUnderlying(), Time.apply(time));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+
+  @Override
+  protected Runnable getGroupSinkRunnable(PhaseSpec phaseSpec, Set<String> groupStages,
+                                          Map<String, StageStatisticsCollector> collectors,
+                                          SparkCollection<RecordInfo<Object>> fullInput, Set<String> groupSinks,
+                                          long time) {
+    if (!stateStoreEnabled) {
+      return super.getGroupSinkRunnable(phaseSpec, groupStages, collectors, fullInput, groupSinks, time);
+    }
+
+    return () -> {
+      try {
+        new StreamingMultiSinkFunction(sec, phaseSpec, groupStages, groupSinks, collectors).call(
+          fullInput.getUnderlying(), Time.apply(time));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGeneratorTest.java
@@ -73,7 +73,7 @@ public class DataStreamsPipelineSpecGeneratorTest {
     specGenerator.configureAtleastOnceMode(etlConfig, builder);
 
     DataStreamsPipelineSpec pipelineSpec = builder.build();
-    Assert.assertTrue(pipelineSpec.getStateSpec().getMode() == DataStreamsStateSpec.Mode.NATIVE_STATE_STORE);
+    Assert.assertTrue(pipelineSpec.getStateSpec().getMode() == DataStreamsStateSpec.Mode.STATE_STORE);
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/cdap-data-streams2_2.11/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams2_2.11/pom.xml
@@ -109,6 +109,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.11</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/cdap-app-templates/cdap-etl/cdap-data-streams3_2.12/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams3_2.12/pom.xml
@@ -119,6 +119,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.12</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingEventHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingEventHandler.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.streaming;
+
+/**
+ * Interface for handling Streaming batch events
+ */
+public interface StreamingEventHandler {
+
+  /**
+   * Call on each completed batch.
+   *
+   * @param streamingContext @link{StreamingContext} Context object for this stage
+   */
+  void onBatchCompleted(StreamingContext streamingContext);
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/EmittedRecords.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/EmittedRecords.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark;
+
+import io.cdap.cdap.etl.api.Alert;
+import io.cdap.cdap.etl.api.ErrorRecord;
+import io.cdap.cdap.etl.common.RecordInfo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Holds all records emitted by a stage.
+ */
+public class EmittedRecords {
+  private final SparkCollection<RecordInfo<Object>> rawData;
+  private final Map<String, SparkCollection<Object>> outputPortRecords;
+  private final SparkCollection<Object> outputRecords;
+  private final SparkCollection<ErrorRecord<Object>> errorRecords;
+  private final SparkCollection<Alert> alertRecords;
+
+  private EmittedRecords(SparkCollection<RecordInfo<Object>> rawData,
+                         Map<String, SparkCollection<Object>> outputPortRecords,
+                         SparkCollection<Object> outputRecords,
+                         SparkCollection<ErrorRecord<Object>> errorRecords,
+                         SparkCollection<Alert> alertRecords) {
+    this.rawData = rawData;
+    this.outputPortRecords = outputPortRecords;
+    this.outputRecords = outputRecords;
+    this.errorRecords = errorRecords;
+    this.alertRecords = alertRecords;
+  }
+
+  public SparkCollection<RecordInfo<Object>> getRawData() {
+    return rawData;
+  }
+
+  public Map<String, SparkCollection<Object>> getOutputPortRecords() {
+    return outputPortRecords;
+  }
+
+  public SparkCollection<Object> getOutputRecords() {
+    return outputRecords;
+  }
+
+  public SparkCollection<ErrorRecord<Object>> getErrorRecords() {
+    return errorRecords;
+  }
+
+  public SparkCollection<Alert> getAlertRecords() {
+    return alertRecords;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private SparkCollection<RecordInfo<Object>> rawData;
+    private Map<String, SparkCollection<Object>> outputPortRecords;
+    private SparkCollection<Object> outputRecords;
+    private SparkCollection<ErrorRecord<Object>> errorRecords;
+    private SparkCollection<Alert> alertRecords;
+
+    private Builder() {
+      outputPortRecords = new HashMap<>();
+    }
+
+    public Builder setRawData(SparkCollection<RecordInfo<Object>> rawData) {
+      this.rawData = rawData;
+      return this;
+    }
+
+    public Builder addPort(String port, SparkCollection<Object> records) {
+      outputPortRecords.put(port, records);
+      return this;
+    }
+
+    public Builder setOutput(SparkCollection<Object> records) {
+      outputRecords = records;
+      return this;
+    }
+
+    public Builder setErrors(SparkCollection<ErrorRecord<Object>> errors) {
+      errorRecords = errors;
+      return this;
+    }
+
+    public Builder setAlerts(SparkCollection<Alert> alerts) {
+      alertRecords = alerts;
+      return this;
+    }
+
+    public EmittedRecords build() {
+      return new EmittedRecords(rawData, outputPortRecords, outputRecords, errorRecords, alertRecords);
+    }
+  }
+}


### PR DESCRIPTION
- New interface StreamingEventHandler is introduced for streaming source DStream to implement
- Refactored SparkPipelineRunner to split the runPipeline method for code reuse
- Moved EmittedRecords to its own class for code reuse
- SparkStreamingPipelineRunner does the following if native state handling is enabled
     - Iterates over RDDs in Dstream from source 
     - In a new transaction, does preliminary transformations and creates a RDDCollection as output
     - Does processing for remaining stages for the RDD in the same transaction
     - Runs sink runnables outside the transaction.
     - Calls onBatchCompleted at the end of the batch on Dstream if StreamingEventHandler is implemented
     - Uses DStreamCollection sink functions instead of RDDCollections sink functions. This is to ensure prepareRun and onRunFinish are called on the sink plugin.

