### PR TITLE
[CDAP-19673] cache common artifacts per CDAP version in GCS

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -84,6 +84,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -92,6 +94,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 
 /**
@@ -1536,31 +1539,42 @@ public class AppMetadataStore {
     List<List<Field<?>>> allKeys = new ArrayList<>();
     for (ProgramRunId programRunId : programRunIds) {
       allKeys.add(getProgramRunInvertedTimeKey(TYPE_RUN_RECORD_ACTIVE, programRunId,
-                                               RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS)));
+                                               RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS),
+                                               false));
     }
-    return getRunRecordsTable().multiRead(allKeys).stream()
-      .map(AppMetadataStore::deserializeRunRecordMeta)
-      .collect(Collectors.toMap(RunRecordDetail::getProgramRunId, r -> r, (r1, r2) -> {
-        throw new IllegalStateException("Duplicate run record for " + r1.getProgramRunId());
-      }, LinkedHashMap::new));
+    
+    return getRunsByKeys(allKeys);
   }
 
   private Map<ProgramRunId, RunRecordDetail> getCompletedRuns(Set<ProgramRunId> programRunIds) throws IOException {
     List<List<Field<?>>> allKeys = new ArrayList<>();
     for (ProgramRunId programRunId : programRunIds) {
-      List<Field<?>> keys = getRunRecordProgramPrefix(TYPE_RUN_RECORD_COMPLETED, programRunId.getParent());
+      // Get all keys without version
+      List<Field<?>> keysWithoutVersion = getRunRecordProgramPrefix(TYPE_RUN_RECORD_COMPLETED,
+                                                                    programRunId.getParent(),
+                                                                    false);
       // Get start time from RunId
       long programStartSecs = RunIds.getTime(RunIds.fromString(programRunId.getRun()), TimeUnit.SECONDS);
-      keys.add(Fields.longField(StoreDefinition.AppMetadataStore.RUN_START_TIME,
-                                getInvertedTsKeyPart(programStartSecs)));
-      keys.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, programRunId.getRun()));
-      allKeys.add(keys);
+      keysWithoutVersion.add(Fields.longField(StoreDefinition.AppMetadataStore.RUN_START_TIME,
+                                              getInvertedTsKeyPart(programStartSecs)));
+      keysWithoutVersion.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, programRunId.getRun()));
+      allKeys.add(keysWithoutVersion);
     }
-    return getRunRecordsTable().multiRead(allKeys).stream()
-      .map(AppMetadataStore::deserializeRunRecordMeta)
-      .collect(Collectors.toMap(RunRecordDetail::getProgramRunId, r -> r, (r1, r2) -> {
-        throw new IllegalStateException("Duplicate run record for " + r1.getProgramRunId());
-      }, LinkedHashMap::new));
+
+    return getRunsByKeys(allKeys);
+  }
+
+  private Map<ProgramRunId, RunRecordDetail> getRunsByKeys(List<List<Field<?>>> allKeys) throws IOException {
+    Collection<Range> ranges = allKeys.stream().map(Range::singleton).collect(Collectors.toList());
+
+    try (CloseableIterator<StructuredRow> iterator =
+           getRunRecordsTable().multiScan(ranges, Integer.MAX_VALUE)) {
+      return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
+          .map(AppMetadataStore::deserializeRunRecordMeta)
+          .collect(Collectors.toMap(RunRecordDetail::getProgramRunId, r -> r, (r1, r2) -> {
+            throw new IllegalStateException("Duplicate run record for " + r1.getProgramRunId());
+          }, LinkedHashMap::new));
+    }
   }
 
   /**
@@ -2027,12 +2041,21 @@ public class AppMetadataStore {
   }
 
   private List<Field<?>> getRunRecordProgramPrefix(String status, @Nullable ProgramId programId) {
+    return getRunRecordProgramPrefix(status, programId, true);
+  }
+
+  private List<Field<?>> getRunRecordProgramPrefix(String status,
+                                                   @Nullable ProgramId programId,
+                                                   boolean includeVersion) {
+    List<Field<?>> fields = getRunRecordStatusPrefix(status);
     if (programId == null) {
-      return getRunRecordStatusPrefix(status);
+      return fields;
     }
-    List<Field<?>> fields =
-      getRunRecordApplicationPrefix(
-        status, new ApplicationId(programId.getNamespace(), programId.getApplication(), programId.getVersion()));
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD, programId.getNamespace()));
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_FIELD, programId.getApplication()));
+    if (includeVersion) {
+      fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.VERSION_FIELD, programId.getVersion()));
+    }
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_TYPE_FIELD, programId.getType().name()));
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_FIELD, programId.getProgram()));
     return fields;
@@ -2058,17 +2081,19 @@ public class AppMetadataStore {
     return (String) field.getValue();
   }
 
-  private List<Field<?>> addProgramPrimaryKeys(ProgramId programRunId, List<Field<?>> fields) {
+  private List<Field<?>> addProgramPrimaryKeys(ProgramId programRunId, List<Field<?>> fields, boolean includeVersion) {
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD, programRunId.getNamespace()));
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_FIELD, programRunId.getApplication()));
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.VERSION_FIELD, programRunId.getVersion()));
+    if (includeVersion) {
+      fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.VERSION_FIELD, programRunId.getVersion()));
+    }
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_TYPE_FIELD, programRunId.getType().name()));
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_FIELD, programRunId.getProgram()));
     return fields;
   }
 
   private List<Field<?>> getProgramRunPrimaryKeys(ProgramRunId programRunId) {
-    List<Field<?>> fields = addProgramPrimaryKeys(programRunId.getParent(), new ArrayList<>());
+    List<Field<?>> fields = addProgramPrimaryKeys(programRunId.getParent(), new ArrayList<>(), true);
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, programRunId.getRun()));
     return fields;
   }
@@ -2080,9 +2105,14 @@ public class AppMetadataStore {
   }
 
   private List<Field<?>> getProgramRunInvertedTimeKey(String recordType, ProgramRunId runId, long startTs) {
+    return getProgramRunInvertedTimeKey(recordType, runId, startTs, true);
+  }
+
+  private List<Field<?>> getProgramRunInvertedTimeKey(String recordType, ProgramRunId runId,
+                                                      long startTs, boolean includeVersion) {
     List<Field<?>> fields = new ArrayList<>();
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_STATUS, recordType));
-    addProgramPrimaryKeys(runId.getParent(), fields);
+    addProgramPrimaryKeys(runId.getParent(), fields, includeVersion);
     fields.add(Fields.longField(StoreDefinition.AppMetadataStore.RUN_START_TIME, getInvertedTsKeyPart(startTs)));
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, runId.getRun()));
     return fields;
@@ -2091,7 +2121,7 @@ public class AppMetadataStore {
   private List<Field<?>> getProgramCountPrimaryKeys(String type, ProgramId programId) {
     List<Field<?>> fields = new ArrayList<>();
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.COUNT_TYPE, type));
-    return addProgramPrimaryKeys(programId, fields);
+    return addProgramPrimaryKeys(programId, fields, true);
   }
 
   @Nullable

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
@@ -175,7 +175,7 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
 
     String opsDashboardQueryPath =
       String.format("%s/dashboard?start=%s&duration=%s&namespace=%s&namespace=%s", BASE_PATH,
-                    String.valueOf(startTime1), String.valueOf(endTime), ns1.getNamespace(), ns2.getNamespace());
+                    startTime1, endTime, ns1.getNamespace(), ns2.getNamespace());
     // get ops dashboard query results
     HttpResponse response = doGet(opsDashboardQueryPath);
     Assert.assertEquals(200, response.getResponseCode());
@@ -191,7 +191,7 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
     // for the same time range query only in namespace ns1 to ensure filtering works fine
     opsDashboardQueryPath =
       String.format("%s/dashboard?start=%s&duration=%s&namespace=%s", BASE_PATH,
-                    String.valueOf(startTime1), String.valueOf(endTime), ns2.getNamespace());
+                    startTime1, endTime, ns2.getNamespace());
 
     // get ops dashboard query results
     response = doGet(opsDashboardQueryPath);
@@ -371,7 +371,7 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
 
     String opsDashboardQueryPath =
       String.format("%s/dashboard?start=%s&duration=%s&namespace=%s", BASE_PATH,
-                    String.valueOf(startTime1), String.valueOf(endTime), ns3.getNamespace());
+                    startTime1, endTime, ns3.getNamespace());
 
     // get ops dashboard query results
     HttpResponse response = doGet(opsDashboardQueryPath);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcherTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcherTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.deploy;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public class InMemoryProgramRunDispatcherTest {
+
+  @Test
+  public void testTimeBucketHash() {
+    long currentTime = System.currentTimeMillis();
+    int window = 15;
+    Set<String> results1 = new HashSet<>();
+    Set<String> results2 = new HashSet<>();
+    long dayInMilliSec = TimeUnit.DAYS.toMillis(1);
+    for (int i = 0; i < 15; i++) {
+      results1.add(InMemoryProgramRunDispatcher.timeBucketHash("hash1", window, currentTime + (i * dayInMilliSec)));
+      results2.add(InMemoryProgramRunDispatcher.timeBucketHash("hash2", window, currentTime + (i * dayInMilliSec)));
+    }
+
+    // for 15 days window, we should have maximum 2 time buckets
+    Assert.assertTrue(results1.size() >= 1 && results1.size() <= 2);
+    Assert.assertTrue(results2.size() >= 1 && results2.size() <= 2);
+
+    for (String res : results1) {
+      results2.remove(res);
+    }
+
+    for (String res : results2) {
+      results1.remove(res);
+    }
+
+    // ensures that jitter works so all keys do not end up in the same bucket
+    Assert.assertNotEquals(results1.size(), 0);
+    Assert.assertNotEquals(results2.size(), 0);
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -1311,9 +1311,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
   }
 
   private void testReEnableSchedule(String scheduleName) throws Exception {
-    ProtoTrigger.TimeTrigger protoTime = new ProtoTrigger.TimeTrigger("0 * * * ?");
-    ProtoTrigger.PartitionTrigger protoPartition =
-      new ProtoTrigger.PartitionTrigger(NamespaceId.DEFAULT.dataset("data"), 5);
     String description = "Something";
     ScheduleProgramInfo programInfo = new ScheduleProgramInfo(SchedulableProgramType.WORKFLOW,
                                                               AppWithSchedule.WORKFLOW_NAME);

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -238,6 +238,7 @@ public final class Constants {
     public static final String PROGRAM_TERMINATE_TIME_BUFFER_SECS = "app.program.terminate.time.buffer.secs";
     public static final String PROGRAM_TERMINATOR_TX_BATCH_SIZE = "app.program.terminator.tx.batch.size";
     public static final String ARTIFACTS_COMPUTE_HASH = "app.artifact.compute.hash";
+    public static final String ARTIFACTS_COMPUTE_HASH_TIME_BUCKET_DAYS = "app.artifact.compute.hash.time.bucket.days";
     public static final String ARTIFACTS_COMPUTE_HASH_SNAPSHOT = "app.artifact.compute.hash.snapshot";
     public static final String SYSTEM_ARTIFACTS_DIR = "app.artifact.dir";
     public static final String SYSTEM_ARTIFACTS_MAX_PARALLELISM = "app.artifact.parallelism.max";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -417,6 +417,15 @@
 
   <!-- Applications Configuration -->
   <property>
+    <name>app.artifact.compute.hash.time.bucket.days</name>
+    <value>15</value>
+    <description>
+      If greater than 0, ensures that has values are time bucketed every x days.
+      Therefore, generating hash of an identical value x days apart will result in different hash values.
+    </description>
+  </property>
+
+  <property>
     <name>app.artifact.compute.hash</name>
     <value>false</value>
     <description>

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2019-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -128,10 +129,69 @@ public final class NoSqlStructuredTable implements StructuredTable {
   @Override
   public CloseableIterator<StructuredRow> scan(Range keyRange, int limit) throws InvalidFieldException {
     LOG.trace("Table {}: Scan range {} with limit {}", schema.getTableId(), keyRange, limit);
-    return new LimitIterator(Collections.singleton(new ScannerIterator(getScanner(keyRange), schema)).iterator(),
-                             limit);
+    return new LimitIterator(Collections.singleton(getFilterByRangeIterator(keyRange)).iterator(), limit);
   }
 
+  /**
+   * Scan the nosql db with a key range. It gets the longest prefix keys,
+   * scan the DB and do a post filtering on the result.
+   *
+   * @param keyRange prefix key range to scan
+   * @return the iterator after filtering
+   * @throws InvalidFieldException if the key is not a primary key
+   */
+  private CloseableIterator<StructuredRow> getFilterByRangeIterator(Range keyRange) {
+    Range prefixRange = getLongestPrefixRange(keyRange);
+    ScannerIterator scannerIterator = new ScannerIterator(getScanner(prefixRange), schema);
+
+    Range filterRange = getFilterRange(keyRange, prefixRange);
+    // Return scannerIterator once we found that there's no need to further filter
+    if (filterRange.getBegin().isEmpty() && filterRange.getEnd().isEmpty()) {
+      return scannerIterator;
+    }
+
+    return new FilterByRangeIterator(Collections.singleton(scannerIterator).iterator(),
+                                     Collections.singleton(filterRange));
+  }
+
+  private Range getLongestPrefixRange(Range range) {
+    fieldValidator.validatePartialPrimaryKeys(range.getBegin());
+    fieldValidator.validatePartialPrimaryKeys(range.getEnd());
+
+    List<Field<?>> beginPrefixKeys = getPrefixPrimaryKeys(range.getBegin());
+    List<Field<?>> endPrefixKeys = getPrefixPrimaryKeys(range.getEnd());
+
+    return Range.create(beginPrefixKeys, range.getBeginBound(), endPrefixKeys, range.getEndBound());
+  }
+
+  private Range getFilterRange(Range keyRange, Range prefixRange) {
+    List<Field<?>> beginFilterKeys = getFilterKeys(keyRange.getBegin(), prefixRange.getBegin());
+    List<Field<?>> endFilterKeys = getFilterKeys(keyRange.getEnd(), prefixRange.getEnd());
+
+    return Range.create(beginFilterKeys, keyRange.getBeginBound(), endFilterKeys, keyRange.getEndBound());
+  }
+
+  private List<Field<?>> getFilterKeys(Collection<Field<?>> keys, Collection<Field<?>> prefixKeys) {
+    Set<String> prefixKeysSet = prefixKeys.stream().map(Field::getName).collect(Collectors.toSet());
+
+    return keys.stream()
+      .filter(key -> !prefixKeysSet.contains(key.getName()))
+      .collect(Collectors.toList());
+  }
+
+  private List<Field<?>> getPrefixPrimaryKeys(Collection<Field<?>> partialKeys) {
+    List<Field<?>> prefixKeys = new ArrayList<>();
+    List<String> primaryKeys = schema.getPrimaryKeys();
+    int i = 0;
+    for (Field<?> key : partialKeys) {
+      if (!key.getName().equals(primaryKeys.get(i))) {
+        return prefixKeys;
+      }
+      prefixKeys.add(key);
+      i++;
+    }
+    return prefixKeys;
+  }
 
   /*
    *  Sorting in memory for the no-sql implementation. We sort post table scan.
@@ -148,9 +208,9 @@ public final class NoSqlStructuredTable implements StructuredTable {
       getComparator(orderByField).reversed();
     PriorityQueue<StructuredRow> rows = new PriorityQueue<>(comparator);
 
-    try (ScannerIterator scannerIterator = new ScannerIterator(getScanner(keyRange), schema)) {
-      while (scannerIterator.hasNext()) {
-        rows.offer(scannerIterator.next());
+    try (CloseableIterator<StructuredRow> filterIterator = getFilterByRangeIterator(keyRange)) {
+      while (filterIterator.hasNext()) {
+        rows.offer(filterIterator.next());
       }
     }
     // return an iterator for the sorted elements
@@ -207,17 +267,42 @@ public final class NoSqlStructuredTable implements StructuredTable {
     if (!schema.isIndexColumn(filterIndex.getName())) {
       throw new InvalidFieldException(schema.getTableId(), filterIndex.getName(), "is not an indexed column");
     }
-    ScannerIterator scannerIterator = new ScannerIterator(getScanner(keyRange), schema);
-    FilterByIndexIterator filterByIndexIterator = new FilterByIndexIterator(scannerIterator, filterIndex, schema);
+    FilterByFieldIterator filterByIndexIterator =
+      new FilterByFieldIterator(getFilterByRangeIterator(keyRange), filterIndex, schema);
     return new LimitIterator(Collections.singleton(filterByIndexIterator).iterator(), limit);
   }
 
+  /*
+   * Scan the nosql DB with provided ranges.
+   * Find out the longest prefix ranges, merge them if possible, scan these intervals
+   * then filter by ranges, the result should already be sorted by primary keys.
+   * */
   @Override
