### PR TITLE
CDAP-20041 ensure extra jvm opts are properly set

### DIFF
--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkRuntimeService.java
@@ -629,6 +629,10 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
     prependConfig(configs, "spark.driver.extraJavaOptions", sparkCheckpointTempRewrite, " ");
     prependConfig(configs, "spark.executor.extraJavaOptions", sparkCheckpointTempRewrite, " ");
 
+    // Prepend the extra java opts
+    prependConfig(configs, "spark.driver.extraJavaOptions", cConf.get(Constants.AppFabric.PROGRAM_JVM_OPTS), " ");
+    prependConfig(configs, "spark.executor.extraJavaOptions", cConf.get(Constants.AppFabric.PROGRAM_JVM_OPTS), " ");
+
     // CDAP-5854: On Windows * is a reserved character which cannot be used in paths. So adding the below to
     // classpaths will fail. Please see CDAP-5854.
     // In local mode spark program runs under the same jvm as cdap master and these jars will already be in the
@@ -640,10 +644,6 @@ final class SparkRuntimeService extends AbstractExecutionThreadService {
       // Set extraClasspath config by appending user specified extra classpath
       prependConfig(configs, "spark.driver.extraClassPath", extraClassPath, File.pathSeparator);
       prependConfig(configs, "spark.executor.extraClassPath", extraClassPath, File.pathSeparator);
-
-      // Prepend the extra java opts
-      prependConfig(configs, "spark.driver.extraJavaOptions", cConf.get(Constants.AppFabric.PROGRAM_JVM_OPTS), " ");
-      prependConfig(configs, "spark.executor.extraJavaOptions", cConf.get(Constants.AppFabric.PROGRAM_JVM_OPTS), " ");
     } else {
       // Only need to set this for local mode.
       // In distributed mode, Spark will not use this but instead use the yarn container directory.

--- a/cdap-spark-core3_2.12/src/k8s/entrypoint.sh
+++ b/cdap-spark-core3_2.12/src/k8s/entrypoint.sh
@@ -79,6 +79,9 @@ fi
 # /etc/cdap/localizefiles will contain the logback jar and must come first in the classpath
 CDAP_SPARK_CORE_LIBS=`find /opt/cdap/cdap-spark-core/lib | sort | tr '\n' ':'`
 export CDAP_SPARK_CLASSPATH="/etc/cdap/localizefiles/logback.xml.jar:/opt/cdap/cdap-spark-core/cdap-spark-core.jar:$CDAP_SPARK_CORE_LIBS:/etc/cdap/conf"
+# for the same reasons, spark.driver.extraJavaOptions gets ignored
+# so grab it from the properties and add it to the driver java command manually.
+export DRIVER_EXTRA_OPTS=`grep spark.driver.extraJavaOptions /opt/spark/conf/spark.properties | awk '{ print substr($0, 31) }' | sed 's/\\\=/=/g'`
 
 case "$1" in
   driver)
@@ -87,6 +90,7 @@ case "$1" in
       # launch SparkSubmit with the CDAP launcher, which will
       # setup CDAP classloading and class rewrite
       ${JAVA_HOME}/bin/java
+      ${DRIVER_EXTRA_OPTS}
       # CDAP classpath must come before spark classpath, otherwise
       # recursive logging and task deserialization errors occur
       -cp "$CDAP_SPARK_CLASSPATH:$SPARK_CLASSPATH"


### PR DESCRIPTION
make sure app.program.opts are always set in spark configs regardless of if it's local mode or not. Also fix the modified entrypoint so that these properties are set for the driver java process, since it is getting ignored by spark submit, since we have hijacked the main method.