### PR TITLE
[CDAP-19636] Upgraded k8s java client version to 16.0.2

### DIFF
--- a/cdap-kubernetes/pom.xml
+++ b/cdap-kubernetes/pom.xml
@@ -29,7 +29,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <k8s.version>12.0.1</k8s.version>
+    <k8s.version>16.0.2</k8s.version>
     <!-- Needs to bump the okhttp version for fixing https://github.com/square/okhttp/issues/4029 that hangs on exit -->
     <okhttp.version>4.9.1</okhttp.version>
     <!-- Needs to define the gson and guava versions to override the one from dependency management in cdap pom.xml -->
@@ -67,6 +67,11 @@
     <dependency>
       <groupId>io.kubernetes</groupId>
       <artifactId>client-java</artifactId>
+      <version>${k8s.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.kubernetes</groupId>
+      <artifactId>client-java-api-fluent</artifactId>
       <version>${k8s.version}</version>
     </dependency>
     <dependency>

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/discovery/KubeDiscoveryService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/discovery/KubeDiscoveryService.java
@@ -264,7 +264,7 @@ public class KubeDiscoveryService implements DiscoveryService, DiscoveryServiceC
     service.setSpec(spec);
 
     try {
-      api.createNamespacedService(namespace, service, null, null, null);
+      api.createNamespacedService(namespace, service, null, null, null, null);
       LOG.info("Service created in kubernetes with name {} and port {}", serviceName, port.getPort());
     } catch (ApiException e) {
       // It means the service already exists. In this case we update the port if it is not the same.
@@ -328,7 +328,7 @@ public class KubeDiscoveryService implements DiscoveryService, DiscoveryServiceC
     service.getSpec().setSelector(podLabels);
 
     try {
-      api.replaceNamespacedService(meta.getName(), namespace, service, null, null, null);
+      api.replaceNamespacedService(meta.getName(), namespace, service, null, null, null, null);
       LOG.info("Service updated in kubernetes with name {} and port {}",
                currentService.getMetadata().getName(), port.getPort());
     } catch (ApiException e) {

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -749,7 +749,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
       }
       builder.addToBinaryData(localFile.getName(), Files.readAllBytes(java.nio.file.Paths.get(localFile.getURI())));
     }
-    coreV1Api.createNamespacedConfigMap(programRuntimeNamespace, builder.build(), null, null, null);
+    coreV1Api.createNamespacedConfigMap(programRuntimeNamespace, builder.build(), null, null, null, null);
   }
 
   /**
@@ -777,7 +777,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
       .endSpec()
       .build();
     try {
-      job = batchV1Api.createNamespacedJob(programRuntimeNamespace, job, "true", null, null);
+      job = batchV1Api.createNamespacedJob(programRuntimeNamespace, job, "true", null, null, null);
       LOG.debug("Created Job {} in Kubernetes.", metadata.getName());
       return job;
     } catch (ApiException e) {
@@ -804,7 +804,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
     V1Deployment deployment = buildDeployment(metadata, runtimeSpecs, runtimeConfigLocation);
 
     try {
-      deployment = appsApi.createNamespacedDeployment(programRuntimeNamespace, deployment, "true", null, null);
+      deployment = appsApi.createNamespacedDeployment(programRuntimeNamespace, deployment, "true", null, null, null);
       LOG.info("Created Deployment {} in Kubernetes", metadata.getName());
       return deployment;
     } catch (ApiException e) {
@@ -834,7 +834,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
     V1StatefulSet statefulSet = buildStatefulSet(metadata, runtimeSpecs, runtimeConfigLocation, statefulRunnable);
 
     try {
-      statefulSet = appsApi.createNamespacedStatefulSet(programRuntimeNamespace, statefulSet, "true", null, null);
+      statefulSet = appsApi.createNamespacedStatefulSet(programRuntimeNamespace, statefulSet, "true", null, null, null);
       LOG.info("Created StatefulSet {} in Kubernetes", metadata.getName());
       return statefulSet;
     } catch (ApiException e) {

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -350,7 +350,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
    */
   private void findOrCreateKubeNamespace(String namespace, String cdapNamespace) throws Exception {
     try {
-      V1Namespace existingNamespace = coreV1Api.readNamespace(namespace, null, null, null);
+      V1Namespace existingNamespace = coreV1Api.readNamespace(namespace, null);
       if (existingNamespace.getMetadata() == null) {
         throw new IOException(String.format("Kubernetes namespace %s exists but was not created by CDAP", namespace));
       }
@@ -372,7 +372,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
     V1Namespace namespaceObject = new V1Namespace();
     namespaceObject.setMetadata(new V1ObjectMeta().name(namespace).putLabelsItem(CDAP_NAMESPACE_LABEL, cdapNamespace));
     try {
-      coreV1Api.createNamespace(namespaceObject, null, null, null);
+      coreV1Api.createNamespace(namespaceObject, null, null, null, null);
       LOG.debug("Created Kubernetes namespace {} for namespace {}", namespace, cdapNamespace);
     } catch (ApiException e) {
       try {
@@ -412,7 +412,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
     resourceQuota.setSpec(new V1ResourceQuotaSpec().hard(hardLimitMap));
     try {
       V1ResourceQuota existingResourceQuota = coreV1Api.readNamespacedResourceQuota(RESOURCE_QUOTA_NAME, namespace,
-                                                                                    null, null, null);
+                                                                                    null);
       if (existingResourceQuota.getMetadata() == null) {
         throw new IOException(String.format("%s exists but was not created by CDAP", RESOURCE_QUOTA_NAME));
       }
@@ -423,7 +423,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
       }
       if (!hardLimitMap.equals(existingResourceQuota.getSpec().getHard())) {
         coreV1Api.replaceNamespacedResourceQuota(RESOURCE_QUOTA_NAME, namespace, resourceQuota,
-                                                 null, null, null);
+                                                 null, null, null, null);
       }
     } catch (ApiException e) {
       if (e.getCode() != HttpURLConnection.HTTP_NOT_FOUND) {
@@ -436,7 +436,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
 
   private void createKubeResourceQuota(String namespace, V1ResourceQuota resourceQuota) throws Exception {
     try {
-      coreV1Api.createNamespacedResourceQuota(namespace, resourceQuota, null, null, null);
+      coreV1Api.createNamespacedResourceQuota(namespace, resourceQuota, null, null, null, null);
       LOG.debug("Created resource quota for Kubernetes namespace {}", namespace);
     } catch (ApiException e) {
       throw new IOException("Error occurred while creating Kubernetes resource quota. Error code = "
@@ -454,12 +454,12 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
         if (volume.getSecret() != null) {
           String secretName = volume.getSecret().getSecretName();
           V1Secret existingSecret = coreV1Api.readNamespacedSecret(secretName, podInfo.getNamespace(),
-                                                                   null, null, null);
+                                                                   null);
           V1Secret secret = new V1Secret().data(existingSecret.getData()).type(existingSecret.getType())
             .metadata(new V1ObjectMeta().name(secretName).putLabelsItem(CDAP_NAMESPACE_LABEL,
                                                                         cdapNamespace));
           try {
-            coreV1Api.createNamespacedSecret(namespace, secret, null, null, null);
+            coreV1Api.createNamespacedSecret(namespace, secret, null, null, null, null);
           } catch (ApiException e) {
             if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
               throw e;
@@ -509,7 +509,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
       .metadata(new V1ObjectMeta().name(serviceAccountName)
                   .putLabelsItem(CDAP_NAMESPACE_LABEL, cdapNamespace));
     try {
-      coreV1Api.createNamespacedServiceAccount(namespace, serviceAccount, null, null, null);
+      coreV1Api.createNamespacedServiceAccount(namespace, serviceAccount, null, null, null, null);
     } catch (ApiException e) {
       if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
         throw e;
@@ -537,7 +537,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
                       .withName(serviceAccountName).build())
       .build();
     try {
-      rbacV1Api.createNamespacedRoleBinding(namespace, namespaceWorkloadLauncherBinding, null, null, null);
+      rbacV1Api.createNamespacedRoleBinding(namespace, namespaceWorkloadLauncherBinding, null, null, null, null);
     } catch (ApiException e) {
       if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
         throw e;
@@ -567,7 +567,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
                       .withName(serviceAccountName).build())
       .build();
     try {
-      rbacV1Api.createClusterRoleBinding(clusterWorkloadLauncherBinding, null, null, null);
+      rbacV1Api.createClusterRoleBinding(clusterWorkloadLauncherBinding, null, null, null, null);
     } catch (ApiException e) {
       if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
         throw e;
@@ -585,7 +585,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
    */
   private void deleteKubeNamespace(String namespace, String cdapNamespace) throws Exception {
     try {
-      V1Namespace namespaceObject = coreV1Api.readNamespace(namespace, null, null, null);
+      V1Namespace namespaceObject = coreV1Api.readNamespace(namespace, null);
       if (namespaceObject.getMetadata() != null) {
         Map<String, String> namespaceLabels = namespaceObject.getMetadata().getLabels();
         if (namespaceLabels != null && namespaceLabels.get(CDAP_NAMESPACE_LABEL)

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/util/WorkloadIdentityUtil.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/util/WorkloadIdentityUtil.java
@@ -96,7 +96,7 @@ public class WorkloadIdentityUtil {
     throws ApiException, IOException {
     // Check if workload identity config map already exists
     try {
-      coreV1Api.readNamespacedConfigMap(k8sNamespace, WORKLOAD_IDENTITY_CONFIGMAP_NAME, null, false, false);
+      coreV1Api.readNamespacedConfigMap(k8sNamespace, WORKLOAD_IDENTITY_CONFIGMAP_NAME, null);
       // Workload identity config map already exists, so return early
       LOG.debug("Workload identity config found, returning without creating it...");
       return;
@@ -124,7 +124,7 @@ public class WorkloadIdentityUtil {
     V1ConfigMap configMap = new V1ConfigMap()
       .metadata(new V1ObjectMeta().namespace(k8sNamespace).name(WorkloadIdentityUtil.WORKLOAD_IDENTITY_CONFIGMAP_NAME))
       .data(workloadIdentityConfigMapData);
-    coreV1Api.createNamespacedConfigMap(k8sNamespace, configMap, null, null, null);
+    coreV1Api.createNamespacedConfigMap(k8sNamespace, configMap, null, null, null, null);
   }
 
   /**

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -555,7 +555,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     // Query pod information.
     V1Pod pod;
     try {
-      pod = coreV1Api.readNamespacedPod(podName, namespace, null, null, null);
+      pod = coreV1Api.readNamespacedPod(podName, namespace, null);
     } catch (ApiException e) {
       throw new IOException("Error occurred while getting pod. Error code = "
                               + e.getCode() + ", Body = " + e.getResponseBody(), e);
@@ -664,7 +664,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
                                               .withLabels(podInfo.getLabels())
                                               .withOwnerReferences(podInfo.getOwnerReferences())
                                               .build()).build(),
-                                          null, null, null);
+                                          null, null, null, null);
       this.configMapName = configMapName;
 
       // Add configmap and secrets as a volume to be added to the pod template

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/common/AbstractWatcherThreadTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/common/AbstractWatcherThreadTest.java
@@ -121,7 +121,7 @@ public class AbstractWatcherThreadTest {
     CoreV1Api coreV1Api = new CoreV1Api(apiClient);
 
     // Create a config before starting the thread
-    coreV1Api.createNamespacedConfigMap(namespace, createConfigMap("test", "key", "value"), null, null, null);
+    coreV1Api.createNamespacedConfigMap(namespace, createConfigMap("test", "key", "value"), null, null, null, null);
 
     // Start the thread.
     watcherThread.start();
@@ -132,7 +132,7 @@ public class AbstractWatcherThreadTest {
 
     // Update the configmap and should see the changes
     configMap.data(ImmutableMap.of("key", "newvalue"));
-    coreV1Api.replaceNamespacedConfigMap(name, namespace, configMap, null, null, null);
+    coreV1Api.replaceNamespacedConfigMap(name, namespace, configMap, null, null, null, null);
 
     waitFor(() -> configMapNames.get(name), c -> "newvalue".equals(c.getData().get("key")), 5, TimeUnit.SECONDS);
 
@@ -180,7 +180,7 @@ public class AbstractWatcherThreadTest {
     // Create and delete configmap multiple times with a watch reset in between.
     // This is to make sure during the watch reset, we are not losing any deletion events.
     for (int i = 0; i < 50; i++) {
-      coreV1Api.createNamespacedConfigMap(namespace, createConfigMap("test", "key", "value"), null, null, null);
+      coreV1Api.createNamespacedConfigMap(namespace, createConfigMap("test", "key", "value"), null, null, null, null);
       V1ConfigMap configMap = waitFor(() -> configMapNames.get("test"), Objects::nonNull, 5, TimeUnit.SECONDS);
       String name = configMap.getMetadata().getName();
       watcherThread.closeWatch();

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerServiceTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerServiceTest.java
@@ -117,7 +117,7 @@ public class KubeTwillRunnerServiceTest {
     NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
 
     V1Namespace returnedNamespace = new V1Namespace().metadata(new V1ObjectMeta().name(KUBE_NAMESPACE));
-    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any())).thenReturn(returnedNamespace);
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any())).thenReturn(returnedNamespace);
 
     thrown.expect(IOException.class);
     thrown.expectMessage(String.format("Kubernetes namespace %s exists but was not created by CDAP", KUBE_NAMESPACE));
@@ -133,7 +133,7 @@ public class KubeTwillRunnerServiceTest {
     V1ObjectMeta returnedMeta = new V1ObjectMeta().name(KUBE_NAMESPACE)
       .putLabelsItem("cdap.namespace", "wrong namespace");
     V1Namespace returnedNamespace = new V1Namespace().metadata(returnedMeta);
-    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any())).thenReturn(returnedNamespace);
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any())).thenReturn(returnedNamespace);
 
     thrown.expect(IOException.class);
     thrown.expectMessage(String.format("Kubernetes namespace %s exists but was not created by CDAP namespace %s",
@@ -164,7 +164,7 @@ public class KubeTwillRunnerServiceTest {
     properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
     NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
 
-    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any()))
       .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
     skipRbacSteps();
     try {
@@ -172,7 +172,7 @@ public class KubeTwillRunnerServiceTest {
     } catch (Exception e) {
       Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
     }
-    verify(coreV1Api, times(0)).createNamespacedConfigMap(any(), any(), any(), any(), any());
+    verify(coreV1Api, times(0)).createNamespacedConfigMap(any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -187,10 +187,10 @@ public class KubeTwillRunnerServiceTest {
 
     // throw ApiException when coreV1Api.readNamespace() is called in findOrCreateKubeNamespace()
     // return returnedNamespace when coreV1Api.readNamespace() is called in deleteKubeNamespace()
-    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any()))
       .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"))
       .thenReturn(returnedNamespace);
-    when(coreV1Api.createNamespace(any(), any(), any(), any()))
+    when(coreV1Api.createNamespace(any(), any(), any(), any(), any()))
       .thenThrow(new ApiException());
     when(coreV1Api.deleteNamespace(eq(KUBE_NAMESPACE), any(), any(), any(), any(), any(), any()))
       .thenThrow(new ApiException(HttpURLConnection.HTTP_INTERNAL_ERROR, "internal error message"));
@@ -212,7 +212,7 @@ public class KubeTwillRunnerServiceTest {
     properties.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
     NamespaceDetail namespaceDetail = new NamespaceDetail(CDAP_NAMESPACE, properties);
 
-    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any()))
       .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
     try {
       twillRunnerService.onNamespaceDeletion(namespaceDetail);
@@ -233,9 +233,9 @@ public class KubeTwillRunnerServiceTest {
 
     enableWorkloadIdentity();
 
-    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any()))
       .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
-    when(coreV1Api.readNamespacedConfigMap(eq(KUBE_NAMESPACE), eq("workload-identity-config"), any(), any(), any()))
+    when(coreV1Api.readNamespacedConfigMap(eq(KUBE_NAMESPACE), eq("workload-identity-config"), any()))
       .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "config map not found"));
     skipRbacSteps();
     try {
@@ -243,7 +243,7 @@ public class KubeTwillRunnerServiceTest {
     } catch (Exception e) {
       Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
     }
-    verify(coreV1Api, times(1)).createNamespacedConfigMap(any(), any(), any(), any(), any());
+    verify(coreV1Api, times(1)).createNamespacedConfigMap(any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -257,9 +257,9 @@ public class KubeTwillRunnerServiceTest {
 
     enableWorkloadIdentity();
 
-    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any()))
       .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
-    when(coreV1Api.readNamespacedConfigMap(eq(KUBE_NAMESPACE), eq("workload-identity-config"), any(), any(), any()))
+    when(coreV1Api.readNamespacedConfigMap(eq(KUBE_NAMESPACE), eq("workload-identity-config"), any()))
       .thenReturn(new V1ConfigMap().metadata(new V1ObjectMeta().name("workload-identity-config")
                                                .namespace(KUBE_NAMESPACE)));
     skipRbacSteps();
@@ -268,7 +268,7 @@ public class KubeTwillRunnerServiceTest {
     } catch (Exception e) {
       Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
     }
-    verify(coreV1Api, times(0)).createNamespacedConfigMap(any(), any(), any(), any(), any());
+    verify(coreV1Api, times(0)).createNamespacedConfigMap(any(), any(), any(), any(), any(), any());
   }
 
   @Test(expected = IOException.class)
@@ -282,11 +282,11 @@ public class KubeTwillRunnerServiceTest {
 
     enableWorkloadIdentity();
 
-    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any()))
       .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
-    when(coreV1Api.readNamespacedConfigMap(any(), any(), any(), any(), any()))
+    when(coreV1Api.readNamespacedConfigMap(any(), any(), any()))
       .thenThrow(new ApiException(HttpURLConnection.HTTP_INTERNAL_ERROR, "internal error"));
-    when(coreV1Api.createNamespacedConfigMap(any(), any(), any(), any(), any())).thenThrow(new ApiException());
+    when(coreV1Api.createNamespacedConfigMap(any(), any(), any(), any(), any(), any())).thenThrow(new ApiException());
     skipRbacSteps();
     twillRunnerService.onNamespaceCreation(namespaceDetail);
   }
@@ -302,11 +302,11 @@ public class KubeTwillRunnerServiceTest {
 
     enableWorkloadIdentity();
 
-    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any()))
       .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
-    when(coreV1Api.readNamespacedConfigMap(eq(KUBE_NAMESPACE), eq("workload-identity-config"), any(), any(), any()))
+    when(coreV1Api.readNamespacedConfigMap(eq(KUBE_NAMESPACE), eq("workload-identity-config"), any()))
       .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "config map not found"));
-    when(coreV1Api.createNamespacedConfigMap(any(), any(), any(), any(), any())).thenThrow(new ApiException());
+    when(coreV1Api.createNamespacedConfigMap(any(), any(), any(), any(), any(), any())).thenThrow(new ApiException());
     skipRbacSteps();
     twillRunnerService.onNamespaceCreation(namespaceDetail);
   }
@@ -320,7 +320,7 @@ public class KubeTwillRunnerServiceTest {
 
     enableWorkloadIdentity();
 
-    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any(), any(), any()))
+    when(coreV1Api.readNamespace(eq(KUBE_NAMESPACE), any()))
       .thenThrow(new ApiException(HttpURLConnection.HTTP_NOT_FOUND, "namespace not found"));
     skipRbacSteps();
     try {
@@ -328,8 +328,8 @@ public class KubeTwillRunnerServiceTest {
     } catch (Exception e) {
       Assert.fail("Kubernetes creation should not error if namespace does not exist. Exception: " + e);
     }
-    verify(coreV1Api, times(0)).createNamespacedConfigMap(any(), any(), any(), any(), any());
-    verify(coreV1Api, times(0)).readNamespacedConfigMap(any(), any(), any(), any(), any());
+    verify(coreV1Api, times(0)).createNamespacedConfigMap(any(), any(), any(), any(), any(), any());
+    verify(coreV1Api, times(0)).readNamespacedConfigMap(any(), any(), any());
 
   }
 


### PR DESCRIPTION
Upgraded the k8s Java Client Library version to 16.0.2 from 12.0.1: 
- Included `client-java-api-fluent` package as builder classes are repackaged into that

[JIRA](https://cdap.atlassian.net/browse/CDAP-19636)