### PR TITLE
Adding interface for scan by keyrange and index

### DIFF
--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
@@ -153,6 +153,41 @@ public interface StructuredTable extends Closeable {
   CloseableIterator<StructuredRow> scan(Field<?> index) throws InvalidFieldException, IOException;
 
   /**
+   * Read a set of rows from the table matching the index and the key range.
+   * The rows returned will be sorted on the primary key order.
+   *
+   * @param keyRange key range for the scan
+   * @param limit maximum number of rows to return
+   * @param filterIndex the index to filter upon
+   * @return a {@link CloseableIterator} of rows
+   * @throws InvalidFieldException if the field is not part of the table schema, or is not an indexed column,
+   *                               or the type does not match the schema
+   * @throws IOException if there is an error scanning the table
+   */
+  default CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Field<?> filterIndex)
+    throws InvalidFieldException,
+    IOException {
+    throw new UnsupportedOperationException("No supported implementation.");
+  }
+
+  /**
+   * Read a set of rows from the table matching the key range, return by sortOrder of specified index field.
+   *
+   * @param keyRange key range for the scan
+   * @param limit maximum number of rows to return
+   * @param orderByField the field to sort upon
+   * @param sortOrder the sort order of the index field
+   * @return a {@link CloseableIterator} of rows
+   * @throws InvalidFieldException if the field is not part of the table schema, or is not an indexed column,
+   *                               or the type does not match the schema
+   * @throws IOException if there is an error scanning the table
+   */
+  default CloseableIterator<StructuredRow> scan(Range keyRange, int limit, String orderByField, SortOrder sortOrder)
+    throws InvalidFieldException, IOException {
+    throw new UnsupportedOperationException("No supported implementation.");
+  }
+
+  /**
    * Read a set of rows from the table matching the set of key ranges.
    * The rows returned will be sorted on the primary key order.
    *


### PR DESCRIPTION
Discarding #14541.


We need these functions in LCM for:

Scan the table based off primary key prefix (namespace id and app name) and index field (latest == true) -> to retrieve latest version of the app.
Scan the table based off primary key prefix (namespace id and app name) and sort based on index field (created time DESC) -> to retrieve the versions of the app in the GET /apps endpoint.