### PR TITLE
CDAP-20043 remove versionid from schedule

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/metadata/MetadataEntity.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/metadata/MetadataEntity.java
@@ -99,8 +99,7 @@ public class MetadataEntity implements Iterable<MetadataEntity.KeyValue> {
     typesToKeys.put(PLUGIN, new String[][]{{NAMESPACE, ARTIFACT, VERSION, TYPE, PLUGIN}});
     typesToKeys.put(PROGRAM, new String[][]{{NAMESPACE, APPLICATION, VERSION, TYPE, PROGRAM},
       {NAMESPACE, APPLICATION, TYPE, PROGRAM}});
-    typesToKeys.put(SCHEDULE, new String[][]{{NAMESPACE, APPLICATION, VERSION, SCHEDULE},
-      {NAMESPACE, APPLICATION, SCHEDULE}});
+    typesToKeys.put(SCHEDULE, new String[][]{{NAMESPACE, APPLICATION, SCHEDULE}});
     typesToKeys.put(PROGRAM_RUN, new String[][]{{NAMESPACE, APPLICATION, VERSION, TYPE, PROGRAM, PROGRAM_RUN},
       {NAMESPACE, APPLICATION, TYPE, PROGRAM, PROGRAM_RUN}});
     TYPES_TO_KEY_SEQUENCES = Collections.unmodifiableMap(typesToKeys);

--- a/cdap-api/src/test/java/io/cdap/cdap/api/metadata/MetadataEntityTest.java
+++ b/cdap-api/src/test/java/io/cdap/cdap/api/metadata/MetadataEntityTest.java
@@ -169,7 +169,7 @@ public class MetadataEntityTest {
     MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").appendAsType(MetadataEntity.APPLICATION, "myApp")
       .appendAsType(MetadataEntity.SCHEDULE, "sched").build();
     MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns").appendAsType(MetadataEntity.APPLICATION, "myApp")
-      .append(MetadataEntity.VERSION, "1").appendAsType(MetadataEntity.SCHEDULE, "sched").build();
+      .appendAsType(MetadataEntity.SCHEDULE, "sched").build();
     try {
       MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "ns")
         .appendAsType(MetadataEntity.SCHEDULE, "sched").build();

--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/WorkflowHttpHandlerTest.java
@@ -848,7 +848,6 @@ public class WorkflowHttpHandlerTest extends AppFabricTestBase {
     Assert.assertEquals(1, schedules.size());
     Assert.assertEquals(TEST_NAMESPACE2, schedules.get(0).getNamespace());
     Assert.assertEquals(appName, schedules.get(0).getApplication());
-    Assert.assertEquals(ApplicationId.DEFAULT_VERSION, schedules.get(0).getApplicationVersion());
     Assert.assertEquals(sampleSchedule, schedules.get(0).getName());
 
     List<ScheduledRuntime> runtimes = getScheduledRunTimes(programId.toEntityId(), true);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/ProgramSchedule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/ProgramSchedule.java
@@ -132,9 +132,9 @@ public class ProgramSchedule {
   public ScheduleDetail toScheduleDetail() {
     ScheduleProgramInfo programInfo =
       new ScheduleProgramInfo(programId.getType().getSchedulableType(), programId.getProgram());
-    return new ScheduleDetail(scheduleId.getNamespace(), scheduleId.getApplication(), scheduleId.getVersion(),
-                              scheduleId.getSchedule(), description, programInfo, properties, trigger, constraints,
-                              timeoutMillis, null, null);
+    return new ScheduleDetail(scheduleId.getNamespace(), scheduleId.getApplication(), scheduleId.getSchedule(),
+                              description, programInfo, properties, trigger, constraints, timeoutMillis,
+                              null, null);
   }
 
   public static ProgramSchedule fromScheduleDetail(ScheduleDetail schedule) throws IllegalArgumentException {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/ProgramScheduleRecord.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/ProgramScheduleRecord.java
@@ -74,7 +74,7 @@ public class ProgramScheduleRecord {
       new ScheduleProgramInfo(schedule.getProgramId().getType().getSchedulableType(),
                               schedule.getProgramId().getProgram());
     ScheduleId scheduleId = schedule.getScheduleId();
-    return new ScheduleDetail(scheduleId.getNamespace(), scheduleId.getApplication(), scheduleId.getVersion(),
+    return new ScheduleDetail(scheduleId.getNamespace(), scheduleId.getApplication(),
                               scheduleId.getSchedule(), schedule.getDescription(), programInfo,
                               schedule.getProperties(), schedule.getTrigger(), schedule.getConstraints(),
                               schedule.getTimeoutMillis(), meta.getStatus().name(), meta.getLastUpdated());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/queue/JobQueueTable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/queue/JobQueueTable.java
@@ -407,7 +407,6 @@ public class JobQueueTable implements JobQueue {
     int hash = Hashing.murmur3_32().newHasher()
       .putString(scheduleId.getNamespace())
       .putString(scheduleId.getApplication())
-      .putString(scheduleId.getVersion())
       .putString(scheduleId.getSchedule())
       .hash().asInt();
     return Math.abs(hash) % numPartitions;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/store/ProgramScheduleStoreDataset.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/store/ProgramScheduleStoreDataset.java
@@ -648,7 +648,7 @@ public class ProgramScheduleStoreDataset {
     List<Field<?>> keys = new ArrayList<>();
     keys.add(Fields.stringField(StoreDefinition.ProgramScheduleStore.NAMESPACE_FIELD, scheduleId.getNamespace()));
     keys.add(Fields.stringField(StoreDefinition.ProgramScheduleStore.APPLICATION_FIELD, scheduleId.getApplication()));
-    keys.add(Fields.stringField(StoreDefinition.ProgramScheduleStore.VERSION_FIELD, scheduleId.getVersion()));
+    keys.add(Fields.stringField(StoreDefinition.ProgramScheduleStore.VERSION_FIELD, ApplicationId.DEFAULT_VERSION));
     keys.add(Fields.stringField(StoreDefinition.ProgramScheduleStore.SCHEDULE_NAME, scheduleId.getSchedule()));
     return keys;
   }
@@ -674,7 +674,6 @@ public class ProgramScheduleStoreDataset {
   private static ScheduleId rowToScheduleId(StructuredRow row) {
     return new ScheduleId(row.getString(StoreDefinition.ProgramScheduleStore.NAMESPACE_FIELD),
                           row.getString(StoreDefinition.ProgramScheduleStore.APPLICATION_FIELD),
-                          row.getString(StoreDefinition.ProgramScheduleStore.VERSION_FIELD),
                           row.getString(StoreDefinition.ProgramScheduleStore.SCHEDULE_NAME));
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteScheduleFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteScheduleFetcher.java
@@ -71,8 +71,8 @@ public class RemoteScheduleFetcher implements ScheduleFetcher {
   public ScheduleDetail get(ScheduleId scheduleId)
     throws IOException, ScheduleNotFoundException, UnauthorizedException {
     String url = String.format(
-      "namespaces/%s/apps/%s/versions/%s/schedules/%s",
-      scheduleId.getNamespace(), scheduleId.getApplication(), scheduleId.getVersion(), scheduleId.getSchedule());
+      "namespaces/%s/apps/%s/schedules/%s",
+      scheduleId.getNamespace(), scheduleId.getApplication(), scheduleId.getSchedule());
     HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.GET, url);
     HttpResponse httpResponse;
     try {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricClient.java
@@ -623,14 +623,14 @@ public class AppFabricClient {
 
   public void enableSchedule(ScheduleId scheduleId) throws Exception {
     MockResponder responder = new MockResponder();
-    String uri = String.format("%s/apps/%s/versions/%s/program-type/schedules/program-id/%s/action/enable",
-                               getNamespacePath(scheduleId.getNamespace()), scheduleId.getVersion(),
-                               scheduleId.getApplication(), scheduleId.getSchedule());
+    String uri = String.format("%s/apps/%s/program-type/schedules/program-id/%s/action/enable",
+                               getNamespacePath(scheduleId.getNamespace()), scheduleId.getApplication(),
+                               scheduleId.getSchedule());
     FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, uri);
     HttpUtil.setContentLength(request, 0);
-    programLifecycleHttpHandler.performActionVersioned(request, responder, scheduleId.getNamespace(),
-                                              scheduleId.getApplication(), scheduleId.getVersion(),
-                                              "schedules", scheduleId.getSchedule(), "enable");
+    programLifecycleHttpHandler.performAction(request, responder, scheduleId.getNamespace(),
+                                              scheduleId.getApplication(), "schedules",
+                                              scheduleId.getSchedule(), "enable");
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Enable schedule failed");
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -1330,10 +1330,10 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
                                                               AppWithSchedule.WORKFLOW_NAME);
     ImmutableMap<String, String> properties = ImmutableMap.of("a", "b", "c", "d");
     TimeTrigger timeTrigger = new TimeTrigger("0 * * * ?");
-    ScheduleDetail timeDetail = new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, ApplicationId.DEFAULT_VERSION,
-                                                   scheduleName, description, programInfo, properties,
-                                                   timeTrigger, Collections.emptyList(),
-                                                   Schedulers.JOB_QUEUE_TIMEOUT_MILLIS, null, null);
+    ScheduleDetail timeDetail = new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, scheduleName,
+                                                   description, programInfo, properties, timeTrigger,
+                                                   Collections.emptyList(), Schedulers.JOB_QUEUE_TIMEOUT_MILLIS,
+                                                   null, null);
     HttpResponse response = addSchedule(TEST_NAMESPACE1, AppWithSchedule.NAME, scheduleName, timeDetail);
     Assert.assertEquals(HttpResponseStatus.OK.code(), response.getResponseCode());
 
@@ -1372,32 +1372,31 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
                                                               AppWithSchedule.WORKFLOW_NAME);
     ImmutableMap<String, String> properties = ImmutableMap.of("a", "b", "c", "d");
     TimeTrigger timeTrigger = new TimeTrigger("0 * * * ?");
-    ScheduleDetail timeDetail = new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, version, scheduleName,
+    ScheduleDetail timeDetail = new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, scheduleName,
                                                    description, programInfo, properties,
                                                    timeTrigger, Collections.emptyList(),
                                                    Schedulers.JOB_QUEUE_TIMEOUT_MILLIS, null, null);
     PartitionTrigger partitionTrigger =
       new PartitionTrigger(protoPartition.getDataset(), protoPartition.getNumPartitions());
     ScheduleDetail expectedPartitionDetail =
-      new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, ApplicationId.DEFAULT_VERSION,
-                         partitionScheduleName, description, programInfo, properties, partitionTrigger,
-                         Collections.emptyList(), Schedulers.JOB_QUEUE_TIMEOUT_MILLIS, null, null);
+      new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, partitionScheduleName, description,
+                         programInfo, properties, partitionTrigger, Collections.emptyList(),
+                         Schedulers.JOB_QUEUE_TIMEOUT_MILLIS, null, null);
 
     ScheduleDetail requestPartitionDetail =
-      new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, ApplicationId.DEFAULT_VERSION,
-                         partitionScheduleName, description, programInfo, properties, protoPartition,
-                         Collections.emptyList(), Schedulers.JOB_QUEUE_TIMEOUT_MILLIS, null, null);
+      new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, partitionScheduleName, description,
+                         programInfo, properties, protoPartition, Collections.emptyList(),
+                         Schedulers.JOB_QUEUE_TIMEOUT_MILLIS, null, null);
 
     ScheduleDetail expectedOrDetail =
-      new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, ApplicationId.DEFAULT_VERSION,
-                         orScheduleName, description, programInfo, properties,
-                         new OrTrigger(timeTrigger, partitionTrigger),
-                         Collections.emptyList(), Schedulers.JOB_QUEUE_TIMEOUT_MILLIS, null, null);
+      new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, orScheduleName, description, programInfo,
+                         properties, new OrTrigger(timeTrigger, partitionTrigger), Collections.emptyList(),
+                         Schedulers.JOB_QUEUE_TIMEOUT_MILLIS, null, null);
 
     ScheduleDetail requestOrDetail =
-      new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, ApplicationId.DEFAULT_VERSION,
-                         orScheduleName, description, programInfo, properties, protoOr,
-                         Collections.emptyList(), Schedulers.JOB_QUEUE_TIMEOUT_MILLIS, null, null);
+      new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, orScheduleName, description, programInfo,
+                         properties, protoOr, Collections.emptyList(), Schedulers.JOB_QUEUE_TIMEOUT_MILLIS,
+                         null, null);
 
     // trying to add the schedule with different name in path param than schedule spec should fail
     HttpResponse response = addSchedule(TEST_NAMESPACE1, AppWithSchedule.NAME, "differentName", timeDetail);
