### PR TITLE
CDAP-19468 configure Spark to return after submitting the job

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -129,6 +129,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String SPARK_KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label.";
   private static final String SPARK_KUBERNETES_EXECUTOR_LABEL_PREFIX = "spark.kubernetes.executor.label.";
   private static final String SPARK_KUBERNETES_NAMESPACE = "spark.kubernetes.namespace";
+  private static final String SPARK_KUBERNETES_WAIT_IN_SUBMIT = "spark.kubernetes.submission.waitAppCompletion";
   @VisibleForTesting
   static final String SPARK_KUBERNETES_DRIVER_POD_TEMPLATE = "spark.kubernetes.driver.podTemplateFile";
   @VisibleForTesting
@@ -405,6 +406,10 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     String master = kubeMasterPathProvider.getMasterPath();
 
     Map<String, String> sparkConfMap = new HashMap<>(additionalSparkConfs);
+
+    // CDAP-19468 -- Spark seems to have a bug where it can wait forever for the driver to complete even after the
+    // driver has already completed.
+    sparkConfMap.put(SPARK_KUBERNETES_WAIT_IN_SUBMIT, "false");
     // Create pod template with config maps and add to spark conf.
     sparkConfMap.put(SPARK_KUBERNETES_DRIVER_POD_TEMPLATE,
                      getDriverPodTemplate(podInfo, sparkSubmitContext).getAbsolutePath());

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
@@ -157,7 +157,7 @@ public class MasterEnvironmentSparkSubmitter extends AbstractSparkSubmitter {
 
   @Override
   protected boolean waitForFinish() throws Exception {
-    return sparkDriverWatcher.waitForFinish().get(10, TimeUnit.MINUTES);
+    return sparkDriverWatcher.waitForFinish().get();
   }
 
   private SparkConfig generateOrGetSparkConfig() throws Exception {


### PR DESCRIPTION
Configure Spark to avoid waiting for the job to complete in SparkSubmit and rely on our own pod watcher to determine if the job is complete. Since we already are watching the pod, this reduces the load on Kubernetes. It also bypasses a Spark bug where it can wait forever even after the job is complete.