### PR TITLE
Change the wait duration from 1 milisecond to 1 second as MacOS files…

### DIFF
--- a/cdap-common/src/test/java/io/cdap/cdap/common/io/CachingLocationTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/io/CachingLocationTest.java
@@ -195,8 +195,9 @@ public class CachingLocationTest {
     Assert.assertEquals(1, cachingPathProvider.getCacheEntries().size());
 
     // Modify the file, last modified should change, adding a new entry in the cache map.
-    // Sleep for a while to ensure at least 1 millis has passed.
-    Thread.sleep(1);
+    // Sleep for a while to ensure at least 1 second has passed.
+    // Because 1 second is the minimum resolution of the last modified time in MacOS.
+    Thread.sleep(1000);
     try (OutputStream os = location.getOutputStream()) {
       os.write((message + message).getBytes(StandardCharsets.UTF_8));
     }


### PR DESCRIPTION
…ystem keeps the granularity at seconds level.
More info - https://stackoverflow.com/questions/18403588/how-to-return-millisecond-information-for-file-access-on-mac-os-x-in-java