### PR TITLE
[Cherry-pick][CDAP-19941] Append dataproc job status details to failed pipeline logs

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobDetail.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobDetail.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.runtimejob;
+
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
+
+import java.util.Objects;
+
+/**
+ * Status details of dataproc runtime job.
+ */
+public class DataprocRuntimeJobDetail extends RuntimeJobDetail {
+
+  private final String jobStatusDetails;
+
+  public DataprocRuntimeJobDetail(ProgramRunInfo runInfo, RuntimeJobStatus status, String jobStatusDetails) {
+    super(runInfo, status);
+    this.jobStatusDetails = jobStatusDetails;
+  }
+
+  /**
+   * Returns string representation of dataproc job status details.
+   */
+  public String getJobStatusDetails() {
+    return jobStatusDetails;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    if (this.getClass() != o.getClass()) {
+      return false;
+    }
+
+    DataprocRuntimeJobDetail that = (DataprocRuntimeJobDetail) o;
+    return Objects.equals(jobStatusDetails, that.jobStatusDetails);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.getRunInfo(), this.getStatus(), jobStatusDetails);
+  }
+}

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -84,6 +84,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /**
  * Dataproc runtime job manager. This class is responsible for launching a hadoop job on dataproc cluster and managing
@@ -331,7 +332,9 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
                                                   .setRegion(region)
                                                   .setJobId(jobId)
                                                   .build());
-      return Optional.of(new RuntimeJobDetail(getProgramRunInfo(job), getRuntimeJobStatus(job)));
+      return Optional.of(new DataprocRuntimeJobDetail(getProgramRunInfo(job),
+                                                      getRuntimeJobStatus(job),
+                                                      getJobStatusDetails(job)));
     } catch (ApiException e) {
       if (e.getStatusCode().getCode() != StatusCode.Code.NOT_FOUND) {
         throw new Exception(String.format("Error while getting details for job %s on cluster %s.",
@@ -687,6 +690,15 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
                                                       job.getPlacement().getClusterName()));
     }
     return runtimeJobStatus;
+  }
+
+  /**
+   * Returns job state details, such as an error description if the state is ERROR.
+   * For other job states, returns null.
+   */
+  @Nullable
+  private String getJobStatusDetails(Job job) {
+    return job.getStatus().getDetails();
   }
 
   /**


### PR DESCRIPTION
[CDAP-19941] Append dataproc job status details to failed pipeline logs

Cherry-pick https://github.com/cdapio/cdap/pull/14651 to `release/6.8`

[CDAP-19941]: https://cdap.atlassian.net/browse/CDAP-19941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