### PR TITLE
CDAP-20179 Appfabric and Preview pods to watch only the resources they create

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -110,6 +110,7 @@ import javax.annotation.Nullable;
  * cdap.twill.runner=k8s
  * cdap.twill.run.id=[run id]
  * cdap.twill.app=[cleansed app name]
+ * cdap.twill.parent.pod=[name of the pod which creates the resource]
  *
  * and annotations:
  *
@@ -125,6 +126,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
   private static final String CDAP_NAMESPACE_LABEL = "cdap.namespace";
   private static final String NAMESPACE_CPU_LIMIT_PROPERTY = "k8s.namespace.cpu.limits";
   private static final String NAMESPACE_MEMORY_LIMIT_PROPERTY = "k8s.namespace.memory.limits";
+  public static final String PARENT_POD_LABEL = "twill.parent.pod";
   public static final String RUN_ID_LABEL = "cdap.twill.run.id";
   private static final String RUNNER_LABEL = "cdap.twill.runner";
   private static final String RUNNER_LABEL_VAL = "k8s";
@@ -171,7 +173,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
                                 String workloadLauncherRoleNameForNamespace,
                                 String workloadLauncherRoleNameForCluster,
                                 String workloadIdentityPool,
-                                String workloadIdentityProvider) {
+                                String workloadIdentityProvider) throws IllegalStateException {
     this.masterEnvContext = masterEnvContext;
     this.apiClientFactory = apiClientFactory;
     this.kubeNamespace = kubeNamespace;
@@ -180,8 +182,9 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
     this.discoveryServiceClient = discoveryServiceClient;
     this.extraLabels = Collections.unmodifiableMap(new HashMap<>(extraLabels));
 
-    // Selects all runs started by the k8s twill runner that has the run id label
-    this.selector = String.format("%s=%s,%s", RUNNER_LABEL, RUNNER_LABEL_VAL, RUN_ID_LABEL);
+    // Selects all runs started by the k8s twill runner that has the run id label and
+    // has parent pod label equal to current pod, if the pod is from a stateful set.
+    this.selector = generateSelector();
     // Contains mapping of the Kubernetes namespace to a map of resource types and the watcher threads
     this.resourceWatchers = new HashMap<>();
     this.liveInfos = new ConcurrentSkipListMap<>();
@@ -192,6 +195,31 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
     this.workloadLauncherRoleNameForCluster = workloadLauncherRoleNameForCluster;
     this.workloadIdentityPool = workloadIdentityPool;
     this.workloadIdentityProvider = workloadIdentityProvider;
+  }
+
+  /**
+   * Throws an exception if Pod is not controlled by a StatefulSet.
+   */
+  private void validatePodIsControlledByStatefulSet() throws IllegalStateException {
+    if (!this.podInfo.getOwnerReferences().stream().anyMatch(r -> r.getKind().equals("StatefulSet"))) {
+      throw new IllegalStateException("Pod: " + podInfo.getName() + " should be controlled by a stateful set");
+    }
+  }
+
+  /**
+   * Generates k8s label selector which selects all runs started by the k8s twill runner that has the run id label.
+   * If the pod is controlled by a StatefulSet it also adds a PARENT_POD_LABEL to the selector.
+   * The PARENT_POD_LABEL is meant to be an identifier for the resources created by the current pod.
+   * Unlike a Deployment, a StatefulSet maintains a sticky identity for each of their Pods.
+   * (https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
+   * Therefore, even if the pod goes down, it will come up with the same pod name and this selector can
+   * be continued to be used.
+   * Throws an exception if pod is not controlled by StatefulSet.
+   */
+  private String generateSelector() throws IllegalStateException {
+    validatePodIsControlledByStatefulSet();
+    return String.format("%s=%s,%s=%s,%s", PARENT_POD_LABEL, podInfo.getName(),
+                         RUNNER_LABEL, RUNNER_LABEL_VAL, RUN_ID_LABEL);
   }
 
   @Override
