### PR TITLE
Refactor AppDeploymentInfo class

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryConfigurator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2019 Cask Data, Inc.
+ * Copyright © 2014-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -100,7 +100,7 @@ public final class InMemoryConfigurator implements Configurator {
     this.pluginFinder = pluginFinder;
     this.appNamespace = Id.Namespace.fromEntityId(deploymentInfo.getNamespaceId());
     this.artifactId = Id.Artifact.fromEntityId(deploymentInfo.getArtifactId());
-    this.appClassName = deploymentInfo.getApplicationClassName();
+    this.appClassName = deploymentInfo.getApplicationClass().getClassName();
     this.applicationName = deploymentInfo.getApplicationName();
     this.applicationVersion = deploymentInfo.getApplicationVersion();
     this.configString = deploymentInfo.getConfigString() == null ? "" : deploymentInfo.getConfigString();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java
@@ -318,12 +318,18 @@ public class InMemoryProgramRunDispatcher implements ProgramRunDispatcher {
                       artifactDetail.getDescriptor().getArtifactId(), programId.getNamespace()));
     }
 
-    AppDeploymentInfo deploymentInfo =
-      new AppDeploymentInfo(artifactId, artifactDetail.getDescriptor().getLocation(), programId.getNamespaceId(),
-                            appClass, existingAppSpec.getName(), existingAppSpec.getAppVersion(),
-                            existingAppSpec.getConfiguration(), null, false,
-                            new AppDeploymentRuntimeInfo(existingAppSpec, options.getUserArguments().asMap(),
-                                                         options.getArguments().asMap()));
+    AppDeploymentInfo deploymentInfo = AppDeploymentInfo.builder()
+      .setArtifactId(artifactId)
+      .setArtifactLocation(artifactDetail.getDescriptor().getLocation())
+      .setNamespaceId(programId.getNamespaceId())
+      .setApplicationClass(appClass)
+      .setAppName(existingAppSpec.getName())
+      .setAppVersion(existingAppSpec.getAppVersion())
+      .setConfigString(existingAppSpec.getConfiguration())
+      .setUpdateSchedules(false)
+      .setRuntimeInfo(new AppDeploymentRuntimeInfo(existingAppSpec,
+                                                   options.getUserArguments().asMap(), options.getArguments().asMap()))
+      .build();
     Configurator configurator = new InMemoryConfigurator(cConf, pluginFinder, impersonator, artifactRepository,
                                                          factory, deploymentInfo);
     ListenableFuture<ConfigResponse> future = configurator.config();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2020 Cask Data, Inc.
+ * Copyright © 2015-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -20,6 +20,7 @@ import com.google.gson.annotations.SerializedName;
 import io.cdap.cdap.api.app.Application;
 import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.internal.app.deploy.LocalApplicationManager;
