### PR TITLE
CDAP-19563 | Add warning message as untested usage for more than one source to discourage users

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -98,6 +98,11 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
       }
     }
 
+    // Add warning message to discourage users from using multiple streaming sources.
+    if (numSources > 1) {
+      LOG.warn("Using multiple streaming sources in a pipeline is not recommended.");
+    }
+
     SparkConf sparkConf = new SparkConf();
     // we do not do checkpointing during preview. Skip enabling write-ahead logs in that case to avoid spark exception
     if (!spec.isPreviewEnabled(context) && spec.getStateSpec()


### PR DESCRIPTION
JIRA: https://cdap.atlassian.net/browse/CDAP-19563

Test warning message: 
2022-09-29 11:14:49,639 - WARN  [SparkRunner-DataStreamsSparkStreaming:i.c.c.d.DataStreamsSparkLauncher@103] - Using multiple streaming sources in a pipeline is not recommended.