### PR TITLE
[CDAP-19941] Append dataproc job status details to failed pipeline logs

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -33,9 +33,11 @@ import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSpecification;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSystemContext;
 import io.cdap.cdap.runtime.spi.runtimejob.DataprocClusterInfo;
+import io.cdap.cdap.runtime.spi.runtimejob.DataprocRuntimeJobDetail;
 import io.cdap.cdap.runtime.spi.runtimejob.DataprocRuntimeJobManager;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobDetail;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobManager;
+import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,6 +117,16 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
         RuntimeJobDetail jobDetail = jobManager.getDetail(context.getProgramRunInfo()).orElse(null);
         if (jobDetail != null && !jobDetail.getStatus().isTerminated()) {
           return ClusterStatus.RUNNING;
+        }
+
+        if (jobDetail != null
+            && jobDetail.getStatus() == RuntimeJobStatus.FAILED
+            && (jobDetail instanceof DataprocRuntimeJobDetail)) {
+          // Status details is specific to dataproc jobs, so it was not added to RuntimeJobDetail spi.
+          String statusDetails = ((DataprocRuntimeJobDetail) jobDetail).getJobStatusDetails();
+          if (statusDetails != null) {
+            LOG.error("Dataproc job failed with the status details: {}", statusDetails);
+          }
         }
       } finally {
         jobManager.close();

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobDetail.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobDetail.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.runtimejob;
+
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
+
+import java.util.Objects;
+
+/**
+ * Status details of dataproc runtime job.
+ */
+public class DataprocRuntimeJobDetail extends RuntimeJobDetail {
+
+  private final String jobStatusDetails;
+
+  public DataprocRuntimeJobDetail(ProgramRunInfo runInfo, RuntimeJobStatus status, String jobStatusDetails) {
+    super(runInfo, status);
+    this.jobStatusDetails = jobStatusDetails;
+  }
+
+  /**
+   * Returns string representation of dataproc job status details.
+   */
+  public String getJobStatusDetails() {
+    return jobStatusDetails;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    if (this.getClass() != o.getClass()) {
+      return false;
+    }
+
+    DataprocRuntimeJobDetail that = (DataprocRuntimeJobDetail) o;
+    return Objects.equals(jobStatusDetails, that.jobStatusDetails);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.getRunInfo(), this.getStatus(), jobStatusDetails);
+  }
+}


### PR DESCRIPTION
When dataproc job fails due to OOM on master node, the pipeline logs don’t show proper error message. Dataproc job status details has additional information about OOM or memory pressure which would be useful to understand the cause of failed pipelines.