### PR TITLE
Fixed issue with a null logger name causing an NPE when processing buffered log messages

### DIFF
--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/pipeline/queue/TimeEventQueueProcessor.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/pipeline/queue/TimeEventQueueProcessor.java
@@ -127,6 +127,13 @@ public class TimeEventQueueProcessor<OFFSET extends Comparable<OFFSET>> {
       minDelay = delay < minDelay ? delay : minDelay;
       maxDelay = delay > maxDelay ? delay : maxDelay;
 
+      // Skip entry if the logger name is null. This avoids an NPE when appending to the effectiveLogger below.
+      if (event.getLoggerName() == null) {
+        LOG.warn("Invalid logging event found: {}", event);
+        iterator.remove();
+        continue;
+      }
+
       try {
         // Otherwise, append the event
         ch.qos.logback.classic.Logger effectiveLogger = context.getEffectiveLogger(event.getLoggerName());


### PR DESCRIPTION
This avoids the possibility of the log reader being stuck in a loop where log entries cannot be processed.