### PR TITLE
CDAP-19635 - Retry on failures for streaming pipelines

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpec.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.etl.api.Engine;
 import io.cdap.cdap.etl.proto.Connection;
 import io.cdap.cdap.etl.proto.v2.spec.PipelineSpec;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.streaming.StreamingRetrySettings;
 
 import java.util.Map;
 import java.util.Objects;
@@ -40,6 +41,8 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
   @Deprecated
   private final String checkpointDirectory;
   private final String pipelineId;
+  private final StreamingRetrySettings streamingRetrySettings;
+
   private final DataStreamsStateSpec stateSpec;
 
   private DataStreamsPipelineSpec(Set<StageSpec> stages, Set<Connection> connections,
@@ -49,7 +52,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
                                   boolean stopGracefully, Map<String, String> properties,
                                   boolean checkpointsDisabled, boolean isUnitTest, String checkpointDirectory,
                                   String pipelineId, Set<String> connectionsUsed, Engine engine,
-                                  DataStreamsStateSpec stateSpec) {
+                                  DataStreamsStateSpec stateSpec, StreamingRetrySettings streamingRetrySettings) {
     super(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled, processTimingEnabled,
           numOfRecordsPreview, properties, connectionsUsed, engine);
     this.batchIntervalMillis = batchIntervalMillis;
@@ -60,6 +63,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
     this.checkpointDirectory = checkpointDirectory;
     this.pipelineId = pipelineId;
     this.stateSpec = stateSpec;
+    this.streamingRetrySettings = streamingRetrySettings;
   }
 
   public long getBatchIntervalMillis() {
@@ -92,6 +96,10 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
 
   public DataStreamsStateSpec getStateSpec() {
     return stateSpec;
+  }
+
+  public StreamingRetrySettings getStreamingRetrySettings() {
+    return streamingRetrySettings;
   }
 
   @Override
@@ -157,6 +165,7 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
     private boolean isUnitTest;
     private String checkpointDirectory;
     private String pipelineId;
+    private StreamingRetrySettings streamingRetrySettings;
     private DataStreamsStateSpec stateSpec;
 
     public Builder(long batchIntervalMillis) {
@@ -203,13 +212,18 @@ public class DataStreamsPipelineSpec extends PipelineSpec {
       return this;
     }
 
+    public Builder setStreamingRetrySettings(StreamingRetrySettings streamingRetrySettings) {
+      this.streamingRetrySettings = streamingRetrySettings;
+      return this;
+    }
+
     @Override
     public DataStreamsPipelineSpec build() {
       return new DataStreamsPipelineSpec(stages, connections, resources, driverResources, clientResources,
                                          stageLoggingEnabled, processTimingEnabled, batchIntervalMillis, extraJavaOpts,
                                          numOfRecordsPreview, stopGracefully, properties,
                                          checkpointsDisabled, isUnitTest, checkpointDirectory, pipelineId,
-                                         connectionsUsed, Engine.SPARK, stateSpec);
+                                         connectionsUsed, Engine.SPARK, stateSpec, streamingRetrySettings);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGeneratorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/test/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGeneratorTest.java
@@ -26,11 +26,13 @@ import io.cdap.cdap.etl.api.batch.BatchSink;
 import io.cdap.cdap.etl.api.batch.SparkSink;
 import io.cdap.cdap.etl.api.streaming.StreamingSource;
 import io.cdap.cdap.etl.api.streaming.Windower;
+import io.cdap.cdap.etl.common.Constants;
 import io.cdap.cdap.etl.mock.spark.streaming.MockSink;
 import io.cdap.cdap.etl.mock.spark.streaming.MockSource;
 import io.cdap.cdap.etl.proto.v2.DataStreamsConfig;
 import io.cdap.cdap.etl.proto.v2.ETLPlugin;
 import io.cdap.cdap.etl.proto.v2.ETLStage;
+import io.cdap.cdap.etl.spark.streaming.StreamingRetrySettings;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -87,11 +89,26 @@ public class DataStreamsPipelineSpecGeneratorTest {
         return true;
       }
     };
+    RuntimeConfigurer runtimeConfigurer = getTestRuntimeConfigurer(
+      Collections.singletonMap("cdap.streaming.atleastonce.enabled", "false"));
+    DataStreamsPipelineSpecGenerator specGenerator = new DataStreamsPipelineSpecGenerator("test", null,
+                                                                                          runtimeConfigurer,
+                                                                                          SOURCE_PLUGIN_TYPES,
+                                                                                          SINK_PLUGIN_TYPES,
+                                                                                          featureFlagsProvider);
+    specGenerator.configureSourcePlugin("source", new MockStateHandlerSource(new MockSource.Conf()), null, null);
+    specGenerator.configureAtleastOnceMode(etlConfig, builder);
+
+    DataStreamsPipelineSpec pipelineSpec = builder.build();
+    Assert.assertTrue(pipelineSpec.getStateSpec().getMode() == DataStreamsStateSpec.Mode.NONE);
+  }
+
+  private RuntimeConfigurer getTestRuntimeConfigurer(Map<String, String> runTimeArgumentsMap) {
     RuntimeConfigurer runtimeConfigurer = new RuntimeConfigurer() {
 
       @Override
       public Map<String, String> getRuntimeArguments() {
-        return Collections.singletonMap("cdap.streaming.atleastonce.enabled", "false");
+        return runTimeArgumentsMap;
       }
 
       @Nullable
@@ -112,16 +129,7 @@ public class DataStreamsPipelineSpecGeneratorTest {
         return null;
       }
     };
-    DataStreamsPipelineSpecGenerator specGenerator = new DataStreamsPipelineSpecGenerator("test", null,
-                                                                                          runtimeConfigurer,
-                                                                                          SOURCE_PLUGIN_TYPES,
-                                                                                          SINK_PLUGIN_TYPES,
-                                                                                          featureFlagsProvider);
-    specGenerator.configureSourcePlugin("source", new MockStateHandlerSource(new MockSource.Conf()), null, null);
-    specGenerator.configureAtleastOnceMode(etlConfig, builder);
-
-    DataStreamsPipelineSpec pipelineSpec = builder.build();
-    Assert.assertTrue(pipelineSpec.getStateSpec().getMode() == DataStreamsStateSpec.Mode.NONE);
+    return runtimeConfigurer;
   }
 
   @Test
