### PR TITLE
fix(CDAP-20174): fix performance issue caused by scanning runs ignoring version

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -328,6 +328,16 @@ public interface Store {
   RunRecordDetail getRun(ProgramRunId id);
 
   /**
+   * Fetches the run record for particular run of a program without version.
+   *
+   * @param programRef    versionless program id of the run
+   * @param runId         the run id
+   * @return          run record for the specified program and runRef, null if not found
+   */
+  @Nullable
+  RunRecordDetail getRun(ProgramReference programRef, String runId);
+
+  /**
    * Creates new application if it doesn't exist. Updates existing one otherwise.
    * @param id            application id
    * @param meta          application metadata to store

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandlerInternal.java
@@ -24,8 +24,7 @@ import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.proto.ProgramType;
-import io.cdap.cdap.proto.id.ApplicationId;
-import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.http.HttpHandler;
 import io.cdap.http.HttpResponder;
 import io.netty.handler.codec.http.HttpRequest;
@@ -73,8 +72,8 @@ public class ProgramLifecycleHttpHandlerInternal extends AbstractAppFabricHttpHa
                                       @PathParam("program-name") String programName,
                                       @PathParam("run-id") String runid) throws Exception {
     ProgramType programType = ProgramType.valueOfCategoryName(type, BadRequestException::new);
-    ProgramId programId = new ApplicationId(namespaceId, appName, appVersion).program(programType, programName);
-    RunRecordDetail runRecordMeta = programLifecycleService.getRunRecordMeta(programId.run(runid));
+    ProgramReference programRef = new ProgramReference(namespaceId, appName, programType, programName);
+    RunRecordDetail runRecordMeta = programLifecycleService.getRunRecordMeta(programRef, runid);
     responder.sendJson(HttpResponseStatus.OK, GSON.toJson(runRecordMeta));
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -86,8 +86,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
@@ -96,7 +94,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 
 /**
@@ -496,7 +493,7 @@ public class AppMetadataStore {
         if (appMeta == null) {
           throw new IOException("Missing application metadata for application " + appId);
         }
-        
+
         ApplicationReference appRef = appId.getAppReference();
         Boolean isLatest = row.getBoolean(StoreDefinition.AppMetadataStore.LATEST_FIELD);
         // Get either the latest versioned or "-SNAPSHOT" programs.
@@ -692,26 +689,18 @@ public class AppMetadataStore {
 
     // Get the run record of the Workflow which started this program
     List<Field<?>> runRecordFields = getProgramRunInvertedTimeKey(TYPE_RUN_RECORD_ACTIVE, workflowRunId,
-                                                                  RunIds.getTime(workflowRun, TimeUnit.SECONDS),
-                                                                  false);
-    RunRecordDetail record;
+                                                                  RunIds.getTime(workflowRun, TimeUnit.SECONDS));
 
-    try (CloseableIterator<StructuredRow> iterator =
-           getRunRecordsTable().scan(Range.singleton(runRecordFields), 1)) {
-      record =  iterator.hasNext() ? deserializeRunRecordMeta(iterator.next()) : null;
-    }
+    RunRecordDetail record = getRunRecordsTable().read(runRecordFields)
+      .map(AppMetadataStore::deserializeRunRecordMeta)
+      .orElse(null);
 
     // If the workflow is gone, just ignore the update
     if (record == null) {
       return;
     }
 
-    // Use the actual ProgramRunId from DB
-    ProgramRunId actualProgramRunId = record.getProgramRunId();
-    List<Field<?>> actualRunRecordFields = getProgramRunInvertedTimeKey(TYPE_RUN_RECORD_ACTIVE, actualProgramRunId,
-                                                                        RunIds.getTime(workflowRun, TimeUnit.SECONDS));
-
-    List<Field<?>> primaryKeys = getWorkflowPrimaryKeys(actualProgramRunId, workflowNodeId);
+    List<Field<?>> primaryKeys = getWorkflowPrimaryKeys(workflowRunId, workflowNodeId);
     WorkflowNodeStateDetail nodeState = getWorkflowNodeStateTable().read(primaryKeys)
       .map(r -> r.getString(StoreDefinition.AppMetadataStore.NODE_STATE_DATA))
       .map(f -> GSON.fromJson(f, WorkflowNodeStateDetail.class))
@@ -735,7 +724,7 @@ public class AppMetadataStore {
       Map<String, String> properties = new HashMap<>(record.getProperties());
       properties.put(workflowNodeId, programRunId.getRun());
       writeToStructuredTableWithPrimaryKeys(
-        actualRunRecordFields, RunRecordDetail.builder(record).setProperties(properties).setSourceId(sourceId).build(),
+        runRecordFields, RunRecordDetail.builder(record).setProperties(properties).setSourceId(sourceId).build(),
         getRunRecordsTable(), StoreDefinition.AppMetadataStore.RUN_RECORD_DATA);
     }
   }
@@ -1646,16 +1635,45 @@ public class AppMetadataStore {
     Map<ProgramRunId, RunRecordDetail> unfinishedRunsMap = getUnfinishedRuns(Collections.singleton(programRun));
     // If program is running, this will not be empty
     if (unfinishedRunsMap.size() > 0) {
-      return unfinishedRunsMap.values().iterator().next();
+      return unfinishedRunsMap.get(programRun);
     }
 
     // If program is not running, query completed run records
     Map<ProgramRunId, RunRecordDetail> completedRunsMap = getCompletedRuns(Collections.singleton(programRun));
     if (completedRunsMap.size() > 0) {
-      return completedRunsMap.values().iterator().next();
+      return completedRunsMap.get(programRun);
     }
 
     return null;
+  }
+
+  // Fetching run record ignoring versions
+  // We do this for places like LogHandler APIs that does not pass in a version
+  @Nullable
+  public RunRecordDetail getRun(ProgramReference programRef, String runId) throws IOException {
+    // Query active run record first
+    List<Field<?>> unFinishedKeys = getProgramRunInvertedTimeKey(
+      TYPE_RUN_RECORD_ACTIVE, programRef, runId, RunIds.getTime(runId, TimeUnit.SECONDS));
+    RunRecordDetail unfinishedRun = scanRunByReference(unFinishedKeys);
+    // If program is running, this will not be empty
+    if (unfinishedRun != null) {
+      return unfinishedRun;
+    }
+
+    // If program is not running, query completed run records
+    List<Field<?>> finishedKeys = getProgramRunInvertedTimeKey(
+      TYPE_RUN_RECORD_COMPLETED, programRef, runId, RunIds.getTime(runId, TimeUnit.SECONDS));
+    return scanRunByReference(finishedKeys);
+  }
+
+  private RunRecordDetail scanRunByReference(Collection<Field<?>> keys)
+    throws IOException {
+    try (CloseableIterator<StructuredRow> iterator = getRunRecordsTable().scan(Range.singleton(keys), 1)) {
+      if (iterator.hasNext()) {
+        return deserializeRunRecordMeta(iterator.next());
+      }
+      return null;
+    }
   }
 
   /**
@@ -1690,48 +1708,32 @@ public class AppMetadataStore {
     getRunRecordsTable().delete(key);
   }
 
-  /**
-   * @return run records for unfinished run ignoring version
-   */
   private Map<ProgramRunId, RunRecordDetail> getUnfinishedRuns(Set<ProgramRunId> programRunIds) throws IOException {
     List<List<Field<?>>> allKeys = new ArrayList<>();
     for (ProgramRunId programRunId : programRunIds) {
       allKeys.add(getProgramRunInvertedTimeKey(TYPE_RUN_RECORD_ACTIVE, programRunId,
-                                               RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS),
-                                               false));
+                                               RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS)));
     }
