### PR TITLE
CDAP-19979 unversioned get /runs api returns all runs

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -193,6 +193,21 @@ public interface Store {
                                              long startTime, long endTime, int limit);
 
   /**
+   * Fetches all run records for all versions of a program.
+   * Returned ProgramRunRecords are sorted by their startTime.
+   *
+   * @param programReference programReference of the program
+   * @param status           status of the program running/completed/failed or all
+   * @param startTime        fetch run history that has started after the startTime in seconds
+   * @param endTime          fetch run history that has started before the endTime in seconds
+   * @param limit            max number of entries to fetch for this history call
+   * @return                 map of logged runs
+   */
+  Map<ProgramRunId, RunRecordDetail> getAllRuns(ProgramReference programReference, ProgramRunStatus status,
+                                                long startTime, long endTime, int limit,
+                                                Predicate<RunRecordDetail> filter);
+
+  /**
    * Fetches the run records for the particular status. Same as calling
    * {@link #getRuns(ProgramRunStatus, long, long, int, Predicate)
    * getRuns(status, 0, Long.MAX_VALUE, Integer.MAX_VALUE, filter)}
@@ -564,12 +579,21 @@ public interface Store {
   long getProgramRunCount(ProgramId programId) throws NotFoundException;
 
   /**
+   * Get the run count of the given program across all versions.
+   *
+   * @param programReference the program to get the count
+   * @return the number of run count
+   * @throws NotFoundException if the app or the program does not exist
+   */
+  long getProgramTotalRunCount(ProgramReference programReference) throws NotFoundException;
+
+  /**
    * Get the run count of the given program collection
    *
    * @param programRefs collection of program ids to get the count
    * @return the run count result of each program in the collection
    */