@@ -1417,8 +1416,8 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
 
     // adding a schedule for a program that does not exist
     ScheduleDetail nonExistingDetail =
-      new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, ApplicationId.DEFAULT_VERSION,
-                         scheduleName, description, new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE, "nope"),
+      new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, scheduleName, description,
+                         new ScheduleProgramInfo(SchedulableProgramType.MAPREDUCE, "nope"),
                          properties, timeTrigger, Collections.emptyList(),
                          Schedulers.JOB_QUEUE_TIMEOUT_MILLIS, null, null);
     response = addSchedule(TEST_NAMESPACE1, AppWithSchedule.NAME, scheduleName, nonExistingDetail);
@@ -1465,9 +1464,8 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     Assert.assertEquals(schedules2, schedulesForApp2);
 
     // Add a schedule with no schedule name in spec
-    ScheduleDetail detail2 = new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, version,
-                                                null, "Something 2", programInfo, properties,
-                                                new TimeTrigger("0 * * * ?"),
+    ScheduleDetail detail2 = new ScheduleDetail(TEST_NAMESPACE1, AppWithSchedule.NAME, null, "Something 2",
+                                                programInfo, properties, new TimeTrigger("0 * * * ?"),
                                                 Collections.emptyList(), TimeUnit.HOURS.toMillis(6), null, null);
     response = addSchedule(TEST_NAMESPACE1, AppWithSchedule.NAME, "schedule-100", detail2);
     Assert.assertEquals(HttpResponseStatus.OK.code(), response.getResponseCode());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/ScheduleFetcherTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/ScheduleFetcherTest.java
