### PR TITLE
Update the deprecated spark configuration key

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -121,7 +121,7 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
     }
     sparkConf.set("spark.streaming.backpressure.enabled", "true");
     sparkConf.set("spark.spark.streaming.blockInterval", String.valueOf(spec.getBatchIntervalMillis() / 5));
-    sparkConf.set("spark.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
+    sparkConf.set("spark.network.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
 
     // spark... makes you set this to at least the number of receivers (streaming sources)
     // because it holds one thread per receiver, or one core in distributed mode.

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
@@ -102,7 +102,7 @@ public class ETLSpark extends AbstractSpark {
     // turn off auto-broadcast by default until we better understand the implications and can set this to a
     // value that we are confident is safe.
     sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1");
-    sparkConf.set("spark.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
+    sparkConf.set("spark.network.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
     sparkConf.set("spark.network.timeout", "600s");
     // Disable yarn app retries since spark already performs retries at a task level.
     sparkConf.set("spark.yarn.maxAppAttempts", "1");


### PR DESCRIPTION
Update the configuration key name to `spark.network.maxRemoteBlockSizeFetchToMem` from `spark.maxRemoteBlockSizeFetchToMem`

Addressing the following warning in the logs: 
```
2021-10-13 02:14:35,968 - WARN  [main:o.a.s.SparkConf@69] - The configuration key 'spark.maxRemoteBlockSizeFetchToMem' has been deprecated as of Spark 3.0 and may be removed in the future. Please use the new key 'spark.network.maxRemoteBlockSizeFetchToMem' instead.
```

Testing Done:
1. Ran a sample pipeline and observed no such warning messages in the pipeline logs.
2. observed the logs show that the new name is passed as a config to the spark program - 
```
2022-09-21 19:20:11,908 - DEBUG [spark-submitter-phase-1-51a0fad1-39e2-11ed-b18a-6683acc1b012:i.c.c.a.r.s.s.AbstractSparkSubmitter@194] - Calling SparkSubmit for program:default.DataFusionQuickstart.-SNAPSHOT.spark.phase-1 51a0fad1-39e2-11ed-b18a-6683acc1b012: [--master, k8s://https://10.76.16.1:443, --deploy-mode, cluster, --conf, spark.app.name=phase-1, 
...
--conf, spark.network.maxRemoteBlockSizeFetchToMem=2147483135, 
...
```