### PR TITLE
Fix security vulnerability in org.apache.ivy:ivy dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1290,6 +1290,10 @@
         <version>${hive.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
@@ -1496,6 +1500,10 @@
         <version>${spark3.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
@@ -1547,6 +1555,10 @@
         <artifactId>spark-core_2.11</artifactId>
         <version>${spark2.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>


### PR DESCRIPTION
**Change Description**

Fixed security vulnerabilities for dependencies:

- ivy


```
[INFO] io.cdap.cdap:cdap-gateway:jar:6.9.0-SNAPSHOT
[INFO] \- io.cdap.cdap:cdap-explore:jar:6.9.0-SNAPSHOT:compile
[INFO]    \- org.apache.hive:hive-exec:jar:1.2.1:compile
[INFO]       \- org.apache.ivy:ivy:jar:2.4.0:compile


[INFO] \- io.cdap.cdap:hydrator-test:jar:6.9.0-SNAPSHOT:provided
[INFO]    \- io.cdap.cdap:cdap-unit-test:jar:6.9.0-SNAPSHOT:provided
[INFO]       \- io.cdap.cdap:cdap-spark-core2_2.11:jar:6.9.0-SNAPSHOT:provided
[INFO]          \- org.apache.spark:spark-core_2.11:jar:2.1.3:provided
[INFO]             \- org.apache.ivy:ivy:jar:2.4.0:provided

[INFO] io.cdap.cdap:cdap-unit-test-spark3_2.12:jar:6.9.0-SNAPSHOT
[INFO] \- io.cdap.cdap:cdap-spark-core3_2.12:jar:6.9.0-SNAPSHOT:compile
[INFO]    \- org.apache.spark:spark-core_2.12:jar:3.1.1:compile
[INFO]       \- `org.apache.ivy:ivy:jar:2.4.0:compile
```




Changes:

- Excluded transitive dependencies from spark2-core,spark3-core and hive-exec in main pom.xml.

Verification

- Verified dependency exclusion using mvn dependency:tree.

- Build cdap.