### PR TITLE
fix(CDAP-20111): return runs sorted by starting time

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -1774,7 +1774,8 @@ public class AppMetadataStore {
                                                               @Nullable Predicate<RunRecordDetail> predicate,
                                                               int limit) throws IOException {
     CloseableIterator<StructuredRow> iterator = getRunRecordsTable()
-      .scan(range, predicate == null && keyPredicate == null ? limit : Integer.MAX_VALUE);
+      .scan(range, predicate == null && keyPredicate == null ? limit : Integer.MAX_VALUE,
+            StoreDefinition.AppMetadataStore.RUN_START_TIME, SortOrder.ASC);
 
     return new AbstractCloseableIterator<RunRecordDetail>() {
 


### PR DESCRIPTION
What:

Before LCM, the runs API only returns the `-SNAPSHOT` version, sorted by `RUN_START_TIME`. When LCM enabled, /runs API is returning runs for all versions, we should specifically set the sorting order, otherwise it will sort on versions