### PR TITLE
[6.8 Cherry-pick] [CDAP-20275] Do more rare reloads

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1810,6 +1810,7 @@ public final class Constants {
     public static final String SYSTEM_PROPERTY_PREFIX = "provisioner.system.properties.";
     public static final String EXECUTOR_THREADS = "provisioner.executor.threads";
     public static final String CONTEXT_EXECUTOR_THREADS = "provisioner.context.executor.threads";
+    public static final String RELOAD_INTERVAL = "provisioner.cconf.reload.interval.ms";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3091,6 +3091,13 @@
     </description>
   </property>
 
+  <property>
+    <name>provisioner.cconf.reload.interval.ms</name>
+    <value>-1</value>
+    <description>
+      Minimum interval in milliseconds to reload configration in provisioner operations.
+    </description>
+  </property>
 
   <!-- Runtime Monitor Configuration -->
 


### PR DESCRIPTION
Code to be able to reload cconf rarely. Note: Disabled by default in 6.8.
Cherry-pick of https://github.com/cdapio/cdap/pull/14839