### PR TITLE
Enable state handling in StreamingContext

### DIFF
--- a/cdap-api-spark-base/src/main/scala/io/cdap/cdap/api/spark/SparkExecutionContextBase.scala
+++ b/cdap-api-spark-base/src/main/scala/io/cdap/cdap/api/spark/SparkExecutionContextBase.scala
@@ -22,6 +22,7 @@ import io.cdap.cdap.api.TaskLocalizationContext
 import io.cdap.cdap.api.Transactional
 import io.cdap.cdap.api.TxRunnable
 import io.cdap.cdap.api.annotation.Beta
+import io.cdap.cdap.api.app.AppStateStore
 import io.cdap.cdap.api.data.batch.Split
 import io.cdap.cdap.api.lineage.field.LineageRecorder
 import io.cdap.cdap.api.messaging.MessagingContext
@@ -45,7 +46,8 @@ import scala.reflect.ClassTag
   */
 @Beta
 trait SparkExecutionContextBase extends RuntimeContext
-  with Transactional with MetadataReader with MetadataWriter with LineageRecorder {
+  with Transactional with MetadataReader with MetadataWriter with LineageRecorder
+  with AppStateStore {
 
   /**
     * @return The specification used to configure this Spark job instance.

--- a/cdap-api/src/main/java/io/cdap/cdap/api/app/AppStateStore.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/app/AppStateStore.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.app;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Saves and reads state for the given app.
+ */
+public interface AppStateStore {
+
+  /**
+   * Returns the saved state for given app and key.
+   * @param key Key for the state, should not be null
+   * @return value as Optional<byte[]> . Value will not be present if key is not present in the store.
+   * @throws IOException if the namespace/app is not available or otherwise unable to fetch state
+   * @throws IllegalArgumentException if the key is null or empty
+   */
+  Optional<byte[]> getState(String key) throws IOException;
+
+  /**
+   * Saves the state for an app with a key. This state is removed when the app is deleted.
+   * @param key Key for the state, should not be null
+   * @param value value as byte[], should not be null
+   * @throws IOException if the app is not available or otherwise unable to save state
+   * @throws IllegalArgumentException if the key/value is null or empty
+   */
+  void saveState(String key, byte[] value) throws IOException;
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppStateModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppStateModule.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
+import io.cdap.cdap.internal.app.runtime.RemoteAppStateStoreProvider;
+
+/**
+ * Module for bindings related to application state.
+ */
+public class AppStateModule extends AbstractModule {
+  @Override
+  protected void configure() {
+    bind(AppStateStoreProvider.class).to(RemoteAppStateStoreProvider.class).in(Scopes.SINGLETON);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
@@ -159,6 +159,7 @@ public class DistributedProgramContainerModule extends AbstractModule {
     modules.add(new AuthorizationEnforcementModule().getDistributedModules());
     modules.add(new SecureStoreClientModule());
     modules.add(new MetadataReaderWriterModules().getDistributedModules());
+    modules.add(new AppStateModule());
     modules.add(new NamespaceQueryAdminModule());
     modules.add(new DataSetsModules().getDistributedModules());
     modules.add(new ProgramStateWriterModule(clusterMode, systemArgs.hasOption(ProgramOptionConstants.PEER_NAME)));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/InMemoryProgramRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/InMemoryProgramRunnerModule.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.app.runtime.ProgramRuntimeProvider;
 import io.cdap.cdap.app.runtime.ProgramRuntimeService;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.discovery.ResolvingDiscoverable;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactManagerFactory;
 import io.cdap.cdap.internal.app.runtime.artifact.LocalArtifactManager;
 import io.cdap.cdap.internal.app.runtime.batch.MapReduceProgramRunner;
@@ -68,6 +69,9 @@ final class InMemoryProgramRunnerModule extends PrivateModule {
               .implement(ArtifactManager.class, LocalArtifactManager.class)
               .build(ArtifactManagerFactory.class));
     expose(ArtifactManagerFactory.class);
+
+    install(new AppStateModule());
+    expose(AppStateStoreProvider.class);
 
     // Bind ProgramRunner
     MapBinder<ProgramType, ProgramRunner> runnerFactoryBinder =

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppStateHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppStateHandler.java
@@ -57,6 +57,8 @@ public class AppStateHandler extends AbstractHttpHandler {
 
   /**
    * Get state for a given app-name and state-key.
+   * Returns null as response if the app is valid, but there is no entry for the key
+   * Returns {@link HttpResponseStatus.NOT_FOUND} if namespace or app is not valid
    */
   @GET
   @Path("/namespaces/{namespace}/apps/{app-name}/states/{state-key}")
@@ -71,12 +73,13 @@ public class AppStateHandler extends AbstractHttpHandler {
       responder.sendByteArray(HttpResponseStatus.OK, appStateResponse.get(),
                               EmptyHttpHeaders.INSTANCE);
     } else {
-      responder.sendStatus(HttpResponseStatus.NOT_FOUND);
+      responder.sendStatus(HttpResponseStatus.OK, EmptyHttpHeaders.INSTANCE);
     }
   }
 
   /**
    * Save state for a given app-name and state-key.
+   * All params and state value should be present
    */
   @PUT
   @Path("/namespaces/{namespace}/apps/{app-name}/states/{state-key}")

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/AppStateStoreProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/AppStateStoreProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime;
+
+import io.cdap.cdap.api.app.AppStateStore;
+
+/**
+ * Provides implementation for {@link AppStateStore}.
+ */
+public interface AppStateStoreProvider {
+  /**
+   * Returns implementation for {@link AppStateStore} for this app
+   * @param namespace Namespace for the app
+   * @param applicationName Application name
+   * @return AppStateStore implementation
+   */
+  AppStateStore getStateStore(String namespace, String applicationName);
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/RemoteAppStateStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/RemoteAppStateStore.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime;
+
+import io.cdap.cdap.api.app.AppStateStore;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.ServiceUnavailableException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.common.service.Retries;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.common.service.RetryStrategy;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpResponse;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+/**
+ * Remote implementation for application state read/write.
+ */
+public class RemoteAppStateStore implements AppStateStore {
+
+  private static final String REMOTE_END_POINT = "/namespaces/%s/apps/%s/states/%s";
+
+  private final RetryStrategy retryStrategy;
+  private final RemoteClient remoteClient;
+  private final String appName;
+  private final String namespace;
+
+  RemoteAppStateStore(CConfiguration cConf, RemoteClientFactory remoteClientFactory, String namespace,
+                      String appName) {
+    this.namespace = namespace;
+    this.appName = appName;
+    this.remoteClient = remoteClientFactory.createRemoteClient(Constants.Service.APP_FABRIC_HTTP,
+                                                               new DefaultHttpRequestConfig(false),
+                                                               Constants.Gateway.INTERNAL_API_VERSION_3);
+    this.retryStrategy = RetryStrategies.fromConfiguration(cConf, Constants.AppFabric.APP_STATE + ".");
+  }
+
+  @Override
+  public Optional<byte[]> getState(String key) throws IOException {
+    if (key == null || key.isEmpty()) {
+      throw new IllegalArgumentException("Received null or empty value for required argument 'key'");
+    }
+    try {
+      return Retries.callWithRetries(() -> {
+        HttpRequest.Builder requestBuilder =
+          remoteClient.requestBuilder(HttpMethod.GET,
+                                      String.format(REMOTE_END_POINT, namespace, appName, key));
+        HttpResponse httpResponse = remoteClient.execute(requestBuilder.build());
+        int responseCode = httpResponse.getResponseCode();
+        if (responseCode == 200) {
+          byte[] responseBody = httpResponse.getResponseBody();
+          if (responseBody.length == 0) {
+            return Optional.empty();
+          }
+          return Optional.of(responseBody);
+        }
+        String notFoundExceptionMessage = String.format("Namespace %s or application %s not found.",
+                                                        namespace, appName, key);
+        handleErrorResponse(responseCode, httpResponse.getResponseBodyAsString(), notFoundExceptionMessage);
+        return null;
+      }, retryStrategy);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public void saveState(String key, byte[] value) throws IOException {
+    if (key == null || key.isEmpty()) {
+      throw new IllegalArgumentException("Received null or empty value for required argument 'key'");
+    }
+    if (value == null || value.length == 0) {
+      throw new IllegalArgumentException("Received null or empty value for required argument 'value'");
+    }
+    try {
+      //Retries are ok since this is a PUT request
+      Retries.runWithRetries(() -> {
+        HttpRequest.Builder requestBuilder =
+          remoteClient.requestBuilder(HttpMethod.PUT, String.format(REMOTE_END_POINT, namespace, appName, key))
+            .withBody(ByteBuffer.wrap(value));
+        HttpResponse httpResponse = remoteClient.execute(requestBuilder.build());
+        int responseCode = httpResponse.getResponseCode();
+        if (responseCode != 200) {
+          String notFoundExceptionMessage = String.format("Namespace %s or application %s not found.", namespace,
+                                                          appName);
+          handleErrorResponse(responseCode, httpResponse.getResponseBodyAsString(), notFoundExceptionMessage);
+        }
+      }, retryStrategy);
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
+  }
+
+  private void handleErrorResponse(int responseCode, String responseBody,
+                                   String notFoundExceptionMessage) throws NotFoundException, IOException {
+    switch (responseCode) {
+      // throw retryable error if service is not available, might be temporary
+      case HttpURLConnection.HTTP_BAD_GATEWAY:
+      case HttpURLConnection.HTTP_UNAVAILABLE:
+      case HttpURLConnection.HTTP_GATEWAY_TIMEOUT:
+        throw new ServiceUnavailableException(Constants.Service.APP_FABRIC_HTTP,
+                                              Constants.Service.APP_FABRIC_HTTP +
+                                                " service is not available with status " + responseCode);
+      case HttpURLConnection.HTTP_NOT_FOUND:
+        throw new NotFoundException(notFoundExceptionMessage);
+    }
+    throw new IOException("Remote call failed with error response: " + responseCode + ": " + responseBody);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/RemoteAppStateStoreProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/RemoteAppStateStoreProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime;
+
+import io.cdap.cdap.api.app.AppStateStore;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+
+import javax.inject.Inject;
+
+/**
+ * Provides {@link RemoteAppStateStore} implementation for {@link AppStateStore}.
+ */
+public class RemoteAppStateStoreProvider implements AppStateStoreProvider {
+
+  private final CConfiguration cConf;
+  private final RemoteClientFactory remoteClientFactory;
+
+  @Inject
+  RemoteAppStateStoreProvider(CConfiguration cConf, RemoteClientFactory remoteClientFactory) {
+    this.cConf = cConf;
+    this.remoteClientFactory = remoteClientFactory;
+  }
+
+  @Override
+  public AppStateStore getStateStore(String namespace, String applicationName) {
+    return new RemoteAppStateStore(cConf, remoteClientFactory, namespace, applicationName);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/BasicMapReduceContext.java
@@ -43,6 +43,7 @@ import io.cdap.cdap.data2.metadata.lineage.AccessType;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.internal.app.runtime.batch.dataset.DatasetInputFormatProvider;
 import io.cdap.cdap.internal.app.runtime.batch.dataset.input.MapperInput;
@@ -109,11 +110,12 @@ final class BasicMapReduceContext extends AbstractContext implements MapReduceCo
                         MessagingService messagingService, MetadataReader metadataReader,
                         MetadataPublisher metadataPublisher,
                         NamespaceQueryAdmin namespaceQueryAdmin,
-                        FieldLineageWriter fieldLineageWriter, RemoteClientFactory remoteClientFactory) {
+                        FieldLineageWriter fieldLineageWriter, RemoteClientFactory remoteClientFactory,
+                        AppStateStoreProvider appStateStoreProvider) {
     super(program, programOptions, cConf, spec.getDataSets(), dsFramework, txClient, false,
           metricsCollectionService, createMetricsTags(workflowProgramInfo), secureStore, secureStoreManager,
           messagingService, pluginInstantiator, metadataReader, metadataPublisher, namespaceQueryAdmin,
-          fieldLineageWriter, remoteClientFactory);
+          fieldLineageWriter, remoteClientFactory, appStateStoreProvider);
 
     this.workflowProgramInfo = workflowProgramInfo;
     this.spec = spec;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/BasicMapReduceTaskContext.java
@@ -57,6 +57,7 @@ import io.cdap.cdap.data2.metadata.lineage.AccessType;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.DefaultTaskLocalizationContext;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.internal.app.runtime.batch.dataset.CloseableBatchWritable;
@@ -144,12 +145,12 @@ public class BasicMapReduceTaskContext<KEYOUT, VALUEOUT> extends AbstractContext
                             MessagingService messagingService, MapReduceClassLoader mapReduceClassLoader,
                             MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                             NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter,
-                            RemoteClientFactory remoteClientFactory) {
+                            RemoteClientFactory remoteClientFactory, AppStateStoreProvider appStateStoreProvider) {
     super(program, programOptions, cConf, ImmutableSet.of(), dsFramework, txClient,
           true, metricsCollectionService, createMetricsTags(programOptions,
                                                             taskId, type, workflowProgramInfo), secureStore,
           secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
+          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory, appStateStoreProvider);
     this.cConf = cConf;
     this.workflowProgramInfo = workflowProgramInfo;
     this.transaction = transaction;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceProgramRunner.java
@@ -47,6 +47,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.BasicProgramContext;
 import io.cdap.cdap.internal.app.runtime.DataSetFieldSetter;
 import io.cdap.cdap.internal.app.runtime.MetricsFieldSetter;
@@ -97,6 +98,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final MetadataPublisher metadataPublisher;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final RemoteClientFactory remoteClientFactory;
+  private final AppStateStoreProvider appStateStoreProvider;
 
   @Inject
   public MapReduceProgramRunner(Injector injector, CConfiguration cConf, Configuration hConf,
@@ -108,7 +110,8 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                 SecureStore secureStore, SecureStoreManager secureStoreManager,
                                 MessagingService messagingService, MetadataReader metadataReader,
                                 MetadataPublisher metadataPublisher, FieldLineageWriter fieldLineageWriter,
-                                NamespaceQueryAdmin namespaceQueryAdmin, RemoteClientFactory remoteClientFactory) {
+                                NamespaceQueryAdmin namespaceQueryAdmin, RemoteClientFactory remoteClientFactory,
+                                AppStateStoreProvider appStateStoreProvider) {
     super(cConf);
     this.injector = injector;
     this.cConf = cConf;
@@ -126,6 +129,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.fieldLineageWriter = fieldLineageWriter;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.remoteClientFactory = remoteClientFactory;
+    this.appStateStoreProvider = appStateStoreProvider;
   }
 
   @Override
@@ -176,7 +180,7 @@ public class MapReduceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                   metricsCollectionService, txSystemClient, programDatasetFramework,
                                   getPluginArchive(options), pluginInstantiator, secureStore, secureStoreManager,
                                   messagingService, metadataReader, metadataPublisher, namespaceQueryAdmin,
-                                  fieldLineageWriter, remoteClientFactory);
+                                  fieldLineageWriter, remoteClientFactory, appStateStoreProvider);
       closeables.add(context);
 
       Reflections.visit(mapReduce, mapReduce.getClass(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceTaskContextProvider.java
@@ -40,6 +40,7 @@ import io.cdap.cdap.data.ProgramContextAware;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.BasicArguments;
 import io.cdap.cdap.internal.app.runtime.BasicProgramContext;
 import io.cdap.cdap.internal.app.runtime.ProgramRunners;
@@ -181,6 +182,7 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
     MetadataPublisher metadataPublisher = injector.getInstance(MetadataPublisher.class);
     FieldLineageWriter fieldLineageWriter = injector.getInstance(FieldLineageWriter.class);
     RemoteClientFactory remoteClientFactory = injector.getInstance(RemoteClientFactory.class);
+    AppStateStoreProvider appStateStoreProvider = injector.getInstance(AppStateStoreProvider.class);
 
     return new CacheLoader<ContextCacheKey, BasicMapReduceTaskContext>() {
       @Override
@@ -254,7 +256,7 @@ public class MapReduceTaskContextProvider extends AbstractIdleService {
           contextConfig.getLocalizedResources(), secureStore, secureStoreManager,
           accessEnforcer, authenticationContext, messagingService, mapReduceClassLoader, metadataReader,
           metadataPublisher, namespaceQueryAdmin, fieldLineageWriter,
-          remoteClientFactory);
+          remoteClientFactory, appStateStoreProvider);
       }
     };
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/customaction/BasicCustomActionContext.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
 import io.cdap.cdap.messaging.MessagingService;
@@ -61,13 +62,14 @@ public class BasicCustomActionContext extends AbstractContext implements CustomA
                                   SecureStore secureStore, SecureStoreManager secureStoreManager,
                                   MessagingService messagingService, MetadataReader metadataReader,
                                   MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin,
-                                  FieldLineageWriter fieldLineageWriter, RemoteClientFactory remoteClientFactory) {
+                                  FieldLineageWriter fieldLineageWriter, RemoteClientFactory remoteClientFactory,
+                                  AppStateStoreProvider appStateStoreProvider) {
 
     super(workflow, programOptions, cConf, customActionSpecification.getDatasets(),
           datasetFramework, txClient, false,
           metricsCollectionService, workflowProgramInfo.updateMetricsTags(new HashMap<>()), secureStore,
           secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
+          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory, appStateStoreProvider);
 
     this.customActionSpecification = customActionSpecification;
     this.workflowProgramInfo = workflowProgramInfo;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/BasicServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/BasicServiceContext.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.messaging.MessagingService;
 import org.apache.tephra.TransactionSystemClient;
@@ -67,11 +68,12 @@ public class BasicServiceContext extends AbstractContext implements ServiceConte
                              MessagingService messagingService, MetadataReader metadataReader,
                              MetadataPublisher metadataPublisher,
                              NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter,
-                             RemoteClientFactory remoteClientFactory, ArtifactManager artifactManager) {
+                             RemoteClientFactory remoteClientFactory, ArtifactManager artifactManager,
+                             AppStateStoreProvider appStateStoreProvider) {
     super(program, programOptions, cConf, Collections.emptySet(), datasetFramework, transactionSystemClient, false,
           metricsCollectionService, ImmutableMap.of(), secureStore, secureStoreManager, messagingService,
           pluginInstantiator, metadataReader, metadataPublisher, namespaceQueryAdmin, fieldLineageWriter,
-          remoteClientFactory);
+          remoteClientFactory, appStateStoreProvider);
     this.instanceCount = instanceCount;
     this.instanceId = instanceId;
     this.specification = spec;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/BasicSystemServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/BasicSystemServiceContext.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.app.services.DefaultSystemTableConfigurer;
 import io.cdap.cdap.messaging.MessagingService;
@@ -66,11 +67,11 @@ public class BasicSystemServiceContext extends BasicServiceContext implements Sy
                                    MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                                    NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter,
                                    TransactionRunner transactionRunner, RemoteClientFactory remoteClientFactory,
-                                   ArtifactManager artifactManager) {
+                                   ArtifactManager artifactManager, AppStateStoreProvider appStateStoreProvider) {
     super(spec, program, programOptions, instanceId, instanceCount, cConf, metricsCollectionService, datasetFramework,
           transactionSystemClient, pluginInstantiator, secureStore, secureStoreManager,
           messagingService, metadataReader, metadataPublisher, namespaceQueryAdmin, fieldLineageWriter,
-          remoteClientFactory, artifactManager);
+          remoteClientFactory, artifactManager, appStateStoreProvider);
     this.namespaceId = program.getId().getNamespaceId();
     this.transactionRunner = transactionRunner;
     this.namespaceQueryAdmin = namespaceQueryAdmin;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/ServiceProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/ServiceProgramRunner.java
@@ -40,6 +40,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.BasicProgramContext;
 import io.cdap.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
@@ -88,6 +89,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final RemoteClientFactory remoteClientFactory;
   private final ContextAccessEnforcer contextAccessEnforcer;
   private final CommonNettyHttpServiceFactory commonNettyHttpServiceFactory;
+  private final AppStateStoreProvider appStateStoreProvider;
 
   @Inject
   public ServiceProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
@@ -101,7 +103,8 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                               FieldLineageWriter fieldLineageWriter, TransactionRunner transactionRunner,
                               PreferencesFetcher preferencesFetcher, RemoteClientFactory remoteClientFactory,
                               ContextAccessEnforcer contextAccessEnforcer,
-                              CommonNettyHttpServiceFactory commonNettyHttpServiceFactory) {
+                              CommonNettyHttpServiceFactory commonNettyHttpServiceFactory,
+                              AppStateStoreProvider appStateStoreProvider) {
     super(cConf);
     this.metricsCollectionService = metricsCollectionService;
     this.datasetFramework = datasetFramework;
@@ -122,6 +125,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.remoteClientFactory = remoteClientFactory;
     this.contextAccessEnforcer = contextAccessEnforcer;
     this.commonNettyHttpServiceFactory = commonNettyHttpServiceFactory;
+    this.appStateStoreProvider = appStateStoreProvider;
   }
 
   @Override
@@ -166,7 +170,7 @@ public class ServiceProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           metadataPublisher, namespaceQueryAdmin, pluginFinder,
                                                           fieldLineageWriter, transactionRunner, preferencesFetcher,
                                                           remoteClientFactory, contextAccessEnforcer,
-                                                          commonNettyHttpServiceFactory);
+                                                          commonNettyHttpServiceFactory, appStateStoreProvider);
 
       // Add a service listener to make sure the plugin instantiator is closed when the http server is finished.
       component.addListener(createRuntimeServiceListener(Collections.singleton(pluginInstantiator)),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicHttpServiceContext.java
@@ -40,6 +40,7 @@ import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.DefaultServicePluginConfigurer;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.ProgramRunners;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
@@ -117,12 +118,13 @@ public class BasicHttpServiceContext extends AbstractContext implements HttpServ
                                  MetadataPublisher metadataPublisher,
                                  NamespaceQueryAdmin namespaceQueryAdmin,
                                  PluginFinder pluginFinder,
-                                 FieldLineageWriter fieldLineageWriter, RemoteClientFactory remoteClientFactory) {
+                                 FieldLineageWriter fieldLineageWriter, RemoteClientFactory remoteClientFactory,
+                                 AppStateStoreProvider appStateStoreProvider) {
     super(program, programOptions, cConf, spec == null ? Collections.emptySet() : spec.getDatasets(),
           dsFramework, txClient, false,
           metricsCollectionService, createMetricsTags(spec, instanceId),
           secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
+          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory, appStateStoreProvider);
     this.cConf = cConf;
     this.artifactId = ProgramRunners.getArtifactId(programOptions);
     this.spec = spec;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicSystemHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicSystemHttpServiceContext.java
@@ -40,6 +40,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.RemoteTaskExecutor;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.MacroParser;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
@@ -94,11 +95,12 @@ public class BasicSystemHttpServiceContext extends BasicHttpServiceContext imple
                                        NamespaceQueryAdmin namespaceQueryAdmin, PluginFinder pluginFinder,
                                        FieldLineageWriter fieldLineageWriter, TransactionRunner transactionRunner,
                                        PreferencesFetcher preferencesFetcher, RemoteClientFactory remoteClientFactory,
-                                       ContextAccessEnforcer contextAccessEnforcer) {
+                                       ContextAccessEnforcer contextAccessEnforcer,
+                                       AppStateStoreProvider appStateStoreProvider) {
     super(program, programOptions, cConf, spec, instanceId, instanceCount, metricsCollectionService, dsFramework,
           discoveryServiceClient, txClient, pluginInstantiator, secureStore, secureStoreManager, messagingService,
           artifactManager, metadataReader, metadataPublisher, namespaceQueryAdmin, pluginFinder, fieldLineageWriter,
-          remoteClientFactory);
+          remoteClientFactory, appStateStoreProvider);
 
     this.namespaceId = program.getId().getNamespaceId();
     this.transactionRunner = transactionRunner;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/worker/BasicWorkerContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/worker/BasicWorkerContext.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.messaging.MessagingService;
 import org.apache.tephra.TransactionSystemClient;
@@ -61,12 +62,12 @@ final class BasicWorkerContext extends AbstractContext implements WorkerContext 
                      MessagingService messagingService, MetadataReader metadataReader,
                      MetadataPublisher metadataPublisher,
                      NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter,
-                     RemoteClientFactory remoteClientFactory) {
+                     RemoteClientFactory remoteClientFactory, AppStateStoreProvider appStateStoreProvider) {
     super(program, programOptions, cConf, spec.getDatasets(),
           datasetFramework, transactionSystemClient, true,
           metricsCollectionService, ImmutableMap.of(Constants.Metrics.Tag.INSTANCE_ID, String.valueOf(instanceId)),
           secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
+          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory, appStateStoreProvider);
 
     this.specification = spec;
     this.instanceId = instanceId;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/worker/WorkerProgramRunner.java
@@ -38,6 +38,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.BasicProgramContext;
 import io.cdap.cdap.internal.app.runtime.ProgramControllerServiceAdapter;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
@@ -72,6 +73,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final FieldLineageWriter fieldLineageWriter;
   private final RemoteClientFactory remoteClientFactory;
+  private final AppStateStoreProvider appStateStoreProvider;
 
   @Inject
   public WorkerProgramRunner(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
@@ -80,7 +82,8 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
                              SecureStore secureStore, SecureStoreManager secureStoreManager,
                              MessagingService messagingService, MetadataReader metadataReader,
                              MetadataPublisher metadataPublisher, NamespaceQueryAdmin namespaceQueryAdmin,
-                             FieldLineageWriter fieldLineageWriter, RemoteClientFactory remoteClientFactory) {
+                             FieldLineageWriter fieldLineageWriter, RemoteClientFactory remoteClientFactory,
+                             AppStateStoreProvider appStateStoreProvider) {
     super(cConf);
     this.cConf = cConf;
     this.metricsCollectionService = metricsCollectionService;
@@ -95,6 +98,7 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.fieldLineageWriter = fieldLineageWriter;
     this.remoteClientFactory = remoteClientFactory;
+    this.appStateStoreProvider = appStateStoreProvider;
   }
 
   @Override
@@ -138,7 +142,8 @@ public class WorkerProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                           discoveryServiceClient,
                                                           pluginInstantiator, secureStore, secureStoreManager,
                                                           messagingService, metadataReader, metadataPublisher,
-                                                          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
+                                                          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory,
+                                                          appStateStoreProvider);
 
       WorkerDriver worker = new WorkerDriver(program, newWorkerSpec, context);
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/BasicWorkflowContext.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.ProgramRunners;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.messaging.MessagingService;
@@ -70,13 +71,13 @@ final class BasicWorkflowContext extends AbstractContext implements WorkflowCont
                        MessagingService messagingService, @Nullable ConditionSpecification conditionSpecification,
                        MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                        NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter,
-                       RemoteClientFactory remoteClientFactory) {
+                       RemoteClientFactory remoteClientFactory, AppStateStoreProvider appStateStoreProvider) {
     super(program, programOptions, cConf, new HashSet<>(),
           datasetFramework, txClient, false,
           metricsCollectionService, Collections.singletonMap(Constants.Metrics.Tag.WORKFLOW_RUN_ID,
                                                              ProgramRunners.getRunId(programOptions).getId()),
           secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
+          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory, appStateStoreProvider);
     this.workflowSpec = workflowSpec;
     this.conditionSpecification = conditionSpecification;
     this.token = token;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/WorkflowProgramRunner.java
@@ -40,6 +40,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.BasicProgramContext;
 import io.cdap.cdap.internal.app.runtime.ProgramRunners;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
@@ -75,6 +76,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
   private final FieldLineageWriter fieldLineageWriter;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final RemoteClientFactory remoteClientFactory;
+  private final AppStateStoreProvider appStateStoreProvider;
 
   @Inject
   public WorkflowProgramRunner(ProgramRunnerFactory programRunnerFactory,
@@ -84,7 +86,8 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
                                SecureStoreManager secureStoreManager, MessagingService messagingService,
                                ProgramStateWriter programStateWriter, MetadataReader metadataReader,
                                MetadataPublisher metadataPublisher, FieldLineageWriter fieldLineageWriter,
-                               NamespaceQueryAdmin namespaceQueryAdmin, RemoteClientFactory remoteClientFactory) {
+                               NamespaceQueryAdmin namespaceQueryAdmin, RemoteClientFactory remoteClientFactory,
+                               AppStateStoreProvider appStateStoreProvider) {
     super(cConf);
     this.programRunnerFactory = programRunnerFactory;
     this.metricsCollectionService = metricsCollectionService;
@@ -102,6 +105,7 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
     this.fieldLineageWriter = fieldLineageWriter;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.remoteClientFactory = remoteClientFactory;
+    this.appStateStoreProvider = appStateStoreProvider;
   }
 
   @Override
@@ -138,7 +142,8 @@ public class WorkflowProgramRunner extends AbstractProgramRunnerWithPlugin {
                                                  txClient, workflowStateWriter, cConf, pluginInstantiator,
                                                  secureStore, secureStoreManager, messagingService,
                                                  programStateWriter, metadataReader, metadataPublisher,
-                                                 fieldLineageWriter, namespaceQueryAdmin, remoteClientFactory);
+                                                 fieldLineageWriter, namespaceQueryAdmin, remoteClientFactory,
+                                                 appStateStoreProvider);
 
       // Controller needs to be created before starting the driver so that the state change of the driver
       // service can be fully captured by the controller.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ServiceHttpServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ServiceHttpServer.java
@@ -50,6 +50,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.data2.transaction.Transactions;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.DataSetFieldSetter;
 import io.cdap.cdap.internal.app.runtime.MetricsFieldSetter;
 import io.cdap.cdap.internal.app.runtime.ThrowingRunnable;
@@ -108,7 +109,8 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                            PluginFinder pluginFinder, FieldLineageWriter fieldLineageWriter,
                            TransactionRunner transactionRunner, PreferencesFetcher preferencesFetcher,
                            RemoteClientFactory remoteClientFactory, ContextAccessEnforcer contextAccessEnforcer,
-                           CommonNettyHttpServiceFactory commonNettyHttpServiceFactory) {
+                           CommonNettyHttpServiceFactory commonNettyHttpServiceFactory,
+                           AppStateStoreProvider appStateStoreProvider) {
     super(host, program, programOptions, instanceId, serviceAnnouncer, TransactionControl.IMPLICIT);
 
     this.cConf = cConf;
@@ -120,7 +122,8 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                txClient, pluginInstantiator, secureStore, secureStoreManager,
                                                messagingService, artifactManager, metadataReader, metadataPublisher,
                                                pluginFinder, fieldLineageWriter, transactionRunner,
-                                               preferencesFetcher, remoteClientFactory, contextAccessEnforcer);
+                                               preferencesFetcher, remoteClientFactory, contextAccessEnforcer,
+                                               appStateStoreProvider);
 
     Class<?> serviceClass = null;
     try {
@@ -136,14 +139,14 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                           secureStore, secureStoreManager, messagingService,
                                                           metadataReader, metadataPublisher, namespaceQueryAdmin,
                                                           fieldLineageWriter, transactionRunner, remoteClientFactory,
-                                                          artifactManager);
+                                                          artifactManager, appStateStoreProvider);
     } else {
       this.serviceContext = new BasicServiceContext(spec, program, programOptions, instanceId, this.instanceCount,
                                                     cConf, metricsCollectionService, datasetFramework, txClient,
                                                     pluginInstantiator,
                                                     secureStore, secureStoreManager, messagingService, metadataReader,
                                                     metadataPublisher, namespaceQueryAdmin, fieldLineageWriter,
-                                                    remoteClientFactory, artifactManager);
+                                                    remoteClientFactory, artifactManager, appStateStoreProvider);
     }
     this.httpServiceContext = contextFactory.create(null, null);
     this.namespaceQueryAdmin = namespaceQueryAdmin;
