### PR TITLE
[CDAP-20275] Do more rare reloads

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1734,6 +1734,7 @@ public final class Constants {
     public static final String SYSTEM_PROPERTY_PREFIX = "provisioner.system.properties.";
     public static final String EXECUTOR_THREADS = "provisioner.executor.threads";
     public static final String CONTEXT_EXECUTOR_THREADS = "provisioner.context.executor.threads";
+    public static final String RELOAD_INTERVAL = "provisioner.cconf.reload.interval.ms";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2978,6 +2978,13 @@
     </description>
   </property>
 
+  <property>
+    <name>provisioner.cconf.reload.interval.ms</name>
+    <value>10000</value>
+    <description>
+      Minimum interval in milliseconds to reload configration in provisioner operations.
+    </description>
+  </property>
 
   <!-- Runtime Monitor Configuration -->
 


### PR DESCRIPTION
Provisioner reloads cconf on every call and it's too heavy global lock. This change makes it do it only each 10 seconds