### PR TITLE
CDAP-19543 make schedule versionless and schedules carryover

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/store/ProgramScheduleStoreDataset.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/store/ProgramScheduleStoreDataset.java
@@ -463,7 +463,7 @@ public class ProgramScheduleStoreDataset {
    */
   public List<ProgramScheduleRecord> listScheduleRecords(ProgramId programId) throws IOException {
     return listSchedulesRecordsWithPrefix(getScheduleKeysForApplicationScan(programId.getParent()),
-                                          schedule -> programId.equals(schedule.getProgramId()));
+                                          schedule -> programId.isSameProgramExceptVersion(schedule.getProgramId()));
   }
 
   /**
@@ -688,7 +688,7 @@ public class ProgramScheduleStoreDataset {
     List<Field<?>> keys = new ArrayList<>();
     keys.add(Fields.stringField(StoreDefinition.ProgramScheduleStore.NAMESPACE_FIELD, appId.getNamespace()));
     keys.add(Fields.stringField(StoreDefinition.ProgramScheduleStore.APPLICATION_FIELD, appId.getApplication()));
-    keys.add(Fields.stringField(StoreDefinition.ProgramScheduleStore.VERSION_FIELD, appId.getVersion()));
+    keys.add(Fields.stringField(StoreDefinition.ProgramScheduleStore.VERSION_FIELD, ApplicationId.DEFAULT_VERSION));
     return keys;
   }
 

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/ScheduleDetail.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/ScheduleDetail.java
@@ -36,7 +36,7 @@ public class ScheduleDetail {
 
   private final String namespace;
   private final String application;
-  private final String applicationVersion;
+  private final transient String applicationVersion;
   private final String name;
   private final String description;
   private final ScheduleProgramInfo program;

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ProgramId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ProgramId.java
@@ -118,6 +118,17 @@ public class ProgramId extends NamespacedEntityId implements ParentedId<Applicat
       Objects.equals(program, programId.program);
   }
 
+  /**
+   * Check whether two programs are the same except version
+   */
+  public boolean isSameProgramExceptVersion(Object o) {
+    ProgramId programId = (ProgramId) o;
+    return Objects.equals(namespace, programId.namespace) &&
+      Objects.equals(application, programId.application) &&
+      Objects.equals(type, programId.type) &&
+      Objects.equals(program, programId.program);
+  }
+
   @Override
   public int hashCode() {
     Integer hashCode = this.hashCode;

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ScheduleId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ScheduleId.java
@@ -56,7 +56,7 @@ public class ScheduleId extends NamespacedEntityId implements ParentedId<Applica
       throw new NullPointerException("Schedule id cannot be null.");
     }
     this.application = application;
-    this.version = appId.getVersion();
+    this.version = ApplicationId.DEFAULT_VERSION;
     this.schedule = schedule;
   }
 


### PR DESCRIPTION
[JIRA - CDAP-19543](https://cdap.atlassian.net/browse/CDAP-19543)
This PR is to make schedule versionless by setting version in scheduleId to "-SNAPSHOT" regardless the version in appId. 
When a schedule gets triggered, scheduleTaskRunner will execute the latest version of a program (Either the program marked as latest=true or the last created one).
The version in ScheduleDetails is made transient so that it will not show up in json response and confuse users. 

Some of the unit tests needs to be rewritten since now schedule behaves differently. 