### PR TITLE
[CDAP-19444] Enabling Artifact Localizer service in system pods

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -369,6 +369,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
           // ArtifactRepositoryReader is required by DefaultArtifactRepository.
           // Keep ArtifactRepositoryReader private to minimize the scope of the binding visibility.
           bind(ArtifactRepositoryReader.class).to(LocalArtifactRepositoryReader.class).in(Scopes.SINGLETON);
+          expose(ArtifactRepositoryReader.class);
 
           bind(ArtifactRepository.class)
             .annotatedWith(Names.named(NOAUTH_ARTIFACT_REPO))


### PR DESCRIPTION
This PR enables the Artifact Localizer service in system pods. Artifacts will be fetched from AppFabric and cached while launching a program run. For all subsequent runs, the freshness of the artifact will be checked and the same artifact will be used if it's the latest version offered by AppFabric.