### PR TITLE
[CDAP-19500] add retries for connection macro evaluator

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/common/Constants.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/common/Constants.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.common;
+
+import java.net.HttpURLConnection;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Constants used by different systems are all defined here.
+ */
+public class Constants {
+  public static final List<Integer> RETRYABLE_HTTP_CODES = Collections.unmodifiableList(
+    Arrays.asList(HttpURLConnection.HTTP_BAD_GATEWAY, HttpURLConnection.HTTP_UNAVAILABLE,
+                  HttpURLConnection.HTTP_GATEWAY_TIMEOUT));
+}


### PR DESCRIPTION
This change fixes two issues:

1.
```
java.util.concurrent.ExecutionException: io.cdap.cdap.api.macro.InvalidMacroException: java.io.IOException: Failed to call Connection service with status 500
at io.cdap.cdap.etl.common.AbstractServiceRetryableMacroEvaluator.validateAndRetrieveContent(AbstractServiceRetryableMacroEvaluator.java:119)
```
2.
```
io.cdap.cdap.api.macro.InvalidMacroException: java.net.SocketTimeoutException: Read timed out
at io.cdap.cdap.etl.common.AbstractServiceRetryableMacroEvaluator.validateAndRetrieveContent(AbstractServiceRetryableMacroEvaluator.java:110)
```