### PR TITLE
[CDAP-20168] fix NPE while running preview when runtime args are null

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
@@ -181,7 +181,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
 
     PreferencesDetail preferences = preferencesFetcher.get(programId, true);
     Map<String, String> userProps = new HashMap<>(preferences.getProperties());
-    if (previewConfig != null) {
+    if (previewConfig != null && previewConfig.getRuntimeArgs() != null) {
       userProps.putAll(previewConfig.getRuntimeArgs());
     }
 


### PR DESCRIPTION
Tested using preview rest api in local cdap sandbox.