### PR TITLE
Fix security vulnerabilities due to netty dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <mockito.version>1.10.19</mockito.version>
     <mysql.version>5.1.21</mysql.version>
     <netty.http.version>1.7.0</netty.http.version>
-    <netty.version>4.1.16.Final</netty.version>
+    <netty.version>4.1.75.Final</netty.version>
     <powermock.version>1.7.4</powermock.version>
     <quartz.version>2.2.0</quartz.version>
     <resteasy.version>3.0.8.Final</resteasy.version>


### PR DESCRIPTION
## Vulnerability Details:
CVE-2019-20444
CVE-2019-20445
CVE-2015-2156
CVE-2019-16869
CVE-2019-9518
CVE-2020-7238
CVE-2021-37136
CVE-2021-37137
CVE-2021-43797
CVE-2021-21295
CVE-2021-21290
CVE-2014-0193

## Change:
updated `netty.version` from `4.1.16.Final` to `4.1.75.Final`
