### PR TITLE
CDAP-19777 make programId default version in different schedule services

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ScheduledRunTimeTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ScheduledRunTimeTest.java
@@ -38,7 +38,6 @@ import io.cdap.common.http.HttpResponse;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -76,8 +75,6 @@ public class ScheduledRunTimeTest extends AppFabricTestBase {
   }
 
   @Test
-  @Ignore
-  // TODO fix this CDAP-19777
   public void testGetNextRun() throws Exception {
     ApplicationId appId = NamespaceId.DEFAULT.app("test");
     deploy(appId, new AppRequest<>(new ArtifactSummary(ARTIFACT_ID.getName(), ARTIFACT_ID.getVersion().getVersion())));
@@ -107,8 +104,6 @@ public class ScheduledRunTimeTest extends AppFabricTestBase {
   }
 
   @Test
-  @Ignore
-  // TODO fix this CDAP-19777
   public void testBatchGetNextRun() throws Exception {
     // deploys 5 apps and create schedules for each of them
     long now = System.currentTimeMillis();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -785,7 +785,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                           @PathParam("namespace-id") String namespaceId,
                           @PathParam("app-name") String appName,
                           @PathParam("schedule-name") String scheduleName) throws Exception {
-    doGetSchedule(responder, namespaceId, appName, ApplicationId.DEFAULT_VERSION, scheduleName);
+    doGetSchedule(responder, namespaceId, appName, scheduleName);
   }
 
   @GET
@@ -795,12 +795,12 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                           @PathParam("app-name") String appName,
                           @PathParam("app-version") String appVersion,
                           @PathParam("schedule-name") String scheduleName) throws Exception {
-    doGetSchedule(responder, namespaceId, appName, appVersion, scheduleName);
+    doGetSchedule(responder, namespaceId, appName, scheduleName);
   }
 
