### PR TITLE
CDAP-20019 improve unit test coverage for ProgramLCHttpHandler

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ScheduledRunTimeTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ScheduledRunTimeTest.java
@@ -86,7 +86,7 @@ public class ScheduledRunTimeTest extends AppFabricTestBase {
     Constraint constraint = new DelayConstraint(1, TimeUnit.HOURS);
     ScheduleProgramInfo scheduleProgramInfo = new ScheduleProgramInfo(programId.getType().getSchedulableType(),
                                                                       programId.getProgram());
-    addSchedule(appId.getNamespace(), appId.getApplication(), appId.getVersion(), scheduleName,
+    addSchedule(appId.getNamespace(), appId.getApplication(), scheduleName,
                 new ScheduleDetail(scheduleName, null, scheduleProgramInfo, null,
                                    new TimeTrigger("0 0 * * * "), Collections.singletonList(constraint), null));
 
@@ -124,7 +124,7 @@ public class ScheduledRunTimeTest extends AppFabricTestBase {
 
       ScheduleProgramInfo scheduleProgramInfo = new ScheduleProgramInfo(programId.getType().getSchedulableType(),
                                                                         programId.getProgram());
-      addSchedule(appId.getNamespace(), appId.getApplication(), appId.getVersion(), scheduleName,
+      addSchedule(appId.getNamespace(), appId.getApplication(), scheduleName,
                   new ScheduleDetail(scheduleName, null, scheduleProgramInfo, null,
                                      new TimeTrigger("0 0 * * * "), Collections.singletonList(constraint), null));
       HttpResponse response = enableSchedule(programId.getNamespace(), programId.getApplication(),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/SleepingWorkflowApp.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/SleepingWorkflowApp.java
@@ -42,10 +42,11 @@ public class SleepingWorkflowApp extends AbstractApplication {
    *
    */
   public static class SleepWorkflow extends AbstractWorkflow {
+    public static final String NAME = "SleepWorkflow";
 
     @Override
     public void configure() {
-      setName("SleepWorkflow");
+      setName(NAME);
       setDescription("FunWorkflow description");
       addAction(new CustomAction("verify"));
     }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppScheduleUpdateTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppScheduleUpdateTest.java
@@ -70,8 +70,7 @@ public class AppScheduleUpdateTest extends AppFabricTestBase {
     Assert.assertEquals(200, deploy(defaultAppId, request).getResponseCode());
 
     List<ScheduleDetail> actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
-                                                        defaultAppId.getApplication(),
-                                                        defaultAppId.getVersion());
+                                                        defaultAppId.getApplication());
 
     // none of the schedules will be added - by default we have set update schedules to be false as system property.
     Assert.assertEquals(0, actualSchSpecs.size());
@@ -83,8 +82,7 @@ public class AppScheduleUpdateTest extends AppFabricTestBase {
     Assert.assertEquals(200, deploy(defaultAppId, request).getResponseCode());
 
     actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
-                                                               defaultAppId.getApplication(),
-                                                               defaultAppId.getVersion());
+                                   defaultAppId.getApplication());
 
     // both the schedules will be added as now,
     // we have provided update schedules property to be true manually in appRequest
@@ -97,8 +95,7 @@ public class AppScheduleUpdateTest extends AppFabricTestBase {
     Assert.assertEquals(200, deploy(defaultAppId, request).getResponseCode());
 
     actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
-                                   defaultAppId.getApplication(),
-                                   defaultAppId.getVersion());
+                                   defaultAppId.getApplication());
 
     // no changes will be made, as default behavior is dont update schedules, so both the schedules should be there
     Assert.assertEquals(2, actualSchSpecs.size());
@@ -110,8 +107,7 @@ public class AppScheduleUpdateTest extends AppFabricTestBase {
     Assert.assertEquals(200, deploy(defaultAppId, request).getResponseCode());
 
     actualSchSpecs = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
-                                   defaultAppId.getApplication(),
-                                   defaultAppId.getVersion());
+                                   defaultAppId.getApplication());
 
     // workflow is deleted, so the schedules will be deleted now
     Assert.assertEquals(0, actualSchSpecs.size());


### PR DESCRIPTION
[JIRA Ticket](https://cdap.atlassian.net/browse/CDAP-20019)
This PR is created improve unit test coverage for ProgramLCHttpHandler. A few versioned api will not be covered in this PR since we are deprecating these api. In these cases, users should use the unversioned api to perform action on the latest version of a program.

Refactored the schedule api calls in the unit tests to use the unverioned schedule apis since schedule is versionless and versioned schedule apis (add, update, supend...) will deprecate soon.