### PR TITLE
Refactor the logic of getApplicationMeta in DefaultStore

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandlerInternal.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
 import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.ApplicationRecord;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.spi.data.SortOrder;
@@ -161,7 +162,8 @@ public class AppLifecycleHttpHandlerInternal extends AbstractAppFabricHttpHandle
       throw new NamespaceNotFoundException(namespaceId);
     }
     responder.sendJson(HttpResponseStatus.OK,
-                       GSON.toJson(applicationLifecycleService.getLatestAppDetail(namespaceId, application)));
+                       GSON.toJson(applicationLifecycleService.getLatestAppDetail(
+                         new ApplicationReference(namespaceId, application))));
   }
 
   /**
@@ -184,6 +186,9 @@ public class AppLifecycleHttpHandlerInternal extends AbstractAppFabricHttpHandle
       throw new NamespaceNotFoundException(namespaceId);
     }
     ApplicationId appId = new ApplicationId(namespace, application, version);
-    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(applicationLifecycleService.getAppDetail(appId)));
+    ApplicationDetail appDetail = ApplicationId.DEFAULT_VERSION.equals(version)
+      ? applicationLifecycleService.getLatestAppDetail(appId.getAppReference())
+      : applicationLifecycleService.getAppDetail(appId);
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(appDetail));
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/PreferencesHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/PreferencesHttpHandler.java
@@ -307,7 +307,7 @@ public class PreferencesHttpHandler extends AbstractAppFabricHttpHandler {
    * @return latest app version
    */
   private String getLatestAppVersion(NamespaceId namespaceId, String appId) throws ApplicationNotFoundException {
-    ApplicationMeta latestApplicationMeta = store.getLatest(namespaceId, appId);
+    ApplicationMeta latestApplicationMeta = store.getLatest(namespaceId.appReference(appId));
     if (latestApplicationMeta == null) {
       throw new ApplicationNotFoundException(new ApplicationId(namespaceId.getNamespace(), appId));
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/WorkflowHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/WorkflowHttpHandler.java
@@ -142,7 +142,7 @@ public class WorkflowHttpHandler extends AbstractAppFabricHttpHandler {
   private ProgramController getProgramController(String namespace, String appName,
                                                  String workflowName, String runId) throws NotFoundException {
     NamespaceId namespaceId = Ids.namespace(namespace);
-    ApplicationMeta appMeta = store.getLatest(namespaceId, appName);
+    ApplicationMeta appMeta = store.getLatest(namespaceId.appReference(appName));
     if (appMeta == null || appMeta.getSpec() == null) {
       throw new NotFoundException(namespaceId.app(appName));
     }
@@ -212,7 +212,7 @@ public class WorkflowHttpHandler extends AbstractAppFabricHttpHandler {
   private WorkflowToken getWorkflowToken(String namespace, String appName, String workflow,
                                          String runId) throws NotFoundException {
     NamespaceId namespaceId = Ids.namespace(namespace);
-    ApplicationMeta appMeta = store.getLatest(namespaceId, appName);
+    ApplicationMeta appMeta = store.getLatest(namespaceId.appReference(appName));
     if (appMeta == null || appMeta.getSpec() == null) {
       throw new NotFoundException(namespaceId.app(appName));
     }
@@ -236,7 +236,7 @@ public class WorkflowHttpHandler extends AbstractAppFabricHttpHandler {
                                     @PathParam("run-id") String runId)
     throws NotFoundException {
     NamespaceId namespace = Ids.namespace(namespaceId);
-    ApplicationMeta appMeta = store.getLatest(namespace, applicationId);
+    ApplicationMeta appMeta = store.getLatest(namespace.appReference(applicationId));
     if (appMeta == null || appMeta.getSpec() == null) {
       throw new NotFoundException(namespace.app(applicationId));
     }
@@ -328,7 +328,7 @@ public class WorkflowHttpHandler extends AbstractAppFabricHttpHandler {
   private WorkflowSpecification getWorkflowSpecForValidRun(String namespaceId, String applicationId,
                                                            String workflowId, String runId) throws NotFoundException {
     NamespaceId namespace = Ids.namespace(namespaceId);
-    ApplicationMeta appMeta = store.getLatest(namespace, applicationId);
+    ApplicationMeta appMeta = store.getLatest(namespace.appReference(applicationId));
     if (appMeta == null || appMeta.getSpec() == null) {
       throw new NotFoundException(namespace.app(applicationId));
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
@@ -54,7 +54,8 @@ public class ApplicationRegistrationStage extends AbstractStage<ApplicationWithP
   @Override
   public void process(ApplicationWithPrograms input) throws Exception {
     ApplicationSpecification applicationSpecification = input.getSpecification();
-    Collection<ApplicationId> allAppVersionsAppIds = store.getAllAppVersionsAppIds(input.getApplicationId());
+    Collection<ApplicationId> allAppVersionsAppIds =
+      store.getAllAppVersionsAppIds(input.getApplicationId().getAppReference());
     boolean ownerAdded = addOwnerIfRequired(input, allAppVersionsAppIds);
     ApplicationMeta appMeta = new ApplicationMeta(applicationSpecification.getName(), input.getSpecification(),
                                                   input.getChangeDetail());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationVerificationStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationVerificationStage.java
@@ -104,7 +104,7 @@ public class ApplicationVerificationStage extends AbstractStage<ApplicationDeplo
       SecurityUtil.validateKerberosPrincipal(input.getOwnerPrincipal());
     }
 
-    Collection<ApplicationId> allAppVersionsAppIds = store.getAllAppVersionsAppIds(appId);
+    Collection<ApplicationId> allAppVersionsAppIds = store.getAllAppVersionsAppIds(appId.getAppReference());
     // if allAppVersionsAppIds.isEmpty() is false that means some version of this app already exists so we should
     // verify that the owner is same
     if (!allAppVersionsAppIds.isEmpty()) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.app.deploy.Configurator;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.internal.app.deploy.ConfiguratorFactory;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
 import io.cdap.cdap.internal.capability.CapabilityReader;
 import io.cdap.cdap.metadata.MetadataValidator;
 import io.cdap.cdap.pipeline.AbstractStage;
@@ -37,6 +38,7 @@ import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import org.apache.twill.filesystem.Location;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -113,8 +115,11 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
         metadataValidator.validateTags(appEntity, metadata.getTags());
       }
     }
+    ApplicationSpecification appSpec = Optional.ofNullable(store.getLatest(applicationId.getAppReference()))
+      .map(ApplicationMeta::getSpec)
+      .orElse(null);
     emit(new ApplicationDeployable(deploymentInfo.getArtifactId(), deploymentInfo.getArtifactLocation(),
-                                   applicationId, specification, store.getApplication(applicationId),
+                                   applicationId, specification, appSpec,
                                    ApplicationDeployScope.USER, deploymentInfo.getApplicationClass(),
                                    deploymentInfo.getOwnerPrincipal(), deploymentInfo.canUpdateSchedules(),
                                    appSpecInfo.getSystemTables(), metadatas, deploymentInfo.getChangeDetail()));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/ScheduleTaskRunner.java
@@ -38,7 +38,6 @@ import io.cdap.cdap.internal.app.services.PropertiesResolver;
 import io.cdap.cdap.internal.app.store.ApplicationMeta;
 import io.cdap.cdap.internal.capability.CapabilityNotAvailableException;
 import io.cdap.cdap.proto.id.ApplicationId;
-import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
@@ -148,8 +147,7 @@ public final class ScheduleTaskRunner {
    * Get the ProgramId of the latest version.
    */
   private ProgramId getLatestAppProgramId(ProgramId programId) throws ProgramNotFoundException {
-    ApplicationMeta applicationMeta = store.getLatest(new NamespaceId(programId.getNamespace()),
-                                                      programId.getApplication());
+    ApplicationMeta applicationMeta = store.getLatest(programId.getAppReference());
     if (applicationMeta == null) {
       throw new ProgramNotFoundException(programId);
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/TriggerInfoContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/TriggerInfoContext.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.internal.app.runtime.schedule.trigger;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.workflow.WorkflowToken;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramSchedule;
@@ -26,7 +25,6 @@ import io.cdap.cdap.internal.app.runtime.schedule.queue.Job;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.proto.Notification;
 import io.cdap.cdap.proto.ProgramType;
-import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.WorkflowId;
@@ -66,10 +64,6 @@ public class TriggerInfoContext {
    */
   public List<Notification> getNotifications() {
     return job.getNotifications();
-  }
-
-  public ApplicationSpecification getApplicationSpecification(ApplicationId applicationId) {
-    return store.getApplication(applicationId);
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/SystemApplication.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/SystemApplication.java
@@ -30,15 +30,13 @@ public class SystemApplication {
 
   private final String namespace;
   private final String name;
-  private final String version;
   private final ArtifactSummary artifact;
   private final JsonObject config;
 
-  public SystemApplication(String namespace, String applicationName, @Nullable String version,
+  public SystemApplication(String namespace, String applicationName,
                            ArtifactSummary artifact, @Nullable JsonObject config) {
     this.namespace = namespace;
     this.name = applicationName;
-    this.version = version;
     this.artifact = artifact;
     this.config = config;
   }
@@ -55,14 +53,6 @@ public class SystemApplication {
    */
   public String getName() {
     return name;
-  }
-
-  /**
-   * @return version {@link String}, could be null
-   */
-  @Nullable
-  public String getVersion() {
-    return version;
   }
 
   /**
@@ -91,13 +81,12 @@ public class SystemApplication {
     SystemApplication otherApplication = (SystemApplication) other;
     return Objects.equals(namespace, otherApplication.namespace) &&
       Objects.equals(name, otherApplication.name) &&
-      Objects.equals(version, otherApplication.version) &&
       Objects.equals(artifact, otherApplication.artifact) &&
       Objects.equals(config, otherApplication.config);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(namespace, name, version, artifact, config);
+    return Objects.hash(namespace, name, artifact, config);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/SystemProgram.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/SystemProgram.java
@@ -30,16 +30,14 @@ public class SystemProgram {
   private final String application;
   private final String type;
   private final String name;
-  private final String version;
   private final Map<String, String> args;
 
-  public SystemProgram(String namespace, String application, String type, String name, @Nullable String version,
+  public SystemProgram(String namespace, String application, String type, String name,
                        @Nullable Map<String, String> args) {
     this.namespace = namespace;
     this.application = application;
     this.type = type;
     this.name = name;
-    this.version = version;
     this.args = args == null ? Collections.emptyMap() : args;
   }
 
@@ -71,13 +69,6 @@ public class SystemProgram {
     return name;
   }
 
-  /**
-   * @return version {@link String}, could be nullable
-   */
-  @Nullable
-  public String getVersion() {
-    return version;
-  }
 
   /**
    * @return {@link Map<String, String>} of runtime arguments
@@ -102,12 +93,11 @@ public class SystemProgram {
       Objects.equals(application, program.application) &&
       Objects.equals(type, program.type) &&
       Objects.equals(name, program.name) &&
-      Objects.equals(version, program.version) &&
       Objects.equals(args, program.args);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(namespace, application, type, name, version, args);
+    return Objects.hash(namespace, application, type, name, args);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcher.java
@@ -19,7 +19,7 @@ package io.cdap.cdap.metadata;
 import io.cdap.cdap.common.NamespaceNotFoundException;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.proto.ApplicationDetail;
-import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 
 import java.io.IOException;
@@ -31,13 +31,13 @@ import java.util.function.Consumer;
 public interface ApplicationDetailFetcher {
 
   /**
-   * Get the application detail for the given application id
-   * @param appId the id of the application
+   * Get the application detail for the given application reference
+   * @param appRef the versionless ID of the application
    * @return the detail of the given application
    * @throws IOException if failed to get {@code ApplicationDetail}
    * @throws NotFoundException if the application or namespace identified by the supplied id doesn't exist
    */
-  ApplicationDetail get(ApplicationId appId) throws IOException, NotFoundException, UnauthorizedException;
+  ApplicationDetail get(ApplicationReference appRef) throws IOException, NotFoundException, UnauthorizedException;
 
   /**
    * Scans all application details in the given namespace

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalApplicationDetailFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalApplicationDetailFetcher.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
 import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
 import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.NamespaceId;
 
 import java.io.IOException;
@@ -47,21 +48,19 @@ public class LocalApplicationDetailFetcher implements ApplicationDetailFetcher {
   /**
    * Get {@link ApplicationDetail} for the given {@link ApplicationId}
    *
-   * @param appId the id of the application
+   * @param appRef the versionless id of the application
    * @return {@link ApplicationDetail} for the given application
    * @throws IOException if failed to get {@link ApplicationDetail} for the given {@link ApplicationId}
    * @throws NotFoundException if the given the given application doesn't exist
    */
   @Override
-  public ApplicationDetail get(ApplicationId appId) throws IOException, NotFoundException {
-    ApplicationDetail detail = null;
+  public ApplicationDetail get(ApplicationReference appRef) throws IOException, NotFoundException {
     try {
-      detail = applicationLifecycleService.getAppDetail(appId);
+      return applicationLifecycleService.getLatestAppDetail(appRef);
     } catch (Exception e) {
       Throwables.propagateIfPossible(e, NotFoundException.class, IOException.class);
       throw new IOException(e);
     }
-    return detail;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteApplicationDetailFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteApplicationDetailFetcher.java
@@ -29,7 +29,7 @@ import io.cdap.cdap.common.internal.remote.RemoteClient;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.proto.ApplicationDetail;
-import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.common.http.HttpMethod;
@@ -65,12 +65,12 @@ public class RemoteApplicationDetailFetcher implements ApplicationDetailFetcher 
   }
 
   /**
-   * Get the application detail for the given application id
+   * Get the application detail for the given application reference
    */
-  public ApplicationDetail get(ApplicationId appId)
+  public ApplicationDetail get(ApplicationReference appRef)
     throws IOException, NotFoundException, UnauthorizedException {
-    String url = String.format("namespaces/%s/app/%s/versions/%s",
-                               appId.getNamespace(), appId.getApplication(), appId.getVersion());
+    String url = String.format("namespaces/%s/app/%s",
+                               appRef.getNamespace(), appRef.getApplication());
     HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.GET, url);
     HttpResponse httpResponse;
     httpResponse = execute(requestBuilder.build());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
@@ -216,7 +216,7 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
                                                         appWithWorkflowClass.getSimpleName());
     appId = new ApplicationId(NamespaceId.DEFAULT.getNamespace(), appWithWorkflowClass.getSimpleName(),
                               applicationDetail.getAppVersion());
-    applicationLifecycleService.removeApplication(appId);
+    applicationLifecycleService.removeApplication(appId.getAppReference());
   }
 
   @Test
@@ -242,7 +242,7 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     });
     // check the tags contain all the tags emitted by the app
     Assert.assertTrue(systemMetadata.getTags(MetadataScope.SYSTEM).containsAll(MetadataEmitApp.SYS_METADATA.getTags()));
-    applicationLifecycleService.removeApplication(appId);
+    applicationLifecycleService.removeApplication(appId.getAppReference());
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/CapabilityManagementServiceTest.java
@@ -141,7 +141,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
     //deploy the artifact
     deployTestArtifact(namespace, appName, version, appClass);
 
-    ApplicationId applicationId = new ApplicationId(namespace, appName, version);
+    ApplicationId applicationId = new ApplicationId(namespace, appName);
     ProgramId programId = new ProgramId(applicationId, ProgramType.SERVICE, programName);
     String externalConfigPath = tmpFolder.newFolder("capability-config-test").getAbsolutePath();
     cConfiguration.set(Constants.Capability.CONFIG_DIR, externalConfigPath);
@@ -230,7 +230,7 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
     //deploy the artifact
     deployTestArtifact(namespace, appName, version, appClass);
 
-    ApplicationId applicationId = new ApplicationId(namespace, appName, version);
+    ApplicationId applicationId = new ApplicationId(namespace, appName);
     ProgramId programId = new ProgramId(applicationId, ProgramType.SERVICE, programName);
     //check that app is not available
     List<JsonObject> appList = getAppList(namespace);
@@ -281,13 +281,12 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
     String appName = AllProgramsApp.NAME;
     String programName = AllProgramsApp.NoOpService.NAME;
     Class<AllProgramsApp> appClass = AllProgramsApp.class;
-    String appVersion = "1.0.0";
     String namespace = NamespaceId.SYSTEM.getNamespace();
     //deploy the artifact with older version.
     String oldArtifactVersion = "1.0.0";
     deployTestArtifact(namespace, appName, oldArtifactVersion, appClass);
 
-    ApplicationId applicationId = new ApplicationId(namespace, appName, appVersion);
+    ApplicationId applicationId = new ApplicationId(namespace, appName);
     ProgramId programId = new ProgramId(applicationId, ProgramType.SERVICE, programName);
     //check that app is not available
     List<JsonObject> appList = getAppList(namespace);
@@ -373,13 +372,12 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
     String appName = AllProgramsApp.NAME;
     String programName = AllProgramsApp.NoOpService.NAME;
     Class<AllProgramsApp> appClass = AllProgramsApp.class;
-    String appVersion = "1.0.0";
     String namespace = NamespaceId.SYSTEM.getNamespace();
     //deploy the artifact with older version.
     String artifactVersion = "1.0.0";
     deployTestArtifact(namespace, appName, artifactVersion, appClass);
 
-    ApplicationId applicationId = new ApplicationId(namespace, appName, appVersion);
+    ApplicationId applicationId = new ApplicationId(namespace, appName);
     ProgramId programId = new ProgramId(applicationId, ProgramType.SERVICE, programName);
     //check that app is not available
     List<JsonObject> appList = getAppList(namespace);
@@ -493,7 +491,8 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
     String appNameWithOutCapability = appWithWorkflowClass.getSimpleName() + UUID.randomUUID();
     deployArtifactAndApp(appNoCapabilityClass, appNameWithOutCapability, testVersion);
     ApplicationDetail appWithOutCapabilityDetail =
-      applicationLifecycleService.getLatestAppDetail(NamespaceId.DEFAULT, appNameWithOutCapability);
+      applicationLifecycleService.getLatestAppDetail(
+        new ApplicationReference(NamespaceId.DEFAULT, appNameWithOutCapability));
 
     //enable the capabilities
     List<CapabilityConfig> capabilityConfigs = Arrays.stream(declaredAnnotation.capabilities())
@@ -514,12 +513,13 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
                  null, programId -> {
         });
     ApplicationDetail appWithCapabilityDetail =
-      applicationLifecycleService.getLatestAppDetail(NamespaceId.DEFAULT, appNameWithCapability);
+      applicationLifecycleService.getLatestAppDetail(
+        new ApplicationReference(NamespaceId.DEFAULT, appNameWithCapability));
 
     applicationLifecycleService.removeApplication(
-      NamespaceId.DEFAULT.app(appNameWithCapability, appWithCapabilityDetail.getAppVersion()));
+      NamespaceId.DEFAULT.appReference(appNameWithCapability));
     applicationLifecycleService.removeApplication(
-      NamespaceId.DEFAULT.app(appNameWithOutCapability, appWithOutCapabilityDetail.getAppVersion()));
+      NamespaceId.DEFAULT.appReference(appNameWithOutCapability));
     artifactRepository.deleteArtifact(Id.Artifact
                                         .from(new Id.Namespace(NamespaceId.DEFAULT.getNamespace()),
                                               appNameWithCapability, testVersion));
@@ -785,14 +785,12 @@ public class CapabilityManagementServiceTest extends AppFabricTestBase {
   private CapabilityConfig getTestConfig(String artifactVersion) {
     String appName = AllProgramsApp.NAME;
     String programName = AllProgramsApp.NoOpService.NAME;
-    String appVersion = "1.0.0";
     String namespace = NamespaceId.SYSTEM.getNamespace();
     String label = "Enable capability";
     String capability = "test";
     ArtifactSummary artifactSummary = new ArtifactSummary(appName, artifactVersion, ArtifactScope.SYSTEM);
-    SystemApplication application = new SystemApplication(namespace, appName, appVersion, artifactSummary, null);
-    SystemProgram program = new SystemProgram(namespace, appName, ProgramType.SERVICE.name(),
-                                              programName, appVersion, null);
+    SystemApplication application = new SystemApplication(namespace, appName, artifactSummary, null);
+    SystemProgram program = new SystemProgram(namespace, appName, ProgramType.SERVICE.name(), programName, null);
     return new CapabilityConfig(label, CapabilityStatus.ENABLED, capability,
                                 Collections.singletonList(application), Collections.singletonList(program),
                                 Collections.emptyList());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/ApplicationDetailFetcherTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/ApplicationDetailFetcherTest.java
@@ -25,7 +25,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.gateway.handlers.AppLifecycleHttpHandlerInternal;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
 import io.cdap.cdap.proto.ApplicationDetail;
-import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -78,10 +78,7 @@ public class ApplicationDetailFetcherTest extends AppFabricTestBase {
   @Test(expected = NotFoundException.class)
   public void testGetApplicationNotFound() throws Exception {
     ApplicationDetailFetcher fetcher = getApplicationDetailFetcher(fetcherType);
-    String namespace = TEST_NAMESPACE1;
-    String appName = AllProgramsApp.NAME;
-    ApplicationId appId = new ApplicationId(namespace, appName);
-    fetcher.get(appId);
+    fetcher.get(new ApplicationReference(TEST_NAMESPACE1, AllProgramsApp.NAME));
   }
 
   /**
@@ -117,10 +114,8 @@ public class ApplicationDetailFetcherTest extends AppFabricTestBase {
 
     // Deploy the application
     deploy(AllProgramsApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, namespace);
-    ApplicationDetail appDetails = getAppDetails(namespace, appName);
     // Get and validate the application
-    ApplicationId appId = new ApplicationId(namespace, appName, appDetails.getAppVersion());
-    ApplicationDetail appDetail = fetcher.get(appId);
+    ApplicationDetail appDetail = fetcher.get(new ApplicationReference(namespace, appName));
     assertAllProgramAppDetail(appDetail);
 
     // Delete the application

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
@@ -25,7 +25,7 @@ import io.cdap.cdap.api.artifact.ArtifactScope;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.retry.RetryableException;
-import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.ApplicationNotFoundException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.service.Retries;
@@ -131,7 +131,7 @@ public class DataPipelineServiceTest extends HydratorTestBase {
       try {
         appManager.getInfo();
         throw new RetryableException(String.format("App %s not yet removed", pipeline));
-      } catch (NotFoundException exception) {
+      } catch (ApplicationNotFoundException exception) {
         return false;
       }
     }, RetryStrategies.limit(10, RetryStrategies.fixDelay(15, TimeUnit.SECONDS)));

--- a/cdap-common/src/main/java/io/cdap/cdap/common/ApplicationNotFoundException.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/ApplicationNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/cdap-common/src/main/java/io/cdap/cdap/common/ProgramNotFoundException.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/ProgramNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2014 Cask Data, Inc.
+ * Copyright © 2014-2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,20 +17,26 @@
 package io.cdap.cdap.common;
 
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 
 /**
  * Thrown when a program is not found
  */
 public class ProgramNotFoundException extends NotFoundException {
 
-  private final ProgramId id;
+  private final ProgramReference ref;
 
   public ProgramNotFoundException(ProgramId programId) {
     super(programId);
-    this.id = programId;
+    this.ref = programId.getProgramReference();
   }
 
-  public ProgramId getId() {
-    return id;
+  public ProgramNotFoundException(ProgramReference programRef) {
+    super(programRef);
+    this.ref = programRef;
+  }
+
+  public ProgramReference getId() {
+    return ref;
   }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/element/EntityType.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/element/EntityType.java
@@ -74,7 +74,6 @@ public enum EntityType {
   SUPPORT_BUNDLE(SupportBundleEntityId.class),
   SYSTEM_SERVICE(SystemServiceId.class),
   SYSTEM_APP_ENTITY(SystemAppEntityId.class);
-  ;
 
   private final Class<? extends EntityId> idClass;
   @Nullable

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ApplicationReference.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ApplicationReference.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.proto.id;
 
 import io.cdap.cdap.api.metadata.MetadataEntity;
+import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.element.EntityType;
 
 import java.util.Arrays;
@@ -50,6 +51,10 @@ public class ApplicationReference extends NamespacedEntityId implements Parented
 
   public ApplicationId app(String version) {
     return new ApplicationId(namespace, application, version);
+  }
+
+  public ProgramReference program(ProgramType type, String program) {
+    return new ProgramReference(this, type, program);
   }
 
   @Override

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/field/FieldValidator.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/field/FieldValidator.java
@@ -64,7 +64,7 @@ public final class FieldValidator {
    * its field is not present in the given schema,
    * its field type is different from the given schema,
    * if its field is a primary key but the given value is null,
-   * or it is not Rang.all() and does not start with a primary key.
+   * or it is not Rang.all() and does not start with the first primary key.
    *
    * @param range the range to validate
    * @throws InvalidFieldException if the field does not pass the validation
@@ -87,7 +87,7 @@ public final class FieldValidator {
     if (!firstField.getName().equals(tableSchema.getPrimaryKeys().get(0))) {
       throw new InvalidFieldException(
         tableSchema.getTableId(), fields,
-        String.format("Given Range fields %s do not start with a primary key", fields));
+        String.format("Given Range fields %s do not start with the first primary key", fields));
     }
   }
 

--- a/cdap-support-bundle/src/main/java/io/cdap/cdap/support/task/SupportBundlePipelineInfoTask.java
+++ b/cdap-support-bundle/src/main/java/io/cdap/cdap/support/task/SupportBundlePipelineInfoTask.java
@@ -107,7 +107,7 @@ public class SupportBundlePipelineInfoTask implements SupportBundleTask {
       } else {
         try {
           processApplicationDetail(namespaceId, remoteApplicationDetailFetcher.get(
-            new ApplicationId(namespaceId.getNamespace(), requestApplication)));
+            namespaceId.appReference(requestApplication)));
         } catch (NotFoundException e) {
           LOG.debug("Failed to find application {} ", requestApplication, e);
           continue;


### PR DESCRIPTION
What:

Instead of implicitly mapping "-SNAPSHOT" to latest inside AppMetaStore, we should surface up the mapping to handler/service level, which is less error-prone