### PR TITLE
CDAP-19630: Inconsistency between bucket property keys used for overriding gcsBucket

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -57,7 +57,9 @@ import javax.annotation.Nullable;
  * This class contains common methods that are needed by DataprocProvisioner and DataprocRuntimeJobManager.
  */
 public final class DataprocUtils {
-
+  // The property name for the GCS bucket used by the runtime job manager for launching jobs via the job API
+  // It can be overridden by profile runtime arguments (system.profile.properties.bucket)
+  public static final String BUCKET = "bucket";
   public static final String CDAP_GCS_ROOT = "cdap-job";
   public static final String CDAP_CACHED_ARTIFACTS = "cached-artifacts";
   public static final String WORKER_CPU_PREFIX = "Up to";


### PR DESCRIPTION
**_CDAP-19630: Inconsistency between bucket property keys used for overriding gcsBucket_**
**Description:**
GCS bucket key that is used for setting and getting gcs bucket are different:

https://github.com/cdapio/cdap/blob/43ed7b5460c294d145cf38da668603a33be8645b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java#L629

https://github.com/cdapio/cdap/blob/43ed7b5460c294d145cf38da668603a33be8645b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java#L62

In one place we use gcsBucket and in another place we use bucket

So if gcsBucket key is used for setting gcs bucket in compute profile as follows:

      {
      "name": "gcsBucket",
      "value": "test-bucket",
      "isEditable": true
      },
test-bucket bucket will still not be used for uploading artifacts into it.


**Workaround:**
both keys should be used as follows:

      {
      "name": "gcsBucket",
      "value": "test-bucket",
      "isEditable": true
      },
      {
      "name": "bucket",
      "value": "test-bucket",
      "isEditable": true
      },

**Solution:**
If gcsBucket property is null, then the default value will be used and if it's not null, then the String specified in the gcsBucket property will be used.

**Testing:**
The change was tested thoroughly and the artifacts were getting uploaded to the specified bucket if gcsBucket property wasn't empty or else to the default bucket. And the runId folder was also getting deleted once the pipeline run completed.