### PR TITLE
CDAP-19076 fix spark metrics warnings on kubernetes

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -426,7 +426,9 @@ public class KubeMasterEnvironment implements MasterEnvironment {
                      getDriverPodTemplate(podInfo, sparkSubmitContext).getAbsolutePath());
     sparkConfMap.put(SPARK_KUBERNETES_EXECUTOR_POD_TEMPLATE,
                      getExecutorPodTemplateFile(sparkSubmitContext).getAbsolutePath());
-    sparkConfMap.put(SPARK_KUBERNETES_METRICS_PROPERTIES_CONF, "/opt/spark/work-dir/metrics.properties");
+    if (sparkSubmitContext.getLocalizeResources().containsKey("metrics.properties")) {
+      sparkConfMap.put(SPARK_KUBERNETES_METRICS_PROPERTIES_CONF, "/opt/spark/work-dir/metrics.properties");
+    }
 
     Map<String, String> submitConfigs = sparkSubmitContext.getConfig();
     String executionNamespace = submitConfigs.getOrDefault(NAMESPACE_PROPERTY, podInfo.getNamespace());


### PR DESCRIPTION
Fixed the Kubernetes spark submission to only set the path to the metrics.properties file if one exists. This removes a bunch of misleading log messages that complain about the metrics file no existing.