### PR TITLE
[cherry-pick] [CDAP-19687] Replaces ref-counting algorithm for cacheable artifacts with time-bucket hash

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcherTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcherTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.deploy;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public class InMemoryProgramRunDispatcherTest {
+
+  @Test
+  public void testTimeBucketHash() {
+    long currentTime = System.currentTimeMillis();
+    int window = 15;
+    Set<String> results1 = new HashSet<>();
+    Set<String> results2 = new HashSet<>();
+    long dayInMilliSec = TimeUnit.DAYS.toMillis(1);
+    for (int i = 0; i < 15; i++) {
+      results1.add(InMemoryProgramRunDispatcher.timeBucketHash("hash1", window, currentTime + (i * dayInMilliSec)));
+      results2.add(InMemoryProgramRunDispatcher.timeBucketHash("hash2", window, currentTime + (i * dayInMilliSec)));
+    }
+
+    // for 15 days window, we should have maximum 2 time buckets
+    Assert.assertTrue(results1.size() >= 1 && results1.size() <= 2);
+    Assert.assertTrue(results2.size() >= 1 && results2.size() <= 2);
+
+    for (String res : results1) {
+      results2.remove(res);
+    }
+
+    for (String res : results2) {
+      results1.remove(res);
+    }
+
+    // ensures that jitter works so all keys do not end up in the same bucket
+    Assert.assertNotEquals(results1.size(), 0);
+    Assert.assertNotEquals(results2.size(), 0);
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -238,6 +238,7 @@ public final class Constants {
     public static final String PROGRAM_TERMINATE_TIME_BUFFER_SECS = "app.program.terminate.time.buffer.secs";
     public static final String PROGRAM_TERMINATOR_TX_BATCH_SIZE = "app.program.terminator.tx.batch.size";
     public static final String ARTIFACTS_COMPUTE_HASH = "app.artifact.compute.hash";
+    public static final String ARTIFACTS_COMPUTE_HASH_TIME_BUCKET_DAYS = "app.artifact.compute.hash.time.bucket.days";
     public static final String ARTIFACTS_COMPUTE_HASH_SNAPSHOT = "app.artifact.compute.hash.snapshot";
     public static final String SYSTEM_ARTIFACTS_DIR = "app.artifact.dir";
     public static final String SYSTEM_ARTIFACTS_MAX_PARALLELISM = "app.artifact.parallelism.max";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -417,6 +417,15 @@
 
   <!-- Applications Configuration -->
   <property>
+    <name>app.artifact.compute.hash.time.bucket.days</name>
+    <value>15</value>
+    <description>
+      If greater than 0, ensures that has values are time bucketed every x days.
+      Therefore, generating hash of an identical value x days apart will result in different hash values.
+    </description>
+  </property>
+
+  <property>
     <name>app.artifact.compute.hash</name>
     <value>false</value>
     <description>

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -23,7 +23,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.runtime.spi.VersionInfo;
-import io.cdap.cdap.runtime.spi.common.ArtifactCacheManager;
 import io.cdap.cdap.runtime.spi.common.DataprocImageVersion;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import io.cdap.cdap.runtime.spi.provisioner.Capabilities;
@@ -130,7 +129,6 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
         .setCredentials(conf.getDataprocCredentials()).build().getService();
       String runId = context.getProgramRunInfo().getRun();
       String runRootPath = getPath(DataprocUtils.CDAP_GCS_ROOT, runId);
-      new ArtifactCacheManager().releaseCacheUsageForArtifacts(storageClient, bucket, runRootPath, runId);
       DataprocUtils.deleteGCSPath(storageClient, bucket, runRootPath);
     }
 

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -50,7 +50,6 @@ import com.google.common.io.ByteStreams;
 import io.cdap.cdap.error.api.ErrorTagProvider;
 import io.cdap.cdap.runtime.spi.CacheableLocalFile;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
-import io.cdap.cdap.runtime.spi.common.ArtifactCacheManager;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 import io.cdap.cdap.runtime.spi.provisioner.dataproc.DataprocRuntimeException;
@@ -74,12 +73,10 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
@@ -230,7 +227,6 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
 
       // step 2: upload all the necessary files to gcs so that those files are available to dataproc job
       List<Future<LocalFile>> uploadFutures = new ArrayList<>();
-      Set<String> cachedFiles = new HashSet<>();
       for (LocalFile fileToUpload : localFiles) {
         boolean isCacheable = !disableGCSCaching && fileToUpload instanceof CacheableLocalFile;
         String targetFilePath = getPath(isCacheable ? cacheRootPath : runRootPath, fileToUpload.getName());
@@ -238,13 +234,6 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
           provisionerContext.execute(() -> isCacheable ? uploadCacheableFile(bucket, targetFilePath, fileToUpload) :
               uploadFile(bucket, targetFilePath, fileToUpload, false))
             .toCompletableFuture());
-        if (isCacheable) {
-          cachedFiles.add(fileToUpload.getName());
-        }
-      }
-      if (!cachedFiles.isEmpty()) {
-        new ArtifactCacheManager().recordCacheUsageForArtifacts(getStorageClient(), bucket, cachedFiles, runRootPath,
-                                                                cacheRootPath, runInfo.getRun());
       }
 
       List<LocalFile> uploadedFiles = new ArrayList<>();
@@ -420,7 +409,6 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
                                     URI.create(String.format("gs://%s/%s", bucket, targetFilePath)),
                                     localFile.getLastModified(), localFile.getSize(),
                                     localFile.isArchive(), localFile.getPattern());
-      DataprocUtils.setTemporaryHoldOnGCSObject(storage, bucket, blob, targetFilePath);
     } else {
       result = uploadFile(bucket, targetFilePath, localFile, true);
     }
@@ -433,12 +421,12 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
    */
   private LocalFile uploadFile(String bucket, String targetFilePath,
                                LocalFile localFile, boolean isCacheable)
-    throws IOException, StorageException, InterruptedException {
+    throws IOException, StorageException {
     BlobId blobId = BlobId.of(bucket, targetFilePath);
     String contentType = "application/octet-stream";
     BlobInfo.Builder blobInfoBuilder = BlobInfo.newBuilder(blobId);
     if (isCacheable) {
-      blobInfoBuilder.setCustomTime(System.currentTimeMillis()).setTemporaryHold(true);
+      blobInfoBuilder.setCustomTime(System.currentTimeMillis());
     }
     BlobInfo blobInfo = blobInfoBuilder.setContentType(contentType).build();
     Storage storage = getStorageClient();
@@ -462,11 +450,11 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
         throw e;
       }
 
-      Blob blob = storage.get(blobId);
       if (!isCacheable) {
         // Precondition fails means the blob already exists, most likely happens due to retries
         // https://cloud.google.com/storage/docs/request-preconditions#special-case
         // Overwrite the file
+        Blob blob = storage.get(blobId);
         BlobInfo existingBlobInfo = BlobInfo.newBuilder(blob.getBlobId()).setContentType(contentType).build();
         uploadToGCS(localFile.getURI(), storage, existingBlobInfo, Storage.BlobWriteOption.generationMatch());
         LOG.debug("Successfully uploaded file {} to gs://{}/{} by overwriting due to conflict",
@@ -474,7 +462,6 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
       } else {
         LOG.debug("Skip uploading file {} to gs://{}/{} because it exists.",
                   localFile.getURI(), bucket, targetFilePath);
-        DataprocUtils.setTemporaryHoldOnGCSObject(storage, bucket, blob, targetFilePath);
       }
     }
 


### PR DESCRIPTION
Cherry picking [PR](https://github.com/cdapio/cdap/pull/14638) into release/6.8