### PR TITLE
feat(CDAP-19664): relaxing range restriction on existing scan methods & update in logHandler

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -84,6 +84,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -92,6 +94,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 
 /**
@@ -1520,31 +1523,42 @@ public class AppMetadataStore {
     List<List<Field<?>>> allKeys = new ArrayList<>();
     for (ProgramRunId programRunId : programRunIds) {
       allKeys.add(getProgramRunInvertedTimeKey(TYPE_RUN_RECORD_ACTIVE, programRunId,
-                                               RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS)));
+                                               RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS),
+                                               false));
     }
-    return getRunRecordsTable().multiRead(allKeys).stream()
-      .map(AppMetadataStore::deserializeRunRecordMeta)
-      .collect(Collectors.toMap(RunRecordDetail::getProgramRunId, r -> r, (r1, r2) -> {
-        throw new IllegalStateException("Duplicate run record for " + r1.getProgramRunId());
-      }, LinkedHashMap::new));
+    
+    return getRunsByKeys(allKeys);
   }
 
   private Map<ProgramRunId, RunRecordDetail> getCompletedRuns(Set<ProgramRunId> programRunIds) throws IOException {
     List<List<Field<?>>> allKeys = new ArrayList<>();
     for (ProgramRunId programRunId : programRunIds) {
-      List<Field<?>> keys = getRunRecordProgramPrefix(TYPE_RUN_RECORD_COMPLETED, programRunId.getParent());
+      // Get all keys without version
+      List<Field<?>> keysWithoutVersion = getRunRecordProgramPrefix(TYPE_RUN_RECORD_COMPLETED,
+                                                                    programRunId.getParent(),
+                                                                    false);
       // Get start time from RunId
       long programStartSecs = RunIds.getTime(RunIds.fromString(programRunId.getRun()), TimeUnit.SECONDS);
-      keys.add(Fields.longField(StoreDefinition.AppMetadataStore.RUN_START_TIME,
-                                getInvertedTsKeyPart(programStartSecs)));
-      keys.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, programRunId.getRun()));
-      allKeys.add(keys);
+      keysWithoutVersion.add(Fields.longField(StoreDefinition.AppMetadataStore.RUN_START_TIME,
+                                              getInvertedTsKeyPart(programStartSecs)));
+      keysWithoutVersion.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, programRunId.getRun()));
+      allKeys.add(keysWithoutVersion);
     }
-    return getRunRecordsTable().multiRead(allKeys).stream()
-      .map(AppMetadataStore::deserializeRunRecordMeta)
-      .collect(Collectors.toMap(RunRecordDetail::getProgramRunId, r -> r, (r1, r2) -> {
-        throw new IllegalStateException("Duplicate run record for " + r1.getProgramRunId());
-      }, LinkedHashMap::new));
+
+    return getRunsByKeys(allKeys);
+  }
+
+  private Map<ProgramRunId, RunRecordDetail> getRunsByKeys(List<List<Field<?>>> allKeys) throws IOException {
+    Collection<Range> ranges = allKeys.stream().map(Range::singleton).collect(Collectors.toList());
+
+    try (CloseableIterator<StructuredRow> iterator =
+           getRunRecordsTable().multiScan(ranges, Integer.MAX_VALUE)) {
+      return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
+          .map(AppMetadataStore::deserializeRunRecordMeta)
+          .collect(Collectors.toMap(RunRecordDetail::getProgramRunId, r -> r, (r1, r2) -> {
+            throw new IllegalStateException("Duplicate run record for " + r1.getProgramRunId());
+          }, LinkedHashMap::new));
+    }
   }
 
   /**
@@ -2004,12 +2018,21 @@ public class AppMetadataStore {
   }
 
   private List<Field<?>> getRunRecordProgramPrefix(String status, @Nullable ProgramId programId) {
+    return getRunRecordProgramPrefix(status, programId, true);
+  }
+
+  private List<Field<?>> getRunRecordProgramPrefix(String status,
+                                                   @Nullable ProgramId programId,
+                                                   boolean includeVersion) {
+    List<Field<?>> fields = getRunRecordStatusPrefix(status);
     if (programId == null) {
-      return getRunRecordStatusPrefix(status);
+      return fields;
     }
-    List<Field<?>> fields =
-      getRunRecordApplicationPrefix(
-        status, new ApplicationId(programId.getNamespace(), programId.getApplication(), programId.getVersion()));
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD, programId.getNamespace()));
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_FIELD, programId.getApplication()));
+    if (includeVersion) {
+      fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.VERSION_FIELD, programId.getVersion()));
+    }
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_TYPE_FIELD, programId.getType().name()));
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_FIELD, programId.getProgram()));
     return fields;
@@ -2035,17 +2058,19 @@ public class AppMetadataStore {
     return (String) field.getValue();
   }
 
-  private List<Field<?>> addProgramPrimaryKeys(ProgramId programRunId, List<Field<?>> fields) {
+  private List<Field<?>> addProgramPrimaryKeys(ProgramId programRunId, List<Field<?>> fields, boolean includeVersion) {
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD, programRunId.getNamespace()));
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_FIELD, programRunId.getApplication()));
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.VERSION_FIELD, programRunId.getVersion()));
+    if (includeVersion) {
+      fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.VERSION_FIELD, programRunId.getVersion()));
+    }
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_TYPE_FIELD, programRunId.getType().name()));
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_FIELD, programRunId.getProgram()));
     return fields;
   }
 
   private List<Field<?>> getProgramRunPrimaryKeys(ProgramRunId programRunId) {
-    List<Field<?>> fields = addProgramPrimaryKeys(programRunId.getParent(), new ArrayList<>());
+    List<Field<?>> fields = addProgramPrimaryKeys(programRunId.getParent(), new ArrayList<>(), true);
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, programRunId.getRun()));
     return fields;
   }
@@ -2057,9 +2082,14 @@ public class AppMetadataStore {
   }
 
   private List<Field<?>> getProgramRunInvertedTimeKey(String recordType, ProgramRunId runId, long startTs) {
+    return getProgramRunInvertedTimeKey(recordType, runId, startTs, true);
+  }
+
+  private List<Field<?>> getProgramRunInvertedTimeKey(String recordType, ProgramRunId runId,
+                                                      long startTs, boolean includeVersion) {
     List<Field<?>> fields = new ArrayList<>();
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_STATUS, recordType));
-    addProgramPrimaryKeys(runId.getParent(), fields);
+    addProgramPrimaryKeys(runId.getParent(), fields, includeVersion);
     fields.add(Fields.longField(StoreDefinition.AppMetadataStore.RUN_START_TIME, getInvertedTsKeyPart(startTs)));
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, runId.getRun()));
     return fields;
@@ -2068,7 +2098,7 @@ public class AppMetadataStore {
   private List<Field<?>> getProgramCountPrimaryKeys(String type, ProgramId programId) {
     List<Field<?>> fields = new ArrayList<>();
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.COUNT_TYPE, type));
-    return addProgramPrimaryKeys(programId, fields);
+    return addProgramPrimaryKeys(programId, fields, true);
   }
 
   @Nullable

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
@@ -175,7 +175,7 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
 
     String opsDashboardQueryPath =
       String.format("%s/dashboard?start=%s&duration=%s&namespace=%s&namespace=%s", BASE_PATH,
-                    String.valueOf(startTime1), String.valueOf(endTime), ns1.getNamespace(), ns2.getNamespace());
+                    startTime1, endTime, ns1.getNamespace(), ns2.getNamespace());
     // get ops dashboard query results
     HttpResponse response = doGet(opsDashboardQueryPath);
     Assert.assertEquals(200, response.getResponseCode());
@@ -191,7 +191,7 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
     // for the same time range query only in namespace ns1 to ensure filtering works fine
     opsDashboardQueryPath =
       String.format("%s/dashboard?start=%s&duration=%s&namespace=%s", BASE_PATH,
-                    String.valueOf(startTime1), String.valueOf(endTime), ns2.getNamespace());
+                    startTime1, endTime, ns2.getNamespace());
 
     // get ops dashboard query results
     response = doGet(opsDashboardQueryPath);
@@ -371,7 +371,7 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
 
     String opsDashboardQueryPath =
       String.format("%s/dashboard?start=%s&duration=%s&namespace=%s", BASE_PATH,
-                    String.valueOf(startTime1), String.valueOf(endTime), ns3.getNamespace());
+                    startTime1, endTime, ns3.getNamespace());
 
     // get ops dashboard query results
     HttpResponse response = doGet(opsDashboardQueryPath);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -1320,9 +1320,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
   }
 
   private void testReEnableSchedule(String scheduleName) throws Exception {
-    ProtoTrigger.TimeTrigger protoTime = new ProtoTrigger.TimeTrigger("0 * * * ?");
-    ProtoTrigger.PartitionTrigger protoPartition =
-      new ProtoTrigger.PartitionTrigger(NamespaceId.DEFAULT.dataset("data"), 5);
     String description = "Something";
     ScheduleProgramInfo programInfo = new ScheduleProgramInfo(SchedulableProgramType.WORKFLOW,
                                                               AppWithSchedule.WORKFLOW_NAME);

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2019-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -128,10 +129,69 @@ public final class NoSqlStructuredTable implements StructuredTable {
   @Override
   public CloseableIterator<StructuredRow> scan(Range keyRange, int limit) throws InvalidFieldException {
     LOG.trace("Table {}: Scan range {} with limit {}", schema.getTableId(), keyRange, limit);
-    return new LimitIterator(Collections.singleton(new ScannerIterator(getScanner(keyRange), schema)).iterator(),
-                             limit);
+    return new LimitIterator(Collections.singleton(getFilterByRangeIterator(keyRange)).iterator(), limit);
   }
 
+  /**
+   * Scan the nosql db with a key range. It gets the longest prefix keys,
+   * scan the DB and do a post filtering on the result.
+   *
+   * @param keyRange prefix key range to scan
+   * @return the iterator after filtering
+   * @throws InvalidFieldException if the key is not a primary key
+   */
+  private CloseableIterator<StructuredRow> getFilterByRangeIterator(Range keyRange) {
+    Range prefixRange = getLongestPrefixRange(keyRange);
+    ScannerIterator scannerIterator = new ScannerIterator(getScanner(prefixRange), schema);
+
+    Range filterRange = getFilterRange(keyRange, prefixRange);
+    // Return scannerIterator once we found that there's no need to further filter
+    if (filterRange.getBegin().isEmpty() && filterRange.getEnd().isEmpty()) {
+      return scannerIterator;
+    }
+
+    return new FilterByRangeIterator(Collections.singleton(scannerIterator).iterator(),
+                                     Collections.singleton(filterRange));
+  }
+
+  private Range getLongestPrefixRange(Range range) {
+    fieldValidator.validatePartialPrimaryKeys(range.getBegin());
+    fieldValidator.validatePartialPrimaryKeys(range.getEnd());
+
+    List<Field<?>> beginPrefixKeys = getPrefixPrimaryKeys(range.getBegin());
+    List<Field<?>> endPrefixKeys = getPrefixPrimaryKeys(range.getEnd());
+
+    return Range.create(beginPrefixKeys, range.getBeginBound(), endPrefixKeys, range.getEndBound());
+  }
+
+  private Range getFilterRange(Range keyRange, Range prefixRange) {
+    List<Field<?>> beginFilterKeys = getFilterKeys(keyRange.getBegin(), prefixRange.getBegin());
+    List<Field<?>> endFilterKeys = getFilterKeys(keyRange.getEnd(), prefixRange.getEnd());
+
+    return Range.create(beginFilterKeys, keyRange.getBeginBound(), endFilterKeys, keyRange.getEndBound());
+  }
+
+  private List<Field<?>> getFilterKeys(Collection<Field<?>> keys, Collection<Field<?>> prefixKeys) {
+    Set<String> prefixKeysSet = prefixKeys.stream().map(Field::getName).collect(Collectors.toSet());
+
+    return keys.stream()
+      .filter(key -> !prefixKeysSet.contains(key.getName()))
+      .collect(Collectors.toList());
+  }
+
+  private List<Field<?>> getPrefixPrimaryKeys(Collection<Field<?>> partialKeys) {
+    List<Field<?>> prefixKeys = new ArrayList<>();
+    List<String> primaryKeys = schema.getPrimaryKeys();
+    int i = 0;
+    for (Field<?> key : partialKeys) {
+      if (!key.getName().equals(primaryKeys.get(i))) {
+        return prefixKeys;
+      }
+      prefixKeys.add(key);
+      i++;
+    }
+    return prefixKeys;
+  }
 
   /*
    *  Sorting in memory for the no-sql implementation. We sort post table scan.
@@ -148,9 +208,9 @@ public final class NoSqlStructuredTable implements StructuredTable {
       getComparator(orderByField).reversed();
     PriorityQueue<StructuredRow> rows = new PriorityQueue<>(comparator);
 
-    try (ScannerIterator scannerIterator = new ScannerIterator(getScanner(keyRange), schema)) {
-      while (scannerIterator.hasNext()) {
-        rows.offer(scannerIterator.next());
+    try (CloseableIterator<StructuredRow> filterIterator = getFilterByRangeIterator(keyRange)) {
+      while (filterIterator.hasNext()) {
+        rows.offer(filterIterator.next());
       }
     }
     // return an iterator for the sorted elements
@@ -207,17 +267,42 @@ public final class NoSqlStructuredTable implements StructuredTable {
     if (!schema.isIndexColumn(filterIndex.getName())) {
       throw new InvalidFieldException(schema.getTableId(), filterIndex.getName(), "is not an indexed column");
     }
-    ScannerIterator scannerIterator = new ScannerIterator(getScanner(keyRange), schema);
-    FilterByIndexIterator filterByIndexIterator = new FilterByIndexIterator(scannerIterator, filterIndex, schema);
+    FilterByFieldIterator filterByIndexIterator =
+      new FilterByFieldIterator(getFilterByRangeIterator(keyRange), filterIndex, schema);
     return new LimitIterator(Collections.singleton(filterByIndexIterator).iterator(), limit);
   }
 
+  /*
+   * Scan the nosql DB with provided ranges.
+   * Find out the longest prefix ranges, merge them if possible, scan these intervals
+   * then filter by ranges, the result should already be sorted by primary keys.
+   * */
   @Override
