### PR TITLE
[CDAP-20206] Fix flaky CDAPLogAppenderTest

### DIFF
--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/system/CDAPLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/system/CDAPLogAppenderTest.java
@@ -125,7 +125,7 @@ public class CDAPLogAppenderTest {
   @Test
   public void testCDAPLogAppender() {
     int syncInterval = 1024 * 1024;
-    CDAPLogAppender cdapLogAppender = new CDAPLogAppender();
+    CDAPLogAppender cdapLogAppender = new CDAPLogAppender(true);
 
     cdapLogAppender.setSyncIntervalBytes(syncInterval);
     cdapLogAppender.setMaxFileLifetimeMs(TimeUnit.DAYS.toMillis(1));
@@ -190,7 +190,7 @@ public class CDAPLogAppenderTest {
   public void testCDAPLogAppenderRotation() throws Exception {
     int syncInterval = 1024 * 1024;
     FileMetaDataReader fileMetaDataReader = injector.getInstance(FileMetaDataReader.class);
-    CDAPLogAppender cdapLogAppender = new CDAPLogAppender();
+    CDAPLogAppender cdapLogAppender = new CDAPLogAppender(true);
     AppenderContext context = new LocalAppenderContext(injector.getInstance(TransactionRunner.class),
                                                        injector.getInstance(LocationFactory.class),
                                                        new NoOpMetricsCollectionService());
@@ -261,7 +261,7 @@ public class CDAPLogAppenderTest {
   public void testCDAPLogAppenderSizeBasedRotation() throws Exception {
     int syncInterval = 1024 * 1024;
     FileMetaDataReader fileMetaDataReader = injector.getInstance(FileMetaDataReader.class);
-    CDAPLogAppender cdapLogAppender = new CDAPLogAppender();
+    CDAPLogAppender cdapLogAppender = new CDAPLogAppender(true);
     AppenderContext context = new LocalAppenderContext(injector.getInstance(TransactionRunner.class),
                                                        injector.getInstance(LocationFactory.class),
                                                        new NoOpMetricsCollectionService());


### PR DESCRIPTION
Flakiness is caused by the LogCleaner class removing the logs directory needed by the other tests. Since junit temporary directories are cleaned up, we don't need to have a log cleaner during unit tests.