-  private void doGetSchedule(HttpResponder responder, String namespace,
-                             String app, String version, String scheduleName) throws Exception {
-    ScheduleId scheduleId = new ApplicationId(namespace, app, version).schedule(scheduleName);
+  private void doGetSchedule(HttpResponder responder, String namespace, String app, String scheduleName)
+    throws Exception {
+    ScheduleId scheduleId = new ApplicationId(namespace, app).schedule(scheduleName);
     ProgramScheduleRecord record = programScheduleService.getRecord(scheduleId);
     ScheduleDetail detail = record.toScheduleDetail();
     responder.sendJson(HttpResponseStatus.OK, GSON.toJson(detail, ScheduleDetail.class));
@@ -816,8 +816,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                               @PathParam("app-name") String appName,
                               @QueryParam("trigger-type") String triggerType,
                               @QueryParam("schedule-status") String scheduleStatus) throws Exception {
-    getAllSchedulesVersioned(request, responder, namespaceId, appName,
-                    getLatestAppVersion(new NamespaceId(namespaceId), appName), triggerType, scheduleStatus);
+    doGetSchedules(responder, new NamespaceId(namespaceId).app(appName), null, triggerType, scheduleStatus);
   }
 
   /**
@@ -839,7 +838,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                               @PathParam("app-version") String appVersion,
                               @QueryParam("trigger-type") String triggerType,
                               @QueryParam("schedule-status") String scheduleStatus) throws Exception {
-    doGetSchedules(responder, new NamespaceId(namespaceId).app(appName, appVersion), null, triggerType, scheduleStatus);
+    doGetSchedules(responder, new NamespaceId(namespaceId).app(appName), null, triggerType, scheduleStatus);
   }
 
   /**
@@ -854,9 +853,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                   @PathParam("program-name") String program,
                                   @QueryParam("trigger-type") String triggerType,
                                   @QueryParam("schedule-status") String scheduleStatus) throws Exception {
-    getProgramSchedulesVersioned(request, responder, namespace, application,
-                        getLatestAppVersion(new NamespaceId(namespace), application),
-                        type, program, triggerType, scheduleStatus);
+    getProgramSchedulesVersioned(request, responder, namespace, application, ApplicationId.DEFAULT_VERSION,
+                                 type, program, triggerType, scheduleStatus);
   }
 
   /**
@@ -878,8 +876,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       throw new BadRequestException("Program type " + programType + " cannot have schedule");
     }
 
-    ProgramId programId = new ApplicationId(namespace, application, appVersion).program(programType, program);
-    doGetSchedules(responder, new NamespaceId(namespace).app(application, appVersion), programId,
+    ProgramId programId = new ApplicationId(namespace, application).program(programType, program);
+    doGetSchedules(responder, new NamespaceId(namespace).app(application), programId,
                    triggerType, scheduleStatus);
   }
 
@@ -1098,7 +1096,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                           @PathParam("app-name") String appName,
                           @PathParam("schedule-name") String scheduleName)
     throws Exception {
-    doAddSchedule(request, responder, namespaceId, appName, ApplicationId.DEFAULT_VERSION, scheduleName);
+    doAddSchedule(request, responder, namespaceId, appName, scheduleName);
   }
 
   @PUT
@@ -1110,13 +1108,13 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                           @PathParam("app-version") String appVersion,
                           @PathParam("schedule-name") String scheduleName)
     throws Exception {
-    doAddSchedule(request, responder, namespaceId, appName, appVersion, scheduleName);
+    doAddSchedule(request, responder, namespaceId, appName, scheduleName);
   }
 
   private void doAddSchedule(FullHttpRequest request, HttpResponder responder, String namespace, String appName,
-                             String appVersion, String scheduleName) throws Exception {
+                             String scheduleName) throws Exception {
 
-    final ApplicationId applicationId = new ApplicationId(namespace, appName, appVersion);
+    final ApplicationId applicationId = new ApplicationId(namespace, appName);
     ScheduleDetail scheduleFromRequest = readScheduleDetailBody(request, scheduleName);
 
     if (scheduleFromRequest.getProgram() == null) {
@@ -1155,7 +1153,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                              @PathParam("namespace-id") String namespaceId,
                              @PathParam("app-name") String appName,
                              @PathParam("schedule-name") String scheduleName) throws Exception {
-    doUpdateSchedule(request, responder, namespaceId, appName, ApplicationId.DEFAULT_VERSION, scheduleName);
+    doUpdateSchedule(request, responder, namespaceId, appName, scheduleName);
   }
 
   @POST
@@ -1166,13 +1164,13 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                              @PathParam("app-name") String appName,
                              @PathParam("app-version") String appVersion,
                              @PathParam("schedule-name") String scheduleName) throws Exception {
-    doUpdateSchedule(request, responder, namespaceId, appName, appVersion, scheduleName);
+    doUpdateSchedule(request, responder, namespaceId, appName, scheduleName);
   }
 
   private void doUpdateSchedule(FullHttpRequest request, HttpResponder responder, String namespaceId, String appId,
-                                String appVersion, String scheduleName) throws Exception {
+                                String scheduleName) throws Exception {
 
-    ScheduleId scheduleId = new ApplicationId(namespaceId, appId, appVersion).schedule(scheduleName);
+    ScheduleId scheduleId = new ApplicationId(namespaceId, appId).schedule(scheduleName);
     ScheduleDetail scheduleDetail = readScheduleDetailBody(request, scheduleName);
 
     programScheduleService.update(scheduleId, scheduleDetail);
@@ -1216,7 +1214,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                              @PathParam("namespace-id") String namespaceId,
                              @PathParam("app-name") String appName,
                              @PathParam("schedule-name") String scheduleName) throws Exception {
-    doDeleteSchedule(responder, namespaceId, appName, ApplicationId.DEFAULT_VERSION, scheduleName);
+    doDeleteSchedule(responder, namespaceId, appName, scheduleName);
   }
 
   @DELETE
@@ -1226,12 +1224,12 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                              @PathParam("app-name") String appName,
                              @PathParam("app-version") String appVersion,
                              @PathParam("schedule-name") String scheduleName) throws Exception {
-    doDeleteSchedule(responder, namespaceId, appName, appVersion, scheduleName);
+    doDeleteSchedule(responder, namespaceId, appName, scheduleName);
   }
 
   private void doDeleteSchedule(HttpResponder responder, String namespaceId, String appName,
-                                String appVersion, String scheduleName) throws Exception {
-    ScheduleId scheduleId = new ApplicationId(namespaceId, appName, appVersion).schedule(scheduleName);
+                                String scheduleName) throws Exception {
+    ScheduleId scheduleId = new ApplicationId(namespaceId, appName).schedule(scheduleName);
     programScheduleService.delete(scheduleId);
     responder.sendStatus(HttpResponseStatus.OK);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/AbstractTimeSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/AbstractTimeSchedulerService.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.AbstractSatisfiableCompositeTrigger;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.TimeTrigger;
 import io.cdap.cdap.proto.ScheduledRuntime;
+import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ProgramId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,7 +136,7 @@ public abstract class AbstractTimeSchedulerService extends AbstractIdleService i
   }
 
   public static String programIdFor(ProgramId program, SchedulableProgramType programType) {
-    return String.format("%s:%s:%s:%s:%s", program.getNamespace(), program.getApplication(), program.getVersion(),
-                         programType.name(), program.getProgram());
+    return String.format("%s:%s:%s:%s:%s", program.getNamespace(), program.getApplication(),
+                         ApplicationId.DEFAULT_VERSION, programType.name(), program.getProgram());
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/store/ProgramScheduleStoreDataset.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/store/ProgramScheduleStoreDataset.java
@@ -301,7 +301,7 @@ public class ProgramScheduleStoreDataset {
         String serializedSchedule = row.getString(StoreDefinition.ProgramScheduleStore.SCHEDULE);
         if (serializedSchedule != null) {
           ProgramSchedule schedule = GSON.fromJson(serializedSchedule, ProgramSchedule.class);
-          if (programId.equals(schedule.getProgramId())) {
+          if (programId.isSameProgramExceptVersion(schedule.getProgramId())) {
             markScheduleAsDeleted(row, deleteTime);
             Collection<Field<?>> deleteKeys = getScheduleKeys(row);
             triggerStore.deleteAll(Range.singleton(deleteKeys));
@@ -442,7 +442,7 @@ public class ProgramScheduleStoreDataset {
    */
   public List<ProgramSchedule> listSchedules(ProgramId programId) throws IOException {
     return listSchedulesWithPrefix(getScheduleKeysForApplicationScan(programId.getParent()),
-                                   schedule -> programId.equals(schedule.getProgramId()));
+                                   schedule -> programId.isSameProgramExceptVersion(schedule.getProgramId()));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/store/Schedulers.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/store/Schedulers.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.gson.reflect.TypeToken;
 import io.cdap.cdap.api.ProgramStatus;
 import io.cdap.cdap.proto.ScheduleDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
@@ -58,7 +59,10 @@ public class Schedulers {
   }
 
   public static String triggerKeyForProgramStatus(ProgramId programId, ProgramStatus programStatus) {
-    return "programStatus:" + programId.toString() +  "." + programStatus.toString().toLowerCase();
+    return String.format("programStatus:program:%s.%s.%s.%s.%s.%s", programId.getNamespace(),
+                         programId.getApplication(), ApplicationId.DEFAULT_VERSION,
+                         programId.getType().getPrettyName().toLowerCase(),
+                         programId.getProgram(), programStatus.toString().toLowerCase());
   }
 
   public static Set<String> triggerKeysForProgramStatuses(ProgramId programId, Set<ProgramStatus> programStatuses) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/AndTrigger.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/AndTrigger.java
@@ -62,7 +62,7 @@ public class AndTrigger extends AbstractSatisfiableCompositeTrigger {
     List<SatisfiableTrigger> updatedTriggers = new ArrayList<>();
     for (SatisfiableTrigger trigger : getTriggers()) {
       if (trigger instanceof ProgramStatusTrigger &&
-        programId.equals(((ProgramStatusTrigger) trigger).getProgramId())) {
+        programId.isSameProgramExceptVersion(((ProgramStatusTrigger) trigger).getProgramId())) {
         // this program status trigger will never be satisfied, so the current AND trigger will never be satisfied
         return null;
       }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/OrTrigger.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/OrTrigger.java
@@ -60,7 +60,7 @@ public class OrTrigger extends AbstractSatisfiableCompositeTrigger {
     List<SatisfiableTrigger> updatedTriggers = new ArrayList<>();
     for (SatisfiableTrigger trigger : getTriggers()) {
       if (trigger instanceof ProgramStatusTrigger &&
-        programId.equals(((ProgramStatusTrigger) trigger).getProgramId())) {
+        programId.isSameProgramExceptVersion(((ProgramStatusTrigger) trigger).getProgramId())) {
         // this program status trigger will never be satisfied, skip adding it to updatedTriggers
         continue;
       }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/ProgramStatusTrigger.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/ProgramStatusTrigger.java
@@ -127,7 +127,7 @@ public class ProgramStatusTrigger extends ProtoTrigger.ProgramStatusTrigger impl
       }
       ProgramRunId programRunId = GSON.fromJson(programRunIdString, ProgramRunId.class);
       ProgramId triggeringProgramId = programRunId.getParent();
-      if (this.programId.equals(triggeringProgramId) && programStatuses.contains(programStatus)) {
+      if (this.programId.isSameProgramExceptVersion(triggeringProgramId) && programStatuses.contains(programStatus)) {
         return function.apply(new ProgramRunInfo(programStatus, programRunId));
       }
     }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -85,7 +85,6 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -935,7 +934,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
   }
 
   @Test
-  @Ignore // TODO : To be fixed in CDAP 19777
   public void testMultipleWorkflowSchedules() throws Exception {
     // Deploy the app
     NamespaceId testNamespace2 = new NamespaceId(TEST_NAMESPACE2);
@@ -1052,8 +1050,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     assertProgramInSchedules(AppWithMultipleSchedules.ANOTHER_WORKFLOW, anotherSchedules2);
 
     deleteApp(appDefault, 200);
-    deleteApp(app1, 200);
-    deleteApp(app2, 200);
   }
 
   private void assertProgramInSchedules(String programName, List<ScheduleDetail> schedules) {
@@ -1179,7 +1175,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
   }
 
   @Test
-  @Ignore // TODO : To be fixed in CDAP 19777
   public void testUpdateSchedulesFlag() throws Exception {
     // deploy an app with schedule
     AppWithSchedule.AppConfig config = new AppWithSchedule.AppConfig(true, true, true);
@@ -1234,7 +1229,7 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     actualSchedules = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
                                     defaultAppId.getApplication(),
                                     appDetails.getAppVersion());
-    Assert.assertEquals(2, actualSchedules.size());
+    Assert.assertEquals(0, actualSchedules.size());
 
     // with workflow and  one schedule, schedule should be added
     config = new AppWithSchedule.AppConfig(true, true, false);

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
@@ -143,7 +143,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -544,8 +543,6 @@ public class DataPipelineTest extends HydratorTestBase {
   }
 
   @Test
-  @Ignore
-  // TODO: (CDAP-19777) ignoring this test until the schedule bug is fixed
   public void testScheduledPipelines() throws Exception {
     // Deploy middle pipeline scheduled to be triggered by the completion of head pipeline
     String expectedValue1 = "headArgValue";

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/test/app/TestFrameworkTestRun.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/test/app/TestFrameworkTestRun.java
@@ -854,9 +854,6 @@ public class TestFrameworkTestRun extends TestFrameworkTestBase {
     return runId;
   }
 
-  /*
-  * TODO : To be ignored until CDAP-19777 is fixed
-  * */
   @Category(XSlowTests.class)
   @Test
   @Ignore


### PR DESCRIPTION
[CDAP-19777](https://cdap.atlassian.net/browse/CDAP-19777). ProgramId is very closely tied to Schedule, eg ProgramSchedule and ProgramStatusTrigger. Since Schedule is now versionless, it doesn't make sense to have a versioned ProgramId for those classes because the version can be changing. And when it comes to comparing two same programs with different version, the currently logic in scheduler will break.
Thus adding a new method to construct a ProgramId with default version out of an existing programId. This default version programId will be used/stored/compared for the schedule operations. 

As for backward compatibility, i assume once the LCM flag is turned on it is not allowed to turn off, so in that case ProgramId used for schedules should be "-SNAPSHOT" even before users upgrade their instances to 6.8, so this change should not break things during the upgrade.