### PR TITLE
CDAP-19916: Batch retrieve latest programs

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -44,6 +44,7 @@ import io.cdap.cdap.proto.WorkflowStatistics;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.WorkflowId;
 import org.apache.twill.api.RunId;
@@ -284,13 +285,13 @@ public interface Store {
   Map<ProgramRunId, RunRecordDetail> getActiveRuns(ProgramId programId);
 
   /**
-   * Fetches active runs for a set of programs.
+   * Fetches the latest active runs for a set of programs.
    *
-   * @param programIds collection of program ids for fetching active run records.
+   * @param programRefs collection of program ids for fetching active run records.
    * @return a {@link Map} from the {@link ProgramId} to the list of run records; there will be no entry for programs
    * that do not exist.
    */
-  Map<ProgramId, Collection<RunRecordDetail>> getActiveRuns(Collection<ProgramId> programIds);
+  Map<ProgramId, Collection<RunRecordDetail>> getActiveRuns(Collection<ProgramReference> programRefs);
 
   /**
    * Fetches the run record for particular run of a program.
@@ -547,10 +548,10 @@ public interface Store {
   /**
    * Get the run count of the given program collection
    *
-   * @param programIds collection of program ids to get the count
+   * @param programRefs collection of program ids to get the count
    * @return the run count result of each program in the collection
    */
-  List<RunCountResult> getProgramRunCounts(Collection<ProgramId> programIds);
+  List<RunCountResult> getProgramRunCounts(Collection<ProgramReference> programRefs);
 
   /**
    * Fetches run records for multiple programs.
@@ -562,7 +563,7 @@ public interface Store {
    * @param limitPerProgram     max number of runs to fetch for each program
    * @return          runs for each program
    */
-  List<ProgramHistory> getRuns(Collection<ProgramId> programs, ProgramRunStatus status,
+  List<ProgramHistory> getRuns(Collection<ProgramReference> programs, ProgramRunStatus status,
                                long startTime, long endTime, int limitPerProgram);
 
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -94,6 +94,7 @@ import io.cdap.cdap.proto.ServiceInstances;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.ScheduleId;
 import io.cdap.cdap.scheduler.ProgramScheduleService;
@@ -212,8 +213,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                @PathParam("app-id") String appId,
                                @PathParam("mapreduce-id") String mapreduceId,
                                @PathParam("run-id") String runId) throws IOException, NotFoundException {
-    String appVersion = getLatestAppVersion(new NamespaceId(namespaceId), appId);
-    ProgramId programId = new ApplicationId(namespaceId, appId, appVersion).program(ProgramType.MAPREDUCE, mapreduceId);
+    // Pass in "-SNAPSHOT" version regardless
+    ProgramId programId = new ApplicationId(namespaceId, appId).program(ProgramType.MAPREDUCE, mapreduceId);
     ProgramRunId run = programId.run(runId);
     ApplicationSpecification appSpec = store.getApplication(programId.getParent());
     if (appSpec == null) {
@@ -222,6 +223,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     if (!appSpec.getMapReduce().containsKey(mapreduceId)) {
       throw new NotFoundException(programId);
     }
+    // runId is uuid, can be retrieved ignoring version
     RunRecordDetail runRecordMeta = store.getRun(run);
     if (runRecordMeta == null || isTetheredRunRecord(runRecordMeta)) {
       throw new NotFoundException(run);
@@ -239,7 +241,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       mrJobInfo.setStopTime(TimeUnit.SECONDS.toMillis(stopTs));
     }
 
-    // JobClient (in DistributedMRJobInfoFetcher) can return NaN as some of the values, and GSON otherwise fails
+    // JobClient (in DistributedMRJobInfoFetcher) can return NaN as some values, and GSON otherwise fails
     Gson gson = new GsonBuilder().serializeSpecialFloatingPointValues().create();
     responder.sendJson(HttpResponseStatus.OK, gson.toJson(mrJobInfo, mrJobInfo.getClass()));
   }
@@ -254,8 +256,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                         @PathParam("app-id") String appId,
                         @PathParam("program-type") String type,
                         @PathParam("program-id") String programId) throws Exception {
-    getStatus(request, responder, namespaceId, appId,
-              getLatestAppVersion(new NamespaceId(namespaceId), appId), type, programId);
+    getStatus(request, responder, namespaceId, appId, ApplicationId.DEFAULT_VERSION, type, programId);
   }
 
   /**
@@ -272,11 +273,12 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     ApplicationId applicationId = new ApplicationId(namespaceId, appId, versionId);
     if (SCHEDULES.equals(type)) {
       JsonObject json = new JsonObject();
-      ScheduleId scheduleId = applicationId.schedule(programId);
       ApplicationSpecification appSpec = store.getApplication(applicationId);
       if (appSpec == null) {
         throw new NotFoundException(applicationId);
       }
+      // Use the actual version from appSpec
+      ScheduleId scheduleId = applicationId.getAppReference().app(appSpec.getAppVersion()).schedule(programId);
       json.addProperty("status", programScheduleService.getStatus(scheduleId).toString());
       responder.sendJson(HttpResponseStatus.OK, json.toString());
       return;
@@ -1021,7 +1023,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   private List<BatchProgramSchedule> batchRunTimes(String namespace, Collection<? extends BatchProgram> programs,
                                                    boolean previous) throws Exception {
     List<ProgramId> programIds = programs.stream()
-      .map(p -> batchProgramToProgramId(namespace, p))
+      .map(p -> new ProgramId(namespace, p.getAppId(), p.getProgramType(), p.getProgramId()))
       .collect(Collectors.toList());
 
     Set<ApplicationId> appIds = programIds.stream().map(ProgramId::getParent).collect(Collectors.toSet());
@@ -1321,20 +1323,24 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void getStatuses(FullHttpRequest request, HttpResponder responder,
                           @PathParam("namespace-id") String namespaceId) throws Exception {
     List<BatchProgram> batchPrograms = validateAndGetBatchInput(request, BATCH_PROGRAMS_TYPE);
-    Map<BatchProgram, ProgramId> programsMap = batchPrograms.stream()
-      .collect(Collectors.toMap(p -> p, p -> batchProgramToProgramId(namespaceId, p)));
+    List<ProgramReference> programs = batchPrograms.stream()
+      .map(p -> new ProgramReference(namespaceId, p.getAppId(), p.getProgramType(), p.getProgramId()))
+      .collect(Collectors.toList());
 
-    Map<ProgramId, ProgramStatus> statuses = lifecycleService.getProgramStatuses(programsMap.values());
+    Map<ProgramId, ProgramStatus> statuses = lifecycleService.getProgramStatuses(programs);
 
-    List<BatchProgramStatus> result = new ArrayList<>(programsMap.size());
-    for (BatchProgram program : batchPrograms) {
-      ProgramId programId = programsMap.get(program);
-      ProgramStatus status = statuses.get(programId);
-      if (status == null) {
-        result.add(new BatchProgramStatus(program, HttpResponseStatus.NOT_FOUND.code(),
-                                          new NotFoundException(programId).getMessage(), null));
+    Map<ProgramReference, ProgramId> programRefsMap =
+      statuses.keySet().stream().collect(Collectors.toMap(ProgramId::getProgramReference, p -> p));
+
+    List<BatchProgramStatus> result = new ArrayList<>(programs.size());
+    for (ProgramReference program : programs) {
+      ProgramId programId = programRefsMap.get(program);
+      if (programId == null) {
+        result.add(new BatchProgramStatus(program.getBatchProgram(), HttpResponseStatus.NOT_FOUND.code(),
+                                          new NotFoundException(program).getMessage(), null));
       } else {
-        result.add(new BatchProgramStatus(program, HttpResponseStatus.OK.code(), null, status.name()));
+        result.add(new BatchProgramStatus(program.getBatchProgram(), HttpResponseStatus.OK.code(),
+                                          null, statuses.get(programId).name()));
       }
     }
     responder.sendJson(HttpResponseStatus.OK, GSON.toJson(result));
@@ -1578,11 +1584,12 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                                     "supported is 100", programs.size()));
     }
 
-    List<ProgramId> programIds = programs.stream()
-      .map(batchProgram -> batchProgramToProgramId(namespaceId, batchProgram)).collect(Collectors.toList());
+    List<ProgramReference> programRefs = programs.stream()
+      .map(p -> new ProgramReference(namespaceId, p.getAppId(), p.getProgramType(), p.getProgramId()))
+      .collect(Collectors.toList());
 
     List<BatchProgramCount> counts = new ArrayList<>(programs.size());
-    for (RunCountResult runCountResult : lifecycleService.getProgramRunCounts(programIds)) {
+    for (RunCountResult runCountResult : lifecycleService.getProgramRunCounts(programRefs)) {
       ProgramId programId = runCountResult.getProgramId();
       Exception exception = runCountResult.getException();
       if (exception == null) {
@@ -1638,12 +1645,12 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   public void getLatestRuns(FullHttpRequest request, HttpResponder responder,
                             @PathParam("namespace-id") String namespaceId) throws Exception {
     List<BatchProgram> programs = validateAndGetBatchInput(request, BATCH_PROGRAMS_TYPE);
-    List<ProgramId> programIds =
-      programs.stream().map(batchProgram -> batchProgramToProgramId(namespaceId, batchProgram))
+    List<ProgramReference> programRefs =
+      programs.stream().map(p -> new ProgramReference(namespaceId, p.getAppId(), p.getProgramType(), p.getProgramId()))
         .collect(Collectors.toList());
 
     List<BatchProgramHistory> response = new ArrayList<>(programs.size());
-    List<ProgramHistory> result = lifecycleService.getRunRecords(programIds, ProgramRunStatus.ALL, 0,
+    List<ProgramHistory> result = lifecycleService.getRunRecords(programRefs, ProgramRunStatus.ALL, 0,
                                                                  Long.MAX_VALUE, 1);
     for (ProgramHistory programHistory : result) {
       ProgramId programId = programHistory.getProgramId();
@@ -2116,22 +2123,5 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       throw new ApplicationNotFoundException(new ApplicationId(namespaceId.getNamespace(), appId));
     }
     return latestApplicationMeta.getSpec().getAppVersion();
-  }
-
-  /**
-   * Convert BatchProgram to ProgramId with the latest App version.
-   * Since a programId is needed in BatchProgramResult, default version will be used here if application
-   * can not be found.
-   */
-  private ProgramId batchProgramToProgramId(String namespace, BatchProgram batchProgram) {
-    try {
-      ApplicationId applicationId = new ApplicationId(namespace, batchProgram.getAppId(),
-                                                      getLatestAppVersion(new NamespaceId(namespace),
-                                                                          batchProgram.getAppId()));
-      return new ProgramId(applicationId, batchProgram.getProgramType(), batchProgram.getProgramId());
-    } catch (ApplicationNotFoundException e) {
-      return new ProgramId(namespace, batchProgram.getAppId(), batchProgram.getProgramType(),
-                           batchProgram.getProgramId());
-    }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -183,11 +183,6 @@ public class ProgramLifecycleService {
       throw new NotFoundException(appId);
     }
 
-    programId = new ProgramId(programId.getNamespace(),
-                              programId.getApplication(),
-                              appSpec.getAppVersion(),
-                              programId.getType(),
-                              programId.getProgram());
     return getExistingAppProgramStatus(appSpec, programId);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -76,6 +76,7 @@ import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.profile.Profile;
 import io.cdap.cdap.proto.provisioner.ProvisionerDetail;
@@ -182,24 +183,30 @@ public class ProgramLifecycleService {
       throw new NotFoundException(appId);
     }
 
+    programId = new ProgramId(programId.getNamespace(),
+                              programId.getApplication(),
+                              appSpec.getAppVersion(),
+                              programId.getType(),
+                              programId.getProgram());
     return getExistingAppProgramStatus(appSpec, programId);
   }
 
   /**
    * Gets the {@link ProgramStatus} for the given set of programs.
    *
-   * @param programIds collection of program ids for retrieving status
+   * @param programRefs collection of versionless program ids for retrieving status
    * @return a {@link Map} from the {@link ProgramId} to the corresponding status; there will be no entry for programs
    * that do not exist.
    */
-  public Map<ProgramId, ProgramStatus> getProgramStatuses(Collection<ProgramId> programIds) throws Exception {
+  public Map<ProgramId, ProgramStatus> getProgramStatuses(Collection<ProgramReference> programRefs) throws Exception {
     // filter the result
-    Set<? extends EntityId> visibleEntities = accessEnforcer.isVisible(new LinkedHashSet<>(programIds),
-                                                                              authenticationContext.getPrincipal());
-    List<ProgramId> filteredIds = programIds.stream().filter(visibleEntities::contains).collect(Collectors.toList());
+    Set<? extends EntityId> visibleEntities = accessEnforcer.isVisible(new LinkedHashSet<>(programRefs),
+                                                                       authenticationContext.getPrincipal());
+    List<ProgramReference> filteredRefs = programRefs.stream()
+      .filter(visibleEntities::contains).collect(Collectors.toList());
 
     Map<ProgramId, ProgramStatus> result = new HashMap<>();
-    for (Map.Entry<ProgramId, Collection<RunRecordDetail>> entry : store.getActiveRuns(filteredIds).entrySet()) {
+    for (Map.Entry<ProgramId, Collection<RunRecordDetail>> entry : store.getActiveRuns(filteredRefs).entrySet()) {
       result.put(entry.getKey(), getProgramStatus(entry.getValue()));
     }
     return result;
@@ -221,21 +228,22 @@ public class ProgramLifecycleService {
   /**
    * Returns the program run count of the given program id list.
    *
-   * @param programIds the list of program ids to get the count
+   * @param programRefs the list of program ids to get the count
    * @return the counts of given program ids
    */
-  public List<RunCountResult> getProgramRunCounts(List<ProgramId> programIds) throws Exception {
+  public List<RunCountResult> getProgramRunCounts(List<ProgramReference> programRefs) throws Exception {
     // filter the result
     Principal principal = authenticationContext.getPrincipal();
-    Set<? extends EntityId> visibleEntities = accessEnforcer.isVisible(new HashSet<>(programIds), principal);
-    Set<ProgramId> filteredIds = programIds.stream().filter(visibleEntities::contains).collect(Collectors.toSet());
+    Set<? extends EntityId> visibleEntities = accessEnforcer.isVisible(new HashSet<>(programRefs), principal);
+    Set<ProgramReference> filteredRefs = programRefs.stream()
+      .filter(visibleEntities::contains).collect(Collectors.toSet());
 
-    Map<ProgramId, RunCountResult> programCounts = store.getProgramRunCounts(filteredIds).stream()
+    Map<ProgramId, RunCountResult> programCounts = store.getProgramRunCounts(filteredRefs).stream()
       .collect(Collectors.toMap(RunCountResult::getProgramId, c -> c));
 
     List<RunCountResult> result = new ArrayList<>();
-    for (ProgramId programId : programIds) {
-      if (!visibleEntities.contains(programId)) {
+    for (ProgramId programId : programCounts.keySet()) {
+      if (!visibleEntities.contains(programId.getProgramReference())) {
         result.add(new RunCountResult(programId, null, new UnauthorizedException(principal, programId)));
       } else {
         RunCountResult count = programCounts.get(programId);
@@ -315,14 +323,14 @@ public class ProgramLifecycleService {
    * @throws UnauthorizedException if the principal does not have access to the program
    * @throws Exception if there was some other exception performing authorization checks
    */
-  public List<ProgramHistory> getRunRecords(Collection<ProgramId> programs, ProgramRunStatus programRunStatus,
+  public List<ProgramHistory> getRunRecords(Collection<ProgramReference> programs, ProgramRunStatus programRunStatus,
                                             long start, long end, int limit) throws Exception {
     List<ProgramHistory> result = new ArrayList<>();
 
     // do this in batches to avoid transaction timeouts.
-    List<ProgramId> batch = new ArrayList<>(20);
+    List<ProgramReference> batch = new ArrayList<>(20);
 
-    for (ProgramId program : programs) {
+    for (ProgramReference program : programs) {
       batch.add(program);
 
       if (batch.size() >= 20) {
@@ -336,17 +344,19 @@ public class ProgramLifecycleService {
     return result;
   }
 
-  private void addProgramHistory(List<ProgramHistory> histories, List<ProgramId> programs,
+  private void addProgramHistory(List<ProgramHistory> histories, List<ProgramReference> programs,
                                  ProgramRunStatus programRunStatus, long start, long end, int limit) throws Exception {
     Set<? extends EntityId> visibleEntities = accessEnforcer.isVisible(new HashSet<>(programs),
-                                                                              authenticationContext.getPrincipal());
+                                                                       authenticationContext.getPrincipal());
+
     for (ProgramHistory programHistory : store.getRuns(programs, programRunStatus, start, end, limit)) {
-      ProgramId programId = programHistory.getProgramId();
+      ProgramReference programId = programHistory.getProgramId().getProgramReference();
       if (visibleEntities.contains(programId)) {
         histories.add(programHistory);
       } else {
-        histories.add(new ProgramHistory(programId, Collections.emptyList(),
-                                      new UnauthorizedException(authenticationContext.getPrincipal(), programId)));
+        histories.add(new ProgramHistory(programHistory.getProgramId(), Collections.emptyList(),
+                                         new UnauthorizedException(authenticationContext.getPrincipal(),
+                                                                   programHistory.getProgramId())));
       }
     }
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -547,8 +547,6 @@ public class AppMetadataStore {
           .app(latestAppVersions.get(appRef))
           .program(programRef.getType(), programRef.getProgram());
         versionedProgramIds.add(actualProgramId);
-      } else {
-        versionedProgramIds.add(programRef.id(ApplicationId.DEFAULT_VERSION));
       }
     }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -59,6 +59,7 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.WorkflowId;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
@@ -432,11 +433,11 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public Map<ProgramId, Collection<RunRecordDetail>> getActiveRuns(Collection<ProgramId> programIds) {
+  public Map<ProgramId, Collection<RunRecordDetail>> getActiveRuns(Collection<ProgramReference> programRefs) {
     return TransactionRunners.run(transactionRunner, context -> {
       AppMetadataStore appMetadataStore = getAppMetadataStore(context);
       // Get the active runs for programs that exist
-      return getAppMetadataStore(context).getActiveRuns(appMetadataStore.filterProgramsExistence(programIds));
+      return appMetadataStore.getActiveRuns(appMetadataStore.filterProgramsExistence(programRefs));
     });
   }
 
@@ -901,20 +902,24 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public List<RunCountResult> getProgramRunCounts(Collection<ProgramId> programIds) {
+  public List<RunCountResult> getProgramRunCounts(Collection<ProgramReference> programRefs) {
     return TransactionRunners.run(transactionRunner, context -> {
       List<RunCountResult> result = new ArrayList<>();
       AppMetadataStore appMetadataStore = getAppMetadataStore(context);
 
       Map<ProgramId, Long> runCounts = appMetadataStore.getProgramRunCounts(
-        appMetadataStore.filterProgramsExistence(programIds));
+        appMetadataStore.filterProgramsExistence(programRefs));
 
-      for (ProgramId programId : programIds) {
-        Long count = runCounts.get(programId);
-        if (count == null) {
-          result.add(new RunCountResult(programId, null, new NotFoundException(programId)));
+      Map<ProgramReference, ProgramId> programRefsMap =
+        runCounts.keySet().stream().collect(Collectors.toMap(ProgramId::getProgramReference, p -> p));
+
+      for (ProgramReference programRef : programRefs) {
+        ProgramId program = programRefsMap.get(programRef);
+        if (program == null) {
+          result.add(new RunCountResult(programRef.id(ApplicationId.DEFAULT_VERSION),
+                                        null, new NotFoundException(programRef)));
         } else {
-          result.add(new RunCountResult(programId, count, null));
+          result.add(new RunCountResult(program, runCounts.get(program), null));
         }
       }
       return result;
@@ -922,25 +927,30 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public List<ProgramHistory> getRuns(Collection<ProgramId> programs, ProgramRunStatus status,
+  public List<ProgramHistory> getRuns(Collection<ProgramReference> programs, ProgramRunStatus status,
                                       long startTime, long endTime, int limitPerProgram) {
     return TransactionRunners.run(transactionRunner, context -> {
       List<ProgramHistory> result = new ArrayList<>(programs.size());
       AppMetadataStore appMetadataStore = getAppMetadataStore(context);
 
       Set<ProgramId> existingPrograms = appMetadataStore.filterProgramsExistence(programs);
+      Map<ProgramReference, ProgramId> programRefsMap =
+        existingPrograms.stream().collect(Collectors.toMap(ProgramId::getProgramReference, p -> p));
 
-      for (ProgramId programId : programs) {
-        if (!existingPrograms.contains(programId)) {
-          result.add(new ProgramHistory(programId, Collections.emptyList(), new ProgramNotFoundException(programId)));
+      for (ProgramReference programRef : programs) {
+        ProgramId latestProgramId = programRefsMap.get(programRef);
+        if (latestProgramId == null) {
+          ProgramId defaultVersion = programRef.id(ApplicationId.DEFAULT_VERSION);
+          result.add(new ProgramHistory(defaultVersion, Collections.emptyList(),
+                                        new ProgramNotFoundException(defaultVersion)));
           continue;
         }
 
-        List<RunRecord> runs = appMetadataStore.getRuns(programId, status, startTime, endTime,
+        List<RunRecord> runs = appMetadataStore.getRuns(latestProgramId, status, startTime, endTime,
                                                         limitPerProgram, null)
           .values().stream()
           .map(record -> RunRecord.builder(record).build()).collect(Collectors.toList());
-        result.add(new ProgramHistory(programId, runs, null));
+        result.add(new ProgramHistory(latestProgramId, runs, null));
       }
 
       return result;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -539,7 +539,7 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     args.put(SystemArguments.PROFILE_PROPERTIES_PREFIX + MockProvisioner.WAIT_CREATE_MS, Integer.toString(120000));
     startProgram(workflowId, args);
 
-    // should be safe to wait for starting since the provisioner is configure to sleep while creating a cluster
+    // should be safe to wait for starting since the provisioner is configured to sleep while creating a cluster
     waitState(workflowId, io.cdap.cdap.proto.ProgramStatus.STARTING.name());
     List<RunRecord> runRecords = getProgramRuns(workflowId, ProgramRunStatus.PENDING);
     Assert.assertEquals(1, runRecords.size());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/DefaultStoreTest.java
@@ -681,9 +681,11 @@ public abstract class DefaultStoreTest {
       setStart(serviceId.run(RunIds.generate()), Collections.emptyMap(), Collections.emptyMap(), testArtifact);
     }
 
-    List<RunCountResult> result = store.getProgramRunCounts(ImmutableList.of(workflowId, serviceId,
-                                                                             nonExistingAppProgramId,
-                                                                             nonExistingProgramId));
+    List<RunCountResult> result =
+      store.getProgramRunCounts(ImmutableList.of(workflowId.getProgramReference(),
+                                                 serviceId.getProgramReference(),
+                                                 nonExistingAppProgramId.getProgramReference(),
+                                                 nonExistingProgramId.getProgramReference()));
 
     // compare the result
     Assert.assertEquals(4, result.size());
@@ -701,7 +703,8 @@ public abstract class DefaultStoreTest {
 
     // remove the app should remove all run count
     store.removeApplication(appId);
-    for (RunCountResult runCountResult : store.getProgramRunCounts(ImmutableList.of(workflowId, serviceId))) {
+    for (RunCountResult runCountResult : store.getProgramRunCounts(ImmutableList.of(workflowId.getProgramReference(),
+                                                                                    serviceId.getProgramReference()))) {
       Assert.assertNull(runCountResult.getCount());
       Assert.assertTrue(runCountResult.getException() instanceof NotFoundException);
     }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/element/EntityType.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/element/EntityType.java
@@ -16,6 +16,7 @@
 package io.cdap.cdap.proto.element;
 
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.DatasetModuleId;
@@ -27,6 +28,7 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.PluginId;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.QueryId;
 import io.cdap.cdap.proto.id.ScheduleId;
@@ -51,7 +53,9 @@ public enum EntityType {
   INSTANCE(InstanceId.class),
   KERBEROSPRINCIPAL(KerberosPrincipalId.class),
   NAMESPACE(NamespaceId.class),
+  APPLICATIONREFERENCE(ApplicationReference.class),
   APPLICATION(ApplicationId.class),
+  PROGRAMREFERENCE(ProgramReference.class),
   PROGRAM(ProgramId.class),
   PROGRAM_RUN(ProgramRunId.class),
 

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ApplicationId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ApplicationId.java
@@ -76,6 +76,10 @@ public class ApplicationId extends NamespacedEntityId implements ParentedId<Name
     return new NamespaceId(namespace);
   }
 
+  public ApplicationReference getAppReference() {
+    return new ApplicationReference(namespace, application);
+  }
+
   public ProgramId program(ProgramType type, String program) {
     return new ProgramId(this, type, program);
   }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ApplicationReference.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ApplicationReference.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.id;
+
+import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.proto.element.EntityType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * Identifies a versionless application.
+ */
+public class ApplicationReference extends NamespacedEntityId implements ParentedId<NamespaceId> {
+  private final String application;
+  private transient Integer hashCode;
+
+  public ApplicationReference(String namespace, String application) {
+    super(namespace, EntityType.APPLICATIONREFERENCE);
+    if (application == null) {
+      throw new NullPointerException("Application ID cannot be null.");
+    }
+    ensureValidId("application", application);
+    this.application = application;
+  }
+
+  public String getApplication() {
+    return application;
+  }
+
+  public ApplicationId app(String version) {
+    return new ApplicationId(namespace, application, version);
+  }
+
+  @Override
+  public Iterable<String> toIdParts() {
+    return Collections.unmodifiableList(Arrays.asList(namespace, application));
+  }
+
+  @Override
+  public String getEntityName() {
+    return getApplication();
+  }
+
+  @Override
+  public MetadataEntity toMetadataEntity() {
+    return MetadataEntity.builder().append(MetadataEntity.NAMESPACE, namespace)
+      .appendAsType(MetadataEntity.APPLICATION, application)
+      .build();
+  }
+
+  @Override
+  public NamespaceId getParent() {
+    return new NamespaceId(namespace);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    ApplicationReference that = (ApplicationReference) o;
+    return Objects.equals(namespace, that.namespace) && Objects.equals(application, that.application);
+  }
+
+  @SuppressWarnings("unused")
+  public static ApplicationReference fromIdParts(Iterable<String> idString) {
+    Iterator<String> iterator = idString.iterator();
+    return new ApplicationReference(next(iterator, "namespace"), next(iterator, "application"));
+  }
+
+  @Override
+  public int hashCode() {
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, application);
+    }
+    return hashCode;
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ProgramId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ProgramId.java
@@ -16,6 +16,7 @@
 package io.cdap.cdap.proto.id;
 
 import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.proto.BatchProgram;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.element.EntityType;
 import org.apache.twill.api.RunId;
@@ -97,6 +98,18 @@ public class ProgramId extends NamespacedEntityId implements ParentedId<Applicat
     return new ApplicationId(namespace, application, version);
   }
 
+  public ApplicationReference getAppReference() {
+    return new ApplicationReference(namespace, application);
+  }
+
+  public ProgramReference getProgramReference() {
+    return new ProgramReference(getAppReference(), getType(), getProgram());
+  }
+
+  public BatchProgram getBatchProgram() {
+    return new BatchProgram(application, type, program);
+  }
+
   /**
    * Creates a {@link ProgramRunId} of this program id with the given run id.
    */
@@ -127,10 +140,7 @@ public class ProgramId extends NamespacedEntityId implements ParentedId<Applicat
    */
   public boolean isSameProgramExceptVersion(Object o) {
     ProgramId programId = (ProgramId) o;
-    return Objects.equals(namespace, programId.namespace) &&
-      Objects.equals(application, programId.application) &&
-      Objects.equals(type, programId.type) &&
-      Objects.equals(program, programId.program);
+    return Objects.equals(getProgramReference(), programId.getProgramReference());
   }
 
   @Override

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ProgramReference.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ProgramReference.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.id;
+
+import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.proto.BatchProgram;
+import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.element.EntityType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * Identifies a versionless program.
+ */
+public class ProgramReference extends NamespacedEntityId implements ParentedId<ApplicationReference> {
+  private final String application;
+  private final ProgramType type;
+  private final String program;
+  private transient Integer hashCode;
+
+  public ProgramReference(ApplicationReference appRef, ProgramType type, String program) {
+    super(appRef.getNamespace(), EntityType.PROGRAMREFERENCE);
+    if (type == null) {
+      throw new NullPointerException("Program type cannot be null.");
+    }
+    if (program == null) {
+      throw new NullPointerException("Program ID cannot be null.");
+    }
+    this.application = appRef.getApplication();
+    this.type = type;
+    this.program = program;
+  }
+
+  public ProgramReference(String namespace, String application, ProgramType type, String program) {
+    this(new ApplicationReference(namespace, application), type, program);
+  }
+
+  public String getApplication() {
+    return application;
+  }
+
+  public ProgramType getType() {
+    return type;
+  }
+
+  public String getProgram() {
+    return program;
+  }
+
+  public BatchProgram getBatchProgram() {
+    return new BatchProgram(application, type, program);
+  }
+
+  public ProgramId id(String version) {
+    return new ProgramId(new ApplicationId(namespace, application, version), type, program);
+  }
+
+  @Override
+  public Iterable<String> toIdParts() {
+    return Collections.unmodifiableList(
+      Arrays.asList(namespace, application, type.getPrettyName().toLowerCase(), program));
+  }
+
+  @SuppressWarnings("unused")
+  public static ProgramReference fromIdParts(Iterable<String> idString) {
+    Iterator<String> iterator = idString.iterator();
+    return new ProgramReference(
+      next(iterator, "namespace"), next(iterator, "application"),
+      ProgramType.valueOfPrettyName(next(iterator, "type")),
+      nextAndEnd(iterator, "program"));
+  }
+
+  @Override
+  public String getEntityName() {
+    return getProgram();
+  }
+
+  @Override
+  public MetadataEntity toMetadataEntity() {
+    return MetadataEntity.builder().append(MetadataEntity.NAMESPACE, namespace)
+      .append(MetadataEntity.APPLICATION, application)
+      .append(MetadataEntity.TYPE, type.getPrettyName())
+      .appendAsType(MetadataEntity.PROGRAM, program)
+      .build();
+  }
+
+  @Override
+  public ApplicationReference getParent() {
+    return new ApplicationReference(namespace, application);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    ProgramReference programRef = (ProgramReference) o;
+    return Objects.equals(getParent(), programRef.getParent()) &&
+      Objects.equals(type, programRef.type) &&
+      Objects.equals(program, programRef.program);
+  }
+
+  @Override
+  public int hashCode() {
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), getNamespace(), getApplication(), type, program);
+    }
+    return hashCode;
+  }
+}


### PR DESCRIPTION
In programlifecyclehandler, there are several batch apis that retrieve multiple program run records. We should avoid loops hitting database. Instead, we could use multiScan to fetch once. 

TODO: define and update the behaviors for `/runs`, `/runcount`, `/status` APIs: previously they are default to get the `-SNAPSHOT` versioned programs, now we need to decide whether to fetch all versions, or just the `latest` version. The PR is based on the `latest` version assumption.