### PR TITLE
[CDAP-20269] Avoid unnecessary cconf creation in TetheringProvisioner

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringProvisioner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringProvisioner.java
@@ -52,6 +52,7 @@ public class TetheringProvisioner implements Provisioner {
   private MessagingService messagingService;
   private TetheringStore tetheringStore;
   private LocationFactory locationFactory;
+  private CConfiguration cConf;
 
   /**
    * Using method injection instead of constructor injection because {@link ServiceLoader} (used by
@@ -73,6 +74,11 @@ public class TetheringProvisioner implements Provisioner {
   @SuppressWarnings("unused")
   void setLocationFactory(LocationFactory locationFactory) {
     this.locationFactory = locationFactory;
+  }
+
+  @Inject
+  void setCConf(CConfiguration cConf) {
+    this.cConf = cConf;
   }
 
   @Override
@@ -125,7 +131,6 @@ public class TetheringProvisioner implements Provisioner {
   @Override
   public Optional<RuntimeJobManager> getRuntimeJobManager(ProvisionerContext context) {
     TetheringConf conf = TetheringConf.fromProperties(context.getProperties());
-    CConfiguration cConf = CConfiguration.create();
     return Optional.of(new TetheringRuntimeJobManager(conf, cConf, messagingService, tetheringStore, locationFactory));
   }
 }


### PR DESCRIPTION
![Screenshot 2023-01-10 at 6 32 39 PM](https://user-images.githubusercontent.com/2873805/211711668-6394c6a1-9fc5-4cfb-af4a-3848af9aff2a.png)
CConf creation is expensive, don't create it every time `TetheringProvisioner.getRuntimeJobManager()` is called.