### PR TITLE
fix(CDAP-19936): add a table to catch edit # metric and prevent race condition

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -601,6 +601,7 @@ public class DefaultStore implements Store {
       getAppStateTable(context).deleteAll(id.getNamespaceId(), id.getApplication());
       AppMetadataStore metaStore = getAppMetadataStore(context);
       metaStore.deleteApplication(id.getNamespace(), id.getApplication(), id.getVersion());
+      metaStore.deleteApplicationEditRecord(id.getAppReference());
       metaStore.deleteProgramHistory(id.getNamespace(), id.getApplication(), id.getVersion());
     });
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -24,13 +24,16 @@ import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.app.store.ScanApplicationsRequest;
 import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.common.utils.ProjectInfo;
 import io.cdap.cdap.internal.AppFabricTestHelper;
+import io.cdap.cdap.internal.app.DefaultApplicationSpecification;
 import io.cdap.cdap.internal.app.deploy.Specifications;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
@@ -43,6 +46,8 @@ import org.apache.twill.api.RunId;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -58,6 +63,9 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -70,6 +78,8 @@ import java.util.stream.Stream;
  * Test AppMetadataStore.
  */
 public abstract class AppMetadataStoreTest {
+  private static final Logger LOG = LoggerFactory.getLogger(AppMetadataStoreTest.class);
+
   protected static TransactionRunner transactionRunner;
   private static final List<ProgramRunStatus> STOP_STATUSES =
     ImmutableList.of(ProgramRunStatus.COMPLETED, ProgramRunStatus.FAILED, ProgramRunStatus.KILLED);
@@ -1348,6 +1358,116 @@ public abstract class AppMetadataStoreTest {
     });
   }
 
