### PR TITLE
[CDAP-19551] Add Dataproc config to explicitly disable GCS caching in a profile

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -52,6 +52,7 @@ public final class DataprocUtils {
   public static final String CDAP_GCS_ROOT = "cdap-job";
   public static final String CDAP_CACHED_ARTIFACTS = "cached-artifacts";
   public static final String WORKER_CPU_PREFIX = "Up to";
+  public static final String DISABLE_GCS_CACHING = "disableGCSCaching";
 
   /**
    * HTTP Status-Code 429: RESOURCE_EXHAUSTED.

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -92,6 +92,8 @@ final class DataprocConf {
   public static final String COMPUTE_HTTP_REQUEST_READ_TIMEOUT = "compute.request.read.timeout.millis";
   private static final int COMPUTE_HTTP_REQUEST_READ_TIMEOUT_DEFAULT = 20000;
 
+  // If true, artifacts will not be cached in GCS regardless of cConf setting.
+  static final String DISABLE_GCS_CACHING = "disableGCSCaching";
 
   private final String accountKey;
   private final String region;
@@ -158,6 +160,8 @@ final class DataprocConf {
   private final int computeReadTimeout;
   private final int computeConnectionTimeout;
 
+  private final boolean disableGCSCaching;
+
   private DataprocConf(@Nullable String accountKey, String region, String zone, String projectId,
                        @Nullable String networkHostProjectId, @Nullable String network, @Nullable String subnet,
                        int masterNumNodes, int masterCPUs, int masterMemoryMB,
@@ -178,7 +182,8 @@ final class DataprocConf {
                        boolean integrityMonitoringEnabled, boolean clusterReuseEnabled,
                        long clusterReuseThresholdMinutes, @Nullable String clusterReuseKey,
                        boolean enablePredefinedAutoScaling, int computeReadTimeout, int computeConnectionTimeout,
-                       @Nullable String rootUrl) {
+                       @Nullable String rootUrl,
+                       boolean disableGCSCaching) {
     this.accountKey = accountKey;
     this.region = region;
     this.zone = zone;
@@ -232,6 +237,7 @@ final class DataprocConf {
     this.computeReadTimeout = computeReadTimeout;
     this.computeConnectionTimeout = computeConnectionTimeout;
     this.rootUrl = rootUrl;
+    this.disableGCSCaching = disableGCSCaching;
   }
 
   String getRegion() {
@@ -674,6 +680,9 @@ final class DataprocConf {
                                           COMPUTE_HTTP_REQUEST_CONNECTION_TIMEOUT_DEFAULT);
     String rootUrl = getString(properties, ROOT_URL);
 
+    boolean disableGCSCaching = Boolean.parseBoolean(
+      properties.getOrDefault(DISABLE_GCS_CACHING, "false"));
+
     return new DataprocConf(accountKey, region, zone, projectId, networkHostProjectID, network, subnet,
                             masterNumNodes, masterCPUs, masterMemoryGB, masterDiskGB,
                             masterDiskType, masterMachineType,
@@ -687,7 +696,8 @@ final class DataprocConf {
                             initActions, runtimeJobManagerEnabled, clusterProps, autoScalingPolicy, idleTTL,
                             tokenEndpoint, secureBootEnabled, vTpmEnabled, integrityMonitoringEnabled,
                             clusterReuseEnabled, clusterReuseThresholdMinutes, clusterReuseKey,
-                            enablePredefinedAutoScaling, computeReadTimeout, computeConnectionTimeout, rootUrl);
+                            enablePredefinedAutoScaling, computeReadTimeout, computeConnectionTimeout, rootUrl,
+                            disableGCSCaching);
   }
 
   // the UI never sends nulls, it only sends empty strings.

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -177,6 +177,9 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
 
   @Override
   public void launch(RuntimeJobInfo runtimeJobInfo) throws Exception {
+    boolean disableGCSCaching = Boolean.parseBoolean(
+      provisionerContext.getProperties().getOrDefault(DataprocUtils.DISABLE_GCS_CACHING, "false"));
+
     String bucket = DataprocUtils.getBucketName(this.bucket);
 
     ProgramRunInfo runInfo = runtimeJobInfo.getProgramRunInfo();
@@ -198,7 +201,7 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
       // step 2: upload all the necessary files to gcs so that those files are available to dataproc job
       List<Future<LocalFile>> uploadFutures = new ArrayList<>();
       for (LocalFile fileToUpload : localFiles) {
-        boolean isCacheable = fileToUpload instanceof CacheableLocalFile;
+        boolean isCacheable = !disableGCSCaching && fileToUpload instanceof CacheableLocalFile;
         String targetFilePath = getPath(isCacheable ? cacheRootPath :
                                           runRootPath, fileToUpload.getName());
         uploadFutures.add(

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
@@ -442,6 +442,13 @@
       "label": "Advanced Settings",
       "properties": [
         {
+          "widget-type": "hidden",
+          "name": "disableGCSCaching",
+          "widget-attributes": {
+            "default": "false"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Image Version",
           "name": "imageVersion",
@@ -681,6 +688,20 @@
         },
         {
           "name": "autoScalingPolicy",
+          "type": "property"
+        }
+      ]
+    },
+    {
+      "name": "Show disableGCSCaching",
+      "condition": {
+        "property": "disableGCSCaching",
+        "operator": "equal",
+        "value": "true"
+      },
+      "show": [
+        {
+          "name": "disableGCSCaching",
           "type": "property"
         }
       ]

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-existing-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-existing-dataproc.json
@@ -73,6 +73,13 @@
           "widget-attributes": {
             "placeholder": "Specify the GCP service account"
           }
+        },
+        {
+          "widget-type": "hidden",
+          "name": "disableGCSCaching",
+          "widget-attributes": {
+            "default": "false"
+          }
         }
       ]
     },
@@ -98,6 +105,22 @@
           "widget-attributes": {
             "placeholder": "Specify the private key for SSH"
           }
+        }
+      ]
+    }
+  ],
+  "filters": [
+    {
+      "name": "Show disableGCSCaching",
+      "condition": {
+        "property": "disableGCSCaching",
+        "operator": "equal",
+        "value": "true"
+      },
+      "show": [
+        {
+          "name": "disableGCSCaching",
+          "type": "property"
         }
       ]
     }


### PR DESCRIPTION
This PR allows users to explicitly disable GCS caching for a particular Dataproc profile. 