### PR TITLE
fix(CDAP-19688): fix the edge case in nosql table that longest prefix range should be default as INCLUSIVE if the range has omitted fields

### DIFF
--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
@@ -216,7 +216,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
     public Row next() {
       if (iterator.hasNext()) {
         int i = iterator.next();
-        return createResult(new MDSKey.Builder().add("tableNamePrefix").add(i).add((long) i)
+        return createResult(new MDSKey.Builder().add("tableNamePrefix").add(i).add((long) i).add("key3")
                               .build().getKey(),
                             "c" + i, "v" + i);
       }


### PR DESCRIPTION
What is changed:

Since we relaxed the range scan in table. There could be edge case like: for table with primary keys of [KEY, KEY2, KEY3...]
We give range that is missing KEY2: ([KEY: "ns1", KEY3: 123], EXCLUSIVE, [KEY: "ns1", KEY3: 789], EXCLUSIVE)
KEY: "ns1" should be INCLUSIVE while scanning
The longest prefix range should only be EXCLUSIVE when there's no keyholes and bound is EXCLUSIVE


CDAP doesn't yet have use cases for this scenario. But we should fix it as soon as we found it in case it's used in future. 