### PR TITLE
Revert "Fix security vulnerabilities due to netty dependency"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
     <mockito.version>1.10.19</mockito.version>
     <mysql.version>5.1.21</mysql.version>
     <netty.http.version>1.7.0</netty.http.version>
-    <netty.version>4.1.75.Final</netty.version>
+    <netty.version>4.1.16.Final</netty.version>
     <powermock.version>1.7.4</powermock.version>
     <quartz.version>2.2.0</quartz.version>
     <resteasy.version>3.0.8.Final</resteasy.version>


### PR DESCRIPTION
Revert #14789 

Revert "Fix security vulnerabilities due to netty dependency"

This temporarily reverts commit [c230667](https://github.com/cdapio/cdap/pull/14789/commits/c230667eb8a007ff4fca971ca3d33aabac49a6ea)

Reverting the netty upgrade temporarily to unblock the merge for #14802 
