### PR TITLE
 fix(CDAP-19783&CDAP-20018): use stream fashion for getApplications

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/ApplicationFilter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/ApplicationFilter.java
@@ -89,30 +89,7 @@ public abstract class ApplicationFilter {
   }
 
   /**
-   * The filter that check if application id exactly equals to a string (case-sensitive).
-   */
-  public static class ApplicationIdEqualsCaseSensitiveFilter extends ApplicationIdFilter {
-    private final String searchFor;
-
-    public ApplicationIdEqualsCaseSensitiveFilter(String searchFor) {
-      this.searchFor = searchFor;
-    }
-
-    @Override
-    public boolean test(ApplicationId applicationId) {
-      return applicationId.getApplication().equals(searchFor);
-    }
-
-    @Override
-    public String toString() {
-      return "ApplicationIdEqualsCaseSensitiveFilter{" +
-        "searchFor='" + searchFor + '\'' +
-        '}';
-    }
-  }
-
-  /**
-   * Returns true if the application artifact is in a allow list of names
+   * Returns true if the application artifact is in an allowed list of names
    */
   public static class ArtifactNamesInFilter extends ArtifactIdFilter {
     private final Set<String> names;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -375,14 +375,6 @@ public interface Store {
   ApplicationMeta getLatest(ApplicationReference appRef);
 
   /**
-   * Returns a collection of all application specs in the specified namespace
-   *
-   * @param id the namespace to get application specs from
-   * @return collection of all application specs in the namespace
-   */
-  Collection<ApplicationSpecification> getAllApplications(NamespaceId id);
-
-  /**
    * Scans for applications across all namespaces.
    *
    * @param txBatchSize maximum number of applications to scan in one transaction to
@@ -410,14 +402,6 @@ public interface Store {
    * @return collection of application specs. For applications that don't exist, there will be no entry in the result.
    */
   Map<ApplicationId, ApplicationSpecification> getApplications(Collection<ApplicationId> ids);
-
-  /**
-   * Returns a Map of {@link ApplicationSpecification} for the given set of {@link ApplicationReference}.
-   *
-   * @param appRef the application reference
-   * @return collection of application specs. For applications that don't exist, there will be no entry in the result.
-   */
-  Map<ApplicationId, ApplicationSpecification> getApplications(ApplicationReference appRef);
 
   /**
    * Returns a map of latest programIds given programReferences

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -325,7 +325,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       if (nameFilterType != null) {
         switch (nameFilterType) {
           case EQUALS:
-            builder.addFilter(new ApplicationFilter.ApplicationIdEqualsCaseSensitiveFilter(nameFilter));
+            builder.setApplicationReference(new ApplicationReference(namespaceId, nameFilter));
             break;
           case CONTAINS:
             builder.addFilter(new ApplicationFilter.ApplicationIdContainsFilter(nameFilter));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -648,14 +648,6 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public Collection<ApplicationSpecification> getAllApplications(NamespaceId id) {
-    return TransactionRunners.run(transactionRunner, context -> {
-      return getAppMetadataStore(context).getAllApplications(id.getNamespace()).stream()
-        .map(ApplicationMeta::getSpec).collect(Collectors.toList());
-    });
-  }
-
-  @Override
   public void scanApplications(int txBatchSize, BiConsumer<ApplicationId, ApplicationMeta> consumer) {
     scanApplications(ScanApplicationsRequest.builder().build(), txBatchSize, consumer);
   }
@@ -684,7 +676,7 @@ public class DefaultStore implements Store {
         if (requestRef.get().getSortOrder() != SortOrder.DESC || count.get() != 0) {
           throw e;
         }
-        return scanApplicationwWithReorder(requestRef.get(), txBatchSize, consumer);
+        return scanApplicationsWithReorder(requestRef.get(), txBatchSize, consumer);
       }
 
       if (lastKey.get() == null) {
@@ -706,7 +698,7 @@ public class DefaultStore implements Store {
    * We scan keys in large batches and serve backwards
    * @return if we read records up to request limit
    */
-  private boolean scanApplicationwWithReorder(ScanApplicationsRequest request,
+  private boolean scanApplicationsWithReorder(ScanApplicationsRequest request,
                                               int txBatchSize,
                                               BiConsumer<ApplicationId, ApplicationMeta> consumer) {
     AtomicReference<ScanApplicationsRequest> forwardRequest =
@@ -758,14 +750,6 @@ public class DefaultStore implements Store {
     return TransactionRunners.run(transactionRunner, context -> {
       return getAppMetadataStore(context).getApplicationsForAppIds(ids).entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getSpec()));
-    });
-  }
-
-  @Override
-  public Map<ApplicationId, ApplicationSpecification> getApplications(ApplicationReference appRef) {
-    return TransactionRunners.run(transactionRunner, context -> {
-      return getAppMetadataStore(context).getAllAppVersions(appRef).stream()
-        .collect(Collectors.toMap(e -> appRef.app(e.getSpec().getAppVersion()), ApplicationMeta::getSpec));
     });
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/app/store/ScanApplicationsRequestTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/app/store/ScanApplicationsRequestTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2022 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.store;
+
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.proto.id.NamespaceId;
+import org.junit.Test;
+
+public class ScanApplicationsRequestTest {
+  final NamespaceId nameSpace1 = new NamespaceId("namespace1");
+  final NamespaceId nameSpace2 = new NamespaceId("namespace2");
+  final ApplicationReference appRef1 = new ApplicationReference(nameSpace1, "app1");
+  final ApplicationReference appRef2 = new ApplicationReference(nameSpace2, "app2");
+  final ApplicationId appId1 = appRef1.app(ApplicationId.DEFAULT_VERSION);
+  final ApplicationId appId2 = appRef2.app(ApplicationId.DEFAULT_VERSION);
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidNamespaceWithScanFrom() {
+    ScanApplicationsRequest.builder().setNamespaceId(nameSpace1).setScanFrom(appId2).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidNamespaceWithScanTo() {
+    ScanApplicationsRequest.builder().setNamespaceId(nameSpace2).setScanTo(appId1).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidNamespaceWithApplicationName() {
+    ScanApplicationsRequest.builder().setApplicationReference(appRef2).setNamespaceId(null).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidAppRefWithScanFrom() {
+    ScanApplicationsRequest.builder().setApplicationReference(appRef1).setScanFrom(appId2).build();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidAppRefWithScanTo() {
+    ScanApplicationsRequest.builder().setApplicationReference(appRef2).setScanTo(appId1).build();
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -1386,7 +1386,14 @@ public abstract class AppMetadataStoreTest {
     AtomicInteger appEditNumber = new AtomicInteger();
     TransactionRunners.run(transactionRunner, context -> {
       AppMetadataStore metaStore = AppMetadataStore.create(context);
-      List<ApplicationMeta> allVersions = metaStore.getAllAppVersions(appRef);
+      List<ApplicationMeta> allVersions = new ArrayList<>();
+      metaStore.scanApplications(
+        ScanApplicationsRequest.builder().setApplicationReference(appRef).build(),
+        entry -> {
+          allVersions.add(entry.getValue());
+          return true;
+        });
+
       List<String> latestVersions = allVersions
         .stream()
         .filter(version -> {
@@ -1447,7 +1454,13 @@ public abstract class AppMetadataStoreTest {
     AtomicInteger appEditNumber = new AtomicInteger();
     TransactionRunners.run(transactionRunner, context -> {
       AppMetadataStore metaStore = AppMetadataStore.create(context);
-      List<ApplicationMeta> allVersions = metaStore.getAllAppVersions(appRef);
+      List<ApplicationMeta> allVersions = new ArrayList<>();
+      metaStore.scanApplications(
+        ScanApplicationsRequest.builder().setApplicationReference(appRef).build(),
+        entry -> {
+          allVersions.add(entry.getValue());
+          return true;
+        });
       List<String> latestVersions = allVersions
         .stream()
         .filter(version -> {


### PR DESCRIPTION
What:

ApplicationSpecification is a heavy object and it can easily be more than 100 versions of the same app or in a namespace. Instead we do it in a streaming fashion