### PR TITLE
CDAP-19630: Inconsistency between bucket property keys used for overriding gcsBucket 2

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -58,6 +58,9 @@ import javax.annotation.Nullable;
  */
 public final class DataprocUtils {
 
+  // The property name for the GCS bucket used by the runtime job manager for launching jobs via the job API
+  // It can be overridden by profile runtime arguments (system.profile.properties.gcsBucket)
+  public static final String BUCKET = "gcsBucket";
   public static final String CDAP_GCS_ROOT = "cdap-job";
   public static final String CDAP_CACHED_ARTIFACTS = "cached-artifacts";
   public static final String WORKER_CPU_PREFIX = "Up to";

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -129,7 +129,7 @@ public final class DataprocUtils {
    * Removes prefix gs:// and returns bucket name
    */
   public static String getBucketName(String bucket) {
-    if (bucket.startsWith(GS_PREFIX)) {
+    if (bucket != null && bucket.startsWith(GS_PREFIX)) {
       return bucket.substring(GS_PREFIX.length());
     }
     return bucket;

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -60,7 +60,7 @@ public final class DataprocUtils {
 
   // The property name for the GCS bucket used by the runtime job manager for launching jobs via the job API
   // It can be overridden by profile runtime arguments (system.profile.properties.gcsBucket)
-  public static final String BUCKET = "gcsBucket";
+  public static final String GCS_BUCKET = "gcsBucket";
   public static final String CDAP_GCS_ROOT = "cdap-job";
   public static final String CDAP_CACHED_ARTIFACTS = "cached-artifacts";
   public static final String WORKER_CPU_PREFIX = "Up to";

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -59,10 +59,6 @@ import javax.annotation.Nullable;
 public abstract class AbstractDataprocProvisioner implements Provisioner {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractDataprocProvisioner.class);
-
-  // The property name for the GCS bucket used by the runtime job manager for launching jobs via the job API
-  // It can be overridden by profile runtime arguments (system.profile.properties.bucket)
-  private static final String BUCKET = "gcsBucket";
   // Keys for looking up system properties
   private static final String LABELS_PROPERTY = "labels";
   private static final Pattern SIMPLE_VERSION_PATTERN = Pattern.compile("^([0-9][0-9.]*)$");
@@ -125,7 +121,7 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
         jobManager.close();
       }
 
-      String bucket = DataprocUtils.getBucketName(properties.get(BUCKET));
+      String bucket = DataprocUtils.getBucketName(properties.get(DataprocUtils.GCS_BUCKET));
       Storage storageClient = StorageOptions.newBuilder().setProjectId(conf.getProjectId())
         .setCredentials(conf.getDataprocCredentials()).build().getService();
       String runId = context.getProgramRunInfo().getRun();
@@ -191,7 +187,7 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
       String clusterName = getClusterName(context);
       String projectId = conf.getProjectId();
       String region = conf.getRegion();
-      String bucket = properties.get(BUCKET);
+      String bucket = properties.get(DataprocUtils.GCS_BUCKET);
 
       Map<String, String> systemLabels = getSystemLabels();
       return Optional.of(
@@ -222,7 +218,7 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
     if (DataprocConf.CLUSTER_PROPERTIES_PATTERN.matcher(property).find()) {
       return true;
     }
-    return ImmutableSet.of(DataprocConf.RUNTIME_JOB_MANAGER, BUCKET, DataprocConf.TOKEN_ENDPOINT_KEY,
+    return ImmutableSet.of(DataprocConf.RUNTIME_JOB_MANAGER, DataprocUtils.GCS_BUCKET, DataprocConf.TOKEN_ENDPOINT_KEY,
                            DataprocUtils.TROUBLESHOOTING_DOCS_URL_KEY,
                            DataprocConf.ENCRYPTION_KEY_NAME, DataprocConf.ROOT_URL,
                            DataprocConf.COMPUTE_HTTP_REQUEST_CONNECTION_TIMEOUT,

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -62,7 +62,7 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
 
   // The property name for the GCS bucket used by the runtime job manager for launching jobs via the job API
   // It can be overridden by profile runtime arguments (system.profile.properties.bucket)
-  private static final String BUCKET = "bucket";
+  private static final String BUCKET = "gcsBucket";
   // Keys for looking up system properties
   private static final String LABELS_PROPERTY = "labels";
   private static final Pattern SIMPLE_VERSION_PATTERN = Pattern.compile("^([0-9][0-9.]*)$");

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -219,7 +219,7 @@ final class DataprocConf {
     this.pollDeleteDelay = pollDeleteDelay;
     this.pollInterval = pollInterval;
     this.encryptionKeyName = encryptionKeyName;
-    this.gcsBucket = DataprocUtils.getBucketName(gcsBucket);
+    this.gcsBucket = gcsBucket;
     this.serviceAccount = serviceAccount;
     this.preferExternalIP = preferExternalIP;
     this.stackdriverLoggingEnabled = stackdriverLoggingEnabled;
@@ -642,7 +642,7 @@ final class DataprocConf {
     String imageVersion = getString(properties, IMAGE_VERSION);
     String customImageUri = getString(properties, CUSTOM_IMAGE_URI);
     String gcpCmekKeyName = getString(properties, ENCRYPTION_KEY_NAME);
-    String gcpCmekBucket = getString(properties, "gcsBucket");
+    String gcpCmekBucket = DataprocUtils.getBucketName(getString(properties, "gcsBucket"));
 
     Map<String, String> clusterMetaData = Collections.unmodifiableMap(
       DataprocUtils.parseKeyValueConfig(getString(properties, CLUSTER_META_DATA), ";", "\\|"));

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -642,7 +642,7 @@ final class DataprocConf {
     String imageVersion = getString(properties, IMAGE_VERSION);
     String customImageUri = getString(properties, CUSTOM_IMAGE_URI);
     String gcpCmekKeyName = getString(properties, ENCRYPTION_KEY_NAME);
-    String gcpCmekBucket = DataprocUtils.getBucketName(getString(properties, DataprocUtils.BUCKET));
+    String gcpCmekBucket = DataprocUtils.getBucketName(getString(properties, DataprocUtils.GCS_BUCKET));
 
     Map<String, String> clusterMetaData = Collections.unmodifiableMap(
       DataprocUtils.parseKeyValueConfig(getString(properties, CLUSTER_META_DATA), ";", "\\|"));

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -642,7 +642,7 @@ final class DataprocConf {
     String imageVersion = getString(properties, IMAGE_VERSION);
     String customImageUri = getString(properties, CUSTOM_IMAGE_URI);
     String gcpCmekKeyName = getString(properties, ENCRYPTION_KEY_NAME);
-    String gcpCmekBucket = DataprocUtils.getBucketName(getString(properties, "gcsBucket"));
+    String gcpCmekBucket = DataprocUtils.getBucketName(getString(properties, DataprocUtils.BUCKET));
 
     Map<String, String> clusterMetaData = Collections.unmodifiableMap(
       DataprocUtils.parseKeyValueConfig(getString(properties, CLUSTER_META_DATA), ";", "\\|"));

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -219,7 +219,7 @@ final class DataprocConf {
     this.pollDeleteDelay = pollDeleteDelay;
     this.pollInterval = pollInterval;
     this.encryptionKeyName = encryptionKeyName;
-    this.gcsBucket = gcsBucket;
+    this.gcsBucket = DataprocUtils.getBucketName(gcsBucket);
     this.serviceAccount = serviceAccount;
     this.preferExternalIP = preferExternalIP;
     this.stackdriverLoggingEnabled = stackdriverLoggingEnabled;

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
@@ -470,7 +470,7 @@
           "widget-type": "textbox",
           "label": "GCS Bucket",
           "name": "gcsBucket",
-          "description": "Google Cloud Storage bucket used to stage job dependencies and config files for running pipelines in Google Cloud Dataproc. If the bucket is unspecified, then the bucket created during an instance creation will be used",
+          "description": "Google Cloud Storage bucket used to stage job dependencies and config files for running pipelines in Google Cloud Dataproc. If the bucket is not specified, then the bucket created during the instance creation will be used",
           "widget-attributes": {
             "size": "medium"
           }

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
@@ -470,7 +470,7 @@
           "widget-type": "textbox",
           "label": "GCS Bucket",
           "name": "gcsBucket",
-          "description": "Google Cloud Storage bucket used to stage job dependencies and config files for running pipelines in Google Cloud Dataproc",
+          "description": "Google Cloud Storage bucket used to stage job dependencies and config files for running pipelines in Google Cloud Dataproc. If the bucket is unspecified, then the bucket created during an instance creation will be used",
           "widget-attributes": {
             "size": "medium"
           }


### PR DESCRIPTION
**_CDAP-19630: Inconsistency between bucket property keys used for overriding gcsBucket_**
**Description:**
GCS bucket key that is used for setting and getting gcs bucket are different:

https://github.com/cdapio/cdap/blob/43ed7b5460c294d145cf38da668603a33be8645b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java#L629

https://github.com/cdapio/cdap/blob/43ed7b5460c294d145cf38da668603a33be8645b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java#L62

In one place we use gcsBucket and in another place we use bucket

So if gcsBucket key is used for setting gcs bucket in compute profile as follows:

      {
      "name": "gcsBucket",
      "value": "test-bucket",
      "isEditable": true
      },
test-bucket bucket will still not be used for uploading artifacts into it.


**Workaround:**
both keys should be used as follows:

      {
      "name": "gcsBucket",
      "value": "test-bucket",
      "isEditable": true
      },
      {
      "name": "bucket",
      "value": "test-bucket",
      "isEditable": true
      },

**Solution:**
Use variable 'gcsBucket' to get the dataproc bucket of an instance and change the variable name 'bucket' to 'gcsBucket' in clh as well for versions greater than or equal to 6.8.0.

**Testing:**
The change was tested thoroughly and the artifacts were getting uploaded to the specified bucket. And the runId folder was also getting deleted once the pipeline run completed.