### PR TITLE
CDAP-19948 & CDAP-19977: return app versions of latest=[true, null], return latest version by default for GET `/apps` endpoint

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -272,10 +272,10 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                          @QueryParam("orderBy") SortOrder orderBy,
                          @QueryParam("nameFilter") String nameFilter,
                          @QueryParam("nameFilterType") NameFilterType nameFilterType,
-                         @QueryParam("latestOnly") Boolean latestOnly,
-                         @QueryParam("sortCreationTime") Boolean sortCreationTime
-      )
-      throws Exception {
+                         @QueryParam("latestOnly") @DefaultValue("true") Boolean latestOnly,
+                         @QueryParam("sortCreationTime") Boolean sortCreationTime)
+    throws Exception {
+
     validateNamespace(namespaceId);
 
     Set<String> names = new HashSet<>();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -606,7 +606,8 @@ public abstract class AppFabricTestBase {
   }
 
   protected List<JsonObject> getAppList(String namespace) throws Exception {
-    HttpResponse response = doGet(getVersionedAPIPath("apps/", Constants.Gateway.API_VERSION_3_TOKEN, namespace));
+    HttpResponse response = doGet(getVersionedAPIPath("apps/?latestOnly=false",
+                                                      Constants.Gateway.API_VERSION_3_TOKEN, namespace));
     assertResponseCode(200, response);
     return readResponse(response, LIST_JSON_OBJECT_TYPE);
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -754,7 +754,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
     isLastPage = false;
     currentResultSize = 0;
     while (!isLastPage) {
-      JsonObject result = getAppListForPaginatedApi(TEST_NAMESPACE1, 3, token, AllProgramsApp.NAME, null, null, null);
+      JsonObject result = getAppListForPaginatedApi(TEST_NAMESPACE1, 3, token, AllProgramsApp.NAME, null, false, null);
       currentResultSize = result.get("applications").getAsJsonArray().size();
       count += currentResultSize;
       token = result.get("nextPageToken") == null ? null : result.get("nextPageToken").getAsString();

--- a/cdap-client-tests/src/test/java/io/cdap/cdap/client/ApplicationClientTestRun.java
+++ b/cdap-client-tests/src/test/java/io/cdap/cdap/client/ApplicationClientTestRun.java
@@ -284,7 +284,6 @@ public class ApplicationClientTestRun extends ClientTestBase {
       ApplicationDetail fakeAppDetail2 = appClient.get(new ApplicationId(NamespaceId.DEFAULT.getNamespace(),
                                                                          FakeApp.NAME, version));
 
-
       // app2 should use fake-0.1.0-SNAPSHOT
       appClient.deploy(appId2, new AppRequest<Config>(new ArtifactSummary("fake", "0.1.0-SNAPSHOT")));
       version = appClient.listAppVersions(NamespaceId.DEFAULT, "fake2").get(0);

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/MetricStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/MetricStructuredTable.java
@@ -178,9 +178,9 @@ public class MetricStructuredTable implements StructuredTable {
   }
 
   @Override
-  public CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Field<?> filterIndex)
+  public CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Collection<Field<?>> filterIndexes)
     throws InvalidFieldException, IOException {
-    return scan(() -> structuredTable.scan(keyRange, limit, filterIndex), "index.range.scan.");
+    return scan(() -> structuredTable.scan(keyRange, limit, filterIndexes), "index.range.scan.");
   }
 
   @Override
@@ -190,9 +190,10 @@ public class MetricStructuredTable implements StructuredTable {
   }
 
   @Override
-  public CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Field<?> filterIndex, SortOrder sortOrder)
+  public CloseableIterator<StructuredRow> scan(Range keyRange, int limit,
+                                               Collection<Field<?>> filterIndexes, SortOrder sortOrder)
     throws InvalidFieldException, IOException {
-    return scan(() -> structuredTable.scan(keyRange, limit, filterIndex, sortOrder),
+    return scan(() -> structuredTable.scan(keyRange, limit, filterIndexes, sortOrder),
                 "sort.index.range.scan.");
   }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
@@ -273,15 +273,16 @@ public final class NoSqlStructuredTable implements StructuredTable {
    * Filtering post table scan.
    * */
   @Override
-  public CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Field<?> filterIndex)
+  public CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Collection<Field<?>> filterIndexes)
     throws InvalidFieldException, IOException {
-    LOG.trace("Table {}: Scan range {} with limit {} and index {}", schema.getTableId(), keyRange, limit, filterIndex);
-    fieldValidator.validateField(filterIndex);
-    if (!schema.isIndexColumn(filterIndex.getName())) {
-      throw new InvalidFieldException(schema.getTableId(), filterIndex.getName(), "is not an indexed column");
+    LOG.trace("Table {}: Scan range {} with limit {} and index {}", schema.getTableId(),
+              keyRange, limit, filterIndexes);
+    filterIndexes.forEach(fieldValidator::validateField);
+    if (!schema.isIndexColumns(filterIndexes.stream().map(Field::getName).collect(Collectors.toList()))) {
+      throw new InvalidFieldException(schema.getTableId(), filterIndexes, "are not all indexed columns");
     }
     FilterByFieldIterator filterByIndexIterator =
-      new FilterByFieldIterator(getFilterByRangeIterator(keyRange), filterIndex, schema);
+      new FilterByFieldIterator(getFilterByRangeIterator(keyRange), filterIndexes, schema);
     return new LimitIterator(Collections.singleton(filterByIndexIterator).iterator(), limit);
   }
 
@@ -683,31 +684,30 @@ public final class NoSqlStructuredTable implements StructuredTable {
   @VisibleForTesting
   static final class FilterByFieldIterator extends AbstractCloseableIterator<StructuredRow> {
     private final CloseableIterator<StructuredRow> scannerIterator;
-    private final Predicate<StructuredRow> predicate;
+    private final StructuredTableSchema schema;
+    private final Collection<Predicate<StructuredRow>> predicates;
 
-    FilterByFieldIterator(CloseableIterator<StructuredRow> scannerIterator, Field<?> filterField,
+    FilterByFieldIterator(CloseableIterator<StructuredRow> scannerIterator, Collection<Field<?>> filterFields,
                           StructuredTableSchema schema) {
       this.scannerIterator = scannerIterator;
+      this.predicates = filterFields.stream().map(this::buildPredicate).collect(Collectors.toList());
+      this.schema = schema;
+    }
 
+    private Predicate<StructuredRow> buildPredicate(Field<?> filterField) {
       switch (filterField.getFieldType()) {
         case INTEGER:
-          predicate = row -> Objects.equals(row.getInteger(filterField.getName()), filterField.getValue());
-          break;
+          return row -> Objects.equals(row.getInteger(filterField.getName()), filterField.getValue());
         case LONG:
-          predicate = row -> Objects.equals(row.getLong(filterField.getName()), filterField.getValue());
-          break;
+          return row -> Objects.equals(row.getLong(filterField.getName()), filterField.getValue());
         case FLOAT:
-          predicate = row -> Objects.equals(row.getFloat(filterField.getName()), filterField.getValue());
-          break;
+          return row -> Objects.equals(row.getFloat(filterField.getName()), filterField.getValue());
         case DOUBLE:
-          predicate = row -> Objects.equals(row.getDouble(filterField.getName()), filterField.getValue());
-          break;
+          return row -> Objects.equals(row.getDouble(filterField.getName()), filterField.getValue());
         case STRING:
-          predicate = row -> Objects.equals(row.getString(filterField.getName()), filterField.getValue());
-          break;
+          return row -> Objects.equals(row.getString(filterField.getName()), filterField.getValue());
         case BYTES:
-          predicate = row -> Arrays.equals(row.getBytes(filterField.getName()), (byte[]) filterField.getValue());
-          break;
+          return row -> Arrays.equals(row.getBytes(filterField.getName()), (byte[]) filterField.getValue());
         default:
           throw new InvalidFieldException(schema.getTableId(), filterField.getName());
       }
@@ -718,8 +718,10 @@ public final class NoSqlStructuredTable implements StructuredTable {
       // Post filtering on scanned rows by specified field
       while (scannerIterator.hasNext()) {
         StructuredRow row = scannerIterator.next();
-        if (predicate.test(row)) {
-          return row;
+        for (Predicate<StructuredRow> predicate : predicates) {
+          if (predicate.test(row)) {
+            return row;
+          }
         }
       }
       return endOfData();

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
@@ -172,7 +172,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
     Field<?> filterIndex = Fields.intField("key", 9);
     List<Integer> actual = new ArrayList<>();
     try (NoSqlStructuredTable.FilterByFieldIterator closeableIterator = new NoSqlStructuredTable.FilterByFieldIterator(
-      (new NoSqlStructuredTable.ScannerIterator(scanner, SCHEMA)), filterIndex, SCHEMA)) {
+      (new NoSqlStructuredTable.ScannerIterator(scanner, SCHEMA)), Collections.singleton(filterIndex), SCHEMA)) {
       while (closeableIterator.hasNext()) {
         actual.add(closeableIterator.next().getInteger("key"));
         Assert.assertFalse(scanner.isClosed());
@@ -190,7 +190,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
     Field<?> filterIndex = Fields.intField("key", 9);
     List<Integer> actual = new ArrayList<>();
     try (NoSqlStructuredTable.FilterByFieldIterator closeableIterator = new NoSqlStructuredTable.FilterByFieldIterator(
-      new NoSqlStructuredTable.ScannerIterator(scanner, SCHEMA), filterIndex, SCHEMA)) {
+      new NoSqlStructuredTable.ScannerIterator(scanner, SCHEMA), Collections.singleton(filterIndex), SCHEMA)) {
       while (closeableIterator.hasNext()) {
         actual.add(closeableIterator.next().getInteger("key"));
         Assert.assertFalse(scanner.isClosed());

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
@@ -158,13 +158,13 @@ public interface StructuredTable extends Closeable {
    *
    * @param keyRange key range for the scan
    * @param limit maximum number of rows to return
-   * @param filterIndex the index to filter upon
+   * @param filterIndexes the indexes to filter upon, OR logic will be applied
    * @return a {@link CloseableIterator} of rows
    * @throws InvalidFieldException if the field is not part of the table schema, or is not an indexed column,
    *                               or the type does not match the schema
    * @throws IOException if there is an error scanning the table
    */
-  default CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Field<?> filterIndex)
+  default CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Collection<Field<?>> filterIndexes)
     throws InvalidFieldException, IOException {
     throw new UnsupportedOperationException("No supported implementation.");
   }
@@ -175,18 +175,19 @@ public interface StructuredTable extends Closeable {
    *
    * @param keyRange key range for the scan
    * @param limit maximum number of rows to return
-   * @param filterIndex the index to filter upon
+   * @param filterIndexes the index to filter upon
    * @param sortOrder defined primary key sort order. Note that the comparator used is specific to the underlying
-   *                  store and is not nessesarily lexographic.
+   *                  store and is not necessarily lexicographic.
    * @return a {@link CloseableIterator} of rows
    * @throws InvalidFieldException if the field is not part of the table schema, or is not an indexed column,
    *                               or the type does not match the schema
    * @throws IOException if there is an error scanning the table
    */
-  default CloseableIterator<StructuredRow> scan(Range keyRange, int limit, Field<?> filterIndex, SortOrder sortOrder)
+  default CloseableIterator<StructuredRow> scan(Range keyRange, int limit,
+                                                Collection<Field<?>> filterIndexes, SortOrder sortOrder)
     throws InvalidFieldException, IOException {
     if (sortOrder == SortOrder.ASC) {
-      return scan(keyRange, limit, filterIndex);
+      return scan(keyRange, limit, filterIndexes);
     }
     throw new UnsupportedOperationException("No supported implementation.");
   }

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/StructuredTableSchema.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/StructuredTableSchema.java
@@ -87,6 +87,16 @@ public class StructuredTableSchema {
   }
 
   /**
+   * Check if the given field names are index columns.
+   *
+   * @param fieldNames the field names to be checked
+   * @return true if this field name is an index column, false otherwise
+   */
+  public boolean isIndexColumns(Collection<String> fieldNames) {
+    return indexes.containsAll(fieldNames);
+  }
+
+  /**
    * Get the field type of the given field name.
    *
    * @param fieldName the field name

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableTest.java
@@ -1071,33 +1071,70 @@ public abstract class StructuredTableTest {
     // Scan by range and index
     getTransactionRunner().run(context -> {
       StructuredTable table = context.getTable(SIMPLE_TABLE);
+      // Scan single index
       try (CloseableIterator<StructuredRow> iterator =
              table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)), Range.Bound.INCLUSIVE,
-                                     Collections.singleton(Fields.intField(KEY, num)), Range.Bound.EXCLUSIVE),
+                                     Collections.singleton(Fields.intField(KEY, num * 2)), Range.Bound.EXCLUSIVE),
                         num * 10,
-                        Fields.stringField(STRING_COL, "abc"))) {
+                        Collections.singletonList(Fields.stringField(STRING_COL, "abc")))) {
         List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
         Assert.assertEquals(expected.subList(0, num), rows);
+      }
+
+      // Scan multiple indexes
+      try (CloseableIterator<StructuredRow> iterator =
+             table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)), Range.Bound.INCLUSIVE,
+                                     Collections.singleton(Fields.intField(KEY, num * 2)), Range.Bound.EXCLUSIVE),
+                        num * 10,
+                        Arrays.asList(Fields.stringField(STRING_COL, "abc"),
+                                      Fields.stringField(STRING_COL, "def")))) {
+        List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
+        Assert.assertEquals(expected.subList(0, num * 2), rows);
+      }
+
+      // Scan multiple indexes with null values
+      try (CloseableIterator<StructuredRow> iterator =
+             table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)), Range.Bound.INCLUSIVE,
+                                     Collections.singleton(Fields.intField(KEY, num * 2)), Range.Bound.EXCLUSIVE),
+                        num * 10,
+                        Arrays.asList(Fields.stringField(STRING_COL, "abc"),
+                                      Fields.longField(IDX_COL, null)))) {
+        List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
+        Assert.assertEquals(expected.subList(0, num * 2), rows);
       }
 
       // Partial primary keys range
       try (CloseableIterator<StructuredRow> iterator =
              table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)),
                                      Range.Bound.INCLUSIVE,
-                                     Arrays.asList(Fields.intField(KEY, num),
-                                                   Fields.longField(KEY2, num * 100L)),
+                                     Arrays.asList(Fields.intField(KEY, num * 2),
+                                                   Fields.longField(KEY2, num * 200L)),
                                      Range.Bound.EXCLUSIVE),
                         num * 10,
-                        Fields.stringField(STRING_COL, "abc"))) {
+                        Collections.singletonList(Fields.stringField(STRING_COL, "abc")))) {
         List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
         Assert.assertEquals(expected.subList(0, num), rows);
+      }
+
+      // Partial primary keys range with multiple indexes
+      try (CloseableIterator<StructuredRow> iterator =
+             table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)),
+                                     Range.Bound.INCLUSIVE,
+                                     Arrays.asList(Fields.intField(KEY, num * 2),
+                                                   Fields.longField(KEY2, num * 200L)),
+                                     Range.Bound.EXCLUSIVE),
+                        num * 10,
+                        Arrays.asList(Fields.stringField(STRING_COL, "abc"),
+                                      Fields.stringField(STRING_COL, "def")))) {
+        List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
+        Assert.assertEquals(expected.subList(0, num * 2), rows);
       }
 
       try (CloseableIterator<StructuredRow> iterator =
              table.scan(Range.create(Collections.singleton(Fields.intField(KEY, num)), Range.Bound.INCLUSIVE,
                                      Collections.singleton(Fields.intField(KEY, num * 2)), Range.Bound.EXCLUSIVE),
                         num * 10,
-                        Fields.stringField(STRING_COL, "def"))) {
+                        Collections.singletonList(Fields.stringField(STRING_COL, "def")))) {
         List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
         Assert.assertEquals(expected.subList(num, 2 * num), rows);
       }
@@ -1107,7 +1144,7 @@ public abstract class StructuredTableTest {
              table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)), Range.Bound.INCLUSIVE,
                                      Collections.singleton(Fields.intField(KEY, num)), Range.Bound.EXCLUSIVE),
                         num * 10,
-                        Fields.stringField(STRING_COL, "def"))) {
+                        Collections.singletonList(Fields.stringField(STRING_COL, "def")))) {
         List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
         Assert.assertEquals(Collections.emptyList(), rows);
       }
@@ -1117,7 +1154,7 @@ public abstract class StructuredTableTest {
              table.scan(Range.create(Collections.singleton(Fields.intField(KEY, num)), Range.Bound.INCLUSIVE,
                                      Collections.singleton(Fields.intField(KEY, num * 2)), Range.Bound.EXCLUSIVE),
                         num * 10,
-                        Fields.stringField(STRING_COL, "non"))) {
+                        Collections.singletonList(Fields.stringField(STRING_COL, "non")))) {
         List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
         Assert.assertEquals(Collections.emptyList(), rows);
       }
@@ -1127,7 +1164,7 @@ public abstract class StructuredTableTest {
         table.scan(Range.create(Collections.singleton(Fields.intField(KEY, num)), Range.Bound.INCLUSIVE,
                                 Collections.singleton(Fields.intField(KEY, num * 2)), Range.Bound.EXCLUSIVE),
                    num * 10,
-                   Fields.longField(LONG_COL, 1L));
+                   Collections.singletonList(Fields.longField(LONG_COL, 1L)));
         Assert.fail("Expected InvalidFieldException for scanning a non-index column");
       } catch (InvalidFieldException e) {
         // Expected
@@ -1255,7 +1292,9 @@ public abstract class StructuredTableTest {
       try (CloseableIterator<StructuredRow> iterator =
              table.scan(Range.create(Collections.singleton(Fields.intField(KEY, num)), Range.Bound.INCLUSIVE,
                                      Collections.singleton(Fields.intField(KEY, num * 3)), Range.Bound.EXCLUSIVE),
-                        num * 10, Fields.longField(IDX_COL, (long) 100), SortOrder.ASC)) {
+                        num * 10,
+                        Collections.singletonList(Fields.longField(IDX_COL, (long) 100)),
+                        SortOrder.ASC)) {
         List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
         List<Collection<Field<?>>> expectedSubList = expected.subList(num, num * 3);
 
@@ -1265,7 +1304,9 @@ public abstract class StructuredTableTest {
       try (CloseableIterator<StructuredRow> iterator =
              table.scan(Range.create(Collections.singleton(Fields.intField(KEY, 0)), Range.Bound.INCLUSIVE,
                                      Collections.singleton(Fields.intField(KEY, num * 2)), Range.Bound.EXCLUSIVE),
-                        num * 10, Fields.longField(IDX_COL, (long) 100), SortOrder.DESC)) {
+                        num * 10,
+                        Collections.singletonList(Fields.longField(IDX_COL, (long) 100)),
+                        SortOrder.DESC)) {
         List<Collection<Field<?>>> rows = convertRowsToFields(iterator, columns);
         List<Collection<Field<?>>> expectedSubList = expected.subList(0, num * 2);
         Collections.reverse(expectedSubList);


### PR DESCRIPTION
What: 

1. For the deployed application list page, we need to display all latest versions: that is latest in ['true', NULL]. latest="false" is excluded specifically this way, ['true', NULL] is latest version for both post-6.8 and pre-6.8 applications
2. Return latest apps by default for GET `/apps` endpoint