### PR TITLE
API to retrieve list of endpoints for a pipeline run

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/FieldLineageAdmin.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/FieldLineageAdmin.java
@@ -36,8 +36,10 @@ import io.cdap.cdap.data2.metadata.lineage.field.FieldLineageInfo;
 import io.cdap.cdap.data2.metadata.lineage.field.FieldLineageReader;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.metadata.lineage.DatasetField;
+import io.cdap.cdap.proto.metadata.lineage.EndpointsSummary;
 import io.cdap.cdap.proto.metadata.lineage.Field;
 import io.cdap.cdap.proto.metadata.lineage.FieldLineageDetails;
 import io.cdap.cdap.proto.metadata.lineage.FieldLineageSummary;
@@ -48,6 +50,7 @@ import io.cdap.cdap.proto.metadata.lineage.ProgramFieldOperationInfo;
 import io.cdap.cdap.proto.metadata.lineage.ProgramInfo;
 import io.cdap.cdap.proto.metadata.lineage.ProgramRunOperations;
 import io.cdap.cdap.spi.metadata.MetadataConstants;
+import org.apache.twill.api.RunId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -383,5 +386,17 @@ public class FieldLineageAdmin {
     return fields.stream().filter(field ->
                                     field.getName().toLowerCase().startsWith(prefix.toLowerCase()))
       .collect(Collectors.toSet());
+  }
+
+  /**
+   * Retrieves a summary of all endpoints in a given program run.
+   *
+   * @param namespaceId program namespace
+   * @param programReference start time of the run in millis corresponding to the id of a program run
+   * @param runId run ID which is a UUID
+   * @return Summary of all Endpoints in the particular run of the pipeline.
+   */
+  public EndpointsSummary getEndpoints(String namespaceId, ProgramReference programReference, RunId runId) {
+    return new EndpointsSummary(fieldLineageReader.getEndpoints(namespaceId, programReference, runId));
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/FakeFieldLineageReader.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/FakeFieldLineageReader.java
@@ -19,7 +19,9 @@ package io.cdap.cdap.metadata;
 import io.cdap.cdap.api.lineage.field.EndPoint;
 import io.cdap.cdap.data2.metadata.lineage.field.EndPointField;
 import io.cdap.cdap.data2.metadata.lineage.field.FieldLineageReader;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.metadata.lineage.ProgramRunOperations;
+import org.apache.twill.api.RunId;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -84,5 +86,10 @@ public class FakeFieldLineageReader implements FieldLineageReader {
   @Override
   public List<ProgramRunOperations> getOutgoingOperations(EndPointField endPointField, long start, long end) {
     return programRunOperations;
+  }
+
+  @Override
+  public List<EndPoint> getEndpoints(String namespaceId, ProgramReference programReference, RunId runId) {
+    return new ArrayList<>();
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/lineage/FieldLineageProcessorTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/test/java/io/cdap/cdap/etl/lineage/FieldLineageProcessorTest.java
@@ -88,22 +88,24 @@ public class FieldLineageProcessorTest {
 
     Map<String, List<FieldOperation>> fieldOperations =
       ImmutableMap.of("src", Collections.singletonList(
-        new FieldReadOperation("Read", "1st operation", EndPoint.of("file"), ImmutableList.of("body", "offset"))),
+        new FieldReadOperation("Read", "1st operation", EndPoint.of("ns", "file"), ImmutableList.of("body", "offset"))),
                       "transform1", Collections.emptyList(),
                       "transform2", Collections.emptyList(),
                       "sink", Collections.singletonList(
-          new FieldWriteOperation("Write", "4th operation", EndPoint.of("sink"), ImmutableList.of("id", "name"))));
+          new FieldWriteOperation("Write", "4th operation", EndPoint.of("ns", "sink"),
+                                  ImmutableList.of("id", "name"))));
     Set<Operation> operations = processor.validateAndConvert(fieldOperations);
 
     Set<Operation> expected = ImmutableSet.of(
-      new ReadOperation("src.Read", "1st operation", EndPoint.of("file"), ImmutableList.of("body", "offset")),
+      new ReadOperation("src.Read", "1st operation", EndPoint.of("ns", "file", ImmutableMap.of("stageName", "src")),
+                        ImmutableList.of("body", "offset")),
       new TransformOperation("transform1.Transform", "",
                              ImmutableList.of(InputField.of("src.Read", "body"),
                                               InputField.of("src.Read", "offset")), "body"),
       new TransformOperation("transform2.Transform", "",
                              ImmutableList.of(InputField.of("transform1.Transform", "body")),
                              ImmutableList.of("id", "name")),
-      new WriteOperation("sink.Write", "4th operation", EndPoint.of("sink"),
+      new WriteOperation("sink.Write", "4th operation", EndPoint.of("ns", "sink", ImmutableMap.of("stageName", "sink")),
                          ImmutableList.of(InputField.of("transform2.Transform", "id"),
                                           InputField.of("transform2.Transform", "name"))));
     Assert.assertEquals(expected, operations);

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/field/DefaultFieldLineageReader.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/field/DefaultFieldLineageReader.java
@@ -21,9 +21,11 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.lineage.field.EndPoint;
 import io.cdap.cdap.api.lineage.field.Operation;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.metadata.lineage.ProgramRunOperations;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import org.apache.twill.api.RunId;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -74,6 +76,14 @@ public class DefaultFieldLineageReader implements FieldLineageReader {
   @Override
   public List<ProgramRunOperations> getOutgoingOperations(EndPointField endPointField, long start, long end) {
     return computeFieldOperations(false, endPointField, start, end);
+  }
+
+  @Override
+  public List<EndPoint> getEndpoints(String namespaceId, ProgramReference programReference, RunId runId) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      FieldLineageTable fieldLineageTable = FieldLineageTable.create(context);
+      return fieldLineageTable.getEndpoints(namespaceId, programReference, runId);
+    });
   }
 
   private List<ProgramRunOperations> computeFieldOperations(boolean incoming, EndPointField endPointField,

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/field/FieldLineageReader.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/field/FieldLineageReader.java
@@ -18,7 +18,9 @@ package io.cdap.cdap.data2.metadata.lineage.field;
 
 import io.cdap.cdap.api.lineage.field.EndPoint;
 import io.cdap.cdap.api.lineage.field.WriteOperation;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.metadata.lineage.ProgramRunOperations;
+import org.apache.twill.api.RunId;
 
 import java.util.List;
 import java.util.Set;
@@ -89,4 +91,14 @@ public interface FieldLineageReader {
    * @return the operations and program run information
    */
   List<ProgramRunOperations> getOutgoingOperations(EndPointField endPointField, long start, long end);
+
+  /**
+   * Get the list of Endpoints in pipeline run corresponding to the input run.
+   *
+   * @param namespaceId the namespace in which the pipeline ran
+   * @param programReference the program run ID
+   * @param runId run ID which is a UUID
+   * @return the list of endpoints in the pipeline run
+   */
+  List<EndPoint> getEndpoints(String namespaceId, ProgramReference programReference, RunId runId);
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
@@ -901,6 +901,7 @@ public final class StoreDefinition {
     public static final String DIRECTION_FIELD = "direction";
     public static final String ENDPOINT_NAMESPACE_FIELD = "endpoint_namespace";
     public static final String ENDPOINT_NAME_FIELD = "endpoint";
+    public static final String ENDPOINT_PROPERTIES_FIELD = "endpoint_properties";
     public static final String START_TIME_FIELD = "start_time";
     public static final String CHECKSUM_FIELD = "checksum";
     public static final String PROGRAM_RUN_FIELD = "program_run";
@@ -914,6 +915,7 @@ public final class StoreDefinition {
         .withFields(Fields.stringType(DIRECTION_FIELD),
                     Fields.stringType(ENDPOINT_NAMESPACE_FIELD),
                     Fields.stringType(ENDPOINT_NAME_FIELD),
+                    Fields.stringType(ENDPOINT_PROPERTIES_FIELD),
                     Fields.longType(START_TIME_FIELD),
                     Fields.longType(CHECKSUM_FIELD),
                     Fields.stringType(PROGRAM_RUN_FIELD))

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
@@ -122,6 +122,7 @@ public final class RouterPathLookup extends AbstractHttpHandler {
       endsWith(uriParts, "metadata", "tags") || endsWith(uriParts, "metadata", "tags", null) ||
       endsWith(uriParts, "metadata", "search") ||
       beginsWith(uriParts, "v3", "namespaces", null, "datasets", null, "lineage") ||
+      endsWith(uriParts, "runs", null, "endpoints") ||
       beginsWith(uriParts, "v3", "metadata", "search"))) {
       return METADATA_SERVICE;
     } else if (beginsWith(uriParts, "v3", "security", "authorization") ||

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/metadata/lineage/EndpointsSummary.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/metadata/lineage/EndpointsSummary.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.metadata.lineage;
+
+import io.cdap.cdap.api.lineage.field.EndPoint;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The summary about all the Endpoints in a program run.
+ */
+public class EndpointsSummary {
+  private final List<EndPoint> endpoints;
+
+  public EndpointsSummary(List<EndPoint> endpoints) {
+    this.endpoints = Collections.unmodifiableList(new ArrayList<>(endpoints));
+  }
+
+  public List<EndPoint> getEndpoints() {
+    return this.endpoints;
+  }
+
+  @Override
+  public String toString() {
+    return "EndpointsSummary{" +
+      "endpoints=" + endpoints +
+      '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    EndpointsSummary that = (EndpointsSummary) o;
+    return Objects.equals(endpoints, that.endpoints);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(endpoints);
+  }
+}


### PR DESCRIPTION
This API is required to retrieve list of endpoints for a run. This is required by to view lineage in the absence of a reference name

Jira: https://cdap.atlassian.net/browse/CDAP-19966

Testing:

`GET` on `namespaces/default/apps/bigquery-to-bigquery/workflows/DataPipelineWorkflow/runs/e40883b1-608a-11ed-8b1f-000000b6a272/endpoints` gives the below response
```
{
  "endpoints": [
    {
      "namespace": "default",
      "name": "bigquery.cdf-dc-int-1.realtime.tab8",
      "properties": {
        "fqn": "bigquery:cdf-dc-int-1.realtime.tab8",
        "location": "US",
        "stageName": "BigQuery2"
      }
    },
    {
      "namespace": "default",
      "name": "bigquery.cdf-dc-int-1.realtime.tab11",
      "properties": {
        "fqn": "bigquery:cdf-dc-int-1.realtime.tab11",
        "location": "US",
        "stageName": "BigQuery"
      }
    }
  ]
}
```