### PR TITLE
[CDAP-19673] cache common artifacts per CDAP version in GCS

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/utils/ProjectInfo.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/utils/ProjectInfo.java
@@ -133,6 +133,7 @@ public final class ProjectInfo {
       this.buildTime = buildTime;
     }
 
+    @Override
     public int getMajor() {
       return major;
     }
@@ -141,14 +142,17 @@ public final class ProjectInfo {
       return minor;
     }
 
+    @Override
     public int getFix() {
       return fix;
     }
 
+    @Override
     public boolean isSnapshot() {
       return snapshot;
     }
 
+    @Override
     public long getBuildTime() {
       return buildTime;
     }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocImageVersion.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocImageVersion.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.runtime.spi.common;
 
 import com.google.common.base.Strings;
-import io.cdap.cdap.runtime.spi.VersionInfo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +27,7 @@ import javax.annotation.Nullable;
 /**
  * Class used to compare versions from Dataproc cluster images
  */
-public class DataprocImageVersion implements VersionInfo {
+public class DataprocImageVersion implements Comparable<Object> {
   private static final Pattern IS_NUMBER_PATTERN = Pattern.compile("^\\d+$");
   private final List<Integer> versionSegments;
 

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -63,7 +63,9 @@ public final class DataprocUtils {
   public static final String CDAP_GCS_ROOT = "cdap-job";
   public static final String CDAP_CACHED_ARTIFACTS = "cached-artifacts";
   public static final String WORKER_CPU_PREFIX = "Up to";
-  public static final String DISABLE_GCS_CACHING = "disableGCSCaching";
+  // The property name for disabling caching of artifacts in GCS uploaded to GCS Bucket used by Dataproc.
+  // It can be overridden by profile runtime arguments (system.profile.properties.gcsCacheEnabled)
+  public static final String GCS_CACHE_ENABLED = "gcsCacheEnabled";
   public static final Path CACHE_DIR_PATH = Paths.get(System.getProperty("java.io.tmpdir"),
                                                       "dataproc.launcher.cache");
   public static final String LOCAL_CACHE_DISABLED = "disableLocalCaching";

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -22,7 +22,6 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
-import io.cdap.cdap.runtime.spi.VersionInfo;
 import io.cdap.cdap.runtime.spi.common.DataprocImageVersion;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import io.cdap.cdap.runtime.spi.provisioner.Capabilities;
@@ -62,7 +61,7 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
   private static final String LABELS_PROPERTY = "labels";
   private static final Pattern SIMPLE_VERSION_PATTERN = Pattern.compile("^([0-9][0-9.]*)$");
   private static final Pattern CLUSTER_VERSION_PATTERN = Pattern.compile("^([0-9][0-9.]*)-.*");
-  protected static final VersionInfo DATAPROC_1_5_VERSION = new DataprocImageVersion("1.5");
+  protected static final DataprocImageVersion DATAPROC_1_5_VERSION = new DataprocImageVersion("1.5");
   public static final String LABEL_VERSON = "cdap-version";
   public static final String LABEL_PROFILE = "cdap-profile";
   public static final String LABEL_REUSE_KEY = "cdap-reuse-key";
@@ -190,11 +189,10 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
 
       Map<String, String> systemLabels = getSystemLabels();
       return Optional.of(
-        new DataprocRuntimeJobManager(new DataprocClusterInfo(context, clusterName, conf.getDataprocCredentials(),
-                                                              getRootUrl(conf),
-                                                              projectId, region, bucket, systemLabels),
-                                      Collections.unmodifiableMap(properties)
-        ));
+        new DataprocRuntimeJobManager(
+          new DataprocClusterInfo(context, clusterName, conf.getDataprocCredentials(), getRootUrl(conf), projectId,
+                                  region, bucket, systemLabels),
+          Collections.unmodifiableMap(properties), context.getCDAPVersionInfo()));
     } catch (Exception e) {
       throw new RuntimeException("Error while getting credentials for dataproc. ", e);
     }
@@ -295,7 +293,7 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
   }
 
   @Nullable