+  @Test
+  public void testConcurrentCreateAppFirstVersion() throws Exception {
+    String appName = "application1";
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
+    ApplicationReference appRef = new ApplicationReference(NamespaceId.DEFAULT, appName);
+    
+    // Concurrently deploy different fist version of the same application
+    int numThreads = 10;
+    AtomicInteger idGenerator = new AtomicInteger();
+    runConcurrentOperation("concurrent-first-deploy-application", numThreads, () ->
+      TransactionRunners.run(transactionRunner, context -> {
+        AppMetadataStore metaStore = AppMetadataStore.create(context);
+        int id = idGenerator.getAndIncrement();
+        ApplicationId appId = appRef.app(appName + "_version_" + id);
+        ApplicationSpecification spec = createDummyAppSpec(appId.getApplication(), appId.getVersion(), artifactId);
+        ApplicationMeta meta = new ApplicationMeta(spec.getName(), spec,
+                                                   new ChangeDetail(null, null, null,
+                                                                    creationTimeMillis + id));
+        metaStore.createApplicationVersion(appId, meta);
+      })
+    );
+
+    // Verify latest version
+    AtomicInteger latestVersionCount = new AtomicInteger();
+    AtomicInteger allVersionsCount = new AtomicInteger();
+    AtomicInteger appEditNumber = new AtomicInteger();
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore metaStore = AppMetadataStore.create(context);
+      List<ApplicationMeta> allVersions = metaStore.getAllAppVersions(appRef);
+      List<String> latestVersions = allVersions
+        .stream()
+        .filter(version -> {
+          Assert.assertNotNull(version.getChange());
+          Assert.assertNotNull(version.getChange().getLatest());
+          return version.getChange().getLatest().equals(true);
+        })
+        .map(version -> version.getSpec().getAppVersion())
+        .collect(Collectors.toList());
+      allVersionsCount.set(allVersions.size());
+      latestVersionCount.set(latestVersions.size());
+      appEditNumber.set(metaStore.getApplicationEditNumber(appRef));
+    });
+    
+    // There can only be one latest version
+    Assert.assertEquals(1, latestVersionCount.get());
+    Assert.assertEquals(numThreads, allVersionsCount.get());
+    Assert.assertEquals(numThreads, appEditNumber.get());
+  }
+
+  @Test
+  public void testConcurrentCreateAppAfterTheFirstVersion() throws Exception {
+    String appName = "application1";
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
+    ApplicationReference appRef = new ApplicationReference(NamespaceId.DEFAULT, appName);
+
+    AtomicInteger idGenerator = new AtomicInteger();
+    // Deploy the first version
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore metaStore = AppMetadataStore.create(context);
+      int id = idGenerator.getAndIncrement();
+      ApplicationId appId = appRef.app(appName + "_version_" + id);
+      ApplicationSpecification spec = createDummyAppSpec(appId.getApplication(), appId.getVersion(), artifactId);
+      ApplicationMeta meta = new ApplicationMeta(spec.getName(), spec,
+                                                 new ChangeDetail(null, null, null,
+                                                                  creationTimeMillis + id));
+      metaStore.createApplicationVersion(appId, meta);
+    });
+
+    // Concurrently deploy different versions of the same application
+    int numThreads = 10;
+    runConcurrentOperation("concurrent-second-deploy-application", numThreads, () ->
+      TransactionRunners.run(transactionRunner, context -> {
+        AppMetadataStore metaStore = AppMetadataStore.create(context);
+        int id = idGenerator.getAndIncrement();
+        ApplicationId appId = appRef.app(appName + "_version_" + id);
+        ApplicationSpecification spec = createDummyAppSpec(appId.getApplication(), appId.getVersion(), artifactId);
+        ApplicationMeta meta = new ApplicationMeta(spec.getName(), spec,
+                                                   new ChangeDetail(null, null, null,
+                                                                    creationTimeMillis + id));
+        metaStore.createApplicationVersion(appId, meta);
+      })
+    );
+
+    // Verify latest version
+    AtomicInteger latestVersionCount = new AtomicInteger();
+    AtomicInteger allVersionsCount = new AtomicInteger();
+    AtomicInteger appEditNumber = new AtomicInteger();
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore metaStore = AppMetadataStore.create(context);
+      List<ApplicationMeta> allVersions = metaStore.getAllAppVersions(appRef);
+      List<String> latestVersions = allVersions
+        .stream()
+        .filter(version -> {
+          Assert.assertNotNull(version.getChange());
+          Assert.assertNotNull(version.getChange().getLatest());
+          return version.getChange().getLatest().equals(true);
+        })
+        .map(version -> version.getSpec().getAppVersion())
+        .collect(Collectors.toList());
+      allVersionsCount.set(allVersions.size());
+      latestVersionCount.set(latestVersions.size());
+      appEditNumber.set(metaStore.getApplicationEditNumber(appRef));
+    });
+
+    // There can only be one latest version
+    Assert.assertEquals(1, latestVersionCount.get());
+    Assert.assertEquals(1 + numThreads, allVersionsCount.get());
+    Assert.assertEquals(1 + numThreads, appEditNumber.get());
+  }
+
   private List<ProgramRunId> addProgramCount(ProgramId programId, int count) throws Exception {
     List<ProgramRunId> runIds = new ArrayList<>();
     for (int i = 0; i < count; i++) {
@@ -1360,5 +1480,37 @@ public abstract class AppMetadataStoreTest {
       });
     }
     return runIds;
