### PR TITLE
Add program.jar to GCS caching

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java
@@ -280,6 +280,21 @@ public class InMemoryProgramRunDispatcher implements ProgramRunDispatcher {
     }
 
     if (!tetheredRun) {
+      ArtifactDescriptor artifactDescriptor = artifactDetail.getDescriptor();
+      if (artifactsComputeHash && (artifactsComputeHashSnapshot ||
+        !artifactDescriptor.getArtifactId().getVersion().isSnapshot())) {
+        Hasher hasher = Hashing.sha256().newHasher();
+        hasher.putString(artifactDescriptor.getNamespace());
+        hasher.putString(artifactDescriptor.getArtifactId().getName());
+        hasher.putString(artifactDescriptor.getArtifactId().getScope().name());
+        hasher.putString(artifactDescriptor.getArtifactId().getVersion().getVersion());
+        Map<String, String> arguments = new HashMap<>(options.getArguments().asMap());
+        arguments.put(ProgramOptionConstants.PROGRAM_JAR_HASH, hasher.hash().toString());
+
+        options = new SimpleProgramOptions(options.getProgramId(), new BasicArguments(arguments),
+                                           new BasicArguments(options.getUserArguments().asMap()), options.isDebug());
+      }
+
       updatedOptions = updateProgramOptions(artifactId, programId, options, runId, clusterMode,
                                             Iterables.getFirst(artifactDetail.getMeta().getClasses().getApps(),
                                                                null),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -117,6 +117,11 @@ public final class ProgramOptionConstants {
   public static final String PLUGIN_DIR_HASH = "pluginDirHash";
 
   /**
+   * Option to hash value of local file path of program.jar
+   */
+  public static final String PROGRAM_JAR_HASH = "ProgramJarHash";
+
+  /**
    * Option to cacheable file names.
    */
   public static final String CACHEABLE_FILES = "cacheableFiles";


### PR DESCRIPTION
Why: similar to artifacts and artifacts_archive, program.jar also can be cached in GCS.