-    
-    return getRunsByKeys(allKeys);
+
+    return getRunsByFullKeys(allKeys);
   }
 
   private Map<ProgramRunId, RunRecordDetail> getCompletedRuns(Set<ProgramRunId> programRunIds) throws IOException {
     List<List<Field<?>>> allKeys = new ArrayList<>();
     for (ProgramRunId programRunId : programRunIds) {
-      // Get all keys without version
-      List<Field<?>> keysWithoutVersion = getRunRecordProgramRefPrefix(TYPE_RUN_RECORD_COMPLETED,
-                                                                       programRunId.getParent().getProgramReference());
-      // Get start time from RunId
-      long programStartSecs = RunIds.getTime(RunIds.fromString(programRunId.getRun()), TimeUnit.SECONDS);
-      keysWithoutVersion.add(Fields.longField(StoreDefinition.AppMetadataStore.RUN_START_TIME,
-                                              getInvertedTsKeyPart(programStartSecs)));
-      keysWithoutVersion.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, programRunId.getRun()));
-      allKeys.add(keysWithoutVersion);
+      allKeys.add(getProgramRunInvertedTimeKey(TYPE_RUN_RECORD_COMPLETED, programRunId,
+                                               RunIds.getTime(programRunId.getRun(), TimeUnit.SECONDS)));
     }
 
