### PR TITLE
fix(CDAP-19802): form primary key by correct order

### DIFF
--- a/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableAdminTest.java
+++ b/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableAdminTest.java
@@ -117,6 +117,24 @@ public class SpannerStructuredTableAdminTest extends StructuredTableAdminTest {
     Assert.assertTrue(updateSimpleTableSchema.isCompatible(UPDATED_SIMPLE_TABLE_SPEC));
   }
 
+  @Test
+  @Override
+  public void testInconsistentKeyOrderInSchema() throws Exception {
+    StructuredTableAdmin admin = getStructuredTableAdmin();
+
+    // Assert INCONSISTENT_PRIMARY_KEY_TABLE Empty
+    Assert.assertFalse(admin.exists(INCONSISTENT_PRIMARY_KEY_TABLE));
+
+    // Create INCONSISTENT_PRIMARY_KEY_TABLE
+    admin.createOrUpdate(INCONSISTENT_PRIMARY_KEY_TABLE_SPEC);
+    Assert.assertTrue(admin.exists(INCONSISTENT_PRIMARY_KEY_TABLE));
+
+    // Assert INCONSISTENT_PRIMARY_KEY_TABLE schema
+    StructuredTableSchema tableSchema = admin.getSchema(INCONSISTENT_PRIMARY_KEY_TABLE);
+    // ONLY checking compatibility because of INT/LONG to INT64 conversion in Spanner
+    Assert.assertTrue(tableSchema.isCompatible(INCONSISTENT_PRIMARY_KEY_TABLE_SPEC));
+  }
+
   private static final class MockStorageProviderContext implements StorageProviderContext {
 
     private final Map<String, String> config;


### PR DESCRIPTION
The change:

When we form the table schema directly from DB, we form primary keys by the order of fields. This wouldn't be a problem if the StructuredTableSpecification is defined with primary keys and fields having the same order.  But in the case that they have different orders, we need to correctly honor the order of primary keys' indexes