### PR TITLE
[CDAP-18966] Run kubeJobCleaner only in appfabric pod

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -397,7 +397,12 @@ public class KubeMasterEnvironment implements MasterEnvironment {
 
   @Override
   public Collection<MasterEnvironmentTask> getTasks() {
-    return Arrays.asList(podKillerTask, kubeJobCleaner);
+    Set<MasterEnvironmentTask> set = new HashSet<>(2);
+    set.add(kubeJobCleaner);
+    if (podKillerTask != null) {
+      set.add(podKillerTask);
+    }
+    return set;
   }
 
   @Override

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerServiceTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerServiceTest.java
@@ -81,7 +81,7 @@ public class KubeTwillRunnerServiceTest {
     ApiClientFactory apiClientFactory = new DefaultApiClientFactory(10, 300);
     twillRunnerService = new KubeTwillRunnerService(context, apiClientFactory,
                                                     KUBE_NAMESPACE, discoveryServiceClient, podInfo,
-                                                    "", Collections.emptyMap(), 1, 1,
+                                                    "", Collections.emptyMap(),
                                                     true, false,
                                                     null, null,
                                                     null, null);

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/MasterEnvironment.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/MasterEnvironment.java
@@ -24,8 +24,9 @@ import org.apache.twill.api.TwillRunnerService;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -53,11 +54,10 @@ public interface MasterEnvironment {
   }
 
   /**
-   * Returns a {@link Optional} {@link MasterEnvironmentTask} to be executed periodically.
-   * It is guaranteed that there is no concurrent call to the task returned.
+   * Returns a list of {@link MasterEnvironmentTask}s to be executed periodically.
    */
-  default Optional<MasterEnvironmentTask> getTask() {
-    return Optional.empty();
+  default Collection<MasterEnvironmentTask> getTasks() {
+    return Collections.emptySet();
   }
 
   /**

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/MasterEnvironmentTask.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/MasterEnvironmentTask.java
@@ -43,4 +43,12 @@ public interface MasterEnvironmentTask {
   default long failureRetryDelay(Throwable t) {
     return 5000L;
   }
+
+  /**
+   * Returns the name of the task.
+   * @return task name
+   */
+  default String getName() {
+    return getClass().getSimpleName();
+  }
 }

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -164,8 +164,8 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
       services.add(injector.getInstance(SystemWorkerServiceLauncher.class));
     }
 
-    // Optionally adds the master environment task
-    masterEnv.getTask().ifPresent(task -> services.add(new MasterTaskExecutorService(task, masterEnvContext)));
+    // Adds the master environment tasks
+    masterEnv.getTasks().forEach(task -> services.add(new MasterTaskExecutorService(task, masterEnvContext)));
   }
 
   @Nullable

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MasterTaskExecutorService.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MasterTaskExecutorService.java
@@ -47,7 +47,8 @@ final class MasterTaskExecutorService extends AbstractScheduledService {
 
   @Override
   protected ScheduledExecutorService executor() {
-    executor = Executors.newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory("master-env-executor"));
+    executor = Executors.newSingleThreadScheduledExecutor(Threads.createDaemonThreadFactory(
+      "master-env-task-" + task.getName()));
     return executor;
   }
 


### PR DESCRIPTION
Currently the kubeJobCleaner background thread runs in both AppFabric and Preview services where only 1 is required.

Testing Done:
1. Change cdapmasters CR with a. trace log level for io.cdap.cdap.k8s.runtime b. reduce cleanup interval with program.container.cleaner.interval.mins: 10
2. Run pipeline with runtime param system.runtime.cleanup.disabled=true in k8s native env.
3. observe the appFabric and preview pod logs and confirm cleanup is only running in appfabric.
4. verify the pipeline specific entities are cleaned up after jobcleaner executes.