### PR TITLE
[CDAP-19145] Ensure that program running in non-default namespaces us…

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramTwillApplication.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Iterators;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.twill.TwillAppNames;
 import io.cdap.cdap.master.spi.twill.ExtendedTwillApplication;
+import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.twill.api.EventHandler;
 import org.apache.twill.api.TwillApplication;
@@ -135,5 +136,10 @@ public final class ProgramTwillApplication implements ExtendedTwillApplication {
   @Override
   public String getRunId() {
     return programRunId.getRun();
+  }
+
+  @Override
+  public boolean isSystemApplication() {
+    return programRunId.getNamespaceId().equals(NamespaceId.SYSTEM);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
@@ -44,6 +44,7 @@ import io.cdap.cdap.security.auth.context.WorkerAuthenticationContext;
 import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.spi.authenticator.RemoteAuthenticator;
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,16 +102,28 @@ public class MasterEnvironmentMain {
         throw new IllegalArgumentException("Missing runnable class name");
       }
 
-      CConfiguration cConf = CConfiguration.create();
-      SConfiguration sConf = SConfiguration.create();
       if (options.getExtraConfPath() != null) {
-        cConf.addResource(new File(options.getExtraConfPath(), "cdap-site.xml").toURI().toURL());
-        sConf.addResource(new File(options.getExtraConfPath(), "cdap-security.xml").toURI().toURL());
+        // Copy config files from per-run configmap to the working directory
+        FileUtils.copyDirectory(new File(options.getExtraConfPath()), new File("."));
+      }
+      CConfiguration cConf = CConfiguration.create();
+      File cConfFile = new File("cConf.xml");
+      if (cConfFile.exists()) {
+        cConf.addResource(cConfFile.toURI().toURL());
+      }
+      SConfiguration sConf = SConfiguration.create();
+      File sConfFile = new File("sConf.xml");
+      if (sConfFile.exists()) {
+        sConf.addResource(sConfFile.toURI().toURL());
       }
 
       SecurityUtil.loginForMasterService(cConf);
 
       Configuration hConf = new Configuration();
+      File hConfFile = new File("hConf.xml");
+      if (hConfFile.exists()) {
+        hConf.addResource(hConfFile.toURI().toURL());
+      }
 
       // Creates the master environment and load the MasterEnvironmentRunnable class from it.
       MasterEnvironment masterEnv = MasterEnvironments.setMasterEnvironment(

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -40,6 +40,9 @@ import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.AppsV1Api;
 import io.kubernetes.client.openapi.apis.BatchV1Api;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1ConfigMapBuilder;
+import io.kubernetes.client.openapi.models.V1ConfigMapVolumeSourceBuilder;
 import io.kubernetes.client.openapi.models.V1Container;
 import io.kubernetes.client.openapi.models.V1ContainerBuilder;
 import io.kubernetes.client.openapi.models.V1Deployment;
@@ -66,6 +69,7 @@ import io.kubernetes.client.openapi.models.V1StatefulSet;
 import io.kubernetes.client.openapi.models.V1StatefulSetBuilder;
 import io.kubernetes.client.openapi.models.V1Volume;
 import io.kubernetes.client.openapi.models.V1VolumeMount;
+import io.kubernetes.client.openapi.models.V1VolumeMountBuilder;
 import org.apache.twill.api.ClassAcceptor;
 import org.apache.twill.api.Configs;
 import org.apache.twill.api.LocalFile;
@@ -136,7 +140,7 @@ import java.util.stream.Stream;
  * main container, and the rest will be treated as sidecar containers.
  * TODO (CDAP-18058): This assumption needs to be changed by using {@link TwillSpecification.PlacementPolicy}.
  */
-class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer, SecureTwillPreparer {
+public class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer, SecureTwillPreparer {
   private static final Logger LOG = LoggerFactory.getLogger(KubeTwillPreparer.class);
 
   @VisibleForTesting
@@ -155,10 +159,14 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
   @VisibleForTesting
   static final String PROGRAM_MEMORY_MULTIPLIER = "program.k8s.container.memory.multiplier";
   private static final String DEFAULT_PROGRAM_MEMORY_MULTIPLIER = "0.5";
+  // Configmap that stores localized config files
+  private static final String CONFIGMAP_MOUNTPATH = "/config";
+  public static final String CONFIGMAP_NAME_PREFIX = "cdap-config-";
 
   private final MasterEnvironmentContext masterEnvContext;
   private final ApiClient apiClient;
   private final BatchV1Api batchV1Api;
+  private final CoreV1Api coreV1Api;
   private final String kubeNamespace;
   private final PodInfo podInfo;
   private final List<String> arguments;
@@ -199,6 +207,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
     this.masterEnvContext = masterEnvContext;
     this.apiClient = apiClient;
     this.batchV1Api = new BatchV1Api(apiClient);
+    this.coreV1Api = new CoreV1Api(apiClient);
     this.kubeNamespace = kubeNamespace;
     this.programRuntimeNamespace = kubeNamespace;
     this.podInfo = podInfo;
@@ -213,7 +222,8 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
     this.appLocation = appLocation;
     this.twillSpec = spec;
     this.resourcePrefix = resourcePrefix;
-    this.extraLabels = extraLabels;
+    this.extraLabels = extraLabels == null ? Collections.emptyMap() :
+      extraLabels.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> asLabel(e.getValue())));
     this.dependentRunnableNames = new HashSet<>();
     this.serviceAccountName = null;
     this.secretDiskRunnables = new HashMap<>();
@@ -605,6 +615,11 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
         }
       }
 
+      if (!isSystemNamespace(cdapRuntimeNamespace)) {
+        // We only create a per-run configmap for user programs
+        createConfigMap();
+      }
+
       V1ObjectMeta metadata = createResourceMetadata(resourceType, mainRuntimeSpec.getName(),
                                                      timeoutUnit.toMillis(timeout), runtimeCleanupDisabled);
       if (V1Job.class.equals(resourceType)) {
@@ -622,6 +637,14 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
       } catch (IOException ex) {
         e.addSuppressed(ex);
       }
+      try {
+        coreV1Api.deleteNamespacedConfigMap(CONFIGMAP_NAME_PREFIX + twillRunId.getId(), programRuntimeNamespace,
+                                            null, null, null, null, null, null);
+      } catch (ApiException ex) {
+        if (ex.getCode() != 404) {
+          e.addSuppressed(ex);
+        }
+      }
       throw new RuntimeException("Unable to create Kubernetes resource while attempting to start program.", e);
     }
   }
