### PR TITLE
CDAP-19465 Refactoring the Kill() method in RemoteExecutionTwillController.complete()

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionService.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.common.service.AbstractRetryableScheduledService;
 import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.logging.context.LoggingContextHelper;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobStatus;
 import org.apache.twill.common.Cancellable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,7 +136,7 @@ class RemoteExecutionService extends AbstractRetryableScheduledService {
       LOG.error("Failed to monitor the remote process and exhausted retries. Terminating the program {}",
                 programRunId, e);
       try {
-        processController.kill();
+        processController.kill(RuntimeJobStatus.RUNNING);
       } catch (Exception e1) {
         LOG.warn("Failed to kill the remote process for program {}. "
                    + "The remote process may need to be killed manually.", programRunId, e1);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillController.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.common.service.Retries;
 import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.common.service.RetryStrategy;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobStatus;
 import org.apache.twill.api.Command;
 import org.apache.twill.api.ResourceReport;
 import org.apache.twill.api.RunId;
@@ -118,25 +119,27 @@ class RemoteExecutionTwillController implements TwillController {
   public void complete() {
     terminateOnServiceStop = true;
     executionService.stop();
-
     try {
+      RuntimeJobStatus status;
       RetryStrategy retryStrategy = RetryStrategies.timeLimit(
         5, TimeUnit.SECONDS, RetryStrategies.exponentialDelay(500, 2000, TimeUnit.MILLISECONDS));
 
       // Make sure the remote execution is completed
       // Give 5 seconds for the remote process to shutdown. After 5 seconds, issues a kill.
       long startTime = System.currentTimeMillis();
-      while (Retries.callWithRetries(remoteProcessController::isRunning, retryStrategy, Exception.class::isInstance)) {
+      while ((status = Retries.callWithRetries(
+        remoteProcessController::getStatus, retryStrategy, Exception.class::isInstance)) == RuntimeJobStatus.RUNNING) {
         if (System.currentTimeMillis() - startTime >= 5000) {
           throw new IllegalStateException("Remote process for " + programRunId + " is still running");
         }
         TimeUnit.SECONDS.sleep(1);
       }
+      remoteProcessController.kill(status);
     } catch (Exception e) {
       // If there is exception, use the remote execution controller to try killing the remote process
       try {
         LOG.debug("Force termination of remote process for program run {}", programRunId);
-        remoteProcessController.kill();
+        remoteProcessController.kill(RuntimeJobStatus.RUNNING);
       } catch (Exception ex) {
         LOG.warn("Failed to terminate remote process for program run {}", programRunId, ex);
       }
@@ -189,7 +192,7 @@ class RemoteExecutionTwillController implements TwillController {
   @Override
   public void kill() {
     try {
-      remoteProcessController.kill();
+      remoteProcessController.kill(RuntimeJobStatus.RUNNING);
     } catch (Exception e) {
       throw new RuntimeException("Failed when requesting program " + programRunId + " to stop", e);
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteExecutionTwillRunnerService.java
@@ -60,6 +60,7 @@ import io.cdap.cdap.runtime.spi.RuntimeMonitorType;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.Node;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobManager;
+import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobStatus;
 import io.cdap.cdap.runtime.spi.ssh.SSHKeyPair;
 import io.cdap.cdap.security.auth.AccessToken;
 import io.cdap.cdap.security.auth.AccessTokenCodec;
@@ -613,7 +614,7 @@ public class RemoteExecutionTwillRunnerService implements TwillRunnerService, Pr
               startupTaskFuture.cancel(true);
               try {
                 // Attempt to force kill the remote process. If there is no such process found, it won't throw.
-                processController.kill();
+                processController.kill(RuntimeJobStatus.RUNNING);
               } catch (Exception e) {
                 LOG.warn("Force termination of remote process for {} failed", programRunId, e);
               }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteProcessController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RemoteProcessController.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.internal.app.runtime.distributed.remote;
 
+import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobStatus;
+
 /**
  * Interface that exposes methods for controlling remote execution process.
  */
@@ -30,14 +32,22 @@ public interface RemoteProcessController {
   boolean isRunning() throws Exception;
 
   /**
+   * Returns the runtime status {@link RuntimeJobStatus} of the remote process for the program execution.
+   *
+   * @throws Exception if not able to determine the status of the remote process
+   */
+  RuntimeJobStatus getStatus() throws Exception;
+
+  /**
    * Graceful shutdown of the remote process
    * @throws Exception if not able to terminate the remote process
    */
   void terminate() throws Exception;
 
   /**
-   * Forcefully kills the remote process
+   * Kills the remote process depending on the ProgramStatus
    * @throws Exception if not able to kill the remote process
+   * @param runtimeJobStatus
    */
-  void kill() throws Exception;
+  void kill(RuntimeJobStatus runtimeJobStatus) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RuntimeJobRemoteProcessController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RuntimeJobRemoteProcessController.java
@@ -61,6 +61,15 @@ class RuntimeJobRemoteProcessController implements RemoteProcessController {
   }
 
   @Override
+  public RuntimeJobStatus getStatus() throws Exception {
+    try (RuntimeJobManager runtimeJobManager = runtimeJobManagerSupplier.get()) {
+      return runtimeJobManager.getDetail(programRunInfo)
+        .map(RuntimeJobDetail::getStatus)
+        .orElse(RuntimeJobStatus.UNKNOWN);
+    }
+  }
+
+  @Override
   public void terminate() throws Exception {
     LOG.debug("Stopping program run {}", programRunId);
     try (RuntimeJobManager runtimeJobManager = runtimeJobManagerSupplier.get()) {
@@ -69,10 +78,9 @@ class RuntimeJobRemoteProcessController implements RemoteProcessController {
   }
 
   @Override
-  public void kill() throws Exception {
-    LOG.debug("Force stopping program run {}", programRunId);
+  public void kill(RuntimeJobStatus status) throws Exception {
     try (RuntimeJobManager runtimeJobManager = runtimeJobManagerSupplier.get()) {
-      runtimeJobManager.kill(programRunInfo);
+      runtimeJobManager.kill(new RuntimeJobDetail(programRunInfo, status));
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/SSHRemoteProcessController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/SSHRemoteProcessController.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.internal.provision.ProvisioningService;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
+import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobStatus;
 import io.cdap.cdap.runtime.spi.ssh.SSHProcess;
 import io.cdap.cdap.runtime.spi.ssh.SSHSession;
 import org.slf4j.Logger;
@@ -89,6 +90,11 @@ final class SSHRemoteProcessController implements RemoteProcessController {
   }
 
   @Override
+  public RuntimeJobStatus getStatus() throws Exception {
+    return isRunning() ? RuntimeJobStatus.RUNNING : RuntimeJobStatus.UNKNOWN;
+  }
+
+  @Override
   public void terminate() throws Exception {
     // SIGTERM
     LOG.debug("Stopping program run {}", programRunId);
@@ -96,7 +102,7 @@ final class SSHRemoteProcessController implements RemoteProcessController {
   }
 
   @Override
-  public void kill() throws Exception {
+  public void kill(RuntimeJobStatus runtimeJobStatus) throws Exception {
     // SIGKILL
     LOG.debug("Force stopping program run {}", programRunId);
     killProcess(9);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManager.java
@@ -55,9 +55,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.zip.GZIPOutputStream;
@@ -106,16 +104,17 @@ public class TetheringRuntimeJobManager implements RuntimeJobManager {
     publishToControlChannel(message);
   }
 
+  /**
+   * This method should be used carefully as currently it always returns UNKNOWN as RuntimeJobStatus.
+   * For the tethering case, in case of a successful program run, a call is made to
+   * kill(programRunInfo), for any status other than UNKNOWN or TERMINATING, a kill() is issued on the control
+   * channel. Returning UNKNOWN from this method makes sure, an unnecessary kill() is not issued
+   * In the future, if it were possible to get the actual job status from the tethered instance,
+   * this method should be changed to reflect the same.
+  * */
   @Override
   public Optional<RuntimeJobDetail> getDetail(ProgramRunInfo programRunInfo) {
-    // TODO: CDAP-18739 - pull job status instead of always treating it as RUNNING
-    return Optional.of(new RuntimeJobDetail(programRunInfo, RuntimeJobStatus.RUNNING));
-  }
-
-  @Override
-  public List<RuntimeJobDetail> list() throws Exception {
-    // TODO: CDAP-18739 - pull list of all running jobs in tethered instance. This method is unused
-    return new ArrayList<>();
+    return Optional.of(new RuntimeJobDetail(programRunInfo, RuntimeJobStatus.UNKNOWN));
   }
 
   @Override
@@ -136,16 +135,23 @@ public class TetheringRuntimeJobManager implements RuntimeJobManager {
     publishToControlChannel(message);
   }
 
+  /**
+   * Unless RuntimeJobStatus is explicitly set as RUNNING, this method gets jobDetail from
+   * getDetails() which is equivalent to using RuntimeJobStatus.UNKNOWN
+   * */
   @Override
-  public void kill(ProgramRunInfo programRunInfo) throws Exception {
-    RuntimeJobDetail jobDetail = getDetail(programRunInfo).orElse(null);
+  public void kill(RuntimeJobDetail jobDetail) throws Exception {
     if (jobDetail == null) {
       return;
     }
+
     RuntimeJobStatus status = jobDetail.getStatus();
-    if (status.isTerminated()) {
+    ProgramRunInfo programRunInfo = jobDetail.getRunInfo();
+
+    if (status.isTerminated() || status == RuntimeJobStatus.UNKNOWN) {
       return;
     }
+
     LOG.debug("Killing program run {} with following configurations: tethered instance name {}, tethered namespace {}.",
               programRunInfo, tetheredInstanceName, tetheredNamespace);
     TetheringControlMessage message = createProgramTerminatePayload(programRunInfo,

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -31,7 +31,6 @@ import com.google.cloud.dataproc.v1beta2.JobControllerSettings;
 import com.google.cloud.dataproc.v1beta2.JobPlacement;
 import com.google.cloud.dataproc.v1beta2.JobReference;
 import com.google.cloud.dataproc.v1beta2.JobStatus;
-import com.google.cloud.dataproc.v1beta2.ListJobsRequest;
 import com.google.cloud.dataproc.v1beta2.SubmitJobRequest;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
@@ -70,12 +69,10 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -284,49 +281,23 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
   }
 
   @Override
-  public List<RuntimeJobDetail> list() throws IOException {
-    Set<String> filters = new HashSet<>();
-    // Dataproc jobs can be filtered by status.state filter. In this case we only want ACTIVE jobs.
-    filters.add("status.state=ACTIVE");
-    // Filter by labels that were added to the job when this runtime job manager submitted dataproc job. Note that
-    // dataproc only supports AND filter.
-    for (Map.Entry<String, String> entry : labels.entrySet()) {
-      filters.add("labels." + entry.getKey() + "=" + entry.getValue());
-    }
-    String jobFilter = Joiner.on(" AND ").join(filters);
-
-    LOG.debug("Getting a list of jobs under project {}, region {}, cluster {} with filter {}.", projectId, region,
-              clusterName, jobFilter);
-    JobControllerClient.ListJobsPagedResponse listJobsPagedResponse =
-      getJobControllerClient().listJobs(
-        ListJobsRequest.newBuilder()
-          .setProjectId(projectId).setRegion(region).setClusterName(clusterName)
-          .setFilter(jobFilter).build());
-
-    List<RuntimeJobDetail> jobsDetail = new ArrayList<>();
-    for (Job job : listJobsPagedResponse.iterateAll()) {
-      jobsDetail.add(new RuntimeJobDetail(getProgramRunInfo(job), getRuntimeJobStatus(job)));
-    }
-    return jobsDetail;
+  public void stop(ProgramRunInfo programRunInfo) throws Exception {
+    RuntimeJobDetail jobDetail = getDetail(programRunInfo).orElse(null);
+    kill(jobDetail);
   }
 
   @Override
-  public void stop(ProgramRunInfo programRunInfo) throws Exception {
-    RuntimeJobDetail jobDetail = getDetail(programRunInfo).orElse(null);
+  public void kill(RuntimeJobDetail jobDetail) throws Exception {
     if (jobDetail == null) {
       return;
     }
+
     RuntimeJobStatus status = jobDetail.getStatus();
     if (status.isTerminated() || status == RuntimeJobStatus.STOPPING) {
       return;
     }
     // stop dataproc job
     stopJob(getJobId(jobDetail.getRunInfo()));
-  }
-
-  @Override
-  public void kill(ProgramRunInfo programRunInfo) throws Exception {
-    stop(programRunInfo);
   }
 
   @Override

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobManager.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobManager.java
@@ -49,7 +49,10 @@ public interface RuntimeJobManager extends Closeable {
    * @return a list job details
    * @throws Exception thrown if any exception while getting list of running jobs
    */
-  List<RuntimeJobDetail> list() throws Exception;
+  @Deprecated
+  default List<RuntimeJobDetail> list() {
+    throw new UnsupportedOperationException("The list method is deprecated it shouldn't be used.");
+  }
 
   /**
    * Gracefully stops a running job. If the job is already in terminal status, then this method should be a no-op. If
@@ -67,7 +70,19 @@ public interface RuntimeJobManager extends Closeable {
    * @param programRunInfo program run info
    * @throws Exception thrown if any exception while killing the job
    */
-  void kill(ProgramRunInfo programRunInfo) throws Exception;
+  @Deprecated
+  default void kill(ProgramRunInfo programRunInfo) throws Exception {
+    kill(new RuntimeJobDetail(programRunInfo, RuntimeJobStatus.RUNNING));
+  }
+
+  /**
+   * Forcefully kills a running job. If the job is already in terminal status, then this method should be a no-op. If
+   * the job does not exist, this method should be a no-op.
+   *
+   * @param runtimeJobDetail runtime Job Detail
+   * @throws Exception thrown if any exception while killing the job
+   */
+  void kill(RuntimeJobDetail runtimeJobDetail) throws Exception;
 
   /**
    * This method is responsible to perform clean up for runtime manager.

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobStatus.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobStatus.java
@@ -25,7 +25,8 @@ public enum RuntimeJobStatus {
   STOPPING(false),
   STOPPED(true),
   COMPLETED(true),
-  FAILED(true);
+  FAILED(true),
+  UNKNOWN(false);
 
   private final boolean terminated;
 


### PR DESCRIPTION
**CDAP 19465 In tethered mode, RemoteExecutionTwillController issues kill despite successful pipeline run**

Currently, the RemoteExecutionTwillController executes a kill() even on pipeline complete. In DataProc mode this works fine as the kill() is used to signal to DataProc to clean up resources. But this behavior is not required in Tethered mode.

**Solution**:  Adding kill(RuntimeJobDetail) method to TetheringRuntimeJobManager to handle the case where the Program is completed and therefore a terminate should not be issued.  
    


**Testing -** 
    Deployed the CDAP image on K8S and ran a pipeline in tethered mode.
    Logs on pipeline completion, when testing the pipeline in Tethered mode - 


   ```

2022-10-03 23:21:52,904 - DEBUG [appfabric-executor-12:i.c.c.i.t.TetheringServerHandler@321] - Received notification from peer hdf-itn-instance-ameya about program run {"application":"tethering","version":"-SNAPSHOT","type":"Spark","program":"phase-1","run":"e2757f71-4371-11ed-9dd0-06a30cd97321","namespace":"default","entity":"PROGRAM_RUN"} in state COMPLETED
2022-10-03 23:21:56,626 - DEBUG [appfabric-executor-7:i.c.c.i.t.TetheringServerHandler@321] - Received notification from peer hdf-itn-instance-ameya about program run {"application":"tethering","version":"-SNAPSHOT","type":"Workflow","program":"DataPipelineWorkflow","run":"84ddb081-4371-11ed-9367-2a6a967a8bdf","namespace":"default","entity":"PROGRAM_RUN"} in state COMPLETED
2022-10-03 23:21:56,820 - DEBUG [runtime-scheduler-13:i.c.c.c.s.AbstractRetryableScheduledService@109] - Stopping scheduled service runtime-service-84ddb081-4371-11ed-9367-2a6a967a8bdf
2022-10-03 23:21:56,821 - INFO  [runtime-scheduler-13:i.c.c.i.a.r.d.AbstractTwillProgramController@75] - Twill program terminated: program_run:default.tethering.-SNAPSHOT.workflow.DataPipelineWorkflow.84ddb081-4371-11ed-9367-2a6a967a8bdf, twill runId: 84ddb081-4371-11ed-9367-2a6a967a8bdf, status: SUCCEEDED
2022-10-03 23:21:56,823 - DEBUG [pcontroller-program:default.tethering.-SNAPSHOT.workflow.DataPipelineWorkflow-84ddb081-4371-11ed-9367-2a6a967a8bdf-2:i.c.c.a.r.AbstractProgramRuntimeService@334] - RuntimeInfo removed: program_run:default.tethering.-SNAPSHOT.workflow.DataPipelineWorkflow.84ddb081-4371-11ed-9367-2a6a967a8bdf
2022-10-03 23:21:56,831 - DEBUG [program.status:i.c.c.i.a.r.d.r.RuntimeJobRemoteProcessController@82] - Force stopping program run program_run:default.tethering.-SNAPSHOT.workflow.DataPipelineWorkflow.84ddb081-4371-11ed-9367-2a6a967a8bdf based on program status UNKNOWN
2022-10-03 23:21:56,871 - DEBUG [program.status:i.c.c.i.p.t.ProvisioningTask@87] - Created DEPROVISION task for program run program_run:default.tethering.-SNAPSHOT.workflow.DataPipelineWorkflow.84ddb081-4371-11ed-9367-2a6a967a8bdf.
2022-10-03 23:21:56,887 - DEBUG [provisioning-task-2:i.c.c.i.p.t.ProvisioningTask@126] - Executing DEPROVISION subtask REQUESTING_DELETE for program run program_run:default.tethering.-SNAPSHOT.workflow.DataPipelineWorkflow.84ddb081-4371-11ed-9367-2a6a967a8bdf.
2022-10-03 23:21:56,887 - DEBUG [provisioning-task-2:i.c.c.i.p.t.ProvisioningTask@130] - Completed DEPROVISION subtask REQUESTING_DELETE for program run program_run:default.tethering.-SNAPSHOT.workflow.DataPipelineWorkflow.84ddb081-4371-11ed-9367-2a6a967a8bdf.
2022-10-03 23:21:57,142 - DEBUG [provisioning-task-3:i.c.c.i.p.t.ProvisioningTask@117] - Completed DEPROVISION task for program run program_run:default.tethering.-SNAPSHOT.workflow.DataPipelineWorkflow.84ddb081-4371-11ed-9367-2a6a967a8bdf.




```
    

Logs on pipeline completion in non-tethered mode (using Dataproc compute profile)- 

```
2022-10-02 15:39:31,291 - INFO  [runtime-scheduler-7:i.c.c.i.a.r.d.AbstractTwillProgramController@75] - Twill program terminated: program_run:default.non-tethered.-SNAPSHOT.workflow.DataPipelineWorkflow.a9d9ee92-4267-11ed-9699-9e665e71ec33, twill runId: a9d9ee92-4267-11ed-9699-9e665e71ec33, status: SUCCEEDED
2022-10-02 15:39:31,292 - DEBUG [pcontroller-program:default.non-tethered.-SNAPSHOT.workflow.DataPipelineWorkflow-a9d9ee92-4267-11ed-9699-9e665e71ec33-1:i.c.c.a.r.AbstractProgramRuntimeService@334] - RuntimeInfo removed: program_run:default.non-tethered.-SNAPSHOT.workflow.DataPipelineWorkflow.a9d9ee92-4267-11ed-9699-9e665e71ec33
2022-10-02 15:39:31,417 - DEBUG [program.status:i.c.c.i.a.r.d.r.RuntimeJobRemoteProcessController@82] - Force stopping program run program_run:default.non-tethered.-SNAPSHOT.workflow.DataPipelineWorkflow.a9d9ee92-4267-11ed-9699-9e665e71ec33 based on program status COMPLETED
2022-10-02 15:39:31,497 - DEBUG [program.status:i.c.c.i.p.t.ProvisioningTask@86] - Created DEPROVISION task for program run program_run:default.non-tethered.-SNAPSHOT.workflow.DataPipelineWorkflow.a9d9ee92-4267-11ed-9699-9e665e71ec33.
2022-10-02 15:39:31,515 - DEBUG [provisioning-task-2:i.c.c.i.p.t.ProvisioningTask@125] - Executing DEPROVISION subtask REQUESTING_DELETE for program run program_run:default.non-tethered.-SNAPSHOT.workflow.DataPipelineWorkflow.a9d9ee92-4267-11ed-9699-9e665e71ec33.
2022-10-02 15:39:32,530 - DEBUG [provisioning-task-2:i.c.c.i.p.t.ProvisioningTask@129] - Completed DEPROVISION subtask REQUESTING_DELETE for program run program_run:default.non-tethered.-SNAPSHOT.workflow.DataPipelineWorkflow.a9d9ee92-4267-11ed-9699-9e665e71ec33.
2022-10-02 15:40:02,667 - DEBUG [provisioning-task-2:i.c.c.i.p.t.ProvisioningTask@125] - Executing DEPROVISION subtask POLLING_DELETE for program run program_run:default.non-tethered.-SNAPSHOT.workflow.DataPipelineWorkflow.a9d9ee92-4267-11ed-9699-9e665e71ec33.
2022-10-02 15:40:02,912 - DEBUG [provisioning-task-2:i.c.c.i.p.t.ProvisioningTask@129] - Completed DEPROVISION subtask POLLING_DELETE for program run program_run:default.non-tethered.-SNAPSHOT.workflow.DataPipelineWorkflow.a9d9ee92-4267-11ed-9699-9e665e71ec33.
2022-10-02 15:40:02,924 - DEBUG [provisioning-task-2:i.c.c.i.p.t.ProvisioningTask@116] - Completed DEPROVISION task for program run program_run:default.non-tethered.-SNAPSHOT.workflow.DataPipelineWorkflow.a9d9ee92-4267-11ed-9699-9e665e71ec33.


```
    