-    return getRunsByKeys(allKeys);
+    return getRunsByFullKeys(allKeys);
   }
 
-  private Map<ProgramRunId, RunRecordDetail> getRunsByKeys(List<List<Field<?>>> allKeys) throws IOException {
-    Collection<Range> ranges = allKeys.stream().map(Range::singleton).collect(Collectors.toList());
-
-    try (CloseableIterator<StructuredRow> iterator =
-           getRunRecordsTable().multiScan(ranges, Integer.MAX_VALUE)) {
-      return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false)
-          .map(AppMetadataStore::deserializeRunRecordMeta)
-          .collect(Collectors.toMap(RunRecordDetail::getProgramRunId, r -> r, (r1, r2) -> {
-            throw new IllegalStateException("Duplicate run record for " + r1.getProgramRunId());
-          }, LinkedHashMap::new));
-    }
+  private Map<ProgramRunId, RunRecordDetail> getRunsByFullKeys(List<List<Field<?>>> keys) throws IOException {
+    return getRunRecordsTable().multiRead(keys).stream()
+      .map(AppMetadataStore::deserializeRunRecordMeta)
+      .collect(Collectors.toMap(RunRecordDetail::getProgramRunId, r -> r, (r1, r2) -> {
+        throw new IllegalStateException("Duplicate run record for " + r1.getProgramRunId());
+      }, LinkedHashMap::new));
   }
 
   /**
@@ -2366,22 +2368,21 @@ public class AppMetadataStore {
   }
 
   private List<Field<?>> getProgramRunInvertedTimeKey(String recordType, ProgramRunId runId, long startTs) {
-    return getProgramRunInvertedTimeKey(recordType, runId, startTs, true);
-  }
-
-  // TODO: CDAP-20031 use ProgramRunReference whenever version should be excluded from keys
-  private List<Field<?>> getProgramRunInvertedTimeKey(String recordType, ProgramRunId runId,
-                                                      long startTs, boolean includeVersion) {
     List<Field<?>> fields = new ArrayList<>();
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_STATUS, recordType));
-    if (includeVersion) {
-      addProgramPrimaryKeys(runId.getParent(), fields);
-    } else {
-      addProgramReferenceKeys(runId.getParent().getProgramReference(), fields);
-    }
-
+    addProgramPrimaryKeys(runId.getParent(), fields);
     fields.add(Fields.longField(StoreDefinition.AppMetadataStore.RUN_START_TIME, getInvertedTsKeyPart(startTs)));
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, runId.getRun()));
+    return fields;
+  }
+
+  private List<Field<?>> getProgramRunInvertedTimeKey(String recordType, ProgramReference programRef,
+                                                      String runId, long startTs) {
+    List<Field<?>> fields = new ArrayList<>();
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_STATUS, recordType));
+    addProgramReferenceKeys(programRef, fields);
+    fields.add(Fields.longField(StoreDefinition.AppMetadataStore.RUN_START_TIME, getInvertedTsKeyPart(startTs)));
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, runId));
     return fields;
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -476,7 +476,7 @@ public class DefaultStore implements Store {
   }
 
   /**
-   * Returns run record for a given run.
+   * Returns run record for a given run id.
    *
    * @param id program run id
    * @return run record for runid
@@ -485,6 +485,20 @@ public class DefaultStore implements Store {
   public RunRecordDetail getRun(ProgramRunId id) {
     return TransactionRunners.run(transactionRunner, context -> {
       return getAppMetadataStore(context).getRun(id);
+    });
+  }
+
+  /**
+   * Returns run record for a given run reference.
+   *
+   * @param programRef    versionless program id of the run
+   * @param runId         the run id
+   * @return run record for run reference
+   */
+  @Override
+  public RunRecordDetail getRun(ProgramReference programRef, String runId) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      return getAppMetadataStore(context).getRun(programRef, runId);
     });
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/StoreProgramRunRecordFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/StoreProgramRunRecordFetcher.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.internal.app.store;
 import com.google.inject.Inject;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.logging.gateway.handlers.ProgramRunRecordFetcher;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
