### PR TITLE
[CDAP-20017] fix ITN metadata tests

### DIFF
--- a/cdap-integration-test/src/main/java/io/cdap/cdap/test/IntegrationTestBase.java
+++ b/cdap-integration-test/src/main/java/io/cdap/cdap/test/IntegrationTestBase.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.client.ProgramClient;
 import io.cdap.cdap.client.config.ClientConfig;
 import io.cdap.cdap.client.config.ConnectionConfig;
 import io.cdap.cdap.client.util.RESTClient;
+import io.cdap.cdap.common.ApplicationNotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.data2.datafabric.DefaultDatasetNamespace;
@@ -398,7 +399,11 @@ public abstract class IntegrationTestBase {
 
     // delete all apps in the namespace
     for (ApplicationRecord app : getApplicationClient().list(namespace)) {
-      getApplicationClient().delete(namespace.app(app.getName(), app.getAppVersion()));
+      try {
+        getApplicationClient().deleteApp(namespace.app(app.getName(), ApplicationId.DEFAULT_VERSION));
+      } catch (ApplicationNotFoundException e) {
+        // it's ok application is not found in clean up, do nothing
+      }
     }
     // delete all dataset instances
     for (DatasetSpecificationSummary datasetSpecSummary : getDatasetClient().list(namespace)) {


### PR DESCRIPTION
# Background: why this was broken?
Since LCM is introduced, `ApplicationClient.delete` will not be able to delete things fully, because it is calling the delete endpoint with 'versionid' (something that we we deprecate in the future).

# Solution
Instead, we should call `ApplicationClient.deleteApp`, which will delete all versions and all programs, metadata, etc, associated with the application. I made a workaround to get unique app names because multiple `deleteApp` call on the same appName will throw error. I don't want to rely on changing queryparam `latestOnly` to true or false on the list api, since application prior to 6.8 will not have this field so might miss one or two.