### PR TITLE
[CDAP-19567] Reusing existing blob info while updating temporary hold on GCS object

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/ArtifactCacheManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/ArtifactCacheManager.java
@@ -122,8 +122,8 @@ public class ArtifactCacheManager {
       .forEach(artifact -> {
         String cachedArtifactFilePath = getPath(cachedArtifactsPath, artifact);
         try {
-          DataprocUtils.setCustomTimeOnGCSObject(client, bucket, BlobId.of(bucket, cachedArtifactFilePath),
-                                                 cachedArtifactFilePath, false);
+          DataprocUtils.removeTemporaryHoldOnGCSObject(client, bucket, BlobId.of(bucket, cachedArtifactFilePath),
+                                                       cachedArtifactFilePath);
         } catch (InterruptedException e) {
           LOG.warn("Unable to update custom time and temporary hold on cached artifacts", e);
         }


### PR DESCRIPTION
This PR reuses the existing blob information that we fetch before updating temporary hold on GCS object. This way we save an additional GCS fetch call.