-  public CloseableIterator<StructuredRow> multiScan(Collection<Range> keyRanges,
-                                                    int limit) throws InvalidFieldException, IOException {
-    // Sort the scan keys by the start key and merge overlapping ranges.
+  public CloseableIterator<StructuredRow> multiScan(Collection<Range> keyRanges, int limit)
+    throws InvalidFieldException, IOException {
+
+    if (keyRanges.isEmpty()) {
+      return CloseableIterator.empty();
+    }
+
+    // Call scan single range when there's only range
+    if (keyRanges.size() == 1) {
+      return scan(keyRanges.iterator().next(), limit);
+    }
+
+    FilterByRangeIterator filterIterator =
+      new FilterByRangeIterator(getPrefixRangeScannerIterator(keyRanges), keyRanges);
+    return new LimitIterator(filterIterator, limit);
+  }
+
+  /*
+   * Merge the longest prefix ranges and scan one by one
+   * */
+  private AbstractIterator<ScannerIterator> getPrefixRangeScannerIterator(Collection<Range> keyRanges) {
     Deque<ImmutablePair<byte[], byte[]>> scanKeys = new LinkedList<>();
+    // Sort the scan keys by the start key and merge overlapping ranges.
     keyRanges.stream()
+      .map(this::getLongestPrefixRange)
       .map(this::createScanKeys)
       .sorted((o1, o2) -> Bytes.compareTo(o1.getFirst(), o2.getFirst()))
       .forEach(range -> {
@@ -239,7 +324,7 @@ public final class NoSqlStructuredTable implements StructuredTable {
       });
 
     Iterator<ImmutablePair<byte[], byte[]>> rangeIterator = scanKeys.iterator();
-    return new LimitIterator(new AbstractIterator<ScannerIterator>() {
+    return new AbstractIterator<ScannerIterator>() {
       @Override
       protected ScannerIterator computeNext() {
         if (!rangeIterator.hasNext()) {
@@ -248,7 +333,7 @@ public final class NoSqlStructuredTable implements StructuredTable {
         ImmutablePair<byte[], byte[]> range = rangeIterator.next();
         return new ScannerIterator(table.scan(range.getFirst(), range.getSecond()), schema);
       }
-    }, limit);
+    };
   }
 
   @Override
@@ -283,8 +368,7 @@ public final class NoSqlStructuredTable implements StructuredTable {
     }
 
     return table.compareAndSwap(convertKeyToBytes(keys, false), Bytes.toBytes(oldValue.getName()),
-                                fieldToBytes(oldValue),
-                                fieldToBytes(newValue));
+                                fieldToBytes(oldValue), fieldToBytes(newValue));
   }
 
   @Override
@@ -314,10 +398,9 @@ public final class NoSqlStructuredTable implements StructuredTable {
   @Override
   public void deleteAll(Range keyRange) throws InvalidFieldException, IOException {
     LOG.trace("Table {}: DeleteAll with range {}", schema.getTableId(), keyRange);
-    try (Scanner scanner = getScanner(keyRange)) {
-      Row row;
-      while ((row = scanner.next()) != null) {
-        table.delete(row.getRow());
+    try (CloseableIterator<StructuredRow> iterator = getFilterByRangeIterator(keyRange)) {
+      while (iterator.hasNext()) {
+        table.delete(convertKeyToBytes(iterator.next().getPrimaryKeys(), false));
       }
     }
   }
@@ -326,11 +409,12 @@ public final class NoSqlStructuredTable implements StructuredTable {
   public long count(Collection<Range> keyRanges) throws IOException {
     LOG.trace("Table {}: count with ranges {}", schema.getTableId(), keyRanges);
     long count = 0;
-    for (Range keyRange: keyRanges) {
-      try (Scanner scanner = getScanner(keyRange)) {
-        while (scanner.next() != null) {
-          count++;
-        }
+    // Instead of scanning ranges one by one, we call multiScan,
+    // which can deduplicate and sort the result
+    try (CloseableIterator<StructuredRow> iterator = multiScan(keyRanges, Integer.MAX_VALUE)) {
+      while (iterator.hasNext()) {
+        iterator.next();
+        count++;
       }
     }
     return count;
@@ -345,8 +429,8 @@ public final class NoSqlStructuredTable implements StructuredTable {
    * Convert the keys to corresponding byte array. The keys can either be a prefix or complete primary keys depending
    * on the value of allowPrefix. The method will always prepend the table name as a prefix for the row keys.
    *
-   * @param keys keys to convert
-   * @param allowPrefix true if the keys can be prefix false if the keys have to contain all the primary keys.
+   * @param keys        keys to convert
+   * @param allowPrefix true if the keys can be prefixed false if the keys have to contain all the primary keys.
    * @return the byte array converted
    * @throws InvalidFieldException if the key are not prefix or complete primary keys
    */
@@ -581,44 +665,44 @@ public final class NoSqlStructuredTable implements StructuredTable {
   }
 
   /**
-   * Filters elements matching an index {@link ScannerIterator}.
+   * Filters elements matching a field {@link ScannerIterator}.
    */
   @VisibleForTesting
-  static final class FilterByIndexIterator extends AbstractCloseableIterator<StructuredRow> {
+  static final class FilterByFieldIterator extends AbstractCloseableIterator<StructuredRow> {
     private final CloseableIterator<StructuredRow> scannerIterator;
     private final Predicate<StructuredRow> predicate;
 
-    FilterByIndexIterator(CloseableIterator<StructuredRow> scannerIterator, Field<?> filterIndex,
+    FilterByFieldIterator(CloseableIterator<StructuredRow> scannerIterator, Field<?> filterField,
                           StructuredTableSchema schema) {
       this.scannerIterator = scannerIterator;
 
-      switch (filterIndex.getFieldType()) {
+      switch (filterField.getFieldType()) {
         case INTEGER:
-          predicate = row -> Objects.equals(row.getInteger(filterIndex.getName()), filterIndex.getValue());
+          predicate = row -> Objects.equals(row.getInteger(filterField.getName()), filterField.getValue());
           break;
         case LONG:
-          predicate = row -> Objects.equals(row.getLong(filterIndex.getName()), filterIndex.getValue());
+          predicate = row -> Objects.equals(row.getLong(filterField.getName()), filterField.getValue());
           break;
         case FLOAT:
-          predicate = row -> Objects.equals(row.getFloat(filterIndex.getName()), filterIndex.getValue());
+          predicate = row -> Objects.equals(row.getFloat(filterField.getName()), filterField.getValue());
           break;
         case DOUBLE:
-          predicate = row -> Objects.equals(row.getDouble(filterIndex.getName()), filterIndex.getValue());
+          predicate = row -> Objects.equals(row.getDouble(filterField.getName()), filterField.getValue());
           break;
         case STRING:
-          predicate = row -> Objects.equals(row.getString(filterIndex.getName()), filterIndex.getValue());
+          predicate = row -> Objects.equals(row.getString(filterField.getName()), filterField.getValue());
           break;
         case BYTES:
-          predicate = row -> Arrays.equals(row.getBytes(filterIndex.getName()), (byte[]) filterIndex.getValue());
+          predicate = row -> Arrays.equals(row.getBytes(filterField.getName()), (byte[]) filterField.getValue());
           break;
         default:
-          throw new InvalidFieldException(schema.getTableId(), filterIndex.getName());
+          throw new InvalidFieldException(schema.getTableId(), filterField.getName());
       }
     }
 
     @Override
     protected StructuredRow computeNext() {
-      // Postfiltering on scanned rows by index
+      // Post filtering on scanned rows by specified field
       while (scannerIterator.hasNext()) {
         StructuredRow row = scannerIterator.next();
         if (predicate.test(row)) {
@@ -631,6 +715,127 @@ public final class NoSqlStructuredTable implements StructuredTable {
     @Override
     public void close() {
       scannerIterator.close();
+    }
+  }
+
+  /**
+   * Filters elements matching a range {@link ScannerIterator}.
+   */
+  @VisibleForTesting
+  static final class FilterByRangeIterator extends AbstractCloseableIterator<StructuredRow> {
+    private final Iterator<? extends CloseableIterator<StructuredRow>> scannerIterator;
+    private CloseableIterator<StructuredRow> currentScanner;
+    private final Collection<Predicate<StructuredRow>> predicates;
+
+    FilterByRangeIterator(Iterator<? extends CloseableIterator<StructuredRow>> scannerIterator,
+                          Collection<Range> filterRanges) {
+      this.scannerIterator = scannerIterator;
+      this.currentScanner = scannerIterator.hasNext() ? scannerIterator.next() : CloseableIterator.empty();
+      this.predicates = filterRanges.stream().map(this::buildPredicate).collect(Collectors.toList());
+    }
+
+    private Predicate<StructuredRow> buildPredicate(Range filterRange) {
+      return row -> {
+        int beginIndex = 1;
+        int beginFieldsCount = filterRange.getBegin().size();
+        for (Field<?> beginField : filterRange.getBegin()) {
+          int comp = compareRowAndField(row, beginField);
+          // comp should be at least >= 0
+          if (comp < 0) {
+            return false;
+          }
+          // Edge case for = when we filter by the last field
+          // This is for case like ([KEY: "ns1", KEY2: 123], EXCLUSIVE, [KEY: "ns1", KEY2: 250], INCLUSIVE)
+          // We need to check the ending bound for KEY2, not KEY
+          if (beginIndex == beginFieldsCount
+            && filterRange.getBeginBound().equals(Range.Bound.EXCLUSIVE)
+            && comp == 0) {
+            return false;
+          }
+          beginIndex++;
+        }
+
+        int endIndex = 1;
+        int endFieldsCount = filterRange.getEnd().size();
+        for (Field<?> endField : filterRange.getEnd()) {
+          int comp = compareRowAndField(row, endField);
+          // comp should be at least <= 0
+          if (comp > 0) {
+            return false;
+          }
+          // Edge case for = when we filter by the last field
+          // This is for case like ([KEY: "ns1", KEY2: 123], INCLUSIVE, [KEY: "ns1", KEY2: 250], EXCLUSIVE)
+          // We need to check the ending bound for KEY2, not KEY
+          if (endIndex == endFieldsCount
+            && filterRange.getEndBound().equals(Range.Bound.EXCLUSIVE)
+            && comp == 0) {
+            return false;
+          }
+          endIndex++;
+        }
+
+        return true;
+      };
+    }
+
+    private int compareRowAndField(StructuredRow row, Field<?> field) {
+      String fieldName = field.getName();
+      switch (field.getFieldType()) {
+        case INTEGER:
+          return Objects.compare(row.getInteger(fieldName), (Integer) field.getValue(), Integer::compare);
+        case LONG:
+          return Objects.compare(row.getLong(fieldName), (Long) (field.getValue()), Long::compare);
+        case FLOAT:
+          return Objects.compare(row.getFloat(fieldName), (Float) (field.getValue()), Float::compare);
+        case DOUBLE:
+          return Objects.compare(row.getDouble(fieldName), (Double) (field.getValue()), Double::compare);
+        case STRING:
+          return Objects.compare(row.getString(fieldName), (String) (field.getValue()), String::compareTo);
+        case BYTES:
+          return new Bytes.ByteArrayComparator().compare(row.getBytes(fieldName), (byte[]) field.getValue());
+        default:
+          throw new RuntimeException(String.format("Exception while comparing row: %s and field: %s", row, field));
+      }
+    }
+
+    @Override
+    protected StructuredRow computeNext() {
+      // Find the next Scanner that is not iterated
+      while (!currentScanner.hasNext() && scannerIterator.hasNext()) {
+        closeScanner();
+        currentScanner = scannerIterator.next();
+      }
+
+      // The case that we iterate to the end of last scanner
+      if (!currentScanner.hasNext()) {
+        return endOfData();
+      }
+
+      // Iterator the current scanner, return when we find a matching element
+      while (currentScanner.hasNext()) {
+        StructuredRow row = currentScanner.next();
+        for (Predicate<StructuredRow> predicate : predicates) {
+          if (predicate.test(row)) {
+            return row;
+          }
+        }
+      }
+
+      // Recursion call
+      // Done with the current scanner, got to next scanner and repeat
+      return computeNext();
+    }
+
+    @Override
+    public void close() {
+      closeScanner();
+    }
+
+    private void closeScanner() {
+      if (currentScanner != null) {
+        currentScanner.close();
+        currentScanner = null;
+      }
     }
   }
 

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
@@ -171,7 +171,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
     MockScanner scanner = new MockScanner(expected.iterator());
     Field<?> filterIndex = Fields.intField("key", 9);
     List<Integer> actual = new ArrayList<>();
-    try (NoSqlStructuredTable.FilterByIndexIterator closeableIterator = new NoSqlStructuredTable.FilterByIndexIterator(
+    try (NoSqlStructuredTable.FilterByFieldIterator closeableIterator = new NoSqlStructuredTable.FilterByFieldIterator(
       (new NoSqlStructuredTable.ScannerIterator(scanner, SCHEMA)), filterIndex, SCHEMA)) {
       while (closeableIterator.hasNext()) {
         actual.add(closeableIterator.next().getInteger("key"));
@@ -189,7 +189,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
     MockScanner scanner = new MockScanner(expected.iterator());
     Field<?> filterIndex = Fields.intField("key", 9);
     List<Integer> actual = new ArrayList<>();
-    try (NoSqlStructuredTable.FilterByIndexIterator closeableIterator = new NoSqlStructuredTable.FilterByIndexIterator(
+    try (NoSqlStructuredTable.FilterByFieldIterator closeableIterator = new NoSqlStructuredTable.FilterByFieldIterator(
       new NoSqlStructuredTable.ScannerIterator(scanner, SCHEMA), filterIndex, SCHEMA)) {
       while (closeableIterator.hasNext()) {
         actual.add(closeableIterator.next().getInteger("key"));

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -62,6 +62,7 @@ public final class DataprocUtils {
   public static final String CDAP_CACHED_ARTIFACTS = "cached-artifacts";
   public static final String WORKER_CPU_PREFIX = "Up to";
   public static final String DISABLE_GCS_CACHING = "disableGCSCaching";
+  public static final String ENABLE_GCS_CACHING_SNAPSHOT = "enableGCSCachingSnapshot";
   public static final Path CACHE_DIR_PATH = Paths.get(System.getProperty("java.io.tmpdir"),
                                                       "dataproc.launcher.cache");
   public static final String LOCAL_CACHE_DISABLED = "disableLocalCaching";

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -23,7 +23,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.runtime.spi.VersionInfo;
-import io.cdap.cdap.runtime.spi.common.ArtifactCacheManager;
 import io.cdap.cdap.runtime.spi.common.DataprocImageVersion;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import io.cdap.cdap.runtime.spi.provisioner.Capabilities;
@@ -130,7 +129,6 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
         .setCredentials(conf.getDataprocCredentials()).build().getService();
       String runId = context.getProgramRunInfo().getRun();
       String runRootPath = getPath(DataprocUtils.CDAP_GCS_ROOT, runId);
-      new ArtifactCacheManager().releaseCacheUsageForArtifacts(storageClient, bucket, runRootPath, runId);
       DataprocUtils.deleteGCSPath(storageClient, bucket, runRootPath);
     }
 

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -196,7 +196,8 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
         new DataprocRuntimeJobManager(new DataprocClusterInfo(context, clusterName, conf.getDataprocCredentials(),
                                                               getRootUrl(conf),
                                                               projectId, region, bucket, systemLabels),
-                                      Collections.unmodifiableMap(properties)
+                                      Collections.unmodifiableMap(properties),
+                                      context.getCDAPVersionInfo()
         ));
     } catch (Exception e) {
       throw new RuntimeException("Error while getting credentials for dataproc. ", e);

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -95,6 +95,8 @@ final class DataprocConf {
 
   // If true, artifacts will not be cached in GCS regardless of cConf setting.
   static final String DISABLE_GCS_CACHING = "disableGCSCaching";
+  // If true, snapshot artifacts which are same per CDAP version will be cached in GCS.
+  static final String ENABLE_GCS_CACHING_SNAPSHOT = DataprocUtils.ENABLE_GCS_CACHING_SNAPSHOT;
 
   private final String accountKey;
   private final String region;
@@ -164,6 +166,7 @@ final class DataprocConf {
 
   private final boolean disableGCSCaching;
   private  final String troubleshootingDocsUrl;
+  private final boolean enableGCSCachingSnapshot;
 
   public String getTroubleshootingDocsUrl() {
     return troubleshootingDocsUrl;
@@ -190,7 +193,7 @@ final class DataprocConf {
                        long clusterReuseThresholdMinutes, @Nullable String clusterReuseKey,
                        boolean enablePredefinedAutoScaling, int computeReadTimeout, int computeConnectionTimeout,
                        @Nullable String rootUrl, boolean disableGCSCaching, boolean disableLocalCaching,
-                       String troubleshootingDocsUrl) {
+                       String troubleshootingDocsUrl, boolean enableGCSCachingSnapshot) {
     this.accountKey = accountKey;
     this.region = region;
     this.zone = zone;
@@ -198,6 +201,7 @@ final class DataprocConf {
     this.clusterReuseEnabled = clusterReuseEnabled;
     this.clusterReuseThresholdMinutes = clusterReuseThresholdMinutes;
     this.clusterReuseKey = clusterReuseKey;
+    this.enableGCSCachingSnapshot = enableGCSCachingSnapshot;
     this.networkHostProjectID = Strings.isNullOrEmpty(networkHostProjectId) ? projectId : networkHostProjectId;
     this.network = network;
     this.subnet = subnet;
@@ -698,6 +702,8 @@ final class DataprocConf {
 
     boolean disableGCSCaching = Boolean.parseBoolean(
       properties.getOrDefault(DISABLE_GCS_CACHING, "false"));
+    boolean enableGCSCachingSnapshot = Boolean.parseBoolean(
+      properties.getOrDefault(ENABLE_GCS_CACHING_SNAPSHOT, "false"));
     String troubleshootingDocsURL =
       properties.getOrDefault(DataprocUtils.TROUBLESHOOTING_DOCS_URL_KEY,
                               DataprocUtils.TROUBLESHOOTING_DOCS_URL_DEFAULT);
@@ -716,7 +722,7 @@ final class DataprocConf {
                             tokenEndpoint, secureBootEnabled, vTpmEnabled, integrityMonitoringEnabled,
                             clusterReuseEnabled, clusterReuseThresholdMinutes, clusterReuseKey,
                             enablePredefinedAutoScaling, computeReadTimeout, computeConnectionTimeout, rootUrl,
-                            disableGCSCaching, disableLocalCaching, troubleshootingDocsURL);
+                            disableGCSCaching, disableLocalCaching, troubleshootingDocsURL, enableGCSCachingSnapshot);
   }
 
   // the UI never sends nulls, it only sends empty strings.

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -50,6 +50,7 @@ import com.google.common.io.ByteStreams;
 import io.cdap.cdap.error.api.ErrorTagProvider;
 import io.cdap.cdap.runtime.spi.CacheableLocalFile;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
+import io.cdap.cdap.runtime.spi.VersionInfo;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 import io.cdap.cdap.runtime.spi.provisioner.dataproc.DataprocRuntimeException;
@@ -71,6 +72,7 @@ import java.net.URI;
 import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -116,9 +118,13 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
   private final String bucket;
   private final Map<String, String> labels;
   private final Map<String, String> provisionerProperties;
+  private final VersionInfo cdapVersionInfo;
 
   private volatile Storage storageClient;
   private volatile JobControllerClient jobControllerClient;
+  List<String> commonArtifactsPerCDAPVersion = new ArrayList<>(
+    Arrays.asList(Constants.Files.TWILL_JAR, Constants.Files.LAUNCHER_JAR, Constants.Files.APPLICATION_JAR)
+  );
 
   /**
    * Created by dataproc provisioner with properties that are needed by dataproc runtime job manager.
@@ -126,7 +132,7 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
    * @param clusterInfo dataproc cluster information
    */
   public DataprocRuntimeJobManager(DataprocClusterInfo clusterInfo,
-                                   Map<String, String> provisionerProperties) {
+                                   Map<String, String> provisionerProperties, VersionInfo cdapVersionInfo) {
     this.provisionerContext = clusterInfo.getProvisionerContext();
     this.clusterName = clusterInfo.getClusterName();
     this.credentials = clusterInfo.getCredentials();
@@ -138,6 +144,7 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
     // Provisioner properties contains overrides for properties defined in cdap-site.
     // These properties are absent in provisionerContext.getProperties().
     this.provisionerProperties = provisionerProperties;
+    this.cdapVersionInfo = cdapVersionInfo;
   }
 
   /**
@@ -216,6 +223,13 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
     // In dataproc bucket, the shared folder for artifacts will be <bucket>/cdap-job/cached-artifacts.
     // All instances of CacheableLocalFile will be copied to the shared folder if they do not exist.
     String cacheRootPath = getPath(DataprocUtils.CDAP_GCS_ROOT, DataprocUtils.CDAP_CACHED_ARTIFACTS);
+    boolean enableGCSCachingSnapshot = Boolean.parseBoolean(
+      provisionerContext.getProperties().getOrDefault(DataprocUtils.ENABLE_GCS_CACHING_SNAPSHOT, "false"));
+    // cdap_version is of the form "major.minor.fix-buildTime"/"major.minor.fix-SNAPSHOT-buildTime"
+    String[] appCDAPVersion = cdapVersionInfo.toString().split("-");
+    boolean enableCommonArtifactsCaching = !disableGCSCaching &&
+      ((appCDAPVersion.length > 1 && !"SNAPSHOT".equals(appCDAPVersion[1])) || enableGCSCachingSnapshot);
+
     try {
       // step 1: build twill.jar and launcher.jar and add them to files to be copied to gcs
       if (disableLocalCaching) {
@@ -230,10 +244,22 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
       for (LocalFile fileToUpload : localFiles) {
         boolean isCacheable = !disableGCSCaching && fileToUpload instanceof CacheableLocalFile;
         String targetFilePath = getPath(isCacheable ? cacheRootPath : runRootPath, fileToUpload.getName());
-        uploadFutures.add(
-          provisionerContext.execute(() -> isCacheable ? uploadCacheableFile(bucket, targetFilePath, fileToUpload) :
-              uploadFile(bucket, targetFilePath, fileToUpload, false))
-            .toCompletableFuture());
+        String targetFilePathWithVersion = getPath(cacheRootPath, appCDAPVersion[0], fileToUpload.getName());
+
+        if (commonArtifactsPerCDAPVersion.contains(fileToUpload.getName()) && enableCommonArtifactsCaching) {
+          // upload artifacts common per cdap version to <bucket>/cdap-job/cached-artifacts/<cdapVersion>/
+          uploadFutures.add(
+            provisionerContext.execute(
+              () -> uploadCommonArtifactsPerCDAPVersion(bucket, targetFilePathWithVersion, fileToUpload))
+              .toCompletableFuture());
+        } else {
+          // upload cacheable artifacts to <bucket>/cdap-job/cached-artifacts/ and
+          // non-cacheable artifacts to <bucket>/cdap-job/<runid>/
+          uploadFutures.add(
+            provisionerContext.execute(() -> isCacheable ? uploadCacheableFile(bucket, targetFilePath, fileToUpload) :
+                uploadFile(bucket, targetFilePath, fileToUpload, false, false))
+              .toCompletableFuture());
+        }
       }
 
       List<LocalFile> uploadedFiles = new ArrayList<>();
@@ -285,6 +311,27 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
         DataprocUtils.deleteDirectoryContents(tempDir);
       }
     }
+  }
+
+  private LocalFile uploadCommonArtifactsPerCDAPVersion(String bucket, String targetFilePath, LocalFile localFile)
+    throws IOException, InterruptedException {
+    Storage storage = getStorageClient();
+    BlobId blobId = BlobId.of(bucket, targetFilePath);
+    Blob blob = storage.get(blobId);
+    LocalFile result;
+
+    if (blob != null && blob.exists()) {
+      LOG.debug("Skip uploading file {} to gs://{}/{} because it exists.",
+                localFile.getURI(), bucket, targetFilePath);
+      result = new DefaultLocalFile(localFile.getName(),
+                                    URI.create(String.format("gs://%s/%s", bucket, targetFilePath)),
+                                    localFile.getLastModified(), localFile.getSize(),
+                                    localFile.isArchive(), localFile.getPattern());
+    } else {
+      result = uploadFile(bucket, targetFilePath, localFile, false, true);
+    }
+
+    return result;
   }
 
   @Override
@@ -410,7 +457,7 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
                                     localFile.getLastModified(), localFile.getSize(),
                                     localFile.isArchive(), localFile.getPattern());
     } else {
-      result = uploadFile(bucket, targetFilePath, localFile, true);
+      result = uploadFile(bucket, targetFilePath, localFile, true, false);
     }
 
     return result;
@@ -419,8 +466,8 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
   /**
    * Uploads files to gcs.
    */
-  private LocalFile uploadFile(String bucket, String targetFilePath,
-                               LocalFile localFile, boolean isCacheable)
+  private LocalFile uploadFile(String bucket, String targetFilePath, LocalFile localFile,
+                               boolean isCacheable, boolean isCacheablePerVersion)
     throws IOException, StorageException {
     BlobId blobId = BlobId.of(bucket, targetFilePath);
     String contentType = "application/octet-stream";
@@ -450,7 +497,7 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
         throw e;
       }
 
-      if (!isCacheable) {
+      if (!isCacheable && !isCacheablePerVersion) {
         // Precondition fails means the blob already exists, most likely happens due to retries
         // https://cloud.google.com/storage/docs/request-preconditions#special-case
         // Overwrite the file

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -50,7 +50,6 @@ import com.google.common.io.ByteStreams;
 import io.cdap.cdap.error.api.ErrorTagProvider;
 import io.cdap.cdap.runtime.spi.CacheableLocalFile;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
-import io.cdap.cdap.runtime.spi.common.ArtifactCacheManager;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 import io.cdap.cdap.runtime.spi.provisioner.dataproc.DataprocRuntimeException;
@@ -74,12 +73,10 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -230,7 +227,6 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
 
       // step 2: upload all the necessary files to gcs so that those files are available to dataproc job
       List<Future<LocalFile>> uploadFutures = new ArrayList<>();
-      Set<String> cachedFiles = new HashSet<>();
       for (LocalFile fileToUpload : localFiles) {
         boolean isCacheable = !disableGCSCaching && fileToUpload instanceof CacheableLocalFile;
         String targetFilePath = getPath(isCacheable ? cacheRootPath : runRootPath, fileToUpload.getName());
@@ -238,13 +234,6 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
           provisionerContext.execute(() -> isCacheable ? uploadCacheableFile(bucket, targetFilePath, fileToUpload) :
               uploadFile(bucket, targetFilePath, fileToUpload, false))
             .toCompletableFuture());
-        if (isCacheable) {
-          cachedFiles.add(fileToUpload.getName());
-        }
-      }
-      if (!cachedFiles.isEmpty()) {
-        new ArtifactCacheManager().recordCacheUsageForArtifacts(getStorageClient(), bucket, cachedFiles, runRootPath,
-                                                                cacheRootPath, runInfo.getRun());
       }
 
       List<LocalFile> uploadedFiles = new ArrayList<>();
@@ -420,7 +409,6 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
                                     URI.create(String.format("gs://%s/%s", bucket, targetFilePath)),
                                     localFile.getLastModified(), localFile.getSize(),
                                     localFile.isArchive(), localFile.getPattern());
-      DataprocUtils.setTemporaryHoldOnGCSObject(storage, bucket, blob, targetFilePath);
     } else {
       result = uploadFile(bucket, targetFilePath, localFile, true);
     }
@@ -433,12 +421,12 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
    */
   private LocalFile uploadFile(String bucket, String targetFilePath,
                                LocalFile localFile, boolean isCacheable)
-    throws IOException, StorageException, InterruptedException {
+    throws IOException, StorageException {
     BlobId blobId = BlobId.of(bucket, targetFilePath);
     String contentType = "application/octet-stream";
     BlobInfo.Builder blobInfoBuilder = BlobInfo.newBuilder(blobId);
     if (isCacheable) {
-      blobInfoBuilder.setCustomTime(System.currentTimeMillis()).setTemporaryHold(true);
+      blobInfoBuilder.setCustomTime(System.currentTimeMillis());
     }
     BlobInfo blobInfo = blobInfoBuilder.setContentType(contentType).build();
     Storage storage = getStorageClient();
@@ -462,11 +450,11 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
         throw e;
       }
 
-      Blob blob = storage.get(blobId);
       if (!isCacheable) {
         // Precondition fails means the blob already exists, most likely happens due to retries
         // https://cloud.google.com/storage/docs/request-preconditions#special-case
         // Overwrite the file
+        Blob blob = storage.get(blobId);
         BlobInfo existingBlobInfo = BlobInfo.newBuilder(blob.getBlobId()).setContentType(contentType).build();
         uploadToGCS(localFile.getURI(), storage, existingBlobInfo, Storage.BlobWriteOption.generationMatch());
         LOG.debug("Successfully uploaded file {} to gs://{}/{} by overwriting due to conflict",
@@ -474,7 +462,6 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
       } else {
         LOG.debug("Skip uploading file {} to gs://{}/{} because it exists.",
                   localFile.getURI(), bucket, targetFilePath);
-        DataprocUtils.setTemporaryHoldOnGCSObject(storage, bucket, blob, targetFilePath);
       }
     }
 

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
@@ -125,7 +125,7 @@ public interface StructuredTable extends Closeable {
    * @param keyRange key range for the scan
    * @param limit maximum number of rows to return
    * @param sortOrder defined primary key sort order. Note that the comparator used is specific to the underlying
-   *                  store and is not nessesarily lexographic.
+   *                  store and is not necessarily lexicographic.
    * @return a {@link CloseableIterator} of rows
    * @throws InvalidFieldException if any of the keys are not part of the table schema, or the types of the value
    *                               do not match

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -199,9 +200,217 @@ public abstract class StructuredTableTest {
       Range.singleton(Collections.singleton(Fields.intField(KEY, 46))), max);
     Assert.assertEquals(expected.subList(46, 47), actual);
 
-    // TODO: test invalid range
-    // TODO: test begin only range
-    // TODO: test end only range
+    // Test partial keys singleton scan
+    actual = scanSimpleStructuredRows(
+      Range.singleton(Collections.singleton(Fields.longField(KEY2, (long) 46))), max);
+    Assert.assertEquals(expected.subList(46, 47), actual);
+
+    actual =
+      scanSimpleStructuredRows(
+        Range.singleton(Arrays.asList(Fields.intField(KEY, 2), Fields.longField(KEY2, (long) 35))), max);
+    Assert.assertTrue(actual.isEmpty());
+
+    // Test partial keys actual range scan
+    actual =
+      scanSimpleStructuredRows(
+        Range.create(Collections.singleton(Fields.intField(KEY, 30)), Range.Bound.EXCLUSIVE,
+                     Collections.singleton(Fields.longField(KEY2, (long) 40)), Range.Bound.EXCLUSIVE), max);
+    Assert.assertEquals(expected.subList(31, 40), actual);
+
+    actual =
+      scanSimpleStructuredRows(
+        Range.create(Collections.singleton(Fields.intField(KEY, 5)), Range.Bound.INCLUSIVE,
+                     Collections.singleton(Fields.longField(KEY2, (long) 15)), Range.Bound.EXCLUSIVE), max);
+    Assert.assertEquals(expected.subList(5, 15), actual);
+
+    // Test begin only range
+    actual =
+      scanSimpleStructuredRows(
+        Range.create(Collections.singleton(Fields.longField(KEY2, (long) 5)), Range.Bound.EXCLUSIVE,
+                     null, Range.Bound.INCLUSIVE), max);
+    Assert.assertEquals(expected.subList(6, max), actual);
+
+    // Test end only range
+    actual =
+      scanSimpleStructuredRows(
+        Range.create(null, Range.Bound.INCLUSIVE,
+                     Collections.singleton(Fields.longField(KEY2, (long) 18)), Range.Bound.INCLUSIVE), max);
+    Assert.assertEquals(expected.subList(0, 19), actual);
+
+    // Test invalid range
+    getTransactionRunner().run(context -> {
+      StructuredTable table = context.getTable(SIMPLE_TABLE);
+      try {
+        table.scan(
+          Range.create(Collections.singleton(Fields.stringField(STRING_COL, "invalid")), Range.Bound.EXCLUSIVE,
+                       Collections.singleton(Fields.longField(KEY2, (long) 40)), Range.Bound.EXCLUSIVE), max);
+        Assert.fail("Expected InvalidFieldException since STRING_COL is not primary key");
+      } catch (InvalidFieldException e) {
+        // Expected, see the exception message above
+      }
+    });
+
+    getTransactionRunner().run(context -> {
+      StructuredTable table = context.getTable(SIMPLE_TABLE);
+      try {
+        table.scan(Range.singleton(Collections.singleton(Fields.doubleField(DOUBLE_COL, 1.0))), max);
+        Assert.fail("Expected InvalidFieldException since DOUBLE_COL is not primary key");
+      } catch (InvalidFieldException e) {
+        // Expected, see the exception message above
+      }
+    });
+  }
+
+  @Test
+  public void testMultiRangeScanDuplicateSecondKey() throws Exception {
+    int max = 100;
+
+    List<Collection<Field<?>>> expectedAll = writeRowsWithDuplicateSecondKeyPrefix(max, "");
+
+    Collection<Range> ranges = Collections.singletonList(
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 26), Fields.longField(KEY2, (long) 6))));
+
+    List<String> outPutFields = Arrays.asList(KEY, KEY2, STRING_COL, DOUBLE_COL, FLOAT_COL, BYTES_COL);
+
+    List<Collection<Field<?>>> actual = runMultiScan(ranges, max, outPutFields);
+    Assert.assertEquals(expectedAll.subList(26, 27), actual);
+
+    // MultiScan with inclusive beginning and exclusive ending
+    ranges = Collections.singletonList(
+      Range.create(Collections.singletonList(Fields.longField(KEY2, (long) 3)),
+                   Range.Bound.INCLUSIVE,
+                   Collections.singletonList(Fields.longField(KEY2, (long) 5)),
+                   Range.Bound.EXCLUSIVE));
+    actual = runMultiScan(ranges, max, outPutFields);
+    List<Collection<Field<?>>> expected = new LinkedList<>();
+    for (int i = 0; i < max / 10; i++) {
+      expected.addAll(expectedAll.subList(i * 10 + 3, i * 10 + 5));
+    }
+    Assert.assertEquals(expected, actual);
+
+    // MultiScan with inclusive beginning and inclusive ending
+    ranges = Collections.singletonList(
+      Range.create(Collections.singletonList(Fields.longField(KEY2, (long) 3)),
+                   Range.Bound.INCLUSIVE,
+                   Collections.singletonList(Fields.longField(KEY2, (long) 5)),
+                   Range.Bound.INCLUSIVE));
+    actual = runMultiScan(ranges, max, outPutFields);
+    expected = new LinkedList<>();
+    for (int i = 0; i < max / 10; i++) {
+      expected.addAll(expectedAll.subList(i * 10 + 3, i * 10 + 6));
+    }
+    Assert.assertEquals(expected, actual);
+
+    // MultiScan with exclusive beginning and inclusive ending
+    ranges = Collections.singletonList(
+      Range.create(Collections.singletonList(Fields.longField(KEY2, (long) 3)),
+                   Range.Bound.EXCLUSIVE,
+                   Collections.singletonList(Fields.longField(KEY2, (long) 5)),
+                   Range.Bound.INCLUSIVE));
+    actual = runMultiScan(ranges, max, outPutFields);
+    expected = new LinkedList<>();
+    for (int i = 0; i < max / 10; i++) {
+      expected.addAll(expectedAll.subList(i * 10 + 4, i * 10 + 6));
+    }
+    Assert.assertEquals(expected, actual);
+
+    // MultiScan with singleton ranges
+    ranges = Arrays.asList(
+      Range.singleton(Collections.singletonList(Fields.longField(KEY2, (long) 3))),
+      Range.singleton(Collections.singletonList(Fields.longField(KEY2, (long) 4))));
+    actual = runMultiScan(ranges, max, outPutFields);
+    expected = new LinkedList<>();
+    for (int i = 0; i < max / 10; i++) {
+      expected.addAll(expectedAll.subList(i * 10 + 3, i * 10 + 5));
+    }
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testPartialKeysMultiRangeScan() throws Exception {
+    int max = 100;
+
+    List<Collection<Field<?>>> expectedAll = writeStructuredRowsWithDuplicatePrefix(max, "");
+
+    Collection<Range> ranges = Collections.singletonList(
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 2), Fields.longField(KEY2, (long) 26))));
+
+    List<String> outPutFields = Arrays.asList(KEY, KEY2, STRING_COL, DOUBLE_COL, FLOAT_COL, BYTES_COL);
+
+    List<Collection<Field<?>>> actual = runMultiScan(ranges, max, outPutFields);
+    Assert.assertEquals(expectedAll.subList(26, 27), actual);
+
+    // MultiScan with multiple ranges
+    ranges = Arrays.asList(
+      // INCLUSIVE beginning and INCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 1), Fields.longField(KEY2, (long) 11)),
+                   Range.Bound.INCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 1), Fields.longField(KEY2, (long) 15)),
+                   Range.Bound.INCLUSIVE),
+      // INCLUSIVE beginning and EXCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 2), Fields.longField(KEY2, (long) 21)),
+                   Range.Bound.INCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 2), Fields.longField(KEY2, (long) 25)),
+                   Range.Bound.EXCLUSIVE),
+      // EXCLUSIVE beginning and EXCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 3), Fields.longField(KEY2, (long) 31)),
+                   Range.Bound.EXCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 3), Fields.longField(KEY2, (long) 35)),
+                   Range.Bound.EXCLUSIVE),
+      // EXCLUSIVE beginning and INCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 4), Fields.longField(KEY2, (long) 41)),
+                   Range.Bound.EXCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 4), Fields.longField(KEY2, (long) 49)),
+                   Range.Bound.INCLUSIVE));
+    
+    actual = runMultiScan(ranges, max, outPutFields);
+    List<Collection<Field<?>>> newExpected = new LinkedList<>();
+    newExpected.addAll(expectedAll.subList(11, 16));
+    newExpected.addAll(expectedAll.subList(21, 25));
+    newExpected.addAll(expectedAll.subList(32, 35));
+    newExpected.addAll(expectedAll.subList(42, 50));
+    Assert.assertEquals(newExpected, actual);
+
+    // MultiScan partialKeys with multiple collections of fields
+    ranges = Arrays.asList(
+      Range.singleton(Collections.singletonList(Fields.intField(KEY, 3))),
+      Range.singleton(Collections.singletonList(Fields.intField(KEY, 4))));
+    actual = runMultiScan(ranges, max, outPutFields);
+    Assert.assertEquals(expectedAll.subList(30, 50), actual);
+
+    // MultiScan partialKeys with a mix of singleton and range, mixed ordering
+    ranges = Arrays.asList(
+      Range.singleton(Collections.singletonList(Fields.longField(KEY2, (long) 29))),
+      Range.singleton(Collections.singletonList(Fields.longField(KEY2, (long) 28))),
+      Range.singleton(Collections.singletonList(Fields.intField(KEY, 3))));
+    actual = runMultiScan(ranges, max, outPutFields);
+    Assert.assertEquals(expectedAll.subList(28, 40), actual);
+
+    // MultiScan partialKeys with overlapping ranges
+    ranges = Arrays.asList(
+      Range.singleton(Collections.singletonList(Fields.longField(KEY2, (long) 29))),
+      Range.singleton(Collections.singletonList(Fields.longField(KEY2, (long) 28))),
+      Range.singleton(Collections.singletonList(Fields.intField(KEY, 2))));
+
+    actual = runMultiScan(ranges, max, outPutFields);
+    Assert.assertEquals(expectedAll.subList(20, 30), actual);
+
+    ranges = Arrays.asList(
+      Range.create(Collections.singleton(Fields.longField(KEY2, (long) 5)), Range.Bound.EXCLUSIVE,
+                   Collections.singleton(Fields.longField(KEY2, (long) 45)), Range.Bound.EXCLUSIVE),
+      Range.create(Collections.singleton(Fields.longField(KEY2, (long) 15)), Range.Bound.INCLUSIVE,
+                   Collections.singleton(Fields.longField(KEY2, (long) 60)), Range.Bound.INCLUSIVE));
+
+    actual = runMultiScan(ranges, max, outPutFields);
+    Assert.assertEquals(expectedAll.subList(6, 61), actual);
+
+    // MultiScan partialKeys with limit
+    ranges = Arrays.asList(
+      Range.singleton(Collections.singletonList(Fields.intField(KEY, 4))),
+      Range.singleton(Collections.singletonList(Fields.intField(KEY, 3))));
+    actual = runMultiScan(ranges, 15, outPutFields);
+
+    Assert.assertEquals(expectedAll.subList(30, 45), actual);
   }
 
   @Test
@@ -294,14 +503,49 @@ public abstract class StructuredTableTest {
     );
     result = runMultiScan(ranges, Integer.MAX_VALUE, KEY, KEY2);
     Assert.assertEquals(expected, result);
+
+    // Multiscan with singleton ranges of mixed fields
+    expected = IntStream.concat(IntStream.range(1, 2), IntStream.range(51, 52))
+      .mapToObj(i -> Arrays.asList(Fields.intField(KEY, i / 10), Fields.longField(KEY2, (long) i)))
+      .collect(Collectors.toList());
+
+    ranges = Arrays.asList(
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 0),
+                                    Fields.longField(KEY2, (long) 1))),
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 5),
+                                    Fields.longField(KEY2, (long) 51)))
+    );
+
+    result = runMultiScan(ranges, Integer.MAX_VALUE, KEY, KEY2);
+    Assert.assertEquals(expected, result);
+
+    expected = IntStream.concat(IntStream.range(1, 2), IntStream.range(50, 61))
+      .mapToObj(i -> Arrays.asList(Fields.intField(KEY, i / 10), Fields.longField(KEY2, (long) i)))
+      .collect(Collectors.toList());
+
+    ranges = Arrays.asList(
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 0),
+                                    Fields.longField(KEY2, (long) 1))),
+      Range.singleton(Collections.singletonList(Fields.intField(KEY, 5))),
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 6),
+                                    Fields.longField(KEY2, (long) 60)))
+    );
+
+    result = runMultiScan(ranges, Integer.MAX_VALUE, KEY, KEY2);
+    Assert.assertEquals(expected, result);
   }
 
   private List<Collection<Field<?>>> runMultiScan(Collection<Range> ranges, int limit,
                                                   String... outputFields) throws Exception {
+    return runMultiScan(ranges, limit, Arrays.asList(outputFields));
+  }
+
+  private List<Collection<Field<?>>> runMultiScan(Collection<Range> ranges, int limit,
+                                                  List<String> outputFields) throws Exception {
     return TransactionRunners.run(getTransactionRunner(), context -> {
       StructuredTable table = context.getTable(SIMPLE_TABLE);
       try (CloseableIterator<StructuredRow> iterator = table.multiScan(ranges, limit)) {
-        return convertRowsToFields(iterator, Arrays.asList(outputFields));
+        return convertRowsToFields(iterator, outputFields);
       }
     });
   }
