### PR TITLE
[CDAP-20171] fix pushdown config with lcm

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultPluginConfigurer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultPluginConfigurer.java
@@ -37,6 +37,8 @@ import io.cdap.cdap.internal.app.runtime.plugin.PluginNotExistsException;
 import io.cdap.cdap.internal.lang.CallerClassSecurityManager;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -50,7 +52,7 @@ import javax.annotation.Nullable;
  * Abstract base implementation of {@link PluginConfigurer}.
  */
 public class DefaultPluginConfigurer implements PluginConfigurer {
-
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultPluginConfigurer.class);
   protected final PluginInstantiator pluginInstantiator;
   protected final Map<String, PluginWithLocation> plugins;
   protected final NamespaceId pluginNamespaceId;
@@ -81,7 +83,10 @@ public class DefaultPluginConfigurer implements PluginConfigurer {
     try {
       Plugin plugin = addPlugin(pluginType, pluginName, pluginId, properties, selector);
       return pluginInstantiator.newInstance(plugin);
-    } catch (PluginNotExistsException | IOException e) {
+    } catch (PluginNotExistsException e) {
+      return null;
+    } catch (IOException e) {
+      LOG.error("Unexpected error while instantiating {} plugin {}", pluginType, pluginName, e);
       return null;
     } catch (ClassNotFoundException e) {
       // Shouldn't happen
@@ -96,7 +101,10 @@ public class DefaultPluginConfigurer implements PluginConfigurer {
     try {
       Plugin plugin = addPlugin(pluginType, pluginName, pluginId, properties, selector);
       return pluginInstantiator.loadClass(plugin);
-    } catch (PluginNotExistsException | IOException e) {
+    } catch (PluginNotExistsException e) {
+      return null;
+    } catch (IOException e) {
+      LOG.error("Unexpected error while instantiating {} plugin {}", pluginType, pluginName, e);
       return null;
     } catch (ClassNotFoundException e) {
       // Shouldn't happen

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteIsolatedPluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteIsolatedPluginFinder.java
@@ -65,7 +65,7 @@ public class RemoteIsolatedPluginFinder extends RemotePluginFinder {
                                artifactId.getNamespace(),
                                artifactId.getArtifact(),
                                artifactId.getVersion(),
-                               artifactId.getNamespace().equals(NamespaceId.SYSTEM) ?
+                               artifactId.getNamespace().equalsIgnoreCase(NamespaceId.SYSTEM.getNamespace()) ?
                                  ArtifactScope.SYSTEM.name().toLowerCase() : ArtifactScope.USER.name().toLowerCase());
 
     HttpURLConnection urlConn = remoteClientInternal.openConnection(HttpMethod.GET, url);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
@@ -115,8 +115,11 @@ public class RemotePluginFinder implements PluginFinder {
           throw new PluginNotExistsException(pluginNamespaceId, pluginType, pluginName);
         }
 
-        Location artifactLocation = getArtifactLocation(Artifacts.toProtoArtifactId(pluginNamespaceId,
-                                                                                    selected.getKey()));
+
+        Location artifactLocation = getArtifactLocation(
+          Artifacts.toProtoArtifactId(selected.getKey().getScope().equals(ArtifactScope.SYSTEM) ?
+                                        NamespaceId.SYSTEM : pluginNamespaceId,
+                                      selected.getKey()));
         return Maps.immutableEntry(new ArtifactDescriptor(pluginNamespaceId.getEntityName(),
                                                           selected.getKey(), artifactLocation), selected.getValue());
       }, retryStrategy);

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/spec/PipelineSpecGenerator.java
@@ -519,6 +519,7 @@ public abstract class PipelineSpecGenerator<C extends ETLConfig, P extends Pipel
 
       collector.addFailure(errorMessage, correctiveAction)
         .withPluginNotFound(stageName, pluginName, type, requestedArtifactId, suggestedArtifactId);
+      LOG.info("Requested artifact {} cannot be found, suggest to use {}", requestedArtifactId, suggestedArtifactId);
 
       // throw validation exception if the plugin is not initialized
       collector.getOrThrowException();


### PR DESCRIPTION
root cause is `getArtifactLocation` is always using USER artifact scope

[CDAP-20171](https://cdap.atlassian.net/browse/CDAP-20171)