### PR TITLE
(CDAP-19827) Fix a race condition in AbstractProgramController

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/AbstractProgramController.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/AbstractProgramController.java
@@ -33,10 +33,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -222,8 +223,8 @@ public abstract class AbstractProgramController implements ProgramController {
     };
 
     try {
-      // Use a synchronous queue to communicate the Cancellable to return
-      final SynchronousQueue<Cancellable> result = new SynchronousQueue<>();
+      // Use a blocking queue to communicate the Cancellable to return
+      BlockingQueue<Cancellable> result = new ArrayBlockingQueue<>(1);
 
       // Use the single thread executor to add the listener and call init
       executor.submit(() -> {


### PR DESCRIPTION
https://cdap.atlassian.net/browse/CDAP-19827

The AbstractProgramController.addListener() can leave behind an executor thread that is blocked forever if thread interruption was issued to the caller thread of the addListener method. This is because a SynchronousQueue was used to coordinate between the executor thread and the caller thread. If the caller thread is interrupted, it will unblock the take method, hence subsequence call to the put method from the executor thread will get blocked forever.