### PR TITLE
[CDAP-20220] re-initialise job controller client in case of app-fabric restarts

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -723,7 +723,7 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
    */
   private void stopJob(String jobId) throws Exception {
     try {
-      jobControllerClient.cancelJob(projectId, region, jobId);
+      getJobControllerClient().cancelJob(projectId, region, jobId);
       LOG.debug("Stopped the job {} on cluster {}.", jobId, clusterName);
     } catch (ApiException e) {
       if (e.getStatusCode().getCode() != StatusCode.Code.FAILED_PRECONDITION) {


### PR DESCRIPTION
Context: Under high load, some dataproc jobs fail to successfully finish while pipeline status is succeeded.
```
2022-12-27 20:16:31,127 - WARN  [program.status:i.c.c.i.a.r.d.r.RemoteExecutionTwillController@144] - Failed to terminate remote process for program run program_run:default.pipeline3.-SNAPSHOT.workflow.DataPipelineWorkflow.170b4ecb-8622-11ed-8948-4a9514b51490
java.lang.NullPointerException: null
	at io.cdap.cdap.runtime.spi.runtimejob.DataprocRuntimeJobManager.stopJob(DataprocRuntimeJobManager.java:726)
	at io.cdap.cdap.runtime.spi.runtimejob.DataprocRuntimeJobManager.kill(DataprocRuntimeJobManager.java:366)
	at io.cdap.cdap.internal.app.runtime.distributed.remote.RuntimeJobRemoteProcessController.kill(RuntimeJobRemoteProcessController.java:83)
```
Re-initialising `jobControllerClient` if it is null fixes the issue and dataproc job gets terminated.

Tested the change after submitting `800` pipelines concurrently.