@@ -618,6 +862,16 @@ public abstract class StructuredTableTest {
         Assert.assertEquals(expected.subList(0, num), rows);
       }
 
+      // Partial primary keys range
+      try (CloseableIterator<StructuredRow> iterator =
+             table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)), Range.Bound.INCLUSIVE,
+                                     Collections.singleton(Fields.longField(KEY2, num * 100L)), Range.Bound.EXCLUSIVE),
+                        num * 10,
+                        Fields.stringField(STRING_COL, "abc"))) {
+        List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
+        Assert.assertEquals(expected.subList(0, num), rows);
+      }
+
       try (CloseableIterator<StructuredRow> iterator =
              table.scan(Range.create(Collections.singleton(Fields.intField(KEY, num)), Range.Bound.INCLUSIVE,
                                      Collections.singleton(Fields.intField(KEY, num * 2)), Range.Bound.EXCLUSIVE),
@@ -698,6 +952,17 @@ public abstract class StructuredTableTest {
       try (CloseableIterator<StructuredRow> iterator =
              table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)), Range.Bound.INCLUSIVE,
                                      Collections.singleton(Fields.intField(KEY, num * 2)), Range.Bound.EXCLUSIVE),
+                        num * 10, IDX_COL, SortOrder.DESC)) {
+        List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
+        List<Collection<Field<?>>> expectedSubList = expected.subList(0, num * 2);
+
+        Assert.assertEquals(expectedSubList, rows);
+      }
+
+      // Partial primary keys range
+      try (CloseableIterator<StructuredRow> iterator =
+             table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)), Range.Bound.INCLUSIVE,
+                                     Collections.singleton(Fields.longField(KEY2, num * 200L)), Range.Bound.EXCLUSIVE),
                         num * 10, IDX_COL, SortOrder.DESC)) {
         List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
         List<Collection<Field<?>>> expectedSubList = expected.subList(0, num * 2);
@@ -797,8 +1062,17 @@ public abstract class StructuredTableTest {
 
       Collection<Range> ranges = Arrays.asList(Range.to(Collections.singletonList(Fields.intField(KEY, 2)),
                                                         Range.Bound.INCLUSIVE),
-                                               Range.from(Collections.singletonList(Fields.intField(KEY, 2)),
+                                               // Intentionally create overlapping range
+                                               Range.from(Collections.singletonList(Fields.intField(KEY, 0)),
                                                           Range.Bound.EXCLUSIVE));
+      Assert.assertEquals(max, table.count(ranges));
+
+      // Partial primary keys range
+      ranges = Arrays.asList(Range.to(Collections.singletonList(Fields.intField(KEY, 4)),
+                                      Range.Bound.INCLUSIVE),
+                             // Intentionally create overlapping range
+                             Range.from(Collections.singletonList(Fields.longField(KEY2, (long) 0)),
+                                        Range.Bound.EXCLUSIVE));
       Assert.assertEquals(max, table.count(ranges));
     });
   }
