### PR TITLE
fix(CDAP-19936): create unique index on latest application version

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -540,7 +540,7 @@ public class AppMetadataStore {
     if (latest != null) {
       List<Field<?>> fields = getApplicationPrimaryKeys(id.getNamespace(), id.getApplication(),
                                                         latest.getSpec().getAppVersion());
-      fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.LATEST_FIELD, "false"));
+      fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.LATEST_FIELD, null));
       getApplicationSpecificationTable().upsert(fields);
     }
     // Add a new version of the app

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -540,6 +540,8 @@ public class AppMetadataStore {
     if (latest != null) {
       List<Field<?>> fields = getApplicationPrimaryKeys(id.getNamespace(), id.getApplication(),
                                                         latest.getSpec().getAppVersion());
+      // We have null-filtered unique index on (namespace, application, latest)
+      // latest = null indicates this version is no longer the latest version
       fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.LATEST_FIELD, null));
       getApplicationSpecificationTable().upsert(fields);
     }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
@@ -404,6 +404,7 @@ public final class StoreDefinition {
                     Fields.stringType(LATEST_FIELD))
         .withPrimaryKeys(NAMESPACE_FIELD, APPLICATION_FIELD, VERSION_FIELD)
         .withIndexes(LATEST_FIELD, CREATION_TIME_FIELD)
+        .withUniqueIndexes(NAMESPACE_FIELD, APPLICATION_FIELD, LATEST_FIELD)
         .build();
 
     public static final StructuredTableSpecification WORKFLOW_NODE_STATES_SPEC =

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
@@ -112,6 +112,12 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
     // no implementation
   }
 
+  @Override
+  @Ignore
+  public void testUniqueIndex() throws Exception {
+    // TODO: https://cdap.atlassian.net/browse/CDAP-19950
+  }
+
   private void testScannerIterator(int max) throws Exception {
     List<Integer> expected = IntStream.range(0, max).boxed().collect(Collectors.toList());
     MockScanner scanner = new MockScanner(expected.iterator());

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/StructuredTableSchema.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/StructuredTableSchema.java
@@ -40,18 +40,21 @@ public class StructuredTableSchema {
   // primary keys have to be ordered as defined in the table schema
   private final List<String> primaryKeys;
   private final Set<String> indexes;
+  private final List<String> uniqueIndexes;
 
   public StructuredTableSchema(StructuredTableSpecification spec) {
-    this(spec.getTableId(), spec.getFieldTypes(), spec.getPrimaryKeys(), spec.getIndexes());
+    this(spec.getTableId(), spec.getFieldTypes(), spec.getPrimaryKeys(), spec.getIndexes(), spec.getUniqueIndexes());
   }
 
   public StructuredTableSchema(StructuredTableId tableId, List<FieldType> fields,
-                               List<String> primaryKeys, Collection<String> indexes) {
+                               List<String> primaryKeys, Collection<String> indexes,
+                               Collection<String> uniqueIndexes) {
     this.tableId = tableId;
     this.fields = Collections.unmodifiableMap(fields.stream().collect(
       Collectors.toMap(FieldType::getName, FieldType::getType)));
     this.primaryKeys = Collections.unmodifiableList(new ArrayList<>(primaryKeys));
     this.indexes = Collections.unmodifiableSet(new HashSet<>(indexes));
+    this.uniqueIndexes = Collections.unmodifiableList(new ArrayList<>(uniqueIndexes));
   }
 
   public StructuredTableId getTableId() {
@@ -64,6 +67,10 @@ public class StructuredTableSchema {
 
   public Set<String> getIndexes() {
     return indexes;
+  }
+
+  public List<String> getUniqueIndexes() {
+    return uniqueIndexes;
   }
 
   /**
@@ -113,12 +120,13 @@ public class StructuredTableSchema {
     return Objects.equals(tableId, that.tableId)
       && Objects.equals(fields, that.fields)
       && Objects.equals(primaryKeys, that.primaryKeys)
-      && Objects.equals(indexes, that.indexes);
+      && Objects.equals(indexes, that.indexes)
+      && Objects.equals(uniqueIndexes, that.uniqueIndexes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tableId, fields, primaryKeys, indexes);
+    return Objects.hash(tableId, fields, primaryKeys, indexes, uniqueIndexes);
   }
 
   /**
@@ -161,6 +169,9 @@ public class StructuredTableSchema {
    *   </li>
    *   <li>
    *     The new schema contains all the indexes in the existing schema.
+   *   </li>
+   *   <li>
+   *     The new schema contains all the unique indexes in the existing schema.
    *   </li>
    * </ol>
    *

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableAdminTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableAdminTest.java
@@ -56,6 +56,7 @@ public abstract class StructuredTableAdminTest {
         Fields.longType("updated_field2"))
       .withPrimaryKeys(KEY_FIELD.getName())
       .withIndexes(STR_FIELD.getName(), LONG_FIELD.getName())
+      .withUniqueIndexes(KEY_FIELD.getName(), LONG_FIELD.getName())
       .build();
 
   protected static final StructuredTableSpecification INCOMPATIBLE_TABLE_SPEC =


### PR DESCRIPTION
Change:

1. Support adding unique index in postgresql and spanner implementation, the index will be null filtered
2. For LCM, application version can only have two states: `true` and null