### PR TITLE
Window aggregation Bigquery Pushdown  CDAP 

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/DeduplicateAggregationDefinition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/DeduplicateAggregationDefinition.java
@@ -47,9 +47,17 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
   }
 
   /**
+   * @return A builder to create a DeduplicateAggregationDefinition.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
    * Get the list of expressions using which a single record will be selected from a group of records for deduplication.
    * Each entry in the list is defined as a pair of an {@link Expression} and {@link FilterFunction}, specifying
    * the function to be executed on the expression.
+   *
    * @return A {@link List} of {@link FilterExpression} objects, each of which is a pair of an {@link Expression}
    * and a {@link FilterFunction}.
    */
@@ -77,7 +85,8 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
 
     /**
      * Creates a new {@link FilterExpression} using the specified {@link Expression} and {@link FilterFunction}.
-     * @param expression the expression using which filtering of duplicate records is to be performed
+     *
+     * @param expression     the expression using which filtering of duplicate records is to be performed
      * @param filterFunction the function to be applied on the duplicate records to select a single record
      */
     public FilterExpression(Expression expression, FilterFunction filterFunction) {
@@ -86,7 +95,6 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
     }
 
     /**
-     *
      * @return the expression used for filtering duplicate records
      */
     public Expression getExpression() {
@@ -94,7 +102,6 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
     }
 
     /**
-     *
      * @return the function applied to select a single record from duplicate records
      */
     public FilterFunction getFilterFunction() {
@@ -120,21 +127,14 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
   }
 
   /**
-   * @return A builder to create a DeduplicateAggregationDefinition.
-   */
-  public static Builder builder() {
-    return new Builder();
-  }
-
-  /**
    * Builds a DeduplicateAggregationDefinition using fields to dedup on, fields to select,
    * and fields to use to filter the first record to be output when removing duplicates.
    * The fields to dedup on and the fields to select must be specified.
    */
   public static class Builder {
+    List<FilterExpression> filterExpressions;
     private List<Expression> groupByExpressions;
     private Map<String, Expression> selectExpressions;
-    List<FilterExpression> filterExpressions;
 
     public Builder() {
       groupByExpressions = Collections.emptyList();
@@ -146,6 +146,7 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
      * Sets the list of expressions to use to group records together with the same value so that
      * only one record from the group is extracted.
      * Any existing dedup expression list is overwritten.
+     *
      * @param dedupExpressions list of {@link Expression}s to deduplicate on.
      * @return a {@link Builder} with the currently built {@link DeduplicateAggregationDefinition}.
      */
@@ -158,6 +159,7 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
      * Sets the expressions to use to group records together with the same value so that
      * only one record from the group is extracted.
      * Any existing dedup expression list is overwritten.
+     *
      * @param dedupExpressions {@link Expression}s to deduplicate on.
      * @return a {@link Builder} with the currently built {@link DeduplicateAggregationDefinition}.
      */
@@ -168,6 +170,7 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
     /**
      * Sets the list of expressions to select to the specified list of expressions.
      * Any existing list of select expressions is overwritten.
+     *
      * @param selectExpressions list of {@link Expression}s to select.
      * @return a {@link Builder} with the currently built {@link DeduplicateAggregationDefinition}.
      */
@@ -179,7 +182,8 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
     /**
      * Sets the list of expressions to select to the specified expressions.
      * Any existing list of select expressions is overwritten.
-     * @param key the key to use for this expression
+     *
+     * @param key        the key to use for this expression
      * @param expression expression to use
      * @return a {@link Builder} with the currently built {@link DeduplicateAggregationDefinition}.
      */
@@ -192,8 +196,9 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
      * Adds the specified expression with the specified filter function to the list of filter expressions.
      * This function is applied on this expression for all the records for which the values of the dedup expressions
      * specified in <code>dedupOn</code> is the same, and the resultant row is extracted by the dedup operation.
+     *
      * @param filterExpression an {@link Expression} on which the filter function will be applied.
-     * @param filterFunction a {@link FilterFunction} to be applied to the filter expression.
+     * @param filterFunction   a {@link FilterFunction} to be applied to the filter expression.
      * @return a {@link Builder} with the currently built {@link DeduplicateAggregationDefinition}.
      */
     public Builder filterDuplicatesBy(Expression filterExpression, FilterFunction filterFunction) {
@@ -206,6 +211,7 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
      * The filter function is applied to the respective filter expression for all the records for which the values
      * of the dedup expressions specified in <code>dedupOn</code> is the same, and the resultant row is extracted
      * by the dedup operation.
+     *
      * @param filterExpressions a {@link List} of {@link FilterExpression}.
      * @return a {@link Builder} with the currently built {@link DeduplicateAggregationDefinition}.
      */
@@ -216,6 +222,7 @@ public class DeduplicateAggregationDefinition extends AggregationDefinition {
 
     /**
      * Builds a DeduplicateAggregationDefinition.
+     *
      * @return The DeduplicateAggregationDefinition object.
      * @throws IllegalStateException in case if any of the required fields aren't specified.
      */

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/WindowAggregationDefinition.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/aggregation/WindowAggregationDefinition.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.aggregation;
+
+import io.cdap.cdap.etl.api.relational.Expression;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Specifies how a window aggregation operation should be executed.
+ */
+public class WindowAggregationDefinition {
+  private List<Expression> partitionExpressions;
+  private Map<String, Expression> selectExpressions;
+  private List<OrderByExpression> orderByExpressions;
+  private WindowFrameType windowFrameType;
+
+  private WindowAggregationDefinition(Map<String, Expression> selectExpressions,
+                                      List<Expression> partitionExpressions,
+                                      List<OrderByExpression> orderByExpressions,
+                                      WindowFrameType windowFrameType) {
+    this.selectExpressions = selectExpressions;
+    this.partitionExpressions = partitionExpressions;
+    this.orderByExpressions = orderByExpressions;
+    this.windowFrameType = windowFrameType;
+  }
+
+  /**
+   * @return A builder to create a WindowAggregationDefinition.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * @return select expressions of WindowAggregationDefinition.
+   */
+  public Map<String, Expression> getSelectExpressions() {
+    return selectExpressions;
+  }
+
+  /**
+   * @return window frame type value of WindowAggregationDefinition.
+   */
+  public WindowFrameType getWindowFrameType() {
+    return windowFrameType;
+  }
+
+  /**
+   * @return order by expressions of WindowAggregationDefinition.
+   */
+  public List<OrderByExpression> getOrderByExpressions() {
+    return orderByExpressions;
+  }
+
+  /**
+   * @return partition expressions of WindowAggregationDefinition.
+   */
+  public List<Expression> getPartitionExpressions() {
+    return partitionExpressions;
+  }
+
+  /**
+   * An enumeration that specifies the type of windowFrame
+   */
+  public enum WindowFrameType {
+    ROW,
+    RANGE,
+    NONE
+  }
+
+  /**
+   * An enumeration that specifies the type of order by
+   */
+  public enum OrderBy {
+    ASCENDING,
+    DESCENDING
+  }
+
+  /**
+   * A class to combine an {@link Expression} and a {@link OrderBy} into a single object.
+   */
+  public static class OrderByExpression {
+    private final Expression expression;
+    private final OrderBy orderBy;
+
+    /**
+     * Creates a new {@link OrderByExpression} using the specified {@link Expression} and {@link orderBy}.
+     *
+     * @param expression the expression using which ordering of records is to be performed
+     * @param orderBy    the function to be applied on the records to choose order
+     */
+    public OrderByExpression(Expression expression, OrderBy orderBy) {
+      this.expression = expression;
+      this.orderBy = orderBy;
+    }
+
+    /**
+     * @return the expression used for ordering records
+     */
+    public Expression getExpression() {
+      return expression;
+    }
+
+    /**
+     * @return the function applied to order ascending or descending records
+     */
+    public OrderBy getOrderBy() {
+      return orderBy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      OrderByExpression that = (OrderByExpression) o;
+      return Objects.equals(getExpression(), that.getExpression()) && getOrderBy() == that.getOrderBy();
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getExpression(), getOrderBy());
+    }
+  }
+
+  /**
+   * Builds a WindowAggregationDefinition using fields to partition  and fields to select.
+   * The fields to select must be specified.
+   */
+  public static class Builder {
+    private List<Expression> partitionExpressions;
+    private Map<String, Expression> selectExpressions;
+    private List<OrderByExpression> orderByExpressions;
+    private WindowFrameType windowFrameType;
+
+    private Builder() {
+      partitionExpressions = new ArrayList();
+      selectExpressions = new HashMap();
+      orderByExpressions = new ArrayList();
+      windowFrameType = WindowFrameType.NONE;
+    }
+
+    /**
+     * Sets the list of expressions to perform partition to the specified list.
+     *
+     * @param partitionExpressions list of {@link Expression}s.
+     * @return a {@link Builder} with the currently built {@link WindowAggregationDefinition}.
+     */
+    public Builder partition(List<Expression> partitionExpressions) {
+      this.partitionExpressions = partitionExpressions;
+      return this;
+    }
+
+    /**
+     * Sets the list of expressions to perform order by to the specified list.
+     *
+     * @param orderByExpressions list of {@link Expression}s.
+     * @return a {@link Builder} with the currently built {@link WindowAggregationDefinition}.
+     */
+    public Builder orderBy(List<OrderByExpression> orderByExpressions) {
+      this.orderByExpressions = orderByExpressions;
+      return this;
+    }
+
+    /**
+     * Sets the list of expressions to perform partition to the specified expressions.
+     * Any existing partition expression list is overwritten.
+     *
+     * @param partitionExpressions {@link Expression}s.
+     * @return a {@link Builder} with the currently built {@link WindowAggregationDefinition}.
+     */
+    public Builder partition(Expression... partitionExpressions) {
+      return partition(Arrays.asList(partitionExpressions));
+    }
+
+    /**
+     * Any window frame type value is overwritten.
+     *
+     * @return a {@link Builder} with the currently built {@link WindowAggregationDefinition}.
+     */
+    public Builder windowFrameType(WindowFrameType windowFrameType) {
+      this.windowFrameType = windowFrameType;
+      return this;
+    }
+
+    /**
+     * Sets the list of expressions to perform order by to the specified expressions.
+     * Any existing order by expression list is overwritten.
+     * @return a {@link Builder} with the currently built {@link WindowAggregationDefinition}.
+     */
+    public Builder orderBy(Expression expression, OrderBy orderBy) {
+      this.orderByExpressions.add(new OrderByExpression(expression, orderBy));
+      return this;
+    }
+
+    /**
+     * Sets the list of expressions to select to the specified expressions.
+     * Any existing list of select expressions is overwritten.
+     *
+     * @param selectExpressions to use
+     * @return a {@link Builder} with the currently built {@link WindowAggregationDefinition}.
+     */
+    public Builder select(Map<String, Expression> selectExpressions) {
+      this.selectExpressions = selectExpressions;
+      return this;
+    }
+
+    /**
+     * Builds a WindowAggregationDefinition.
+     *
+     * @return A WindowAggregationDefinition object.
+     * @throws IllegalStateException in case the fields to select are not specified.
+     */
+    public WindowAggregationDefinition build() {
+      if (selectExpressions.isEmpty()) {
+        throw new IllegalStateException("Can't build a WindowAggregationDefinition without select fields");
+      } else if (partitionExpressions.isEmpty()) {
+        throw new IllegalStateException("Can't build a WindowAggregationDefinition without fields to partition");
+      }
+      return new WindowAggregationDefinition(selectExpressions, partitionExpressions, orderByExpressions,
+                                             windowFrameType);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/InvalidRelation.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/InvalidRelation.java
@@ -22,6 +22,7 @@ package io.cdap.cdap.etl.api.relational;
 
 import io.cdap.cdap.etl.api.aggregation.DeduplicateAggregationDefinition;
 import io.cdap.cdap.etl.api.aggregation.GroupByAggregationDefinition;
+import io.cdap.cdap.etl.api.aggregation.WindowAggregationDefinition;
 
 import java.util.Map;
 
@@ -69,6 +70,11 @@ public class InvalidRelation implements Relation {
 
     @Override
     public Relation deduplicate(DeduplicateAggregationDefinition aggregationDefinition) {
+        return this;
+    }
+
+    @Override
+    public Relation window(WindowAggregationDefinition aggregationDefinition) {
         return this;
     }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/Relation.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/Relation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2021-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,7 @@ package io.cdap.cdap.etl.api.relational;
 
 import io.cdap.cdap.etl.api.aggregation.DeduplicateAggregationDefinition;
 import io.cdap.cdap.etl.api.aggregation.GroupByAggregationDefinition;
+import io.cdap.cdap.etl.api.aggregation.WindowAggregationDefinition;
 
 import java.util.Map;
 
@@ -72,7 +73,6 @@ public interface Relation {
    * @return a new relation with same set of columns, but only rows where filter value is true
    */
   Relation filter(Expression filter);
-
   /**
    * Allows to perform a group by based on an aggregation definition.
    * @param aggregationDefinition specifies the details for the group by operation.
@@ -81,7 +81,14 @@ public interface Relation {
   default Relation groupBy(GroupByAggregationDefinition aggregationDefinition) {
     return new InvalidRelation("GroupBy is unsupported");
   }
-
+  /**
+   * Allows to perform a window operation based on an aggregation definition.
+   * @param aggregationDefinition specifies the details for the window aggregation operation.
+   * @return a new relation after the window operation is performed.
+   */
+  default Relation window(WindowAggregationDefinition aggregationDefinition) {
+    return new InvalidRelation("WindowAggregation is unsupported");
+  }
   /**
    * Allows to perform a deduplicate operation based on an aggregation definition.
    * @param aggregationDefinition specifies the details for the deduplicate operation.

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/aggregation/WindowAggregationDefinitionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/test/java/io/cdap/cdap/etl/api/aggregation/WindowAggregationDefinitionTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.aggregation;
+
+import io.cdap.cdap.etl.api.relational.Capability;
+import io.cdap.cdap.etl.api.relational.Expression;
+import io.cdap.cdap.etl.api.relational.ExpressionFactory;
+import io.cdap.cdap.etl.api.relational.ExpressionFactoryType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tests for {@link WindowAggregationDefinition} and related builders.
+ */
+public class WindowAggregationDefinitionTest {
+
+  @Test
+  public void testDefinitionBuild() {
+    List<Expression> partitionExpressions = new ArrayList<>();
+    List<WindowAggregationDefinition.OrderByExpression> orderByExpressions = new ArrayList<>();
+    Map<String, Expression> selectExpressions = new HashMap<>();
+    WindowAggregationDefinition.WindowFrameType windowFrameType = WindowAggregationDefinition.WindowFrameType.ROW;
+    ExpressionFactory<String> factory = new ExpressionFactory<String>() {
+      @Override
+      public ExpressionFactoryType<String> getType() {
+        return null;
+      }
+
+      @Override
+      public Set<Capability> getCapabilities() {
+        return null;
+      }
+
+      @Override
+      public Expression compile(String expression) {
+        return new Expression() {
+          @Override
+          public boolean isValid() {
+            return true;
+          }
+
+          @Override
+          public String getValidationError() {
+            return null;
+          }
+        };
+      }
+    };
+    Expression ageExpression = factory.compile("age");
+
+    partitionExpressions.add(factory.compile("firstName"));
+    partitionExpressions.add(factory.compile("managerId"));
+    selectExpressions.put("employeeId", factory.compile("employeeId"));
+    selectExpressions.put("firstName", factory.compile("firstName"));
+    selectExpressions.put("lastName", factory.compile("lastName"));
+    orderByExpressions.add(new WindowAggregationDefinition.OrderByExpression(factory.compile("age"),
+      WindowAggregationDefinition.OrderBy.ASCENDING));
+    WindowAggregationDefinition definition = WindowAggregationDefinition.builder()
+      .partition(partitionExpressions)
+      .select(selectExpressions)
+      .orderBy(orderByExpressions)
+      .windowFrameType(windowFrameType)
+      .build();
+
+    Assert.assertEquals(partitionExpressions, definition.getPartitionExpressions());
+    Assert.assertEquals(selectExpressions, definition.getSelectExpressions());
+    Assert.assertEquals(orderByExpressions, definition.getOrderByExpressions());
+    Assert.assertEquals(windowFrameType, definition.getWindowFrameType());
+
+    try {
+      WindowAggregationDefinition invalidDefinition = WindowAggregationDefinition.builder()
+        .partition(partitionExpressions)
+        .orderBy(orderByExpressions)
+        .windowFrameType(windowFrameType)
+        .build();
+      Assert.fail("Expected IllegalStateException");
+    } catch (IllegalStateException ignored) {
+      // expected
+    }
+
+    try {
+      WindowAggregationDefinition invalidSelectDefinition = WindowAggregationDefinition.builder()
+        .select(selectExpressions)
+        .build();
+      Assert.fail("Expected IllegalStateException");
+    } catch (IllegalStateException ignored) {
+      // expected
+    }
+  }
+}

--- a/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
+++ b/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -33,7 +33,8 @@ public enum Feature {
   PUSHDOWN_TRANSFORMATION_DEDUPLICATE("6.7.0"),
   STREAMING_PIPELINE_CHECKPOINT_DELETION("6.7.1"),
   LIFECYCLE_MANAGEMENT_EDIT("6.8.0"),
-  STREAMING_PIPELINE_NATIVE_STATE_TRACKING("6.8.0", false);
+  STREAMING_PIPELINE_NATIVE_STATE_TRACKING("6.8.0", false),
+  PUSHDOWN_TRANSFORMATION_WINDOWAGGREGATION("6.9.0");
 
   private final PlatformInfo.Version versionIntroduced;
   private final boolean defaultAfterIntroduction;
@@ -82,3 +83,4 @@ public enum Feature {
   }
 
 }
+


### PR DESCRIPTION
As per https://cdap.atlassian.net/browse/CDAP-19628, BQ pushdown has to be implemented for Window-aggregation to reduce the pipeline startup time by perfoming SQL operations in Bigquery instead of Spark.This PR has the Window Aggregation Definition in CDAP platform.After merge of WindowsAggregationDefinition,PRs from Google-cloud and Window-aggregation repo changes will be sent