### PR TITLE
fix(CDAP-20031): use scan run in WorkflowHttpHandler and ProgramLifecycleHttpHandler where version is not available

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -1941,7 +1941,7 @@ public class AppMetadataStore {
 
     if (!row.isPresent()) {
       LOG.debug("No workflow token available for workflow: {}, runId: {}", workflowId, workflowRunId);
-      // Its ok to not allow any updates by returning a 0 size token.
+      // It's ok to not allow any updates by returning a 0 size token.
       return new BasicWorkflowToken(0);
     }
 


### PR DESCRIPTION
What:

In WorkflowHttpHandler, WorkflowStatsSLAHttpHandler and ProgramLifecycleHttpHandler, we should scan the runrecord when version is not available instead of scanning the latest version of application and pass in that version.