-  protected VersionInfo extractVersion(String imageVersion) {
+  protected DataprocImageVersion extractVersion(String imageVersion) {
     try {
       // Test simple version numbers (e.g. 1.3 1.5 2.0)
       Matcher simpleVersionMatcher = SIMPLE_VERSION_PATTERN.matcher(imageVersion);

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -86,15 +86,11 @@ final class DataprocConf {
   static final String WORKER_NUM_NODES = "workerNumNodes";
   static final String SECONDARY_WORKER_NUM_NODES = "secondaryWorkerNumNodes";
   static final String AUTOSCALING_POLICY = "autoScalingPolicy";
-  static final String LOCAL_CACHE_DISABLED = DataprocUtils.LOCAL_CACHE_DISABLED;
 
   public static final String COMPUTE_HTTP_REQUEST_CONNECTION_TIMEOUT = "compute.request.connection.timeout.millis";
   private static final int COMPUTE_HTTP_REQUEST_CONNECTION_TIMEOUT_DEFAULT = 20000;
   public static final String COMPUTE_HTTP_REQUEST_READ_TIMEOUT = "compute.request.read.timeout.millis";
   private static final int COMPUTE_HTTP_REQUEST_READ_TIMEOUT_DEFAULT = 20000;
-
-  // If true, artifacts will not be cached in GCS regardless of cConf setting.
-  static final String DISABLE_GCS_CACHING = "disableGCSCaching";
 
   private final String accountKey;
   private final String region;
@@ -162,7 +158,7 @@ final class DataprocConf {
   private final int computeReadTimeout;
   private final int computeConnectionTimeout;
 
-  private final boolean disableGCSCaching;
+  private final boolean gcsCacheEnabled;
   private  final String troubleshootingDocsUrl;
 
   public String getTroubleshootingDocsUrl() {
@@ -189,7 +185,7 @@ final class DataprocConf {
                        boolean integrityMonitoringEnabled, boolean clusterReuseEnabled,
                        long clusterReuseThresholdMinutes, @Nullable String clusterReuseKey,
                        boolean enablePredefinedAutoScaling, int computeReadTimeout, int computeConnectionTimeout,
-                       @Nullable String rootUrl, boolean disableGCSCaching, boolean disableLocalCaching,
+                       @Nullable String rootUrl, boolean gcsCacheEnabled, boolean disableLocalCaching,
                        String troubleshootingDocsUrl) {
     this.accountKey = accountKey;
     this.region = region;
@@ -244,7 +240,7 @@ final class DataprocConf {
     this.computeReadTimeout = computeReadTimeout;
     this.computeConnectionTimeout = computeConnectionTimeout;
     this.rootUrl = rootUrl;
-    this.disableGCSCaching = disableGCSCaching;
+    this.gcsCacheEnabled = gcsCacheEnabled;
     this.disableLocalCaching = disableLocalCaching;
     this.troubleshootingDocsUrl = troubleshootingDocsUrl;
   }
@@ -575,9 +571,6 @@ final class DataprocConf {
     boolean enablePredefinedAutoScaling =
       Boolean.parseBoolean(properties.getOrDefault(PREDEFINED_AUTOSCALE_ENABLED, "false"));
 
-    boolean disableLocalCaching =
-      Boolean.parseBoolean(properties.getOrDefault(LOCAL_CACHE_DISABLED, "false"));
-
     if (enablePredefinedAutoScaling) {
       workerNumNodes = PredefinedAutoScaling.getPrimaryWorkerInstances();
       secondaryWorkerNumNodes = PredefinedAutoScaling.getMinSecondaryWorkerInstances();
@@ -696,8 +689,12 @@ final class DataprocConf {
                                           COMPUTE_HTTP_REQUEST_CONNECTION_TIMEOUT_DEFAULT);
     String rootUrl = getString(properties, ROOT_URL);
 
-    boolean disableGCSCaching = Boolean.parseBoolean(
-      properties.getOrDefault(DISABLE_GCS_CACHING, "false"));
+    // If false, artifacts will not be cached in GCS regardless of cConf setting.
+    boolean gcsCacheEnabled = Boolean.parseBoolean(
+      properties.getOrDefault(DataprocUtils.GCS_CACHE_ENABLED, "true"));
+    // If true, artifacts will not be cached locally.
+    boolean disableLocalCaching =
+      Boolean.parseBoolean(properties.getOrDefault(DataprocUtils.LOCAL_CACHE_DISABLED, "false"));
     String troubleshootingDocsURL =
       properties.getOrDefault(DataprocUtils.TROUBLESHOOTING_DOCS_URL_KEY,
                               DataprocUtils.TROUBLESHOOTING_DOCS_URL_DEFAULT);
@@ -716,7 +713,7 @@ final class DataprocConf {
                             tokenEndpoint, secureBootEnabled, vTpmEnabled, integrityMonitoringEnabled,
                             clusterReuseEnabled, clusterReuseThresholdMinutes, clusterReuseKey,
                             enablePredefinedAutoScaling, computeReadTimeout, computeConnectionTimeout, rootUrl,
-                            disableGCSCaching, disableLocalCaching, troubleshootingDocsURL);
+                            gcsCacheEnabled, disableLocalCaching, troubleshootingDocsURL);
   }
 
   // the UI never sends nulls, it only sends empty strings.

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.error.api.ErrorTagProvider.ErrorTag;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.RuntimeMonitorType;
-import io.cdap.cdap.runtime.spi.VersionInfo;
+import io.cdap.cdap.runtime.spi.common.DataprocImageVersion;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
@@ -185,7 +185,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
       // Check dataproc cluster version if a custom image is not being used
       if (conf.getCustomImageUri() == null) {
         // Determine cluster version and fail if version is smaller than 1.5
-        VersionInfo comparableImageVersion = extractVersion(imageVersion);
+        DataprocImageVersion comparableImageVersion = extractVersion(imageVersion);
         if (comparableImageVersion == null) {
           LOG.warn("Unable to extract Dataproc version from string '{}'.", imageVersion);
         } else if (DATAPROC_1_5_VERSION.compareTo(comparableImageVersion) > 0) {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/ExistingDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/ExistingDataprocProvisioner.java
@@ -19,7 +19,7 @@ package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 import com.google.common.base.Strings;
 import io.cdap.cdap.error.api.ErrorTagProvider.ErrorTag;
 import io.cdap.cdap.runtime.spi.RuntimeMonitorType;
-import io.cdap.cdap.runtime.spi.VersionInfo;
+import io.cdap.cdap.runtime.spi.common.DataprocImageVersion;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
 import io.cdap.cdap.runtime.spi.provisioner.PollingStrategies;
@@ -113,7 +113,7 @@ public class ExistingDataprocProvisioner extends AbstractDataprocProvisioner {
 
       // Determine cluster version and fail if version is smaller than 1.5
       Optional<String> optImageVer = client.getClusterImageVersion(clusterName);
-      Optional<VersionInfo> optComparableImageVer = optImageVer.map(this::extractVersion);
+      Optional<DataprocImageVersion> optComparableImageVer = optImageVer.map(this::extractVersion);
       if (!optImageVer.isPresent()) {
         LOG.warn("Unable to determine Dataproc version.");
       } else if (!optComparableImageVer.isPresent()) {

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.runtime.spi.MockVersionInfo;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.SparkCompat;
-import io.cdap.cdap.runtime.spi.VersionInfo;
 import io.cdap.cdap.runtime.spi.common.DataprocImageVersion;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
@@ -250,11 +249,11 @@ public class DataprocProvisionerTest {
     Assert.assertEquals("2.0", provisioner.getImageVersion(context, defaultConf));
     Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
 
-    context.setAppCDAPVersionInfo(new MockVersionInfo("6.5"));
+    context.setAppCDAPVersionInfo(new MockVersionInfo("6.5.0"));
     Assert.assertEquals("2.0", provisioner.getImageVersion(context, defaultConf));
     Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
 
-    context.setAppCDAPVersionInfo(new MockVersionInfo("6.4"));
+    context.setAppCDAPVersionInfo(new MockVersionInfo("6.4.0"));
     Assert.assertEquals("2.0", provisioner.getImageVersion(context, defaultConf));
     Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
 
@@ -364,21 +363,21 @@ public class DataprocProvisionerTest {
 
   @Test
   public void testVersionComparison() {
-    VersionInfo v0 = new DataprocImageVersion("0");
-    VersionInfo v1 = new DataprocImageVersion("1");
-    VersionInfo v1debian = new DataprocImageVersion("1-debian");
-    VersionInfo v1dot4 = new DataprocImageVersion("1.4");
-    VersionInfo v1dot4dot99 = new DataprocImageVersion("1.4.99");
-    VersionInfo v1dot5 = new DataprocImageVersion("1.5");
-    VersionInfo v1dot5debian = new DataprocImageVersion("1.5-debian");
-    VersionInfo v1dot5dot0 = new DataprocImageVersion("1.5.0");
-    VersionInfo v1dot5dot0debian = new DataprocImageVersion("1.5.0-debian");
-    VersionInfo v1dot5dot0dot0 = new DataprocImageVersion("1.5.0.0");
-    VersionInfo v1dot5dot1 = new DataprocImageVersion("1.5.1");
-    VersionInfo v1dot6 = new DataprocImageVersion("1.6");
-    VersionInfo v2 = new DataprocImageVersion("2");
-    VersionInfo v2debian = new DataprocImageVersion("2-debian");
-    VersionInfo v2dot0 = new DataprocImageVersion("2.0");
+    DataprocImageVersion v0 = new DataprocImageVersion("0");
+    DataprocImageVersion v1 = new DataprocImageVersion("1");
+    DataprocImageVersion v1debian = new DataprocImageVersion("1-debian");
+    DataprocImageVersion v1dot4 = new DataprocImageVersion("1.4");
+    DataprocImageVersion v1dot4dot99 = new DataprocImageVersion("1.4.99");
+    DataprocImageVersion v1dot5 = new DataprocImageVersion("1.5");
+    DataprocImageVersion v1dot5debian = new DataprocImageVersion("1.5-debian");
+    DataprocImageVersion v1dot5dot0 = new DataprocImageVersion("1.5.0");
+    DataprocImageVersion v1dot5dot0debian = new DataprocImageVersion("1.5.0-debian");
+    DataprocImageVersion v1dot5dot0dot0 = new DataprocImageVersion("1.5.0.0");
+    DataprocImageVersion v1dot5dot1 = new DataprocImageVersion("1.5.1");
+    DataprocImageVersion v1dot6 = new DataprocImageVersion("1.6");
+    DataprocImageVersion v2 = new DataprocImageVersion("2");
+    DataprocImageVersion v2debian = new DataprocImageVersion("2-debian");
+    DataprocImageVersion v2dot0 = new DataprocImageVersion("2.0");
 
     Assert.assertTrue(v1dot5.compareTo(v0) > 0);
     Assert.assertTrue(v1dot5.compareTo(v1) > 0);
@@ -399,22 +398,22 @@ public class DataprocProvisionerTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testNullDataprocImageVersion() {
-    VersionInfo nullVersion = new DataprocImageVersion(null);
+    DataprocImageVersion nullVersion = new DataprocImageVersion(null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testEmptyDataprocImageVersion() {
-    VersionInfo emptyVersion = new DataprocImageVersion("");
+    DataprocImageVersion emptyVersion = new DataprocImageVersion("");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidSegmentDataprocImageVersion() {
-    VersionInfo emptyVersion = new DataprocImageVersion("1.2.3..6");
+    DataprocImageVersion emptyVersion = new DataprocImageVersion("1.2.3..6");
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidDataprocImageVersion() {
-    VersionInfo emptyVersion = new DataprocImageVersion("abcd");
+    DataprocImageVersion emptyVersion = new DataprocImageVersion("abcd");
   }
 
 }

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/VersionInfo.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/VersionInfo.java
@@ -23,4 +23,88 @@ package io.cdap.cdap.runtime.spi;
  */
 public interface VersionInfo extends Comparable<Object> {
 
+  /**
+   * Gets the major version part of the version string. The default implementation is to parse the version string,
+   * in the format "major.minor.fix-buildTime"/"major.minor.fix-SNAPSHOT-buildTime".
+   * @return the major version.
+   */
+  default int getMajor() {
+    String[] versionInfo = this.toString().split("-");
+    if (versionInfo.length > 0) {
+      int idx = versionInfo[0].indexOf('.');
+      if (idx > 0) {
+        return Integer.parseInt(versionInfo[0].substring(0, idx));
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * Gets the minor version part of the version string. The default implementation is to parse the version string,
+   * in the format "major.minor.fix-buildTime"/"major.minor.fix-SNAPSHOT-buildTime".
+   * @return the minor version.
+   */
+  default int getMinor() {
+    String[] versionInfo = this.toString().split("-");
+    if (versionInfo.length > 0) {
+      int major = getMajor();
+      int idx = versionInfo[0].indexOf(String.valueOf(major)) + 2;
+      int endIdx = versionInfo[0].indexOf('.', idx);
+      if (endIdx > 0 && endIdx - idx > 0) {
+        return Integer.parseInt(versionInfo[0].substring(idx, endIdx));
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * Gets the fix version part of the version string. The default implementation is to parse the version string,
+   * in the format "major.minor.fix-buildTime"/"major.minor.fix-SNAPSHOT-buildTime".
+   * @return the fix version.
+   */
+  default int getFix() {
+    String[] versionInfo = this.toString().split("-");
+    if (versionInfo.length > 0) {
+      int major = getMajor();
+      int idx = versionInfo[0].indexOf(String.valueOf(major)) + 2;
+      int midIdx = versionInfo[0].indexOf('.', idx) + 1;
+      if (midIdx > 0 && midIdx - idx > 0) {
+        int endIdx = versionInfo[0].indexOf('-', midIdx);
+        if (endIdx > 0 && endIdx - idx > 0) {
+          return Integer.parseInt(versionInfo[0].substring(midIdx, endIdx));
+        }
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * checks if the version is snapshot. The default implementation is to parse the version string,
+   * in the format "major.minor.fix-buildTime"/"major.minor.fix-SNAPSHOT-buildTime".
+   * @return true if version is snapshot, otherwise false.
+   */
+  default boolean isSnapshot() {
+    String[] versionInfo = this.toString().split("-");
+    if (versionInfo.length > 1) {
+      return "SNAPSHOT".equals(versionInfo[1]);
+    }
+    return false;
+  }
+
+  /**
+   * Gets the buildTime part of the version string. The default implementation is to parse the version string,
+   * in the format "major.minor.fix-buildTime"/"major.minor.fix-SNAPSHOT-buildTime".
+   * @return the buildTime.
+   */
+  default long getBuildTime() {
+    String[] versionInfo = this.toString().split("-");
+    if (isSnapshot() && versionInfo.length > 2) {
+      return Long.parseLong(versionInfo[2]);
+    }
+    if (!isSnapshot() && versionInfo.length > 1) {
+      return Long.parseLong(versionInfo[1]);
+    }
+    return 0;
+  }
+
 }


### PR DESCRIPTION
**[CDAP-19673](https://cdap.atlassian.net/browse/CDAP-19673):** cache twill, launcher and application jars in GCS to prevent uploading for every pipeline run

**Description:**
- Currently we upload the twill, launcher and application jars for every pipeline run which remain same for particular CDAP version.

**Solution:**
- Caching them in the `cached_artifacts` directory in the GCS bucket for particular instance.

**Testing:**
- Deployed the CDAP image on k8s and ran the pipeline successfully.
- Performed a burst scalability launch test of 50 pipelines.

**[CDAP-19788](https://cdap.atlassian.net/browse/CDAP-19788)**: Replace artifacts in GCS if build time is newer than the GCS object creation time.