@@ -218,6 +246,8 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
     labels.put(RUNNER_LABEL, RUNNER_LABEL_VAL);
     labels.put(APP_LABEL, spec.getName());
     labels.put(RUN_ID_LABEL, runId.getId());
+    labels.put(PARENT_POD_LABEL, podInfo.getName());
+
 
     return new KubeTwillPreparer(masterEnvContext, apiClient, kubeNamespace, podInfo,
                                  spec, runId, appLocation, resourcePrefix, labels,

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -243,7 +243,8 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   }
 
   @Override
-  public void initialize(MasterEnvironmentContext context) throws IOException, IllegalArgumentException, ApiException {
+  public void initialize(MasterEnvironmentContext context)
+    throws IOException, IllegalArgumentException, ApiException, IllegalStateException {
     LOG.info("Initializing Kubernetes environment");
 
     Map<String, String> conf = context.getConfigurations();


### PR DESCRIPTION
JIRA - https://cdap.atlassian.net/browse/CDAP-20179

    - Adding a parent pod label to the k8s resources created by AppFabric and Preview pods.
    - Modifying selector so that pod watches only the resources with parent pod label equal to the pod name.
    - Throws an exception, if the pod is not part of stateful set.




Testing - 

With the code changes the labels appear in the sts as follows - 

```
Labels:        cdap.container=PreviewRunnerTwillRunnable
                    cdap.instance=ameya-cdap-20179-debug
                    cdap.twill.app=preview-runner
                    cdap.twill.parent.pod=cdap-ameya-cdap-20179-debug-preview-0
                    cdap.twill.run.id=3ae76a5b-f107-443e-8a0b-227bd18b0d5b
                    cdap.twill.runner=k8s
                    k8s.namespace=default
```
                    **cdap.twill.parent.pod=cdap-ameya-cdap-20179-debug-preview-0**



Both the preview-runner sts and the task-worker sts were deleted and logs observed in appFabric and preview pods - 

```
➜  cdap git:(bugfix/CDAP-20179) ✗ kb delete sts cdap-ameya-cdap-20179-debug-preview-runne-2e81d3027d
statefulset.apps "cdap-ameya-cdap-20179-debug-preview-runne-2e81d3027d" deleted
➜  cdap git:(bugfix/CDAP-20179) ✗ kb delete sts cdap-ameya-cdap-20179-debug-task-worker-3-0678b67462
statefulset.apps "cdap-ameya-cdap-20179-debug-task-worker-3-0678b67462" deleted
```

AppFabric Logs - 

```
➜  ~ kb logs cdap-ameya-cdap-20179-debug-appfabric-0 appfabric -f | grep "Deleting StatefulSet"
2023-01-12 03:32:37,028 - DEBUG [kube-statefulsets-watch:i.c.c.k.r.KubeTwillController@485] - Deleting StatefulSet cdap-ameya-cdap-20179-debug-task-worker-3-0678b67462
2023-01-12 03:32:37,045 - DEBUG [kube-statefulsets-watch:i.c.c.k.r.KubeTwillController@485] - Deleting StatefulSet cdap-ameya-cdap-20179-debug-task-worker-3-0678b67462
^C


```

Preview pod Logs - 

```
➜  cdap git:(bugfix/CDAP-20179) ✗  kb logs cdap-ameya-cdap-20179-debug-preview-0 preview -f | grep "Deleting StatefulSet"
2023-01-12 03:32:07,322 - DEBUG [kube-statefulsets-watch:i.c.c.k.r.KubeTwillController@485] - Deleting StatefulSet cdap-ameya-cdap-20179-debug-preview-runne-2e81d3027d
2023-01-12 03:32:07,344 - DEBUG [kube-statefulsets-watch:i.c.c.k.r.KubeTwillController@485] - Deleting StatefulSet cdap-ameya-cdap-20179-debug-preview-runne-2e81d3027d
^C

```