@@ -43,5 +44,16 @@ public class StoreProgramRunRecordFetcher implements ProgramRunRecordFetcher {
     return Optional.ofNullable(TransactionRunners.run(txRunner, context -> {
       return AppMetadataStore.create(context).getRun(runId);
     }, IOException.class)).orElseThrow(() -> new NotFoundException(runId));
+  }
+
+  @Override
+  public RunRecordDetail getRunRecordMeta(ProgramReference programRef, String runId)
+    throws IOException, NotFoundException {
+    return Optional.ofNullable(TransactionRunners.run(txRunner, context -> {
+      return AppMetadataStore.create(context).getRun(programRef, runId);
+    }, IOException.class))
+      .orElseThrow(
+        () -> new NotFoundException(
+          String.format("No run record found for program %s and runID: %s", programRef, runId)));
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidatorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidatorTest.java
@@ -47,6 +47,7 @@ import io.cdap.cdap.logging.gateway.handlers.ProgramRunRecordFetcher;
 import io.cdap.cdap.messaging.data.MessageId;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.proto.security.StandardPermission;
@@ -77,6 +78,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 
@@ -295,6 +297,20 @@ public class DirectRuntimeRequestValidatorTest {
       }
       if (!runId.equals(runRecord.getProgramRunId())) {
         throw new NotFoundException(runId);
+      }
+      return runRecord;
+    }
+
+    @Override
+    public RunRecordDetail getRunRecordMeta(ProgramReference programRef, String runId) throws NotFoundException {
+      if (runRecord == null) {
+        throw new NotFoundException(String.format("No run record found for program %s and runID: %s",
+                                                  programRef, runId));
+      }
+      if (!Objects.equals(programRef, runRecord.getProgramRunId().getParent().getProgramReference())
+        || !Objects.equals(runId, runRecord.getProgramRunId().getRun())) {
+        throw new NotFoundException(String.format("No run record found for program %s and runID: %s",
+                                                  programRef, runId));
       }
       return runRecord;
     }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
@@ -150,6 +150,10 @@ public final class NoSqlStructuredTable implements StructuredTable {
       return scannerIterator;
     }
 
+    // TODO: remove this warning after CDAP-20177
+    LOG.warn("Potential performance impact while scanning table {} with range {} " +
+               "which does in-memory filtering with filterRange {}",
+             schema.getTableId(), keyRange, filterRange);
     return new FilterByRangeIterator(Collections.singleton(scannerIterator).iterator(),
                                      Collections.singleton(filterRange));
   }

