### PR TITLE
[CDAP-20201] Set Spark k8s connect/read timeouts based on the CDAP k8…

### DIFF
--- a/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/stepsdesign/KubernetesNamespaceCreation.java
+++ b/cdap-kubernetes/src/e2e-test/java/io/cdap/cdap/master/environment/k8s/stepsdesign/KubernetesNamespaceCreation.java
@@ -89,7 +89,7 @@ public class KubernetesNamespaceCreation implements CdfHelper {
   @Then("Verify Kubernetes namespace {string} exists")
   public static void verifyKubeNamespaceExists(String namespace) throws IOException {
     try {
-      coreV1Api.readNamespace(namespace, null, null, null);
+      coreV1Api.readNamespace(namespace, null);
     } catch (ApiException e) {
       throw new IOException("Error occurred while checking for Kubernetes namespace. Error code = "
                               + e.getCode() + ", Body = " + e.getResponseBody(), e);
@@ -102,7 +102,7 @@ public class KubernetesNamespaceCreation implements CdfHelper {
                                                          new Quantity(memLimit));
     try {
       V1ResourceQuota resourceQuota = coreV1Api.readNamespacedResourceQuota(KubeTwillRunnerService.RESOURCE_QUOTA_NAME,
-                                                                            namespace, null, null, null);
+                                                                            namespace, null);
       if (resourceQuota.getSpec() == null) {
         throw new IOException("Resource quota not created");
       } else if (!hardLimitMap.equals(resourceQuota.getSpec().getHard())) {

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
@@ -108,6 +108,38 @@ public class KubeMasterEnvironmentTest {
   }
 
   @Test
+  public void testGenerateSparkConfigWithDriverTimeouts() throws Exception {
+    Map<String, String> config = new HashMap<>();
+    String requestTimeout = "20000";
+    String connectTimeout = "20000";
+    config.put(KubeMasterEnvironment.SPARK_DRIVER_REQUEST_TIMEOUT_MILLIS, requestTimeout);
+    config.put(KubeMasterEnvironment.SPARK_DRIVER_CONNECTION_TIMEOUT_MILLIS, connectTimeout);
+
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap(), config, 1, 1);
+    SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
+    Assert.assertEquals(requestTimeout,
+                        sparkConfig.getConfigs().get(KubeMasterEnvironment.SPARK_DRIVER_REQUEST_TIMEOUT_MILLIS));
+    Assert.assertEquals(connectTimeout,
+                        sparkConfig.getConfigs().get(KubeMasterEnvironment.SPARK_DRIVER_CONNECTION_TIMEOUT_MILLIS));
+  }
+
+  @Test
+  public void testGenerateSparkConfigWithDefaultDriverTimeouts() throws Exception {
+    SparkSubmitContext sparkSubmitContext = new SparkSubmitContext(Collections.emptyMap(), Collections.emptyMap(),
+                                                                   1, 1);
+    kubeMasterEnvironment.setConnectTimeout(Integer.parseInt(KubeMasterEnvironment.CONNECT_TIMEOUT_DEFAULT));
+    kubeMasterEnvironment.setReadTimeout(Integer.parseInt(KubeMasterEnvironment.READ_TIMEOUT_DEFAULT));
+
+    SparkConfig sparkConfig = kubeMasterEnvironment.generateSparkSubmitConfig(sparkSubmitContext);
+    int readTimeoutMillis = Integer.parseInt(KubeMasterEnvironment.READ_TIMEOUT_DEFAULT) * 1000;
+    Assert.assertEquals(String.valueOf(readTimeoutMillis),
+                        sparkConfig.getConfigs().get(KubeMasterEnvironment.SPARK_DRIVER_REQUEST_TIMEOUT_MILLIS));
+    int connectTimeoutMillis = Integer.parseInt(KubeMasterEnvironment.CONNECT_TIMEOUT_DEFAULT) * 1000;
+    Assert.assertEquals(String.valueOf(connectTimeoutMillis),
+                        sparkConfig.getConfigs().get(KubeMasterEnvironment.SPARK_DRIVER_CONNECTION_TIMEOUT_MILLIS));
+  }
+
+  @Test
   public void testGenerateSparkConfigWithWorkloadIdentityEnabledInNonInstallNamespaceMountsConfigMap()
     throws Exception {
     String workloadIdentityPool = "test-workload-pool";


### PR DESCRIPTION
…s timeout settings

Also fixed kubernetes e2e tests which were broken by #14771.