-  public CloseableIterator<StructuredRow> multiScan(Collection<Range> keyRanges,
-                                                    int limit) throws InvalidFieldException, IOException {
-    // Sort the scan keys by the start key and merge overlapping ranges.
+  public CloseableIterator<StructuredRow> multiScan(Collection<Range> keyRanges, int limit)
+    throws InvalidFieldException, IOException {
+
+    if (keyRanges.isEmpty()) {
+      return CloseableIterator.empty();
+    }
+
+    // Call scan single range when there's only range
+    if (keyRanges.size() == 1) {
+      return scan(keyRanges.iterator().next(), limit);
+    }
+
+    FilterByRangeIterator filterIterator =
+      new FilterByRangeIterator(getPrefixRangeScannerIterator(keyRanges), keyRanges);
+    return new LimitIterator(filterIterator, limit);
+  }
+
+  /*
+   * Merge the longest prefix ranges and scan one by one
+   * */
+  private AbstractIterator<ScannerIterator> getPrefixRangeScannerIterator(Collection<Range> keyRanges) {
     Deque<ImmutablePair<byte[], byte[]>> scanKeys = new LinkedList<>();
+    // Sort the scan keys by the start key and merge overlapping ranges.
     keyRanges.stream()
+      .map(this::getLongestPrefixRange)
       .map(this::createScanKeys)
       .sorted((o1, o2) -> Bytes.compareTo(o1.getFirst(), o2.getFirst()))
       .forEach(range -> {
@@ -239,7 +324,7 @@ public final class NoSqlStructuredTable implements StructuredTable {
       });
 
     Iterator<ImmutablePair<byte[], byte[]>> rangeIterator = scanKeys.iterator();
-    return new LimitIterator(new AbstractIterator<ScannerIterator>() {
+    return new AbstractIterator<ScannerIterator>() {
       @Override
       protected ScannerIterator computeNext() {
         if (!rangeIterator.hasNext()) {
@@ -248,7 +333,7 @@ public final class NoSqlStructuredTable implements StructuredTable {
         ImmutablePair<byte[], byte[]> range = rangeIterator.next();
         return new ScannerIterator(table.scan(range.getFirst(), range.getSecond()), schema);
       }
-    }, limit);
+    };
   }
 
   @Override
@@ -283,8 +368,7 @@ public final class NoSqlStructuredTable implements StructuredTable {
     }
 
     return table.compareAndSwap(convertKeyToBytes(keys, false), Bytes.toBytes(oldValue.getName()),
-                                fieldToBytes(oldValue),
-                                fieldToBytes(newValue));
+                                fieldToBytes(oldValue), fieldToBytes(newValue));
   }
 
   @Override
@@ -314,10 +398,9 @@ public final class NoSqlStructuredTable implements StructuredTable {
   @Override
   public void deleteAll(Range keyRange) throws InvalidFieldException, IOException {
     LOG.trace("Table {}: DeleteAll with range {}", schema.getTableId(), keyRange);
-    try (Scanner scanner = getScanner(keyRange)) {
-      Row row;
-      while ((row = scanner.next()) != null) {
-        table.delete(row.getRow());
+    try (CloseableIterator<StructuredRow> iterator = getFilterByRangeIterator(keyRange)) {
+      while (iterator.hasNext()) {
+        table.delete(convertKeyToBytes(iterator.next().getPrimaryKeys(), false));
       }
     }
   }
@@ -326,11 +409,12 @@ public final class NoSqlStructuredTable implements StructuredTable {
   public long count(Collection<Range> keyRanges) throws IOException {
     LOG.trace("Table {}: count with ranges {}", schema.getTableId(), keyRanges);
     long count = 0;
-    for (Range keyRange: keyRanges) {
-      try (Scanner scanner = getScanner(keyRange)) {
-        while (scanner.next() != null) {
-          count++;
-        }
+    // Instead of scanning ranges one by one, we call multiScan,
+    // which can deduplicate and sort the result
+    try (CloseableIterator<StructuredRow> iterator = multiScan(keyRanges, Integer.MAX_VALUE)) {
+      while (iterator.hasNext()) {
+        iterator.next();
+        count++;
       }
     }
     return count;
@@ -345,8 +429,8 @@ public final class NoSqlStructuredTable implements StructuredTable {
    * Convert the keys to corresponding byte array. The keys can either be a prefix or complete primary keys depending
    * on the value of allowPrefix. The method will always prepend the table name as a prefix for the row keys.
    *
-   * @param keys keys to convert
-   * @param allowPrefix true if the keys can be prefix false if the keys have to contain all the primary keys.
+   * @param keys        keys to convert
+   * @param allowPrefix true if the keys can be prefixed false if the keys have to contain all the primary keys.
    * @return the byte array converted
    * @throws InvalidFieldException if the key are not prefix or complete primary keys
    */
@@ -581,44 +665,44 @@ public final class NoSqlStructuredTable implements StructuredTable {
   }
 
   /**
-   * Filters elements matching an index {@link ScannerIterator}.
+   * Filters elements matching a field {@link ScannerIterator}.
    */
   @VisibleForTesting
-  static final class FilterByIndexIterator extends AbstractCloseableIterator<StructuredRow> {
+  static final class FilterByFieldIterator extends AbstractCloseableIterator<StructuredRow> {
     private final CloseableIterator<StructuredRow> scannerIterator;
     private final Predicate<StructuredRow> predicate;
 
-    FilterByIndexIterator(CloseableIterator<StructuredRow> scannerIterator, Field<?> filterIndex,
+    FilterByFieldIterator(CloseableIterator<StructuredRow> scannerIterator, Field<?> filterField,
                           StructuredTableSchema schema) {
       this.scannerIterator = scannerIterator;
 
-      switch (filterIndex.getFieldType()) {
+      switch (filterField.getFieldType()) {
         case INTEGER:
-          predicate = row -> Objects.equals(row.getInteger(filterIndex.getName()), filterIndex.getValue());
+          predicate = row -> Objects.equals(row.getInteger(filterField.getName()), filterField.getValue());
           break;
         case LONG:
-          predicate = row -> Objects.equals(row.getLong(filterIndex.getName()), filterIndex.getValue());
+          predicate = row -> Objects.equals(row.getLong(filterField.getName()), filterField.getValue());
           break;
         case FLOAT:
-          predicate = row -> Objects.equals(row.getFloat(filterIndex.getName()), filterIndex.getValue());
+          predicate = row -> Objects.equals(row.getFloat(filterField.getName()), filterField.getValue());
           break;
         case DOUBLE:
-          predicate = row -> Objects.equals(row.getDouble(filterIndex.getName()), filterIndex.getValue());
+          predicate = row -> Objects.equals(row.getDouble(filterField.getName()), filterField.getValue());
           break;
         case STRING:
-          predicate = row -> Objects.equals(row.getString(filterIndex.getName()), filterIndex.getValue());
+          predicate = row -> Objects.equals(row.getString(filterField.getName()), filterField.getValue());
           break;
         case BYTES:
-          predicate = row -> Arrays.equals(row.getBytes(filterIndex.getName()), (byte[]) filterIndex.getValue());
+          predicate = row -> Arrays.equals(row.getBytes(filterField.getName()), (byte[]) filterField.getValue());
           break;
         default:
-          throw new InvalidFieldException(schema.getTableId(), filterIndex.getName());
+          throw new InvalidFieldException(schema.getTableId(), filterField.getName());
       }
     }
 
     @Override
     protected StructuredRow computeNext() {
-      // Postfiltering on scanned rows by index
+      // Post filtering on scanned rows by specified field
       while (scannerIterator.hasNext()) {
         StructuredRow row = scannerIterator.next();
         if (predicate.test(row)) {
@@ -631,6 +715,127 @@ public final class NoSqlStructuredTable implements StructuredTable {
     @Override
     public void close() {
       scannerIterator.close();
+    }
+  }
+
+  /**
+   * Filters elements matching a range {@link ScannerIterator}.
+   */
+  @VisibleForTesting
+  static final class FilterByRangeIterator extends AbstractCloseableIterator<StructuredRow> {
+    private final Iterator<? extends CloseableIterator<StructuredRow>> scannerIterator;
+    private CloseableIterator<StructuredRow> currentScanner;
+    private final Collection<Predicate<StructuredRow>> predicates;
+
+    FilterByRangeIterator(Iterator<? extends CloseableIterator<StructuredRow>> scannerIterator,
+                          Collection<Range> filterRanges) {
+      this.scannerIterator = scannerIterator;
+      this.currentScanner = scannerIterator.hasNext() ? scannerIterator.next() : CloseableIterator.empty();
+      this.predicates = filterRanges.stream().map(this::buildPredicate).collect(Collectors.toList());
+    }
+
+    private Predicate<StructuredRow> buildPredicate(Range filterRange) {
+      return row -> {
+        int beginIndex = 1;
+        int beginFieldsCount = filterRange.getBegin().size();
+        for (Field<?> beginField : filterRange.getBegin()) {
+          int comp = compareRowAndField(row, beginField);
+          // comp should be at least >= 0
+          if (comp < 0) {
+            return false;
+          }
+          // Edge case for = when we filter by the last field
+          // This is for case like ([KEY: "ns1", KEY2: 123], EXCLUSIVE, [KEY: "ns1", KEY2: 250], INCLUSIVE)
+          // We need to check the ending bound for KEY2, not KEY
+          if (beginIndex == beginFieldsCount
+            && filterRange.getBeginBound().equals(Range.Bound.EXCLUSIVE)
+            && comp == 0) {
+            return false;
+          }
+          beginIndex++;
+        }
+
+        int endIndex = 1;
+        int endFieldsCount = filterRange.getEnd().size();
+        for (Field<?> endField : filterRange.getEnd()) {
+          int comp = compareRowAndField(row, endField);
+          // comp should be at least <= 0
+          if (comp > 0) {
+            return false;
+          }
+          // Edge case for = when we filter by the last field
+          // This is for case like ([KEY: "ns1", KEY2: 123], INCLUSIVE, [KEY: "ns1", KEY2: 250], EXCLUSIVE)
+          // We need to check the ending bound for KEY2, not KEY
+          if (endIndex == endFieldsCount
+            && filterRange.getEndBound().equals(Range.Bound.EXCLUSIVE)
+            && comp == 0) {
+            return false;
+          }
+          endIndex++;
+        }
+
+        return true;
+      };
+    }
+
+    private int compareRowAndField(StructuredRow row, Field<?> field) {
+      String fieldName = field.getName();
+      switch (field.getFieldType()) {
+        case INTEGER:
+          return Objects.compare(row.getInteger(fieldName), (Integer) field.getValue(), Integer::compare);
+        case LONG:
+          return Objects.compare(row.getLong(fieldName), (Long) (field.getValue()), Long::compare);
+        case FLOAT:
+          return Objects.compare(row.getFloat(fieldName), (Float) (field.getValue()), Float::compare);
+        case DOUBLE:
+          return Objects.compare(row.getDouble(fieldName), (Double) (field.getValue()), Double::compare);
+        case STRING:
+          return Objects.compare(row.getString(fieldName), (String) (field.getValue()), String::compareTo);
+        case BYTES:
+          return new Bytes.ByteArrayComparator().compare(row.getBytes(fieldName), (byte[]) field.getValue());
+        default:
+          throw new RuntimeException(String.format("Exception while comparing row: %s and field: %s", row, field));
+      }
+    }
+
+    @Override
+    protected StructuredRow computeNext() {
+      // Find the next Scanner that is not iterated
+      while (!currentScanner.hasNext() && scannerIterator.hasNext()) {
+        closeScanner();
+        currentScanner = scannerIterator.next();
+      }
+
+      // The case that we iterate to the end of last scanner
+      if (!currentScanner.hasNext()) {
+        return endOfData();
+      }
+
+      // Iterator the current scanner, return when we find a matching element
+      while (currentScanner.hasNext()) {
+        StructuredRow row = currentScanner.next();
+        for (Predicate<StructuredRow> predicate : predicates) {
+          if (predicate.test(row)) {
+            return row;
+          }
+        }
+      }
+
+      // Recursion call
+      // Done with the current scanner, got to next scanner and repeat
+      return computeNext();
+    }
+
+    @Override
+    public void close() {
+      closeScanner();
+    }
+
+    private void closeScanner() {
+      if (currentScanner != null) {
+        currentScanner.close();
+        currentScanner = null;
+      }
     }
   }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStructuredTable.java
@@ -210,8 +210,8 @@ public class PostgreSqlStructuredTable implements StructuredTable {
     throws InvalidFieldException, IOException {
 
     LOG.trace("Table {}: Scan range {} with limit {} order {}", tableSchema.getTableId(), keyRange, limit, sortOrder);
-    fieldValidator.validatePrimaryKeys(keyRange.getBegin(), true);
-    fieldValidator.validatePrimaryKeys(keyRange.getEnd(), true);
+    fieldValidator.validatePartialPrimaryKeys(keyRange.getBegin());
+    fieldValidator.validatePartialPrimaryKeys(keyRange.getEnd());
     String scanQuery = getScanQuery(keyRange, limit, tableSchema.getPrimaryKeys(), sortOrder);
 
     // We don't close the statement here because once it is closed, the result set is also closed.
@@ -240,15 +240,15 @@ public class PostgreSqlStructuredTable implements StructuredTable {
 
     // Validate all ranges. Also, find if there is any range that is open on both ends.
     // Also split the scans into actual range scans and singleton scan, which can be done via IN condition.
-    Map<String, Set<Field<?>>> keyFields = new LinkedHashMap<>();
+    List<Range> singletonScans = new ArrayList<>();
     List<Range> rangeScans = new ArrayList<>();
     boolean scanAll = false;
     for (Range range : keyRanges) {
-      fieldValidator.validatePrimaryKeys(range.getBegin(), true);
-      fieldValidator.validatePrimaryKeys(range.getEnd(), true);
+      fieldValidator.validatePartialPrimaryKeys(range.getBegin());
+      fieldValidator.validatePartialPrimaryKeys(range.getEnd());
 
       if (range.isSingleton()) {
-        range.getBegin().forEach(f -> keyFields.computeIfAbsent(f.getName(), k -> new LinkedHashSet<>()).add(f));
+        singletonScans.add(range);
       } else {
         if (range.getBegin().isEmpty() && range.getEnd().isEmpty()) {
           scanAll = true;
@@ -262,7 +262,7 @@ public class PostgreSqlStructuredTable implements StructuredTable {
 
     try {
       // Don't close the statement. Leave it to the ResultSetIterator.close() to close it.
-      PreparedStatement statement = prepareMultiScanQuery(keyFields, rangeScans, limit);
+      PreparedStatement statement = prepareMultiScanQuery(singletonScans, rangeScans, limit);
       LOG.trace("MultiScan SQL statement: {}", statement);
 
       ResultSet resultSet = statement.executeQuery();
@@ -278,33 +278,37 @@ public class PostgreSqlStructuredTable implements StructuredTable {
    * clause using the {@link #appendRange(StringBuilder, Range)} method. The where clause of each range are OR together.
    * E.g.
    * <p>
-   * SELECT * FROM table WHERE key1 in (?,?) AND key2 in (?,?)
+   * SELECT * FROM table WHERE (key1 = ? AND key2 = ?) OR (key1 = ? AND key2 = ?)
    * OR ((key3 >= ?) AND (key3 <= ?)) OR ((key4 >= ?) AND (key4 <= ?)) LIMIT limit
    *
-   * @param keyFields a map from field name to field values that the query has to match with
-   * @param ranges    the list of ranges to scan
-   * @param limit     number of result
+   * @param singletonRanges the list of singleton ranges to scan
+   * @param ranges          the list of ranges to scan
+   * @param limit           number of result
    * @return a select query
    */
-  private PreparedStatement prepareMultiScanQuery(Map<String, Set<Field<?>>> keyFields,
+  private PreparedStatement prepareMultiScanQuery(Collection<Range> singletonRanges,
                                                   Collection<Range> ranges, int limit) throws SQLException {
+    // TODO: CDAP-19734, refactor cases like
+    //  (namespace >= 'default' and namespace <= 'default' and app >='a' and app <= 'b')
+    //  to (namespace = 'default' and app >='a' and app <= 'b')
     StringBuilder query = new StringBuilder("SELECT * FROM ")
       .append(tableSchema.getTableId().getName()).append(" WHERE ");
 
-    // Generates "key1 in (?,?) AND key2 in (?,?)..." clause
+    // Generates "(key1 = ? AND key2 = ?) OR (key1 = ? AND key2 = ?)..." clause
     String separator = "";
-    for (Map.Entry<String, Set<Field<?>>> entry : keyFields.entrySet()) {
+    Collection<Field<?>> singletonFields = new ArrayList<>();
+    for (Range singleton : singletonRanges) {
       query
         .append(separator)
-        .append(entry.getKey()).append(" IN (")
-        .append(IntStream.range(0, entry.getValue().size()).mapToObj(i -> "?").collect(Collectors.joining(",")))
-        .append(")");
-      separator = " AND ";
+        .append(singleton.getBegin().stream().map(field -> field.getName() + " = ?")
+          .collect(Collectors.joining(" AND ", "(", ")")));
+      separator = " OR ";
+      singletonFields.addAll(singleton.getBegin());
     }
 
     // Generates the ((key3 >= ?) AND (key3 <= ?)) OR ((key4 >= ?) AND (key4 <= ?))
     if (!ranges.isEmpty()) {
-      separator = keyFields.isEmpty() ? "(" : " OR (";
+      separator = singletonRanges.isEmpty() ? "(" : " OR (";
       for (Range range : ranges) {
         query.append(separator).append("(");
         appendRange(query, range);
@@ -320,7 +324,7 @@ public class PostgreSqlStructuredTable implements StructuredTable {
     statement.setFetchSize(fetchSize);
 
     // Set the parameters
-    int index = setFields(statement, keyFields.values().stream().flatMap(Collection::stream)::iterator, 1);
+    int index = setFields(statement, singletonFields, 1);
     for (Range range : ranges) {
       index = setStatementFieldByRange(range, statement, index);
     }
@@ -354,8 +358,8 @@ public class PostgreSqlStructuredTable implements StructuredTable {
   public CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Field<?> filterIndex)
     throws InvalidFieldException, IOException {
 
-    fieldValidator.validatePrimaryKeys(keyRange.getBegin(), true);
-    fieldValidator.validatePrimaryKeys(keyRange.getEnd(), true);
+    fieldValidator.validatePartialPrimaryKeys(keyRange.getBegin());
+    fieldValidator.validatePartialPrimaryKeys(keyRange.getEnd());
     fieldValidator.validateField(filterIndex);
     if (!tableSchema.isIndexColumn(filterIndex.getName())) {
       throw new InvalidFieldException(tableSchema.getTableId(), filterIndex.getName(), "is not an indexed column");
@@ -387,8 +391,8 @@ public class PostgreSqlStructuredTable implements StructuredTable {
 
     LOG.trace("Table {}: Scan range {} with limit {} order {} on index field {}",
               tableSchema.getTableId(), keyRange, limit, sortOrder, orderByField);
-    fieldValidator.validatePrimaryKeys(keyRange.getBegin(), true);
-    fieldValidator.validatePrimaryKeys(keyRange.getEnd(), true);
+    fieldValidator.validatePartialPrimaryKeys(keyRange.getBegin());
+    fieldValidator.validatePartialPrimaryKeys(keyRange.getEnd());
     if (!tableSchema.isIndexColumn(orderByField)) {
       throw new InvalidFieldException(tableSchema.getTableId(), orderByField, "is not an indexed column");
     }
@@ -890,9 +894,9 @@ public class PostgreSqlStructuredTable implements StructuredTable {
       valueJoiner.add("?");
     }
 
-    sb.append(keyJoiner.toString())
+    sb.append(keyJoiner)
       .append(comparator)
-      .append(valueJoiner.toString());
+      .append(valueJoiner);
   }
 
   private String getDeleteQuery(Collection<Field<?>> keys) {
@@ -913,8 +917,8 @@ public class PostgreSqlStructuredTable implements StructuredTable {
     StringBuilder statement = new StringBuilder("SELECT COUNT(*) FROM ").append(tableSchema.getTableId().getName());
     boolean whereAdded = false;
     for (Range range : ranges) {
-      fieldValidator.validatePrimaryKeys(range.getBegin(), true);
-      fieldValidator.validatePrimaryKeys(range.getEnd(), true);
+      fieldValidator.validatePartialPrimaryKeys(range.getBegin());
+      fieldValidator.validatePartialPrimaryKeys(range.getEnd());
 
       if (!range.getBegin().isEmpty() || !range.getEnd().isEmpty()) {
         if (!whereAdded) {

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
@@ -164,7 +164,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
     MockScanner scanner = new MockScanner(expected.iterator());
     Field<?> filterIndex = Fields.intField("key", 9);
     List<Integer> actual = new ArrayList<>();
-    try (NoSqlStructuredTable.FilterByIndexIterator closeableIterator = new NoSqlStructuredTable.FilterByIndexIterator(
+    try (NoSqlStructuredTable.FilterByFieldIterator closeableIterator = new NoSqlStructuredTable.FilterByFieldIterator(
       (new NoSqlStructuredTable.ScannerIterator(scanner, SCHEMA)), filterIndex, SCHEMA)) {
       while (closeableIterator.hasNext()) {
         actual.add(closeableIterator.next().getInteger("key"));
@@ -182,7 +182,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
     MockScanner scanner = new MockScanner(expected.iterator());
     Field<?> filterIndex = Fields.intField("key", 9);
     List<Integer> actual = new ArrayList<>();
-    try (NoSqlStructuredTable.FilterByIndexIterator closeableIterator = new NoSqlStructuredTable.FilterByIndexIterator(
+    try (NoSqlStructuredTable.FilterByFieldIterator closeableIterator = new NoSqlStructuredTable.FilterByFieldIterator(
       new NoSqlStructuredTable.ScannerIterator(scanner, SCHEMA), filterIndex, SCHEMA)) {
       while (closeableIterator.hasNext()) {
         actual.add(closeableIterator.next().getInteger("key"));

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
@@ -125,7 +125,7 @@ public interface StructuredTable extends Closeable {
    * @param keyRange key range for the scan
    * @param limit maximum number of rows to return
    * @param sortOrder defined primary key sort order. Note that the comparator used is specific to the underlying
-   *                  store and is not nessesarily lexographic.
+   *                  store and is not necessarily lexicographic.
    * @return a {@link CloseableIterator} of rows
    * @throws InvalidFieldException if any of the keys are not part of the table schema, or the types of the value
    *                               do not match

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/table/field/FieldValidatorTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/table/field/FieldValidatorTest.java
@@ -59,7 +59,7 @@ public class FieldValidatorTest {
 
     // Success case with prefix
     validator.validatePrimaryKeys(Arrays.asList(Fields.intField(KEY, 10), Fields.longField(KEY2, 100L)),
-                                                true);
+                                  true);
     validator.validatePrimaryKeys(Collections.singletonList(Fields.intField(KEY, 10)), true);
 
     // Test invalid type
@@ -75,6 +75,45 @@ public class FieldValidatorTest {
     try {
       validator.validatePrimaryKeys(Arrays.asList(Fields.intField(KEY, 10), Fields.longField(KEY2, 100L)),
                                     false);
+      Assert.fail("Expected InvalidFieldException");
+    } catch (InvalidFieldException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testValidatePartialPrimaryKeys() {
+    FieldValidator validator = new FieldValidator(schema);
+
+    // Success case
+    validator.validatePartialPrimaryKeys(Arrays.asList(Fields.intField(KEY, 10),
+                                                       Fields.longField(KEY2, 100L),
+                                                       Fields.stringField(KEY3, "s")));
+
+    // Success case with prefix
+    validator.validatePartialPrimaryKeys(Arrays.asList(Fields.intField(KEY, 10),
+                                                       Fields.longField(KEY2, 100L)));
+
+    // Success case with partial keys
+    validator.validatePartialPrimaryKeys(Arrays.asList(Fields.intField(KEY2, 10),
+                                                       Fields.stringField(KEY3, "s")));
+
+    // Test invalid type
+    try {
+      validator.validatePartialPrimaryKeys(Arrays.asList(Fields.stringField(KEY3, "s"),
+                                                         Fields.floatField(KEY, 10.0f),
+                                                         Fields.longField(KEY2, 100L)));
+      Assert.fail("Expected InvalidFieldException");
+    } catch (InvalidFieldException e) {
+      // expected
+    }
+
+    // Test invalid number
+    try {
+      validator.validatePartialPrimaryKeys(Arrays.asList(Fields.intField(KEY, 10),
+                                                         Fields.longField(KEY2, 100L),
+                                                         Fields.longField("notExitField", 100L),
+                                                         Fields.longField(KEY2, 100L)));
       Assert.fail("Expected InvalidFieldException");
     } catch (InvalidFieldException e) {
       // expected


### PR DESCRIPTION
PR changes:
1. Relaxed range restriction on existing scan methods. Previously we have restriction that the given range to table scan method has to be prefixed by primary keys. eg. if the table primary keys are [KEY, KEY1, KEY2], the range has to contain fields like [key, key1], it won't work for [key, key2](which is missing KEY1). This is mainly due to nosql db limitation. SQL table should be efficiently handling this. 
The implementation changed to: 
  a) For nosql single range scans, we find the longest prefix keys, then do post filtering based on fields
  b) For nosql multi range scans, we find and merge the longest prefix keys (which should be above to contain all the ranges' elements), then we do a post filtering. This should be able to avoid wild range scans and repeated range scans. Time and memory complexity should be fine since only local sanbox uses nosql DB


2. For `RunRecordsTable` read, we changed to scan by keys without version info. We do this workaround because the primary key runId is time based UUID, we don't need the version info to retrieve it. Secondly, the Loghttphandler is not taking version info in the endpoint paths, and it always defaults to `-SNAPSHOT` version, in pipelines lifecycle management, we're introducing versions to pipelines. We need to be able to retrieve logs / runs history for all versions.


 