--- a/cdap-support-bundle/src/main/java/io/cdap/cdap/support/task/SupportBundlePipelineInfoTask.java
+++ b/cdap-support-bundle/src/main/java/io/cdap/cdap/support/task/SupportBundlePipelineInfoTask.java
@@ -119,18 +119,17 @@ public class SupportBundlePipelineInfoTask implements SupportBundleTask {
   private void processApplicationDetail(NamespaceId namespaceId, ApplicationDetail appDetail)
     throws IOException, NotFoundException {
     String application = appDetail.getName();
-    ApplicationId applicationId = new ApplicationId(namespaceId.getNamespace(), application);
+    ApplicationId applicationId = new ApplicationId(namespaceId.getNamespace(), application, appDetail.getAppVersion());
 
     File appFolderPath = new File(basePath, appDetail.getName());
     DirUtils.mkdirs(appFolderPath);
     try (FileWriter file = new FileWriter(new File(appFolderPath, appDetail.getName() + ".json"))) {
       GSON.toJson(appDetail, file);
     }
-    ProgramId programId = new ProgramId(namespaceId.getNamespace(), appDetail.getName(), programType, programName);
+    ProgramId programId = applicationId.program(programType, programName);
     Iterable<RunRecord> runRecordList;
     if (runId != null) {
-      ProgramRunId programRunId =
-        new ProgramRunId(namespaceId.getNamespace(), appDetail.getName(), programType, programName, runId);
+      ProgramRunId programRunId = programId.run(runId);
       RunRecordDetail runRecordDetail = remoteProgramRunRecordFetcher.getRunRecordMeta(programRunId);
       runRecordList = Collections.singletonList(runRecordDetail);
     } else {

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/context/LoggingContextHelper.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/context/LoggingContextHelper.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.logging.filter.MdcExpression;
 import io.cdap.cdap.logging.filter.OrFilter;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 
 import java.util.Collection;
@@ -174,8 +175,13 @@ public final class LoggingContextHelper {
 
   public static LoggingContext getLoggingContextWithRunId(ProgramRunId programRun,
                                                           @Nullable Map<String, String> systemArgs) {
-    return getLoggingContext(programRun.getNamespace(), programRun.getApplication(), programRun.getProgram(),
-                             programRun.getType(), programRun.getRun(), systemArgs);
+    return getLoggingContextWithRunId(programRun.getParent().getProgramReference(), programRun.getRun(), systemArgs);
+  }
+
+  public static LoggingContext getLoggingContextWithRunId(ProgramReference programRef, String runId,
+                                                          @Nullable Map<String, String> systemArgs) {
+    return getLoggingContext(programRef.getNamespace(), programRef.getApplication(), programRef.getProgram(),
+                             programRef.getType(), runId, systemArgs);
   }
 
   public static LoggingContext getLoggingContext(String namespaceId, String applicationId, String entityId,

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/LocalProgramRunRecordFetcher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/LocalProgramRunRecordFetcher.java
@@ -20,6 +20,7 @@ import com.google.inject.Inject;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.logging.gateway.handlers.store.ProgramStore;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 
 /**
@@ -35,6 +36,7 @@ public class LocalProgramRunRecordFetcher implements ProgramRunRecordFetcher {
 
   /**
    * Get {@link RunRecordDetail} for the given {@link ProgramRunId}
+   * Default to get with run reference without version info
    *
    * @param runId identifies the program run to get {@link RunRecordDetail}
    * @return {@link RunRecordDetail}
@@ -42,9 +44,21 @@ public class LocalProgramRunRecordFetcher implements ProgramRunRecordFetcher {
    */
   @Override
   public RunRecordDetail getRunRecordMeta(ProgramRunId runId) throws NotFoundException {
-    RunRecordDetail runRecord = programStore.getRun(runId);
+    return getRunRecordMeta(runId.getParent().getProgramReference(), runId.getVersion());
+  }
+
+  /**
+   Return {@link RunRecordDetail} for the given {@link ProgramReference} and run id
+   * @param programRef for which to fetch {@link RunRecordDetail}
+   * @param runId for which to fetch {@link RunRecordDetail}
+   * @return {@link RunRecordDetail}
+   * @throws NotFoundException if the given {@link ProgramRunId} is not found
+   */
+  @Override
+  public RunRecordDetail getRunRecordMeta(ProgramReference programRef, String runId) throws NotFoundException {
+    RunRecordDetail runRecord = programStore.getRun(programRef, runId);
     if (runRecord == null) {
-      throw new NotFoundException(runId);
+      throw new NotFoundException(String.format("No run record found for program %s and runID: %s", programRef, runId));
     }
     return runRecord;
   }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/LogHttpHandler.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/LogHttpHandler.java
@@ -30,7 +30,7 @@ import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
-import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
@@ -104,9 +104,9 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                            @QueryParam("suppress") List<String> suppress) throws Exception {
     ensureVisibilityOnProgram(namespaceId, appId, programType, programId);
     ProgramType type = ProgramType.valueOfCategoryName(programType);
-    ProgramRunId programRunId = new ProgramRunId(namespaceId, appId, type, programId, runId);
-    RunRecordDetail runRecord = getRunRecordMeta(programRunId);
-    LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRunId,
+    ProgramReference programRef = new ProgramReference(namespaceId, appId, type, programId);
+    RunRecordDetail runRecord = getRunRecordMeta(programRef, runId);
+    LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRef, runId,
                                                                                     runRecord.getSystemArgs());
 
     doGetLogs(logReader, responder, loggingContext, fromTimeSecsParam, toTimeSecsParam,
@@ -143,9 +143,9 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                         @QueryParam("suppress") List<String> suppress) throws Exception {
     ensureVisibilityOnProgram(namespaceId, appId, programType, programId);
     ProgramType type = ProgramType.valueOfCategoryName(programType);
-    ProgramRunId programRunId = new ProgramRunId(namespaceId, appId, type, programId, runId);
-    RunRecordDetail runRecord = getRunRecordMeta(programRunId);
-    LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRunId,
+    ProgramReference programRef = new ProgramReference(namespaceId, appId, type, programId);
+    RunRecordDetail runRecord = getRunRecordMeta(programRef, runId);
+    LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRef, runId,
                                                                                     runRecord.getSystemArgs());
 
     doNext(logReader, responder, loggingContext, maxEvents, fromOffsetStr,
@@ -182,9 +182,9 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
                         @QueryParam("suppress") List<String> suppress) throws Exception {
     ensureVisibilityOnProgram(namespaceId, appId, programType, programId);
     ProgramType type = ProgramType.valueOfCategoryName(programType);
-    ProgramRunId programRunId = new ProgramRunId(namespaceId, appId, type, programId, runId);
-    RunRecordDetail runRecord = getRunRecordMeta(programRunId);
-    LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRunId,
+    ProgramReference programRef = new ProgramReference(namespaceId, appId, type, programId);
+    RunRecordDetail runRecord = getRunRecordMeta(programRef, runId);
+    LoggingContext loggingContext = LoggingContextHelper.getLoggingContextWithRunId(programRef, runId,
                                                                                     runRecord.getSystemArgs());
 
     doPrev(logReader, responder, loggingContext, maxEvents, fromOffsetStr,
@@ -239,11 +239,11 @@ public class LogHttpHandler extends AbstractLogHttpHandler {
     doPrev(logReader, responder, loggingContext, maxEvents, fromOffsetStr, escape, filterStr, null, format, suppress);
   }
 
-  private RunRecordDetail getRunRecordMeta(ProgramRunId programRunId)
+  private RunRecordDetail getRunRecordMeta(ProgramReference programRef, String runId)
     throws IOException, NotFoundException, UnauthorizedException {
-    RunRecordDetail runRecordMeta = programRunRecordFetcher.getRunRecordMeta(programRunId);
+    RunRecordDetail runRecordMeta = programRunRecordFetcher.getRunRecordMeta(programRef, runId);
     if (runRecordMeta == null) {
-      throw new NotFoundException(programRunId);
+      throw new NotFoundException(String.format("No run record found for program %s and runID: %s", programRef, runId));
     }
     return runRecordMeta;
   }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/ProgramRunRecordFetcher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/ProgramRunRecordFetcher.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.logging.gateway.handlers;
 
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 
@@ -35,4 +36,15 @@ public interface ProgramRunRecordFetcher {
    * @throws NotFoundException if the program or runid is not found
    */
   RunRecordDetail getRunRecordMeta(ProgramRunId runId) throws IOException, NotFoundException, UnauthorizedException;
+
+  /**
+   * Return {@link RunRecordDetail} for the given {@link ProgramReference} and run id
+   * @param programRef for which to fetch {@link RunRecordDetail}
+   * @param runId for which to fetch {@link RunRecordDetail}
+   * @return {@link RunRecordDetail}
+   * @throws IOException if failed to fetch the {@link RunRecordDetail}
+   * @throws NotFoundException if the program or runid is not found
+   */
+  RunRecordDetail getRunRecordMeta(ProgramReference programRef, String runId)
+    throws IOException, NotFoundException, UnauthorizedException;
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteProgramRunRecordFetcher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteProgramRunRecordFetcher.java
@@ -24,6 +24,8 @@ import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.common.http.HttpMethod;
@@ -71,6 +73,19 @@ public class RemoteProgramRunRecordFetcher implements ProgramRunRecordFetcher {
     return RunRecordDetail.builder(GSON.fromJson(httpResponse.getResponseBodyAsString(), RunRecordDetail.class))
       .setProgramRunId(runId)
       .build();
+  }
+
+  /**
+   * Return {@link RunRecordDetail} for the given {@link ProgramReference} and run id
+   * @param programRef for which to fetch {@link RunRecordDetail}
+   * @param runId for which to fetch {@link RunRecordDetail}
+   * @return {@link RunRecordDetail}
+   * @throws IOException if failed to fetch {@link RunRecordDetail}
+   * @throws NotFoundException if the program or run ref is not found
+   */
+  public RunRecordDetail getRunRecordMeta(ProgramReference programRef, String runId)
+    throws IOException, NotFoundException, UnauthorizedException {
+    return getRunRecordMeta(programRef.id(ApplicationId.DEFAULT_VERSION).run(runId));
   }
 
   private HttpResponse execute(HttpRequest request) throws IOException, NotFoundException, UnauthorizedException {

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/store/AppMetadataStore.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/store/AppMetadataStore.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.spi.data.StructuredRow;
 import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.table.field.Field;
@@ -55,24 +56,42 @@ public class AppMetadataStore {
   // TODO: getRun is duplicated from cdap-app-fabric AppMetadataStore class.
   // Any changes made here will have to be made over there too.
   // JIRA https://issues.cask.co/browse/CDAP-2172
-  public RunRecordDetail getRun(ProgramId programId, String runId) throws IOException {
+  public RunRecordDetail getRun(ProgramReference programRef, String runId) throws IOException {
     // Query active run record first
-    RunRecordDetail running = getUnfinishedRun(programId, runId);
+    RunRecordDetail running = getUnfinishedRun(programRef, runId);
     // If program is running, this will be non-null
     if (running != null) {
       return running;
     }
     // If program is not running, query completed run records
-    return getCompletedRun(programId, runId);
+    return getCompletedRun(programRef, runId);
   }
 
 
-  private RunRecordDetail getUnfinishedRun(ProgramId programId, String runId) throws IOException {
-    List<Field<?>> runningKey = getRunRecordProgramPrefix(TYPE_RUN_RECORD_ACTIVE, programId);
-    runningKey.add(Fields.longField(
-      StoreDefinition.AppMetadataStore.RUN_START_TIME, getInvertedTsKeyPart(RunIds.getTime(runId, TimeUnit.SECONDS))));
-    runningKey.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, runId));
-    return getRunRecordMeta(runningKey);
+  private RunRecordDetail getUnfinishedRun(ProgramReference programRef, String runId) throws IOException {
+    List<Field<?>> runningKeys = new ArrayList<>();
+    runningKeys.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_STATUS, TYPE_RUN_RECORD_ACTIVE));
+    addProgramRunReferenceKeys(runningKeys, programRef, runId);
+    return getRunRecordMeta(runningKeys);
+  }
+
+  private RunRecordDetail getCompletedRun(ProgramReference programRef, String runId)
+    throws IOException {
+    List<Field<?>> completedKeys = new ArrayList<>();
+    completedKeys.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_STATUS, TYPE_RUN_RECORD_COMPLETED));
+    addProgramRunReferenceKeys(completedKeys, programRef, runId);
+    return getRunRecordMeta(completedKeys);
+  }
+
+  private void addProgramRunReferenceKeys(List<Field<?>> fields, ProgramReference programRef, String runId) {
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD, programRef.getNamespace()));
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_FIELD, programRef.getApplication()));
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_TYPE_FIELD, programRef.getType().name()));
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_FIELD, programRef.getProgram()));
+    fields.add(Fields.longField(
+      StoreDefinition.AppMetadataStore.RUN_START_TIME,
+      getInvertedTsKeyPart(RunIds.getTime(runId, TimeUnit.SECONDS))));
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, runId));
   }
 
   @Nullable
