### PR TITLE
[CDAP-19581] Cherry-pick 6.7

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeAPIException.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeAPIException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.k8s.runtime;
+
+import io.kubernetes.client.openapi.ApiException;
+
+/**
+ * Represents a wrapped {@link io.kubernetes.client.openapi.ApiException} which has the status code and response body
+ * in the message.
+ */
+public class KubeAPIException extends Exception {
+
+  KubeAPIException(String messagePrefix, ApiException cause) {
+    super(String.format("%s\nReceived status code %d with response: %s", messagePrefix, cause.getCode(),
+                        cause.getResponseBody()), cause);
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -1004,11 +1004,12 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
       return;
     }
     Map<Type, AppResourceWatcherThread<?>> typeMap = new HashMap<>();
+    // Batch jobs are k8s jobs, and streaming pipelines are k8s deployments
     typeMap.put(V1Job.class, AppResourceWatcherThread.createJobWatcher(namespace, selector, apiClientFactory));
-    // We only create deployments and stateful in the system namespace, so only add watchers for them in that namespace
+    typeMap.put(V1Deployment.class,
+                AppResourceWatcherThread.createDeploymentWatcher(namespace, selector, apiClientFactory));
+    // We only create statefulsets in the system namespace, so only add watchers for them in that namespace
     if (namespace.equals(kubeNamespace)) {
-      typeMap.put(V1Deployment.class,
-                  AppResourceWatcherThread.createDeploymentWatcher(namespace, selector, apiClientFactory));
       typeMap.put(V1StatefulSet.class,
                   AppResourceWatcherThread.createStatefulSetWatcher(namespace, selector, apiClientFactory));
     }


### PR DESCRIPTION
Cherry-pick of #14524 

[CDAP-19581] Start deployment watcher thread for non-system namespaces and add logs to CDAP resource creation failure in k8s

[CDAP-19581] Add KubeAPIException which wraps ApiException to make the statue code and response body visible in the error message

[CDAP-19581]: https://cdap.atlassian.net/browse/CDAP-19581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-19581]: https://cdap.atlassian.net/browse/CDAP-19581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