@@ -632,9 +655,6 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
   private V1ObjectMeta createResourceMetadata(Type resourceType, String runnableName, long startTimeoutMillis,
                                               boolean runtimeCleanupDisabled) {
     String resourceName = getResourceName(twillSpec.getName(), twillRunId, getMaxLength(resourceType));
-
-    Map<String, String> extraLabels = this.extraLabels.entrySet().stream()
-      .collect(Collectors.toMap(Map.Entry::getKey, e -> asLabel(e.getValue())));
 
     // labels have more strict requirements around valid character sets,
     // so use annotations to store the app name.
@@ -705,6 +725,25 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
   private String cleanse(String val, int maxLength) {
     String cleansed = val.replaceAll("[^A-Za-z0-9\\-]", "-").toLowerCase();
     return cleansed.length() > maxLength ? cleansed.substring(0, maxLength) : cleansed;
+  }
+
+  /**
+   * Creates per-run configmap containing config files.
+   */
+  private void createConfigMap() throws ApiException, IOException {
+    String configMapName = CONFIGMAP_NAME_PREFIX + twillRunId.getId();
+    V1ConfigMapBuilder builder = new V1ConfigMapBuilder()
+      .withMetadata(new V1ObjectMeta().name(configMapName).labels(extraLabels));
+    String runnableName = getMainRuntimeSpecification(twillSpec.getRunnables()).getName();
+    for (LocalFile localFile : twillSpec.getRunnables().get(runnableName).getLocalFiles()) {
+      // Only add xml config files to the configmap. We skip over jars as they are too large store in a
+      // configmap (max size = 1 MB. See https://kubernetes.io/docs/concepts/configuration/configmap).
+      if (!localFile.getName().endsWith(".xml")) {
+        continue;
+      }
+      builder.addToBinaryData(localFile.getName(), Files.readAllBytes(java.nio.file.Paths.get(localFile.getURI())));
+    }
+    coreV1Api.createNamespacedConfigMap(programRuntimeNamespace, builder.build(), null, null, null);
   }
 
   /**
@@ -935,6 +974,10 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
       Collection<LocalFile> runnableFiles = localFiles.computeIfAbsent(runnableName, k -> new ArrayList<>());
 
       for (LocalFile localFile : entry.getValue().getLocalFiles()) {
+        if (localFile.getName().endsWith(".xml") && !isSystemNamespace(cdapRuntimeNamespace)) {
+          // Skip over xml config files as they are stored on the per-run configmap for user programs
+          continue;
+        }
         Location location;
 
         URI uri = localFile.getURI();
@@ -1004,9 +1047,19 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
 
     String workDir = "/workDir-" + twillRunId.getId();
 
-    List<V1Volume> additionalVolumes = new ArrayList<>();
-    additionalVolumes.add(podInfoVolume);
-    additionalVolumes.add(workDirVolume);
+    List<V1Volume> volumes = new ArrayList<>();
+    volumes.add(podInfoVolume);
+    volumes.add(workDirVolume);
+    String configMapName = CONFIGMAP_NAME_PREFIX + twillRunId.getId();
+    if (isSystemNamespace(cdapRuntimeNamespace)) {
+      // Add cconf, hconf volumes from the current pod
+      volumes.addAll(podInfo.getVolumes());
+    } else {
+      // Add configmap volume containing localized config files for user program runs
+      V1Volume configMapVolume = new V1Volume().name(configMapName)
+        .configMap(new V1ConfigMapVolumeSourceBuilder().withName(configMapName).build());
+      volumes.add(configMapVolume);
+    }
 
     RuntimeSpecification mainRuntimeSpec = getMainRuntimeSpecification(runtimeSpecs);
     String runnableName = mainRuntimeSpec.getName();
@@ -1025,8 +1078,17 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
     initContainerEnvirons.put(JAVA_OPTS_KEY, masterEnvContext.getConfigurations()
       .getOrDefault(FILE_LOCALIZER_JVM_OPTS, FILE_LOCALIZER_DEFAULT_JVM_OPTS));
 
-    // Add volume mounts to the container. Add those from the current pod for mount cdap and hadoop conf.
-    List<V1VolumeMount> volumeMounts = new ArrayList<>(podInfo.getContainerVolumeMounts());
+    List<V1VolumeMount> volumeMounts = new ArrayList<>();
+    if (isSystemNamespace(cdapRuntimeNamespace)) {
+      // Add volume mounts to the container. Add those from the current pod to mount cdap and hadoop conf.
+      volumeMounts.addAll(podInfo.getContainerVolumeMounts());
+    } else {
+      // For user programs, add volume mount containing localized per-run config files
+      volumeMounts.add(new V1VolumeMountBuilder()
+                         .withName(configMapName)
+                         .withMountPath(CONFIGMAP_MOUNTPATH)
+                         .build());
+    }
     volumeMounts.add(new V1VolumeMount().name(podInfoVolume.getName())
                        .mountPath(podInfo.getPodInfoDir()).readOnly(true));
     // Add the working directory the file localization by the init container
@@ -1038,7 +1100,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
     if (workloadIdentityEnabled && WorkloadIdentityUtil.shouldMountWorkloadIdentity(cdapInstallNamespace,
                                                                                     programRuntimeNamespace,
                                                                                     workloadIdentityServiceAccount)) {
-      additionalVolumes.add(WorkloadIdentityUtil.generateWorkloadIdentityVolume(workloadIdentityKSATTL,
+      volumes.add(WorkloadIdentityUtil.generateWorkloadIdentityVolume(workloadIdentityKSATTL,
                                                                                 workloadIdentityPool));
       volumeMounts.add(WorkloadIdentityUtil.generateWorkloadIdentityVolumeMount());
 
@@ -1062,17 +1124,22 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
       serviceAccountName = podInfo.getServiceAccountName();
     }
 
+    List<String> containerArgs = new ArrayList<>(args);
+    if (!isSystemNamespace(cdapRuntimeNamespace)) {
+      // Pass the per-run configmap mount path to MasterEnvironmentMain as extraConfPath arg
+      containerArgs.add(String.format("--conf=%s", CONFIGMAP_MOUNTPATH));
+    }
+
     return podSpecBuilder
       .withServiceAccountName(serviceAccountName)
       .withRuntimeClassName(podInfo.getRuntimeClassName())
-      .addAllToVolumes(podInfo.getVolumes())
-      .addAllToVolumes(additionalVolumes)
+      .addAllToVolumes(volumes)
       .withInitContainers(createContainer("file-localizer", podInfo.getContainerImage(),
                                           podInfo.getImagePullPolicy(), workDir, initContainerResourceRequirements,
                                           initContainerVolumeMounts, initContainerEnvirons, FileLocalizer.class,
                                           runtimeConfigLocation.toURI().toString(),
                                           mainRuntimeSpec.getName()))
-      .withContainers(createContainers(resourceType, runtimeSpecs, workDir, containerVolumeMounts, args))
+      .withContainers(createContainers(resourceType, runtimeSpecs, workDir, containerVolumeMounts, containerArgs))
       .withSecurityContext(podInfo.getSecurityContext())
       .withRestartPolicy(restartPolicy)
       .build();
@@ -1199,7 +1266,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
 
     // Use separate multiplier for user pods
     // System pods have the 'system' namespace
-    if (cdapRuntimeNamespace != null && !isSystemNamespace(cdapRuntimeNamespace)) {
+    if (!isSystemNamespace(cdapRuntimeNamespace)) {
       // For job type use program multipliers.
       cpuMultiplier = Float.parseFloat(cConf.getOrDefault(PROGRAM_CPU_MULTIPLIER, DEFAULT_PROGRAM_CPU_MULTIPLIER));
       memoryMultiplier = Float.parseFloat(
@@ -1237,7 +1304,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
    * @param namespace a namespace ID
    * @return whether the given namespace is the system namespace
    */
-  public static boolean isSystemNamespace(String namespace) {
+  private boolean isSystemNamespace(String namespace) {
     return "system".equals(namespace);
   }
 
@@ -1293,7 +1360,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
   private List<V1VolumeMount> addSecreteVolMountIfNeeded(RuntimeSpecification runtimeSpec, List<V1VolumeMount> mounts) {
     List<V1VolumeMount> updatedMounts = new ArrayList<>(mounts);
     // Add secret disks as secret volume mounts
-    if (secretDiskRunnables.containsKey(runtimeSpec.getName())) {
+    if (secretDiskRunnables.containsKey(runtimeSpec.getName()) && isSystemNamespace(cdapRuntimeNamespace)) {
       for (SecretDisk secretDisk : secretDiskRunnables.get(runtimeSpec.getName()).getSecretDisks()) {
         String secretName = secretDisk.getName();
         String mountPath = secretDisk.getPath();

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -38,7 +38,6 @@ import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.apis.RbacAuthorizationV1Api;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBinding;
 import io.kubernetes.client.openapi.models.V1ClusterRoleBindingBuilder;
-import io.kubernetes.client.openapi.models.V1ConfigMap;
 import io.kubernetes.client.openapi.models.V1Deployment;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobStatus;
@@ -52,11 +51,9 @@ import io.kubernetes.client.openapi.models.V1ResourceQuotaSpec;
 import io.kubernetes.client.openapi.models.V1RoleBinding;
 import io.kubernetes.client.openapi.models.V1RoleBindingBuilder;
 import io.kubernetes.client.openapi.models.V1RoleRefBuilder;
-import io.kubernetes.client.openapi.models.V1Secret;
 import io.kubernetes.client.openapi.models.V1ServiceAccount;
 import io.kubernetes.client.openapi.models.V1StatefulSet;
 import io.kubernetes.client.openapi.models.V1SubjectBuilder;
-import io.kubernetes.client.openapi.models.V1Volume;
 import org.apache.twill.api.ResourceSpecification;
 import org.apache.twill.api.RunId;
 import org.apache.twill.api.SecureStoreUpdater;
@@ -126,7 +123,6 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
   private static final String CDAP_NAMESPACE_LABEL = "cdap.namespace";
   private static final String NAMESPACE_CPU_LIMIT_PROPERTY = "k8s.namespace.cpu.limits";
   private static final String NAMESPACE_MEMORY_LIMIT_PROPERTY = "k8s.namespace.memory.limits";
-  private static final String RUN_ID_LABEL = "cdap.twill.run.id";
   private static final String RUNNER_LABEL = "cdap.twill.runner";
   private static final String RUNNER_LABEL_VAL = "k8s";
   private static final String WORKLOAD_LAUNCHER_NAMESPACE_ROLE_BINDING_NAME
@@ -136,6 +132,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
   private static final String RBAC_V1_API_GROUP = "rbac.authorization.k8s.io";
   private static final String CLUSTER_ROLE_KIND = "ClusterRole";
   private static final String SERVICE_ACCOUNT_KIND = "ServiceAccount";
+  public static final String RUN_ID_LABEL = "cdap.twill.run.id";
   public static final String RESOURCE_QUOTA_NAME = "cdap-resource-quota";
   public static final String WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY =
     "workload.identity.gcp.service.account.email";
@@ -163,6 +160,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
   private String workloadIdentityPool;
   private String workloadIdentityProvider;
   private RbacAuthorizationV1Api rbacV1Api;
+  private boolean isUserProgram;
 
   public KubeTwillRunnerService(MasterEnvironmentContext masterEnvContext, ApiClientFactory apiClientFactory,
                                 String kubeNamespace, DiscoveryServiceClient discoveryServiceClient,
@@ -193,6 +191,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
     this.workloadLauncherRoleNameForCluster = workloadLauncherRoleNameForCluster;
     this.workloadIdentityPool = workloadIdentityPool;
     this.workloadIdentityProvider = workloadIdentityProvider;
+    this.isUserProgram = false;
   }
 
   @Override
@@ -210,7 +209,9 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
     TwillSpecification spec = application.configure();
     RunId runId;
     if (application instanceof ExtendedTwillApplication) {
-      runId = RunIds.fromString(((ExtendedTwillApplication) application).getRunId());
+      ExtendedTwillApplication extendedApp = (ExtendedTwillApplication) application;
+      runId = RunIds.fromString(extendedApp.getRunId());
+      isUserProgram = !extendedApp.isSystemApplication();
     } else {
       runId = RunIds.generate();
     }
@@ -316,7 +317,6 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
     KubeUtil.validateRFC1123LabelName(namespace);
     findOrCreateKubeNamespace(namespace, cdapNamespace);
     updateOrCreateResourceQuota(namespace, cdapNamespace, properties);
-    copyVolumes(namespace, cdapNamespace);
     createWorkloadServiceAccount(namespace, cdapNamespace);
     if (workloadIdentityEnabled) {
       String workloadIdentityServiceAccountEmail = properties.get(WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY);
@@ -441,57 +441,6 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
       LOG.debug("Created resource quota for Kubernetes namespace {}", namespace);
     } catch (ApiException e) {
       throw new IOException("Error occurred while creating Kubernetes resource quota. Error code = "
-                              + e.getCode() + ", Body = " + e.getResponseBody(), e);
-    }
-  }
-
-  /**
-   * Copy volumes into the new namespace for deployments created via the KubeTwillRunnerService
-   * TODO: (CDAP-18956) improve this logic to be for each pipeline run
-   */
-  private void copyVolumes(String namespace, String cdapNamespace) throws IOException {
-    try {
-      for (V1Volume volume : podInfo.getVolumes()) {
-        if (volume.getConfigMap() != null) {
-          String configMapName = volume.getConfigMap().getName();
-          V1ConfigMap existingMap = coreV1Api.readNamespacedConfigMap(configMapName, podInfo.getNamespace(),
-                                                                      null, null, null);
-          V1ConfigMap configMap = new V1ConfigMap().data(existingMap.getData())
-            .metadata(new V1ObjectMeta().name(configMapName).putLabelsItem(CDAP_NAMESPACE_LABEL,
-                                                                           cdapNamespace));
-          try {
-            coreV1Api.createNamespacedConfigMap(namespace, configMap, null, null, null);
-          } catch (ApiException e) {
-            if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
-              throw e;
-            }
-            LOG.warn("The configmap already exists '{}:{}' : {}. Ignoring creation of the configmap.", namespace,
-                     configMapName, e.getResponseBody());
-          }
-          LOG.debug("Created configMap {} in Kubernetes namespace {}", configMapName, namespace);
-        }
-
-        if (volume.getSecret() != null) {
-          String secretName = volume.getSecret().getSecretName();
-          V1Secret existingSecret = coreV1Api.readNamespacedSecret(secretName, podInfo.getNamespace(),
-                                                                   null, null, null);
-          V1Secret secret = new V1Secret().data(existingSecret.getData()).type(existingSecret.getType())
-            .metadata(new V1ObjectMeta().name(secretName).putLabelsItem(CDAP_NAMESPACE_LABEL,
-                                                                        cdapNamespace));
-          try {
-            coreV1Api.createNamespacedSecret(namespace, secret, null, null, null);
-          } catch (ApiException e) {
-            if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
-              throw e;
-            }
-            LOG.warn("The secret '{}:{}' already exists : {}. Ignoring creation of the secret.", namespace,
-                     secret.getMetadata().getName(), e.getResponseBody());
-          }
-          LOG.debug("Created secret {} in Kubernetes namespace {}", secretName, namespace);
-        }
-      }
-    } catch (ApiException e) {
-      throw new IOException("Error occurred while copying volumes. Error code = "
                               + e.getCode() + ", Body = " + e.getResponseBody(), e);
     }
   }
@@ -948,7 +897,8 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
                                                         Type resourceType, V1ObjectMeta meta) {
     CompletableFuture<Void> startupTaskCompletion = new CompletableFuture<>();
     KubeTwillController controller = new KubeTwillController(meta.getNamespace(), runId, discoveryServiceClient,
-                                                             apiClient, resourceType, meta, startupTaskCompletion);
+                                                             apiClient, resourceType, meta, startupTaskCompletion,
+                                                             isUserProgram);
 
     Location appLocation = getApplicationLocation(appName, runId);
     controller.onTerminated(() -> {

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillControllerTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillControllerTest.java
@@ -17,11 +17,15 @@
 package io.cdap.cdap.k8s.runtime;
 
 import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1JobStatus;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import org.apache.twill.api.RunId;
 import org.apache.twill.api.ServiceController;
 import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.internal.RunIds;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,24 +33,32 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class KubeTwillControllerTest {
   @Test
-  public void testTerminate() {
+  public void testTerminate() throws ApiException {
     DiscoveryServiceClient mockDiscoveryServiceClient = mock(DiscoveryServiceClient.class);
     ApiClient mockApiClient = mock(ApiClient.class);
     // obj meta with disable cleanup annotation
     V1ObjectMeta objMetaWithAnnotation = new V1ObjectMeta().name("test-job-name")
       .putAnnotationsItem(KubeTwillRunnerService.RUNTIME_CLEANUP_DISABLED, "true");
     CompletableFuture<Void> startupTaskCompletion = new CompletableFuture<>();
-    KubeTwillController controller = new KubeTwillController("default", null, mockDiscoveryServiceClient,
+    RunId runId = RunIds.generate();
+    KubeTwillController controller = new KubeTwillController("default", runId, mockDiscoveryServiceClient,
                                                              mockApiClient, V1Job.class, objMetaWithAnnotation,
-                                                             startupTaskCompletion);
+                                                             startupTaskCompletion, true);
+    CoreV1Api mockCoreV1Api = mock(CoreV1Api.class);
+    controller.setCoreV1Api(mockCoreV1Api);
     V1JobStatus jobStatus = new V1JobStatus();
     jobStatus.setFailed(1);
     controller.setJobStatus(jobStatus);
 
     Future<? extends ServiceController> terminateFuture = controller.terminate();
     Assert.assertTrue(terminateFuture.isDone());
+    String configMapName = KubeTwillPreparer.CONFIGMAP_NAME_PREFIX + runId.getId();
+    verify(mockCoreV1Api, times(1))
+      .deleteNamespacedConfigMap(configMapName, "default", null, null, null, null, null, null);
   }
 }

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
@@ -152,6 +152,9 @@ public class KubeTwillPreparerTest {
                                                        createPodInfo(), createTwillSpecification(), null, null,
                                                        null, null, null);
     ResourceSpecification resourceSpecification = new DefaultResourceSpecification(1, 100, 1, 1, 1);
+    Map<String, String> config = new HashMap<>();
+    config.put(MasterOptionConstants.RUNTIME_NAMESPACE, "system");
+    preparer.withConfiguration(config);
     V1ResourceRequirements gotResourceRequirements = preparer.createResourceRequirements(resourceSpecification);
     Assert.assertEquals("1", gotResourceRequirements.getRequests().get("cpu").toSuffixedString());
     Assert.assertEquals("100Mi", gotResourceRequirements.getRequests().get("memory").toSuffixedString());
@@ -180,6 +183,9 @@ public class KubeTwillPreparerTest {
     KubeTwillPreparer preparer = new KubeTwillPreparer(masterEnvironmentContext, null, "default",
                                                        createPodInfo(), createTwillSpecification(), null, null,
                                                        null, null, null);
+    Map<String, String> config = new HashMap<>();
+    config.put(MasterOptionConstants.RUNTIME_NAMESPACE, "system");
+    preparer.withConfiguration(config);
     ResourceSpecification resourceSpecification = new DefaultResourceSpecification(1, 100, 1, 1, 1);
     V1ResourceRequirements gotResourceRequirements = preparer.createResourceRequirements(resourceSpecification);
     Assert.assertEquals("500m", gotResourceRequirements.getRequests().get("cpu").toSuffixedString());

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillApplication.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillApplication.java
@@ -25,4 +25,11 @@ public interface ExtendedTwillApplication extends TwillApplication {
 
   String getRunId();
 
+  /**
+   * Returns if the application is a system application.
+   *
+   * @return true if the application is a system application, false otherwise.
+   */
+  boolean isSystemApplication();
+
 }


### PR DESCRIPTION
…e updated configuration

### Why do we need this change?
When a config is modified in CDAP CR (e.g: spark driver/executor image), this change gets reflected in the cconf configmap in the default namespace, but not in any other k8s namespaces. So pipelines runs in the default namespace will pick up the updated configuration, but pipelines runs in non-default namespaces will use old configuration.

### How are we fixing this?
Instead of relying on cconf, hconf configmaps (that are created by copying from configmaps in default namespace on namespace creation), we create a per-run configmap that contains localized config files copied from the twill spec for user program runs. This configmap is mounted on the workflow pod. It gets removed up when the job is deleted.
