### PR TITLE
Refactor schedule to use ProgramReference in all places where version is not needed

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/schedule/ScheduleBuilder.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/schedule/ScheduleBuilder.java
@@ -145,27 +145,16 @@ public interface ScheduleBuilder {
   ScheduleCreationSpec triggerOnPartitions(String datasetNamespace, String datasetName, int numPartitions);
 
   /**
-   * Create a schedule which is triggered when the given program in the given namespace, application, and
-   * application version transitions to any one of the given program statuses.
+   * Create a schedule which is triggered when the given program in the given namespace and application
+   * transitions to any one of the given program statuses.
    *
    * @param programNamespace the namespace where this program is defined
    * @param application the name of the application where this program is defined
-   * @param appVersion the version of the application
    * @param programType the type of the program, as supported by the system
    * @param program the name of the program
    * @param programStatuses the set of statuses to trigger the schedule. The schedule will be triggered if the status of
    *                        the specific program transitioned to one of these statuses.
    * @return a {@link ScheduleCreationSpec}
-   */
-  ScheduleCreationSpec triggerOnProgramStatus(String programNamespace, String application, String appVersion,
-                                              ProgramType programType, String program,
-                                              ProgramStatus... programStatuses);
-
-  /**
-   * Create a schedule which is triggered when the given program in the given namespace
-   * and application with default version transitions to any one of the given program statuses.
-   *
-   * @see #triggerOnProgramStatus(String, String, String, ProgramType, String, ProgramStatus...)
    */
   ScheduleCreationSpec triggerOnProgramStatus(String programNamespace, String application, ProgramType programType,
                                               String program, ProgramStatus... programStatuses);

--- a/cdap-api/src/main/java/io/cdap/cdap/api/schedule/TriggerFactory.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/schedule/TriggerFactory.java
@@ -70,27 +70,16 @@ public interface TriggerFactory {
   Trigger onPartitions(String datasetNamespace, String datasetName, int numPartitions);
 
   /**
-   * Creates a trigger which is satisfied when the given program in the given namespace, application, and
-   * application version transitions to any one of the given program statuses.
+   * Creates a trigger which is satisfied when the given program in the given namespace and application
+   * transitions to any one of the given program statuses.
    *
    * @param programNamespace the namespace where this program is defined
    * @param application the name of the application where this program is defined
-   * @param appVersion the version of the application
    * @param programType the type of the program, as supported by the system
    * @param program the name of the program
    * @param programStatuses the set of statuses to trigger the schedule. The schedule will be triggered if the status of
    *                        the specific program transitioned to one of these statuses.
    * @return a {@link Trigger}
-   */
-  Trigger onProgramStatus(String programNamespace, String application, String appVersion,
-                          ProgramType programType, String program,
-                          ProgramStatus... programStatuses);
-
-  /**
-   * Creates a trigger which is satisfied when the given program in the given namespace
-   * and application with default version transitions to any one of the given program statuses.
-   *
-   * @see #onProgramStatus(String, String, String, ProgramType, String, ProgramStatus...)
    */
   Trigger onProgramStatus(String programNamespace, String application, ProgramType programType,
                           String program, ProgramStatus... programStatuses);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -295,7 +295,7 @@ public interface Store {
   Map<ProgramRunId, RunRecordDetail> getActiveRuns(ApplicationId applicationId);
 
   /**
-   * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records for the
+   * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records for any version of the
    * given application.
    * @param applicationReference versionless reference of the application
    * @return map of logged runs. If no active run exists, return an empty map.
@@ -303,7 +303,7 @@ public interface Store {
   Map<ProgramRunId, RunRecordDetail> getAllActiveRuns(ApplicationReference applicationReference);
 
   /**
-   * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records for the
+   * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records for any version of the
    * given program.
    * @param programReference versionless reference of the program
    * @return map of logged runs. If no active run exists, return an empty map.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -303,6 +303,14 @@ public interface Store {
   Map<ProgramRunId, RunRecordDetail> getAllActiveRuns(ApplicationReference applicationReference);
 
   /**
+   * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records for the
+   * given program.
+   * @param programReference versionless reference of the program
+   * @return map of logged runs. If no active run exists, return an empty map.
+   */
+  Map<ProgramRunId, RunRecordDetail> getAllActiveRuns(ProgramReference programReference);
+
+  /**
    * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records against a given ProgramId.
    * @param programId the program id to match against
    * @return map of logged runs

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/config/PreferencesService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/config/PreferencesService.java
@@ -31,12 +31,14 @@ import io.cdap.cdap.proto.EntityScope;
 import io.cdap.cdap.proto.PreferencesDetail;
 import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.InstanceId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.NamespacedEntityId;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.runtime.spi.profile.ProfileStatus;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
@@ -208,6 +210,10 @@ public class PreferencesService {
     return get(applicationId);
   }
 
+  public PreferencesDetail getPreferences(ApplicationReference applicationRef) {
+    return get(applicationRef);
+  }
+
   /**
    * Get program level preferences
    */
@@ -218,6 +224,10 @@ public class PreferencesService {
 
   public PreferencesDetail getPreferences(ProgramId programId) {
     return get(programId);
+  }
+
+  public PreferencesDetail getPreferences(ProgramReference programRef) {
+    return get(programRef);
   }
 
   /**
@@ -255,6 +265,11 @@ public class PreferencesService {
     return getResolved(appId);
   }
 
+  public PreferencesDetail getResolvedPreferences(ApplicationReference applicationRef) {
+    return getResolved(applicationRef);
+  }
+
+
   /**
    * Get program level resolved preferences
    */
@@ -264,6 +279,10 @@ public class PreferencesService {
   }
   public PreferencesDetail getResolvedPreferences(ProgramId programId) {
     return getResolved(programId);
+  }
+
+  public PreferencesDetail getResolvedPreferences(ProgramReference programRef) {
+    return getResolved(programRef);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandler.java
@@ -35,8 +35,9 @@ import io.cdap.cdap.internal.app.runtime.schedule.TimeSchedulerService;
 import io.cdap.cdap.internal.app.runtime.schedule.TriggeringScheduleInfoAdapter;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.proto.ScheduledRuntime;
+import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.ops.DashboardProgramRunRecord;
 import io.cdap.cdap.reporting.ProgramHeartbeatService;
@@ -207,11 +208,11 @@ public class OperationsDashboardHttpHandler extends AbstractAppFabricHttpHandler
   private List<DashboardProgramRunRecord> getScheduledDashboardRecords(ProgramSchedule schedule,
                                                                        long startTimeSecs, long endTimeSecs)
     throws Exception {
-    ProgramId programId = schedule.getProgramId();
+    ProgramReference programReference = schedule.getProgramReference();
     // get all the scheduled run times within the given time range of the given program
     List<ScheduledRuntime> scheduledRuntimes =
-      timeSchedulerService.getAllScheduledRunTimes(programId, programId.getType().getSchedulableType(), startTimeSecs,
-                                                   endTimeSecs);
+      timeSchedulerService.getAllScheduledRunTimes(programReference, programReference.getType().getSchedulableType(),
+                                                   startTimeSecs, endTimeSecs);
     String userId = schedule.getProperties().get(ProgramOptionConstants.USER_ID);
     String artifactId = schedule.getProperties().get(ProgramOptionConstants.ARTIFACT_ID);
     ArtifactSummary artifactSummary =
@@ -219,10 +220,11 @@ public class OperationsDashboardHttpHandler extends AbstractAppFabricHttpHandler
     // for each scheduled runtime, construct a dashboard record for it with the scheduled time as start time
     return scheduledRuntimes.stream()
       .map(scheduledRuntime ->
-             new DashboardProgramRunRecord(programId.getNamespace(), artifactSummary,
+             new DashboardProgramRunRecord(programReference.getNamespace(), artifactSummary,
                                            new DashboardProgramRunRecord.ApplicationNameVersion(
-                                             programId.getApplication(), programId.getVersion()),
-                                           programId.getType().name(), programId.getProgram(), null, userId, SCHEDULED,
+                                             programReference.getApplication(), ApplicationId.DEFAULT_VERSION),
+                                           programReference.getType().name(), programReference.getProgram(),
+                                           null, userId, SCHEDULED,
                                            // convert the scheduled time from millis to seconds as start time
                                            TimeUnit.MILLISECONDS.toSeconds(scheduledRuntime.getTime()),
                                            null, null, null, null, null))

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -751,9 +751,8 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                     e);
     }
 
-    ProgramId triggerProgramId = new NamespaceId(triggerNamespaceId)
-      .app(triggerAppName, triggerAppVersion)
-      .program(programType, triggerProgramName);
+    ProgramReference triggerProgramReference = new ProgramReference(triggerNamespaceId, triggerAppName, programType,
+                                                                    triggerProgramName);
 
     Set<io.cdap.cdap.api.ProgramStatus> queryProgramStatuses = new HashSet<>();
     if (triggerProgramStatuses != null) {
@@ -771,7 +770,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       Collections.addAll(queryProgramStatuses, io.cdap.cdap.api.ProgramStatus.values());
     }
 
-    List<ScheduleDetail> details = programScheduleService.findTriggeredBy(triggerProgramId, queryProgramStatuses)
+    List<ScheduleDetail> details = programScheduleService.findTriggeredBy(triggerProgramReference, queryProgramStatuses)
       .stream()
       .filter(record -> programScheduleStatus == null || record.getMeta().getStatus().equals(programScheduleStatus))
       .map(ProgramScheduleRecord::toScheduleDetail)
@@ -816,7 +815,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                               @PathParam("app-name") String appName,
                               @QueryParam("trigger-type") String triggerType,
                               @QueryParam("schedule-status") String scheduleStatus) throws Exception {
-    doGetSchedules(responder, new NamespaceId(namespaceId).app(appName), null, triggerType, scheduleStatus);
+    doGetSchedules(responder, new ApplicationReference(namespaceId, appName), null, triggerType, scheduleStatus);
   }
 
   /**
@@ -838,7 +837,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                        @PathParam("app-version") String appVersion,
                                        @QueryParam("trigger-type") String triggerType,
                                        @QueryParam("schedule-status") String scheduleStatus) throws Exception {
-    doGetSchedules(responder, new NamespaceId(namespaceId).app(appName), null, triggerType, scheduleStatus);
+    doGetSchedules(responder, new ApplicationReference(namespaceId, appName), null, triggerType, scheduleStatus);
   }
 
   /**
@@ -875,19 +874,19 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       throw new BadRequestException("Program type " + programType + " cannot have schedule");
     }
 
-    ProgramId programId = new ApplicationId(namespace, application).program(programType, program);
-    doGetSchedules(responder, new NamespaceId(namespace).app(application), programId,
+    ProgramReference programReference = new ProgramReference(namespace, application, programType, program);
+    doGetSchedules(responder, new ApplicationReference(namespace, application), programReference,
                    triggerType, scheduleStatus);
   }
 
-  private void doGetSchedules(HttpResponder responder, ApplicationId applicationId,
-                              @Nullable ProgramId programId, @Nullable String triggerTypeStr,
+  private void doGetSchedules(HttpResponder responder, ApplicationReference appReference,
+                              @Nullable ProgramReference programReference, @Nullable String triggerTypeStr,
                               @Nullable String statusStr) throws Exception {
-    ApplicationSpecification appSpec = Optional.ofNullable(store.getLatest(applicationId.getAppReference()))
+    ApplicationSpecification appSpec = Optional.ofNullable(store.getLatest(appReference))
       .map(ApplicationMeta::getSpec)
       .orElse(null);
     if (appSpec == null) {
-      throw new NotFoundException(applicationId);
+      throw new NotFoundException(appReference);
     }
     ProgramScheduleStatus status;
     try {
@@ -913,13 +912,14 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     }
 
     Collection<ProgramScheduleRecord> schedules;
-    if (programId != null) {
-      if (!appSpec.getProgramsByType(programId.getType().getApiProgramType()).contains(programId.getProgram())) {
-        throw new NotFoundException(programId);
+    if (programReference != null) {
+      if (!appSpec.getProgramsByType(programReference.getType().getApiProgramType())
+        .contains(programReference.getProgram())) {
+        throw new NotFoundException(programReference);
       }
-      schedules = programScheduleService.list(programId, predicate);
+      schedules = programScheduleService.list(programReference, predicate);
     } else {
-      schedules = programScheduleService.list(applicationId, predicate);
+      schedules = programScheduleService.list(appReference, predicate);
     }
 
     List<ScheduleDetail> details = schedules.stream()
@@ -940,9 +940,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                           @PathParam("program-name") String program) throws Exception {
     ProgramType programType = getProgramType(type);
     String appVersion = getLatestAppVersion(new NamespaceId(namespaceId), appId);
-    handleScheduleRunTime(responder,
-                          new NamespaceId(namespaceId).app(appId, appVersion).program(programType, program),
-                          true);
+    handleScheduleRunTime(responder, new ProgramReference(namespaceId, appId, programType, program), true);
   }
 
   /**
@@ -956,17 +954,15 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
                                       @PathParam("program-type") String type,
                                       @PathParam("program-name") String program) throws Exception {
     ProgramType programType = getProgramType(type);
-    String appVersion = getLatestAppVersion(new NamespaceId(namespaceId), appId);
-    handleScheduleRunTime(responder,
-                          new NamespaceId(namespaceId).app(appId, appVersion).program(programType, program),
-                          false);
+    handleScheduleRunTime(responder, new ProgramReference(namespaceId, appId, programType, program), false);
   }
 
-  private void handleScheduleRunTime(HttpResponder responder, ProgramId programId,
+  private void handleScheduleRunTime(HttpResponder responder, ProgramReference programReference,
                                      boolean previousRuntimeRequested) throws Exception {
     try {
-      lifecycleService.ensureProgramExists(programId);
-      responder.sendJson(HttpResponseStatus.OK, GSON.toJson(getScheduledRunTimes(programId, previousRuntimeRequested)));
+      lifecycleService.ensureLatestProgramExists(programReference);
+      responder.sendJson(HttpResponseStatus.OK, GSON.toJson(getScheduledRunTimes(programReference,
+                                                                                 previousRuntimeRequested)));
     } catch (SecurityException e) {
       responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
     }
@@ -1049,7 +1045,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       if (programMap.containsKey(programReference)) {
         ProgramId programId = programMap.get(programReference);
         result.add(new BatchProgramSchedule(programId, HttpResponseStatus.OK.code(), null,
-                                            getScheduledRunTimes(programId, previous)));
+                                            getScheduledRunTimes(programReference, previous)));
       } else {
         result.add(new BatchProgramSchedule(programReference, HttpResponseStatus.NOT_FOUND.code(),
                                             new NotFoundException(programReference).getMessage(), null));
@@ -1061,21 +1057,21 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   /**
    * Returns a list of {@link ScheduledRuntime} for the given program.
    *
-   * @param programId the program to fetch schedules for
+   * @param programReference the program to fetch schedules for
    * @param previous  {@code true} to get the previous scheduled times; {@code false} to get the next scheduled times
    * @return a list of {@link ScheduledRuntime}
    * @throws SchedulerException if failed to fetch the schedule
    */
-  private List<ScheduledRuntime> getScheduledRunTimes(ProgramId programId,
+  private List<ScheduledRuntime> getScheduledRunTimes(ProgramReference programReference,
                                                       boolean previous) throws Exception {
-    if (programId.getType().getSchedulableType() == null) {
-      throw new BadRequestException("Program " + programId + " cannot have schedule");
+    if (programReference.getType().getSchedulableType() == null) {
+      throw new BadRequestException("Program " + programReference + " cannot have schedule");
     }
 
     if (previous) {
-      return programScheduleService.getPreviousScheduledRuntimes(programId);
+      return programScheduleService.getPreviousScheduledRuntimes(programReference);
     } else {
-      return programScheduleService.getNextScheduledRuntimes(programId);
+      return programScheduleService.getNextScheduledRuntimes(programReference);
     }
   }
 
@@ -1106,7 +1102,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   private void doAddSchedule(FullHttpRequest request, HttpResponder responder, String namespace, String appName,
                              String scheduleName) throws Exception {
 
-    final ApplicationId applicationId = new ApplicationId(namespace, appName);
+    final ApplicationReference applicationRef = new ApplicationReference(namespace, appName);
     ScheduleDetail scheduleFromRequest = readScheduleDetailBody(request, scheduleName);
 
     if (scheduleFromRequest.getProgram() == null) {
@@ -1123,17 +1119,17 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
     }
     ProgramType programType = ProgramType.valueOfSchedulableType(scheduleFromRequest.getProgram().getProgramType());
     String programName = scheduleFromRequest.getProgram().getProgramName();
-    ProgramId programId = applicationId.program(programType, programName);
+    ProgramReference programRef = applicationRef.program(programType, programName);
 
     // Schedules are versionless
-    lifecycleService.ensureLatestProgramExists(programId.getProgramReference());
+    lifecycleService.ensureLatestProgramExists(programRef);
 
     String description = Objects.firstNonNull(scheduleFromRequest.getDescription(), "");
     Map<String, String> properties = Objects.firstNonNull(scheduleFromRequest.getProperties(), Collections.emptyMap());
     List<? extends Constraint> constraints = Objects.firstNonNull(scheduleFromRequest.getConstraints(), NO_CONSTRAINTS);
     long timeoutMillis =
       Objects.firstNonNull(scheduleFromRequest.getTimeoutMillis(), Schedulers.JOB_QUEUE_TIMEOUT_MILLIS);
-    ProgramSchedule schedule = new ProgramSchedule(scheduleName, description, programId, properties,
+    ProgramSchedule schedule = new ProgramSchedule(scheduleName, description, programRef, properties,
                                                    scheduleFromRequest.getTrigger(), constraints, timeoutMillis);
     programScheduleService.add(schedule);
     responder.sendStatus(HttpResponseStatus.OK);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.pipeline.AbstractStage;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.ProgramTypes;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.scheduler.Scheduler;
 import io.cdap.cdap.spi.metadata.MetadataMutation;
 import org.slf4j.Logger;
@@ -80,9 +81,10 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
       //call the deleted spec
       ProgramType type = ProgramTypes.fromSpecification(spec);
       ProgramId programId = appSpec.getApplicationId().program(type, spec.getName());
+      ProgramReference programRef = programId.getProgramReference();
       programTerminator.stop(programId);
-      programScheduler.deleteSchedules(programId);
-      programScheduler.modifySchedulesTriggeredByDeletedProgram(programId);
+      programScheduler.deleteSchedules(programRef);
+      programScheduler.modifySchedulesTriggeredByDeletedProgram(programRef);
 
       // Remove metadata for the deleted program
       metadataServiceClient.drop(new MetadataMutation.Drop(programId.toMetadataEntity()));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/AbstractTimeSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/AbstractTimeSchedulerService.java
@@ -25,7 +25,7 @@ import io.cdap.cdap.internal.app.runtime.schedule.trigger.AbstractSatisfiableCom
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.TimeTrigger;
 import io.cdap.cdap.proto.ScheduledRuntime;
 import io.cdap.cdap.proto.id.ApplicationId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,35 +108,38 @@ public abstract class AbstractTimeSchedulerService extends AbstractIdleService i
   }
 
   @Override
-  public List<ScheduledRuntime> previousScheduledRuntime(ProgramId program)
+  public List<ScheduledRuntime> previousScheduledRuntime(ProgramReference programReference)
     throws SchedulerException {
-    return timeScheduler.previousScheduledRuntime(program);
+    return timeScheduler.previousScheduledRuntime(programReference);
   }
 
   @Override
-  public List<ScheduledRuntime> nextScheduledRuntime(ProgramId program)
+  public List<ScheduledRuntime> nextScheduledRuntime(ProgramReference programReference)
     throws SchedulerException {
-    return timeScheduler.nextScheduledRuntime(program);
+    return timeScheduler.nextScheduledRuntime(programReference);
   }
 
   @Override
-  public List<ScheduledRuntime> getAllScheduledRunTimes(ProgramId program, SchedulableProgramType programType,
+  public List<ScheduledRuntime> getAllScheduledRunTimes(ProgramReference programReference,
+                                                        SchedulableProgramType programType,
                                                         long startTimeSecs, long endTimeSecs)
     throws SchedulerException {
-    return timeScheduler.getAllScheduledRunTimes(program, programType, startTimeSecs, endTimeSecs);
+    return timeScheduler.getAllScheduledRunTimes(programReference, programType, startTimeSecs, endTimeSecs);
   }
 
-  public static String scheduleIdFor(ProgramId program, SchedulableProgramType programType, String scheduleName) {
-    return String.format("%s:%s", programIdFor(program, programType), scheduleName);
+  public static String scheduleIdFor(ProgramReference programReference, SchedulableProgramType programType,
+                                     String scheduleName) {
+    return String.format("%s:%s", programIdFor(programReference, programType), scheduleName);
   }
 
-  public static String getTriggerName(ProgramId program, SchedulableProgramType programType, String scheduleName,
+  public static String getTriggerName(ProgramReference programReference, SchedulableProgramType programType,
+                                      String scheduleName,
                                       String cronEntry) {
-    return String.format("%s:%s:%s", programIdFor(program, programType), scheduleName, cronEntry);
+    return String.format("%s:%s:%s", programIdFor(programReference, programType), scheduleName, cronEntry);
   }
 
-  public static String programIdFor(ProgramId program, SchedulableProgramType programType) {
-    return String.format("%s:%s:%s:%s:%s", program.getNamespace(), program.getApplication(),
-                         ApplicationId.DEFAULT_VERSION, programType.name(), program.getProgram());
+  public static String programIdFor(ProgramReference programReference, SchedulableProgramType programType) {
+    return String.format("%s:%s:%s:%s:%s", programReference.getNamespace(), programReference.getApplication(),
+                         ApplicationId.DEFAULT_VERSION, programType.name(), programReference.getProgram());
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/DefaultScheduleBuilder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/DefaultScheduleBuilder.java
@@ -128,14 +128,6 @@ public class DefaultScheduleBuilder implements ConstraintProgramScheduleBuilder 
 
   @Override
   public ScheduleCreationSpec triggerOnProgramStatus(String programNamespace, String application,
-                                                     String appVersion, ProgramType programType, String program,
-                                                     ProgramStatus... programStatuses) {
-    return triggerOn(triggerFactory.onProgramStatus(programNamespace, application, appVersion,
-                                                    programType, program, programStatuses));
-  }
-
-  @Override
-  public ScheduleCreationSpec triggerOnProgramStatus(String programNamespace, String application,
                                                      ProgramType programType, String program,
                                                      ProgramStatus... programStatuses) {
     return triggerOn(triggerFactory.onProgramStatus(programNamespace, application,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/ProgramScheduleRecord.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/ProgramScheduleRecord.java
@@ -71,8 +71,8 @@ public class ProgramScheduleRecord {
 
   public ScheduleDetail toScheduleDetail() {
     ScheduleProgramInfo programInfo =
-      new ScheduleProgramInfo(schedule.getProgramId().getType().getSchedulableType(),
-                              schedule.getProgramId().getProgram());
+      new ScheduleProgramInfo(schedule.getProgramReference().getType().getSchedulableType(),
+                              schedule.getProgramReference().getProgram());
     ScheduleId scheduleId = schedule.getScheduleId();
     return new ScheduleDetail(scheduleId.getNamespace(), scheduleId.getApplication(),
                               scheduleId.getSchedule(), schedule.getDescription(), programInfo,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/TimeSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/TimeSchedulerService.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.common.AlreadyExistsException;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.proto.ScheduledRuntime;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 
 import java.util.List;
 
@@ -77,12 +78,12 @@ public interface TimeSchedulerService extends Service {
    + into account schedules based on time. For schedules based on data, an empty list will
    + be returned.
    *
-   * @param program program to fetch the previous runtime.
+   * @param programReference program to fetch the previous runtime.
    * @return list of Scheduled runtimes for the program. Empty list if there are no schedules
    *         or if the program is not found
    * @throws SchedulerException on unforeseen error.
    */
-  List<ScheduledRuntime> previousScheduledRuntime(ProgramId program) throws SchedulerException;
+  List<ScheduledRuntime> previousScheduledRuntime(ProgramReference programReference) throws SchedulerException;
 
   /**
    * Get the next scheduled run time of the program. A program may contain multiple schedules.
@@ -90,12 +91,12 @@ public interface TimeSchedulerService extends Service {
    + into account schedules based on time. For schedules based on data, an empty list will
    + be returned.
    *
-   * @param program program to fetch the next runtime.
+   * @param programReference program to fetch the next runtime.
    * @return list of scheduled runtimes for the program. Empty list if there are no schedules
    *         or if the program is not found
    * @throws SchedulerException on unforeseen error.
    */
-  List<ScheduledRuntime> nextScheduledRuntime(ProgramId program) throws SchedulerException;
+  List<ScheduledRuntime> nextScheduledRuntime(ProgramReference programReference) throws SchedulerException;
 
   /**
    * Get all the scheduled run time of the program within the given time range in the future.
@@ -104,7 +105,7 @@ public interface TimeSchedulerService extends Service {
    + into account schedules based on time. For schedules based on data, an empty list will
    + be returned.
    *
-   * @param program program to fetch the next runtime.
+   * @param programReference program to fetch the next runtime.
    * @param programType type of program.
    * @param startTimeSecs the start of the time range in seconds (inclusive, i.e. scheduled time larger or
    *                      equal to the start will be returned)
@@ -114,6 +115,6 @@ public interface TimeSchedulerService extends Service {
    *         or if the program is not found
    * @throws SchedulerException on unforeseen error.
    */
-  List<ScheduledRuntime> getAllScheduledRunTimes(ProgramId program, SchedulableProgramType programType,
+  List<ScheduledRuntime> getAllScheduledRunTimes(ProgramReference programReference, SchedulableProgramType programType,
                                                  long startTimeSecs, long endTimeSecs) throws SchedulerException;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/ConcurrencyConstraint.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/ConcurrencyConstraint.java
@@ -38,10 +38,10 @@ public class ConcurrencyConstraint extends ProtoConstraint.ConcurrencyConstraint
 
   @Override
   public ConstraintResult check(ProgramSchedule schedule, ConstraintContext context) {
-    Map<ProgramRunId, RunRecordDetail> activeRuns = context.getActiveRuns(schedule.getProgramId());
+    Map<ProgramRunId, RunRecordDetail> activeRuns = context.getActiveRuns(schedule.getProgramReference());
     if (activeRuns.size() >= maxConcurrency) {
       LOG.debug("Skipping run of program {} from schedule {} because there are {} active runs.",
-                schedule.getProgramId(), schedule.getName(), activeRuns.size());
+                schedule.getProgramReference(), schedule.getName(), activeRuns.size());
       return notSatisfied(context);
     }
     return ConstraintResult.SATISFIED;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/ConstraintContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/ConstraintContext.java
@@ -20,7 +20,7 @@ import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.internal.app.runtime.schedule.queue.Job;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.proto.ProgramRunStatus;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 
 import java.util.Map;
@@ -43,13 +43,13 @@ public final class ConstraintContext {
     return checkTimeMillis;
   }
 
-  public Map<ProgramRunId, RunRecordDetail> getActiveRuns(ProgramId programId) {
-    return store.getActiveRuns(programId);
+  public Map<ProgramRunId, RunRecordDetail> getActiveRuns(ProgramReference programRef) {
+    return store.getAllActiveRuns(programRef);
   }
 
-  public Map<ProgramRunId, RunRecordDetail> getProgramRuns(ProgramId programId, ProgramRunStatus status,
+  public Map<ProgramRunId, RunRecordDetail> getProgramRuns(ProgramReference programRef, ProgramRunStatus status,
                                                            long startTime, long endTime, int limit) {
-    return store.getRuns(programId, status, startTime, endTime, limit);
+    return store.getAllRuns(programRef, status, startTime, endTime, limit, null);
   }
 
   public Job getJob() {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/LastRunConstraint.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/LastRunConstraint.java
@@ -42,7 +42,7 @@ public class LastRunConstraint extends ProtoConstraint.LastRunConstraint impleme
     // is for the start time of the program. It may start before `millisSinceLastRun`, but complete after it.
     // Note: this will miss out on active workflow runs that started more than ~1day ago (suspended/lengthy workflows)
     Iterable<RunRecordDetail> runRecords =
-      context.getProgramRuns(schedule.getProgramId(), ProgramRunStatus.ALL,
+      context.getProgramRuns(schedule.getProgramReference(), ProgramRunStatus.ALL,
                              startTime - TimeUnit.DAYS.toSeconds(1), Long.MAX_VALUE, 100).values();
     // We can limit to 100, since just 1 program in the recent history is enough to make the constraint fail.
     // We want use 100 as the limit instead of 1, because we want to attempt to get the latest completed run,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/store/Schedulers.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/store/Schedulers.java
@@ -26,7 +26,7 @@ import io.cdap.cdap.proto.ScheduleDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.spi.data.StructuredTableContext;
 import io.cdap.cdap.spi.data.TableNotFoundException;
 import io.cdap.cdap.store.StoreDefinition;
@@ -58,17 +58,18 @@ public class Schedulers {
     return "partition:" + datasetId.getNamespace() + '.' + datasetId.getDataset();
   }
 
-  public static String triggerKeyForProgramStatus(ProgramId programId, ProgramStatus programStatus) {
-    return String.format("programStatus:program:%s.%s.%s.%s.%s.%s", programId.getNamespace(),
-                         programId.getApplication(), ApplicationId.DEFAULT_VERSION,
-                         programId.getType().getPrettyName().toLowerCase(),
-                         programId.getProgram(), programStatus.toString().toLowerCase());
+  public static String triggerKeyForProgramStatus(ProgramReference programRef, ProgramStatus programStatus) {
+    return String.format("programStatus:program:%s.%s.%s.%s.%s.%s", programRef.getNamespace(),
+                         programRef.getApplication(), ApplicationId.DEFAULT_VERSION,
+                         programRef.getType().getPrettyName().toLowerCase(),
+                         programRef.getProgram(), programStatus.toString().toLowerCase());
   }
 
-  public static Set<String> triggerKeysForProgramStatuses(ProgramId programId, Set<ProgramStatus> programStatuses) {
+  public static Set<String> triggerKeysForProgramStatuses(ProgramReference programReference,
+                                                          Set<ProgramStatus> programStatuses) {
     ImmutableSet.Builder<String> triggerKeysBuilder = ImmutableSet.builder();
     for (ProgramStatus status : programStatuses) {
-      triggerKeysBuilder.add(triggerKeyForProgramStatus(programId, status));
+      triggerKeysBuilder.add(triggerKeyForProgramStatus(programReference, status));
     }
     return triggerKeysBuilder.build();
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/AbstractSatisfiableCompositeTrigger.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/AbstractSatisfiableCompositeTrigger.java
@@ -23,7 +23,7 @@ import io.cdap.cdap.api.schedule.TriggerInfo;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramSchedule;
 import io.cdap.cdap.proto.Notification;
 import io.cdap.cdap.proto.ProtoTrigger;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -117,9 +117,9 @@ public abstract class AbstractSatisfiableCompositeTrigger
    * Create a new trigger where all sub-triggers related to the given program have been removed.
    * Returns null if removing relevant sub-triggers results in a trigger that can never be satisfied.
    *
-   * @param programId the program id of the deleted program
+   * @param programReference the program id of the deleted program
    * @return the new trigger, or {@code null} if result trigger will never be satisfied
    */
   @Nullable
-  public abstract SatisfiableTrigger getTriggerWithDeletedProgram(ProgramId programId);
+  public abstract SatisfiableTrigger getTriggerWithDeletedProgram(ProgramReference programReference);
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/AndTrigger.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/AndTrigger.java
@@ -20,7 +20,7 @@ import io.cdap.cdap.api.schedule.Trigger;
 import io.cdap.cdap.api.schedule.TriggerInfo;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramSchedule;
 import io.cdap.cdap.proto.Notification;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,17 +58,17 @@ public class AndTrigger extends AbstractSatisfiableCompositeTrigger {
 
   @Nullable
   @Override
-  public SatisfiableTrigger getTriggerWithDeletedProgram(ProgramId programId) {
+  public SatisfiableTrigger getTriggerWithDeletedProgram(ProgramReference programReference) {
     List<SatisfiableTrigger> updatedTriggers = new ArrayList<>();
     for (SatisfiableTrigger trigger : getTriggers()) {
       if (trigger instanceof ProgramStatusTrigger &&
-        programId.isSameProgramExceptVersion(((ProgramStatusTrigger) trigger).getProgramId())) {
+        programReference.equals(((ProgramStatusTrigger) trigger).getProgramReference())) {
         // this program status trigger will never be satisfied, so the current AND trigger will never be satisfied
         return null;
       }
       if (trigger instanceof AbstractSatisfiableCompositeTrigger) {
         SatisfiableTrigger updatedTrigger =
-          ((AbstractSatisfiableCompositeTrigger) trigger).getTriggerWithDeletedProgram(programId);
+          ((AbstractSatisfiableCompositeTrigger) trigger).getTriggerWithDeletedProgram(programReference);
         if (updatedTrigger == null) {
           // the updated composite trigger will never be satisfied, so the AND trigger will never be satisfied
           return null;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/DefaultTriggerFactory.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/DefaultTriggerFactory.java
@@ -20,10 +20,9 @@ import io.cdap.cdap.api.ProgramStatus;
 import io.cdap.cdap.api.app.ProgramType;
 import io.cdap.cdap.api.schedule.Trigger;
 import io.cdap.cdap.api.schedule.TriggerFactory;
-import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 
 /**
  * The default implementation of {@link TriggerFactory}
@@ -62,26 +61,20 @@ public class DefaultTriggerFactory implements TriggerFactory {
   }
 
   @Override
-  public Trigger onProgramStatus(String namespace, String application, String appVersion,
-                                 ProgramType programType, String program, ProgramStatus... programStatuses) {
-    return new ProgramStatusTrigger(new ApplicationId(namespace, application, appVersion)
-                                      .program(io.cdap.cdap.proto.ProgramType.valueOf(programType.name()), program),
-                                    programStatuses);
-  }
-
-  @Override
   public Trigger onProgramStatus(String programNamespace, String application, ProgramType programType,
                                  String program, ProgramStatus... programStatuses) {
-    return new ProgramStatusTrigger(new ApplicationId(programNamespace, application)
-                                      .program(io.cdap.cdap.proto.ProgramType.valueOf(programType.name()), program),
+    return new ProgramStatusTrigger(new ProgramReference(programNamespace, application,
+                                                         io.cdap.cdap.proto.ProgramType.valueOf(programType.name()),
+                                                         program),
                                     programStatuses);
   }
 
   @Override
   public Trigger onProgramStatus(String application, ProgramType programType, String program,
                                  ProgramStatus... programStatuses) {
-    return new ProgramStatusTrigger(new ProgramId(namespaceId.getNamespace(), application,
-                                                  io.cdap.cdap.proto.ProgramType.valueOf(programType.name()), program),
+    return new ProgramStatusTrigger(new ProgramReference(namespaceId.getNamespace(), application,
+                                                  io.cdap.cdap.proto.ProgramType.valueOf(programType.name()),
+                                                         program),
                                     programStatuses);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/OrTrigger.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/OrTrigger.java
@@ -19,7 +19,7 @@ package io.cdap.cdap.internal.app.runtime.schedule.trigger;
 import io.cdap.cdap.api.schedule.TriggerInfo;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramSchedule;
 import io.cdap.cdap.proto.Notification;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -56,17 +56,17 @@ public class OrTrigger extends AbstractSatisfiableCompositeTrigger {
 
   @Nullable
   @Override
-  public SatisfiableTrigger getTriggerWithDeletedProgram(ProgramId programId) {
+  public SatisfiableTrigger getTriggerWithDeletedProgram(ProgramReference programReference) {
     List<SatisfiableTrigger> updatedTriggers = new ArrayList<>();
     for (SatisfiableTrigger trigger : getTriggers()) {
       if (trigger instanceof ProgramStatusTrigger &&
-        programId.isSameProgramExceptVersion(((ProgramStatusTrigger) trigger).getProgramId())) {
+        programReference.equals(((ProgramStatusTrigger) trigger).getProgramReference())) {
         // this program status trigger will never be satisfied, skip adding it to updatedTriggers
         continue;
       }
       if (trigger instanceof AbstractSatisfiableCompositeTrigger) {
         SatisfiableTrigger updatedTrigger =
-          ((AbstractSatisfiableCompositeTrigger) trigger).getTriggerWithDeletedProgram(programId);
+          ((AbstractSatisfiableCompositeTrigger) trigger).getTriggerWithDeletedProgram(programReference);
         if (updatedTrigger != null) {
           // add the updated composite trigger into updatedTriggers
           updatedTriggers.add(updatedTrigger);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/ProgramStatusTrigger.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/ProgramStatusTrigger.java
@@ -68,7 +68,7 @@ public class ProgramStatusTrigger extends ProtoTrigger.ProgramStatusTrigger impl
 
   @Override
   public Set<String> getTriggerKeys() {
-    return Schedulers.triggerKeysForProgramStatuses(programReference, programStatuses);
+    return Schedulers.triggerKeysForProgramStatuses(getProgramReference(), programStatuses);
   }
 
   @Override
@@ -78,10 +78,10 @@ public class ProgramStatusTrigger extends ProtoTrigger.ProgramStatusTrigger impl
       public List<TriggerInfo> apply(ProgramRunInfo runInfo) {
         Map<String, String> runtimeArgs = context.getProgramRuntimeArguments(runInfo.getProgramRunId());
         TriggerInfo triggerInfo =
-          new DefaultProgramStatusTriggerInfo(programReference.getNamespace(),
-                                              programReference.getParent().getApplication(),
-                                              ProgramType.valueOf(programReference.getType().name()),
-                                              programReference.getProgram(),
+          new DefaultProgramStatusTriggerInfo(programId.getNamespace(),
+                                              programId.getParent().getApplication(),
+                                              ProgramType.valueOf(programId.getType().name()),
+                                              programId.getProgram(),
                                               RunIds.fromString(runInfo.getProgramRunId().getRun()),
                                               runInfo.getProgramStatus(),
                                               context.getWorkflowToken(runInfo.getProgramRunId()), runtimeArgs);
@@ -128,7 +128,7 @@ public class ProgramStatusTrigger extends ProtoTrigger.ProgramStatusTrigger impl
       }
       ProgramRunId programRunId = GSON.fromJson(programRunIdString, ProgramRunId.class);
       ProgramReference triggeringProgramReference = programRunId.getParent().getProgramReference();
-      if (this.programReference.equals(triggeringProgramReference) && programStatuses.contains(programStatus)) {
+      if (getProgramReference().equals(triggeringProgramReference) && programStatuses.contains(programStatus)) {
         return function.apply(new ProgramRunInfo(programStatus, programRunId));
       }
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/ProgramStatusTrigger.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/ProgramStatusTrigger.java
@@ -31,7 +31,7 @@ import io.cdap.cdap.internal.app.runtime.schedule.store.Schedulers;
 import io.cdap.cdap.proto.Notification;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.ProtoTrigger;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 
 import java.util.Arrays;
@@ -47,13 +47,13 @@ import java.util.Set;
 public class ProgramStatusTrigger extends ProtoTrigger.ProgramStatusTrigger implements SatisfiableTrigger {
   private static final Gson GSON = new Gson();
 
-  public ProgramStatusTrigger(ProgramId programId, Set<ProgramStatus> programStatuses) {
-    super(programId, programStatuses);
+  public ProgramStatusTrigger(ProgramReference programReference, Set<ProgramStatus> programStatuses) {
+    super(programReference, programStatuses);
   }
 
   @VisibleForTesting
-  public ProgramStatusTrigger(ProgramId programId, ProgramStatus... programStatuses) {
-    super(programId, new HashSet<>(Arrays.asList(programStatuses)));
+  public ProgramStatusTrigger(ProgramReference programReference, ProgramStatus... programStatuses) {
+    super(programReference, new HashSet<>(Arrays.asList(programStatuses)));
   }
 
   @Override
@@ -68,7 +68,7 @@ public class ProgramStatusTrigger extends ProtoTrigger.ProgramStatusTrigger impl
 
   @Override
   public Set<String> getTriggerKeys() {
-    return Schedulers.triggerKeysForProgramStatuses(programId, programStatuses);
+    return Schedulers.triggerKeysForProgramStatuses(programReference, programStatuses);
   }
 
   @Override
@@ -78,9 +78,10 @@ public class ProgramStatusTrigger extends ProtoTrigger.ProgramStatusTrigger impl
       public List<TriggerInfo> apply(ProgramRunInfo runInfo) {
         Map<String, String> runtimeArgs = context.getProgramRuntimeArguments(runInfo.getProgramRunId());
         TriggerInfo triggerInfo =
-          new DefaultProgramStatusTriggerInfo(programId.getNamespace(),
-                                              programId.getParent().getApplication(),
-                                              ProgramType.valueOf(programId.getType().name()), programId.getProgram(),
+          new DefaultProgramStatusTriggerInfo(programReference.getNamespace(),
+                                              programReference.getParent().getApplication(),
+                                              ProgramType.valueOf(programReference.getType().name()),
+                                              programReference.getProgram(),
                                               RunIds.fromString(runInfo.getProgramRunId().getRun()),
                                               runInfo.getProgramStatus(),
                                               context.getWorkflowToken(runInfo.getProgramRunId()), runtimeArgs);
@@ -126,8 +127,8 @@ public class ProgramStatusTrigger extends ProtoTrigger.ProgramStatusTrigger impl
         continue;
       }
       ProgramRunId programRunId = GSON.fromJson(programRunIdString, ProgramRunId.class);
-      ProgramId triggeringProgramId = programRunId.getParent();
-      if (this.programId.isSameProgramExceptVersion(triggeringProgramId) && programStatuses.contains(programStatus)) {
+      ProgramReference triggeringProgramReference = programRunId.getParent().getProgramReference();
+      if (this.programReference.equals(triggeringProgramReference) && programStatuses.contains(programStatus)) {
         return function.apply(new ProgramRunInfo(programStatus, programRunId));
       }
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/ProgramStatusTriggerBuilder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/ProgramStatusTriggerBuilder.java
@@ -19,8 +19,7 @@ package io.cdap.cdap.internal.app.runtime.schedule.trigger;
 
 import io.cdap.cdap.api.ProgramStatus;
 import io.cdap.cdap.proto.ProgramType;
-import io.cdap.cdap.proto.id.ApplicationId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 
 import java.util.EnumSet;
 
@@ -51,8 +50,7 @@ public class ProgramStatusTriggerBuilder implements TriggerBuilder {
   @Override
   public ProgramStatusTrigger build(String namespace, String applicationName, String applicationVersion) {
     // Inherit environment attributes from the deployed application
-    ProgramId programId = new ApplicationId(namespace, applicationName, applicationVersion).program(programType,
-                                                                                                    programName);
-    return new ProgramStatusTrigger(programId, programStatuses);
+    ProgramReference programRef = new ProgramReference(namespace, applicationName, programType, programName);
+    return new ProgramStatusTrigger(programRef, programStatuses);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -1170,9 +1170,10 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    */
   private void deleteApp(ApplicationId appId, ApplicationSpecification spec) throws IOException {
     //Delete the schedules
-    scheduler.deleteSchedules(appId);
+    scheduler.deleteSchedules(appId.getAppReference());
     for (WorkflowSpecification workflowSpec : spec.getWorkflows().values()) {
-      scheduler.modifySchedulesTriggeredByDeletedProgram(appId.workflow(workflowSpec.getName()));
+      scheduler.modifySchedulesTriggeredByDeletedProgram(appId.workflow(workflowSpec.getName())
+                                                           .getProgramReference());
     }
 
     deleteMetrics(appId, spec);
@@ -1207,9 +1208,10 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    */
   private void deleteAppVersion(ApplicationId appId, ApplicationSpecification spec) {
     //Delete the schedules
-    scheduler.deleteSchedules(appId);
+    scheduler.deleteSchedules(appId.getAppReference());
     for (WorkflowSpecification workflowSpec : spec.getWorkflows().values()) {
-      scheduler.modifySchedulesTriggeredByDeletedProgram(appId.workflow(workflowSpec.getName()));
+      scheduler.modifySchedulesTriggeredByDeletedProgram(appId.workflow(workflowSpec.getName())
+                                                           .getProgramReference());
     }
     store.removeApplication(appId);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -553,8 +553,8 @@ public class ProgramLifecycleService {
     checkLatestVersionExeceution(programId);
     checkConcurrentExecution(programId);
 
-    Map<String, String> sysArgs = propertiesResolver.getSystemProperties(programId);
-    Map<String, String> userArgs = propertiesResolver.getUserProperties(programId);
+    Map<String, String> sysArgs = propertiesResolver.getSystemProperties(programId.getProgramReference());
+    Map<String, String> userArgs = propertiesResolver.getUserProperties(programId.getProgramReference());
     if (overrides != null) {
       userArgs.putAll(overrides);
     }
@@ -761,12 +761,12 @@ public class ProgramLifecycleService {
     accessEnforcer.enforce(programId, authenticationContext.getPrincipal(), ApplicationPermission.EXECUTE);
     checkConcurrentExecution(programId);
 
-    Map<String, String> sysArgs = propertiesResolver.getSystemProperties(programId);
+    Map<String, String> sysArgs = propertiesResolver.getSystemProperties(programId.getProgramReference());
     addAppCDAPVersion(programId, sysArgs);
     sysArgs.put(ProgramOptionConstants.SKIP_PROVISIONING, "true");
     sysArgs.put(SystemArguments.PROFILE_NAME, ProfileId.NATIVE.getScopedName());
     sysArgs.put(ProgramOptionConstants.IS_PREVIEW, Boolean.toString(isPreview));
-    Map<String, String> userArgs = propertiesResolver.getUserProperties(programId);
+    Map<String, String> userArgs = propertiesResolver.getUserProperties(programId.getProgramReference());
     if (overrides != null) {
       userArgs.putAll(overrides);
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/PropertiesResolver.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/PropertiesResolver.java
@@ -30,7 +30,7 @@ import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.PreferencesDetail;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.security.impersonation.ImpersonationInfo;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
@@ -62,24 +62,24 @@ public class PropertiesResolver {
     this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 
-  public Map<String, String> getUserProperties(ProgramId id)
+  public Map<String, String> getUserProperties(ProgramReference programRef)
     throws IOException, NotFoundException, UnauthorizedException {
-    PreferencesDetail preferencesDetail = preferencesFetcher.get(id, true);
+    PreferencesDetail preferencesDetail = preferencesFetcher.get(programRef, true);
     Map<String, String> userArgs = new HashMap<>(preferencesDetail.getProperties());
     userArgs.put(ProgramOptionConstants.LOGICAL_START_TIME, Long.toString(System.currentTimeMillis()));
     return userArgs;
   }
 
-  public Map<String, String> getSystemProperties(ProgramId id)
+  public Map<String, String> getSystemProperties(ProgramReference programRef)
     throws IOException, NamespaceNotFoundException, AccessException {
     Map<String, String> systemArgs = new HashMap<>();
     systemArgs.put(Constants.CLUSTER_NAME, cConf.get(Constants.CLUSTER_NAME, ""));
-    addNamespaceConfigs(systemArgs, id.getNamespaceId());
+    addNamespaceConfigs(systemArgs, programRef.getNamespaceId());
     if (SecurityUtil.isKerberosEnabled(cConf)) {
-      ImpersonationInfo impersonationInfo = SecurityUtil.createImpersonationInfo(ownerAdmin, cConf, id);
+      ImpersonationInfo impersonationInfo = SecurityUtil.createImpersonationInfo(ownerAdmin, cConf, programRef);
       systemArgs.put(ProgramOptionConstants.PRINCIPAL, impersonationInfo.getPrincipal());
       systemArgs.put(ProgramOptionConstants.APP_PRINCIPAL_EXISTS,
-                     String.valueOf(ownerAdmin.exists(id.getParent())));
+                     String.valueOf(ownerAdmin.exists(programRef.getParent())));
     }
     return systemArgs;
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -1481,6 +1481,18 @@ public class AppMetadataStore {
    * Get active runs in the given program, active runs means program run with status STARTING, PENDING,
    * RUNNING or SUSPENDED.
    *
+   * @param programReference versionless reference of the program
+   * @return map of run id to run record meta
+   */
+  public Map<ProgramRunId, RunRecordDetail> getActiveRuns(ProgramReference programReference) throws IOException {
+    List<Field<?>> prefix = getRunRecordProgramRefPrefix(TYPE_RUN_RECORD_ACTIVE, programReference);
+    return getRuns(Range.singleton(prefix), ProgramRunStatus.ALL, Integer.MAX_VALUE, null, null);
+  }
+
+  /**
+   * Get active runs in the given program, active runs means program run with status STARTING, PENDING,
+   * RUNNING or SUSPENDED.
+   *
    * @param programId given program
    * @return map of run id to run record meta
    */

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -460,6 +460,13 @@ public class DefaultStore implements Store {
   }
 
   @Override
+  public Map<ProgramRunId, RunRecordDetail> getAllActiveRuns(ProgramReference programReference) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      return getAppMetadataStore(context).getActiveRuns(programReference);
+    });
+  }
+
+  @Override
   public Map<ProgramRunId, RunRecordDetail> getActiveRuns(ProgramId programId) {
     return TransactionRunners.run(transactionRunner, context -> {
       return getAppMetadataStore(context).getActiveRuns(programId);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalPreferencesFetcherInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalPreferencesFetcherInternal.java
@@ -20,9 +20,11 @@ import com.google.inject.Inject;
 import io.cdap.cdap.config.PreferencesService;
 import io.cdap.cdap.proto.PreferencesDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 
 /**
  * Fetch preferences locally via {@link PreferencesService}
@@ -54,9 +56,17 @@ public class LocalPreferencesFetcherInternal implements PreferencesFetcher {
         ApplicationId appId = (ApplicationId) entityId;
         detail = resolved ? service.getResolvedPreferences(appId) : service.getPreferences(appId);
         break;
+      case APPLICATIONREFERENCE:
+        ApplicationReference applicationRef = (ApplicationReference) entityId;
+        detail = resolved ? service.getResolvedPreferences(applicationRef) : service.getPreferences(applicationRef);
+        break;
       case PROGRAM:
         ProgramId programId = (ProgramId) entityId;
         detail = resolved ? service.getResolvedPreferences(programId) : service.getPreferences(programId);
+        break;
+      case PROGRAMREFERENCE:
+        ProgramReference programRef = (ProgramReference) entityId;
+        detail = resolved ? service.getResolvedPreferences(programRef) : service.getPreferences(programRef);
         break;
       default:
         throw new UnsupportedOperationException(

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalScheduleFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalScheduleFetcher.java
@@ -23,7 +23,7 @@ import io.cdap.cdap.common.ProgramNotFoundException;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleRecord;
 import io.cdap.cdap.internal.app.runtime.schedule.ScheduleNotFoundException;
 import io.cdap.cdap.proto.ScheduleDetail;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ScheduleId;
 import io.cdap.cdap.scheduler.ProgramScheduleService;
 
@@ -60,11 +60,11 @@ public class LocalScheduleFetcher implements ScheduleFetcher {
   }
 
     @Override
-    public List<ScheduleDetail> list(ProgramId programId) throws IOException, ProgramNotFoundException {
+    public List<ScheduleDetail> list(ProgramReference programRef) throws IOException, ProgramNotFoundException {
       Predicate<ProgramScheduleRecord> predicate  = (record) -> true;
       Collection<ProgramScheduleRecord> schedules = null;
       try {
-        schedules = programScheduleService.list(programId, predicate);
+        schedules = programScheduleService.list(programRef, predicate);
       } catch (Exception e) {
         Throwables.propagateIfPossible(e.getCause(), IOException.class, ProgramNotFoundException.class);
         throw new IOException(e);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemotePreferencesFetcherInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemotePreferencesFetcherInternal.java
@@ -26,9 +26,11 @@ import io.cdap.cdap.common.internal.remote.RemoteClient;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.proto.PreferencesDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
@@ -84,11 +86,22 @@ public class RemotePreferencesFetcherInternal implements PreferencesFetcher {
         uri = String.format("namespaces/%s/apps/%s/preferences",
                             appId.getNamespace(), appId.getApplication());
         break;
+      case APPLICATIONREFERENCE:
+        ApplicationReference applicationRef = (ApplicationReference) entityId;
+        uri = String.format("namespaces/%s/apps/%s/preferences",
+                            applicationRef.getNamespace(), applicationRef.getApplication());
+        break;
       case PROGRAM:
         ProgramId programId = (ProgramId) entityId;
         uri = String.format("namespaces/%s/apps/%s/%s/%s/preferences",
                             programId.getNamespace(), programId.getApplication(), programId.getType().getCategoryName(),
                             programId.getProgram());
+        break;
+      case PROGRAMREFERENCE:
+        ProgramReference programRef = (ProgramReference) entityId;
+        uri = String.format("namespaces/%s/apps/%s/%s/%s/preferences",
+                            programRef.getNamespace(), programRef.getApplication(),
+                            programRef.getType().getCategoryName(), programRef.getProgram());
         break;
       default:
         throw new UnsupportedOperationException(

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteScheduleFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteScheduleFetcher.java
@@ -31,7 +31,7 @@ import io.cdap.cdap.internal.app.runtime.schedule.ScheduleNotFoundException;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
 import io.cdap.cdap.proto.ScheduleDetail;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ScheduleId;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.common.http.HttpMethod;
@@ -87,16 +87,16 @@ public class RemoteScheduleFetcher implements ScheduleFetcher {
    * Get the list of schedules for the given program id
    */
   @Override
-  public List<ScheduleDetail> list(ProgramId programId)
+  public List<ScheduleDetail> list(ProgramReference programRef)
     throws IOException, ProgramNotFoundException, UnauthorizedException {
-    String url = String.format("namespaces/%s/apps/%s/versions/%s/schedules",
-                               programId.getNamespace(), programId.getApplication(), programId.getVersion());
+    String url = String.format("namespaces/%s/apps/%s/schedules",
+                               programRef.getNamespace(), programRef.getApplication());
     HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.GET, url);
     HttpResponse httpResponse = null;
     try {
       httpResponse = execute(requestBuilder.build());
     } catch (NotFoundException e) {
-      throw new ProgramNotFoundException(programId);
+      throw new ProgramNotFoundException(programRef);
     }
     ObjectResponse<List<ScheduleDetail>> objectResponse =
       ObjectResponse.fromJsonBody(httpResponse, SCHEDULE_DETAIL_LIST_TYPE, GSON);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ScheduleFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ScheduleFetcher.java
@@ -19,7 +19,7 @@ package io.cdap.cdap.metadata;
 import io.cdap.cdap.common.ProgramNotFoundException;
 import io.cdap.cdap.internal.app.runtime.schedule.ScheduleNotFoundException;
 import io.cdap.cdap.proto.ScheduleDetail;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ScheduleId;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 
@@ -44,10 +44,11 @@ public interface ScheduleFetcher {
    */
   /**
    * Get the list of schedules for the given program id
-   * @param programId the id of the program to get the list of schedules for
+   * @param programRef the reference of the program to get the list of schedules for
    * @return a list of schedules set on the program
    * @throws IOException if failed to get the list of schedules for the given program
    * @throws ProgramNotFoundException if the given program id doesn't exist
    */
-  List<ScheduleDetail> list(ProgramId programId) throws IOException, ProgramNotFoundException, UnauthorizedException;
+  List<ScheduleDetail> list(ProgramReference programRef) throws IOException, ProgramNotFoundException,
+    UnauthorizedException;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
@@ -219,7 +219,7 @@ public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor
         // make sure the schedule exists before updating
         try {
           ProgramSchedule schedule = scheduleDataset.getSchedule(scheduleId);
-          collectScheduleProfileMetadata(schedule, getResolvedProfileId(schedule.getProgramId()), updates);
+          collectScheduleProfileMetadata(schedule, getResolvedProfileId(schedule.getProgramReference()), updates);
         } catch (NotFoundException e) {
           LOG.debug("Schedule {} is not found, so its profile metadata will not get updated. " +
                       "Ignoring the message {}", scheduleId, message);
@@ -295,7 +295,7 @@ public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor
       : getProfileId(programId).orElse(appProfile);
     addProfileMetadataUpdate(programId, programProfile, updates);
 
-    for (ProgramSchedule schedule : scheduleDataset.listSchedules(programId)) {
+    for (ProgramSchedule schedule : scheduleDataset.listSchedules(programId.getProgramReference())) {
       collectScheduleProfileMetadata(schedule, programProfile, updates);
     }
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/ConstraintCheckerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/ConstraintCheckerService.java
@@ -251,7 +251,7 @@ class ConstraintCheckerService extends AbstractIdleService {
           }, TransactionException.class);
         } catch (TransactionException e) {
           LOG.warn("Failed to run program {} in schedule {}. Skip running this program.",
-                   job.getSchedule().getProgramId(), job.getSchedule().getName(), e);
+                   job.getSchedule().getProgramReference(), job.getSchedule().getName(), e);
         }
         readyJobsIter.remove();
       }
@@ -287,7 +287,7 @@ class ConstraintCheckerService extends AbstractIdleService {
                                      job.getSchedule().getName());
       } catch (Exception e) {
         LOG.error("Skip launching job {} because the program {} encountered an exception while launching.",
-                  job.getJobKey(), job.getSchedule().getProgramId(), e);
+                  job.getJobKey(), job.getSchedule().getProgramReference(), e);
         emitScheduleJobFailureMetric(job.getSchedule().getScheduleId().getApplication(),
                                      job.getSchedule().getName());
       }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/NoOpScheduler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/NoOpScheduler.java
@@ -22,9 +22,9 @@ import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramSchedule;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleRecord;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleStatus;
-import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ScheduleId;
 
 import java.util.Collection;
@@ -72,17 +72,17 @@ public class NoOpScheduler implements Scheduler {
   }
 
   @Override
-  public void deleteSchedules(ApplicationId appId) {
+  public void deleteSchedules(ApplicationReference appReference) {
 
   }
 
   @Override
-  public void deleteSchedules(ProgramId programId) {
+  public void deleteSchedules(ProgramReference programRef) {
 
   }
 
   @Override
-  public void modifySchedulesTriggeredByDeletedProgram(ProgramId programId) {
+  public void modifySchedulesTriggeredByDeletedProgram(ProgramReference programRef) {
 
   }
 
@@ -102,12 +102,12 @@ public class NoOpScheduler implements Scheduler {
   }
 
   @Override
-  public List<ProgramSchedule> listSchedules(ApplicationId appId) {
+  public List<ProgramSchedule> listSchedules(ApplicationReference appRef) {
     return Collections.EMPTY_LIST;
   }
 
   @Override
-  public List<ProgramSchedule> listSchedules(ProgramId programId) {
+  public List<ProgramSchedule> listSchedules(ProgramReference programRef) {
     return Collections.EMPTY_LIST;
   }
 
@@ -118,12 +118,12 @@ public class NoOpScheduler implements Scheduler {
   }
 
   @Override
-  public List<ProgramScheduleRecord> listScheduleRecords(ApplicationId appId) {
+  public List<ProgramScheduleRecord> listScheduleRecords(ApplicationReference appRef) {
     return Collections.EMPTY_LIST;
   }
 
   @Override
-  public List<ProgramScheduleRecord> listScheduleRecords(ProgramId programId) {
+  public List<ProgramScheduleRecord> listScheduleRecords(ProgramReference programReference) {
     return Collections.EMPTY_LIST;
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/ScheduleNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/ScheduleNotificationSubscriberService.java
@@ -41,7 +41,7 @@ import io.cdap.cdap.proto.Notification;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.ScheduleId;
 import io.cdap.cdap.spi.data.StructuredTableContext;
@@ -285,8 +285,8 @@ public class ScheduleNotificationSubscriberService extends AbstractIdleService {
       }
 
       ProgramRunId programRunId = GSON.fromJson(programRunIdString, ProgramRunId.class);
-      ProgramId programId = programRunId.getParent();
-      String triggerKeyForProgramStatus = Schedulers.triggerKeyForProgramStatus(programId, programStatus);
+      ProgramReference programReference = programRunId.getParent().getProgramReference();
+      String triggerKeyForProgramStatus = Schedulers.triggerKeyForProgramStatus(programReference, programStatus);
 
       for (ProgramScheduleRecord schedule : scheduleStore.findSchedules(triggerKeyForProgramStatus)) {
         jobQueue.addNotification(schedule, notification);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/Scheduler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/Scheduler.java
@@ -24,9 +24,9 @@ import io.cdap.cdap.common.ProfileConflictException;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramSchedule;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleRecord;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleStatus;
-import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ScheduleId;
 
 import java.util.Collection;
@@ -108,16 +108,16 @@ public interface Scheduler {
   /**
    * Removes all schedules for a specific application from the store.
    *
-   * @param appId the application id for which to delete the schedules
+   * @param applicationReference the application id for which to delete the schedules
    */
-  void deleteSchedules(ApplicationId appId);
+  void deleteSchedules(ApplicationReference applicationReference);
 
   /**
    * Removes all schedules for a specific program from the store.
    *
-   * @param programId the program id for which to delete the schedules
+   * @param programReference the program id for which to delete the schedules
    */
-  void deleteSchedules(ProgramId programId);
+  void deleteSchedules(ProgramReference programReference);
 
   /**
    * Update all schedules that can be triggered by the given deleted program. Schedules will be removed if they
@@ -125,9 +125,9 @@ public interface Scheduler {
    * composite triggers will be updated if the composite trigger can still be satisfied after the program is deleted,
    * otherwise the schedules will be deleted.
    *
-   * @param programId id of the deleted program
+   * @param programRef programreference of the deleted program
    */
-  void modifySchedulesTriggeredByDeletedProgram(ProgramId programId);
+  void modifySchedulesTriggeredByDeletedProgram(ProgramReference programRef);
 
   /**
    * Read a schedule from the store.
@@ -160,18 +160,18 @@ public interface Scheduler {
   /**
    * Retrieve all schedules for a given application.
    *
-   * @param appId the application for which to list the schedules.
+   * @param appReference the application for which to list the schedules.
    * @return a list of schedules for the application; never null
    */
-  List<ProgramSchedule> listSchedules(ApplicationId appId) throws NotFoundException;
+  List<ProgramSchedule> listSchedules(ApplicationReference appReference) throws NotFoundException;
 
   /**
    * Retrieve all schedules for a given program.
    *
-   * @param programId the program for which to list the schedules.
+   * @param programReference the program for which to list the schedules.
    * @return a list of schedules for the program; never null
    */
-  List<ProgramSchedule> listSchedules(ProgramId programId) throws NotFoundException;
+  List<ProgramSchedule> listSchedules(ProgramReference programReference) throws NotFoundException;
 
   /**
    * Retrieve all schedules for a given namespace
@@ -185,18 +185,18 @@ public interface Scheduler {
   /**
    * Retrieve all schedule records for a given application.
    *
-   * @param appId the application for which to list the schedule records.
+   * @param appReference the application for which to list the schedule records.
    * @return a list of schedule records for the application; never null
    */
-  List<ProgramScheduleRecord> listScheduleRecords(ApplicationId appId);
+  List<ProgramScheduleRecord> listScheduleRecords(ApplicationReference appReference);
 
   /**
    * Retrieve all schedule records for a given program.
    *
-   * @param programId the program for which to list the schedule records.
+   * @param programReference the program for which to list the schedule records.
    * @return a list of schedule records for the program; never null
    */
-  List<ProgramScheduleRecord> listScheduleRecords(ProgramId programId);
+  List<ProgramScheduleRecord> listScheduleRecords(ProgramReference programReference);
 
   /**
    * Find all schedules for a given trigger key

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/OperationsDashboardHttpHandlerTest.java
@@ -245,14 +245,15 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
                           TimeUnit.SECONDS.toMinutes(endTime), sched1Mins, startTime);
 
     List<DashboardProgramRunRecord> expectedRunRecords = new ArrayList<>();
-    String userId = impersonator.getUGI(sched1.getProgramId()).getUserName();
+    String userId = impersonator.getUGI(sched1.getProgramReference()).getUserName();
     for (long runTime : runTimesSchedule1) {
       expectedRunRecords.add(
-        new DashboardProgramRunRecord(sched1.getProgramId().getNamespace(),
+        new DashboardProgramRunRecord(sched1.getProgramReference().getNamespace(),
                                       ArtifactSummary.from(ARTIFACT_ID1.toApiArtifactId()),
                                       new DashboardProgramRunRecord.ApplicationNameVersion(
-                                        sched1.getProgramId().getApplication(), sched1.getProgramId().getVersion()),
-                                      sched1.getProgramId().getType().name(), sched1.getProgramId().getProgram(),
+                                        sched1.getProgramReference().getApplication()),
+                                      sched1.getProgramReference().getType().name(),
+                                      sched1.getProgramReference().getProgram(),
                                       null, userId, "SCHEDULED", runTime, null, null, null, null, null));
     }
     // assert the number of scheduled runs are expected for both programs
@@ -332,9 +333,9 @@ public class OperationsDashboardHttpHandlerTest extends AppFabricTestBase {
   private ProgramSchedule initializeSchedules(int scheduleMins, WorkflowId workflowId)
     throws ConflictException, BadRequestException, NotFoundException {
     ProgramSchedule schedule =
-      new ProgramSchedule(String.format("%dMinSchedule", scheduleMins), "time schedule", workflowId,
-                          Collections.emptyMap(), new TimeTrigger(String.format("*/%d * * * *", scheduleMins)),
-                          Collections.emptyList());
+      new ProgramSchedule(String.format("%dMinSchedule", scheduleMins), "time schedule",
+                          workflowId.getProgramReference(), Collections.emptyMap(),
+                          new TimeTrigger(String.format("*/%d * * * *", scheduleMins)), Collections.emptyList());
     scheduler.addSchedule(schedule);
     scheduler.enableSchedule(schedule.getScheduleId());
     return schedule;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/ConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/ConfiguratorTest.java
@@ -208,6 +208,6 @@ public class ConfiguratorTest {
 
     ProgramStatusTrigger trigger = (ProgramStatusTrigger) specification.getProgramSchedules()
                                                                        .get(ConfigTestApp.SCHEDULE_NAME).getTrigger();
-    Assert.assertEquals(trigger.getProgramId().getProgram(), ConfigTestApp.WORKFLOW_NAME);
+    Assert.assertEquals(trigger.getProgramReference().getProgram(), ConfigTestApp.WORKFLOW_NAME);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/ScheduleTaskRunnerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/ScheduleTaskRunnerTest.java
@@ -57,8 +57,8 @@ public class ScheduleTaskRunnerTest {
 
     ApplicationId appId = NamespaceId.DEFAULT.app("app");
     ProgramSchedule programSchedule = new ProgramSchedule(
-      "schedule", "desc", appId.workflow("wf2"),
-      Collections.singletonMap("key", "val"), new ProgramStatusTrigger(appId.workflow("wf1")),
+      "schedule", "desc", appId.workflow("wf2").getProgramReference(),
+      Collections.singletonMap("key", "val"), new ProgramStatusTrigger(appId.workflow("wf1").getProgramReference()),
       Collections.emptyList());
     Map<String, String> userArgs = ScheduleTaskRunner.getUserArgs(programSchedule, propertiesResolver);
     Assert.assertEquals("val", userArgs.get("key"));

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/TimeSchedulerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/TimeSchedulerTest.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
 import io.cdap.cdap.proto.ScheduledRuntime;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.WorkflowId;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -40,6 +41,7 @@ public class TimeSchedulerTest extends AppFabricTestBase {
   private static final NamespaceId NS_ID = new NamespaceId("schedtest");
   private static final ApplicationId APP1_ID = NS_ID.app("app1");
   private static final WorkflowId PROG1_ID = APP1_ID.workflow("wf1");
+  private static final ProgramReference PROG1_REFERENCE = PROG1_ID.getProgramReference();
 
   private static TimeScheduler timeScheduler;
 
@@ -54,9 +56,10 @@ public class TimeSchedulerTest extends AppFabricTestBase {
   @Test
   public void testNextSchedule() throws Exception {
     // a schedule to be triggered every 5 minutes
-    ProgramSchedule sched = new ProgramSchedule("tsched11", "two times schedule", PROG1_ID,
-      ImmutableMap.of("prop2", "xx"),
-      new TimeTrigger("*/5 * * * *"), Collections.emptyList());
+    ProgramSchedule sched = new ProgramSchedule("tsched11", "two times schedule",
+                                                PROG1_REFERENCE, ImmutableMap.of("prop2", "xx"),
+                                                new TimeTrigger("*/5 * * * *"),
+                                                Collections.emptyList());
     timeScheduler.addProgramSchedule(sched);
     // schedule is by default SUSPENDED after being added, resume it to enable the schedule
     timeScheduler.resumeProgramSchedule(sched);
@@ -64,7 +67,7 @@ public class TimeSchedulerTest extends AppFabricTestBase {
     long startTimeInSeconds = currentTimeInSeconds + TimeUnit.HOURS.toSeconds(1);
     long endTimeInSeconds = currentTimeInSeconds + TimeUnit.HOURS.toSeconds(3);
     List<ScheduledRuntime> nextRuntimes =
-      timeScheduler.getAllScheduledRunTimes(PROG1_ID, SchedulableProgramType.WORKFLOW,
+      timeScheduler.getAllScheduledRunTimes(PROG1_ID.getProgramReference(), SchedulableProgramType.WORKFLOW,
                                             startTimeInSeconds, endTimeInSeconds);
     // for a scan range of 1pm to 3pm. since start time is inclusive, from 1pm tp 2pm we will have 13 schedules
     // and from 2:05 pm to 2:55pm will have 11 schedules as end time is exclusive. in total we expect 24 schedules.
@@ -73,7 +76,7 @@ public class TimeSchedulerTest extends AppFabricTestBase {
 
   @Test
   public void testDeleteNonExisting() throws Exception {
-    ProgramSchedule sched = new ProgramSchedule("name", "description", PROG1_ID,
+    ProgramSchedule sched = new ProgramSchedule("name", "description", PROG1_REFERENCE,
                                                 Collections.emptyMap(),
                                                 new TimeTrigger("*/5 * * * *"), Collections.emptyList());
     timeScheduler.addProgramSchedule(sched);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/ConcurrencyConstraintTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/ConcurrencyConstraintTest.java
@@ -29,10 +29,12 @@ import io.cdap.cdap.internal.app.runtime.schedule.queue.Job;
 import io.cdap.cdap.internal.app.runtime.schedule.queue.SimpleJob;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.PartitionTrigger;
 import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProfileId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.WorkflowId;
 import org.junit.Assert;
@@ -50,6 +52,8 @@ public class ConcurrencyConstraintTest {
   private static final ApplicationId APP_ID = TEST_NS.app("app1");
   private static final ArtifactId ARTIFACT_ID = TEST_NS.artifact("test", "1.0").toApiArtifactId();
   private static final WorkflowId WORKFLOW_ID = APP_ID.workflow("wf1");
+  private static final ProgramReference WORKFLOW_REF = APP_ID.getAppReference().program(ProgramType.WORKFLOW,
+                                                                                        "wf1");
   private static final DatasetId DATASET_ID = TEST_NS.dataset("pfs1");
 
   private static final Map<String, String> EMPTY_MAP = ImmutableMap.of();
@@ -88,7 +92,7 @@ public class ConcurrencyConstraintTest {
     Store store = AppFabricTestHelper.getInjector().getInstance(Store.class);
     try {
       long now = System.currentTimeMillis();
-      ProgramSchedule schedule = new ProgramSchedule("SCHED1", "one partition schedule", WORKFLOW_ID,
+      ProgramSchedule schedule = new ProgramSchedule("SCHED1", "one partition schedule", WORKFLOW_REF,
                                                      ImmutableMap.of("prop3", "abc"),
                                                      new PartitionTrigger(DATASET_ID, 1),
                                                      ImmutableList.of());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/DelayConstraintTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/DelayConstraintTest.java
@@ -24,10 +24,11 @@ import io.cdap.cdap.internal.app.runtime.schedule.queue.SimpleJob;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.PartitionTrigger;
 import io.cdap.cdap.internal.schedule.constraint.Constraint;
 import io.cdap.cdap.proto.Notification;
+import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.proto.id.WorkflowId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,13 +42,14 @@ public class DelayConstraintTest {
 
   private static final NamespaceId TEST_NS = new NamespaceId("DelayConstraintTest");
   private static final ApplicationId APP_ID = TEST_NS.app("app1");
-  private static final WorkflowId WORKFLOW_ID = APP_ID.workflow("wf1");
+  private static final ProgramReference WORKFLOW_REF = APP_ID.getAppReference().program(ProgramType.WORKFLOW,
+                                                                                        "wf1");
   private static final DatasetId DATASET_ID = TEST_NS.dataset("pfs1");
 
   @Test
   public void testDelayConstraint() {
     long now = System.currentTimeMillis();
-    ProgramSchedule schedule = new ProgramSchedule("SCHED1", "one partition schedule", WORKFLOW_ID,
+    ProgramSchedule schedule = new ProgramSchedule("SCHED1", "one partition schedule", WORKFLOW_REF,
                                                    ImmutableMap.of("prop3", "abc"),
                                                    new PartitionTrigger(DATASET_ID, 1),
                                                    ImmutableList.<Constraint>of());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/LastRunConstraintTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/LastRunConstraintTest.java
@@ -29,10 +29,12 @@ import io.cdap.cdap.internal.app.runtime.schedule.queue.Job;
 import io.cdap.cdap.internal.app.runtime.schedule.queue.SimpleJob;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.PartitionTrigger;
 import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProfileId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.WorkflowId;
 import org.junit.Assert;
@@ -50,6 +52,8 @@ public class LastRunConstraintTest {
   private static final ApplicationId APP_ID = TEST_NS.app("app1");
   private static final ArtifactId ARTIFACT_ID = TEST_NS.artifact("test", "1.0").toApiArtifactId();
   private static final WorkflowId WORKFLOW_ID = APP_ID.workflow("wf1");
+  private static final ProgramReference WORKFLOW_REF = APP_ID.getAppReference().program(ProgramType.WORKFLOW,
+                                                                                        "wf1");
   private static final DatasetId DATASET_ID = TEST_NS.dataset("pfs1");
 
   private static final Map<String, String> EMPTY_MAP = ImmutableMap.of();
@@ -80,7 +84,7 @@ public class LastRunConstraintTest {
     try {
       long now = System.currentTimeMillis();
       long nowSec = TimeUnit.MILLISECONDS.toSeconds(now);
-      ProgramSchedule schedule = new ProgramSchedule("SCHED1", "one partition schedule", WORKFLOW_ID,
+      ProgramSchedule schedule = new ProgramSchedule("SCHED1", "one partition schedule", WORKFLOW_REF,
                                                      ImmutableMap.of("prop3", "abc"),
                                                      new PartitionTrigger(DATASET_ID, 1),
                                                      ImmutableList.of());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/TimeRangeConstraintTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/TimeRangeConstraintTest.java
@@ -24,10 +24,11 @@ import io.cdap.cdap.internal.app.runtime.schedule.queue.SimpleJob;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.PartitionTrigger;
 import io.cdap.cdap.internal.schedule.constraint.Constraint;
 import io.cdap.cdap.proto.Notification;
+import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.proto.id.WorkflowId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -42,10 +43,11 @@ public class TimeRangeConstraintTest {
 
   private static final NamespaceId TEST_NS = new NamespaceId("TimeRangeConstraintTest");
   private static final ApplicationId APP_ID = TEST_NS.app("app1");
-  private static final WorkflowId WORKFLOW_ID = APP_ID.workflow("wf1");
+  private static final ProgramReference WORKFLOW_REF = APP_ID.getAppReference().program(ProgramType.WORKFLOW,
+                                                                                        "wf1");
   private static final DatasetId DATASET_ID = TEST_NS.dataset("pfs1");
 
-  private static final ProgramSchedule SCHEDULE = new ProgramSchedule("SCHED1", "one partition schedule", WORKFLOW_ID,
+  private static final ProgramSchedule SCHEDULE = new ProgramSchedule("SCHED1", "one partition schedule", WORKFLOW_REF,
                                                                       ImmutableMap.of("prop3", "abc"),
                                                                       new PartitionTrigger(DATASET_ID, 1),
                                                                       ImmutableList.<Constraint>of());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/queue/JobQueueTableTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/queue/JobQueueTableTest.java
@@ -34,10 +34,11 @@ import io.cdap.cdap.internal.app.runtime.schedule.trigger.OrTriggerBuilder;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.PartitionTrigger;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.TimeTrigger;
 import io.cdap.cdap.proto.Notification;
+import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.proto.id.WorkflowId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import org.junit.After;
@@ -71,15 +72,16 @@ public abstract class JobQueueTableTest {
 
   private static final NamespaceId TEST_NS = new NamespaceId("jobQueueTest");
   private static final ApplicationId APP_ID = TEST_NS.app("app1");
-  private static final WorkflowId WORKFLOW_ID = APP_ID.workflow("wf1");
+  private static final ProgramReference WORKFLOW_REF = APP_ID.getAppReference().program(ProgramType.WORKFLOW,
+                                                                                        "wf1");
   private static final DatasetId DATASET_ID = TEST_NS.dataset("pfs1");
   private static final DatasetId DATASET2_ID = TEST_NS.dataset("pfs2");
 
-  private static final ProgramSchedule SCHED1 = new ProgramSchedule("SCHED1", "one partition schedule", WORKFLOW_ID,
+  private static final ProgramSchedule SCHED1 = new ProgramSchedule("SCHED1", "one partition schedule", WORKFLOW_REF,
                                                                     ImmutableMap.of("prop3", "abc"),
                                                                     new PartitionTrigger(DATASET_ID, 1),
                                                                     ImmutableList.of());
-  private static final ProgramSchedule SCHED2 = new ProgramSchedule("SCHED2", "time schedule", WORKFLOW_ID,
+  private static final ProgramSchedule SCHED2 = new ProgramSchedule("SCHED2", "time schedule", WORKFLOW_REF,
                                                                     ImmutableMap.of("prop3", "abc"),
                                                                     new TimeTrigger("* * * * *"),
                                                                     ImmutableList.of());
@@ -87,7 +89,7 @@ public abstract class JobQueueTableTest {
     new OrTriggerBuilder(new PartitionTrigger(DATASET_ID, 6),
                          new PartitionTrigger(DATASET2_ID, 1))
       .build(APP_ID.getNamespace(), APP_ID.getApplication(), APP_ID.getVersion());
-  private static final ProgramSchedule SCHED3 = new ProgramSchedule("SCHED3", "three partitions schedule", WORKFLOW_ID,
+  private static final ProgramSchedule SCHED3 = new ProgramSchedule("SCHED3", "three partitions schedule", WORKFLOW_REF,
                                                                     ImmutableMap.of("prop1", "abc1"),
                                                                     TRIGGER,
                                                                     ImmutableList.of());
@@ -232,7 +234,7 @@ public abstract class JobQueueTableTest {
       Multimap<Integer, Job> jobsByPartition = HashMultimap.create();
       long now = 1494353984967L;
       for (int i = 0; i < 100; i++) {
-        ProgramSchedule schedule = new ProgramSchedule("sched" + i, "one partition schedule", WORKFLOW_ID,
+        ProgramSchedule schedule = new ProgramSchedule("sched" + i, "one partition schedule", WORKFLOW_REF,
                                                        ImmutableMap.of(),
                                                        new PartitionTrigger(DATASET_ID, 1),
                                                        ImmutableList.of());
@@ -423,7 +425,7 @@ public abstract class JobQueueTableTest {
 
         Assert.assertNull(jobQueue.getJob(SCHED1_JOB.getJobKey()));
 
-        ProgramSchedule scheduleWithTimeout = new ProgramSchedule("SCHED1", "one partition schedule", WORKFLOW_ID,
+        ProgramSchedule scheduleWithTimeout = new ProgramSchedule("SCHED1", "one partition schedule", WORKFLOW_REF,
                                                                   ImmutableMap.of("prop3", "abc"),
                                                                   new PartitionTrigger(DATASET_ID, 1),
                                                                   ImmutableList.of());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/store/ProgramScheduleStoreDatasetTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/store/ProgramScheduleStoreDatasetTest.java
@@ -32,8 +32,10 @@ import io.cdap.cdap.internal.app.runtime.schedule.trigger.TimeTrigger;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
 import io.cdap.cdap.internal.schedule.constraint.Constraint;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.WorkflowId;
 import io.cdap.cdap.spi.data.table.field.Range;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
@@ -61,11 +63,19 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
   private static final ApplicationId APP1_ID = NS1_ID.app("app1", "1");
   private static final ApplicationId APP2_ID = NS1_ID.app("app2");
   private static final ApplicationId APP3_ID = NS2_ID.app("app3", "1");
+  private static final ApplicationReference APP1_REFERENCE = APP1_ID.getAppReference();
+  private static final ApplicationReference APP2_REFERENCE = APP2_ID.getAppReference();
+  private static final ApplicationReference APP3_REFERENCE = APP3_ID.getAppReference();
   private static final WorkflowId PROG1_ID = APP1_ID.workflow("wf1");
   private static final WorkflowId PROG2_ID = APP2_ID.workflow("wf2");
   private static final WorkflowId PROG3_ID = APP2_ID.workflow("wf3");
   private static final WorkflowId PROG4_ID = APP3_ID.workflow("wf4");
   private static final WorkflowId PROG5_ID = APP3_ID.workflow("wf5");
+  private static final ProgramReference PROG1_REFERENCE = PROG1_ID.getProgramReference();
+  private static final ProgramReference PROG2_REFERENCE = PROG2_ID.getProgramReference();
+  private static final ProgramReference PROG3_REFERENCE = PROG3_ID.getProgramReference();
+  private static final ProgramReference PROG4_REFERENCE = PROG4_ID.getProgramReference();
+  private static final ProgramReference PROG5_REFERENCE = PROG5_ID.getProgramReference();
   private static final DatasetId DS1_ID = NS1_ID.dataset("pfs1");
   private static final DatasetId DS2_ID = NS1_ID.dataset("pfs2");
 
@@ -88,14 +98,19 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
   public void testListSchedules() {
     TransactionRunner transactionRunner = getTransactionRunner();
 
-    final ProgramSchedule sched1 = new ProgramSchedule("sched1", "one partition schedule", PROG1_ID,
-      Collections.emptyMap(), new PartitionTrigger(DS1_ID, 1), Collections.emptyList());
-    final ProgramSchedule sched2 = new ProgramSchedule("sched2", "time schedule", PROG2_ID,
-      Collections.emptyMap(), new TimeTrigger("* * * 1 1"), Collections.emptyList());
-    final ProgramSchedule sched3 = new ProgramSchedule("sched3", "two partitions schedule", PROG4_ID,
-      Collections.emptyMap(), new PartitionTrigger(DS1_ID, 2), Collections.emptyList());
-    final ProgramSchedule sched4 = new ProgramSchedule("sched4", "time schedule", PROG5_ID,
-      Collections.emptyMap(), new TimeTrigger("* * * 2 1"), Collections.emptyList());
+    final ProgramSchedule sched1 = new ProgramSchedule("sched1", "one partition schedule",
+                                                       PROG1_REFERENCE, Collections.emptyMap(),
+                                                       new PartitionTrigger(DS1_ID, 1),
+                                                       Collections.emptyList());
+    final ProgramSchedule sched2 = new ProgramSchedule("sched2", "time schedule", PROG2_REFERENCE,
+                                                       Collections.emptyMap(), new TimeTrigger("* * * 1 1"),
+                                                       Collections.emptyList());
+    final ProgramSchedule sched3 = new ProgramSchedule("sched3", "two partitions schedule", PROG4_REFERENCE,
+                                                       Collections.emptyMap(), new PartitionTrigger(DS1_ID, 2),
+                                                       Collections.emptyList());
+    final ProgramSchedule sched4 = new ProgramSchedule("sched4", "time schedule", PROG5_REFERENCE,
+                                                       Collections.emptyMap(), new TimeTrigger("* * * 2 1"),
+                                                       Collections.emptyList());
 
     // assert no schedules exists before adding schedules
     TransactionRunners.run(
@@ -104,13 +119,13 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
         ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
         Assert.assertTrue(store.listSchedules(NS1_ID, schedule -> true).isEmpty());
         Assert.assertTrue(store.listSchedules(NS2_ID, schedule -> true).isEmpty());
-        Assert.assertTrue(store.listScheduleRecords(APP1_ID).isEmpty());
-        Assert.assertTrue(store.listScheduleRecords(APP2_ID).isEmpty());
-        Assert.assertTrue(store.listScheduleRecords(APP3_ID).isEmpty());
-        Assert.assertTrue(store.listScheduleRecords(PROG1_ID).isEmpty());
-        Assert.assertTrue(store.listScheduleRecords(PROG2_ID).isEmpty());
-        Assert.assertTrue(store.listScheduleRecords(PROG3_ID).isEmpty());
-        Assert.assertTrue(store.listScheduleRecords(PROG4_ID).isEmpty());
+        Assert.assertTrue(store.listScheduleRecords(APP1_REFERENCE).isEmpty());
+        Assert.assertTrue(store.listScheduleRecords(APP2_REFERENCE).isEmpty());
+        Assert.assertTrue(store.listScheduleRecords(APP3_REFERENCE).isEmpty());
+        Assert.assertTrue(store.listScheduleRecords(PROG1_REFERENCE).isEmpty());
+        Assert.assertTrue(store.listScheduleRecords(PROG2_REFERENCE).isEmpty());
+        Assert.assertTrue(store.listScheduleRecords(PROG3_REFERENCE).isEmpty());
+        Assert.assertTrue(store.listScheduleRecords(PROG4_REFERENCE).isEmpty());
       }
     );
 
@@ -134,20 +149,20 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
                             new HashSet<>(store.listSchedules(NS2_ID, schedule -> true)));
         // list schedules by app
         Assert.assertEquals(ImmutableSet.of(sched1),
-                            toScheduleSet(store.listScheduleRecords(APP1_ID)));
+                            toScheduleSet(store.listScheduleRecords(APP1_REFERENCE)));
         Assert.assertEquals(ImmutableSet.of(sched2),
-                            toScheduleSet(store.listScheduleRecords(APP2_ID)));
+                            toScheduleSet(store.listScheduleRecords(APP2_REFERENCE)));
         Assert.assertEquals(ImmutableSet.of(sched3, sched4),
-                            toScheduleSet(store.listScheduleRecords(APP3_ID)));
+                            toScheduleSet(store.listScheduleRecords(APP3_REFERENCE)));
         // list schedules by program
         Assert.assertEquals(ImmutableSet.of(sched1),
-                            toScheduleSet(store.listScheduleRecords(PROG1_ID)));
+                            toScheduleSet(store.listScheduleRecords(PROG1_REFERENCE)));
         Assert.assertEquals(ImmutableSet.of(sched2),
-                            toScheduleSet(store.listScheduleRecords(PROG2_ID)));
+                            toScheduleSet(store.listScheduleRecords(PROG2_REFERENCE)));
         Assert.assertEquals(ImmutableSet.of(sched3),
-                            toScheduleSet(store.listScheduleRecords(PROG4_ID)));
+                            toScheduleSet(store.listScheduleRecords(PROG4_REFERENCE)));
         Assert.assertEquals(ImmutableSet.of(sched4),
-                            toScheduleSet(store.listScheduleRecords(PROG5_ID)));
+                            toScheduleSet(store.listScheduleRecords(PROG5_REFERENCE)));
       }
     );
 
@@ -177,15 +192,15 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
       transactionRunner,
       context -> {
         ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
-        store.deleteSchedules(APP1_ID, System.currentTimeMillis());
+        store.deleteSchedules(APP1_REFERENCE, System.currentTimeMillis());
         Assert.assertEquals(ImmutableSet.of(),
-                            toScheduleSet(store.listScheduleRecords(APP1_ID)));
-        store.deleteSchedules(PROG2_ID, System.currentTimeMillis());
+                            toScheduleSet(store.listScheduleRecords(APP1_REFERENCE)));
+        store.deleteSchedules(PROG2_REFERENCE, System.currentTimeMillis());
         Assert.assertEquals(ImmutableSet.of(),
-                            toScheduleSet(store.listScheduleRecords(PROG2_ID)));
-        store.deleteSchedules(APP3_ID, System.currentTimeMillis());
+                            toScheduleSet(store.listScheduleRecords(PROG2_REFERENCE)));
+        store.deleteSchedules(APP3_REFERENCE, System.currentTimeMillis());
         Assert.assertEquals(ImmutableSet.of(),
-                            toScheduleSet(store.listScheduleRecords(APP3_ID)));
+                            toScheduleSet(store.listScheduleRecords(APP3_REFERENCE)));
       }
     );
   }
@@ -194,21 +209,22 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
   public void testFindSchedulesByEventAndUpdateSchedule() {
     TransactionRunner transactionRunner = getTransactionRunner();
 
-    final ProgramSchedule sched11 = new ProgramSchedule("sched11", "one partition schedule", PROG1_ID,
-                                                        ImmutableMap.of("prop3", "abc"),
+    final ProgramSchedule sched11 = new ProgramSchedule("sched11", "one partition schedule",
+                                                        PROG1_REFERENCE, ImmutableMap.of("prop3", "abc"),
                                                         new PartitionTrigger(DS1_ID, 1),
                                                         ImmutableList.<Constraint>of());
-    final ProgramSchedule sched12 = new ProgramSchedule("sched12", "two partition schedule", PROG1_ID,
-                                                        ImmutableMap.of("propper", "popper"),
+    final ProgramSchedule sched12 = new ProgramSchedule("sched12", "two partition schedule",
+                                                        PROG1_REFERENCE, ImmutableMap.of("propper", "popper"),
                                                         new PartitionTrigger(DS2_ID, 2),
                                                         ImmutableList.<Constraint>of());
-    final ProgramSchedule sched22 = new ProgramSchedule("sched22", "twentytwo partition schedule", PROG2_ID,
-                                                        ImmutableMap.of("nn", "4"),
+    final ProgramSchedule sched22 = new ProgramSchedule("sched22", "twentytwo partition schedule",
+                                                        PROG2_REFERENCE, ImmutableMap.of("nn", "4"),
                                                         new PartitionTrigger(DS2_ID, 22),
                                                         ImmutableList.<Constraint>of());
-    final ProgramSchedule sched31 = new ProgramSchedule("sched31", "a program status trigger", PROG3_ID,
-                                                        ImmutableMap.of("propper", "popper"),
-                                                        new ProgramStatusTrigger(PROG1_ID, ProgramStatus.COMPLETED,
+    final ProgramSchedule sched31 = new ProgramSchedule("sched31", "a program status trigger",
+                                                        PROG3_REFERENCE, ImmutableMap.of("propper", "popper"),
+                                                        new ProgramStatusTrigger(PROG1_REFERENCE,
+                                                                                 ProgramStatus.COMPLETED,
                                                                                  ProgramStatus.FAILED,
                                                                                  ProgramStatus.KILLED),
                                                         ImmutableList.<Constraint>of());
@@ -221,11 +237,14 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
         Assert.assertTrue(store.findSchedules(Schedulers.triggerKeyForPartition(DS1_ID)).isEmpty());
         Assert.assertTrue(store.findSchedules(Schedulers.triggerKeyForPartition(DS2_ID)).isEmpty());
         // event for PROG1 should trigger nothing. it should also return an empty collection
-        Assert.assertTrue(store.findSchedules(Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.COMPLETED))
+        Assert.assertTrue(store.findSchedules(Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE,
+                                                                                    ProgramStatus.COMPLETED))
                             .isEmpty());
-        Assert.assertTrue(store.findSchedules(Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.FAILED))
+        Assert.assertTrue(store.findSchedules(Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE,
+                                                                                    ProgramStatus.FAILED))
                             .isEmpty());
-        Assert.assertTrue(store.findSchedules(Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.KILLED))
+        Assert.assertTrue(store.findSchedules(Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE,
+                                                                                    ProgramStatus.KILLED))
                             .isEmpty());
       }
     );
@@ -243,15 +262,15 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
         // event for ProgramStatus should trigger only sched31
         Assert.assertEquals(ImmutableSet.of(sched31),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.COMPLETED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE, ProgramStatus.COMPLETED))));
 
         Assert.assertEquals(ImmutableSet.of(sched31),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.FAILED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE, ProgramStatus.FAILED))));
 
         Assert.assertEquals(ImmutableSet.of(sched31),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.KILLED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE, ProgramStatus.KILLED))));
 
         // event for DS1 should trigger only sched11
         Assert.assertEquals(ImmutableSet.of(sched11),
@@ -262,21 +281,23 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
       }
     );
 
-    final ProgramSchedule sched11New = new ProgramSchedule(sched11.getName(), "time schedule", PROG1_ID,
-                                                           ImmutableMap.of("timeprop", "time"),
+    final ProgramSchedule sched11New = new ProgramSchedule(sched11.getName(), "time schedule",
+                                                           PROG1_REFERENCE, ImmutableMap.of("timeprop", "time"),
                                                            new TimeTrigger("* * * * *"),
                                                            ImmutableList.<Constraint>of());
-    final ProgramSchedule sched12New = new ProgramSchedule(sched12.getName(), "one partition schedule", PROG1_ID,
-                                                           ImmutableMap.of("pp", "p"),
+    final ProgramSchedule sched12New = new ProgramSchedule(sched12.getName(), "one partition schedule",
+                                                           PROG1_REFERENCE, ImmutableMap.of("pp", "p"),
                                                            new PartitionTrigger(DS1_ID, 2),
                                                            ImmutableList.<Constraint>of());
-    final ProgramSchedule sched22New = new ProgramSchedule(sched22.getName(), "program3 failed schedule", PROG2_ID,
-                                                           ImmutableMap.of("ss", "s"),
-                                                           new ProgramStatusTrigger(PROG3_ID, ProgramStatus.FAILED),
+    final ProgramSchedule sched22New = new ProgramSchedule(sched22.getName(), "program3 failed schedule",
+                                                           PROG2_REFERENCE, ImmutableMap.of("ss", "s"),
+                                                           new ProgramStatusTrigger(PROG3_REFERENCE,
+                                                                                    ProgramStatus.FAILED),
                                                            ImmutableList.<Constraint>of());
-    final ProgramSchedule sched31New = new ProgramSchedule(sched31.getName(), "program1 failed schedule", PROG3_ID,
-                                                           ImmutableMap.of("abcd", "efgh"),
-                                                           new ProgramStatusTrigger(PROG1_ID, ProgramStatus.FAILED),
+    final ProgramSchedule sched31New = new ProgramSchedule(sched31.getName(), "program1 failed schedule",
+                                                           PROG3_REFERENCE, ImmutableMap.of("abcd", "efgh"),
+                                                           new ProgramStatusTrigger(PROG1_REFERENCE,
+                                                                                    ProgramStatus.FAILED),
                                                            ImmutableList.<Constraint>of());
 
     TransactionRunners.run(
@@ -303,13 +324,13 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
         // event for PS triggers only for failed program statuses, not completed nor killed
         Assert.assertEquals(ImmutableSet.of(sched31New),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.FAILED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE, ProgramStatus.FAILED))));
         Assert.assertEquals(ImmutableSet.of(),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.COMPLETED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE, ProgramStatus.COMPLETED))));
         Assert.assertEquals(ImmutableSet.of(),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.KILLED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE, ProgramStatus.KILLED))));
       }
     );
   }
@@ -322,29 +343,31 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
   public void testDeleteScheduleByTriggeringProgram() {
     TransactionRunner transactionRunner = getTransactionRunner();
 
-    SatisfiableTrigger prog1Trigger = new ProgramStatusTrigger(PROG1_ID, ProgramStatus.COMPLETED, ProgramStatus.FAILED,
-                                                                ProgramStatus.KILLED);
-    SatisfiableTrigger prog2Trigger = new ProgramStatusTrigger(PROG2_ID, ProgramStatus.COMPLETED, ProgramStatus.FAILED,
-                                                    ProgramStatus.KILLED);
-    final ProgramSchedule sched1 = new ProgramSchedule("sched1", "a program status trigger", PROG3_ID,
-                                                        ImmutableMap.of("propper", "popper"),
-                                                        prog1Trigger, ImmutableList.<Constraint>of());
-    final ProgramSchedule sched2 = new ProgramSchedule("sched2", "a program status trigger", PROG3_ID,
-                                                        ImmutableMap.of("propper", "popper"),
-                                                        prog2Trigger, ImmutableList.<Constraint>of());
+    SatisfiableTrigger prog1Trigger = new ProgramStatusTrigger(PROG1_REFERENCE, ProgramStatus.COMPLETED,
+                                                               ProgramStatus.FAILED, ProgramStatus.KILLED);
+    SatisfiableTrigger prog2Trigger = new ProgramStatusTrigger(PROG2_REFERENCE, ProgramStatus.COMPLETED,
+                                                               ProgramStatus.FAILED, ProgramStatus.KILLED);
+    final ProgramSchedule sched1 = new ProgramSchedule("sched1", "a program status trigger",
+                                                       PROG3_REFERENCE, ImmutableMap.of("propper", "popper"),
+                                                       prog1Trigger, ImmutableList.<Constraint>of());
+    final ProgramSchedule sched2 = new ProgramSchedule("sched2", "a program status trigger",
+                                                       PROG3_REFERENCE, ImmutableMap.of("propper", "popper"),
+                                                       prog2Trigger, ImmutableList.<Constraint>of());
 
-    final ProgramSchedule schedOr = new ProgramSchedule("schedOr", "an OR trigger", PROG3_ID,
+    final ProgramSchedule schedOr = new ProgramSchedule("schedOr", "an OR trigger", PROG3_REFERENCE,
                                                         ImmutableMap.of("propper", "popper"),
-                                                        new OrTrigger(new PartitionTrigger(DS1_ID, 1), prog1Trigger,
+                                                        new OrTrigger(new PartitionTrigger(DS1_ID, 1),
+                                                                      prog1Trigger,
                                                                       new AndTrigger(new OrTrigger(prog1Trigger,
                                                                                                    prog2Trigger),
                                                                                      new PartitionTrigger(DS2_ID, 1)),
                                                                       new OrTrigger(prog2Trigger)),
                                                         ImmutableList.<Constraint>of());
 
-    final ProgramSchedule schedAnd = new ProgramSchedule("schedAnd", "an AND trigger", PROG3_ID,
+    final ProgramSchedule schedAnd = new ProgramSchedule("schedAnd", "an AND trigger", PROG3_REFERENCE,
                                                         ImmutableMap.of("propper", "popper"),
-                                                        new AndTrigger(new PartitionTrigger(DS1_ID, 1), prog2Trigger,
+                                                        new AndTrigger(new PartitionTrigger(DS1_ID, 1),
+                                                                       prog2Trigger,
                                                                        new AndTrigger(prog1Trigger,
                                                                                       new PartitionTrigger(DS2_ID, 1))),
                                                          ImmutableList.<Constraint>of());
@@ -363,11 +386,11 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
         // ProgramStatus event for PROG1_ID should trigger only sched1, schedOr, schedAnd
         Assert.assertEquals(ImmutableSet.of(sched1, schedOr, schedAnd),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.COMPLETED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE, ProgramStatus.COMPLETED))));
         // ProgramStatus event for PROG2_ID should trigger only sched2, schedOr, schedAnd
         Assert.assertEquals(ImmutableSet.of(sched2, schedOr, schedAnd),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG2_ID, ProgramStatus.FAILED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG2_REFERENCE, ProgramStatus.FAILED))));
       }
     );
     // update or delete all schedules triggered by PROG1_ID
@@ -375,10 +398,10 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
       transactionRunner,
       context -> {
         ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
-        store.modifySchedulesTriggeredByDeletedProgram(PROG1_ID);
+        store.modifySchedulesTriggeredByDeletedProgram(PROG1_REFERENCE);
       }
     );
-    final ProgramSchedule schedOrNew = new ProgramSchedule("schedOr", "an OR trigger", PROG3_ID,
+    final ProgramSchedule schedOrNew = new ProgramSchedule("schedOr", "an OR trigger", PROG3_REFERENCE,
                                                            ImmutableMap.of("propper", "popper"),
                                                            new OrTrigger(new PartitionTrigger(DS1_ID, 1),
                                                                          new AndTrigger(prog2Trigger,
@@ -393,17 +416,17 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
         // ProgramStatus event for PROG1_ID should trigger no schedules after modifying schedules triggered by it
         Assert.assertEquals(Collections.emptySet(),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.COMPLETED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE, ProgramStatus.COMPLETED))));
         Assert.assertEquals(Collections.emptySet(),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.FAILED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE, ProgramStatus.FAILED))));
         Assert.assertEquals(Collections.emptySet(),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG1_ID, ProgramStatus.KILLED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG1_REFERENCE, ProgramStatus.KILLED))));
         // ProgramStatus event for PROG2_ID should trigger only sched2 and schedOrNew
         Assert.assertEquals(ImmutableSet.of(sched2, schedOrNew),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG2_ID, ProgramStatus.FAILED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG2_REFERENCE, ProgramStatus.FAILED))));
       }
     );
     // update or delete all schedules triggered by PROG2_ID
@@ -411,10 +434,10 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
       transactionRunner,
       context -> {
         ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
-        store.modifySchedulesTriggeredByDeletedProgram(PROG2_ID);
+        store.modifySchedulesTriggeredByDeletedProgram(PROG2_REFERENCE);
       }
     );
-    final ProgramSchedule schedOrNew1 = new ProgramSchedule("schedOr", "an OR trigger", PROG3_ID,
+    final ProgramSchedule schedOrNew1 = new ProgramSchedule("schedOr", "an OR trigger", PROG3_REFERENCE,
                                                            ImmutableMap.of("propper", "popper"),
                                                            new PartitionTrigger(DS1_ID, 1),
                                                            ImmutableList.of());
@@ -426,13 +449,13 @@ public abstract class ProgramScheduleStoreDatasetTest extends AppFabricTestBase 
         // ProgramStatus event for PROG2_ID should trigger no schedules after modifying schedules triggered by it
         Assert.assertEquals(Collections.emptySet(),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG2_ID, ProgramStatus.COMPLETED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG2_REFERENCE, ProgramStatus.COMPLETED))));
         Assert.assertEquals(Collections.emptySet(),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG2_ID, ProgramStatus.FAILED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG2_REFERENCE, ProgramStatus.FAILED))));
         Assert.assertEquals(Collections.emptySet(),
                             toScheduleSet(store.findSchedules(
-                              Schedulers.triggerKeyForProgramStatus(PROG2_ID, ProgramStatus.KILLED))));
+                              Schedulers.triggerKeyForProgramStatus(PROG2_REFERENCE, ProgramStatus.KILLED))));
         // event for DS1 should trigger only schedOrNew1 since all other schedules are deleted
         ds1Schedules.addAll(toScheduleSet(store.findSchedules(Schedulers.triggerKeyForPartition(DS1_ID))));
       }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/TriggerCodecTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/TriggerCodecTest.java
@@ -28,8 +28,7 @@ import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.ProtoTrigger;
 import io.cdap.cdap.proto.ProtoTriggerCodec;
 import io.cdap.cdap.proto.id.DatasetId;
-import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -103,10 +102,10 @@ public class TriggerCodecTest {
     testSerDeserYieldsTrigger(protoTime, timeTrigger);
 
     ProtoTrigger.ProgramStatusTrigger protoProgramStatus =
-      new ProtoTrigger.ProgramStatusTrigger(new ProgramId("test", "myapp", ProgramType.SERVICE, "myprog"),
+      new ProtoTrigger.ProgramStatusTrigger(new ProgramReference("test", "myapp", ProgramType.SERVICE, "myprog"),
                                             ImmutableSet.of(ProgramStatus.COMPLETED));
     ProgramStatusTrigger programStatusTrigger =
-      new ProgramStatusTrigger(new ProgramId("test", "myapp", ProgramType.SERVICE, "myprog"),
+      new ProgramStatusTrigger(new ProgramReference("test", "myapp", ProgramType.SERVICE, "myprog"),
                              ImmutableSet.of(ProgramStatus.COMPLETED));
     testSerDeserYieldsTrigger(protoProgramStatus, programStatusTrigger);
 
@@ -156,10 +155,10 @@ public class TriggerCodecTest {
     testContainingTrigger(new ProtoTrigger.TimeTrigger("* * * 1 1"),
                           new TimeTrigger("* * * 1 1"));
 
-    testContainingTrigger(new ProtoTrigger.ProgramStatusTrigger(new ProgramId("test", "myapp",
+    testContainingTrigger(new ProtoTrigger.ProgramStatusTrigger(new ProgramReference("test", "myapp",
                                                                               ProgramType.SERVICE, "myprog"),
                                                                 ImmutableSet.of(ProgramStatus.FAILED)),
-                          new ProgramStatusTrigger(new ProgramId("test", "myapp",
+                          new ProgramStatusTrigger(new ProgramReference("test", "myapp",
                                                    ProgramType.SERVICE, "myprog"),
                                                    ImmutableSet.of(ProgramStatus.FAILED)));
 
@@ -167,12 +166,12 @@ public class TriggerCodecTest {
 
   private void testContainingTrigger(ProtoTrigger proto, Trigger trigger) {
     ProgramSchedule proto1 = new ProgramSchedule("sched1", "one partition schedule",
-                                                 new NamespaceId("test").app("a").worker("ww"),
+                                                 new ProgramReference("test", "a", ProgramType.WORKER, "ww"),
                                                  ImmutableMap.of("prop3", "abc"), proto,
                                                  ImmutableList.of());
 
     ProgramSchedule sched1 = new ProgramSchedule("sched1", "one partition schedule",
-                                                 new NamespaceId("test").app("a").worker("ww"),
+                                                 new ProgramReference("test", "a", ProgramType.WORKER, "ww"),
                                                  ImmutableMap.of("prop3", "abc"), trigger,
                                                  ImmutableList.of());
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/MetadataSubscriberServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/MetadataSubscriberServiceTest.java
@@ -459,8 +459,8 @@ public class MetadataSubscriberServiceTest extends AppFabricTestBase {
 
     // add a schedule to schedule store
     ProgramScheduleService scheduleService = injector.getInstance(ProgramScheduleService.class);
-    scheduleService.add(new ProgramSchedule("tsched1", "one time schedule", workflowId,
-                                            Collections.emptyMap(),
+    scheduleService.add(new ProgramSchedule("tsched1", "one time schedule",
+                                            workflowId.getProgramReference(), Collections.emptyMap(),
                                             new TimeTrigger("* * ? * 1"), ImmutableList.of()));
 
     // add a new profile in default namespace

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/ScheduleFetcherTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/ScheduleFetcherTest.java
@@ -25,7 +25,7 @@ import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
 import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.ScheduleDetail;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ScheduleId;
 import org.junit.Assert;
 import org.junit.Test;
@@ -130,12 +130,11 @@ public class ScheduleFetcherTest extends AppFabricTestBase {
     ApplicationDetail appDetails = getAppDetails(namespace, appName);
 
     // Get and validate the schedule
-    ProgramId programId = new ProgramId(namespace,
-                                        appName,
-                                        appDetails.getAppVersion(),
-                                        ProgramType.WORKFLOW,
-                                        AppWithSchedule.WORKFLOW_NAME);
-    List<ScheduleDetail> scheduleList = fetcher.list(programId);
+    ProgramReference programRef = new ProgramReference(namespace,
+                                                appName,
+                                                ProgramType.WORKFLOW,
+                                                AppWithSchedule.WORKFLOW_NAME);
+    List<ScheduleDetail> scheduleList = fetcher.list(programRef);
     Assert.assertEquals(2, scheduleList.size());
     Assert.assertEquals(AppWithSchedule.SCHEDULE, scheduleList.get(0).getName());
     Assert.assertEquals(AppWithSchedule.SCHEDULE_2, scheduleList.get(1).getName());

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
@@ -119,6 +119,7 @@ import io.cdap.cdap.metadata.LineageAdmin;
 import io.cdap.cdap.metadata.MetadataAdmin;
 import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.ProgramRunStatus;
+import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.RunRecord;
 import io.cdap.cdap.proto.ScheduleDetail;
 import io.cdap.cdap.proto.WorkflowTokenDetail;
@@ -127,8 +128,8 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ScheduleId;
-import io.cdap.cdap.proto.id.WorkflowId;
 import io.cdap.cdap.spi.metadata.Metadata;
 import io.cdap.cdap.test.ApplicationManager;
 import io.cdap.cdap.test.DataSetManager;
@@ -640,7 +641,8 @@ public class DataPipelineTest extends HydratorTestBase {
     TriggeringPropertyMapping propertyMapping =
       new TriggeringPropertyMapping(ImmutableList.of(key1MappingWithId), ImmutableList.of(key2MappingWithId));
     ProgramStatusTrigger completeTrigger =
-      new ProgramStatusTrigger(new WorkflowId(defaultNamespace, triggeringPipelineName, SmartWorkflow.NAME),
+      new ProgramStatusTrigger(new ProgramReference(defaultNamespace, triggeringPipelineName,
+                                                    ProgramType.WORKFLOW, SmartWorkflow.NAME),
                                ImmutableSet.of(ProgramStatus.COMPLETED));
     ScheduleId scheduleId = appId.schedule("completeSchedule");
     appManager.addSchedule(

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/ProtoTrigger.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/ProtoTrigger.java
@@ -19,7 +19,7 @@ package io.cdap.cdap.proto;
 import io.cdap.cdap.api.ProgramStatus;
 import io.cdap.cdap.api.schedule.Trigger;
 import io.cdap.cdap.proto.id.DatasetId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -237,19 +237,19 @@ public abstract class ProtoTrigger implements Trigger {
    * Represents a program status trigger for REST requests/responses
    */
   public static class ProgramStatusTrigger extends ProtoTrigger {
-    protected final ProgramId programId;
+    protected final ProgramReference programReference;
     protected final Set<ProgramStatus> programStatuses;
 
-    public ProgramStatusTrigger(ProgramId programId, Set<ProgramStatus> programStatuses) {
+    public ProgramStatusTrigger(ProgramReference programReference, Set<ProgramStatus> programStatuses) {
       super(Type.PROGRAM_STATUS);
 
-      this.programId = programId;
+      this.programReference = programReference;
       this.programStatuses = programStatuses;
       validate();
     }
 
-    public ProgramId getProgramId() {
-      return programId;
+    public ProgramReference getProgramReference() {
+      return programReference;
     }
 
     public Set<ProgramStatus> getProgramStatuses() {
@@ -262,16 +262,16 @@ public abstract class ProtoTrigger implements Trigger {
           getProgramStatuses().contains(ProgramStatus.RUNNING)) {
         throw new IllegalArgumentException(String.format(
                 "Cannot allow triggering program %s with statuses %s: %s statuses are supported",
-                programId.getProgram(), getProgramStatuses(), ProgramStatus.TERMINAL_STATES));
+                programReference.getProgram(), getProgramStatuses(), ProgramStatus.TERMINAL_STATES));
       }
 
-      ProtoTrigger.validateNotNull(getProgramId(), "program id");
+      ProtoTrigger.validateNotNull(getProgramReference(), "program reference");
       ProtoTrigger.validateNotNull(getProgramStatuses(), "program statuses");
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(getProgramId(), getProgramStatuses());
+      return Objects.hash(getProgramReference(), getProgramStatuses());
     }
 
     @Override
@@ -280,12 +280,12 @@ public abstract class ProtoTrigger implements Trigger {
         o != null &&
           getClass().equals(o.getClass()) &&
           Objects.equals(getProgramStatuses(), ((ProgramStatusTrigger) o).getProgramStatuses()) &&
-          Objects.equals(getProgramId(), ((ProgramStatusTrigger) o).getProgramId());
+          Objects.equals(getProgramReference(), ((ProgramStatusTrigger) o).getProgramReference());
     }
 
     @Override
     public String toString() {
-      return String.format("ProgramStatusTrigger(%s, %s)", getProgramId().getProgram(),
+      return String.format("ProgramStatusTrigger(%s, %s)", getProgramReference().getProgram(),
                                                            getProgramStatuses().toString());
     }
   }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ProgramId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ProgramId.java
@@ -135,14 +135,6 @@ public class ProgramId extends NamespacedEntityId implements ParentedId<Applicat
       Objects.equals(program, programId.program);
   }
 
-  /**
-   * Check whether two programs are the same except version
-   */
-  public boolean isSameProgramExceptVersion(Object o) {
-    ProgramId programId = (ProgramId) o;
-    return Objects.equals(getProgramReference(), programId.getProgramReference());
-  }
-
   @Override
   public int hashCode() {
     Integer hashCode = this.hashCode;

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/ops/DashboardProgramRunRecord.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/ops/DashboardProgramRunRecord.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.RunRecord;
+import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 
 import java.util.Objects;
@@ -173,6 +174,10 @@ public class DashboardProgramRunRecord {
     public ApplicationNameVersion(String name, String version) {
       this.name = name;
       this.version = version;
+    }
+
+    public ApplicationNameVersion(String name) {
+      this(name, ApplicationId.DEFAULT_VERSION);
     }
 
     /**

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Authorizable.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Authorizable.java
@@ -78,7 +78,19 @@ public class Authorizable {
         String.format("Cannot extract the entity type from %s", entityString));
     }
     String typeString = typeAndId[0];
-    EntityType type = EntityType.valueOf(typeString.toUpperCase());
+    EntityType type;
+    // since Authorizable is versionless, applicationRef and programRef should be the same type as
+    // application and program
+    switch (typeString) {
+      case "applicationreference":
+        type = EntityType.valueOf("APPLICATION");
+        break;
+      case "programreference":
+        type = EntityType.valueOf("PROGRAM");
+        break;
+      default:
+        type = EntityType.valueOf(typeString.toUpperCase());
+    }
     String idString = typeAndId[1];
     EntityType childType = typeAndId.length == 3 ? EntityType.valueOf(typeAndId[2].toUpperCase()) : null;
 
@@ -260,6 +272,7 @@ public class Authorizable {
         checkParts(EntityType.NAMESPACE, parts, index - 1, entityParts);
         entityParts.put(entityType, parts.get(index));
         break;
+      case PROGRAMREFERENCE:
       case PROGRAM:
         // application have version part to it. We don't support version for authorization purpose.
         // also throw exception only when the actual entity type in question is program not when we

--- a/cdap-proto/src/test/java/io/cdap/cdap/proto/ProtoTriggerCodecTest.java
+++ b/cdap-proto/src/test/java/io/cdap/cdap/proto/ProtoTriggerCodecTest.java
@@ -26,7 +26,7 @@ import io.cdap.cdap.api.schedule.Trigger;
 import io.cdap.cdap.api.workflow.ScheduleProgramInfo;
 import io.cdap.cdap.internal.schedule.constraint.Constraint;
 import io.cdap.cdap.proto.id.DatasetId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -48,7 +48,7 @@ public class ProtoTriggerCodecTest {
 
     ProtoTrigger.ProgramStatusTrigger programStatusTrigger =
       new ProtoTrigger.ProgramStatusTrigger(
-        new ProgramId("test", "myapp", ProgramType.WORKER, "myprog"),
+        new ProgramReference("test", "myapp", ProgramType.WORKER, "myprog"),
         ImmutableSet.of(io.cdap.cdap.api.ProgramStatus.FAILED));
     testTriggerCodec(ProtoTrigger.or(ProtoTrigger.and(partitionTrigger,
                                                       programStatusTrigger.or(timeTrigger, programStatusTrigger)),

--- a/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/DefaultOwnerAdmin.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/impersonation/DefaultOwnerAdmin.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.NamespacedEntityId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 
 import java.io.IOException;
 import java.util.Map;
@@ -115,6 +116,9 @@ public class DefaultOwnerAdmin implements OwnerAdmin {
     // recursively once we have a use-case for it.
     if (entityId.getEntityType().equals(EntityType.PROGRAM)) {
       entityId = ((ProgramId) entityId).getParent();
+    }
+    if (entityId.getEntityType().equals(EntityType.PROGRAMREFERENCE)) {
+      entityId = ((ProgramReference) entityId).getParent();
     }
     return entityId;
   }


### PR DESCRIPTION
JIRA - [CDAP-19989](https://cdap.atlassian.net/browse/CDAP-19989)

This PR is to refactor all schedules and triggers related code to use programReference instead of programId since schedule and trigger should be versionless. 
Since in the existing ProgramSchedule and ProgramStatusTrigger, it is stored as ProgramId already, we cannot replace them easily with ProgramReference. Thus, I will leave the attribute as is to maintain back compatibility during loading. However, this low level detail will be kept within the ProgramSchedule & ProgramStatusTrigger constructor, when creating new ProgramSchedule & ProgramStatusTrigger, ProgramReference should still be used (and it will internally be converted to ProgramId). 

It is tested that the new code is able to load existing ProgramSchedule & ProgramStatusTrigger and can trigger program run successfully. 