-  List<RunCountResult> getProgramRunCounts(Collection<ProgramReference> programRefs);
+  List<RunCountResult> getProgramTotalRunCounts(Collection<ProgramReference> programRefs);
 
   /**
    * Fetches run records for multiple programs.

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.spi.data.SortOrder;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
@@ -1318,10 +1319,13 @@ public abstract class AppMetadataStoreTest {
 
     TransactionRunners.run(transactionRunner, context -> {
       AppMetadataStore store = AppMetadataStore.create(context);
-      Map<ProgramId, Long> counts = store.getProgramRunCounts(ImmutableList.of(programId1, programId2, programId3));
-      Assert.assertEquals(5, (long) counts.get(programId1));
-      Assert.assertEquals(3, (long) counts.get(programId2));
-      Assert.assertEquals(0, (long) counts.get(programId3));
+      Map<ProgramReference, Long> counts =
+        store.getProgramTotalRunCounts(ImmutableList.of(programId1.getProgramReference(),
+                                                        programId2.getProgramReference(),
+                                                        programId3.getProgramReference()));
+      Assert.assertEquals(5, (long) counts.get(programId1.getProgramReference()));
+      Assert.assertEquals(3, (long) counts.get(programId2.getProgramReference()));
+      Assert.assertEquals(0, (long) counts.get(programId3.getProgramReference()));
     });
 
     // after cleanup we should only have 0 runs for all programs
@@ -1334,10 +1338,13 @@ public abstract class AppMetadataStoreTest {
 
     TransactionRunners.run(transactionRunner, context -> {
       AppMetadataStore store = AppMetadataStore.create(context);
-      Map<ProgramId, Long> counts = store.getProgramRunCounts(ImmutableList.of(programId1, programId2, programId3));
-      Assert.assertEquals(0, (long) counts.get(programId1));
-      Assert.assertEquals(0, (long) counts.get(programId2));
-      Assert.assertEquals(0, (long) counts.get(programId3));
+      Map<ProgramReference, Long> counts =
+        store.getProgramTotalRunCounts(ImmutableList.of(programId1.getProgramReference(),
+                                                        programId2.getProgramReference(),
+                                                        programId3.getProgramReference()));
+      Assert.assertEquals(0, (long) counts.get(programId1.getProgramReference()));
+      Assert.assertEquals(0, (long) counts.get(programId2.getProgramReference()));
+      Assert.assertEquals(0, (long) counts.get(programId3.getProgramReference()));
     });
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/DefaultStoreTest.java
@@ -72,6 +72,7 @@ import io.cdap.cdap.proto.id.Ids;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.spi.data.SortOrder;
 import io.cdap.cdap.store.DefaultNamespaceStore;
@@ -682,7 +683,7 @@ public abstract class DefaultStoreTest {
     }
 
     List<RunCountResult> result =
-      store.getProgramRunCounts(ImmutableList.of(workflowId.getProgramReference(),
+      store.getProgramTotalRunCounts(ImmutableList.of(workflowId.getProgramReference(),
                                                  serviceId.getProgramReference(),
                                                  nonExistingAppProgramId.getProgramReference(),
                                                  nonExistingProgramId.getProgramReference()));
@@ -690,9 +691,10 @@ public abstract class DefaultStoreTest {
     // compare the result
     Assert.assertEquals(4, result.size());
     for (RunCountResult runCountResult : result) {
-      ProgramId programId = runCountResult.getProgramId();
+      ProgramReference programReference = runCountResult.getProgramReference();
       Long count = runCountResult.getCount();
-      if (programId.equals(nonExistingAppProgramId) || programId.equals(nonExistingProgramId)) {
+      if (programReference.equals(nonExistingAppProgramId.getProgramReference()) ||
+        programReference.equals(nonExistingProgramId.getProgramReference())) {
         Assert.assertNull(count);
         Assert.assertTrue(runCountResult.getException() instanceof NotFoundException);
       } else {
@@ -703,8 +705,9 @@ public abstract class DefaultStoreTest {
 
     // remove the app should remove all run count
     store.removeApplication(appId);
-    for (RunCountResult runCountResult : store.getProgramRunCounts(ImmutableList.of(workflowId.getProgramReference(),
-                                                                                    serviceId.getProgramReference()))) {
+    for (RunCountResult runCountResult :
+      store.getProgramTotalRunCounts(ImmutableList.of(workflowId.getProgramReference(),
+                                                      serviceId.getProgramReference()))) {
       Assert.assertNull(runCountResult.getCount());
       Assert.assertTrue(runCountResult.getException() instanceof NotFoundException);
     }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/BatchProgramCount.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/BatchProgramCount.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.proto;
 
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -32,8 +32,9 @@ public class BatchProgramCount extends BatchProgramResult {
     this.runCount = runCount;
   }
 
-  public BatchProgramCount(ProgramId programId, int statusCode, @Nullable String error, @Nullable Long runCount) {
-    this(new BatchProgram(programId.getApplication(), programId.getType(), programId.getProgram()),
+  public BatchProgramCount(ProgramReference programReference, int statusCode, @Nullable String error,
+                           @Nullable Long runCount) {
+    this(new BatchProgram(programReference.getApplication(), programReference.getType(), programReference.getProgram()),
          statusCode, error, runCount);
   }
 

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/RunCountResult.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/RunCountResult.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.proto;
 
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -26,18 +26,18 @@ import javax.annotation.Nullable;
  * is contained
  */
 public class RunCountResult {
-  private final ProgramId programId;
+  private final ProgramReference programReference;
   private final Long count;
   private final Exception exception;
 
-  public RunCountResult(ProgramId programId, @Nullable Long count, @Nullable Exception exception) {
-    this.programId = programId;
+  public RunCountResult(ProgramReference programReference, @Nullable Long count, @Nullable Exception exception) {
+    this.programReference = programReference;
     this.count = count;
     this.exception = exception;
   }
 
-  public ProgramId getProgramId() {
-    return programId;
+  public ProgramReference getProgramReference() {
+    return programReference;
   }
 
   @Nullable
@@ -60,13 +60,13 @@ public class RunCountResult {
     }
 
     RunCountResult that = (RunCountResult) o;
-    return Objects.equals(programId, that.programId) &&
+    return Objects.equals(programReference, that.programReference) &&
       Objects.equals(count, that.count) &&
       Objects.equals(exception, that.exception);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(programId, count, exception);
+    return Objects.hash(programReference, count, exception);
   }
 }


### PR DESCRIPTION
In programLifeCycleHttpHandler, the unverioned GET /runs api should return all runs across all versions for a program, instead of just returning runs from the latest version. Also added some code refactoring so that if we call getkeys with programReference, it implicitly retrieve program keys without version in it. 

In follow up PRs, unverioned GET /runcount and batch calls will also follow the same behavior to return results for all versions. 