### PR TITLE
[CDAP-20020] Add --conf field to file-localizer container

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -1137,8 +1137,9 @@ public class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillP
       .withInitContainers(createContainer("file-localizer", podInfo.getContainerImage(),
                                           podInfo.getImagePullPolicy(), workDir, initContainerResourceRequirements,
                                           initContainerVolumeMounts, initContainerEnvirons, FileLocalizer.class,
-                                          runtimeConfigLocation.toURI().toString(),
-                                          mainRuntimeSpec.getName()))
+                                          Stream.concat(Stream.of(runtimeConfigLocation.toURI().toString(),
+                                                                  mainRuntimeSpec.getName()), containerArgs.stream())
+                                            .toArray(String[]::new)))
       .withContainers(createContainers(resourceType, runtimeSpecs, workDir, containerVolumeMounts, containerArgs))
       .withSecurityContext(podInfo.getSecurityContext())
       .withRestartPolicy(restartPolicy)


### PR DESCRIPTION
CConf needs to be mounted to FileLocalizer which depends on knowing the CDAP k8s install namespace to initialize the KubeDiscoveryService.