### PR TITLE
bugfix/CDAP-20031: use programRunReference when version is not needed

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -47,6 +47,7 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 import io.cdap.cdap.proto.id.WorkflowId;
 import org.apache.twill.api.RunId;
 
@@ -250,10 +251,10 @@ public interface Store {
 
   /**
    * Fetches the run records for given ProgramRunIds.
-   * @param programRunIds  list of program RunIds to match against
+   * @param programRunRefs  list of program RunIds to match against
    * @return        map of logged runs
    */
-  Map<ProgramRunId, RunRecordDetail> getRuns(Set<ProgramRunId> programRunIds);
+  Map<ProgramRunReference, RunRecordDetail> getRuns(Set<ProgramRunReference> programRunRefs);
 
   /**
    * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records across all namespaces.
@@ -319,13 +320,13 @@ public interface Store {
   Map<ProgramId, Collection<RunRecordDetail>> getActiveRuns(Collection<ProgramReference> programRefs);
 
   /**
-   * Fetches the run record for particular run of a program.
+   * Fetches the run record for particular run of a program ignoring the version.
    *
-   * @param id        run id of the program
-   * @return          run record for the specified program and runid, null if not found
+   * @param ref       versionless run id of the program
+   * @return          run record for the specified program and run reference, null if not found
    */
   @Nullable
-  RunRecordDetail getRun(ProgramRunId id);
+  RunRecordDetail getRun(ProgramRunReference ref);
 
   /**
    * Creates new application if it doesn't exist. Updates existing one otherwise.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/WorkflowHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/WorkflowHttpHandler.java
@@ -221,7 +221,7 @@ public class WorkflowHttpHandler extends AbstractAppFabricHttpHandler {
     if (!appMeta.getSpec().getWorkflows().containsKey(workflow)) {
       throw new NotFoundException(workflowId);
     }
-    if (store.getRun(workflowId.run(runId)) == null) {
+    if (store.getRun(workflowId.run(runId).getReference()) == null) {
       throw new NotFoundException(workflowId.run(runId));
     }
     return store.getWorkflowToken(workflowId, runId);
@@ -238,7 +238,7 @@ public class WorkflowHttpHandler extends AbstractAppFabricHttpHandler {
     NamespaceId namespace = Ids.namespace(namespaceId);
     ApplicationMeta appMeta = store.getLatest(namespace.appReference(applicationId));
     if (appMeta == null || appMeta.getSpec() == null) {
-      throw new NotFoundException(namespace.app(applicationId));
+      throw new NotFoundException(namespace.appReference(applicationId));
     }
     ApplicationId appId =  namespace.app(applicationId, appMeta.getSpec().getAppVersion());
     ProgramId workflowProgramId = appId.workflow(workflowId);
@@ -249,7 +249,7 @@ public class WorkflowHttpHandler extends AbstractAppFabricHttpHandler {
     }
 
     ProgramRunId workflowRunId = workflowProgramId.run(runId);
-    if (store.getRun(workflowRunId) == null) {
+    if (store.getRun(workflowRunId.getReference()) == null) {
       throw new NotFoundException(workflowRunId);
     }
 
@@ -330,7 +330,7 @@ public class WorkflowHttpHandler extends AbstractAppFabricHttpHandler {
     NamespaceId namespace = Ids.namespace(namespaceId);
     ApplicationMeta appMeta = store.getLatest(namespace.appReference(applicationId));
     if (appMeta == null || appMeta.getSpec() == null) {
-      throw new NotFoundException(namespace.app(applicationId));
+      throw new NotFoundException(namespace.appReference(applicationId));
     }
     ApplicationId appId =  namespace.app(applicationId, appMeta.getSpec().getAppVersion());
     WorkflowSpecification workflowSpec = appMeta.getSpec().getWorkflows().get(workflowId);
@@ -340,7 +340,7 @@ public class WorkflowHttpHandler extends AbstractAppFabricHttpHandler {
     }
 
     ProgramRunId programRunId = programId.run(runId);
-    if (store.getRun(programRunId) == null) {
+    if (store.getRun(programRunId.getReference()) == null) {
       throw new NotFoundException(programRunId);
     }
     return workflowSpec;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteProgramRunDispatcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteProgramRunDispatcher.java
@@ -205,7 +205,7 @@ public class RemoteProgramRunDispatcher implements ProgramRunDispatcher {
   }
 
   private TwillController getRemoteTwillController(ProgramRunId programRunId) {
-    RunRecordDetail runRecordDetail = store.getRun(programRunId);
+    RunRecordDetail runRecordDetail = store.getRun(programRunId.getReference());
     if (runRecordDetail == null) {
       String msg = String.format("Could not find run record for Program %s with runid %s", programRunId.getProgram(),
                                  programRunId.getRun());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramRunExistenceVerifier.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramRunExistenceVerifier.java
@@ -35,7 +35,7 @@ public class ProgramRunExistenceVerifier implements EntityExistenceVerifier<Prog
 
   @Override
   public void ensureExists(ProgramRunId runId) throws NotFoundException {
-    if (store.getRun(runId) == null) {
+    if (store.getRun(runId.getReference()) == null) {
       throw new NotFoundException(runId);
     }
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -138,7 +138,7 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
     ProgramRunId programRunId = programId.run(runId.getId());
     RunRecordDetail record;
     synchronized (this) {
-      record = store.getRun(programRunId);
+      record = store.getRun(programRunId.getReference());
     }
     if (record == null) {
       return null;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidator.java
@@ -107,7 +107,7 @@ public final class DirectRuntimeRequestValidator implements RuntimeRequestValida
     throws IOException, UnauthorizedException {
     try {
       RunRecordDetail runRecord = TransactionRunners.run(txRunner, context -> {
-        return AppMetadataStore.create(context).getRun(programRunId);
+        return AppMetadataStore.create(context).getRun(programRunId.getReference());
       }, IOException.class);
 
       if (runRecord != null) {
@@ -115,7 +115,7 @@ public final class DirectRuntimeRequestValidator implements RuntimeRequestValida
       }
       // If it is not found in the local store, which should be very rare, try to fetch the run record remotely.
       LOG.info("Remotely fetching program run details for {}", programRunId);
-      runRecord = runRecordFetcher.getRunRecordMeta(programRunId);
+      runRecord = runRecordFetcher.getRunRecordMeta(programRunId.getReference());
       // Try to update the local store
       insertRunRecord(programRunId, runRecord);
       return runRecord.getStatus().isEndState() ? Optional.empty() : getValidRunRecordStatus(runRecord);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/TriggerInfoContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/trigger/TriggerInfoContext.java
@@ -85,7 +85,7 @@ public class TriggerInfoContext {
    * @return run time arguments as a map for the specified program and runId, null if not found
    */
   public Map<String, String> getProgramRuntimeArguments(ProgramRunId programRunId) {
-    RunRecordDetail runRecordMeta = store.getRun(programRunId);
+    RunRecordDetail runRecordMeta = store.getRun(programRunId.getReference());
     if (runRecordMeta == null) {
       return Collections.emptyMap();
     }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -350,7 +350,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
       throw new ApplicationNotFoundException(appRef);
     }
 
-    ApplicationId appId = appRef.app(appMeta.getSpec().getAppVersion());
+    ApplicationId appId = appRef.version(appMeta.getSpec().getAppVersion());
     String ownerPrincipal = ownerAdmin.getOwnerPrincipal(appId);
     return enforceApplicationDetailAccess(appId, ApplicationDetail.fromSpec(appMeta.getSpec(), ownerPrincipal,
                                                                             appMeta.getChange()));
@@ -632,7 +632,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
       throw new ApplicationNotFoundException(appRef);
     }
 