@@ -108,54 +127,7 @@ public class AppMetadataStore {
     return (String) field.getValue();
   }
 
-
-  private RunRecordDetail getCompletedRun(ProgramId programId, final String runId)
-    throws IOException {
-    List<Field<?>> completedKey = getRunRecordProgramPrefix(TYPE_RUN_RECORD_COMPLETED, programId);
-    // Get start time from RunId
-    long programStartSecs = RunIds.getTime(RunIds.fromString(runId), TimeUnit.SECONDS);
-    completedKey.add(
-      Fields.longField(StoreDefinition.AppMetadataStore.RUN_START_TIME, getInvertedTsKeyPart(programStartSecs)));
-    completedKey.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_FIELD, runId));
-    return getRunRecordMeta(completedKey);
-  }
-
   private long getInvertedTsKeyPart(long endTime) {
     return Long.MAX_VALUE - endTime;
-  }
-
-  private List<Field<?>> getRunRecordProgramPrefix(String status, @Nullable ProgramId programId) {
-    if (programId == null) {
-      return getRunRecordStatusPrefix(status);
-    }
-    List<Field<?>> fields =
-      getRunRecordApplicationPrefix(
-        status, new ApplicationId(programId.getNamespace(), programId.getApplication(), programId.getVersion()));
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_TYPE_FIELD, programId.getType().name()));
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_FIELD, programId.getProgram()));
-    return fields;
-  }
-
-  private List<Field<?>> getRunRecordStatusPrefix(String status) {
-    List<Field<?>> fields = new ArrayList<>();
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.RUN_STATUS, status));
-    return fields;
-  }
-
-  private List<Field<?>> getRunRecordApplicationPrefix(String status, @Nullable ApplicationId applicationId) {
-    List<Field<?>> fields = getRunRecordStatusPrefix(status);
-    if (applicationId == null) {
-      return fields;
-    }
-    fields.addAll(getNoVersionAppPrimaryKeys(applicationId.getNamespace(),
-                                             applicationId.getApplication()));
-    return fields;
-  }
-
-  private List<Field<?>> getNoVersionAppPrimaryKeys(String namespaceId, String appId) {
-    List<Field<?>> fields = new ArrayList<>();
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD, namespaceId));
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_FIELD, appId));
-    return fields;
   }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/store/ProgramStore.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/store/ProgramStore.java
@@ -18,7 +18,7 @@ package io.cdap.cdap.logging.gateway.handlers.store;
 
 import com.google.inject.Inject;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
-import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
@@ -38,16 +38,17 @@ public class ProgramStore {
   }
 
   /**
-   * Returns run record for a given run.
+   * Returns run record for a given run reference.
    *
-   * @param programRunId program run id
-   * @return run record for runid
+   * @param programRef program id without version
+   * @param runId the run id
+   * @return run record for run reference
    */
-  public RunRecordDetail getRun(ProgramRunId programRunId) {
+  public RunRecordDetail getRun(ProgramReference programRef, String runId) {
     return TransactionRunners.run(transactionRunner, context -> {
       StructuredTable table = context.getTable(StoreDefinition.AppMetadataStore.RUN_RECORDS);
       AppMetadataStore metaStore = new AppMetadataStore(table);
-      return metaStore.getRun(programRunId.getParent(), programRunId.getRun());
+      return metaStore.getRun(programRef, runId);
     });
   }
 }


### PR DESCRIPTION
What:

1. Revert back getRun to read by full keys
2. Instead of blindly scanning all run records ignoring versions, we only ignore for logHandler APIs