+import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -35,48 +36,47 @@ public class AppDeploymentInfo {
   private final ArtifactId artifactId;
   private final transient Location artifactLocation;
   private final NamespaceId namespaceId;
-  private final String applicationClassName;
   private final ApplicationClass applicationClass;
+  @Nullable
   private final String appName;
+  @Nullable
   private final String appVersion;
+  @Nullable
   private final String configString;
+  @Nullable
   @SerializedName("principal")
   private final KerberosPrincipalId ownerPrincipal;
   @SerializedName("update-schedules")
   private final boolean updateSchedules;
+  @Nullable
   private final AppDeploymentRuntimeInfo runtimeInfo;
 
-  public AppDeploymentInfo(AppDeploymentInfo info, Location artifactLocation) {
-    this(info.artifactId, artifactLocation, info.namespaceId, info.applicationClass, info.appName, info.appVersion,
-         info.configString, info.ownerPrincipal, info.updateSchedules, info.runtimeInfo);
+  /**
+   * Creates a new {@link Builder}.
+   */
+  public static Builder builder() {
+    return new Builder();
   }
 
-  public AppDeploymentInfo(ArtifactId artifactId, Location artifactLocation, NamespaceId namespaceId,
-                           ApplicationClass applicationClass, @Nullable String appName, @Nullable String appVersion,
-                           @Nullable String configString) {
-    this(artifactId, artifactLocation, namespaceId, applicationClass, appName, appVersion, configString, null,
-         true, null);
-  }
-
-  public AppDeploymentInfo(ArtifactId artifactId, Location artifactLocation, NamespaceId namespaceId,
-                           ApplicationClass applicationClass, @Nullable String appName, @Nullable String appVersion,
-                           @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal,
-                           boolean updateSchedules, @Nullable AppDeploymentRuntimeInfo runtimeInfo) {
-    this(artifactId, artifactLocation, namespaceId, applicationClass, applicationClass.getClassName(),
-         appName, appVersion, configString, ownerPrincipal, updateSchedules, runtimeInfo);
-  }
-
-  public AppDeploymentInfo(ArtifactId artifactId, Location artifactLocation, NamespaceId namespaceId,
-                           String applicationClassName, @Nullable String appName, @Nullable String appVersion,
-                           @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal,
-                           boolean updateSchedules, @Nullable AppDeploymentRuntimeInfo runtimeInfo) {
-    this(artifactId, artifactLocation, namespaceId, null, applicationClassName, appName, appVersion, configString,
-         ownerPrincipal, updateSchedules, runtimeInfo);
+  /**
+   * Creates a new {@link Builder} by copying all fields from the another {@link AppDeploymentInfo}.
+   */
+  public static Builder copyFrom(AppDeploymentInfo other) {
+    return new Builder()
+      .setArtifactId(other.artifactId)
+      .setArtifactLocation(other.artifactLocation)
+      .setApplicationClass(other.applicationClass)
+      .setNamespaceId(other.namespaceId)
+      .setAppName(other.appName)
+      .setAppVersion(other.appVersion)
+      .setConfigString(other.configString)
+      .setOwnerPrincipal(other.ownerPrincipal)
+      .setUpdateSchedules(other.updateSchedules)
+      .setRuntimeInfo(other.runtimeInfo);
   }
 
   private AppDeploymentInfo(ArtifactId artifactId, Location artifactLocation, NamespaceId namespaceId,
-                            @Nullable ApplicationClass applicationClass, String applicationClassName,
-                            @Nullable String appName, @Nullable String appVersion,
+                            ApplicationClass applicationClass, @Nullable String appName, @Nullable String appVersion,
                             @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal,
                             boolean updateSchedules, @Nullable AppDeploymentRuntimeInfo runtimeInfo) {
     this.artifactId = artifactId;
@@ -88,7 +88,6 @@ public class AppDeploymentInfo {
     this.ownerPrincipal = ownerPrincipal;
     this.updateSchedules = updateSchedules;
     this.applicationClass = applicationClass;
-    this.applicationClassName = applicationClassName;
     this.runtimeInfo = runtimeInfo;
   }
 
@@ -118,19 +117,10 @@ public class AppDeploymentInfo {
   }
 
   /**
-   * Returns the {@link ApplicationClass} associated with this {@link Application} or {@code null} if this is runtime
-   * and cluster mode is ISOLATED, use {@link #getApplicationClassName()} to get the application class name.
+   * Returns the {@link ApplicationClass} associated with this {@link Application}.
    */
-  @Nullable
   public ApplicationClass getApplicationClass() {
     return applicationClass;
-  }
-
-  /**
-   * Returns the application class name for this app, this is needed to instantiate the app
-   */
-  public String getApplicationClassName() {
-    return applicationClassName;
   }
 
   /**
@@ -178,5 +168,101 @@ public class AppDeploymentInfo {
   @Nullable
   public AppDeploymentRuntimeInfo getRuntimeInfo() {
     return runtimeInfo;
+  }
+
+  /**
+   * Builder class for the {@link AppDeploymentInfo}.
+   */
+  public static final class Builder {
+
+    private ArtifactId artifactId;
+    private Location artifactLocation;
+    private ApplicationClass applicationClass;
+    private NamespaceId namespaceId;
+    private String appName;
+    private String appVersion;
+    private String configString;
+    private KerberosPrincipalId ownerPrincipal;
+    // The default behavior of update schedules is to update schedule on deployment.
+    private boolean updateSchedules = true;
+    private AppDeploymentRuntimeInfo runtimeInfo;
+
+    private Builder() {
+      // Only for the builder() method to use
+    }
+
+    public Builder setArtifactId(ArtifactId artifactId) {
+      this.artifactId = artifactId;
+      return this;
+    }
+
+    public Builder setArtifactLocation(Location artifactLocation) {
+      this.artifactLocation = artifactLocation;
+      return this;
+    }
+
+    public Builder setApplicationClass(ApplicationClass applicationClass) {
+      this.applicationClass = applicationClass;
+      return this;
+    }
+
+    public Builder setApplicationId(ApplicationId appId) {
+      setNamespaceId(appId.getNamespaceId());
+      setAppName(appId.getApplication());
+      setAppVersion(appId.getVersion());
+      return this;
+    }
+
+    public Builder setNamespaceId(NamespaceId namespaceId) {
+      this.namespaceId = namespaceId;
+      return this;
+    }
+
+    public Builder setAppName(String appName) {
+      this.appName = appName;
+      return this;
+    }
+
+    public Builder setAppVersion(String appVersion) {
+      this.appVersion = appVersion;
+      return this;
+    }
+
+    public Builder setConfigString(String configString) {
+      this.configString = configString;
+      return this;
+    }
+
+    public Builder setOwnerPrincipal(KerberosPrincipalId ownerPrincipal) {
+      this.ownerPrincipal = ownerPrincipal;
+      return this;
+    }
+
+    public Builder setUpdateSchedules(boolean updateSchedules) {
+      this.updateSchedules = updateSchedules;
+      return this;
+    }
+
+    public Builder setRuntimeInfo(AppDeploymentRuntimeInfo runtimeInfo) {
+      this.runtimeInfo = runtimeInfo;
+      return this;
+    }
+
+    public AppDeploymentInfo build() {
+      if (artifactId == null) {
+        throw new IllegalStateException("Missing artifact ID");
+      }
+      if (artifactLocation == null) {
+        throw new IllegalStateException("Missing artifact location");
+      }
+      if (namespaceId == null) {
+        throw new IllegalStateException("Missing namespace ID");
+      }
+      if (applicationClass == null) {
+        throw new IllegalStateException("Missing application class");
+      }
+      return new AppDeploymentInfo(artifactId, artifactLocation, namespaceId, applicationClass,
+                                   appName, appVersion, configString, ownerPrincipal, updateSchedules, runtimeInfo);
+    }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
@@ -34,6 +34,7 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.name.Names;
 import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.deploy.ConfigResponse;
 import io.cdap.cdap.app.deploy.Configurator;
@@ -349,10 +350,17 @@ public class DefaultRuntimeJob implements RuntimeJob {
       new File(systemArguments.get(ProgramOptionConstants.PROGRAM_JAR)));
 
 
-    AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(
-      programDescriptor.getArtifactId(), programJarLocation, programId.getNamespaceId(), appClassName,
-      programId.getApplication(), programId.getVersion(), existingAppSpec.getConfiguration(), null, false,
-      new AppDeploymentRuntimeInfo(existingAppSpec, userArguments, systemArguments));
+    AppDeploymentInfo deploymentInfo = AppDeploymentInfo.builder()
+      .setArtifactId(programDescriptor.getArtifactId())
+      .setArtifactLocation(programJarLocation)
+      .setApplicationClass(new ApplicationClass(appClassName, "", null))
+      .setApplicationId(programId.getParent())
+      .setConfigString(existingAppSpec.getConfiguration())
+      .setOwnerPrincipal(null)
+      .setUpdateSchedules(false)
+      .setRuntimeInfo(new AppDeploymentRuntimeInfo(existingAppSpec, userArguments, systemArguments))
+      .build();
+
     Configurator configurator = configuratorFactory.create(deploymentInfo);
     ListenableFuture<ConfigResponse> future = configurator.config();
     ConfigResponse response = future.get(120, TimeUnit.SECONDS);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2020 Cask Data, Inc.
+ * Copyright © 2015-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -632,10 +632,15 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     }
 
     // Deploy application with with potentially new app config and new artifact.
-    AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(artifactId, artifactDetail.getDescriptor().getLocation(),
-                                                             appId.getParent(), appClass, appId.getApplication(),
-                                                             appId.getVersion(), updatedAppConfig, ownerPrincipal,
-                                                             updateSchedules, null);
+    AppDeploymentInfo deploymentInfo = AppDeploymentInfo.builder()
+      .setArtifactId(artifactId)
+      .setArtifactLocation(artifactDetail.getDescriptor().getLocation())
+      .setApplicationClass(appClass)
+      .setApplicationId(appId)
+      .setConfigString(updatedAppConfig)
+      .setOwnerPrincipal(ownerPrincipal)
+      .setUpdateSchedules(updateSchedules)
+      .build();
 
     Manager<AppDeploymentInfo, ApplicationWithPrograms> manager = managerFactory.create(programTerminator);
     // TODO: (CDAP-3258) Manager needs MUCH better error handling.
@@ -975,11 +980,18 @@ public class ApplicationLifecycleService extends AbstractIdleService {
       capabilityReader.checkAllEnabled(appClass.getRequirements().getCapabilities());
     }
     // deploy application with newly added artifact
-    AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(
-      Artifacts.toProtoArtifactId(namespaceId, artifactDetail.getDescriptor().getArtifactId()),
-      artifactDetail.getDescriptor().getLocation(), namespaceId, appClass, appName,
-      appVersion, configStr, ownerPrincipal, updateSchedules,
-      isPreview ? new AppDeploymentRuntimeInfo(null, userProps, Collections.emptyMap()) : null);
+    AppDeploymentInfo deploymentInfo = AppDeploymentInfo.builder()
+      .setArtifactId(Artifacts.toProtoArtifactId(namespaceId, artifactDetail.getDescriptor().getArtifactId()))
+      .setArtifactLocation(artifactDetail.getDescriptor().getLocation())
+      .setApplicationClass(appClass)
+      .setNamespaceId(namespaceId)
+      .setAppName(appName)
+      .setAppVersion(appVersion)
+      .setConfigString(configStr)
+      .setOwnerPrincipal(ownerPrincipal)
+      .setUpdateSchedules(updateSchedules)
+      .setRuntimeInfo(isPreview ? new AppDeploymentRuntimeInfo(null, userProps, Collections.emptyMap()) : null)
+      .build();
 
     Manager<AppDeploymentInfo, ApplicationWithPrograms> manager = managerFactory.create(programTerminator);
     // TODO: (CDAP-3258) Manager needs MUCH better error handling.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTask.java
@@ -139,7 +139,7 @@ public class ConfiguratorTask implements RunnableTask {
         .toLocation(artifactLocalizerClient.getUnpackedArtifactLocation(info.getArtifactId()));
 
       // Creates a new deployment info with the newly fetched artifact
-      AppDeploymentInfo deploymentInfo = new AppDeploymentInfo(info, artifactLocation);
+      AppDeploymentInfo deploymentInfo = AppDeploymentInfo.copyFrom(info).setArtifactLocation(artifactLocation).build();
       InMemoryConfigurator configurator = new InMemoryConfigurator(cConf, pluginFinder, impersonator,
                                                                    artifactRepository, remoteClientFactory,
                                                                    deploymentInfo);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2020 Cask Data, Inc.
+ * Copyright © 2014-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -313,10 +313,12 @@ public class AppFabricTestHelper {
     artifactRepository.addArtifact(Id.Artifact.fromEntityId(Artifacts.toProtoArtifactId(namespaceId, artifactId)),
                                    new File(deployedJar.toURI()));
     ApplicationClass applicationClass = new ApplicationClass(appClass.getName(), "", null);
-    AppDeploymentInfo info = new AppDeploymentInfo(Artifacts.toProtoArtifactId(namespaceId, artifactId),
-                                                   deployedJar, namespaceId,
-                                                   applicationClass, null, null,
-                                                   config == null ? null : new Gson().toJson(config));
+    AppDeploymentInfo info = AppDeploymentInfo.builder()
+      .setArtifactId(Artifacts.toProtoArtifactId(namespaceId, artifactId))
+      .setArtifactLocation(deployedJar)
+      .setNamespaceId(namespaceId).setApplicationClass(applicationClass)
+      .setConfigString(config == null ? null : new Gson().toJson(config))
+      .build();
     return getLocalManager().deploy(info).get();
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2019 Cask Data, Inc.
+ * Copyright © 2014-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -112,9 +112,12 @@ public class ConfiguratorTest {
                                                                           authEnforcer, authenticationContext);
     PluginFinder pluginFinder = new LocalPluginFinder(artifactRepo);
 
-    AppDeploymentInfo appDeploymentInfo = new AppDeploymentInfo(artifactId.toEntityId(), appJar,
-      NamespaceId.DEFAULT, new ApplicationClass(AllProgramsApp.class.getName(), "", null),
-      null, null, null);
+    AppDeploymentInfo appDeploymentInfo = AppDeploymentInfo.builder()
+      .setArtifactId(artifactId.toEntityId())
+      .setArtifactLocation(appJar)
+      .setNamespaceId(NamespaceId.DEFAULT)
+      .setApplicationClass(new ApplicationClass(AllProgramsApp.class.getName(), "", null))
+      .build();
 
     // Create a configurator that is testable. Provide it a application.
     Configurator configurator = new InMemoryConfigurator(conf, pluginFinder, new DefaultImpersonator(cConf, null),
@@ -156,9 +159,13 @@ public class ConfiguratorTest {
     PluginFinder pluginFinder = new LocalPluginFinder(artifactRepo);
     ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("myTable");
 
-    AppDeploymentInfo appDeploymentInfo = new AppDeploymentInfo(artifactId.toEntityId(), appJar,
-      NamespaceId.DEFAULT, new ApplicationClass(ConfigTestApp.class.getName(), "", null),
-      null, null, new Gson().toJson(config));
+    AppDeploymentInfo appDeploymentInfo = AppDeploymentInfo.builder()
+      .setArtifactId(artifactId.toEntityId())
+      .setArtifactLocation(appJar)
+      .setNamespaceId(NamespaceId.DEFAULT)
+      .setApplicationClass(new ApplicationClass(ConfigTestApp.class.getName(), "", null))
+      .setConfigString(new Gson().toJson(config))
+      .build();
 
     // Create a configurator that is testable. Provide it an application.
     Configurator configurator = new InMemoryConfigurator(conf, pluginFinder, new DefaultImpersonator(cConf, null),
@@ -178,9 +185,12 @@ public class ConfiguratorTest {
     Assert.assertTrue(specification.getDatasets().containsKey("myTable"));
 
     // Create a deployment info without the app configuration
-    appDeploymentInfo = new AppDeploymentInfo(artifactId.toEntityId(), appJar,
-      NamespaceId.DEFAULT, new ApplicationClass(ConfigTestApp.class.getName(), "", null),
-      null, null, null);
+    appDeploymentInfo = AppDeploymentInfo.builder()
+      .setArtifactId(artifactId.toEntityId())
+      .setArtifactLocation(appJar)
+      .setNamespaceId(NamespaceId.DEFAULT)
+      .setApplicationClass(new ApplicationClass(ConfigTestApp.class.getName(), "", null))
+      .build();
 
     Configurator configuratorWithoutConfig = new InMemoryConfigurator(conf, pluginFinder,
                                                                       new DefaultImpersonator(cConf, null),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/LocalApplicationManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/LocalApplicationManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014-2019 Cask Data, Inc.
+ * Copyright © 2014-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -127,9 +127,12 @@ public class LocalApplicationManagerTest {
     ArtifactId artifactId = new ArtifactId("dummy", new ArtifactVersion("1.0.0-SNAPSHOT"), ArtifactScope.USER);
     String className = "some.class.name";
     ApplicationClass applicationClass = new ApplicationClass(className, "", null);
-    AppDeploymentInfo info = new AppDeploymentInfo(Artifacts.toProtoArtifactId(NamespaceId.DEFAULT, artifactId),
-                                                   jarLoc, NamespaceId.DEFAULT, applicationClass, null,
-                                                   null, null);
+    AppDeploymentInfo info = AppDeploymentInfo.builder()
+      .setArtifactId(Artifacts.toProtoArtifactId(NamespaceId.DEFAULT, artifactId))
+      .setArtifactLocation(jarLoc)
+      .setNamespaceId(NamespaceId.DEFAULT)
+      .setApplicationClass(applicationClass)
+      .build();
     AppFabricTestHelper.getLocalManager().deploy(info).get();
   }
 
@@ -141,9 +144,12 @@ public class LocalApplicationManagerTest {
     Location deployedJar = AppJarHelper.createDeploymentJar(lf, AllProgramsApp.class);
     ArtifactId artifactId = new ArtifactId("app", new ArtifactVersion("1.0.0-SNAPSHOT"), ArtifactScope.USER);
     ApplicationClass applicationClass = new ApplicationClass(AllProgramsApp.class.getName(), "", null);
-    AppDeploymentInfo info = new AppDeploymentInfo(Artifacts.toProtoArtifactId(NamespaceId.DEFAULT, artifactId),
-                                                   deployedJar, NamespaceId.DEFAULT,
-                                                   applicationClass, null, null, null);
+    AppDeploymentInfo info = AppDeploymentInfo.builder()
+      .setArtifactId(Artifacts.toProtoArtifactId(NamespaceId.DEFAULT, artifactId))
+      .setArtifactLocation(deployedJar)
+      .setNamespaceId(NamespaceId.DEFAULT)
+      .setApplicationClass(applicationClass)
+      .build();
     ApplicationWithPrograms input = AppFabricTestHelper.getLocalManager().deploy(info).get();
 
     ApplicationSpecification appSpec = Specifications.from(new AllProgramsApp());
@@ -166,9 +172,14 @@ public class LocalApplicationManagerTest {
     ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("myTable");
     ArtifactId artifactId = new ArtifactId("configtest", new ArtifactVersion("1.0.0-SNAPSHOT"), ArtifactScope.USER);
     ApplicationClass applicationClass = new ApplicationClass(ConfigTestApp.class.getName(), "", null);
-    AppDeploymentInfo info = new AppDeploymentInfo(Artifacts.toProtoArtifactId(NamespaceId.DEFAULT, artifactId),
-                                                   deployedJar, NamespaceId.DEFAULT,
-                                                   applicationClass, "MyApp", null, GSON.toJson(config));
+    AppDeploymentInfo info = AppDeploymentInfo.builder()
+      .setArtifactId(Artifacts.toProtoArtifactId(NamespaceId.DEFAULT, artifactId))
+      .setArtifactLocation(deployedJar)
+      .setNamespaceId(NamespaceId.DEFAULT)
+      .setApplicationClass(applicationClass)
+      .setAppName("MyApp")
+      .setConfigString(GSON.toJson(config))
+      .build();
     AppFabricTestHelper.getLocalManager().deploy(info).get();
   }
 
@@ -177,10 +188,14 @@ public class LocalApplicationManagerTest {
     Location deployedJar = AppJarHelper.createDeploymentJar(lf, ConfigTestApp.class);
     ArtifactId artifactId = new ArtifactId("configtest", new ArtifactVersion("1.0.0-SNAPSHOT"), ArtifactScope.USER);
     ApplicationClass applicationClass = new ApplicationClass(ConfigTestApp.class.getName(), "", null);
-    AppDeploymentInfo info = new AppDeploymentInfo(Artifacts.toProtoArtifactId(NamespaceId.DEFAULT, artifactId),
-                                                   deployedJar, NamespaceId.DEFAULT,
-                                                   applicationClass, "BadApp", null,
-                                                   GSON.toJson("invalid"));
+    AppDeploymentInfo info = AppDeploymentInfo.builder()
+      .setArtifactId(Artifacts.toProtoArtifactId(NamespaceId.DEFAULT, artifactId))
+      .setArtifactLocation(deployedJar)
+      .setNamespaceId(NamespaceId.DEFAULT)
+      .setApplicationClass(applicationClass)
+      .setAppName("BadApp")
+      .setConfigString(GSON.toJson("invalid"))
+      .build();
     AppFabricTestHelper.getLocalManager().deploy(info).get();
   }
 
@@ -189,9 +204,13 @@ public class LocalApplicationManagerTest {
     Location deployedJar = AppJarHelper.createDeploymentJar(lf, AppWithCustomDatasetModule.class);
     ArtifactId artifactId = new ArtifactId("customDSModule", new ArtifactVersion("1.0.0-SNAPSHOT"), ArtifactScope.USER);
     ApplicationClass applicationClass = new ApplicationClass(AppWithCustomDatasetModule.class.getName(), "", null);
-    AppDeploymentInfo info = new AppDeploymentInfo(Artifacts.toProtoArtifactId(NamespaceId.DEFAULT, artifactId),
-                                                   deployedJar, NamespaceId.DEFAULT,
-                                                   applicationClass, "CustomDSApp", null, null);
+    AppDeploymentInfo info = AppDeploymentInfo.builder()
+      .setArtifactId(Artifacts.toProtoArtifactId(NamespaceId.DEFAULT, artifactId))
+      .setArtifactLocation(deployedJar)
+      .setNamespaceId(NamespaceId.DEFAULT)
+      .setApplicationClass(applicationClass)
+      .setAppName("CustomDSApp")
+      .build();
 
     try {
       AppFabricTestHelper.getLocalManager().deploy(info).get();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
@@ -131,10 +131,9 @@ public class RemoteConfiguratorTest {
       .setHttpHandlers(
         new TaskWorkerHttpHandlerInternal(cConf, className -> { }, new NoOpMetricsCollectionService()),
         new ArtifactHttpHandlerInternal(new TestArtifactRepository(cConf), namespaceAdmin),
-        new ArtifactLocalizerHttpHandlerInternal(new ArtifactLocalizer(cConf, remoteClientFactory,
-                                                                       ((namespaceId, retryStrategy) -> {
-                                                                         return new NoOpArtifactManager();
-                                                                       })))
+        new ArtifactLocalizerHttpHandlerInternal(
+          new ArtifactLocalizer(cConf, remoteClientFactory, ((namespaceId, retryStrategy) -> new NoOpArtifactManager()))
+        )
       )
       .setChannelPipelineModifier(new ChannelPipelineModifier() {
         @Override
@@ -173,9 +172,12 @@ public class RemoteConfiguratorTest {
                                                                         artifactId.toApiArtifactId(), appJar),
                                                  new ArtifactMeta(ArtifactClasses.builder().build())));
 
-    AppDeploymentInfo info = new AppDeploymentInfo(artifactId, appJar, NamespaceId.DEFAULT,
-                                                   new ApplicationClass(AllProgramsApp.class.getName(), "", null),
-                                                   null, null, null);
+    AppDeploymentInfo info = AppDeploymentInfo.builder()
+      .setArtifactId(artifactId)
+      .setArtifactLocation(appJar)
+      .setNamespaceId(NamespaceId.DEFAULT)
+      .setApplicationClass(new ApplicationClass(AllProgramsApp.class.getName(), "", null))
+      .build();
 
     Configurator configurator = new RemoteConfigurator(cConf, metricsCollectionService, info, remoteClientFactory);
 
@@ -207,9 +209,12 @@ public class RemoteConfiguratorTest {
 
     // Don't update the artifacts map so that the fetching of artifact would fail.
 
-    AppDeploymentInfo info = new AppDeploymentInfo(artifactId, appJar, NamespaceId.DEFAULT,
-                                                   new ApplicationClass(AllProgramsApp.class.getName(), "", null),
-                                                   null, null, null);
+    AppDeploymentInfo info = AppDeploymentInfo.builder()
+      .setArtifactId(artifactId)
+      .setArtifactLocation(appJar)
+      .setNamespaceId(NamespaceId.DEFAULT)
+      .setApplicationClass(new ApplicationClass(AllProgramsApp.class.getName(), "", null))
+      .build();
 
     Configurator configurator = new RemoteConfigurator(cConf, metricsCollectionService, info, remoteClientFactory);
 
@@ -227,9 +232,14 @@ public class RemoteConfiguratorTest {
                                                                         artifactId.toApiArtifactId(), appJar),
                                                  new ArtifactMeta(ArtifactClasses.builder().build())));
 
-    AppDeploymentInfo info = new AppDeploymentInfo(artifactId, appJar, NamespaceId.DEFAULT,
-                                                   new ApplicationClass(ConfigTestApp.class.getName(), "", null),
-                                                   "BadApp", null, GSON.toJson("invalid"));
+    AppDeploymentInfo info = AppDeploymentInfo.builder()
+      .setArtifactId(artifactId)
+      .setArtifactLocation(appJar)
+      .setNamespaceId(NamespaceId.DEFAULT)
+      .setApplicationClass(new ApplicationClass(ConfigTestApp.class.getName(), "", null))
+      .setAppName("BadApp")
+      .setConfigString(GSON.toJson("invalid"))
+      .build();
 
     Configurator configurator = new RemoteConfigurator(cConf, metricsCollectionService, info, remoteClientFactory);
 


### PR DESCRIPTION
- Use builder instead of multiple constructors for optional fields
- Combine the applicationClass and applicationClassName into one field