### PR TITLE
[CDAP-20172] Fix security vulnerabilities due to hadoop-common dependency

### DIFF
--- a/cdap-kms/pom.xml
+++ b/cdap-kms/pom.xml
@@ -24,9 +24,7 @@
     <groupId>io.cdap.cdap</groupId>
     <version>6.9.0-SNAPSHOT</version>
   </parent>
-  <properties>
-    <hadoop.common.version>2.6.0</hadoop.common.version>
-  </properties>
+
   <artifactId>cdap-kms</artifactId>
   <name>CDAP KMS</name>
   <packaging>jar</packaging>
@@ -38,7 +36,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>${hadoop.common.version}</version>
+      <version>${hadoop.version}</version>
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -32,7 +32,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <sdk.hadoop.version>2.8.0</sdk.hadoop.version>
+    <sdk.hadoop.version>2.8.5</sdk.hadoop.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <gson.version>2.3.1</gson.version>
     <guava.version>13.0.1</guava.version>
     <guice.version>4.0</guice.version>
-    <hadoop.version>2.6.0</hadoop.version>
+    <hadoop.version>2.6.5</hadoop.version>
     <hbase10.version>1.0.1.1</hbase10.version>
     <hbase10cdh.version>1.0.0-cdh5.4.4</hbase10cdh.version>
     <hbase10cdh550.version>1.0.0-cdh5.5.0</hbase10cdh550.version>


### PR DESCRIPTION
### Change Description

Fixed security vulnerabilities:
* [CVE-2018-8009](https://nvd.nist.gov/vuln/detail/CVE-2018-8009)
* [CVE-2016-3086](https://nvd.nist.gov/vuln/detail/CVE-2016-3086)

For dependencies:
* hadoop-common:2.6.0
* hadoop-common:2.8.0

Changes:
* Upgraded `hadoop-common` dependency version in `cdap-standalone` to `2.8.5` from `2.8.0`.
* Upgraded `hadoop-common` dependency version in remaining modules to `2.6.5` from `2.6.0`.

**Note**:
* Hadoop to 2.7+ is incompatible with HBase-server 1.0.x. ([Haddop HBase compatibility matrix](https://hbase.apache.org/book.html#hadoop))
  * HBase is the table storage for CDAP on Hadoop, so it is still used. For eg. ITN installs HBase on the dataproc cluster. 
  * Upgrading to newer versions of HBase would require significant efforts and new hbase-compat module would need to be added.
* CDAP standalone uses a different version of haddop that the rest of CDAP system due to support Azure plugins in cloud sandbox.
  * More details: [CDAP-11599](https://cdap.atlassian.net/browse/CDAP-11599), https://github.com/cdapio/cdap/pull/8840

### Verification
* Verified version override using `mvn dependency:tree`.
* Verified CDAP image build.
* Verified pipeline runs using sandbox image.