### PR TITLE
fix(CDAP-19974&CDAP-19965): When we retrieve the latest version, assign creation time along with latest="false" for pre 6.8 pipeline

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -179,6 +179,15 @@ public interface Store {
   ProgramDescriptor loadProgram(ProgramId program) throws IOException, NotFoundException;
 
   /**
+   * Loads a given versionless program.
+   *
+   * @param programReference reference of the program
+   * @return An instance of {@link ProgramDescriptor} if found.
+   * @throws IOException
+   */
+  ProgramDescriptor loadProgram(ProgramReference programReference) throws IOException, NotFoundException;
+
+  /**
    * Fetches run records for particular program.
    * Returned ProgramRunRecords are sorted by their startTime.
    *

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -234,10 +234,7 @@ public class AppMetadataStore {
   }
 
   /**
-   * Gets the {@link ApplicationMeta} of the given application. If the application version is
-   * {@link ApplicationId#DEFAULT_VERSION}, the latest version of the application will be returned.
-   * If no latest version was found due to legacy app deployment, the one with version equals to
-   * {@link ApplicationId#DEFAULT_VERSION} will be returned.
+   * Gets the {@link ApplicationMeta} of the given application.
    *
    * @param appId the application ID to get the metadata
    * @return the {@link ApplicationMeta} of the given application id, or {@code null} if no such application was found.
@@ -245,10 +242,6 @@ public class AppMetadataStore {
    */
   @Nullable
   public ApplicationMeta getApplication(ApplicationId appId) throws IOException {
-    if (ApplicationId.DEFAULT_VERSION.equals(appId.getVersion())) {
-      return getLatest(appId.getNamespaceId(), appId.getApplication());
-    }
-
     List<Field<?>> fields = getApplicationPrimaryKeys(appId);
     return getApplicationSpecificationTable().read(fields)
       .map(this::decodeRow)
@@ -390,8 +383,8 @@ public class AppMetadataStore {
   }
 
   @Nullable
-  public ApplicationMeta getLatest(NamespaceId namespaceId, String appName) throws IOException {
-    Range range = getNamespaceAndApplicationRange(namespaceId.getNamespace(), appName);
+  public ApplicationMeta getLatest(ApplicationReference appReference) throws IOException {
+    Range range = getNamespaceAndApplicationRange(appReference.getNamespace(), appReference.getApplication());
     // scan based on: latest field set to true
     Field<?> indexField = Fields.stringField(StoreDefinition.AppMetadataStore.LATEST_FIELD, "true");
     StructuredTable appSpecTable = getApplicationSpecificationTable();
@@ -406,7 +399,7 @@ public class AppMetadataStore {
 
     // To handle apps added prior to 6.8.0, which have latest = null in the table, we treat
     // the -SNAPSHOT version as the latest.
-    List<Field<?>> fields = getApplicationPrimaryKeys(namespaceId.app(appName));
+    List<Field<?>> fields = getApplicationPrimaryKeys(appReference.app(ApplicationId.DEFAULT_VERSION));
     ApplicationMeta appMeta = appSpecTable.read(fields).map(this::decodeRow).orElse(null);
     if (appMeta != null) {
       return appMeta;
@@ -577,18 +570,24 @@ public class AppMetadataStore {
     String parentVersion = Optional.ofNullable(appMeta.getChange()).map(ChangeDetail::getParentVersion).orElse(null);
 
     // Fetch the latest version
-    ApplicationMeta latest = getLatest(id.getNamespaceId(), id.getApplication());
+    ApplicationMeta latest = getLatest(id.getAppReference());
     String latestVersion = latest == null ? null : latest.getSpec().getAppVersion();
     if (!deployAppAllowed(parentVersion, latest)) {
       throw new ConflictException(String.format("Cannot deploy the application because parent version '%s' does not " +
-                                                  "match the latest version '%s'.",
-                                                parentVersion,
-                                                latestVersion));
+                                                  "match the latest version '%s'.", parentVersion, latestVersion));
     }
     // When the app does not exist, it is not an edit
     if (latest != null) {
       List<Field<?>> fields = getApplicationPrimaryKeys(id.getNamespace(), id.getApplication(),
                                                         latest.getSpec().getAppVersion());
+      // Assign a creation time if it's null for the previous latest app version
+      // It is for the pre-6.8 application, we mark it as past version (like created 1s ago)
+      // So it's sortable on creation time, especially when UI displays the version history for a pipeline
+      if (latest.getChange() == null) {
+        // appMeta.getChange() should never be null in edit case
+        fields.add(Fields.longField(StoreDefinition.AppMetadataStore.CREATION_TIME_FIELD,
+                                    appMeta.getChange().getCreationTimeMillis() - 1000));
+      }
       fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.LATEST_FIELD, "false"));
       getApplicationSpecificationTable().upsert(fields);
     }
@@ -598,9 +597,9 @@ public class AppMetadataStore {
 
   @VisibleForTesting
   void writeApplication(String namespaceId, String appId, String versionId,
-                        ApplicationSpecification spec, ChangeDetail change) throws IOException {
-    writeApplicationSerialized(namespaceId, appId, versionId, GSON.toJson(new ApplicationMeta(appId, spec, null)),
-                               change.getCreationTimeMillis(), change.getAuthor(), change.getDescription());
+                               ApplicationSpecification spec, @Nullable ChangeDetail change) throws IOException {
+    writeApplicationSerialized(namespaceId, appId, versionId,
+                               GSON.toJson(new ApplicationMeta(appId, spec, null)), change);
   }
 
   /**
@@ -2084,9 +2083,8 @@ public class AppMetadataStore {
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD, appId.getNamespace()));
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_FIELD, appId.getApplication()));
     ApplicationMeta applicationMeta = getApplication(appId);
-    Long creationTime = applicationMeta.getChange() != null ?
-      applicationMeta.getChange().getCreationTimeMillis() :
-      null;
+    Long creationTime = (applicationMeta == null || applicationMeta.getChange() == null)
+      ? null : applicationMeta.getChange().getCreationTimeMillis();
     fields.add(Fields.longField(StoreDefinition.AppMetadataStore.CREATION_TIME_FIELD, creationTime));
     return fields;
   }
@@ -2103,16 +2101,18 @@ public class AppMetadataStore {
         Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_FIELD, applicationId)));
   }
 
-  private void writeApplicationSerialized(String namespaceId, String appId, String versionId, String serialized,
-                                          long creationTimeMillis, @Nullable String author,
-                                          @Nullable String changeSummary)
+  private void writeApplicationSerialized(String namespaceId, String appId, String versionId,
+                                          String serialized, @Nullable ChangeDetail change)
     throws IOException {
     List<Field<?>> fields = getApplicationPrimaryKeys(namespaceId, appId, versionId);
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD, serialized));
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.AUTHOR_FIELD, author));
-    fields.add(Fields.longField(StoreDefinition.AppMetadataStore.CREATION_TIME_FIELD, creationTimeMillis));
+    if (change != null) {
+      fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.AUTHOR_FIELD, change.getAuthor()));
+      fields.add(Fields.longField(StoreDefinition.AppMetadataStore.CREATION_TIME_FIELD,
+                                  change.getCreationTimeMillis()));
+      fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.CHANGE_SUMMARY_FIELD, change.getDescription()));
+    }
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.LATEST_FIELD, "true"));
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.CHANGE_SUMMARY_FIELD, changeSummary));
     getApplicationSpecificationTable().upsert(fields);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -157,6 +157,22 @@ public class DefaultStore implements Store {
   }
 
   @Override
+  public ProgramDescriptor loadProgram(ProgramReference ref) throws NotFoundException {
+    ApplicationMeta appMeta = TransactionRunners.run(transactionRunner, context -> {
+      return getAppMetadataStore(context).getLatest(ref.getParent());
+    });
+
+    if (appMeta == null) {
+      throw new ApplicationNotFoundException(ref.getParent().app(ApplicationId.DEFAULT_VERSION));
+    }
+
+    ProgramId id = ref.id(appMeta.getSpec().getAppVersion());
+
+    Store.ensureProgramExists(id, appMeta.getSpec());
+    return new ProgramDescriptor(id, appMeta.getSpec());
+  }
+
+  @Override
   public void setProvisioning(ProgramRunId id, Map<String, String> runtimeArgs,
                               Map<String, String> systemArgs, byte[] sourceId, ArtifactId artifactId) {
     TransactionRunners.run(transactionRunner, context -> {
@@ -294,7 +310,7 @@ public class DefaultStore implements Store {
   public WorkflowStatistics getWorkflowStatistics(NamespaceId namespaceId, String appName, String workflowName,
                                                   long startTime, long endTime, List<Double> percentiles) {
     return TransactionRunners.run(transactionRunner, context -> {
-      ApplicationMeta latestAppMeta = getAppMetadataStore(context).getLatest(namespaceId, appName);
+      ApplicationMeta latestAppMeta = getAppMetadataStore(context).getLatest(namespaceId.appReference(appName));
       if (latestAppMeta == null) {
         // if app is not found then there is no workflow stats
         return null;
@@ -316,7 +332,7 @@ public class DefaultStore implements Store {
   public WorkflowTable.WorkflowRunRecord getWorkflowRun(NamespaceId namespaceId, String appName, String workflowName,
                                                         String runId) {
     return TransactionRunners.run(transactionRunner, context -> {
-      ApplicationMeta latestAppMeta = getAppMetadataStore(context).getLatest(namespaceId, appName);
+      ApplicationMeta latestAppMeta = getAppMetadataStore(context).getLatest(namespaceId.appReference(appName));
       if (latestAppMeta == null) {
         throw new ApplicationNotFoundException(namespaceId.app(appName));
       }
@@ -331,7 +347,7 @@ public class DefaultStore implements Store {
                                                                            String program, String runId, int limit,
                                                                            long timeInterval) {
     return  TransactionRunners.run(transactionRunner, context -> {
-      ApplicationMeta latestAppMeta = getAppMetadataStore(context).getLatest(namespaceId, appName);
+      ApplicationMeta latestAppMeta = getAppMetadataStore(context).getLatest(namespaceId.appReference(appName));
       if (latestAppMeta == null) {
         throw new ApplicationNotFoundException(namespaceId.app(appName));
       }
@@ -528,7 +544,6 @@ public class DefaultStore implements Store {
                                                                      instances, workerSpec.getPlugins());
       ApplicationSpecification newAppSpec = replaceWorkerInAppSpec(appSpec, id, newSpecification);
       metaStore.updateAppSpec(id.getParent(), newAppSpec);
-
     });
 
     LOG.trace("Setting program instances: namespace: {}, application: {}, worker: {}, new instances count: {}",
@@ -753,7 +768,7 @@ public class DefaultStore implements Store {
   @Nullable
   public ApplicationMeta getLatest(NamespaceId namespace, String appName) {
     return TransactionRunners.run(transactionRunner, context -> {
-      return getAppMetadataStore(context).getLatest(namespace, appName);
+      return getAppMetadataStore(context).getLatest(namespace.appReference(appName));
     });
   }
 
@@ -795,7 +810,9 @@ public class DefaultStore implements Store {
   @Nullable
   private ApplicationMeta getApplicationMeta(AppMetadataStore mds,
                                              ApplicationId id) throws IOException, TableNotFoundException {
-    return mds.getApplication(id);
+    // TODO: more refactor the mapping of "-SNAPSHOT" to latest in CDAP-20033
+    return ApplicationId.DEFAULT_VERSION.equals(id.getVersion())
+      ? mds.getLatest(id.getAppReference()) : mds.getApplication(id);
   }
 
   private static ApplicationSpecification replaceServiceSpec(ApplicationSpecification appSpec,
@@ -1004,7 +1021,7 @@ public class DefaultStore implements Store {
                                        NamespaceId namespaceId,
                                        String appName) throws ApplicationNotFoundException, IOException {
     // Check if app exists
-    ApplicationMeta latest = getAppMetadataStore(context).getLatest(namespaceId, appName);
+    ApplicationMeta latest = getAppMetadataStore(context).getLatest(namespaceId.appReference(appName));
     if (latest == null || latest.getSpec() == null) {
       throw new ApplicationNotFoundException(namespaceId.app(appName));
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/CoreSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/CoreSchedulerService.java
@@ -564,7 +564,9 @@ public class CoreSchedulerService extends AbstractIdleService implements Schedul
     // add artifact id to the schedule property
     ProgramDescriptor programDescriptor;
     try {
-      programDescriptor = appMetaStore.loadProgram(schedule.getProgramId());
+      // Since schedule is versionless (always has "-SNAPSHOT" version)
+      // We call with ProgramReference
+      programDescriptor = appMetaStore.loadProgram(schedule.getProgramId().getProgramReference());
     } catch (Exception e) {
       LOG.error("Exception occurs when looking up program descriptor for program {} in schedule {}",
                 schedule.getProgramId(), schedule, e);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -116,6 +116,7 @@ import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
 import io.cdap.cdap.security.spi.authentication.UnauthenticatedException;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.metadata.MetadataMutation;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.store.StoreDefinition;
@@ -196,6 +197,7 @@ public abstract class AppFabricTestBase {
 
   protected static final String VERSION1 = "1.0.0";
   protected static final String VERSION2 = "2.0.0";
+  protected static TransactionRunner transactionRunner;
 
   private static Injector injector;
 
@@ -287,6 +289,7 @@ public abstract class AppFabricTestBase {
     metadataClient = new MetadataClient(getClientConfig(discoveryClient, Constants.Service.METADATA_SERVICE));
     metadataServiceClient = new DefaultMetadataServiceClient(remoteClientFactory);
     metricStore = injector.getInstance(MetricStore.class);
+    transactionRunner = injector.getInstance(TransactionRunner.class);
 
     Scheduler programScheduler = injector.getInstance(Scheduler.class);
     // Wait for the scheduler to be functional.

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ApplicationReference.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ApplicationReference.java
@@ -40,6 +40,10 @@ public class ApplicationReference extends NamespacedEntityId implements Parented
     this.application = application;
   }
 
+  public ApplicationReference(NamespaceId namespace, String application) {
+    this(namespace.getNamespace(), application);
+  }
+
   public String getApplication() {
     return application;
   }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/NamespaceId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/NamespaceId.java
@@ -56,6 +56,10 @@ public class NamespaceId extends NamespacedEntityId {
     return new ApplicationId(namespace, application);
   }
 
+  public ApplicationReference appReference(String application) {
+    return new ApplicationReference(namespace, application);
+  }
+
   public ApplicationId app(String application, String version) {
     return new ApplicationId(namespace, application, version);
   }


### PR DESCRIPTION
What:

1. Assign creation time along with latest="false" for pre 6.8 "latest" pipeline, this could help fix the history versions UI bug that null created version always shows on top
2. In version history pagination, we should get the actual app instead of implicitly pointing "-SNAPSHOT" to latest. Otherwise the pagination is totally broken

example: null value creationTime version always on top of list
<img width="995" alt="image" src="https://user-images.githubusercontent.com/20428112/198496880-a4e9659d-44ae-4268-9adc-6be0942395de.png">