### PR TITLE
[vuln-fix] exclude xalan:xalan in esapi dependency to resolve vulnerability 

### DIFF
--- a/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
@@ -144,6 +144,10 @@
           <groupId>asm</groupId>
           <artifactId>asm</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xalan</groupId>
+          <artifactId>xalan</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1099,6 +1099,10 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
This PR is to resolve a vulnerability introduced by xalan:xalan in [CVE-2022-34169](https://nvd.nist.gov/vuln/detail/CVE-2022-34169) which is a transitive dependency of esapi. 
Will verify that all unit test and integration test success for excluding this dependency. 