### PR TITLE
[CDAP-19484] Revert CDAP-19448 and unpack artifacts in task workers again

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewPluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewPluginFinder.java
@@ -50,6 +50,6 @@ public class PreviewPluginFinder extends RemotePluginFinder {
   @Override
   protected Location getArtifactLocation(ArtifactId artifactId)
       throws IOException, ArtifactNotFoundException, UnauthorizedException {
-    return Locations.toLocation(artifactLocalizerClient.getArtifactLocation(artifactId));
+    return Locations.toLocation(artifactLocalizerClient.getUnpackedArtifactLocation(artifactId));
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/RemoteWorkerPluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/RemoteWorkerPluginFinder.java
@@ -47,6 +47,6 @@ public class RemoteWorkerPluginFinder extends RemotePluginFinder {
   @Override
   protected Location getArtifactLocation(ArtifactId artifactId)
       throws IOException, ArtifactNotFoundException, UnauthorizedException {
-    return Locations.toLocation(artifactLocalizerClient.getArtifactLocation(artifactId));
+    return Locations.toLocation(artifactLocalizerClient.getUnpackedArtifactLocation(artifactId));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -160,13 +160,13 @@
     <quartz.version>2.2.0</quartz.version>
     <resteasy.version>3.0.8.Final</resteasy.version>
     <rs-api.version>2.0</rs-api.version>
-    <!-- Please keep consistent with the one in Spark 3 -->
-    <scala2.12.version>2.12.10</scala2.12.version>
+    <!-- Please keep consistent with the one in the current Spark 3 version -->
+    <scala2.12.version>2.12.15</scala2.12.version>
     <servlet.api.version>3.0.1</servlet.api.version>
     <slf4j.version>1.7.15</slf4j.version>
     <snappy.version>1.1.1.7</snappy.version>
     <spark3.artifacts.dir>spark3_2.12</spark3.artifacts.dir>
-    <spark3.version>3.1.1</spark3.version>
+    <spark3.version>3.3.1</spark3.version>
     <sshd.version>1.7.0</sshd.version>
     <tephra.version>0.15.0-incubating</tephra.version>
     <tez.version>0.8.4</tez.version>


### PR DESCRIPTION
This depends on the usage of Spark 3.2 which has fixed the bug of parsing a directory ending in `.jar` as a jar file. See https://github.com/scala/bug/issues/12019 for details.