-    ApplicationId currentAppId = appRef.app(currentSpec.getAppVersion());
+    ApplicationId currentAppId = appRef.version(currentSpec.getAppVersion());
 
     return updateApplicationByArtifact(currentAppId, currentSpec, allowedArtifactScopes, allowSnapshot);
   }
@@ -959,7 +959,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    */
   public void removeApplication(ApplicationReference appRef) throws Exception {
     // enforce DELETE privileges on the app
-    accessEnforcer.enforce(appRef.app(ApplicationId.DEFAULT_VERSION),
+    accessEnforcer.enforce(appRef.version(ApplicationId.DEFAULT_VERSION),
                            authenticationContext.getPrincipal(), StandardPermission.DELETE);
     // The latest app is retrieved here and passed to deleteApp -
     // that deletes the schedules, triggers and other metadata info.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/RunRecordCorrectorService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/RunRecordCorrectorService.java
@@ -227,7 +227,7 @@ public abstract class RunRecordCorrectorService extends AbstractIdleService {
         }
 
         // Verify the store, if the workflow status is already in end state, correct the underlying program
-        RunRecordDetail workflowRun = store.getRun(workflowProgramId.run(workflowRunId));
+        RunRecordDetail workflowRun = store.getRun(workflowProgramId.run(workflowRunId).getReference());
         // the null check if just to avoid the NPE warning, it should never be null
         if (timeSinceStart > startTimeoutSecs && (workflowRun == null || workflowRun.getStatus().isEndState())) {
           return true;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/StoreProgramRunRecordFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/StoreProgramRunRecordFetcher.java
@@ -19,7 +19,7 @@ package io.cdap.cdap.internal.app.store;
 import com.google.inject.Inject;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.logging.gateway.handlers.ProgramRunRecordFetcher;
-import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 
@@ -39,9 +39,9 @@ public class StoreProgramRunRecordFetcher implements ProgramRunRecordFetcher {
   }
 
   @Override
-  public RunRecordDetail getRunRecordMeta(ProgramRunId runId) throws IOException, NotFoundException {
+  public RunRecordDetail getRunRecordMeta(ProgramRunReference runRef) throws IOException, NotFoundException {
     return Optional.ofNullable(TransactionRunners.run(txRunner, context -> {
-      return AppMetadataStore.create(context).getRun(runId);
-    }, IOException.class)).orElseThrow(() -> new NotFoundException(runId));
+      return AppMetadataStore.create(context).getRun(runRef);
+    }, IOException.class)).orElseThrow(() -> new NotFoundException(runRef));
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
@@ -393,7 +393,8 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
           Map<String, String> properties = notification.getProperties();
           String programRunId = properties.get(ProgramOptionConstants.PROGRAM_RUN_ID);
           try {
-            RunRecord runRecord = runRecordFetcher.getRunRecordMeta(GSON.fromJson(programRunId, ProgramRunId.class));
+            ProgramRunId runId = GSON.fromJson(programRunId, ProgramRunId.class);
+            RunRecord runRecord = runRecordFetcher.getRunRecordMeta(runId.getReference());
             if (runRecord.getPeerName() != null) {
               String programStatus = properties.get(ProgramOptionConstants.PROGRAM_STATUS);
               LOG.debug("Notifying peer {} about program run {} in state {}",

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/security/impersonation/DefaultUGIProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/security/impersonation/DefaultUGIProvider.java
@@ -224,7 +224,7 @@ public class DefaultUGIProvider extends AbstractCachedUGIProvider {
 
     try {
       RunRecordDetail runRecord = Retries.callWithRetries(() -> {
-        RunRecordDetail rec = store.getRun(runId);
+        RunRecordDetail rec = store.getRun(runId.getReference());
         if (rec != null) {
           return rec;
         }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidatorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidatorTest.java
@@ -48,6 +48,7 @@ import io.cdap.cdap.messaging.data.MessageId;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
@@ -289,12 +290,12 @@ public class DirectRuntimeRequestValidatorTest {
     }
 
     @Override
-    public RunRecordDetail getRunRecordMeta(ProgramRunId runId) throws NotFoundException {
+    public RunRecordDetail getRunRecordMeta(ProgramRunReference runRef) throws NotFoundException {
       if (runRecord == null) {
-        throw new NotFoundException(runId);
+        throw new NotFoundException(runRef);
       }
-      if (!runId.equals(runRecord.getProgramRunId())) {
-        throw new NotFoundException(runId);
+      if (!runRef.equals(runRecord.getProgramRunId().getReference())) {
+        throw new NotFoundException(runRef);
       }
       return runRecord;
     }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/RunRecordCorrectorServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/RunRecordCorrectorServiceTest.java
@@ -161,7 +161,7 @@ public class RunRecordCorrectorServiceTest extends AppFabricTestBase {
     fixer.fixRunRecords();
 
     // check the record is fixed for spark program
-    Assert.assertEquals(ProgramRunStatus.FAILED, store.getRun(spId).getStatus());
+    Assert.assertEquals(ProgramRunStatus.FAILED, store.getRun(spId.getReference()).getStatus());
   }
 
   @Test
@@ -311,7 +311,7 @@ public class RunRecordCorrectorServiceTest extends AppFabricTestBase {
 
   private void validateExpectedState(ProgramRunId programRunId, ProgramRunStatus expectedStatus) throws Exception {
     Tasks.waitFor(ImmutablePair.of(programRunId, expectedStatus), () -> {
-      RunRecordDetail runRecord = store.getRun(programRunId);
+      RunRecordDetail runRecord = store.getRun(programRunId.getReference());
       return ImmutablePair.of(programRunId, runRecord == null ? null : runRecord.getStatus());
     }, 10, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerInternalTest.java
@@ -29,7 +29,7 @@ import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.RunRecord;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
-import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 import io.cdap.common.http.HttpResponse;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -58,7 +58,7 @@ public class ProgramLifecycleHttpHandlerInternalTest extends AppFabricTestBase {
     String application = SleepingWorkflowApp.NAME;
     String program = "SleepWorkflow";
     ProgramId programId = new ProgramId(namespace, application, ProgramType.WORKFLOW, program);
-    ProgramRunId programRunId = null;
+    ProgramRunReference programRunRef = null;
     String runId = null;
 
     // Deploy an app containing a workflow
@@ -75,8 +75,8 @@ public class ProgramLifecycleHttpHandlerInternalTest extends AppFabricTestBase {
     runId = runRecordList.get(0).getPid();
 
     // Get the RunRecordDetail via internal REST API and verify
-    programRunId = new ProgramRunId(namespace, application, ProgramType.WORKFLOW, program, runId);
-    RunRecordDetail runRecordMeta = programRunRecordFetcher.getRunRecordMeta(programRunId);
+    programRunRef = new ProgramRunReference(namespace, application, ProgramType.WORKFLOW, program, runId);
+    RunRecordDetail runRecordMeta = programRunRecordFetcher.getRunRecordMeta(programRunRef);
     Assert.assertTrue(runRecordMeta.getProperties().size() > 0);
     Assert.assertNotNull(runRecordMeta.getCluster());
     Assert.assertEquals(ProfileId.NATIVE, runRecordMeta.getProfileId());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -36,6 +36,7 @@ import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 import io.cdap.cdap.spi.data.SortOrder;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
@@ -480,8 +481,8 @@ public abstract class AppMetadataStoreTest {
     // Add some run records
     final Set<String> expected = new TreeSet<>();
     final Set<String> expectedHalf = new TreeSet<>();
-    final Set<ProgramRunId> programRunIdSet = new HashSet<>();
-    final Set<ProgramRunId> programRunIdSetHalf = new HashSet<>();
+    final Set<ProgramRunReference> programRunRefSet = new HashSet<>();
+    final Set<ProgramRunReference> programRunRefSetHalf = new HashSet<>();
     for (int i = 0; i < 100; ++i) {
       ApplicationId application = NamespaceId.DEFAULT.app("app");
       final ProgramId program = application.program(ProgramType.SERVICE, "program");
@@ -495,11 +496,11 @@ public abstract class AppMetadataStoreTest {
       }
 
       ProgramRunId programRunId = program.run(runId);
-      programRunIdSet.add(programRunId);
+      programRunRefSet.add(programRunId.getReference());
 
       //Add every other programRunId
       if ((i % 2) == 0) {
-        programRunIdSetHalf.add(programRunId);
+        programRunRefSetHalf.add(programRunId.getReference());
       }
 
       // A sourceId to keep incrementing for each call of app meta data store persisting
@@ -519,17 +520,17 @@ public abstract class AppMetadataStoreTest {
 
     TransactionRunners.run(transactionRunner, context -> {
       AppMetadataStore metadataStoreDataset = AppMetadataStore.create(context);
-      Map<ProgramRunId, RunRecordDetail> runMap = metadataStoreDataset.getRuns(programRunIdSet);
+      Map<ProgramRunReference, RunRecordDetail> runMap = metadataStoreDataset.getRuns(programRunRefSet);
       Set<String> actual = new TreeSet<>();
-      for (Map.Entry<ProgramRunId, RunRecordDetail> entry : runMap.entrySet()) {
+      for (Map.Entry<ProgramRunReference, RunRecordDetail> entry : runMap.entrySet()) {
         actual.add(entry.getValue().getPid());
       }
       Assert.assertEquals(expected, actual);
 
 
-      Map<ProgramRunId, RunRecordDetail> runMapHalf = metadataStoreDataset.getRuns(programRunIdSetHalf);
+      Map<ProgramRunReference, RunRecordDetail> runMapHalf = metadataStoreDataset.getRuns(programRunRefSetHalf);
       Set<String> actualHalf = new TreeSet<>();
-      for (Map.Entry<ProgramRunId, RunRecordDetail> entry : runMapHalf.entrySet()) {
+      for (Map.Entry<ProgramRunReference, RunRecordDetail> entry : runMapHalf.entrySet()) {
         actualHalf.add(entry.getValue().getPid());
       }
       Assert.assertEquals(expectedHalf, actualHalf);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/DefaultStoreTest.java
@@ -174,7 +174,7 @@ public abstract class DefaultStoreTest {
     String pid = RunIds.generate().getId();
     store.setStop(programId.run(pid), now, ProgramController.State.ERROR.getRunStatus(),
                   ByteBuffer.allocate(0).array());
-    Assert.assertNull(store.getRun(programId.run(pid)));
+    Assert.assertNull(store.getRun(programId.run(pid).getReference()));
   }
 
   @Test
@@ -336,7 +336,7 @@ public abstract class DefaultStoreTest {
     setStartAndRunning(programId.run(run3.getId()), artifactId);
 
     // For a RunRecordDetail that has not yet been completed, getStopTs should return null
-    RunRecordDetail runRecord = store.getRun(programId.run(run3.getId()));
+    RunRecordDetail runRecord = store.getRun(programId.run(run3.getId()).getReference());
     Assert.assertNotNull(runRecord);
     Assert.assertNull(runRecord.getStopTs());
 
@@ -401,19 +401,19 @@ public abstract class DefaultStoreTest {
     // Get a run record for running program
     RunRecordDetail expectedRunning = runningHistorymap.values().iterator().next();
     Assert.assertNotNull(expectedRunning);
-    RunRecordDetail actualRunning = store.getRun(programId.run(expectedRunning.getPid()));
+    RunRecordDetail actualRunning = store.getRun(programId.run(expectedRunning.getPid()).getReference());
     Assert.assertEquals(expectedRunning, actualRunning);
 
     // Get a run record for completed run
     RunRecordDetail expectedCompleted = successHistorymap.values().iterator().next();
     Assert.assertNotNull(expectedCompleted);
-    RunRecordDetail actualCompleted = store.getRun(programId.run(expectedCompleted.getPid()));
+    RunRecordDetail actualCompleted = store.getRun(programId.run(expectedCompleted.getPid()).getReference());
     Assert.assertEquals(expectedCompleted, actualCompleted);
 
     // Get a run record for suspended run
     RunRecordDetail expectedSuspended = suspendedHistorymap.values().iterator().next();
     Assert.assertNotNull(expectedSuspended);
-    RunRecordDetail actualSuspended = store.getRun(programId.run(expectedSuspended.getPid()));
+    RunRecordDetail actualSuspended = store.getRun(programId.run(expectedSuspended.getPid()).getReference());
     Assert.assertEquals(expectedSuspended, actualSuspended);
 
     ProgramRunCluster emptyCluster = new ProgramRunCluster(ProgramRunClusterStatus.PROVISIONED, null, 0);
@@ -432,7 +432,7 @@ public abstract class DefaultStoreTest {
       .setCluster(emptyCluster)
       .setArtifactId(artifactId)
       .setSourceId(AppFabricTestHelper.createSourceId(sourceId)).build();
-    RunRecordDetail actualRecord7 = store.getRun(programId.run(run7.getId()));
+    RunRecordDetail actualRecord7 = store.getRun(programId.run(run7.getId()).getReference());
     Assert.assertEquals(expectedRunRecord7, actualRecord7);
 
     // Record workflow that starts and suspends before it runs
@@ -447,7 +447,7 @@ public abstract class DefaultStoreTest {
       .setCluster(emptyCluster)
       .setArtifactId(artifactId)
       .setSourceId(AppFabricTestHelper.createSourceId(sourceId)).build();
-    RunRecordDetail actualRecord8 = store.getRun(programId.run(run8.getId()));
+    RunRecordDetail actualRecord8 = store.getRun(programId.run(run8.getId()).getReference());
     Assert.assertEquals(expectedRunRecord8, actualRecord8);
 
     // Record workflow that is killed while suspended
@@ -467,11 +467,11 @@ public abstract class DefaultStoreTest {
       .setCluster(emptyCluster)
       .setArtifactId(artifactId)
       .setSourceId(AppFabricTestHelper.createSourceId(sourceId)).build();
-    RunRecordDetail actualRecord9 = store.getRun(programId.run(run9.getId()));
+    RunRecordDetail actualRecord9 = store.getRun(programId.run(run9.getId()).getReference());
     Assert.assertEquals(expectedRunRecord9, actualRecord9);
 
     // Non-existent run record should give null
-    Assert.assertNull(store.getRun(programId.run(UUID.randomUUID().toString())));
+    Assert.assertNull(store.getRun(programId.run(UUID.randomUUID().toString()).getReference()));
 
     // Searching for history in wrong time range should give us no results
     Assert.assertTrue(
@@ -1235,7 +1235,7 @@ public abstract class DefaultStoreTest {
     store.addApplication(appId, appMeta);
     expectedApps.add(appId);
 
-    ApplicationId newVersionAppId = appId.getAppReference().app("new_version");
+    ApplicationId newVersionAppId = appId.getAppReference().version("new_version");
     spec = createDummyAppSpec(newVersionAppId.getApplication(), newVersionAppId.getVersion(), artifactId);
     ApplicationMeta newAppMeta = new ApplicationMeta(newVersionAppId.getApplication(), spec,
                                                      new ChangeDetail(null, null,
@@ -1245,7 +1245,7 @@ public abstract class DefaultStoreTest {
     expectedApps.add(newVersionAppId);
 
     // Insert a third version
-    ApplicationId anotherVersionAppId = appId.getAppReference().app("another_version");
+    ApplicationId anotherVersionAppId = appId.getAppReference().version("another_version");
     spec = createDummyAppSpec(anotherVersionAppId.getApplication(), anotherVersionAppId.getVersion(), artifactId);
     ApplicationMeta anotherAppMeta = new ApplicationMeta(anotherVersionAppId.getApplication(), spec,
                                                          new ChangeDetail(null, null,
@@ -1287,18 +1287,18 @@ public abstract class DefaultStoreTest {
 
   private void writeStartRecord(ProgramRunId run, ArtifactId artifactId) {
     setStartAndRunning(run, artifactId);
-    Assert.assertNotNull(store.getRun(run));
+    Assert.assertNotNull(store.getRun(run.getReference()));
   }
 
   private void writeStopRecord(ProgramRunId run, long stopTimeInMillis) {
     store.setStop(run, TimeUnit.MILLISECONDS.toSeconds(stopTimeInMillis),
                   ProgramRunStatus.COMPLETED, AppFabricTestHelper.createSourceId(++sourceId));
-    Assert.assertNotNull(store.getRun(run));
+    Assert.assertNotNull(store.getRun(run.getReference()));
   }
 
   private void writeSuspendedRecord(ProgramRunId run) {
     store.setSuspend(run, AppFabricTestHelper.createSourceId(++sourceId), -1);
-    Assert.assertNotNull(store.getRun(run));
+    Assert.assertNotNull(store.getRun(run.getReference()));
   }
 
   private Set<Long> runsToTime(ProgramRunId... runIds) {

--- a/cdap-common/src/main/java/io/cdap/cdap/internal/app/store/RunRecordDetail.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/internal/app/store/RunRecordDetail.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.RunRecord;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -117,6 +118,10 @@ public class RunRecordDetail extends RunRecord {
 
   public ProgramRunId getProgramRunId() {
     return programRunId;
+  }
+
+  public ProgramRunReference getProgramRunReference() {
+    return programRunId.getReference();
   }
 
   /**

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/log/MockLogReader.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/log/MockLogReader.java
@@ -169,7 +169,7 @@ public class MockLogReader implements LogReader {
     long currentTime = TimeUnit.SECONDS.toMillis(10);
     RunId workflowRunId = RunIds.generate(currentTime);
     setStartAndRunning(workflowId.run(workflowRunId.getId()));
-    runRecordMap.put(workflowId, store.getRun(workflowId.run(workflowRunId.getId())));
+    runRecordMap.put(workflowId, store.getRun(workflowId.run(workflowRunId.getId()).getReference()));
     WorkflowLoggingContext wfLoggingContext = new WorkflowLoggingContext(workflowId.getNamespace(),
                                                                          workflowId.getApplication(),
                                                                          workflowId.getProgram(),
@@ -186,7 +186,7 @@ public class MockLogReader implements LogReader {
 
     setStartAndRunning(mapReduceId.run(mapReduceRunId.getId()), new HashMap<>(), systemArgs);
 
-    runRecordMap.put(mapReduceId, store.getRun(mapReduceId.run(mapReduceRunId.getId())));
+    runRecordMap.put(mapReduceId, store.getRun(mapReduceId.run(mapReduceRunId.getId()).getReference()));
     WorkflowProgramLoggingContext context = new WorkflowProgramLoggingContext(workflowId.getNamespace(),
                                                                               workflowId.getApplication(),
                                                                               workflowId.getProgram(),
@@ -204,7 +204,7 @@ public class MockLogReader implements LogReader {
                                  ProgramOptionConstants.WORKFLOW_RUN_ID, workflowRunId.getId());
 
     setStartAndRunning(sparkId.run(sparkRunId.getId()), new HashMap<>(), systemArgs);
-    runRecordMap.put(sparkId, store.getRun(sparkId.run(sparkRunId.getId())));
+    runRecordMap.put(sparkId, store.getRun(sparkId.run(sparkRunId.getId()).getReference()));
     context = new WorkflowProgramLoggingContext(workflowId.getNamespace(), workflowId.getApplication(),
                                                 workflowId.getProgram(), workflowRunId.getId(), ProgramType.SPARK,
                                                 SOME_SPARK, sparkRunId.getId());

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/element/EntityType.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/element/EntityType.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 import io.cdap.cdap.proto.id.QueryId;
 import io.cdap.cdap.proto.id.ScheduleId;
 import io.cdap.cdap.proto.id.SecureKeyId;
@@ -58,6 +59,7 @@ public enum EntityType {
   PROGRAMREFERENCE(ProgramReference.class),
   PROGRAM(ProgramId.class),
   PROGRAM_RUN(ProgramRunId.class),
+  PROGRAMRUNREFERENCE(ProgramRunReference.class),
 
   DATASET_TYPE(DatasetTypeId.class),
   DATASET_MODULE(DatasetModuleId.class),

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ApplicationReference.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ApplicationReference.java
@@ -49,7 +49,7 @@ public class ApplicationReference extends NamespacedEntityId implements Parented
     return application;
   }
 
-  public ApplicationId app(String version) {
+  public ApplicationId version(String version) {
     return new ApplicationId(namespace, application, version);
   }
 

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ProgramRunId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ProgramRunId.java
@@ -82,6 +82,10 @@ public class ProgramRunId extends NamespacedEntityId implements ParentedId<Progr
     return run;
   }
 
+  public ProgramRunReference getReference() {
+    return new ProgramRunReference(namespace, application, type, program, run);
+  }
+
   @Override
   public ProgramId getParent() {
     return new ProgramId(new ApplicationId(getNamespace(), getApplication(), getVersion()), getType(), getProgram());

--- a/cdap-support-bundle/src/main/java/io/cdap/cdap/support/task/SupportBundlePipelineInfoTask.java
+++ b/cdap-support-bundle/src/main/java/io/cdap/cdap/support/task/SupportBundlePipelineInfoTask.java
@@ -32,7 +32,7 @@ import io.cdap.cdap.proto.RunRecord;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
-import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 import io.cdap.cdap.support.job.SupportBundleJob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,9 +129,9 @@ public class SupportBundlePipelineInfoTask implements SupportBundleTask {
     ProgramId programId = new ProgramId(namespaceId.getNamespace(), appDetail.getName(), programType, programName);
     Iterable<RunRecord> runRecordList;
     if (runId != null) {
-      ProgramRunId programRunId =
-        new ProgramRunId(namespaceId.getNamespace(), appDetail.getName(), programType, programName, runId);
-      RunRecordDetail runRecordDetail = remoteProgramRunRecordFetcher.getRunRecordMeta(programRunId);
+      ProgramRunReference programRunRef =
+        new ProgramRunReference(namespaceId.getNamespace(), appDetail.getName(), programType, programName, runId);
+      RunRecordDetail runRecordDetail = remoteProgramRunRecordFetcher.getRunRecordMeta(programRunRef);
       runRecordList = Collections.singletonList(runRecordDetail);
     } else {
       runRecordList = getRunRecords(programId);

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/context/LoggingContextHelper.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/context/LoggingContextHelper.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.logging.filter.OrFilter;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 
 import java.util.Collection;
 import java.util.Map;
@@ -172,10 +173,15 @@ public final class LoggingContextHelper {
     return getLoggingContext(namespaceId, applicationId, entityId, programType, null, null);
   }
 
-  public static LoggingContext getLoggingContextWithRunId(ProgramRunId programRun,
+  public static LoggingContext getLoggingContextWithRunId(ProgramRunReference programRun,
                                                           @Nullable Map<String, String> systemArgs) {
     return getLoggingContext(programRun.getNamespace(), programRun.getApplication(), programRun.getProgram(),
                              programRun.getType(), programRun.getRun(), systemArgs);
+  }
+
+  public static LoggingContext getLoggingContextWithRunId(ProgramRunId programRun,
+                                                          @Nullable Map<String, String> systemArgs) {
+    return getLoggingContextWithRunId(programRun.getReference(), systemArgs);
   }
 
   public static LoggingContext getLoggingContext(String namespaceId, String applicationId, String entityId,

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/LocalProgramRunRecordFetcher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/LocalProgramRunRecordFetcher.java
@@ -20,7 +20,7 @@ import com.google.inject.Inject;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.logging.gateway.handlers.store.ProgramStore;
-import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 
 /**
  * Fetch {@link RunRecordDetail} directly from local {@link ProgramStore}
@@ -34,17 +34,17 @@ public class LocalProgramRunRecordFetcher implements ProgramRunRecordFetcher {
   }
 
   /**
-   * Get {@link RunRecordDetail} for the given {@link ProgramRunId}
+   * Get {@link RunRecordDetail} for the given {@link ProgramRunReference}
    *
-   * @param runId identifies the program run to get {@link RunRecordDetail}
+   * @param runRef identifies the program run to get {@link RunRecordDetail}
    * @return {@link RunRecordDetail}
-   * @throws NotFoundException if the given {@link ProgramRunId} is not found
+   * @throws NotFoundException if the given {@link ProgramRunReference} is not found
    */
   @Override
-  public RunRecordDetail getRunRecordMeta(ProgramRunId runId) throws NotFoundException {
-    RunRecordDetail runRecord = programStore.getRun(runId);
+  public RunRecordDetail getRunRecordMeta(ProgramRunReference runRef) throws NotFoundException {
+    RunRecordDetail runRecord = programStore.getRun(runRef);
     if (runRecord == null) {
-      throw new NotFoundException(runId);
+      throw new NotFoundException(runRef);
     }
     return runRecord;
   }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/LogHttpHandler.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/LogHttpHandler.java
@@ -30,7 +30,7 @@ import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
-import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
@@ -104,9 +104,9 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                            @QueryParam("suppress") List<String> suppress) throws Exception {
     ensureVisibilityOnProgram(namespaceId, appId, programType, programId);
     ProgramType type = ProgramType.valueOfCategoryName(programType);
-    ProgramRunId programRunId = new ProgramRunId(namespaceId, appId, type, programId, runId);
-    RunRecordDetail runRecord = getRunRecordMeta(programRunId);
-    LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRunId,
+    ProgramRunReference programRunRef = new ProgramRunReference(namespaceId, appId, type, programId, runId);
+    RunRecordDetail runRecord = getRunRecordMeta(programRunRef);
+    LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRunRef,
                                                                                     runRecord.getSystemArgs());
 
     doGetLogs(logReader, responder, loggingContext, fromTimeSecsParam, toTimeSecsParam,
@@ -143,9 +143,9 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                         @QueryParam("suppress") List<String> suppress) throws Exception {
     ensureVisibilityOnProgram(namespaceId, appId, programType, programId);
     ProgramType type = ProgramType.valueOfCategoryName(programType);
-    ProgramRunId programRunId = new ProgramRunId(namespaceId, appId, type, programId, runId);
-    RunRecordDetail runRecord = getRunRecordMeta(programRunId);
-    LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRunId,
+    ProgramRunReference programRunRef = new ProgramRunReference(namespaceId, appId, type, programId, runId);
+    RunRecordDetail runRecord = getRunRecordMeta(programRunRef);
+    LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRunRef,
                                                                                     runRecord.getSystemArgs());
 
     doNext(logReader, responder, loggingContext, maxEvents, fromOffsetStr,
@@ -182,9 +182,9 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                         @QueryParam("suppress") List<String> suppress) throws Exception {
     ensureVisibilityOnProgram(namespaceId, appId, programType, programId);
     ProgramType type = ProgramType.valueOfCategoryName(programType);
-    ProgramRunId programRunId = new ProgramRunId(namespaceId, appId, type, programId, runId);
-    RunRecordDetail runRecord = getRunRecordMeta(programRunId);
-    LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRunId,
+    ProgramRunReference programRunRef = new ProgramRunReference(namespaceId, appId, type, programId, runId);
+    RunRecordDetail runRecord = getRunRecordMeta(programRunRef);
+    LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRunRef,
                                                                                     runRecord.getSystemArgs());
 
     doPrev(logReader, responder, loggingContext, maxEvents, fromOffsetStr,
@@ -239,11 +239,11 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
     doPrev(logReader, responder, loggingContext, maxEvents, fromOffsetStr, escape, filterStr, null, format, suppress);
   }
 
-  private RunRecordDetail getRunRecordMeta(ProgramRunId programRunId)
+  private RunRecordDetail getRunRecordMeta(ProgramRunReference programRunRef)
     throws IOException, NotFoundException, UnauthorizedException {
-    RunRecordDetail runRecordMeta = programRunRecordFetcher.getRunRecordMeta(programRunId);
+    RunRecordDetail runRecordMeta = programRunRecordFetcher.getRunRecordMeta(programRunRef);
     if (runRecordMeta == null) {
-      throw new NotFoundException(programRunId);
+      throw new NotFoundException(programRunRef);
     }
     return runRecordMeta;
   }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/ProgramRunRecordFetcher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/ProgramRunRecordFetcher.java
@@ -18,7 +18,7 @@ package io.cdap.cdap.logging.gateway.handlers;
 
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
-import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 
 import java.io.IOException;
@@ -28,11 +28,12 @@ import java.io.IOException;
  */
 public interface ProgramRunRecordFetcher {
   /**
-   * Return {@link RunRecordDetail} for the given {@link ProgramRunId}
-   * @param runId for which to fetch {@link RunRecordDetail}
+   * Return {@link RunRecordDetail} for the given {@link ProgramRunReference}
+   * @param runRef for which to fetch {@link RunRecordDetail}
    * @return {@link RunRecordDetail}
    * @throws IOException if failed to fetch the {@link RunRecordDetail}
-   * @throws NotFoundException if the program or runid is not found
+   * @throws NotFoundException if the program or runRef is not found
    */
-  RunRecordDetail getRunRecordMeta(ProgramRunId runId) throws IOException, NotFoundException, UnauthorizedException;
+  RunRecordDetail getRunRecordMeta(ProgramRunReference runRef)
+    throws IOException, NotFoundException, UnauthorizedException;
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteProgramRunRecordFetcher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteProgramRunRecordFetcher.java
@@ -24,7 +24,8 @@ import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
-import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
@@ -50,26 +51,26 @@ public class RemoteProgramRunRecordFetcher implements ProgramRunRecordFetcher {
   }
 
   /**
-   * Return {@link RunRecordDetail} for the given {@link ProgramRunId}
-   * @param runId for which to fetch {@link RunRecordDetail}
+   * Return {@link RunRecordDetail} for the given {@link ProgramRunReference}
+   * @param runRef for which to fetch {@link RunRecordDetail}
    * @return {@link RunRecordDetail}
    * @throws IOException if failed to fetch {@link RunRecordDetail}
    * @throws NotFoundException if the program or runid is not found
    */
-  public RunRecordDetail getRunRecordMeta(ProgramRunId runId)
+  public RunRecordDetail getRunRecordMeta(ProgramRunReference runRef)
     throws IOException, NotFoundException, UnauthorizedException {
     String url = String.format("namespaces/%s/apps/%s/versions/%s/%s/%s/runs/%s",
-                               runId.getNamespace(),
-                               runId.getApplication(),
-                               runId.getVersion(),
-                               runId.getType().getCategoryName(),
-                               runId.getProgram(),
-                               runId.getRun());
+                               runRef.getNamespace(),
+                               runRef.getApplication(),
+                               ApplicationId.DEFAULT_VERSION,
+                               runRef.getType().getCategoryName(),
+                               runRef.getProgram(),
+                               runRef.getRun());
     HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.GET, url);
     HttpResponse httpResponse;
     httpResponse = execute(requestBuilder.build());
     return RunRecordDetail.builder(GSON.fromJson(httpResponse.getResponseBodyAsString(), RunRecordDetail.class))
-      .setProgramRunId(runId)
+      .setProgramRunId(runRef.version(ApplicationId.DEFAULT_VERSION))
       .build();
   }
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/store/ProgramStore.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/store/ProgramStore.java
@@ -18,7 +18,7 @@ package io.cdap.cdap.logging.gateway.handlers.store;
 
 import com.google.inject.Inject;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
-import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramRunReference;
 import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
@@ -40,14 +40,14 @@ public class ProgramStore {
   /**
    * Returns run record for a given run.
    *
-   * @param programRunId program run id
-   * @return run record for runid
+   * @param runRef versionless program run id
+   * @return run record for runRef
    */
-  public RunRecordDetail getRun(ProgramRunId programRunId) {
+  public RunRecordDetail getRun(ProgramRunReference runRef) {
     return TransactionRunners.run(transactionRunner, context -> {
       StructuredTable table = context.getTable(StoreDefinition.AppMetadataStore.RUN_RECORDS);
       AppMetadataStore metaStore = new AppMetadataStore(table);
-      return metaStore.getRun(programRunId.getParent(), programRunId.getRun());
+      return metaStore.getRun(runRef);
     });
   }
 }


### PR DESCRIPTION
What: 

It is error prone to pass in versioned programRunId and ignoring it while fetching run records. Instead, use programRunReference when version is not needed. 