### PR TITLE
CDAP-19614 - Don't pass ApplicationDescription through the runtime service

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/MessagingProgramStateWriter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/MessagingProgramStateWriter.java
@@ -75,8 +75,13 @@ public final class MessagingProgramStateWriter implements ProgramStateWriter {
       .put(ProgramOptionConstants.PROGRAM_RUN_ID, GSON.toJson(programRunId))
       .put(ProgramOptionConstants.PROGRAM_STATUS, ProgramRunStatus.STARTING.name())
       .put(ProgramOptionConstants.USER_OVERRIDES, GSON.toJson(programOptions.getUserArguments().asMap()))
-      .put(ProgramOptionConstants.SYSTEM_OVERRIDES, GSON.toJson(programOptions.getArguments().asMap()))
-      .put(ProgramOptionConstants.PROGRAM_DESCRIPTOR, GSON.toJson(programDescriptor));
+      .put(ProgramOptionConstants.SYSTEM_OVERRIDES, GSON.toJson(programOptions.getArguments().asMap()));
+
+    if (ProgramStatePublisher.isProgramStartSkipped(programOptions.getArguments().asMap())) {
+      properties.put(ProgramOptionConstants.PROGRAM_ARTIFACT_ID, GSON.toJson(programDescriptor.getArtifactId()));
+    } else {
+      properties.put(ProgramOptionConstants.PROGRAM_DESCRIPTOR, GSON.toJson(programDescriptor));
+    }
 
     if (twillRunId != null) {
       properties.put(ProgramOptionConstants.TWILL_RUN_ID, twillRunId);
@@ -153,7 +158,7 @@ public final class MessagingProgramStateWriter implements ProgramStateWriter {
       .put(ProgramOptionConstants.SYSTEM_OVERRIDES, GSON.toJson(programOptions.getArguments().asMap()))
       .put(ProgramOptionConstants.PROGRAM_STATUS, ProgramRunStatus.REJECTED.name())
       .put(ProgramOptionConstants.USER_ID, userId)
-      .put(ProgramOptionConstants.PROGRAM_DESCRIPTOR, GSON.toJson(programDescriptor))
+      .put(ProgramOptionConstants.PROGRAM_ARTIFACT_ID, GSON.toJson(programDescriptor.getArtifactId()))
       .put(ProgramOptionConstants.PROGRAM_ERROR, GSON.toJson(new BasicThrowable(cause)));
     programStatePublisher.publish(Notification.Type.PROGRAM_STATUS, properties.build());
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/ProgramStatePublisher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/program/ProgramStatePublisher.java
@@ -15,7 +15,11 @@
  */
 package io.cdap.cdap.internal.app.program;
 
+import com.google.gson.Gson;
+import io.cdap.cdap.app.program.ProgramDescriptor;
+import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.proto.Notification;
+import io.cdap.cdap.proto.id.ArtifactId;
 
 import java.util.Map;
 
@@ -23,6 +27,36 @@ import java.util.Map;
  * Publishing program state messages and heartbeats
  */
 public interface ProgramStatePublisher {
+
+  /**
+   *
+   * @return if program status notification with given system arguments would need a program start (false) or not
+   * (true). If true it means that program start is handled elsewhere (e.g. in preview or workflow) and
+   * notification is only to report program start already happened. Such notification would not need to have the
+   * {@link ProgramOptionConstants#PROGRAM_DESCRIPTOR} field and will have
+   * {@link ProgramOptionConstants#PROGRAM_ARTIFACT_ID} field instead.
+   */
+  static boolean isProgramStartSkipped(Map<String, String> systemArguments) {
+    boolean isInWorkflow = systemArguments.containsKey(ProgramOptionConstants.WORKFLOW_NAME);
+    boolean skipProvisioning = Boolean.parseBoolean(systemArguments.get(ProgramOptionConstants.SKIP_PROVISIONING));
+
+    return isInWorkflow || skipProvisioning;
+  }
+
+  /**
+   *
+   * @return {@link ArtifactId} retrieved from either {@link ProgramOptionConstants#PROGRAM_ARTIFACT_ID} or
+   * {@link ProgramOptionConstants#PROGRAM_DESCRIPTOR}
+   */
+  static ArtifactId getArtifactId(Gson gson, Map<String, String> properties) {
+    if (properties.containsKey(ProgramOptionConstants.PROGRAM_ARTIFACT_ID)) {
+      return gson.fromJson(properties.get(ProgramOptionConstants.PROGRAM_ARTIFACT_ID), ArtifactId.class);
+    } else {
+      //Old program notification, it is passing program descriptor
+      return gson.fromJson(properties.get(ProgramOptionConstants.PROGRAM_DESCRIPTOR), ProgramDescriptor.class)
+          .getArtifactId();
+    }
+  }
 
   /**
    * Publish message which is identified by notificationType and the properties.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -49,6 +49,8 @@ public final class ProgramOptionConstants {
 
   public static final String PROGRAM_RUN_ID = "programRunId";
 
+  public static final String PROGRAM_ARTIFACT_ID = "programArtifactId";
+
   public static final String INSTANCE_ID = "instanceId";
 
   public static final String INSTANCES = "instances";

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeProgramStatusSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeProgramStatusSubscriberService.java
@@ -21,12 +21,12 @@ import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
-import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.utils.ImmutablePair;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
+import io.cdap.cdap.internal.app.program.ProgramStatePublisher;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.internal.app.services.AbstractNotificationSubscriberService;
 import io.cdap.cdap.internal.app.store.AppMetadataStore;
@@ -171,13 +171,11 @@ public class RuntimeProgramStatusSubscriberService extends AbstractNotificationS
         store.deleteRunIfTerminated(programRunId, sourceId);
         break;
       case REJECTED: {
-        ProgramDescriptor programDescriptor =
-          GSON.fromJson(properties.get(ProgramOptionConstants.PROGRAM_DESCRIPTOR), ProgramDescriptor.class);
         // Strip off user args and trim down system args as runtime only needs the run status for validation purpose.
         // User and system args could be large and store them in local store can lead to unnecessary storage
         // and processing overhead.
         store.recordProgramRejected(programRunId, Collections.emptyMap(), Collections.emptyMap(),
-                                    sourceId, programDescriptor.getArtifactId().toApiArtifactId());
+                                    sourceId, ProgramStatePublisher.getArtifactId(GSON, properties).toApiArtifactId());
         // We don't need to retain records for terminated programs, hence just delete it
         store.deleteRunIfTerminated(programRunId,  sourceId);
         break;


### PR DESCRIPTION
It's generally not need and puts additional load on runtime service and messaging service under high start load