@@ -908,6 +1182,51 @@ public abstract class StructuredTableTest {
     for (int i = max - 1; i >= 0; i--) {
       List<Field<?>> fields = Arrays.asList(Fields.intField(KEY, i),
                                             Fields.longField(KEY2, (long) i),
+                                            Fields.stringField(STRING_COL, VAL + i + suffix),
+                                            Fields.doubleField(DOUBLE_COL, (double) i),
+                                            Fields.floatField(FLOAT_COL, (float) i),
+                                            Fields.bytesField(BYTES_COL, Bytes.toBytes("bytes-" + i)));
+      expected.add(fields);
+
+      getTransactionRunner().run(context -> {
+        StructuredTable table = context.getTable(SIMPLE_TABLE);
+        table.upsert(fields);
+      });
+    }
+    Collections.reverse(expected);
+    return expected;
+  }
+
+  private List<Collection<Field<?>>> writeStructuredRowsWithDuplicatePrefix(int max, String suffix) throws Exception {
+    List<Collection<Field<?>>> expected = new ArrayList<>(max);
+    // Write rows in reverse order to test sorting
+    for (int i = max - 1; i >= 0; i--) {
+      // Adding rows that have same "KEY" every 10 elements
+      List<Field<?>> fields = Arrays.asList(Fields.intField(KEY, i / 10),
+                                            Fields.longField(KEY2, (long) i),
+                                            Fields.stringField(STRING_COL, VAL + i + suffix),
+                                            Fields.doubleField(DOUBLE_COL, (double) i),
+                                            Fields.floatField(FLOAT_COL, (float) i),
+                                            Fields.bytesField(BYTES_COL, Bytes.toBytes("bytes-" + i)));
+      expected.add(fields);
+
+      getTransactionRunner().run(context -> {
+        StructuredTable table = context.getTable(SIMPLE_TABLE);
+        table.upsert(fields);
+      });
+    }
+    Collections.reverse(expected);
+    return expected;
+  }
+
+  private List<Collection<Field<?>>> writeRowsWithDuplicateSecondKeyPrefix(int max, String suffix)
+    throws Exception {
+    List<Collection<Field<?>>> expected = new ArrayList<>(max);
+    // Write rows in reverse order to test sorting
+    for (int i = max - 1; i >= 0; i--) {
+      // Adding rows that have same "KEY" every 10 elements
+      List<Field<?>> fields = Arrays.asList(Fields.intField(KEY, i),
+                                            Fields.longField(KEY2, (long) i % 10),
                                             Fields.stringField(STRING_COL, VAL + i + suffix),
                                             Fields.doubleField(DOUBLE_COL, (double) i),
                                             Fields.floatField(FLOAT_COL, (float) i),

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/table/field/FieldValidatorTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/table/field/FieldValidatorTest.java
@@ -59,7 +59,7 @@ public class FieldValidatorTest {
 
     // Success case with prefix
     validator.validatePrimaryKeys(Arrays.asList(Fields.intField(KEY, 10), Fields.longField(KEY2, 100L)),
-                                                true);
+                                  true);
     validator.validatePrimaryKeys(Collections.singletonList(Fields.intField(KEY, 10)), true);
 
     // Test invalid type
@@ -75,6 +75,45 @@ public class FieldValidatorTest {
     try {
       validator.validatePrimaryKeys(Arrays.asList(Fields.intField(KEY, 10), Fields.longField(KEY2, 100L)),
                                     false);
+      Assert.fail("Expected InvalidFieldException");
+    } catch (InvalidFieldException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testValidatePartialPrimaryKeys() {
+    FieldValidator validator = new FieldValidator(schema);
+
+    // Success case
+    validator.validatePartialPrimaryKeys(Arrays.asList(Fields.intField(KEY, 10),
+                                                       Fields.longField(KEY2, 100L),
+                                                       Fields.stringField(KEY3, "s")));
+
+    // Success case with prefix
+    validator.validatePartialPrimaryKeys(Arrays.asList(Fields.intField(KEY, 10),
+                                                       Fields.longField(KEY2, 100L)));
+
+    // Success case with partial keys
+    validator.validatePartialPrimaryKeys(Arrays.asList(Fields.intField(KEY2, 10),
+                                                       Fields.stringField(KEY3, "s")));
+
+    // Test invalid type
+    try {
+      validator.validatePartialPrimaryKeys(Arrays.asList(Fields.stringField(KEY3, "s"),
+                                                         Fields.floatField(KEY, 10.0f),
+                                                         Fields.longField(KEY2, 100L)));
+      Assert.fail("Expected InvalidFieldException");
+    } catch (InvalidFieldException e) {
+      // expected
+    }
+
+    // Test invalid number
+    try {
+      validator.validatePartialPrimaryKeys(Arrays.asList(Fields.intField(KEY, 10),
+                                                         Fields.longField(KEY2, 100L),
+                                                         Fields.longField("notExitField", 100L),
+                                                         Fields.longField(KEY2, 100L)));
       Assert.fail("Expected InvalidFieldException");
     } catch (InvalidFieldException e) {
       // expected


### PR DESCRIPTION
CDAP-19569: cache twill, launcher and application jars in GCS to prevent uploading for every pipeline run
Description:
Currently we upload the twill, launcher and application jars for every pipeline run which remain same for particular CDAP version.

Solution
Caching them in the `cached_artifacts` directory in the GCS bucket for particular instance.

Testing
Deployed the CDAP image on k8s and ran the pipeline successfully.
Ran the pipeline with runtimeArg `system.profile.properties.enableGCSCachingSnapshot=true` for enabling the caching for snapshots.
Performed a burst scalability launch test of 50 pipelines.