### PR TITLE
[CDAP-20009] Handle null input in decodeUserId() function

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -1287,7 +1287,10 @@ public class ProgramLifecycleService {
     }
   }
 
-  private  String decodeUserId(String encodedUserId) {
+  private String decodeUserId(@Nullable String encodedUserId) {
+    if (encodedUserId == null) {
+      return "";
+    }
     String decodedUserId = "emptyUserId";
     try {
       byte[] decodedBytes = Base64.getDecoder().decode(encodedUserId);


### PR DESCRIPTION
userId is the id of the user who runs/stops the pipeline.
It will be null if RBAC is not enabled.