### PR TITLE
Create per-run config for user program runs

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
@@ -44,6 +44,7 @@ import io.cdap.cdap.security.auth.context.WorkerAuthenticationContext;
 import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.spi.authenticator.RemoteAuthenticator;
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,16 +102,28 @@ public class MasterEnvironmentMain {
         throw new IllegalArgumentException("Missing runnable class name");
       }
 
-      CConfiguration cConf = CConfiguration.create();
-      SConfiguration sConf = SConfiguration.create();
       if (options.getExtraConfPath() != null) {
-        cConf.addResource(new File(options.getExtraConfPath(), "cdap-site.xml").toURI().toURL());
-        sConf.addResource(new File(options.getExtraConfPath(), "cdap-security.xml").toURI().toURL());
+        // Copy config files from per-run configmap to the working directory
+        FileUtils.copyDirectory(new File(options.getExtraConfPath()), new File("."));
+      }
+      CConfiguration cConf = CConfiguration.create();
+      File cConfFile = new File("cConf.xml");
+      if (cConfFile.exists()) {
+        cConf.addResource(cConfFile.toURI().toURL());
+      }
+      SConfiguration sConf = SConfiguration.create();
+      File sConfFile = new File("sConf.xml");
+      if (sConfFile.exists()) {
+        sConf.addResource(sConfFile.toURI().toURL());
       }
 
       SecurityUtil.loginForMasterService(cConf);
 
       Configuration hConf = new Configuration();
+      File hConfFile = new File("hConf.xml");
+      if (hConfFile.exists()) {
+        hConf.addResource(hConfFile.toURI().toURL());
+      }
 
       // Creates the master environment and load the MasterEnvironmentRunnable class from it.
       MasterEnvironment masterEnv = MasterEnvironments.setMasterEnvironment(

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
@@ -152,6 +152,9 @@ public class KubeTwillPreparerTest {
                                                        createPodInfo(), createTwillSpecification(), null, null,
                                                        null, null, null);
     ResourceSpecification resourceSpecification = new DefaultResourceSpecification(1, 100, 1, 1, 1);
+    Map<String, String> config = new HashMap<>();
+    config.put(MasterOptionConstants.RUNTIME_NAMESPACE, "system");
+    preparer.withConfiguration(config);
     V1ResourceRequirements gotResourceRequirements = preparer.createResourceRequirements(resourceSpecification);
     Assert.assertEquals("1", gotResourceRequirements.getRequests().get("cpu").toSuffixedString());
     Assert.assertEquals("100Mi", gotResourceRequirements.getRequests().get("memory").toSuffixedString());
@@ -180,6 +183,9 @@ public class KubeTwillPreparerTest {
     KubeTwillPreparer preparer = new KubeTwillPreparer(masterEnvironmentContext, null, "default",
                                                        createPodInfo(), createTwillSpecification(), null, null,
                                                        null, null, null);
+    Map<String, String> config = new HashMap<>();
+    config.put(MasterOptionConstants.RUNTIME_NAMESPACE, "system");
+    preparer.withConfiguration(config);
     ResourceSpecification resourceSpecification = new DefaultResourceSpecification(1, 100, 1, 1, 1);
     V1ResourceRequirements gotResourceRequirements = preparer.createResourceRequirements(resourceSpecification);
     Assert.assertEquals("500m", gotResourceRequirements.getRequests().get("cpu").toSuffixedString());


### PR DESCRIPTION
Fixes https://cdap.atlassian.net/browse/CDAP-20020. Initial fix tracked by CDAP-19145 (PR #14594) caused a regression, so it was reverted. This PR rolls back the revert + fixes some issues #14594.

What has been fixed?
1. Copy secrets when creating new namespaces. Filed CDAP-20087 to fix this - ideally we shouldn't be copying secrets
2. pass --conf arg to init container as well
3. Rely on owner reference to clean up the per-run configmap 

