### PR TITLE
[CDAP-19668] add 'latestOnly' and 'nameFilterType' queryparams to GET apps

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/ApplicationFilter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/ApplicationFilter.java
@@ -66,6 +66,52 @@ public abstract class ApplicationFilter {
   }
 
   /**
+   * The filter that check if application id exactly equals to a string (ignoring case).
+   */
+  public static class ApplicationIdEqualsFilter extends ApplicationIdFilter {
+    private final String searchFor;
+
+    public ApplicationIdEqualsFilter(String searchFor) {
+      this.searchFor = searchFor;
+    }
+
+    @Override
+    public boolean test(ApplicationId applicationId) {
+      return applicationId.getApplication().equalsIgnoreCase(searchFor);
+    }
+
+    @Override
+    public String toString() {
+      return "ApplicationIdEqualsFilter{" +
+        "searchFor='" + searchFor + '\'' +
+        '}';
+    }
+  }
+
+  /**
+   * The filter that check if application id exactly equals to a string (case-sensitive).
+   */
+  public static class ApplicationIdEqualsCaseSensitiveFilter extends ApplicationIdFilter {
+    private final String searchFor;
+
+    public ApplicationIdEqualsCaseSensitiveFilter(String searchFor) {
+      this.searchFor = searchFor;
+    }
+
+    @Override
+    public boolean test(ApplicationId applicationId) {
+      return applicationId.getApplication().equals(searchFor);
+    }
+
+    @Override
+    public String toString() {
+      return "ApplicationIdEqualsCaseSensitiveFilter{" +
+        "searchFor='" + searchFor + '\'' +
+        '}';
+    }
+  }
+
+  /**
    * Returns true if the application artifact is in a allow list of names
    */
   public static class ArtifactNamesInFilter extends ArtifactIdFilter {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/ScanApplicationsRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/ScanApplicationsRequest.java
@@ -38,6 +38,7 @@ public class ScanApplicationsRequest {
   private final List<ApplicationFilter> filters;
   private final SortOrder sortOrder;
   private final int limit;
+  private final boolean latestOnly;
 
   /**
    * @param namespaceId  namespace to return applications for or null for all namespaces
@@ -51,13 +52,15 @@ public class ScanApplicationsRequest {
                                   @Nullable ApplicationId scanFrom,
                                   @Nullable ApplicationId scanTo,
                                   List<ApplicationFilter> filters,
-                                  SortOrder sortOrder, int limit) {
+                                  SortOrder sortOrder, int limit,
+                                  boolean latestOnly) {
     this.namespaceId = namespaceId;
     this.scanFrom = scanFrom;
     this.scanTo = scanTo;
     this.filters = filters;
     this.sortOrder = sortOrder;
     this.limit = limit;
+    this.latestOnly = latestOnly;
   }
 
   /**
@@ -113,6 +116,14 @@ public class ScanApplicationsRequest {
     return limit;
   }
 
+  /**
+   *
+   * @return whether to return the latest version of an application
+   */
+  public boolean getLatestOnly() {
+    return latestOnly;
+  }
+
   @Override
   public String toString() {
     return "ScanApplicationsRequest{" +
@@ -122,6 +133,7 @@ public class ScanApplicationsRequest {
       ", filters=" + filters +
       ", sortOrder=" + sortOrder +
       ", limit=" + limit +
+      ", latestOnly=" + latestOnly +
       '}';
   }
 
@@ -152,6 +164,7 @@ public class ScanApplicationsRequest {
     private List<ApplicationFilter> filters = new ArrayList<>();
     private SortOrder sortOrder = SortOrder.ASC;
     private int limit = Integer.MAX_VALUE;
+    private boolean latestOnly;
 
     private Builder() {
     }
@@ -163,6 +176,7 @@ public class ScanApplicationsRequest {
       this.filters = request.filters;
       this.sortOrder = request.sortOrder;
       this.limit = request.limit;
+      this.latestOnly = request.latestOnly;
     }
 
     /**
@@ -228,12 +242,22 @@ public class ScanApplicationsRequest {
       this.limit = limit;
       return this;
     }
+
+    /**
+     *
+     * @param latestOnly whether to return the latest version of an application
+     */
+    public Builder setLatestOnly(boolean latestOnly) {
+      this.latestOnly = latestOnly;
+      return this;
+    }
+
     /**
      *
      * @return new {@link ScanApplicationsRequest}
      */
     public ScanApplicationsRequest build() {
-      return new ScanApplicationsRequest(namespaceId, scanFrom, scanTo, filters, sortOrder, limit);
+      return new ScanApplicationsRequest(namespaceId, scanFrom, scanTo, filters, sortOrder, limit, latestOnly);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/NameFilterType.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/NameFilterType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers;
+
+public enum NameFilterType {
+  CONTAINS, EQUALS, EQUALS_IGNORE_CASE
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -310,7 +310,9 @@ public class AppMetadataStore {
 
     StructuredTable table = getApplicationSpecificationTable();
     int limit = request.getLimit();
-    try (CloseableIterator<StructuredRow> iterator = table.scan(range, Integer.MAX_VALUE, request.getSortOrder())) {
+    boolean latestOnly = request.getLatestOnly();
+    try (CloseableIterator<StructuredRow> iterator = getScanApplicationsIterator(table, range,
+                                                                                 request.getSortOrder(), latestOnly)) {
       boolean keepScanning = true;
       while (iterator.hasNext() && keepScanning && limit > 0) {
         StructuredRow row = iterator.next();
@@ -321,6 +323,17 @@ public class AppMetadataStore {
         }
       }
     }
+  }
+
+  private CloseableIterator<StructuredRow> getScanApplicationsIterator(StructuredTable table,
+                                                                       Range range,
+                                                                       SortOrder sortOrder,
+                                                                       boolean latestOnly) throws IOException {
+    if (latestOnly) {
+      return table.scan(range, Integer.MAX_VALUE,
+                        Fields.stringField(StoreDefinition.AppMetadataStore.LATEST_FIELD, "true"), sortOrder);
+    }
+    return table.scan(range, Integer.MAX_VALUE, sortOrder);
   }
 
   public List<ApplicationMeta> getAllApplications(String namespaceId) throws IOException {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -628,6 +628,33 @@ public abstract class AppFabricTestBase {
     return readResponse(response, JsonObject.class);
   }
 
+  protected JsonObject getAppListForPaginatedApi(String namespace, int pageSize, String token,
+                                                 String filter, String nameFilterType,
+                                                 Boolean latestOnly) throws Exception {
+    String uri = "apps/?pageSize=" + pageSize;
+
+    if (token != null) {
+      uri += ("&pageToken=" + token);
+    }
+
+    if (!Strings.isNullOrEmpty(filter)) {
+      uri += ("&nameFilter=" + filter);
+    }
+
+    if (nameFilterType != null) {
+      uri += ("&nameFilterType=" + nameFilterType);
+    }
+
+    if (latestOnly != null) {
+      uri += ("&latestOnly=" + latestOnly);
+    }
+
+    HttpResponse response = doGet(getVersionedAPIPath(uri,
+                                                      Constants.Gateway.API_VERSION_3_TOKEN, namespace));
+    assertResponseCode(200, response);
+    return readResponse(response, JsonObject.class);
+  }
+
   /**
    * Gets a list of {@link BatchApplicationDetail} from the give set of application version
    *

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/MetricStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/MetricStructuredTable.java
@@ -186,7 +186,14 @@ public class MetricStructuredTable implements StructuredTable {
   @Override
   public CloseableIterator<StructuredRow> scan(Range keyRange, int limit, String orderByField, SortOrder sortOrder)
     throws InvalidFieldException, IOException {
-    return scan(() -> structuredTable.scan(keyRange, limit, orderByField, sortOrder), "sort.index.range.scan.");
+    return scan(() -> structuredTable.scan(keyRange, limit, orderByField, sortOrder), "sort.range.scan.");
+  }
+
+  @Override
+  public CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Field<?> filterIndex, SortOrder sortOrder)
+    throws InvalidFieldException, IOException {
+    return scan(() -> structuredTable.scan(keyRange, limit, filterIndex, sortOrder),
+                "sort.index.range.scan.");
   }
 
   private interface MultiScanFunction {

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStructuredTable.java
@@ -353,6 +353,12 @@ public class PostgreSqlStructuredTable implements StructuredTable {
   @Override
   public CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Field<?> filterIndex)
     throws InvalidFieldException, IOException {
+    return scan(keyRange, limit, filterIndex, SortOrder.ASC);
+  }
+
+  @Override
+  public CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Field<?> filterIndex, SortOrder sortOrder)
+    throws InvalidFieldException, IOException {
 
     fieldValidator.validatePrimaryKeys(keyRange.getBegin(), true);
     fieldValidator.validatePrimaryKeys(keyRange.getEnd(), true);
@@ -361,10 +367,10 @@ public class PostgreSqlStructuredTable implements StructuredTable {
       throw new InvalidFieldException(tableSchema.getTableId(), filterIndex.getName(), "is not an indexed column");
     }
 
-    LOG.trace("Table {}: Scan range {} with filterIndex {} limit {}",
-              tableSchema.getTableId(), keyRange, filterIndex, limit);
+    LOG.trace("Table {}: Scan range {} with filterIndex {} limit {} sortOrder {}",
+              tableSchema.getTableId(), keyRange, filterIndex, limit, sortOrder);
 
-    String scanQuery = getScanIndexQuery(keyRange, limit, filterIndex, SortOrder.ASC);
+    String scanQuery = getScanIndexQuery(keyRange, limit, filterIndex, sortOrder);
 
     try {
       PreparedStatement statement = connection.prepareStatement(scanQuery);

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
@@ -36,6 +36,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -103,6 +104,12 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
   @Test
   public void testScannerIteratorMulti() throws Exception {
     testScannerIterator(10);
+  }
+
+  @Override
+  @Ignore
+  public void testSortedPrimaryKeyFilteredIndexScan() throws Exception {
+    // no implementation
   }
 
   private void testScannerIterator(int max) throws Exception {

--- a/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableTest.java
+++ b/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableTest.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -75,6 +76,12 @@ public class SpannerStructuredTableTest extends StructuredTableTest {
   @AfterClass
   public static void closeSpannerStorageProvider() {
     Optional.ofNullable(storageProvider).ifPresent(SpannerStorageProvider::close);
+  }
+
+  @Override
+  @Ignore
+  public void testSortedPrimaryKeyFilteredIndexScan() {
+    // no implementation
   }
 
   @Override

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
@@ -170,6 +170,28 @@ public interface StructuredTable extends Closeable {
   }
 
   /**
+   * Read a set of rows from the table matching the index and the key range.
+   * The rows returned will be sorted on the primary key order.
+   *
+   * @param keyRange key range for the scan
+   * @param limit maximum number of rows to return
+   * @param filterIndex the index to filter upon
+   * @param sortOrder defined primary key sort order. Note that the comparator used is specific to the underlying
+   *                  store and is not nessesarily lexographic.
+   * @return a {@link CloseableIterator} of rows
+   * @throws InvalidFieldException if the field is not part of the table schema, or is not an indexed column,
+   *                               or the type does not match the schema
+   * @throws IOException if there is an error scanning the table
+   */
+  default CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Field<?> filterIndex, SortOrder sortOrder)
+    throws InvalidFieldException, IOException {
+    if (sortOrder == SortOrder.ASC) {
+      return scan(keyRange, limit, filterIndex);
+    }
+    throw new UnsupportedOperationException("No supported implementation.");
+  }
+
+  /**
    * Read a set of rows from the table matching the key range, return by sortOrder of specified index field.
    *
    * @param keyRange key range for the scan

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
@@ -729,6 +729,62 @@ public abstract class StructuredTableTest {
   }
 
   @Test
+  public void testSortedPrimaryKeyFilteredIndexScan() throws Exception {
+    int num = 100;
+    // Write a few records
+    List<Collection<Field<?>>> expected = new ArrayList<>();
+
+    getTransactionRunner().run(context -> {
+      StructuredTable table = context.getTable(SIMPLE_TABLE);
+      int counter = 0;
+      for (int i = 0; i < num * 3; ++i) {
+        Collection<Field<?>> fields = Arrays.asList(Fields.intField(KEY, counter),
+                                                    Fields.longField(KEY2, counter * 100L),
+                                                    Fields.longField(IDX_COL, (long) 100));
+        table.upsert(fields);
+        expected.add(fields);
+        ++counter;
+      }
+    });
+    List<String> columns = Arrays.asList(KEY, KEY2, IDX_COL);
+
+    // Verify write
+    getTransactionRunner().run(context -> {
+      StructuredTable table = context.getTable(SIMPLE_TABLE);
+      try (CloseableIterator<StructuredRow> iterator = table.scan(Range.all(), num * 10)) {
+        List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
+        Assert.assertEquals(expected, rows);
+      }
+    });
+
+    // Scan by keyRange and filter on index
+    getTransactionRunner().run(context -> {
+      StructuredTable table = context.getTable(SIMPLE_TABLE);
+
+      try (CloseableIterator<StructuredRow> iterator =
+             table.scan(Range.create(Collections.singleton(Fields.intField(KEY, num)), Range.Bound.INCLUSIVE,
+                                     Collections.singleton(Fields.intField(KEY, num * 3)), Range.Bound.EXCLUSIVE),
+                        num * 10, Fields.longField(IDX_COL, (long) 100), SortOrder.ASC)) {
+        List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
+        List<Collection<Field<?>>> expectedSubList = expected.subList(num, num * 3);
+
+        Assert.assertEquals(expectedSubList, rows);
+      }
+
+      try (CloseableIterator<StructuredRow> iterator =
+             table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)), Range.Bound.INCLUSIVE,
+                                     Collections.singleton(Fields.intField(KEY, num * 2)), Range.Bound.EXCLUSIVE),
+                        num * 10, Fields.longField(IDX_COL, (long) 100), SortOrder.DESC)) {
+        List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
+        List<Collection<Field<?>>> expectedSubList = expected.subList(0, num * 2);
+        Collections.reverse(expectedSubList);
+
+        Assert.assertEquals(expectedSubList, rows);
+      }
+    });
+  }
+
+  @Test
   public void testCount() throws Exception {
     // Write records
     int max = 5;


### PR DESCRIPTION
* add `latestOnly` queryparam to filter only latest version of the app, otherwise the deployed pipelines list view will render all the versions of the same app

* add `nameFilterType` queryparam to search for appname either contains or exactly equals `nameFilter` string

Jira: https://cdap.atlassian.net/browse/CDAP-19668