@@ -199,5 +207,53 @@ public class DataStreamsPipelineSpecGeneratorTest {
     return DataStreamsConfig.builder().addStage(new ETLStage("source", plugin))
       .addStage(new ETLStage("sink", MockSink.getPlugin("${tablename}"))).addConnection("source", "sink")
       .setCheckpointDir(null).setBatchInterval("1s").build();
+  }
+
+  @Test
+  public void testConfigureRetriesDefault() throws IOException {
+    DataStreamsConfig etlConfig = DataStreamsConfig.builder()
+      .addStage(new ETLStage("source", MockStateHandlerSource.getPlugin(schema, new ArrayList<>())))
+      .addStage(new ETLStage("sink", MockSink.getPlugin("${tablename}")))
+      .addConnection("source", "sink")
+      .setBatchInterval("1s").build();
+    DataStreamsPipelineSpec.Builder builder = DataStreamsPipelineSpec.builder(System.currentTimeMillis(), "test-id");
+    RuntimeConfigurer mockRuntimeConfigurer = getTestRuntimeConfigurer(Collections.emptyMap());
+    DataStreamsPipelineSpecGenerator specGenerator = new DataStreamsPipelineSpecGenerator("test", null,
+                                                                                          mockRuntimeConfigurer,
+                                                                                          SOURCE_PLUGIN_TYPES,
+                                                                                          SINK_PLUGIN_TYPES,
+                                                                                          null);
+    specGenerator.configureRetries(builder);
+    DataStreamsPipelineSpec pipelineSpec = builder.build();
+    StreamingRetrySettings streamingRetrySettings = pipelineSpec.getStreamingRetrySettings();
+    Assert.assertEquals(360L, streamingRetrySettings.getMaxRetryTimeInMins());
+    Assert.assertEquals(1L, streamingRetrySettings.getBaseDelayInSeconds());
+    Assert.assertEquals(60L, streamingRetrySettings.getMaxDelayInSeconds());
+  }
+
+  @Test
+  public void testConfigureRetries() throws IOException {
+    DataStreamsConfig etlConfig = DataStreamsConfig.builder()
+      .addStage(new ETLStage("source", MockStateHandlerSource.getPlugin(schema, new ArrayList<>())))
+      .addStage(new ETLStage("sink", MockSink.getPlugin("${tablename}")))
+      .addConnection("source", "sink")
+      .setBatchInterval("1s").build();
+    DataStreamsPipelineSpec.Builder builder = DataStreamsPipelineSpec.builder(System.currentTimeMillis(), "test-id");
+    Map<String, String> runtimeArgs = new HashMap<>();
+    runtimeArgs.put(Constants.CDAP_STREAMING_MAX_RETRY_TIME_IN_MINS, "60");
+    runtimeArgs.put(Constants.CDAP_STREAMING_BASE_RETRY_DELAY_IN_SECONDS, "10");
+    runtimeArgs.put(Constants.CDAP_STREAMING_MAX_RETRY_DELAY_IN_SECONDS, "100");
+    RuntimeConfigurer mockRuntimeConfigurer = getTestRuntimeConfigurer(runtimeArgs);
+    DataStreamsPipelineSpecGenerator specGenerator = new DataStreamsPipelineSpecGenerator("test", null,
+                                                                                          mockRuntimeConfigurer,
+                                                                                          SOURCE_PLUGIN_TYPES,
+                                                                                          SINK_PLUGIN_TYPES,
+                                                                                          null);
+    specGenerator.configureRetries(builder);
+    DataStreamsPipelineSpec pipelineSpec = builder.build();
+    StreamingRetrySettings streamingRetrySettings = pipelineSpec.getStreamingRetrySettings();
+    Assert.assertEquals(60L, streamingRetrySettings.getMaxRetryTimeInMins());
+    Assert.assertEquals(10L, streamingRetrySettings.getBaseDelayInSeconds());
+    Assert.assertEquals(100L, streamingRetrySettings.getMaxDelayInSeconds());
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
@@ -44,6 +44,12 @@ public final class Constants {
   public static final String DEFAULT_CACHING_STORAGE_LEVEL = "DISK_ONLY";
   // Can be used as a runtime argument for streaming pipeline to disable at least once processing.
   public static final String CDAP_STREAMING_ATLEASTONCE_ENABLED = "cdap.streaming.atleastonce.enabled";
+  // Can be used as a runtime argument for streaming pipeline to set max retry time in minutes
+  public static final String CDAP_STREAMING_MAX_RETRY_TIME_IN_MINS = "cdap.streaming.maxRetryTimeInMins";
+  // Can be used as a runtime argument for streaming pipeline to set base retry delay in seconds
+  public static final String CDAP_STREAMING_BASE_RETRY_DELAY_IN_SECONDS = "cdap.streaming.baseRetryDelayInSeconds";
+  // Can be used as a runtime argument for streaming pipeline to set max retry delay in seconds
+  public static final String CDAP_STREAMING_MAX_RETRY_DELAY_IN_SECONDS = "cdap.streaming.maxRetryDelayInSeconds";
 
   private Constants() {
     throw new AssertionError("Suppress default constructor for noninstantiability");

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
@@ -72,14 +72,17 @@ public class DStreamCollection<T> implements SparkCollection<T> {
 
   private final JavaSparkExecutionContext sec;
   private final JavaDStream<T> stream;
+  private final StreamingRetrySettings streamingRetrySettings;
   private final FunctionCache.Factory functionCacheFactory;
 
   public DStreamCollection(JavaSparkExecutionContext sec,
                            FunctionCache.Factory functionCacheFactory,
-                           JavaDStream<T> stream) {
+                           JavaDStream<T> stream,
+                           StreamingRetrySettings streamingRetrySettings) {
     this.sec = sec;
     this.functionCacheFactory = functionCacheFactory;
     this.stream = stream;
+    this.streamingRetrySettings = streamingRetrySettings;
   }
 
   @SuppressWarnings("unchecked")
@@ -136,7 +139,8 @@ public class DStreamCollection<T> implements SparkCollection<T> {
 
   @Override
   public <K, V> SparkPairCollection<K, V> flatMapToPair(PairFlatMapFunction<T, K, V> function) {
-    return new PairDStreamCollection<>(sec, functionCacheFactory, stream.flatMapToPair(function));
+    return new PairDStreamCollection<>(sec, functionCacheFactory, stream.flatMapToPair(function),
+                                       streamingRetrySettings);
   }
 
   @Override
@@ -182,7 +186,8 @@ public class DStreamCollection<T> implements SparkCollection<T> {
     return new Runnable() {
       @Override
       public void run() {
-        stream.foreachRDD(new StreamingBatchSinkFunction<T>(sec, stageSpec, functionCacheFactory.newCache()));
+        stream.foreachRDD(new StreamingBatchSinkFunction<T>(sec, stageSpec, functionCacheFactory.newCache(),
+                                                            streamingRetrySettings));
       }
     };
   }
@@ -194,7 +199,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
       @Override
       public void run() {
         ((JavaDStream<RecordInfo<Object>>) stream).foreachRDD(
-              new StreamingMultiSinkFunction(sec, phaseSpec, group, sinks, collectors));
+              new StreamingMultiSinkFunction(sec, phaseSpec, group, sinks, collectors, streamingRetrySettings));
       }
     };
   }
@@ -204,7 +209,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
     return new Runnable() {
       @Override
       public void run() {
-        stream.foreachRDD(new StreamingSparkSinkFunction<T>(sec, stageSpec));
+        stream.foreachRDD(new StreamingSparkSinkFunction<T>(sec, stageSpec, streamingRetrySettings));
       }
     };
   }
@@ -236,6 +241,6 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   }
 
   private <U> SparkCollection<U> wrap(JavaDStream<U> stream) {
-    return new DStreamCollection<>(sec, functionCacheFactory, stream);
+    return new DStreamCollection<>(sec, functionCacheFactory, stream, streamingRetrySettings);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/PairDStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/PairDStreamCollection.java
@@ -36,13 +36,16 @@ public class PairDStreamCollection<K, V> implements SparkPairCollection<K, V> {
   private final JavaSparkExecutionContext sec;
   private final FunctionCache.Factory functionCacheFactory;
   private final JavaPairDStream<K, V> pairStream;
+  private final StreamingRetrySettings streamingRetrySettings;
 
   public PairDStreamCollection(JavaSparkExecutionContext sec,
                                FunctionCache.Factory functionCacheFactory,
-                               JavaPairDStream<K, V> pairStream) {
+                               JavaPairDStream<K, V> pairStream,
+                               StreamingRetrySettings streamingRetrySettings) {
     this.sec = sec;
     this.functionCacheFactory = functionCacheFactory;
     this.pairStream = pairStream;
+    this.streamingRetrySettings = streamingRetrySettings;
   }
 
   @SuppressWarnings("unchecked")
@@ -53,7 +56,7 @@ public class PairDStreamCollection<K, V> implements SparkPairCollection<K, V> {
 
   @Override
   public <T> SparkCollection<T> flatMap(FlatMapFunction<Tuple2<K, V>, T> function) {
-    return new DStreamCollection<>(sec, functionCacheFactory, pairStream.flatMap(function));
+    return new DStreamCollection<>(sec, functionCacheFactory, pairStream.flatMap(function), streamingRetrySettings);
   }
 
   @Override
@@ -102,6 +105,6 @@ public class PairDStreamCollection<K, V> implements SparkPairCollection<K, V> {
   }
 
   private <T, U> PairDStreamCollection<T, U> wrap(JavaPairDStream<T, U> pairStream) {
-    return new PairDStreamCollection<>(sec, functionCacheFactory, pairStream);
+    return new PairDStreamCollection<>(sec, functionCacheFactory, pairStream, streamingRetrySettings);
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/StreamingRetrySettings.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/StreamingRetrySettings.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.streaming;
+
+/**
+ * Class for holding various retry settings
+ */
+public class StreamingRetrySettings {
+  private final long maxRetryTimeInMins;
+  private final long baseDelayInSeconds;
+  private final long maxDelayInSeconds;
+
+  public StreamingRetrySettings(long maxRetryTimeInMins, long baseDelayInSeconds, long maxDelayInSeconds) {
+    this.maxRetryTimeInMins = maxRetryTimeInMins;
+    this.baseDelayInSeconds = baseDelayInSeconds;
+    this.maxDelayInSeconds = maxDelayInSeconds;
+  }
+
+  public long getMaxRetryTimeInMins() {
+    return maxRetryTimeInMins;
+  }
+
+  public long getBaseDelayInSeconds() {
+    return baseDelayInSeconds;
+  }
+
+  public long getMaxDelayInSeconds() {
+    return maxDelayInSeconds;
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/AbstractStreamingSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/AbstractStreamingSinkFunction.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.streaming.function;
+
+import io.cdap.cdap.api.retry.RetryFailedException;
+import io.cdap.cdap.etl.spark.streaming.StreamingRetrySettings;
+import org.apache.spark.api.java.function.VoidFunction2;
+import org.apache.spark.streaming.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Abstract class implementing {@link VoidFunction2} that retries the function call based on
+ * {@link StreamingRetrySettings}
+ *
+ * @param <S>
+ */
+public abstract class AbstractStreamingSinkFunction<S> implements VoidFunction2<S, Time> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractStreamingSinkFunction.class);
+  private final long maxRetryTimeInMillis;
+  private final long baseDelayInMillis;
+  private final long maxDelayInMillis;
+
+  protected AbstractStreamingSinkFunction(StreamingRetrySettings streamingRetrySettings) {
+    this.maxRetryTimeInMillis = TimeUnit.MILLISECONDS.convert(streamingRetrySettings.getMaxRetryTimeInMins(),
+                                                              TimeUnit.MINUTES);
+    this.baseDelayInMillis = TimeUnit.MILLISECONDS.convert(streamingRetrySettings.getBaseDelayInSeconds(),
+                                                           TimeUnit.SECONDS);
+    this.maxDelayInMillis = TimeUnit.MILLISECONDS.convert(streamingRetrySettings.getMaxDelayInSeconds(),
+                                                          TimeUnit.SECONDS);
+    LOG.info("Retry settings in millis : {} , {} ,  {} ", maxRetryTimeInMillis, baseDelayInMillis, maxDelayInMillis);
+  }
+
+  @Override
+  public void call(S v1, Time time) throws Exception {
+    int attempt = 1;
+    long startTimeInMillis = System.currentTimeMillis();
+    while (true) {
+      try {
+        retryableCall(v1, time);
+        LOG.debug("Returning successfully.");
+        return;
+      } catch (Exception e) {
+        long delay = getDelay(maxDelayInMillis, baseDelayInMillis, attempt);
+        if (System.currentTimeMillis() - startTimeInMillis > maxRetryTimeInMillis) {
+          LOG.info("Exceeded maximum retry time limit.");
+          throw e;
+        }
+        LOG.warn("Exception thrown while executing runnable with sinks {} on attempt {}. Retrying in {} ms.",
+                 getSinkNames(), attempt++, delay, e);
+        try {
+          TimeUnit.MILLISECONDS.sleep(delay);
+        } catch (InterruptedException ie) {
+          e.addSuppressed(ie);
+          Thread.currentThread().interrupt();
+          e.addSuppressed(new RetryFailedException("Retry failed. Thread got interrupted.", attempt));
+          throw e;
+        }
+      }
+    }
+  }
+
+  private long getDelay(long maxDelayInMillis, long baseDelayInMillis, int attempt) {
+    long power = attempt > Long.SIZE ? Long.MAX_VALUE : (1L << attempt - 1);
+    long delay = Math.min(baseDelayInMillis * power, maxDelayInMillis);
+    delay = delay < 0 ? maxDelayInMillis : delay;
+    return delay;
+  }
+
+  /**
+   * For the sub classes to override
+   *
+   * @param v1 Type parameter that the subclass is using
+   * @param v2 Time for the batch
+   * @throws Exception
+   */
+  protected abstract void retryableCall(S v1, Time v2) throws Exception;
+
+  /**
+   * Sinks used in this function
+   * @return
+   */
+  protected abstract Set<String> getSinkNames();
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/streaming/function/AbstractStreamingSinkFunctionTest.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/streaming/function/AbstractStreamingSinkFunctionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.streaming.function;
+
+import io.cdap.cdap.etl.spark.streaming.StreamingRetrySettings;
+import org.apache.spark.streaming.Time;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tests for {@link AbstractStreamingSinkFunction}
+ */
+public class AbstractStreamingSinkFunctionTest {
+
+  @Test
+  public void testRetry() throws Exception {
+    AtomicInteger attempt = new AtomicInteger(1);
+    StreamingRetrySettings streamingRetrySettings = new StreamingRetrySettings(2L, 1L, 10L);
+    AbstractStreamingSinkFunction<Object> testFunction =
+      new AbstractStreamingSinkFunction<Object>(streamingRetrySettings) {
+        @Override
+        protected Set<String> getSinkNames() {
+          return Collections.singleton("test-recovering-sink");
+        }
+
+        @Override
+        protected void retryableCall(Object v1, Time v2) throws Exception {
+          if (attempt.getAndIncrement() < 1) {
+            throw new RuntimeException("test exception");
+          }
+        }
+      };
+    // Should run without throwing exception
+    testFunction.call(null, Time.apply(System.currentTimeMillis()));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testRetryTimeout() throws Exception {
+    StreamingRetrySettings streamingRetrySettings = new StreamingRetrySettings(2L, 1L, 10L);
+    long startTime = System.currentTimeMillis();
+    AbstractStreamingSinkFunction<Object> testFunction =
+      new AbstractStreamingSinkFunction<Object>(streamingRetrySettings) {
+        @Override
+        protected Set<String> getSinkNames() {
+          return Collections.singleton("test-sink");
+        }
+
+        @Override
+        protected void retryableCall(Object v1, Time v2) throws Exception {
+          if (System.currentTimeMillis() - startTime > TimeUnit.MINUTES.toMillis(3)) {
+            return;
+          }
+          throw new RuntimeException("test exception");
+        }
+      };
+    testFunction.call(null, Time.apply(System.currentTimeMillis()));
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -86,6 +86,7 @@ import io.cdap.cdap.etl.mock.transform.IdentityTransform;
 import io.cdap.cdap.etl.mock.transform.IntValueFilterTransform;
 import io.cdap.cdap.etl.mock.transform.NullFieldSplitterTransform;
 import io.cdap.cdap.etl.mock.transform.PluginValidationTransform;
+import io.cdap.cdap.etl.mock.transform.RecoveringTransform;
 import io.cdap.cdap.etl.mock.transform.SleepTransform;
 import io.cdap.cdap.etl.mock.transform.StringValueFilterTransform;
 import io.cdap.cdap.proto.id.ApplicationId;
@@ -139,7 +140,7 @@ public class HydratorTestBase extends TestBase {
     StringValueFilterCompute.PLUGIN_CLASS, Window.PLUGIN_CLASS,
     FlattenErrorTransform.PLUGIN_CLASS, FilterErrorTransform.PLUGIN_CLASS,
     NullFieldSplitterTransform.PLUGIN_CLASS, TMSAlertPublisher.PLUGIN_CLASS, NullAlertTransform.PLUGIN_CLASS,
-    SleepTransform.PLUGIN_CLASS
+    SleepTransform.PLUGIN_CLASS, RecoveringTransform.PLUGIN_CLASS
   );
   protected static ArtifactId batchMocksArtifactId;
   protected static ArtifactId streamingMocksArtifactId;

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/transform/RecoveringTransform.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/transform/RecoveringTransform.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.mock.transform;
+
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.annotation.Plugin;
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.etl.api.Emitter;
+import io.cdap.cdap.etl.api.Transform;
+import io.cdap.cdap.etl.proto.v2.ETLPlugin;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Transform that throws exception for first few calls and then recovers.
+ */
+@Plugin(type = Transform.PLUGIN_TYPE)
+@Name(RecoveringTransform.NAME)
+public class RecoveringTransform extends Transform<StructuredRecord, StructuredRecord> {
+
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  public static final String NAME = "RecoveringTransform";
+  private static AtomicInteger exceptionCounter = new AtomicInteger(0);
+
+  @Override
+  public void transform(StructuredRecord input, Emitter<StructuredRecord> emitter) throws Exception {
+    if (exceptionCounter.getAndIncrement() < 3) {
+      throw new RuntimeException("Exception in transform");
+    }
+    emitter.emit(input);
+  }
+
+  public static ETLPlugin getPlugin() {
+    return new ETLPlugin(NAME, Transform.PLUGIN_TYPE, Collections.emptyMap(), null);
+  }
+
+  private static PluginClass getPluginClass() {
+    return PluginClass.builder()
+      .setName(NAME)
+      .setType(Transform.PLUGIN_TYPE)
+      .setDescription("")
+      .setClassName(RecoveringTransform.class.getName())
+      .setProperties(Collections.emptyMap())
+      .build();
+  }
+
+  /**
+   * Reset the static counter to start throwing exceptions again
+   */
+  public static void reset() {
+    exceptionCounter.set(0);
+  }
+}

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5467,7 +5467,7 @@
 
   <property>
     <name>feature.streaming.pipeline.native.state.tracking.enabled</name>
-    <value>false</value>
+    <value>true</value>
     <description>
       Enable native state tracking for streaming pipelines for Atleast Once guarantee
     </description>


### PR DESCRIPTION
CDAP-19635 : Currently the sink functions for streaming pipelines catches exceptions and logs them and continues with processing. This will result in the pipeline ignoring some micro batches if the issue was transient. This will fail at least once semantic. To address this, retry mechanism is introduced. 
- Retry settings are set in DataStreamsPipelineSpec and can be overridden from runtime args
- The function will be retried and will fail with an exception when the retry limit is reached. 
- The implementation is at the sink function to ensure retries work with and without state store