@@ -83,8 +83,7 @@ public class ScheduleFetcherTest extends AppFabricTestBase {
     ApplicationDetail appDetails = getAppDetails(namespace, appName);
 
     // Get and validate the schedule
-    ScheduleId scheduleId = new ScheduleId(namespace, appName, appDetails.getAppVersion(),
-                                           "InvalidSchedule");
+    ScheduleId scheduleId = new ScheduleId(namespace, appName, "InvalidSchedule");
     try {
       ScheduleDetail scheduleDetail = fetcher.get(scheduleId);
     } finally {

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineTest.java
@@ -644,8 +644,7 @@ public class DataPipelineTest extends HydratorTestBase {
                                ImmutableSet.of(ProgramStatus.COMPLETED));
     ScheduleId scheduleId = appId.schedule("completeSchedule");
     appManager.addSchedule(
-      new ScheduleDetail(scheduleId.getNamespace(), scheduleId.getApplication(), scheduleId.getVersion(),
-                         scheduleId.getSchedule(), "",
+      new ScheduleDetail(scheduleId.getNamespace(), scheduleId.getApplication(), scheduleId.getSchedule(), "",
                          new ScheduleProgramInfo(SchedulableProgramType.WORKFLOW, SmartWorkflow.NAME),
                          ImmutableMap.of(SmartWorkflow.TRIGGERING_PROPERTIES_MAPPING, GSON.toJson(propertyMapping)),
                          completeTrigger, ImmutableList.of(), Schedulers.JOB_QUEUE_TIMEOUT_MILLIS, null, null));

--- a/cdap-client/src/main/java/io/cdap/cdap/client/ApplicationClient.java
+++ b/cdap-client/src/main/java/io/cdap/cdap/client/ApplicationClient.java
@@ -679,9 +679,8 @@ public class ApplicationClient {
   public void enableSchedule(ScheduleId scheduleId)
     throws ApplicationNotFoundException, IOException, UnauthenticatedException,
     UnauthorizedException, BadRequestException {
-    String path = String.format("apps/%s/versions/%s/program-type/schedules/program-id/%s/action/enable",
-                                scheduleId.getApplication(), scheduleId.getVersion(),
-                                scheduleId.getSchedule());
+    String path = String.format("apps/%s/program-type/schedules/program-id/%s/action/enable",
+                                scheduleId.getApplication(), scheduleId.getSchedule());
     HttpResponse response = restClient.execute(HttpMethod.PUT,
                                                config.resolveNamespacedURLV3(scheduleId.getParent().getParent(), path),
                                                config.getAccessToken(), HttpURLConnection.HTTP_NOT_FOUND,

--- a/cdap-client/src/main/java/io/cdap/cdap/client/ScheduleClient.java
+++ b/cdap-client/src/main/java/io/cdap/cdap/client/ScheduleClient.java
@@ -129,8 +129,8 @@ public class ScheduleClient {
 
   public void suspend(ScheduleId scheduleId) throws IOException, UnauthenticatedException, NotFoundException,
     UnauthorizedException {
-    String path = String.format("apps/%s/versions/%s/schedules/%s/suspend", scheduleId.getApplication(),
-                                scheduleId.getVersion(), scheduleId.getSchedule());
+    String path = String.format("apps/%s/schedules/%s/suspend", scheduleId.getApplication(),
+                                scheduleId.getSchedule());
     URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -141,8 +141,8 @@ public class ScheduleClient {
 
   public void resume(ScheduleId scheduleId) throws IOException, UnauthenticatedException, NotFoundException,
     UnauthorizedException {
-    String path = String.format("apps/%s/versions/%s/schedules/%s/resume", scheduleId.getApplication(),
-                                scheduleId.getVersion(), scheduleId.getSchedule());
+    String path = String.format("apps/%s/schedules/%s/resume", scheduleId.getApplication(),
+                                scheduleId.getSchedule());
     URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -158,8 +158,8 @@ public class ScheduleClient {
    */
   public void delete(ScheduleId scheduleId) throws IOException, UnauthenticatedException, NotFoundException,
     UnauthorizedException {
-    String path = String.format("apps/%s/versions/%s/schedules/%s", scheduleId.getApplication(),
-                                scheduleId.getVersion(), scheduleId.getSchedule());
+    String path = String.format("apps/%s/schedules/%s", scheduleId.getApplication(),
+                                scheduleId.getSchedule());
     URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpResponse response = restClient.execute(HttpMethod.DELETE, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -170,8 +170,8 @@ public class ScheduleClient {
 
   public String getStatus(ScheduleId scheduleId) throws IOException, UnauthenticatedException, NotFoundException,
     UnauthorizedException {
-    String path = String.format("apps/%s/versions/%s/schedules/%s/status", scheduleId.getApplication(),
-                                scheduleId.getVersion(), scheduleId.getSchedule());
+    String path = String.format("apps/%s/schedules/%s/status", scheduleId.getApplication(),
+                                scheduleId.getSchedule());
     URL url = config.resolveNamespacedURLV3(scheduleId.getParent().getParent(), path);
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
                                                HttpURLConnection.HTTP_NOT_FOUND);
@@ -208,8 +208,7 @@ public class ScheduleClient {
   private void doAdd(ScheduleId scheduleId, String json)  throws IOException,
     UnauthenticatedException, NotFoundException, UnauthorizedException, AlreadyExistsException {
 
-    String path = String.format("apps/%s/versions/%s/schedules/%s",
-                                scheduleId.getApplication(), scheduleId.getVersion(), scheduleId.getSchedule());
+    String path = String.format("apps/%s/schedules/%s", scheduleId.getApplication(), scheduleId.getSchedule());
     URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpRequest request = HttpRequest.put(url).withBody(json).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(),
@@ -225,8 +224,8 @@ public class ScheduleClient {
   private void doUpdate(ScheduleId scheduleId, String json) throws IOException,
     UnauthenticatedException, NotFoundException, UnauthorizedException, AlreadyExistsException {
 
-    String path = String.format("apps/%s/versions/%s/schedules/%s/update",
-                                scheduleId.getApplication(), scheduleId.getVersion(), scheduleId.getSchedule());
+    String path = String.format("apps/%s/schedules/%s/update", scheduleId.getApplication(),
+                                scheduleId.getSchedule());
     URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpRequest request = HttpRequest.post(url).withBody(json).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(),

--- a/cdap-common/src/main/java/io/cdap/cdap/common/metadata/MetadataUtil.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/metadata/MetadataUtil.java
@@ -29,7 +29,6 @@ public final class MetadataUtil {
 
   private static final Set<String> VERSIONED_ENTITY_TYPES = ImmutableSet.of(
     MetadataEntity.APPLICATION,
-    MetadataEntity.SCHEDULE,
     MetadataEntity.PROGRAM,
     MetadataEntity.PROGRAM_RUN);
 

--- a/cdap-common/src/test/java/io/cdap/cdap/common/metadata/MetadataEntityCodecTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/metadata/MetadataEntityCodecTest.java
@@ -62,7 +62,6 @@ public class MetadataEntityCodecTest {
     MetadataEntity scheduleMetadata = MetadataEntity.builder()
       .append(MetadataEntity.NAMESPACE, "ns")
       .append(MetadataEntity.APPLICATION, "myApp")
-      .append(MetadataEntity.VERSION, ApplicationId.DEFAULT_VERSION)
       .append(MetadataEntity.SCHEDULE, "mySchedule")
       .build();
     json = gson.toJson(scheduleMetadata);

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/OwnerTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/OwnerTable.java
@@ -247,7 +247,9 @@ public class OwnerTable {
         builder.append(ROW_KEY_SEPARATOR);
         builder.append(ARTIFACT_VERSION_ROW_KEY_PREFIX);
         builder.append(ROW_KEY_SEPARATOR);
-        builder.append(scheduleId.getVersion());
+        // version is removed from ScheduleId in CDAP-20043, installing default value here because version
+        // is still part of the key in the table
+        builder.append(ApplicationId.DEFAULT_VERSION);
 
         builder.append(ROW_KEY_SEPARATOR);
         builder.append(SCHEDULE_NAME_ROW_KEY_PREFIX);

--- a/cdap-master/src/main/java/io/cdap/cdap/master/upgrade/UpgradeJobMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/upgrade/UpgradeJobMain.java
@@ -127,7 +127,7 @@ public class UpgradeJobMain {
             scheduleClient.listSchedules(workflowId).stream()
               .map(scheduleDetail ->
                      new ScheduleId(namespaceId.getNamespace(), record.getName(),
-                                    record.getAppVersion(), scheduleDetail.getName()))
+                                    scheduleDetail.getName()))
               .collect(Collectors.toList());
           for (ScheduleId scheduleId : scheduleIds) {
             if (scheduleClient.getStatus(scheduleId).equals(SCHEDULED)) {

--- a/cdap-metadata-spi/src/test/java/io/cdap/cdap/spi/metadata/MetadataStorageTest.java
+++ b/cdap-metadata-spi/src/test/java/io/cdap/cdap/spi/metadata/MetadataStorageTest.java
@@ -627,14 +627,6 @@ public abstract class MetadataStorageTest {
       .append(MetadataEntity.TYPE, "Service").appendAsType(MetadataEntity.PROGRAM, "pingService").build();
     testVersionLessEntities(programWithoutVersion, programWithVersion, programWithDefaultVersion);
 
-    MetadataEntity scheduleWithoutVersion = MetadataEntity.builder(appWithoutVersion)
-      .appendAsType(MetadataEntity.SCHEDULE, "pingSchedule").build();
-    MetadataEntity scheduleWithVersion = MetadataEntity.builder(appWithVersion)
-      .appendAsType(MetadataEntity.SCHEDULE, "pingSchedule").build();
-    MetadataEntity scheduleWithDefaultVersion = MetadataEntity.builder(appWithDefaultVersion)
-      .appendAsType(MetadataEntity.SCHEDULE, "pingSchedule").build();
-    testVersionLessEntities(scheduleWithoutVersion, scheduleWithVersion, scheduleWithDefaultVersion);
-
     // artifacts have version but it is not ignored
     MetadataEntity artifactWithVersion = MetadataEntity.builder().append(MetadataEntity.NAMESPACE, "nn")
       .append(MetadataEntity.ARTIFACT, "artifact").append(MetadataEntity.VERSION, "42").build();

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/ScheduleDetail.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/ScheduleDetail.java
@@ -36,7 +36,6 @@ public class ScheduleDetail {
 
   private final String namespace;
   private final String application;
-  private final transient String applicationVersion;
   private final String name;
   private final String description;
   private final ScheduleProgramInfo program;
@@ -54,12 +53,11 @@ public class ScheduleDetail {
                         @Nullable Trigger trigger,
                         @Nullable List<? extends Constraint> constraints,
                         @Nullable Long timeoutMillis) {
-    this(null, null, null, name, description, program, properties, trigger, constraints, timeoutMillis, null, null);
+    this(null, null, name, description, program, properties, trigger, constraints, timeoutMillis, null, null);
   }
 
   public ScheduleDetail(@Nullable String namespace,
                         @Nullable String application,
-                        @Nullable String applicationVersion,
                         @Nullable String name,
                         @Nullable String description,
                         @Nullable ScheduleProgramInfo program,
@@ -71,7 +69,6 @@ public class ScheduleDetail {
                         @Nullable Long lastUpdateTime) {
     this.namespace = namespace;
     this.application = application;
-    this.applicationVersion = applicationVersion;
     this.name = name;
     this.description = description;
     this.program = program;
@@ -91,11 +88,6 @@ public class ScheduleDetail {
   @Nullable
   public String getApplication() {
     return application;
-  }
-
-  @Nullable
-  public String getApplicationVersion() {
-    return applicationVersion;
   }
 
   @Nullable

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/codec/NamespacedEntityIdCodec.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/codec/NamespacedEntityIdCodec.java
@@ -109,9 +109,10 @@ public class NamespacedEntityIdCodec extends AbstractSpecificationCodec<Namespac
   }
 
   private ScheduleId deserializeSchedule(JsonObject id) {
-    ApplicationId app = deserializeApplicationId(id);
+    String namespace = id.get("namespace").getAsString();
+    String applicationId = id.get("application").getAsString();
     String scheduleId = id.get("schedule").getAsString();
-    return new ScheduleId(app.getNamespace(), app.getApplication(), app.getVersion(), scheduleId);
+    return new ScheduleId(namespace, applicationId, scheduleId);
   }
 
   private WorkerId deserializeWorkerId(JsonObject id) {

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/EntityId.java
@@ -191,8 +191,8 @@ public abstract class EntityId {
       // application so append it
       extractedParts.add(new MetadataEntity.KeyValue(MetadataEntity.VERSION, version));
     }
-    if (entityType == EntityType.PROGRAM || entityType == EntityType.SCHEDULE || entityType == EntityType.PROGRAM_RUN) {
-      // if the entity is program or schedule then add the version information at its correct position i.e. 2
+    if (entityType == EntityType.PROGRAM || entityType == EntityType.PROGRAM_RUN) {
+      // if the entity is program or program_run then add the version information at its correct position i.e. 2
       // (namespace, application, version) if the version information is not present
       if (!metadataEntity.containsKey(MetadataEntity.VERSION)) {
         extractedParts.add(2, new MetadataEntity.KeyValue(MetadataEntity.VERSION, version));

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ScheduleId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ScheduleId.java
@@ -28,13 +28,8 @@ import java.util.Objects;
  */
 public class ScheduleId extends NamespacedEntityId implements ParentedId<ApplicationId> {
   private final String application;
-  private final String version;
   private final String schedule;
   private transient Integer hashCode;
-
-  public ScheduleId(String namespace, String application, String version, String schedule) {
-    this(new ApplicationId(namespace, application, version), schedule);
-  }
 
   public ScheduleId(String namespace, String application, String schedule) {
     this(new ApplicationId(namespace, application), schedule);
@@ -56,24 +51,19 @@ public class ScheduleId extends NamespacedEntityId implements ParentedId<Applica
       throw new NullPointerException("Schedule id cannot be null.");
     }
     this.application = application;
-    this.version = ApplicationId.DEFAULT_VERSION;
     this.schedule = schedule;
   }
 
   @Override
   public MetadataEntity toMetadataEntity() {
     return MetadataEntity.builder().append(MetadataEntity.NAMESPACE, namespace)
-      .append(MetadataEntity.APPLICATION, application).append(MetadataEntity.VERSION, version)
+      .append(MetadataEntity.APPLICATION, application)
       .appendAsType(MetadataEntity.SCHEDULE, schedule)
       .build();
   }
 
   public String getApplication() {
     return application;
-  }
-
-  public String getVersion() {
-    return version;
   }
 
   public String getSchedule() {
@@ -93,7 +83,6 @@ public class ScheduleId extends NamespacedEntityId implements ParentedId<Applica
     ScheduleId that = (ScheduleId) o;
     return Objects.equals(namespace, that.namespace) &&
       Objects.equals(application, that.application) &&
-      Objects.equals(version, that.version) &&
       Objects.equals(schedule, that.schedule);
   }
 
@@ -101,27 +90,27 @@ public class ScheduleId extends NamespacedEntityId implements ParentedId<Applica
   public int hashCode() {
     Integer hashCode = this.hashCode;
     if (hashCode == null) {
-      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, application, version, schedule);
+      this.hashCode = hashCode = Objects.hash(super.hashCode(), namespace, application, schedule);
     }
     return hashCode;
   }
 
   @Override
   public ApplicationId getParent() {
-    return new ApplicationId(namespace, application, version);
+    return new ApplicationId(namespace, application);
   }
 
   @SuppressWarnings("unused")
   public static ScheduleId fromIdParts(Iterable<String> idString) {
     Iterator<String> iterator = idString.iterator();
     return new ScheduleId(
-      next(iterator, "namespace"), next(iterator, "application"), next(iterator, "version"),
+      next(iterator, "namespace"), next(iterator, "application"),
       nextAndEnd(iterator, "schedule"));
   }
 
   @Override
   public Iterable<String> toIdParts() {
-    return Collections.unmodifiableList(Arrays.asList(namespace, application, version, schedule));
+    return Collections.unmodifiableList(Arrays.asList(namespace, application, schedule));
   }
 
   public static ScheduleId fromString(String string) {

--- a/cdap-proto/src/test/java/io/cdap/cdap/proto/ProtoTriggerCodecTest.java
+++ b/cdap-proto/src/test/java/io/cdap/cdap/proto/ProtoTriggerCodecTest.java
@@ -68,14 +68,14 @@ public class ProtoTriggerCodecTest {
   public void testObjectContainingTrigger() {
     ScheduleDetail sched1 =
       new ScheduleDetail(
-        "default", "app1", "1.0.0", "sched1", "one partition schedule",
+        "default", "app1", "sched1", "one partition schedule",
         new ScheduleProgramInfo(SchedulableProgramType.WORKFLOW, "ww"),
         ImmutableMap.of("prop3", "abc"),
         new ProtoTrigger.PartitionTrigger(new DatasetId("test1", "pdfs1"), 1),
         ImmutableList.<Constraint>of(), null, "SUSPENDED", null);
     ScheduleDetail sched2 =
       new ScheduleDetail(
-        "default", "app1", "1.0.0", "schedone", "one time schedule",
+        "default", "app1", "schedone", "one time schedule",
         new ScheduleProgramInfo(SchedulableProgramType.WORKFLOW, "wf112"),
         ImmutableMap.of("prop", "all"),
         new ProtoTrigger.TimeTrigger("* * * 1 1"),

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java
@@ -945,10 +945,9 @@ public class AuthorizationTest extends TestBase {
     scheduleManager.suspend();
     Assert.assertEquals(ProgramScheduleStatus.SUSPENDED.name(), scheduleManager.status(HttpURLConnection.HTTP_OK));
 
-    ScheduleId scheduleId = new ScheduleId(appId.getNamespace(), appId.getApplication(), appId.getVersion(),
-                                           "testSchedule");
+    ScheduleId scheduleId = new ScheduleId(appId.getNamespace(), appId.getApplication(), "testSchedule");
     ScheduleDetail scheduleDetail =
-      new ScheduleDetail(AUTH_NAMESPACE.getNamespace(), AppWithSchedule.class.getSimpleName(), "1.0-SNAPSHOT",
+      new ScheduleDetail(AUTH_NAMESPACE.getNamespace(), AppWithSchedule.class.getSimpleName(),
                          "testSchedule", "Something 2",
                          new ScheduleProgramInfo(SchedulableProgramType.WORKFLOW, workflowName),
                          Collections.<String, String>emptyMap(), new TimeTrigger("*/1 * * * *"),


### PR DESCRIPTION
[JIRA link](https://cdap.atlassian.net/browse/CDAP-20043)

Since schedule is versionless, this PR is to remove version from scheduleId. When looking up and write ProgramSchedule from storage, the default “-SNAPSHOT” will be used as a dummy placeholder since it is already part of the primary key (so we can't just remove it for backward compat). 
Moreover, this PR also removes version from schedule MetadataEntity. This should be safe since Metadata is also versionless, and version is not part of the Metadata Entry Key. 