### PR TITLE
[CDAP-19605] Collect logs from the twill AM container as part of program execution logs

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
@@ -53,6 +53,7 @@ import io.cdap.cdap.explore.client.ExploreClient;
 import io.cdap.cdap.explore.client.ProgramDiscoveryExploreClient;
 import io.cdap.cdap.internal.app.program.MessagingProgramStateWriter;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.internal.app.runtime.ProgramRunners;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.internal.app.runtime.monitor.RuntimeMonitors;
 import io.cdap.cdap.internal.app.runtime.workflow.MessagingWorkflowStateWriter;
@@ -144,9 +145,7 @@ public class DistributedProgramContainerModule extends AbstractModule {
 
   private List<Module> getCoreModules() {
     Arguments systemArgs = programOpts.getArguments();
-    ClusterMode clusterMode = systemArgs.hasOption(ProgramOptionConstants.CLUSTER_MODE)
-      ? ClusterMode.valueOf(systemArgs.getOption(ProgramOptionConstants.CLUSTER_MODE))
-      : ClusterMode.ON_PREMISE;
+    ClusterMode clusterMode = ProgramRunners.getClusterMode(programOpts);
 
     List<Module> modules = new ArrayList<>();
 


### PR DESCRIPTION
- Use the EventHander to initialize the CDAP specific log appender to send logs back to CDAP from AM

Highlight of the changes

1. Changing to use the DistributedProgramContainerModule to standardize the guice injection such that it is the same as any other processes we run in Dataproc / Hadoop.
2. Since the Twill library doesn't support file localization to the AM container, I workaround it by using the resources.jar, we have already been using it to localize cConf and hConf XML files to the AM.
3. Since ProgramOptions is a complex object, it is better to just Gson it to a file and deserialize it back from the EventHandler. This is the same mechanism as being used elsewhere in CDAP when running in distributed mode. The serialized file is localized using the resources.jar as mentioned above. Having the program options give us the benefit that most of the program execution related information is there (runId, clusterMode, logger settings... etc).
4. We also need to localize the logback.xml so that logger configuration is consistent with other containers. Again, we use the resources.jar to do so.
5. Since the logback.xml is inside the resources.jar directory, a normal logback library discovery process won't find it. So we have to use the logback.configurationFile property to point it to the correct file path in the AM container directory. However, we need to override it back for other containers (aka TwillRunnables), hence you can see in the code that the mentioned property has been set twice to a different value. 
6. The default logback.xml in CDAP, which is used by CDF as well, has a property CDAP_LOG_DIR that we need to set to the YARN <LOG_DIR> so that YARN can substitute it with the container log directory at run time. You can see in the change that I used the command property for that.

One last point: We duplicated the program option json, cConf, hConf, and logback.xml for the TwillRunnable container (one inside the resources.jar, one through normal file localization that lands them in the YARN container directory). We actually can change them to use the ones inside the resources.jar. However, the change would not be so small because the KubeTwillRunnerService implementation doesn't generate the resources.jar (because there is no AM). Since those files are small and to keep the changes minimal, I decided to just let it be.