@@ -236,7 +239,8 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                               TransactionRunner transactionRunner,
                                                               PreferencesFetcher preferencesFetcher,
                                                               RemoteClientFactory remoteClientFactory,
-                                                              ContextAccessEnforcer contextAccessEnforcer) {
+                                                              ContextAccessEnforcer contextAccessEnforcer,
+                                                              AppStateStoreProvider appStateStoreProvider) {
     return (spec, handlerClass) -> {
       if (handlerClass != null && AbstractSystemHttpServiceHandler.class.isAssignableFrom(handlerClass)) {
         return new BasicSystemHttpServiceContext(program, programOptions, cConf, spec, instanceId, instanceCount,
@@ -245,13 +249,14 @@ public class ServiceHttpServer extends AbstractServiceHttpServer<HttpServiceHand
                                                  messagingService, artifactManager, metadataReader, metadataPublisher,
                                                  namespaceQueryAdmin, pluginFinder, fieldLineageWriter,
                                                  transactionRunner, preferencesFetcher, remoteClientFactory,
-                                                 contextAccessEnforcer);
+                                                 contextAccessEnforcer, appStateStoreProvider);
       }
       return new BasicHttpServiceContext(program, programOptions, cConf, spec, instanceId, instanceCount,
                                          metricsCollectionService, datasetFramework, discoveryServiceClient,
                                          txClient, pluginInstantiator, secureStore, secureStoreManager,
                                          messagingService, artifactManager, metadataReader, metadataPublisher,
-                                         namespaceQueryAdmin, pluginFinder, fieldLineageWriter, remoteClientFactory);
+                                         namespaceQueryAdmin, pluginFinder, fieldLineageWriter, remoteClientFactory,
+                                         appStateStoreProvider);
     };
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/RemoteAppStateStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/RemoteAppStateStoreTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime;
+
+import io.cdap.cdap.common.ApplicationNotFoundException;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.discovery.URIScheme;
+import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
+import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.common.namespace.InMemoryNamespaceAdmin;
+import io.cdap.cdap.common.namespace.NamespaceAdmin;
+import io.cdap.cdap.gateway.handlers.AppStateHandler;
+import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
+import io.cdap.cdap.internal.app.store.state.AppStateKey;
+import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
+import io.cdap.http.NettyHttpService;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.discovery.InMemoryDiscoveryService;
+import org.hamcrest.CoreMatchers;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Tests for {@link RemoteAppStateStore}
+ */
+public class RemoteAppStateStoreTest {
+
+  private static final String NAMESPACE = "ns1";
+
+  private static NettyHttpService httpService;
+  private static ApplicationLifecycleService applicationLifecycleService;
+  private static CConfiguration cConf;
+  private static RemoteClientFactory remoteClientFactory;
+  private static Cancellable cancellable;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    cConf = CConfiguration.create();
+    cConf.set("app.state.retry.policy.base.delay.ms", "10");
+    cConf.set("app.state.retry.policy.max.delay.ms", "2000");
+    cConf.set("app.state.retry.policy.max.retries", "2147483647");
+    cConf.set("app.state.retry.policy.max.time.secs", "60");
+    cConf.set("app.state.retry.policy.type", "exponential.backoff");
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
+    NamespaceAdmin namespaceAdmin = new InMemoryNamespaceAdmin();
+    applicationLifecycleService = Mockito.mock(ApplicationLifecycleService.class);
+    NamespaceMeta testNameSpace = new NamespaceMeta.Builder()
+      .setName(NAMESPACE)
+      .setDescription("This is the default namespace, which is automatically created, and is always available.")
+      .build();
+    namespaceAdmin.create(testNameSpace);
+    remoteClientFactory = new RemoteClientFactory(discoveryService,
+                                                  new DefaultInternalAuthenticator(new AuthenticationTestContext()));
+    httpService = new CommonNettyHttpServiceBuilder(cConf, "appfabric", new NoOpMetricsCollectionService())
+      .setHttpHandlers(new AppStateHandler(applicationLifecycleService, namespaceAdmin)).build();
+    httpService.start();
+    cancellable = discoveryService
+      .register(URIScheme.createDiscoverable(Constants.Service.APP_FABRIC_HTTP, httpService));
+  }
+
+  @AfterClass
+  public static void cleanUp() throws Exception {
+    cancellable.cancel();
+    httpService.stop();
+  }
+
+  @Test
+  public void testSaveSuccess() throws IOException {
+    RemoteAppStateStore remoteAppStateStore = new RemoteAppStateStore(cConf, remoteClientFactory, NAMESPACE, "app1");
+    byte[] value = "testvalue".getBytes();
+    remoteAppStateStore.saveState("key1", value);
+  }
+
+  @Test
+  public void testSaveInvalidNamespace() throws IOException {
+    expectedException.expectCause(CoreMatchers.isA(NotFoundException.class));
+    RemoteAppStateStore remoteAppStateStore = new RemoteAppStateStore(cConf, remoteClientFactory, "invalid", "app1");
+    byte[] value = "testvalue".getBytes();
+    remoteAppStateStore.saveState("key1", value);
+  }
+
+  @Test
+  public void testSaveInvalidApp() throws ApplicationNotFoundException, IOException {
+    expectedException.expectCause(CoreMatchers.isA(NotFoundException.class));
+    String testAppName = "app1";
+    RemoteAppStateStore remoteAppStateStore = new RemoteAppStateStore(cConf, remoteClientFactory, NAMESPACE,
+                                                                      testAppName);
+    byte[] value = "testvalue".getBytes();
+    String testKey = "key1";
+    Mockito.doThrow(new ApplicationNotFoundException(new ApplicationId(
+      NAMESPACE, testAppName))).when(applicationLifecycleService).saveState(Mockito.any());
+    remoteAppStateStore.saveState(testKey, value);
+  }
+
+  @Test
+  public void testSaveFail() throws ApplicationNotFoundException, IOException {
+    expectedException.expectCause(CoreMatchers.isA(IOException.class));
+    String testAppName = "app1";
+    RemoteAppStateStore remoteAppStateStore = new RemoteAppStateStore(cConf, remoteClientFactory, NAMESPACE,
+                                                                      testAppName);
+    byte[] value = "testvalue".getBytes();
+    String testKey = "key1";
+    Mockito.doThrow(new RuntimeException("test")).when(applicationLifecycleService).saveState(Mockito.any());
+    remoteAppStateStore.saveState(testKey, value);
+  }
+
+  @Test
+  public void testGetSuccess() throws ApplicationNotFoundException, IOException {
+    RemoteAppStateStore remoteAppStateStore = new RemoteAppStateStore(cConf, remoteClientFactory, NAMESPACE, "app1");
+    byte[] value = "testvalue".getBytes();
+    Mockito.when(applicationLifecycleService.getState(Mockito.any())).thenReturn(Optional.of(value));
+    Optional<byte[]> state = remoteAppStateStore.getState("key1");
+    Assert.assertEquals(new String(value), new String(state.get()));
+  }
+
+  @Test
+  public void testGetInvalidNamespace() throws IOException {
+    expectedException.expectCause(CoreMatchers.isA(NotFoundException.class));
+    RemoteAppStateStore remoteAppStateStore = new RemoteAppStateStore(cConf, remoteClientFactory, "invalid", "app1");
+    remoteAppStateStore.getState("key1");
+  }
+
+  @Test
+  public void testGetInvalidApp() throws ApplicationNotFoundException, IOException {
+    expectedException.expectCause(CoreMatchers.isA(NotFoundException.class));
+    String testAppName = "app1";
+    RemoteAppStateStore remoteAppStateStore = new RemoteAppStateStore(cConf, remoteClientFactory, NAMESPACE,
+                                                                      testAppName);
+    String testKey = "key1";
+    AppStateKey appStateKey = new AppStateKey(new NamespaceId(NAMESPACE), testAppName, testKey);
+    Mockito.doThrow(new ApplicationNotFoundException(new ApplicationId(
+      NAMESPACE, testAppName))).when(applicationLifecycleService).getState(Mockito.refEq(appStateKey));
+    remoteAppStateStore.getState(testKey);
+  }
+
+  @Test
+  public void testGetInvalidKey() throws ApplicationNotFoundException, IOException {
+    String testAppName = "app2";
+    RemoteAppStateStore remoteAppStateStore = new RemoteAppStateStore(cConf, remoteClientFactory, NAMESPACE,
+                                                                      testAppName);
+    String testKey = "key1";
+    AppStateKey appStateKey = new AppStateKey(new NamespaceId(NAMESPACE), testAppName, testKey);
+    Mockito.when(applicationLifecycleService.getState(Mockito.refEq(appStateKey))).thenReturn(Optional.empty());
+    Optional<byte[]> state = remoteAppStateStore.getState(testKey);
+    Assert.assertEquals(Optional.empty(), state);
+  }
+
+  @Test
+  public void testGetFail() throws ApplicationNotFoundException, IOException {
+    expectedException.expectCause(CoreMatchers.isA(IOException.class));
+    String testAppName = "app3";
+    RemoteAppStateStore remoteAppStateStore = new RemoteAppStateStore(cConf, remoteClientFactory, NAMESPACE,
+                                                                      testAppName);
+    String testKey = "key1";
+    AppStateKey appStateKey = new AppStateKey(new NamespaceId(NAMESPACE), testAppName, testKey);
+    Mockito.doThrow(new RuntimeException("test")).when(applicationLifecycleService)
+      .getState(Mockito.refEq(appStateKey));
+    remoteAppStateStore.getState(testKey);
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/state/AppStateHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/state/AppStateHandlerTest.java
@@ -193,9 +193,10 @@ public class AppStateHandlerTest extends AppFabricTestBase {
 
   @Test
   public void testAppStateDoesNotExist() throws IOException {
-    // Get state that does not exist in table
+    // Get state that does not exist in table, but the app is valid
     HttpResponse response = executeHttpRequest(HttpMethod.GET, endpoint, null);
-    Assert.assertEquals(HttpResponseStatus.NOT_FOUND.code(), response.getResponseCode());
+    Assert.assertEquals(HttpResponseStatus.OK.code(), response.getResponseCode());
+    Assert.assertArrayEquals(new byte[]{}, response.getResponseBody());
   }
 
   private HttpResponse executeHttpRequest(HttpMethod method, String endpoint, String body)

--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingContext.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.etl.api.streaming;
 
 import io.cdap.cdap.api.Transactional;
 import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.api.app.AppStateStore;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.DatasetManagementException;
 import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
@@ -29,7 +30,7 @@ import org.apache.tephra.TransactionFailureException;
  * Context for streaming plugin stages.
  */
 @Beta
-public interface StreamingContext extends StageContext, Transactional {
+public interface StreamingContext extends StageContext, Transactional, AppStateStore {
 
   /**
    * @return Spark JavaStreamingContext for the pipeline.

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DefaultStreamingContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DefaultStreamingContext.java
@@ -36,8 +36,10 @@ import org.apache.tephra.TransactionFailureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Default implementation of StreamingContext for Spark.
@@ -124,5 +126,15 @@ public class DefaultStreamingContext extends AbstractStageContext implements Str
   public void record(List<FieldOperation> operations) {
     throw new UnsupportedOperationException("Field lineage recording is not supported. Please record lineage " +
                                               "in prepareRun() stage");
+  }
+
+  @Override
+  public Optional<byte[]> getState(String key) throws IOException {
+    return sec.getSparkExecutionContext().getState(key);
+  }
+
+  @Override
+  public void saveState(String key, byte[] value) throws IOException {
+    sec.getSparkExecutionContext().saveState(key, value);
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -247,6 +247,7 @@ public final class Constants {
     public static final String SPARK_EVENT_LOGS_DIR = "app.program.spark.event.logs.dir";
     public static final String SPARK_COMPAT = "app.program.spark.compat";
     public static final String RUNTIME_EXT_DIR = "app.program.runtime.extensions.dir";
+    public static final String APP_STATE = "app.state";
     public static final String PROGRAM_MAX_START_SECONDS = "app.program.max.start.seconds";
     public static final String TWILL_CONTROLLER_START_SECONDS = "program.twill.controller.start.seconds";
     public static final String PROGRAM_MAX_STOP_SECONDS = "app.program.max.stop.seconds";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4045,6 +4045,50 @@
     </description>
   </property>
 
+  <!-- Retry configuration for app state handling -->
+  <property>
+    <name>app.state.retry.policy.base.delay.ms</name>
+    <value>10</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>app.state.retry.policy.max.delay.ms</name>
+    <value>2000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <!-- Set to Integer max value, so the retry attempts end based on app.state.retry.policy.max.time.secs -->
+  <property>
+    <name>app.state.retry.policy.max.retries</name>
+    <value>2147483647</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <!-- Set to 60s to match the default http request timeout -->
+  <property>
+    <name>app.state.retry.policy.max.time.secs</name>
+    <value>60</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>app.state.retry.policy.type</name>
+    <value>exponential.backoff</value>
+    <description>
+      The type of retry policy for programs. Allowed options:
+      "none", "fixed.delay", or "exponential.backoff".
+    </description>
+  </property>
+
   <!-- Retry configuration for spark metrics retrieval -->
   <property>
     <name>spark.metrics.strategy.retry.policy.base.delay.ms</name>

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -52,6 +52,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractProgramRunnerWithPlugin;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.BasicProgramContext;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.internal.app.runtime.ProgramRunners;
@@ -112,6 +113,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final RemoteClientFactory remoteClientFactory;
   private final CommonNettyHttpServiceFactory commonNettyHttpServiceFactory;
+  private final AppStateStoreProvider appStateStoreProvider;
 
   @Inject
   SparkProgramRunner(CConfiguration cConf, Configuration hConf, LocationFactory locationFactory,
@@ -123,7 +125,8 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
                      PluginFinder pluginFinder, MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                      FieldLineageWriter fieldLineageWriter, NamespaceQueryAdmin namespaceQueryAdmin,
                      RemoteClientFactory remoteClientFactory,
-                     CommonNettyHttpServiceFactory commonNettyHttpServiceFactory) {
+                     CommonNettyHttpServiceFactory commonNettyHttpServiceFactory,
+                     AppStateStoreProvider appStateStoreProvider) {
     super(cConf);
     this.cConf = cConf;
     this.hConf = hConf;
@@ -144,6 +147,7 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.remoteClientFactory = remoteClientFactory;
     this.commonNettyHttpServiceFactory = commonNettyHttpServiceFactory;
+    this.appStateStoreProvider = appStateStoreProvider;
   }
 
   @Override
@@ -197,8 +201,8 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
                                                                    messagingService, serviceAnnouncer, pluginFinder,
                                                                    locationFactory, metadataReader, metadataPublisher,
                                                                    namespaceQueryAdmin, fieldLineageWriter,
-                                                                   remoteClientFactory, () -> { }
-      );
+                                                                   remoteClientFactory, () -> { },
+                                                                   appStateStoreProvider);
       closeables.addFirst(runtimeContext);
 
       Spark spark;

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContext.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContext.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractContext;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.plugin.PluginInstantiator;
 import io.cdap.cdap.internal.app.runtime.workflow.WorkflowProgramInfo;
@@ -91,11 +92,12 @@ public final class SparkRuntimeContext extends AbstractContext implements Metric
                       PluginFinder pluginFinder, LocationFactory locationFactory,
                       MetadataReader metadataReader, MetadataPublisher metadataPublisher,
                       NamespaceQueryAdmin namespaceQueryAdmin, FieldLineageWriter fieldLineageWriter,
-                      RemoteClientFactory remoteClientFactory, Closeable closeable) {
+                      RemoteClientFactory remoteClientFactory, Closeable closeable,
+                      AppStateStoreProvider appStateStoreProvider) {
     super(program, programOptions, cConf, getSparkSpecification(program).getDatasets(), datasetFramework, txClient,
           true, metricsCollectionService, createMetricsTags(workflowProgramInfo),
           secureStore, secureStoreManager, messagingService, pluginInstantiator, metadataReader, metadataPublisher,
-          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory);
+          namespaceQueryAdmin, fieldLineageWriter, remoteClientFactory, appStateStoreProvider);
     this.cConf = cConf;
     this.hConf = hConf;
     this.hostname = hostname;

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeContextProvider.java
@@ -52,6 +52,7 @@ import io.cdap.cdap.data.ProgramContextAware;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.writer.FieldLineageWriter;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
+import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
 import io.cdap.cdap.internal.app.runtime.BasicProgramContext;
 import io.cdap.cdap.internal.app.runtime.ProgramClassLoader;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
@@ -299,7 +300,8 @@ public final class SparkRuntimeContextProvider {
         injector.getInstance(NamespaceQueryAdmin.class),
         injector.getInstance(FieldLineageWriter.class),
         injector.getInstance(RemoteClientFactory.class),
-        closeable);
+        closeable,
+        injector.getInstance(AppStateStoreProvider.class));
       LoggingContextAccessor.setLoggingContext(sparkRuntimeContext.getLoggingContext());
       return sparkRuntimeContext;
     } catch (Exception e) {

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/AbstractSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/AbstractSparkExecutionContext.scala
@@ -68,11 +68,11 @@ import java.lang
 import java.net.URI
 import java.net.URL
 import java.util
+import java.util.Optional
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
-
 import scala.collection.JavaConversions._
 import scala.collection.mutable
 import scala.reflect.ClassTag
@@ -307,6 +307,14 @@ abstract class AbstractSparkExecutionContext(sparkClassLoader: SparkClassLoader,
 
   override def getMetadata(scope: MetadataScope, metadataEntity: MetadataEntity): Metadata = {
     return runtimeContext.getMetadata(scope, metadataEntity)
+  }
+
+  override def getState(key: String): Optional[Array[Byte]] = {
+    return runtimeContext.getState(key)
+  }
+
+  override def saveState(key: String, value: Array[Byte]): Unit = {
+    runtimeContext.saveState(key, value);
   }
 
   override def addProperties(metadataEntity: MetadataEntity, properties: util.Map[String, String]): Unit = {

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/SerializableSparkExecutionContext.scala
@@ -18,7 +18,6 @@ package io.cdap.cdap.app.runtime.spark
 
 import java.io.{Externalizable, ObjectInput, ObjectOutput}
 import java.{lang, util}
-
 import io.cdap.cdap.api.TxRunnable
 import io.cdap.cdap.api.data.batch.Split
 import io.cdap.cdap.api.lineage.field.Operation
@@ -30,6 +29,7 @@ import io.cdap.cdap.api.spark.dynamic.SparkInterpreter
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
+import java.util.Optional
 import scala.reflect.ClassTag
 
 /**
@@ -120,6 +120,14 @@ class SerializableSparkExecutionContext(val delegate: SparkExecutionContext) ext
 
   override def getMetadata(scope: MetadataScope, metadataEntity: MetadataEntity): Metadata = {
     return delegate.getMetadata(scope, metadataEntity);
+  }
+
+  override def getState(key: String): Optional[Array[Byte]] = {
+    return delegate.getState(key);
+  }
+
+  override def saveState(key: String, value: Array[Byte]): Unit = {
+    delegate.saveState(key, value);
   }
 
   override def addProperties(metadataEntity: MetadataEntity, properties: util.Map[String, String]) = {


### PR DESCRIPTION
- Introduced AppStateReader and AppStateWriter interface for state handling
- RemoteAppStateHandler implements the interfaces and interacts remotely with AppStateHandler
- AbstractContext implements the new interfaces to expose this to all runtime contexts. All implementations binds to RemoteAppStateHandler.
- SparkExecutionContext extends the new interfaces and uses SparkRuntimeContext to delegate the calls
- StreamingContext extends the new interfaces and delegates to SparkExecutionContext . Currently StageContext does not extend the new interfaces to limit the exposure to other plugins. 
