### PR TITLE
CDAP-19688: refactor the multiscan method in nosql table

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -1524,7 +1524,7 @@ public class AppMetadataStore {
                                                false));
     }
     
-    return getRangeScanRunsMap(allKeys);
+    return getRunsByKeys(allKeys);
   }
 
   private Map<ProgramRunId, RunRecordDetail> getCompletedRuns(Set<ProgramRunId> programRunIds) throws IOException {
@@ -1542,10 +1542,10 @@ public class AppMetadataStore {
       allKeys.add(keysWithoutVersion);
     }
 
-    return getRangeScanRunsMap(allKeys);
+    return getRunsByKeys(allKeys);
   }
 
-  private Map<ProgramRunId, RunRecordDetail> getRangeScanRunsMap(List<List<Field<?>>> allKeys) throws IOException {
+  private Map<ProgramRunId, RunRecordDetail> getRunsByKeys(List<List<Field<?>>> allKeys) throws IOException {
     List<RunRecordDetail> runRecordDetails = new ArrayList<>();
 
     try (CloseableIterator<StructuredRow> iterator =
@@ -2017,8 +2017,7 @@ public class AppMetadataStore {
     return fields;
   }
 
-  private List<Field<?>> getRunRecordProgramPrefix(String status,
-                                                   @Nullable ProgramId programId) {
+  private List<Field<?>> getRunRecordProgramPrefix(String status, @Nullable ProgramId programId) {
     return getRunRecordProgramPrefix(status, programId, true);
   }
 
@@ -2082,8 +2081,7 @@ public class AppMetadataStore {
     return fields;
   }
 
-  private List<Field<?>> getProgramRunInvertedTimeKey(String recordType, ProgramRunId runId,
-                                                      long startTs) {
+  private List<Field<?>> getProgramRunInvertedTimeKey(String recordType, ProgramRunId runId, long startTs) {
     return getProgramRunInvertedTimeKey(recordType, runId, startTs, true);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -1547,9 +1547,10 @@ public class AppMetadataStore {
 
   private Map<ProgramRunId, RunRecordDetail> getRunsByKeys(List<List<Field<?>>> allKeys) throws IOException {
     List<RunRecordDetail> runRecordDetails = new ArrayList<>();
+    Collection<Range> ranges = allKeys.stream().map(Range::singleton).collect(Collectors.toList());
 
     try (CloseableIterator<StructuredRow> iterator =
-           getRunRecordsTable().multiScanPartialKeys(allKeys, Integer.MAX_VALUE)) {
+           getRunRecordsTable().multiScan(ranges, Integer.MAX_VALUE)) {
       while (iterator.hasNext()) {
         runRecordDetails.add(deserializeRunRecordMeta(iterator.next()));
       }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
@@ -175,7 +175,7 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
 
     String opsDashboardQueryPath =
       String.format("%s/dashboard?start=%s&duration=%s&namespace=%s&namespace=%s", BASE_PATH,
-                    String.valueOf(startTime1), String.valueOf(endTime), ns1.getNamespace(), ns2.getNamespace());
+                    startTime1, endTime, ns1.getNamespace(), ns2.getNamespace());
     // get ops dashboard query results
     HttpResponse response = doGet(opsDashboardQueryPath);
     Assert.assertEquals(200, response.getResponseCode());
@@ -191,7 +191,7 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
     // for the same time range query only in namespace ns1 to ensure filtering works fine
     opsDashboardQueryPath =
       String.format("%s/dashboard?start=%s&duration=%s&namespace=%s", BASE_PATH,
-                    String.valueOf(startTime1), String.valueOf(endTime), ns2.getNamespace());
+                    startTime1, endTime, ns2.getNamespace());
 
     // get ops dashboard query results
     response = doGet(opsDashboardQueryPath);
@@ -371,7 +371,7 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
 
     String opsDashboardQueryPath =
       String.format("%s/dashboard?start=%s&duration=%s&namespace=%s", BASE_PATH,
-                    String.valueOf(startTime1), String.valueOf(endTime), ns3.getNamespace());
+                    startTime1, endTime, ns3.getNamespace());
 
     // get ops dashboard query results
     HttpResponse response = doGet(opsDashboardQueryPath);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -1320,9 +1320,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
   }
 
   private void testReEnableSchedule(String scheduleName) throws Exception {
-    ProtoTrigger.TimeTrigger protoTime = new ProtoTrigger.TimeTrigger("0 * * * ?");
-    ProtoTrigger.PartitionTrigger protoPartition =
-      new ProtoTrigger.PartitionTrigger(NamespaceId.DEFAULT.dataset("data"), 5);
     String description = "Something";
     ScheduleProgramInfo programInfo = new ScheduleProgramInfo(SchedulableProgramType.WORKFLOW,
                                                               AppWithSchedule.WORKFLOW_NAME);

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/MetricStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/MetricStructuredTable.java
@@ -173,12 +173,6 @@ public class MetricStructuredTable implements StructuredTable {
   }
 
   @Override
-  public CloseableIterator<StructuredRow> scan(Collection<Field<?>> partialKeys, int limit)
-    throws InvalidFieldException, IOException {
-    return scan(() -> structuredTable.scan(partialKeys, limit), "scan.partial.keys");
-  }
-
-  @Override
   public CloseableIterator<StructuredRow> scan(Field<?> index) throws InvalidFieldException, IOException {
     return scan(() -> structuredTable.scan(index), "index.scan.");
   }
@@ -223,38 +217,6 @@ public class MetricStructuredTable implements StructuredTable {
   public CloseableIterator<StructuredRow> multiScan(Collection<Range> keyRanges,
                                                     int limit) throws InvalidFieldException, IOException {
     return multiScan(() -> structuredTable.multiScan(keyRanges, limit), "multi.scan.");
-  }
-
-  private interface MultiScanPartialKeysFunction {
-    CloseableIterator<StructuredRow> multiScanPartialKeys() throws InvalidFieldException, IOException;
-  }
-
-  private CloseableIterator<StructuredRow> multiScanPartialKeys(
-    MultiScanPartialKeysFunction multiScanPartialKeysFunction, String metricNamePrefix) throws IOException {
-    try {
-      CloseableIterator<StructuredRow> result;
-      if (!emitTimeMetrics) {
-        result = multiScanPartialKeysFunction.multiScanPartialKeys();
-      } else {
-        long curTime = System.nanoTime();
-        result = multiScanPartialKeysFunction.multiScanPartialKeys();
-        long duration = System.nanoTime() - curTime;
-        metricsCollector.increment(metricPrefix + metricNamePrefix + "time", duration);
-      }
-      metricsCollector.increment(metricPrefix + metricNamePrefix + "count", 1L);
-      return result;
-    } catch (Exception e) {
-      metricsCollector.increment(metricPrefix + metricNamePrefix + "error", 1L);
-      throw e;
-    }
-  }
-
-  @Override
-  public CloseableIterator<StructuredRow> multiScanPartialKeys(
-    Collection<? extends Collection<Field<?>>> partialKeysCollections,
-    int limit) throws InvalidFieldException, IOException {
-    return multiScanPartialKeys(
-      () -> structuredTable.multiScanPartialKeys(partialKeysCollections, limit), "multi.scan.partial.keys");
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
@@ -164,7 +164,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
     MockScanner scanner = new MockScanner(expected.iterator());
     Field<?> filterIndex = Fields.intField("key", 9);
     List<Integer> actual = new ArrayList<>();
-    try (NoSqlStructuredTable.FilterByIndexIterator closeableIterator = new NoSqlStructuredTable.FilterByIndexIterator(
+    try (NoSqlStructuredTable.FilterByFieldIterator closeableIterator = new NoSqlStructuredTable.FilterByFieldIterator(
       (new NoSqlStructuredTable.ScannerIterator(scanner, SCHEMA)), filterIndex, SCHEMA)) {
       while (closeableIterator.hasNext()) {
         actual.add(closeableIterator.next().getInteger("key"));
@@ -182,7 +182,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
     MockScanner scanner = new MockScanner(expected.iterator());
     Field<?> filterIndex = Fields.intField("key", 9);
     List<Integer> actual = new ArrayList<>();
-    try (NoSqlStructuredTable.FilterByIndexIterator closeableIterator = new NoSqlStructuredTable.FilterByIndexIterator(
+    try (NoSqlStructuredTable.FilterByFieldIterator closeableIterator = new NoSqlStructuredTable.FilterByFieldIterator(
       new NoSqlStructuredTable.ScannerIterator(scanner, SCHEMA), filterIndex, SCHEMA)) {
       while (closeableIterator.hasNext()) {
         actual.add(closeableIterator.next().getInteger("key"));

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
@@ -119,20 +119,6 @@ public interface StructuredTable extends Closeable {
   CloseableIterator<StructuredRow> scan(Range keyRange, int limit) throws InvalidFieldException, IOException;
 
   /**
-   * Scan a collection of rows from the table matching the partial primary keys.
-   * The rows returned will be sorted on the primary key order.
-   *
-   * @param partialKeys partial primary keys for the scan
-   * @param limit maximum number of rows to return
-   * @return a {@link CloseableIterator} of rows
-   * @throws InvalidFieldException if any of the keys are not part of the table schema, or the types of the value
-   *                               do not match
-   * @throws IOException if there is an error scanning the table
-   */
-  CloseableIterator<StructuredRow> scan(Collection<Field<?>> partialKeys, int limit)
-    throws InvalidFieldException, IOException;
-
-  /**
    * Read a set of rows from the table matching the key range.
    * The rows returned will be sorted on the primary key according to sortOrder parameter.
    *
@@ -213,22 +199,6 @@ public interface StructuredTable extends Closeable {
    */
   CloseableIterator<StructuredRow> multiScan(Collection<Range> keyRanges,
                                              int limit) throws InvalidFieldException, IOException;
-
-  /**
-   * Scan a collection of rows from the table matching the set of partial primary keys.
-   * The rows returned will be sorted on the primary key order.
-   *
-   * @param partialKeysCollections collection of key ranges for the scan
-   * @param limit maximum number of rows to return
-   * @return a {@link CloseableIterator} of rows
-   * @throws InvalidFieldException if any of the keys are not part of the table schema, or the types of the value
-   *                               do not match
-   * @throws IOException if there is an error scanning the table
-   */
-  CloseableIterator<StructuredRow> multiScanPartialKeys(
-    Collection<? extends Collection<Field<?>>> partialKeysCollections,
-    int limit)
-    throws InvalidFieldException, IOException;
 
   /**
    * Atomically compare and swap the value of a column in a row if the expected value matches.

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
@@ -119,13 +119,27 @@ public interface StructuredTable extends Closeable {
   CloseableIterator<StructuredRow> scan(Range keyRange, int limit) throws InvalidFieldException, IOException;
 
   /**
+   * Scan a collection of rows from the table matching the partial primary keys.
+   * The rows returned will be sorted on the primary key order.
+   *
+   * @param partialKeys partial primary keys for the scan
+   * @param limit maximum number of rows to return
+   * @return a {@link CloseableIterator} of rows
+   * @throws InvalidFieldException if any of the keys are not part of the table schema, or the types of the value
+   *                               do not match
+   * @throws IOException if there is an error scanning the table
+   */
+  CloseableIterator<StructuredRow> scan(Collection<Field<?>> partialKeys, int limit)
+    throws InvalidFieldException, IOException;
+
+  /**
    * Read a set of rows from the table matching the key range.
    * The rows returned will be sorted on the primary key according to sortOrder parameter.
    *
    * @param keyRange key range for the scan
    * @param limit maximum number of rows to return
    * @param sortOrder defined primary key sort order. Note that the comparator used is specific to the underlying
-   *                  store and is not nessesarily lexographic.
+   *                  store and is not necessarily lexicographic.
    * @return a {@link CloseableIterator} of rows
    * @throws InvalidFieldException if any of the keys are not part of the table schema, or the types of the value
    *                               do not match
@@ -199,6 +213,22 @@ public interface StructuredTable extends Closeable {
    */
   CloseableIterator<StructuredRow> multiScan(Collection<Range> keyRanges,
                                              int limit) throws InvalidFieldException, IOException;
+
+  /**
+   * Scan a collection of rows from the table matching the set of partial primary keys.
+   * The rows returned will be sorted on the primary key order.
+   *
+   * @param partialKeysCollections collection of key ranges for the scan
+   * @param limit maximum number of rows to return
+   * @return a {@link CloseableIterator} of rows
+   * @throws InvalidFieldException if any of the keys are not part of the table schema, or the types of the value
+   *                               do not match
+   * @throws IOException if there is an error scanning the table
+   */
+  CloseableIterator<StructuredRow> multiScanPartialKeys(
+    Collection<? extends Collection<Field<?>>> partialKeysCollections,
+    int limit)
+    throws InvalidFieldException, IOException;
 
   /**
    * Atomically compare and swap the value of a column in a row if the expected value matches.

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/field/FieldValidator.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/field/FieldValidator.java
@@ -21,7 +21,9 @@ import io.cdap.cdap.spi.data.InvalidFieldException;
 import io.cdap.cdap.spi.data.table.StructuredTableSchema;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A field validator class which can be used to validate the given field.
@@ -89,6 +91,30 @@ public final class FieldValidator {
           String.format("Given keys %s are not the prefix of the primary keys %s", keys, primaryKeys));
       }
       i++;
+    }
+  }
+
+  /**
+   * Validate if the given keys are partial primary keys.
+   *
+   * @param keys the keys to validate
+   * @throws InvalidFieldException if the given keys have extra key which is not in primary key.
+   */
+  public void validatePartialPrimaryKeys(Collection<Field<?>> keys) throws InvalidFieldException {
+    Set<String> primaryKeys = new HashSet<>(tableSchema.getPrimaryKeys());
+    if (keys.size() > primaryKeys.size()) {
+      throw new InvalidFieldException(
+        tableSchema.getTableId(), keys,
+        String.format("Given keys %s contain more fields than the primary keys %s", keys, primaryKeys));
+    }
+
+    for (Field<?> key : keys) {
+      validateField(key);
+      if (!primaryKeys.contains(key.getName())) {
+        throw new InvalidFieldException(
+          tableSchema.getTableId(), keys,
+          String.format("Given keys %s are not partial primary keys %s", keys, primaryKeys));
+      }
     }
   }
 }

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
@@ -274,6 +274,33 @@ public abstract class StructuredTableTest {
     List<Collection<Field<?>>> actual = runMultiScan(ranges, max, outPutFields);
     Assert.assertEquals(expected.subList(26, 27), actual);
 
+    // MultiScan with inclusive beginning and exclusive ending
+    ranges = Collections.singletonList(
+      Range.create(Arrays.asList(Fields.intField(KEY, 3), Fields.longField(KEY2, (long) 31)),
+                   Range.Bound.INCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 3), Fields.longField(KEY2, (long) 35)),
+                   Range.Bound.EXCLUSIVE));
+    actual = runMultiScan(ranges, max, outPutFields);
+    Assert.assertEquals(expected.subList(31, 35), actual);
+
+    // MultiScan with exclusive beginning and exclusive ending
+    ranges = Collections.singletonList(
+      Range.create(Arrays.asList(Fields.intField(KEY, 3), Fields.longField(KEY2, (long) 31)),
+                   Range.Bound.EXCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 3), Fields.longField(KEY2, (long) 35)),
+                   Range.Bound.EXCLUSIVE));
+    actual = runMultiScan(ranges, max, outPutFields);
+    Assert.assertEquals(expected.subList(32, 35), actual);
+
+    // MultiScan with exclusive beginning and inclusive ending
+    ranges = Collections.singletonList(
+      Range.create(Arrays.asList(Fields.intField(KEY, 3), Fields.longField(KEY2, (long) 31)),
+                   Range.Bound.EXCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 3), Fields.longField(KEY2, (long) 35)),
+                   Range.Bound.INCLUSIVE));
+    actual = runMultiScan(ranges, max, outPutFields);
+    Assert.assertEquals(expected.subList(32, 36), actual);
+
     // MultiScan partialKeys with multiple collections of fields
     ranges = Arrays.asList(
       Range.singleton(Collections.singletonList(Fields.intField(KEY, 3))),

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/table/field/FieldValidatorTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/table/field/FieldValidatorTest.java
@@ -59,7 +59,7 @@ public class FieldValidatorTest {
 
     // Success case with prefix
     validator.validatePrimaryKeys(Arrays.asList(Fields.intField(KEY, 10), Fields.longField(KEY2, 100L)),
-                                                true);
+                                  true);
     validator.validatePrimaryKeys(Collections.singletonList(Fields.intField(KEY, 10)), true);
 
     // Test invalid type
@@ -75,6 +75,45 @@ public class FieldValidatorTest {
     try {
       validator.validatePrimaryKeys(Arrays.asList(Fields.intField(KEY, 10), Fields.longField(KEY2, 100L)),
                                     false);
+      Assert.fail("Expected InvalidFieldException");
+    } catch (InvalidFieldException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testValidatePartialPrimaryKeys() {
+    FieldValidator validator = new FieldValidator(schema);
+
+    // Success case
+    validator.validatePartialPrimaryKeys(Arrays.asList(Fields.intField(KEY, 10),
+                                                       Fields.longField(KEY2, 100L),
+                                                       Fields.stringField(KEY3, "s")));
+
+    // Success case with prefix
+    validator.validatePartialPrimaryKeys(Arrays.asList(Fields.intField(KEY, 10),
+                                                       Fields.longField(KEY2, 100L)));
+
+    // Success case with partial keys
+    validator.validatePartialPrimaryKeys(Arrays.asList(Fields.intField(KEY2, 10),
+                                                       Fields.stringField(KEY3, "s")));
+
+    // Test invalid type
+    try {
+      validator.validatePartialPrimaryKeys(Arrays.asList(Fields.stringField(KEY3, "s"),
+                                                         Fields.floatField(KEY, 10.0f),
+                                                         Fields.longField(KEY2, 100L)));
+      Assert.fail("Expected InvalidFieldException");
+    } catch (InvalidFieldException e) {
+      // expected
+    }
+
+    // Test invalid number
+    try {
+      validator.validatePartialPrimaryKeys(Arrays.asList(Fields.intField(KEY, 10),
+                                                         Fields.longField(KEY2, 100L),
+                                                         Fields.longField("notExitField", 100L),
+                                                         Fields.longField(KEY2, 100L)));
       Assert.fail("Expected InvalidFieldException");
     } catch (InvalidFieldException e) {
       // expected

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/store/AppMetadataStore.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/store/AppMetadataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2015-2020 Cask Data, Inc.
+ * Copyright © 2015-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,7 @@
 package io.cdap.cdap.logging.gateway.handlers.store;
 
 import com.google.gson.Gson;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.proto.ProgramType;
@@ -31,7 +32,6 @@ import io.cdap.cdap.store.StoreDefinition;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -74,12 +74,16 @@ public class AppMetadataStore {
     return getRunRecordMeta(runningKey);
   }
 
-  private RunRecordDetail getRunRecordMeta(List<Field<?>> primaryKeys) throws IOException {
-    Optional<StructuredRow> row = runRecordsTable.read(primaryKeys);
-    if (!row.isPresent()) {
-      return null;
+  private RunRecordDetail getRunRecordMeta(List<Field<?>> partialPrimaryKeys) throws IOException {
+    // Instead of reading by full primary keys, we scan by all keys without version
+    // Since we made sure run id is unique
+    try (CloseableIterator<StructuredRow> iterator =
+           runRecordsTable.scan(partialPrimaryKeys, 1)) {
+      if (iterator.hasNext()) {
+        return deserializeRunRecordMeta(iterator.next());
+      }
     }
-    return deserializeRunRecordMeta(row.get());
+    return null;
   }
 
   private static RunRecordDetail deserializeRunRecordMeta(StructuredRow row) {
@@ -143,16 +147,15 @@ public class AppMetadataStore {
     if (applicationId == null) {
       return fields;
     }
-    fields.addAll(getApplicationPrimaryKeys(
-      applicationId.getNamespace(), applicationId.getApplication(), applicationId.getVersion()));
+    fields.addAll(getNoVersionAppPrimaryKeys(applicationId.getNamespace(),
+                                             applicationId.getApplication()));
     return fields;
   }
 
-  private List<Field<?>> getApplicationPrimaryKeys(String namespaceId, String appId, String versionId) {
+  private List<Field<?>> getNoVersionAppPrimaryKeys(String namespaceId, String appId) {
     List<Field<?>> fields = new ArrayList<>();
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD, namespaceId));
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_FIELD, appId));
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.VERSION_FIELD, versionId));
     return fields;
   }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/store/AppMetadataStore.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/store/AppMetadataStore.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.spi.data.StructuredRow;
 import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.table.field.Field;
 import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.table.field.Range;
 import io.cdap.cdap.store.StoreDefinition;
 
 import java.io.IOException;
@@ -78,7 +79,7 @@ public class AppMetadataStore {
     // Instead of reading by full primary keys, we scan by all keys without version
     // Since we made sure run id is unique
     try (CloseableIterator<StructuredRow> iterator =
-           runRecordsTable.scan(partialPrimaryKeys, 1)) {
+           runRecordsTable.scan(Range.singleton(partialPrimaryKeys), 1)) {
       if (iterator.hasNext()) {
         return deserializeRunRecordMeta(iterator.next());
       }


### PR DESCRIPTION
This should be based on and merged after https://github.com/cdapio/cdap/pull/14605

In nosql table multiscan, instead of sanning all ranges one by one and post filtering, we could scan the most outboud range only once