### PR TITLE
[CDAP-19145] Copy per-run configmaps from cConf, hConf

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -38,7 +38,6 @@ import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.RbacAuthorizationV1Api;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBinding;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBindingBuilder;
-import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobStatus;
@@ -126,7 +125,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
   private static final String CDAP_NAMESPACE_LABEL = "cdap.namespace";
   private static final String NAMESPACE_CPU_LIMIT_PROPERTY = "k8s.namespace.cpu.limits";
   private static final String NAMESPACE_MEMORY_LIMIT_PROPERTY = "k8s.namespace.memory.limits";
-  private static final String RUN_ID_LABEL = "cdap.twill.run.id";
+  static final String RUN_ID_LABEL = "cdap.twill.run.id";
   private static final String RUNNER_LABEL = "cdap.twill.runner";
   private static final String RUNNER_LABEL_VAL = "k8s";
   private static final String WORKLOAD_LAUNCHER_NAMESPACE_ROLE_BINDING_NAME
@@ -316,7 +315,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
     KubeUtil.validateRFC1123LabelName(namespace);
     findOrCreateKubeNamespace(namespace, cdapNamespace);
     updateOrCreateResourceQuota(namespace, cdapNamespace, properties);
-    copyVolumes(namespace, cdapNamespace);
+    copySecretVolumes(namespace, cdapNamespace);
     createWorkloadServiceAccount(namespace, cdapNamespace);
     if (workloadIdentityEnabled) {
       String workloadIdentityServiceAccountEmail = properties.get(WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY);
@@ -446,31 +445,12 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
   }
 
   /**
-   * Copy volumes into the new namespace for deployments created via the KubeTwillRunnerService
+   * Copy secret volumes into the new namespace for deployments created via the KubeTwillRunnerService
    * TODO: (CDAP-18956) improve this logic to be for each pipeline run
    */
-  private void copyVolumes(String namespace, String cdapNamespace) throws IOException {
+  private void copySecretVolumes(String namespace, String cdapNamespace) throws IOException {
     try {
       for (V1Volume volume : podInfo.getVolumes()) {
-        if (volume.getConfigMap() != null) {
-          String configMapName = volume.getConfigMap().getName();
-          V1ConfigMap existingMap = coreV1Api.readNamespacedConfigMap(configMapName, podInfo.getNamespace(),
-                                                                      null, null, null);
-          V1ConfigMap configMap = new V1ConfigMap().data(existingMap.getData())
-            .metadata(new V1ObjectMeta().name(configMapName).putLabelsItem(CDAP_NAMESPACE_LABEL,
-                                                                           cdapNamespace));
-          try {
-            coreV1Api.createNamespacedConfigMap(namespace, configMap, null, null, null);
-          } catch (ApiException e) {
-            if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
-              throw e;
-            }
-            LOG.warn("The configmap already exists '{}:{}' : {}. Ignoring creation of the configmap.", namespace,
-                     configMapName, e.getResponseBody());
-          }
-          LOG.debug("Created configMap {} in Kubernetes namespace {}", configMapName, namespace);
-        }
-
         if (volume.getSecret() != null) {
           String secretName = volume.getSecret().getSecretName();
           V1Secret existingSecret = coreV1Api.readNamespacedSecret(secretName, podInfo.getNamespace(),
@@ -732,6 +712,9 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
             controller.setJobStatus(((V1Job) resource).getStatus());
             // terminate the job controller
             controller.terminate();
+
+            // delete per-run configmaps
+            deleteConfigMaps((V1Job) resource, runId);
           }
         } else {
           if (isAllReplicasReady(resource)) {
@@ -763,6 +746,10 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
             // This will never happen
           }
           controller.terminate();
+          if (resourceType.equals(V1Job.class)) {
+            // delete per-run configmaps
+            deleteConfigMaps((V1Job) resource, runId);
+          }
         }
       }
     });
@@ -797,6 +784,18 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
     }, Threads.SAME_THREAD_EXECUTOR);
 
     return controller;
+  }
+
+  private void deleteConfigMaps(V1Job job, String runId) {
+    try {
+      LOG.info("Deleting configmaps for runId {} in namespace {}", runId, job.getMetadata().getNamespace());
+      coreV1Api.deleteCollectionNamespacedConfigMap(job.getMetadata().getNamespace(), null, null, null,
+                                                    null, null, RUN_ID_LABEL + "=" + runId, null, null,
+                                                    null, null, null, null, null);
+    } catch (ApiException e) {
+      LOG.warn("Failed to delete configmaps for job {}, runId {}, error: code {},body: {}",
+               job.getMetadata().getName(), runId, e.getCode(), e.getResponseBody());
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

On every pipeline run, create run specific cConf and hConf config maps in the execution namespace that are copied from cConf and hConf configmaps in the namespace where CDAP is installed. These configmaps are deleted when the k8s job completes.

As part of this change, logic to copy cConf, hConf configmaps on namespace creation has been removed as we now create configmaps for every pipeline run.

## Why do we need this?

When config is changed in the CDAP CR (e.g: spark images used for driver and executor), it gets updated in cConf in the CDAP install namespace by the operator. However, cConf configmap in other namespaces are not updated, resulting in config gettting out of sync across namespaces.

## Notes

1. Secrets are still copied on namespace creation. Creating `cdap-security` secret per run can be done in a subsequent PR if needed.
2. In this PR, we are deleting configmaps using a label selector. This requires the following  permissions need to be added to the `cdap-master-workload-launcher` role:
```
- apiGroups:
  - ""
  resources:
  - configmaps
  verbs:
  - create
  - deletecollection
```
