### PR TITLE
[CDAP-19455] Classify dataproc cluster creation and job submission user errors, add links to dataproc troubleshooting docs

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -26,6 +26,7 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageBatch;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
@@ -71,6 +72,11 @@ public final class DataprocUtils {
   private static final SplittableRandom RANDOM = new SplittableRandom();
   private static final int SET_CUSTOM_TIME_MAX_RETRY = 6;
   private static final int SET_CUSTOM_TIME_MAX_SLEEP_MILLIS_BEFORE_RETRY = 20000;
+
+  public static final String TROUBLESHOOTING_DOCS_URL_KEY = "troubleshootingDocsURL";
+  // Empty url will ensure help messages don't appear by default in Dataproc error messages.
+  // This property needs to be overridden in cdap-site.
+  public static final String TROUBLESHOOTING_DOCS_URL_DEFAULT = "";
 
   /**
    * HTTP Status-Code 429: RESOURCE_EXHAUSTED.
@@ -391,6 +397,13 @@ public final class DataprocUtils {
         Thread.sleep(RANDOM.nextInt(SET_CUSTOM_TIME_MAX_SLEEP_MILLIS_BEFORE_RETRY));
       }
     }
+  }
+
+  public static String getTroubleshootingHelpMessage(@Nullable String troubleshootingDocsURL) {
+    if (Strings.isNullOrEmpty(troubleshootingDocsURL)) {
+      return "";
+    }
+    return String.format("For troubleshooting Dataproc errors, refer to %s", troubleshootingDocsURL);
   }
 
   private DataprocUtils() {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -197,7 +197,9 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
       return Optional.of(
         new DataprocRuntimeJobManager(new DataprocClusterInfo(context, clusterName, conf.getDataprocCredentials(),
                                                               getRootUrl(conf),
-                                                              projectId, region, bucket, systemLabels)));
+                                                              projectId, region, bucket, systemLabels),
+                                      Collections.unmodifiableMap(properties)
+        ));
     } catch (Exception e) {
       throw new RuntimeException("Error while getting credentials for dataproc. ", e);
     }
@@ -221,6 +223,7 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
       return true;
     }
     return ImmutableSet.of(DataprocConf.RUNTIME_JOB_MANAGER, BUCKET, DataprocConf.TOKEN_ENDPOINT_KEY,
+                           DataprocUtils.TROUBLESHOOTING_DOCS_URL_KEY,
                            DataprocConf.ENCRYPTION_KEY_NAME, DataprocConf.ROOT_URL,
                            DataprocConf.COMPUTE_HTTP_REQUEST_CONNECTION_TIMEOUT,
                            DataprocConf.COMPUTE_HTTP_REQUEST_READ_TIMEOUT).contains(property);

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -163,6 +163,11 @@ final class DataprocConf {
   private final int computeConnectionTimeout;
 
   private final boolean disableGCSCaching;
+  private  final String troubleshootingDocsUrl;
+
+  public String getTroubleshootingDocsUrl() {
+    return troubleshootingDocsUrl;
+  }
 
   private DataprocConf(@Nullable String accountKey, String region, String zone, String projectId,
                        @Nullable String networkHostProjectId, @Nullable String network, @Nullable String subnet,
@@ -184,7 +189,8 @@ final class DataprocConf {
                        boolean integrityMonitoringEnabled, boolean clusterReuseEnabled,
                        long clusterReuseThresholdMinutes, @Nullable String clusterReuseKey,
                        boolean enablePredefinedAutoScaling, int computeReadTimeout, int computeConnectionTimeout,
-                       @Nullable String rootUrl, boolean disableGCSCaching, boolean disableLocalCaching) {
+                       @Nullable String rootUrl, boolean disableGCSCaching, boolean disableLocalCaching,
+                       String troubleshootingDocsUrl) {
     this.accountKey = accountKey;
     this.region = region;
     this.zone = zone;
@@ -240,6 +246,7 @@ final class DataprocConf {
     this.rootUrl = rootUrl;
     this.disableGCSCaching = disableGCSCaching;
     this.disableLocalCaching = disableLocalCaching;
+    this.troubleshootingDocsUrl = troubleshootingDocsUrl;
   }
 
   String getRegion() {
@@ -691,6 +698,9 @@ final class DataprocConf {
 
     boolean disableGCSCaching = Boolean.parseBoolean(
       properties.getOrDefault(DISABLE_GCS_CACHING, "false"));
+    String troubleshootingDocsURL =
+      properties.getOrDefault(DataprocUtils.TROUBLESHOOTING_DOCS_URL_KEY,
+                              DataprocUtils.TROUBLESHOOTING_DOCS_URL_DEFAULT);
 
     return new DataprocConf(accountKey, region, zone, projectId, networkHostProjectID, network, subnet,
                             masterNumNodes, masterCPUs, masterMemoryGB, masterDiskGB,
@@ -706,7 +716,7 @@ final class DataprocConf {
                             tokenEndpoint, secureBootEnabled, vTpmEnabled, integrityMonitoringEnabled,
                             clusterReuseEnabled, clusterReuseThresholdMinutes, clusterReuseKey,
                             enablePredefinedAutoScaling, computeReadTimeout, computeConnectionTimeout, rootUrl,
-                            disableGCSCaching, disableLocalCaching);
+                            disableGCSCaching, disableLocalCaching, troubleshootingDocsURL);
   }
 
   // the UI never sends nulls, it only sends empty strings.


### PR DESCRIPTION
[CDAP-19455](https://cdap.atlassian.net/browse/CDAP-19455)

Add user tags to invalid argument exceptions returned during Dataproc cluster creation.  
Add links to Dataproc troubleshooting docs to aid users in debugging failures.

**Screenshots**
Logs when cluster creation fails due to invalid argument exception
<img width="2046" alt="Screenshot 2022-09-29 at 4 37 56 PM" src="https://user-images.githubusercontent.com/46515553/193040951-10900110-078b-4206-9d75-77a22595c539.png">

Logs when job rejected by Dataproc's flow control
<img width="2044" alt="Screenshot 2022-09-29 at 5 42 28 PM" src="https://user-images.githubusercontent.com/46515553/193041219-3fa15e0f-608f-4ec3-a44a-50a3d16fd65c.png">
