### PR TITLE
changing creationTimeMillis datatype

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -1965,12 +1965,18 @@ public class AppMetadataStore {
   private ApplicationMeta decodeRow(StructuredRow row) {
     String author = row.getString(StoreDefinition.AppMetadataStore.AUTHOR_FIELD);
     String changeSummary = row.getString(StoreDefinition.AppMetadataStore.CHANGE_SUMMARY_FIELD);
-    long creationTimeMillis = row.getLong(StoreDefinition.AppMetadataStore.CREATION_TIME_FIELD);
+    Long creationTimeMillis = row.getLong(StoreDefinition.AppMetadataStore.CREATION_TIME_FIELD);
     ApplicationMeta meta = GSON.fromJson(row.getString(StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD),
                                          ApplicationMeta.class);
     ApplicationSpecification spec = meta.getSpec();
     String id = meta.getId();
-    return new ApplicationMeta(id, spec, new ChangeDetail(changeSummary, null, author, creationTimeMillis));
+    ChangeDetail changeDetail;
+    if (creationTimeMillis == null) {
+      changeDetail = null;
+    } else {
+      changeDetail = new ChangeDetail(changeSummary, null, author, creationTimeMillis);
+    }
+    return new ApplicationMeta(id, spec, changeDetail);
   }
 
   private void writeToStructuredTableWithPrimaryKeys(

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/ApplicationMeta.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/ApplicationMeta.java
@@ -21,6 +21,8 @@ import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.proto.artifact.ChangeDetail;
 
+import javax.annotation.Nullable;
+
 /**
  * Holds application metadata
  */
@@ -29,9 +31,10 @@ public class ApplicationMeta {
 
   private final String id;
   private final ApplicationSpecification spec;
+  @Nullable
   private final ChangeDetail change;
 
-  public ApplicationMeta(String id, ApplicationSpecification spec, ChangeDetail change) {
+  public ApplicationMeta(String id, ApplicationSpecification spec, @Nullable ChangeDetail change) {
     this.id = id;
     this.spec = spec;
     this.change = change;
@@ -45,6 +48,7 @@ public class ApplicationMeta {
     return spec;
   }
 
+  @Nullable
   public ChangeDetail getChange() {
     return change;
   }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/ApplicationDetail.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/ApplicationDetail.java
@@ -36,6 +36,7 @@ public class ApplicationDetail {
   private final String name;
   private final String appVersion;
   private final String description;
+  @Nullable
   private final ChangeDetail change;
   private final String configuration;
   private final List<DatasetDetail> datasets;
@@ -94,6 +95,7 @@ public class ApplicationDetail {
     return configuration;
   }
 
+  @Nullable
   public ChangeDetail getChange() {
     return change;
   }


### PR DESCRIPTION
The `creationTime` field for existing rows in the table (un-altered by the edit LCM flow) read null. Changing the type to a nullable Long