+  }
+
+  private ApplicationSpecification createDummyAppSpec(String appName, String appVersion, ArtifactId artifactId) {
+    return new DefaultApplicationSpecification(
+      appName, appVersion, ProjectInfo.getVersion().toString(), "desc", null, artifactId,
+      Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+      Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
+      Collections.emptyMap());
+  }
+
+  private void runConcurrentOperation(String name, int numThreads, Runnable runnable) throws Exception {
+    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(numThreads);
+    try {
+      for (int i = 0; i < numThreads; ++i) {
+        executorService.submit(() -> {
+          try {
+            startLatch.await();
+            runnable.run();
+            doneLatch.countDown();
+          } catch (Exception e) {
+            LOG.error("Error performing concurrent operation {}", name, e);
+          }
+        });
+      }
+
+      startLatch.countDown();
+      doneLatch.await(30, TimeUnit.SECONDS);
+    } finally {
+      executorService.shutdown();
+    }
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/DefaultStoreTest.java
@@ -1271,8 +1271,7 @@ public abstract class DefaultStoreTest {
     Assert.assertFalse(store.scanApplications(request, 20, (id, appSpec) -> {
       actualApps.add(id);
       creationTimes.add(appSpec.getChange().getCreationTimeMillis());
-      // TODO: change to boolean after CDAP-19981
-      if (appSpec.getChange().getLatest() == true) {
+      if (Boolean.TRUE.equals(appSpec.getChange().getLatest())) {
         latestVersionCount.getAndIncrement();
         latestAppId.set(id);
       }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
@@ -360,6 +360,7 @@ public final class StoreDefinition {
   public static final class AppMetadataStore {
 
     public static final StructuredTableId APPLICATION_SPECIFICATIONS = new StructuredTableId("application_specs");
+    public static final StructuredTableId APPLICATION_EDIT = new StructuredTableId("application_edit");
     public static final StructuredTableId WORKFLOW_NODE_STATES = new StructuredTableId("workflow_node_states");
     public static final StructuredTableId RUN_RECORDS = new StructuredTableId("run_records");
     public static final StructuredTableId WORKFLOWS = new StructuredTableId("workflows");
@@ -370,6 +371,7 @@ public final class StoreDefinition {
     public static final String NAMESPACE_FIELD = "namespace";
     public static final String APPLICATION_FIELD = "application";
     public static final String VERSION_FIELD = "version";
+    public static final String EDIT_NUM_FIELD = "edit_num";
     public static final String APPLICATION_DATA_FIELD = "application_data";
     public static final String CREATION_TIME_FIELD = "created";
     public static final String CHANGE_SUMMARY_FIELD = "change_summary";
@@ -404,6 +406,18 @@ public final class StoreDefinition {
                     Fields.booleanType(LATEST_FIELD))
         .withPrimaryKeys(NAMESPACE_FIELD, APPLICATION_FIELD, VERSION_FIELD)
         .withIndexes(LATEST_FIELD, CREATION_TIME_FIELD)
+        .build();
+
+    // The table that stores the edit# of an application. It provides:
+    // 1. Keys on namespace + application name to prevent the race of multiple first application versions
+    // 2. Store the number of edits for an application
+    public static final StructuredTableSpecification APPLICATION_EDIT_TABLE_SPEC =
+      new StructuredTableSpecification.Builder()
+        .withId(APPLICATION_EDIT)
+        .withFields(Fields.stringType(NAMESPACE_FIELD),
+                    Fields.stringType(APPLICATION_FIELD),
+                    Fields.intType(EDIT_NUM_FIELD))
+        .withPrimaryKeys(NAMESPACE_FIELD, APPLICATION_FIELD)
         .build();
 
     public static final StructuredTableSpecification WORKFLOW_NODE_STATES_SPEC =
@@ -476,6 +490,7 @@ public final class StoreDefinition {
 
     public static void create(StructuredTableAdmin tableAdmin) throws IOException {
       createIfNotExists(tableAdmin, APPLICATION_SPECIFICATIONS_TABLE_SPEC);
+      createIfNotExists(tableAdmin, APPLICATION_EDIT_TABLE_SPEC);
       createIfNotExists(tableAdmin, WORKFLOW_NODE_STATES_SPEC);
       createIfNotExists(tableAdmin, RUN_RECORDS_SPEC);
       createIfNotExists(tableAdmin, WORKFLOWS_SPEC);


### PR DESCRIPTION
WHAT:

The current LCM work has a concurrency flaw that when multiple transactions try to deploy the first version of the same app, it can result in multiple `latest` versions. This is breaking the assumption that we only have one latest version of an application. 

With the current isolation level(postgreSQL: `TRANSACTION_REPEATABLE_READ`; Spanner: [Locking read-write](https://cloud.google.com/spanner/docs/reference/rest/v1/TransactionOptions#readwrite)]), the other transaction will fail if both try to update the same row (flipping the previous latest version to false). We introduce a new latest version record table that keys on namespace+applicationID to prevent the above race