### PR TITLE
feat(CDAP-19781): Support scan on non-primary-key fields in StructuredTable

### DIFF
--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
@@ -155,8 +155,7 @@ public final class NoSqlStructuredTable implements StructuredTable {
   }
 
   private Range getLongestPrefixRange(Range range) {
-    fieldValidator.validatePartialPrimaryKeys(range.getBegin());
-    fieldValidator.validatePartialPrimaryKeys(range.getEnd());
+    fieldValidator.validateScanRange(range);
 
     List<Field<?>> beginPrefixKeys = getPrefixPrimaryKeys(range.getBegin());
     List<Field<?>> endPrefixKeys = getPrefixPrimaryKeys(range.getEnd());
@@ -171,7 +170,7 @@ public final class NoSqlStructuredTable implements StructuredTable {
         ? Range.Bound.EXCLUSIVE : Range.Bound.INCLUSIVE;
 
     Range.Bound endBound =
-      beginPrefixKeys.size() == range.getBegin().size()
+      endPrefixKeys.size() == range.getEnd().size()
         && range.getEndBound() == Range.Bound.EXCLUSIVE
         ? Range.Bound.EXCLUSIVE : Range.Bound.INCLUSIVE;
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStructuredTable.java
@@ -210,8 +210,7 @@ public class PostgreSqlStructuredTable implements StructuredTable {
     throws InvalidFieldException, IOException {
 
     LOG.trace("Table {}: Scan range {} with limit {} order {}", tableSchema.getTableId(), keyRange, limit, sortOrder);
-    fieldValidator.validatePartialPrimaryKeys(keyRange.getBegin());
-    fieldValidator.validatePartialPrimaryKeys(keyRange.getEnd());
+    fieldValidator.validateScanRange(keyRange);
     String scanQuery = getScanQuery(keyRange, limit, tableSchema.getPrimaryKeys(), sortOrder);
 
     // We don't close the statement here because once it is closed, the result set is also closed.
@@ -244,8 +243,7 @@ public class PostgreSqlStructuredTable implements StructuredTable {
     List<Range> rangeScans = new ArrayList<>();
     boolean scanAll = false;
     for (Range range : keyRanges) {
-      fieldValidator.validatePartialPrimaryKeys(range.getBegin());
-      fieldValidator.validatePartialPrimaryKeys(range.getEnd());
+      fieldValidator.validateScanRange(range);
 
       if (range.isSingleton()) {
         singletonScans.add(range);
@@ -363,9 +361,7 @@ public class PostgreSqlStructuredTable implements StructuredTable {
   @Override
   public CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Field<?> filterIndex, SortOrder sortOrder)
     throws InvalidFieldException, IOException {
-
-    fieldValidator.validatePartialPrimaryKeys(keyRange.getBegin());
-    fieldValidator.validatePartialPrimaryKeys(keyRange.getEnd());
+    fieldValidator.validateScanRange(keyRange);
     fieldValidator.validateField(filterIndex);
     if (!tableSchema.isIndexColumn(filterIndex.getName())) {
       throw new InvalidFieldException(tableSchema.getTableId(), filterIndex.getName(), "is not an indexed column");
@@ -397,8 +393,7 @@ public class PostgreSqlStructuredTable implements StructuredTable {
 
     LOG.trace("Table {}: Scan range {} with limit {} order {} on index field {}",
               tableSchema.getTableId(), keyRange, limit, sortOrder, orderByField);
-    fieldValidator.validatePartialPrimaryKeys(keyRange.getBegin());
-    fieldValidator.validatePartialPrimaryKeys(keyRange.getEnd());
+    fieldValidator.validateScanRange(keyRange);
     if (!tableSchema.isIndexColumn(orderByField)) {
       throw new InvalidFieldException(tableSchema.getTableId(), orderByField, "is not an indexed column");
     }
@@ -537,8 +532,7 @@ public class PostgreSqlStructuredTable implements StructuredTable {
   @Override
   public void deleteAll(Range keyRange) throws InvalidFieldException, IOException {
     LOG.trace("Table {}: DeleteAll with range {}", tableSchema.getTableId(), keyRange);
-    fieldValidator.validatePrimaryKeys(keyRange.getBegin(), true);
-    fieldValidator.validatePrimaryKeys(keyRange.getEnd(), true);
+    fieldValidator.validateScanRange(keyRange);
     String sql = getDeleteAllStatement(keyRange);
     try (PreparedStatement statement = connection.prepareStatement(sql)) {
       setStatementFieldByRange(keyRange, statement);
@@ -923,8 +917,7 @@ public class PostgreSqlStructuredTable implements StructuredTable {
     StringBuilder statement = new StringBuilder("SELECT COUNT(*) FROM ").append(tableSchema.getTableId().getName());
     boolean whereAdded = false;
     for (Range range : ranges) {
-      fieldValidator.validatePartialPrimaryKeys(range.getBegin());
-      fieldValidator.validatePartialPrimaryKeys(range.getEnd());
+      fieldValidator.validateScanRange(range);
 
       if (!range.getBegin().isEmpty() || !range.getEnd().isEmpty()) {
         if (!whereAdded) {

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/field/FieldValidator.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/field/FieldValidator.java
@@ -59,6 +59,37 @@ public final class FieldValidator {
     }
   }
 
+  /**
+   * Validate if the given range fields matches the schema. The given range is invalid if:
+   * its field is not present in the given schema,
+   * its field type is different from the given schema,
+   * if its field is a primary key but the given value is null,
+   * or it is not Rang.all() and does not start with a primary key.
+   *
+   * @param range the range to validate
+   * @throws InvalidFieldException if the field does not pass the validation
+   */
+  public void validateScanRange(Range range) throws InvalidFieldException {
+    range.getBegin().forEach(this::validateField);
+    range.getEnd().forEach(this::validateField);
+
+    validateFirstKeyInScanRange(range.getBegin());
+    validateFirstKeyInScanRange(range.getEnd());
+  }
+
+  private void validateFirstKeyInScanRange(Collection<Field<?>> fields) {
+    if (fields.isEmpty()) {
+      return;
+    }
+    
+    Field<?> firstField = fields.iterator().next();
+
+    if (!firstField.getName().equals(tableSchema.getPrimaryKeys().get(0))) {
+      throw new InvalidFieldException(
+        tableSchema.getTableId(), fields,
+        String.format("Given Range fields %s do not start with a primary key", fields));
+    }
+  }
 
   /**
    * Validate if the given keys are prefix or complete primary keys.

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
@@ -204,10 +204,6 @@ public abstract class StructuredTableTest {
     Assert.assertEquals(expected.subList(46, 47), actual);
 
     // Test partial keys singleton scan
-    actual = scanSimpleStructuredRows(
-      Range.singleton(Collections.singleton(Fields.longField(KEY2, (long) 46))), max);
-    Assert.assertEquals(expected.subList(46, 47), actual);
-
     actual =
       scanSimpleStructuredRows(
         Range.singleton(Arrays.asList(Fields.intField(KEY, 2), Fields.longField(KEY2, (long) 35))), max);
@@ -216,20 +212,26 @@ public abstract class StructuredTableTest {
     // Test partial keys actual range scan
     actual =
       scanSimpleStructuredRows(
-        Range.create(Collections.singleton(Fields.intField(KEY, 30)), Range.Bound.EXCLUSIVE,
-                     Collections.singleton(Fields.longField(KEY2, (long) 40)), Range.Bound.EXCLUSIVE), max);
+        Range.create(Collections.singleton(Fields.intField(KEY, 30)),
+                     Range.Bound.EXCLUSIVE,
+                     Arrays.asList(Fields.intField(KEY, 40),
+                                   Fields.longField(KEY2, (long) 40)),
+                     Range.Bound.EXCLUSIVE), max);
     Assert.assertEquals(expected.subList(31, 40), actual);
 
     actual =
       scanSimpleStructuredRows(
-        Range.create(Collections.singleton(Fields.intField(KEY, 5)), Range.Bound.INCLUSIVE,
-                     Collections.singleton(Fields.longField(KEY2, (long) 15)), Range.Bound.EXCLUSIVE), max);
+        Range.create(Collections.singleton(Fields.intField(KEY, 5)),
+                     Range.Bound.INCLUSIVE,
+                     Arrays.asList(Fields.intField(KEY, 15),
+                                   Fields.longField(KEY2, (long) 15)),
+                     Range.Bound.EXCLUSIVE), max);
     Assert.assertEquals(expected.subList(5, 15), actual);
 
     // Test begin only range
     actual =
       scanSimpleStructuredRows(
-        Range.create(Collections.singleton(Fields.longField(KEY2, (long) 5)), Range.Bound.EXCLUSIVE,
+        Range.create(Collections.singleton(Fields.intField(KEY, 5)), Range.Bound.EXCLUSIVE,
                      null, Range.Bound.INCLUSIVE), max);
     Assert.assertEquals(expected.subList(6, max), actual);
 
@@ -237,7 +239,7 @@ public abstract class StructuredTableTest {
     actual =
       scanSimpleStructuredRows(
         Range.create(null, Range.Bound.INCLUSIVE,
-                     Collections.singleton(Fields.longField(KEY2, (long) 18)), Range.Bound.INCLUSIVE), max);
+                     Collections.singleton(Fields.intField(KEY, 18)), Range.Bound.INCLUSIVE), max);
     Assert.assertEquals(expected.subList(0, 19), actual);
 
     // Test invalid range
@@ -245,19 +247,9 @@ public abstract class StructuredTableTest {
       StructuredTable table = context.getTable(SIMPLE_TABLE);
       try {
         table.scan(
-          Range.create(Collections.singleton(Fields.stringField(STRING_COL, "invalid")), Range.Bound.EXCLUSIVE,
+          Range.create(Collections.singleton(Fields.stringField("NON-EXIST_FIELD", "invalid")), Range.Bound.EXCLUSIVE,
                        Collections.singleton(Fields.longField(KEY2, (long) 40)), Range.Bound.EXCLUSIVE), max);
         Assert.fail("Expected InvalidFieldException since STRING_COL is not primary key");
-      } catch (InvalidFieldException e) {
-        // Expected, see the exception message above
-      }
-    });
-
-    getTransactionRunner().run(context -> {
-      StructuredTable table = context.getTable(SIMPLE_TABLE);
-      try {
-        table.scan(Range.singleton(Collections.singleton(Fields.doubleField(DOUBLE_COL, 1.0))), max);
-        Assert.fail("Expected InvalidFieldException since DOUBLE_COL is not primary key");
       } catch (InvalidFieldException e) {
         // Expected, see the exception message above
       }
@@ -265,13 +257,13 @@ public abstract class StructuredTableTest {
   }
 
   @Test
-  public void testMultiRangeScanDuplicateSecondKey() throws Exception {
+  public void testMultiRangeScanDuplicateKeyPrefix() throws Exception {
     int max = 100;
 
-    List<Collection<Field<?>>> expectedAll = writeRowsWithDuplicateSecondKeyPrefix(max, "");
+    List<Collection<Field<?>>> expectedAll = writeRowsWithDuplicateKeyPrefix(max, "");
 
     Collection<Range> ranges = Collections.singletonList(
-      Range.singleton(Arrays.asList(Fields.intField(KEY, 26), Fields.longField(KEY2, (long) 6))));
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 6), Fields.longField(KEY2, (long) 26))));
 
     List<String> outPutFields = Arrays.asList(KEY, KEY2, KEY3, STRING_COL, DOUBLE_COL, FLOAT_COL, BYTES_COL);
 
@@ -280,51 +272,54 @@ public abstract class StructuredTableTest {
 
     // MultiScan with inclusive beginning and exclusive ending
     ranges = Collections.singletonList(
-      Range.create(Collections.singletonList(Fields.longField(KEY2, (long) 3)),
-                   Range.Bound.INCLUSIVE,
-                   Collections.singletonList(Fields.longField(KEY2, (long) 5)),
-                   Range.Bound.EXCLUSIVE));
+      Range.create(Collections.singletonList(Fields.intField(KEY, 3)), Range.Bound.INCLUSIVE,
+                   Collections.singletonList(Fields.intField(KEY, 5)), Range.Bound.EXCLUSIVE));
     actual = runMultiScan(ranges, max, outPutFields);
     List<Collection<Field<?>>> expected = new LinkedList<>();
-    for (int i = 0; i < max / 10; i++) {
-      expected.addAll(expectedAll.subList(i * 10 + 3, i * 10 + 5));
+    for (int i = 3; i < 5; i++) {
+      for (int j = 0; j < max / 10; j++) {
+        expected.add(expectedAll.get(j * 10 + i));
+      }
     }
+
     Assert.assertEquals(expected, actual);
 
     // MultiScan with inclusive beginning and inclusive ending
     ranges = Collections.singletonList(
-      Range.create(Collections.singletonList(Fields.longField(KEY2, (long) 3)),
-                   Range.Bound.INCLUSIVE,
-                   Collections.singletonList(Fields.longField(KEY2, (long) 5)),
-                   Range.Bound.INCLUSIVE));
+      Range.create(Collections.singletonList(Fields.intField(KEY, 3)), Range.Bound.INCLUSIVE,
+                   Collections.singletonList(Fields.intField(KEY, 5)), Range.Bound.INCLUSIVE));
     actual = runMultiScan(ranges, max, outPutFields);
     expected = new LinkedList<>();
-    for (int i = 0; i < max / 10; i++) {
-      expected.addAll(expectedAll.subList(i * 10 + 3, i * 10 + 6));
+    for (int i = 3; i < 6; i++) {
+      for (int j = 0; j < max / 10; j++) {
+        expected.add(expectedAll.get(j * 10 + i));
+      }
     }
     Assert.assertEquals(expected, actual);
 
     // MultiScan with exclusive beginning and inclusive ending
     ranges = Collections.singletonList(
-      Range.create(Collections.singletonList(Fields.longField(KEY2, (long) 3)),
-                   Range.Bound.EXCLUSIVE,
-                   Collections.singletonList(Fields.longField(KEY2, (long) 5)),
-                   Range.Bound.INCLUSIVE));
+      Range.create(Collections.singletonList(Fields.intField(KEY, 3)), Range.Bound.EXCLUSIVE,
+                   Collections.singletonList(Fields.intField(KEY, 5)), Range.Bound.INCLUSIVE));
     actual = runMultiScan(ranges, max, outPutFields);
     expected = new LinkedList<>();
-    for (int i = 0; i < max / 10; i++) {
-      expected.addAll(expectedAll.subList(i * 10 + 4, i * 10 + 6));
+    for (int i = 4; i < 6; i++) {
+      for (int j = 0; j < max / 10; j++) {
+        expected.add(expectedAll.get(j * 10 + i));
+      }
     }
     Assert.assertEquals(expected, actual);
 
     // MultiScan with singleton ranges
     ranges = Arrays.asList(
-      Range.singleton(Collections.singletonList(Fields.longField(KEY2, (long) 3))),
-      Range.singleton(Collections.singletonList(Fields.longField(KEY2, (long) 4))));
+      Range.singleton(Collections.singletonList(Fields.intField(KEY, 3))),
+      Range.singleton(Collections.singletonList(Fields.intField(KEY, 4))));
     actual = runMultiScan(ranges, max, outPutFields);
     expected = new LinkedList<>();
-    for (int i = 0; i < max / 10; i++) {
-      expected.addAll(expectedAll.subList(i * 10 + 3, i * 10 + 5));
+    for (int i = 3; i < 5; i++) {
+      for (int j = 0; j < max / 10; j++) {
+        expected.add(expectedAll.get(j * 10 + i));
+      }
     }
     Assert.assertEquals(expected, actual);
   }
@@ -351,7 +346,7 @@ public abstract class StructuredTableTest {
                    Arrays.asList(Fields.intField(KEY, 1), Fields.longField(KEY2, (long) 15)),
                    Range.Bound.INCLUSIVE),
       // INCLUSIVE beginning and EXCLUSIVE ending
-      Range.create(Arrays.asList(Fields.intField(KEY, 2), Fields.longField(KEY2, (long) 21)),
+      Range.create(Collections.singletonList(Fields.intField(KEY, 2)),
                    Range.Bound.INCLUSIVE,
                    Arrays.asList(Fields.intField(KEY, 2), Fields.longField(KEY2, (long) 25)),
                    Range.Bound.EXCLUSIVE),
@@ -365,11 +360,11 @@ public abstract class StructuredTableTest {
                    Range.Bound.EXCLUSIVE,
                    Arrays.asList(Fields.intField(KEY, 4), Fields.longField(KEY2, (long) 49)),
                    Range.Bound.INCLUSIVE));
-    
+
     actual = runMultiScan(ranges, max, outPutFields);
     List<Collection<Field<?>>> newExpected = new LinkedList<>();
     newExpected.addAll(expectedAll.subList(11, 16));
-    newExpected.addAll(expectedAll.subList(21, 25));
+    newExpected.addAll(expectedAll.subList(20, 25));
     newExpected.addAll(expectedAll.subList(32, 35));
     newExpected.addAll(expectedAll.subList(42, 50));
     Assert.assertEquals(newExpected, actual);
@@ -382,12 +377,12 @@ public abstract class StructuredTableTest {
                    Arrays.asList(Fields.intField(KEY, 1), Fields.stringField(KEY3, String.valueOf(15))),
                    Range.Bound.INCLUSIVE),
       // INCLUSIVE beginning and EXCLUSIVE ending
-      Range.create(Arrays.asList(Fields.intField(KEY, 3), Fields.stringField(KEY3, String.valueOf(31))),
+      Range.create(Collections.singletonList(Fields.intField(KEY, 3)),
                    Range.Bound.INCLUSIVE,
                    Arrays.asList(Fields.intField(KEY, 3), Fields.stringField(KEY3, String.valueOf(35))),
                    Range.Bound.EXCLUSIVE),
       // EXCLUSIVE beginning and EXCLUSIVE ending
-      Range.create(Arrays.asList(Fields.intField(KEY, 5), Fields.stringField(KEY3, String.valueOf(52))),
+      Range.create(Collections.singletonList(Fields.intField(KEY, 4)),
                    Range.Bound.EXCLUSIVE,
                    Arrays.asList(Fields.intField(KEY, 5), Fields.stringField(KEY3, String.valueOf(58))),
                    Range.Bound.EXCLUSIVE),
@@ -400,8 +395,8 @@ public abstract class StructuredTableTest {
     actual = runMultiScan(ranges, max, outPutFields);
     newExpected = new LinkedList<>();
     newExpected.addAll(expectedAll.subList(11, 16));
-    newExpected.addAll(expectedAll.subList(31, 35));
-    newExpected.addAll(expectedAll.subList(53, 58));
+    newExpected.addAll(expectedAll.subList(30, 35));
+    newExpected.addAll(expectedAll.subList(50, 58));
     newExpected.addAll(expectedAll.subList(72, 80));
     Assert.assertEquals(newExpected, actual);
 
@@ -414,10 +409,26 @@ public abstract class StructuredTableTest {
     Assert.assertEquals(expectedAll.subList(11, 16), actual);
 
     actual = scanSimpleStructuredRows(
+      // INCLUSIVE beginning and INCLUSIVE ending, unmatched partial keys
+      Range.create(Collections.singletonList(Fields.intField(KEY, 1)),
+                   Range.Bound.INCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 1), Fields.longField(KEY2, (long) 15)),
+                   Range.Bound.INCLUSIVE), max);
+    Assert.assertEquals(expectedAll.subList(10, 16), actual);
+
+    actual = scanSimpleStructuredRows(
       // INCLUSIVE beginning and EXCLUSIVE ending
       Range.create(Arrays.asList(Fields.intField(KEY, 3), Fields.stringField(KEY3, String.valueOf(31))),
                    Range.Bound.INCLUSIVE,
                    Arrays.asList(Fields.intField(KEY, 3), Fields.stringField(KEY3, String.valueOf(35))),
+                   Range.Bound.EXCLUSIVE), max);
+    Assert.assertEquals(expectedAll.subList(31, 35), actual);
+
+    actual = scanSimpleStructuredRows(
+      // INCLUSIVE beginning and EXCLUSIVE ending, unmatched partial keys
+      Range.create(Arrays.asList(Fields.intField(KEY, 3), Fields.stringField(KEY3, String.valueOf(31))),
+                   Range.Bound.INCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 3), Fields.longField(KEY2, (long) 35)),
                    Range.Bound.EXCLUSIVE), max);
     Assert.assertEquals(expectedAll.subList(31, 35), actual);
 
@@ -430,10 +441,21 @@ public abstract class StructuredTableTest {
     Assert.assertEquals(expectedAll.subList(53, 58), actual);
 
     actual = scanSimpleStructuredRows(
-      // EXCLUSIVE beginning and INCLUSIVE ending
-      Range.create(Arrays.asList(Fields.intField(KEY, 7), Fields.stringField(KEY3, String.valueOf(71))),
+      // EXCLUSIVE beginning and EXCLUSIVE ending, unmatched partial keys
+      Range.create(Arrays.asList(Fields.intField(KEY, 5), Fields.longField(KEY2, (long) 52)),
                    Range.Bound.EXCLUSIVE,
-                   Arrays.asList(Fields.intField(KEY, 7), Fields.stringField(KEY3, String.valueOf(79))),
+                   Arrays.asList(Fields.intField(KEY, 5), Fields.stringField(KEY3, String.valueOf(58))),
+                   Range.Bound.EXCLUSIVE), max);
+    Assert.assertEquals(expectedAll.subList(53, 58), actual);
+
+    actual = scanSimpleStructuredRows(
+      // EXCLUSIVE beginning and INCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 7),
+                                 Fields.stringField(KEY3, String.valueOf(71))),
+                   Range.Bound.EXCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 7),
+                                 Fields.longField(KEY2, (long) 79),
+                                 Fields.stringField(KEY3, String.valueOf(79))),
                    Range.Bound.INCLUSIVE), max);
     Assert.assertEquals(expectedAll.subList(72, 80), actual);
 
@@ -446,26 +468,30 @@ public abstract class StructuredTableTest {
 
     // MultiScan partialKeys with a mix of singleton and range, mixed ordering
     ranges = Arrays.asList(
-      Range.singleton(Collections.singletonList(Fields.longField(KEY2, (long) 29))),
-      Range.singleton(Collections.singletonList(Fields.longField(KEY2, (long) 28))),
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 2), Fields.longField(KEY2, (long) 29))),
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 2), Fields.longField(KEY2, (long) 28))),
       Range.singleton(Collections.singletonList(Fields.intField(KEY, 3))));
     actual = runMultiScan(ranges, max, outPutFields);
     Assert.assertEquals(expectedAll.subList(28, 40), actual);
 
     // MultiScan partialKeys with overlapping ranges
     ranges = Arrays.asList(
-      Range.singleton(Collections.singletonList(Fields.longField(KEY2, (long) 29))),
-      Range.singleton(Collections.singletonList(Fields.longField(KEY2, (long) 28))),
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 2), Fields.longField(KEY2, (long) 29))),
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 2), Fields.longField(KEY2, (long) 28))),
       Range.singleton(Collections.singletonList(Fields.intField(KEY, 2))));
 
     actual = runMultiScan(ranges, max, outPutFields);
     Assert.assertEquals(expectedAll.subList(20, 30), actual);
 
     ranges = Arrays.asList(
-      Range.create(Collections.singleton(Fields.longField(KEY2, (long) 5)), Range.Bound.EXCLUSIVE,
-                   Collections.singleton(Fields.longField(KEY2, (long) 45)), Range.Bound.EXCLUSIVE),
-      Range.create(Collections.singleton(Fields.longField(KEY2, (long) 15)), Range.Bound.INCLUSIVE,
-                   Collections.singleton(Fields.longField(KEY2, (long) 60)), Range.Bound.INCLUSIVE));
+      Range.create(Arrays.asList(Fields.intField(KEY, 0), Fields.longField(KEY2, (long) 5)),
+                   Range.Bound.EXCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 4), Fields.longField(KEY2, (long) 45)),
+                   Range.Bound.EXCLUSIVE),
+      Range.create(Arrays.asList(Fields.intField(KEY, 1), Fields.longField(KEY2, (long) 15)),
+                   Range.Bound.INCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 6), Fields.longField(KEY2, (long) 60)),
+                   Range.Bound.INCLUSIVE));
 
     actual = runMultiScan(ranges, max, outPutFields);
     Assert.assertEquals(expectedAll.subList(6, 61), actual);
@@ -477,6 +503,123 @@ public abstract class StructuredTableTest {
     actual = runMultiScan(ranges, 15, outPutFields);
 
     Assert.assertEquals(expectedAll.subList(30, 45), actual);
+  }
+
+  @Test
+  public void testNonPrimaryKeysRangeScan() throws Exception {
+    int max = 100;
+    List<Collection<Field<?>>> expectedAll = writeStructuredRowsWithDuplicatePrefix(max, "");
+    List<String> outPutFields = Arrays.asList(KEY, KEY2, KEY3, STRING_COL, DOUBLE_COL, FLOAT_COL, BYTES_COL);
+
+    // Scan on single range
+    List<Collection<Field<?>>> actual = scanSimpleStructuredRows(
+      // INCLUSIVE beginning and INCLUSIVE ending
+      Range.create(Collections.singletonList(Fields.intField(KEY, 1)),
+                   Range.Bound.INCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 1), Fields.doubleField(DOUBLE_COL, (double) 115)),
+                   Range.Bound.INCLUSIVE), max);
+    Assert.assertEquals(expectedAll.subList(10, 20), actual);
+
+    actual = scanSimpleStructuredRows(
+      // INCLUSIVE beginning and EXCLUSIVE ending
+      Range.create(Collections.singletonList(Fields.intField(KEY, 3)),
+                   Range.Bound.INCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 3), Fields.stringField(STRING_COL, VAL + "35")),
+                   Range.Bound.EXCLUSIVE), max);
+    Assert.assertEquals(expectedAll.subList(30, 35), actual);
+
+    actual = scanSimpleStructuredRows(
+      // EXCLUSIVE beginning and EXCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 5), Fields.doubleField(DOUBLE_COL, (double) 52)),
+                   Range.Bound.EXCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 5), Fields.doubleField(DOUBLE_COL, (double) 58)),
+                   Range.Bound.EXCLUSIVE), max);
+    Assert.assertEquals(expectedAll.subList(53, 58), actual);
+
+    actual = scanSimpleStructuredRows(
+      // EXCLUSIVE beginning and INCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 7), Fields.stringField(STRING_COL, VAL + "71")),
+                   Range.Bound.EXCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 7), Fields.stringField(STRING_COL, VAL + "79")),
+                   Range.Bound.INCLUSIVE), max);
+    Assert.assertEquals(expectedAll.subList(72, 80), actual);
+
+    // MultiScan with multiple ranges that cannot merge the longest prefix keys
+    Collection<Range> ranges = Arrays.asList(
+      // INCLUSIVE beginning and INCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 1), Fields.doubleField(DOUBLE_COL, (double) 11)),
+                   Range.Bound.INCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 1), Fields.doubleField(DOUBLE_COL, (double) 15)),
+                   Range.Bound.INCLUSIVE),
+      // INCLUSIVE beginning and EXCLUSIVE ending
+      Range.create(Collections.singletonList(Fields.intField(KEY, 3)),
+                   Range.Bound.INCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 3), Fields.doubleField(DOUBLE_COL, (double) 39)),
+                   Range.Bound.EXCLUSIVE),
+      // EXCLUSIVE beginning and EXCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 5),
+                                 Fields.stringField(STRING_COL, VAL + "53")),
+                   Range.Bound.EXCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 5),
+                                 Fields.longField(KEY2, (long) 55),
+                                 Fields.stringField(STRING_COL, VAL + "55")),
+                   Range.Bound.EXCLUSIVE),
+      // EXCLUSIVE beginning and INCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 7), Fields.doubleField(DOUBLE_COL, (double) 70)),
+                   Range.Bound.EXCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 7), Fields.doubleField(DOUBLE_COL, (double) 79)),
+                   Range.Bound.INCLUSIVE));
+
+    actual = runMultiScan(ranges, max, outPutFields);
+    List<Collection<Field<?>>> newExpected = new LinkedList<>();
+    newExpected.addAll(expectedAll.subList(11, 16));
+    newExpected.addAll(expectedAll.subList(30, 39));
+    newExpected.addAll(expectedAll.subList(54, 55));
+    newExpected.addAll(expectedAll.subList(71, 80));
+    Assert.assertEquals(newExpected, actual);
+
+    // MultiScan with multiple ranges
+    ranges = Arrays.asList(
+      // INCLUSIVE beginning and INCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 1), Fields.doubleField(DOUBLE_COL, (double) 11)),
+                   Range.Bound.INCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 1), Fields.doubleField(DOUBLE_COL, (double) 15)),
+                   Range.Bound.INCLUSIVE),
+      // INCLUSIVE beginning and EXCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 2), Fields.doubleField(DOUBLE_COL, (double) 22)),
+                   Range.Bound.INCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 2), Fields.doubleField(DOUBLE_COL, (double) 29)),
+                   Range.Bound.EXCLUSIVE),
+      // EXCLUSIVE beginning and EXCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 3), Fields.stringField(STRING_COL, VAL + "33")),
+                   Range.Bound.EXCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 3), Fields.stringField(STRING_COL, VAL + "37")),
+                   Range.Bound.EXCLUSIVE),
+      // EXCLUSIVE beginning and INCLUSIVE ending
+      Range.create(Arrays.asList(Fields.intField(KEY, 4), Fields.doubleField(DOUBLE_COL, (double) 40)),
+                   Range.Bound.EXCLUSIVE,
+                   Arrays.asList(Fields.intField(KEY, 4), Fields.doubleField(DOUBLE_COL, (double) 79)),
+                   Range.Bound.INCLUSIVE));
+
+    actual = runMultiScan(ranges, max, outPutFields);
+    newExpected = new LinkedList<>();
+    newExpected.addAll(expectedAll.subList(11, 16));
+    newExpected.addAll(expectedAll.subList(22, 29));
+    newExpected.addAll(expectedAll.subList(34, 37));
+    newExpected.addAll(expectedAll.subList(41, 50));
+    Assert.assertEquals(newExpected, actual);
+
+
+    // MultiScan partialKeys with non-primary keys
+    ranges = Arrays.asList(
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 2),
+                                    Fields.stringField(STRING_COL, VAL + "29"))),
+      Range.singleton(Arrays.asList(Fields.intField(KEY, 3),
+                                    Fields.stringField(STRING_COL, VAL + "30")))
+    );
+
+    actual = runMultiScan(ranges, max, outPutFields);
+    Assert.assertEquals(expectedAll.subList(29, 31), actual);
   }
 
   @Test
@@ -939,8 +1082,11 @@ public abstract class StructuredTableTest {
 
       // Partial primary keys range
       try (CloseableIterator<StructuredRow> iterator =
-             table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)), Range.Bound.INCLUSIVE,
-                                     Collections.singleton(Fields.longField(KEY2, num * 100L)), Range.Bound.EXCLUSIVE),
+             table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)),
+                                     Range.Bound.INCLUSIVE,
+                                     Arrays.asList(Fields.intField(KEY, num),
+                                                   Fields.longField(KEY2, num * 100L)),
+                                     Range.Bound.EXCLUSIVE),
                         num * 10,
                         Fields.stringField(STRING_COL, "abc"))) {
         List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
@@ -1037,8 +1183,11 @@ public abstract class StructuredTableTest {
 
       // Partial primary keys range
       try (CloseableIterator<StructuredRow> iterator =
-             table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)), Range.Bound.INCLUSIVE,
-                                     Collections.singleton(Fields.longField(KEY2, num * 200L)), Range.Bound.EXCLUSIVE),
+             table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)),
+                                     Range.Bound.INCLUSIVE,
+                                     Arrays.asList(Fields.intField(KEY, num * 2),
+                                                   Fields.longField(KEY2, num * 200L)),
+                                     Range.Bound.EXCLUSIVE),
                         num * 10, IDX_COL, SortOrder.DESC)) {
         List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
         List<Collection<Field<?>>> expectedSubList = expected.subList(0, num * 2);
@@ -1148,7 +1297,7 @@ public abstract class StructuredTableTest {
       ranges = Arrays.asList(Range.to(Collections.singletonList(Fields.intField(KEY, 4)),
                                       Range.Bound.INCLUSIVE),
                              // Intentionally create overlapping range
-                             Range.from(Collections.singletonList(Fields.longField(KEY2, (long) 0)),
+                             Range.from(Collections.singletonList(Fields.intField(KEY, 0)),
                                         Range.Bound.EXCLUSIVE));
       Assert.assertEquals(max, table.count(ranges));
     });
@@ -1305,14 +1454,14 @@ public abstract class StructuredTableTest {
     return expected;
   }
 
-  private List<Collection<Field<?>>> writeRowsWithDuplicateSecondKeyPrefix(int max, String suffix)
+  private List<Collection<Field<?>>> writeRowsWithDuplicateKeyPrefix(int max, String suffix)
     throws Exception {
     List<Collection<Field<?>>> expected = new ArrayList<>(max);
     // Write rows in reverse order to test sorting
     for (int i = max - 1; i >= 0; i--) {
       // Adding rows that have same "KEY" every 10 elements
-      List<Field<?>> fields = Arrays.asList(Fields.intField(KEY, i),
-                                            Fields.longField(KEY2, (long) i % 10),
+      List<Field<?>> fields = Arrays.asList(Fields.intField(KEY, i % 10),
+                                            Fields.longField(KEY2, (long) i),
                                             Fields.stringField(KEY3, "key3"),
                                             Fields.stringField(STRING_COL, VAL + i + suffix),
                                             Fields.doubleField(DOUBLE_COL, (double) i),

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/table/field/FieldValidatorTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/table/field/FieldValidatorTest.java
@@ -82,6 +82,58 @@ public class FieldValidatorTest {
   }
 
   @Test
+  public void testValidateScanRange() {
+    FieldValidator validator = new FieldValidator(schema);
+
+    // Success case
+    validator.validateScanRange(Range.all());
+    validator.validateScanRange(Range.create(Arrays.asList(Fields.intField(KEY, 10),
+                                                           Fields.longField(KEY2, 110L)),
+                                             Range.Bound.INCLUSIVE,
+                                             Arrays.asList(Fields.intField(KEY, 20),
+                                                           Fields.longField(KEY2, 100L)),
+                                             Range.Bound.EXCLUSIVE));
+
+    validator.validateScanRange(Range.create(Collections.singletonList(Fields.intField(KEY, 10)),
+                                             Range.Bound.INCLUSIVE,
+                                             Collections.singletonList(Fields.intField(KEY, 20)),
+                                             Range.Bound.INCLUSIVE));
+
+    // Test invalid range: no primary keys
+    try {
+      validator.validateScanRange(Range.create(Collections.singletonList(Fields.stringField(STRING_COL, "110L")),
+                                               Range.Bound.INCLUSIVE,
+                                               Collections.singletonList(Fields.stringField(STRING_COL, "120L")),
+                                               Range.Bound.INCLUSIVE));
+      Assert.fail("Expected InvalidFieldException because of not staring with a primary key");
+    } catch (InvalidFieldException e) {
+      // expected
+    }
+
+    // Test invalid range: no primary keys
+    try {
+      validator.validateScanRange(Range.create(Collections.singletonList(Fields.longField(KEY2, 110L)),
+                                               Range.Bound.INCLUSIVE,
+                                               null,
+                                               Range.Bound.INCLUSIVE));
+      Assert.fail("Expected InvalidFieldException because of not staring with a prefixed key");
+    } catch (InvalidFieldException e) {
+      // expected
+    }
+
+    // Test invalid field
+    try {
+      validator.validateScanRange(Range.create(Collections.singletonList(Fields.intField("NONEXISTKEY", 110)),
+                                               Range.Bound.INCLUSIVE,
+                                               Collections.singletonList(Fields.longField(KEY2, 100L)),
+                                               Range.Bound.INCLUSIVE));
+      Assert.fail("Expected InvalidFieldException because of invalid field");
+    } catch (InvalidFieldException e) {
+      // expected
+    }
+  }
+
+  @Test
   public void testValidatePartialPrimaryKeys() {
     FieldValidator validator = new FieldValidator(schema);
 


### PR DESCRIPTION
What is changed:

Further relaxing the restriction on scan ranges in table implementation. Add validation to Range that it at least has to contain a prefixed key
Added bunch of tests to validate the change.

This could provide benefits for:

1. Pagination for non-primary keys: we can now scan on application latest versions like [namespace: “ns1“, application: “app1“, created: “2019-09-01“] – [namespace: “ns1“, application: “app1“, created: “2022-09-01“], created is non-primary key
2. We could call multiScan to batch retrieve latest app versions which avoid hitting db multiple times. 