### PR TITLE
[CDAP-19488] extend /app/program/runs and /runcount endpoint for all versions

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/program/VersionSelect.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/program/VersionSelect.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.program;
+
+public enum VersionSelect {
+  ALL, LATEST
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.api.workflow.Workflow;
 import io.cdap.cdap.api.workflow.WorkflowToken;
 import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.program.ProgramDescriptor;
+import io.cdap.cdap.app.program.VersionSelect;
 import io.cdap.cdap.common.ApplicationNotFoundException;
 import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.common.NotFoundException;
@@ -192,7 +193,7 @@ public interface Store {
                                              long startTime, long endTime, int limit);
 
   /**
-   * Fetches run records of all versions for particular program.
+   * Fetches run records for particular program.
    * Returned ProgramRunRecords are sorted by their startTime.
    *
    * @param id        id of the program
@@ -202,8 +203,8 @@ public interface Store {
    * @param limit     max number of entries to fetch for this history call
    * @return          map of logged runs
    */
-  Map<ProgramRunId, RunRecordDetail> getAllVersionsRuns(ProgramId id, ProgramRunStatus status,
-                                             long startTime, long endTime, int limit);
+  Map<ProgramRunId, RunRecordDetail> getRuns(ProgramId id, ProgramRunStatus status,
+                                             long startTime, long endTime, int limit, VersionSelect version);
 
   /**
    * Fetches the run records for the particular status. Same as calling
@@ -567,12 +568,12 @@ public interface Store {
   List<RunCountResult> getProgramRunCounts(Collection<ProgramId> programIds);
 
   /**
-   * Get the run count of all versions of the given program collection
+   * Get the run count of whether latest or all based on param of the given program collection
    *
    * @param programIds collection of program ids to get the count
    * @return the run count result of each program in the collection
    */
-  List<RunCountResult> getProgramAllVersionsRunCounts(Collection<ProgramId> programIds);
+  List<RunCountResult> getProgramRunCounts(Collection<ProgramId> programIds, VersionSelect version);
 
   /**
    * Fetches run records for multiple programs.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -192,6 +192,20 @@ public interface Store {
                                              long startTime, long endTime, int limit);
 
   /**
+   * Fetches run records of all versions for particular program.
+   * Returned ProgramRunRecords are sorted by their startTime.
+   *
+   * @param id        id of the program
+   * @param status    status of the program running/completed/failed or all
+   * @param startTime fetch run history that has started after the startTime in seconds
+   * @param endTime   fetch run history that has started before the endTime in seconds
+   * @param limit     max number of entries to fetch for this history call
+   * @return          map of logged runs
+   */
+  Map<ProgramRunId, RunRecordDetail> getAllVersionsRuns(ProgramId id, ProgramRunStatus status,
+                                             long startTime, long endTime, int limit);
+
+  /**
    * Fetches the run records for the particular status. Same as calling
    * {@link #getRuns(ProgramRunStatus, long, long, int, Predicate)
    * getRuns(status, 0, Long.MAX_VALUE, Integer.MAX_VALUE, filter)}
@@ -551,6 +565,14 @@ public interface Store {
    * @return the run count result of each program in the collection
    */
   List<RunCountResult> getProgramRunCounts(Collection<ProgramId> programIds);
+
+  /**
+   * Get the run count of all versions of the given program collection
+   *
+   * @param programIds collection of program ids to get the count
+   * @return the run count result of each program in the collection
+   */
+  List<RunCountResult> getProgramAllVersionsRunCounts(Collection<ProgramId> programIds);
 
   /**
    * Fetches run records for multiple programs.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -482,7 +482,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                              @QueryParam("start") String startTs,
                              @QueryParam("end") String endTs,
                              @QueryParam("limit") @DefaultValue("100") final int resultLimit,
-                             @QueryParam("versionSelect") @DefaultValue("LATEST") VersionSelect versionSelect)
+                             @QueryParam("version-select") @DefaultValue("LATEST") VersionSelect versionSelect)
     throws Exception {
     programHistory(request, responder, namespaceId, appName,
                    getLatestAppVersion(new NamespaceId(namespaceId), appName), type,
@@ -505,7 +505,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                              @QueryParam("start") String startTs,
                              @QueryParam("end") String endTs,
                              @QueryParam("limit") @DefaultValue("100") final int resultLimit,
-                             @QueryParam("versionSelect") @DefaultValue("LATEST")
+                             @QueryParam("version-select") @DefaultValue("LATEST")
                                  VersionSelect versionSelect) throws Exception {
     ProgramType programType = getProgramType(type);
 
@@ -1576,7 +1576,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/runcount")
   public void getRunCounts(FullHttpRequest request, HttpResponder responder,
                            @PathParam("namespace-id") String namespaceId,
-                           @QueryParam("versionSelect") @DefaultValue("LATEST")
+                           @QueryParam("version-select") @DefaultValue("LATEST")
                                VersionSelect versionSelect) throws Exception {
     List<BatchProgram> programs = validateAndGetBatchInput(request, BATCH_PROGRAMS_TYPE);
     if (programs.size() > 100) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -2155,20 +2155,4 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     ApplicationId applicationId = new ApplicationId(namespace, batchProgram.getAppId());
     return new ProgramId(applicationId, batchProgram.getProgramType(), batchProgram.getProgramId());
   }
-
-  /**
-   * Convert BatchProgram to ProgramIds with all app versions
-   */
-  private List<ProgramId> batchProgramToProgramIds(String namespace, BatchProgram batchProgram) {
-    Collection<ApplicationSpecification> allAppVersions = store.getAllAppVersions(
-      new NamespaceId(namespace), batchProgram.getAppId());
-    return allAppVersions.stream().map(applicationSpecification -> {
-                                         ApplicationId applicationId = new ApplicationId(
-                                           namespace, applicationSpecification.getName(),
-                                           applicationSpecification.getAppVersion());
-                                         return new ProgramId(applicationId, batchProgram.getProgramType(),
-                                                              batchProgram.getProgramId());
-                                       }
-    ).collect(Collectors.toList());
-  }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -1576,7 +1576,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   @Path("/runcount")
   public void getRunCounts(FullHttpRequest request, HttpResponder responder,
                            @PathParam("namespace-id") String namespaceId,
-                           @QueryParam("versionSelect") @DefaultValue("LATEST") VersionSelect versionSelect) throws Exception {
+                           @QueryParam("versionSelect") @DefaultValue("LATEST")
+                               VersionSelect versionSelect) throws Exception {
     List<BatchProgram> programs = validateAndGetBatchInput(request, BATCH_PROGRAMS_TYPE);
     if (programs.size() > 100) {
       throw new BadRequestException(String.format("%d programs found in the request, the maximum number " +

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -250,6 +250,37 @@ public class ProgramLifecycleService {
   }
 
   /**
+   * Returns the program run count of all versions of the given program id list.
+   *
+   * @param programIds the list of program ids to get the count
+   * @return the counts of given program ids
+   */
+  public List<RunCountResult> getProgramAllVersionsRunCounts(List<ProgramId> programIds) throws Exception {
+    // filter the result
+    Principal principal = authenticationContext.getPrincipal();
+    Set<? extends EntityId> visibleEntities = accessEnforcer.isVisible(new HashSet<>(programIds), principal);
+    Set<ProgramId> filteredIds = programIds.stream().filter(visibleEntities::contains).collect(Collectors.toSet());
+
+    Map<ProgramId, RunCountResult> programCounts = store.getProgramAllVersionsRunCounts(filteredIds).stream()
+      .collect(Collectors.toMap(RunCountResult::getProgramId, c -> c));
+
+    List<RunCountResult> result = new ArrayList<>();
+    for (ProgramId programId : programIds) {
+      if (!visibleEntities.contains(programId)) {
+        result.add(new RunCountResult(programId, null, new UnauthorizedException(principal, programId)));
+      } else {
+        RunCountResult count = programCounts.get(programId);
+        if (count != null) {
+          result.add(count);
+        } else {
+          result.add(new RunCountResult(programId, 0L, null));
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
    * Returns the {@link RunRecordDetail} for the given program run.
    *
    * @param programRunId the program run to fetch
@@ -295,9 +326,39 @@ public class ProgramLifecycleService {
     return new ArrayList<>(store.getRuns(programId, programRunStatus, start, end, limit).values());
   }
 
+  /**
+   * Get runs of all versions within the specified start and end times for the specified program.
+   *
+   * @param programId the program to get runs for
+   * @param programRunStatus status of runs to return
+   * @param start earliest start time of runs to return
+   * @param end latest start time of runs to return
+   * @param limit the maximum number of runs to return
+   * @return runs of all versions for the program sorted by start time, with the newest run as the first run
+   * @throws NotFoundException if the application to which this program belongs was not found or the program is not
+   *                           found in the app
+   * @throws UnauthorizedException if the principal does not have access to the program
+   * @throws Exception if there was some other exception performing authorization checks
+   */
+  public List<RunRecordDetail> getAllVersionsRunRecordMetas(ProgramId programId, ProgramRunStatus programRunStatus,
+                                                 long start, long end, int limit) throws Exception {
+    accessEnforcer.enforce(programId, authenticationContext.getPrincipal(), StandardPermission.GET);
+    ProgramSpecification programSpec = getProgramSpecificationWithoutAuthz(programId);
+    if (programSpec == null) {
+      throw new NotFoundException(programId);
+    }
+    return new ArrayList<>(store.getAllVersionsRuns(programId, programRunStatus, start, end, limit).values());
+  }
+
   public List<RunRecord> getRunRecords(ProgramId programId, ProgramRunStatus programRunStatus,
                                        long start, long end, int limit) throws Exception {
     return getRunRecordMetas(programId, programRunStatus, start, end, limit).stream()
+      .map(record -> RunRecord.builder(record).build()).collect(Collectors.toList());
+  }
+
+  public List<RunRecord> getAllVersionsRunRecords(ProgramId programId, ProgramRunStatus programRunStatus,
+                                       long start, long end, int limit) throws Exception {
+    return getAllVersionsRunRecordMetas(programId, programRunStatus, start, end, limit).stream()
       .map(record -> RunRecord.builder(record).build()).collect(Collectors.toList());
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricClient.java
@@ -379,7 +379,7 @@ public class AppFabricClient {
                                getNamespacePath(namespace), application, applicationVersion, categoryName, programName);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
     programLifecycleHttpHandler.programHistory(request, responder, namespace, application, applicationVersion,
-                                               categoryName, programName, status.name(), null, null, 100);
+                                               categoryName, programName, status.name(), null, null, 100, null);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Getting workflow history failed");
 
     return responder.decodeResponseContent(RUN_RECORDS_TYPE);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricClient.java
@@ -25,6 +25,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.schedule.Trigger;
 import io.cdap.cdap.api.workflow.WorkflowToken;
+import io.cdap.cdap.app.program.VersionSelect;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.id.Id;
@@ -379,7 +380,8 @@ public class AppFabricClient {
                                getNamespacePath(namespace), application, applicationVersion, categoryName, programName);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
     programLifecycleHttpHandler.programHistory(request, responder, namespace, application, applicationVersion,
-                                               categoryName, programName, status.name(), null, null, 100);
+                                               categoryName, programName, status.name(), null, null, 100,
+                                               VersionSelect.LATEST);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Getting workflow history failed");
 
     return responder.decodeResponseContent(RUN_RECORDS_TYPE);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricClient.java
@@ -379,7 +379,7 @@ public class AppFabricClient {
                                getNamespacePath(namespace), application, applicationVersion, categoryName, programName);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
     programLifecycleHttpHandler.programHistory(request, responder, namespace, application, applicationVersion,
-                                               categoryName, programName, status.name(), null, null, 100, null);
+                                               categoryName, programName, status.name(), null, null, 100);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Getting workflow history failed");
 
     return responder.decodeResponseContent(RUN_RECORDS_TYPE);


### PR DESCRIPTION
# [CDAP-19488] extend /app/program/runs and /runcount endpoint for all versions

![image](https://user-images.githubusercontent.com/98125204/197691904-8acf3ce9-e6a8-4297-8539-780b99b49f4e.png)
UI deployed detail page will show "x of y", `x` needs /app/program/runs to fetch all versions, `y` needs /runcount to fetch all versions
corresponding ui pr: https://github.com/cdapio/cdap-ui/pull/687

[CDAP-19488]: https://cdap.atlassian.net/browse/CDAP-19488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