### PR TITLE
Fix tethering e2e tests

### DIFF
--- a/cdap-e2e-tests/pom.xml
+++ b/cdap-e2e-tests/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
           <groupId>io.cdap.tests.e2e</groupId>
           <artifactId>cdap-e2e-framework</artifactId>
-          <version>0.0.1-SNAPSHOT</version>
+          <version>0.2.0-SNAPSHOT</version>
           <scope>test</scope>
         </dependency>
         <dependency>

--- a/cdap-e2e-tests/src/e2e-test/features/tethering/TetheringRegistration.feature
+++ b/cdap-e2e-tests/src/e2e-test/features/tethering/TetheringRegistration.feature
@@ -86,7 +86,6 @@ Feature: Tethering registration and management
     Given Connect to tethering server Datafusion instance
     Then Reject request on server from client
     Then Verify no pending tethering requests on server
-    Then Delete rejected request on server from client
 
   @TETHERING_CONNECTION_MANAGEMENT
   Scenario: Validate successful connection between client and server
@@ -121,4 +120,4 @@ Feature: Tethering registration and management
     Then Confirm the delete action
     Then Verify the established connection has been deleted on client
     Given Connect to tethering server Datafusion instance
-    Then Delete rejected request on server from client
+    Then Delete tethering connection on server

--- a/cdap-e2e-tests/src/e2e-test/features/tethering/TetheringRuntime.feature
+++ b/cdap-e2e-tests/src/e2e-test/features/tethering/TetheringRuntime.feature
@@ -18,28 +18,6 @@
 # TODO - Add pipeline deployment tests once additional auth options are enabled in e2e framework - see CDAP-19412
 Feature: Tethering profile and runtime
 
-  Scenario: Create established connection
-    Given Open tethering client Datafusion instance
-    When Navigate to tethering page
-    Then Open create new request page
-    Then Click to select a namespace
-    Then Enter project name "test-project"
-    Then Enter region "us-west-1b"
-    Then Enter instance name "test"
-    Then Enter instance url for tethering server
-    Then Enter description "test description"
-    Then Finish creating new tethering request
-    Then Verify the request was created successfully
-    When Navigate to tethering page
-    Then Count number of pending requests on client
-    Then Count number of established connections on server
-    Given Connect to tethering server Datafusion instance
-    Then Accept request on server from client
-    Then Verify no pending tethering requests on server
-    Given Open tethering client Datafusion instance
-    When Navigate to tethering page
-    Then Verify the connection is established
-
   @TETHERING_PROFILE_TEST
   Scenario: Validate creation of tethering compute profile
     Given Connect to tethering server Datafusion instance

--- a/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/stepsdesign/TetheringServer.java
+++ b/cdap-e2e-tests/src/e2e-test/java/io/cdap/cdap/tethering/stepsdesign/TetheringServer.java
@@ -92,8 +92,8 @@ public class TetheringServer implements CdfHelper {
     }
   }
 
-  @Then("Delete rejected request on server from client")
-  public static void deleteRejectedRequest() throws IOException {
+  @Then("Delete tethering connection on server")
+  public static void deleteTethering() throws IOException {
     String clientName = PluginPropertyUtils.pluginProp("clientName");
     HttpURLConnection connection = createConnection("tethering/connections/" + clientName, "DELETE");
     try {


### PR DESCRIPTION
## Fix

Tethering connection is now automatically deleted on the server when it rejects tethering, so don't try to delete tethering after rejecting on the server. 

### Other changes
- Bumped up e2e test framework version
- No need to create tethering connection before creating tethering profile