### PR TITLE
[CDAP-20281] Fix copy directory failures in Intellij

### DIFF
--- a/cdap-unit-test-base/src/main/.gitignore
+++ b/cdap-unit-test-base/src/main/.gitignore
@@ -1,0 +1,8 @@
+# This directory is necesssary in case we want to add files to this directory in the future, otherwise we'll need to
+# re-add configurations for copying and symlinking the main directory for compilation. See CDAP-20281 for details.
+# This file is necessary because git does not allow committing empty directories.
+# Please remove this file when this directory is no longer empty.
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
When you attempt to build in intellij, it will fail with the following error:

```
Maven Resources Compiler: Failed to copy '/Users/lidennis/work/cdap/cdap-unit-test-spark3_2.12/target/generated-sources/cdap-unit-test-base/src/main' to '/Users/lidennis/work/cdap/cdap-unit-test-spark3_2.12/target/classes/src/main': /Users/lidennis/work/cdap/cdap-unit-test-spark3_2.12/target/generated-sources/cdap-unit-test-base/src/main (No such file or directory)
Maven Resources Compiler: Failed to copy '/Users/lidennis/work/cdap/cdap-unit-test-spark2_2.11/target/generated-sources/cdap-unit-test-base/src/main' to '/Users/lidennis/work/cdap/cdap-unit-test-spark2_2.11/target/classes/src/main': /Users/lidennis/work/cdap/cdap-unit-test-spark2_2.11/target/generated-sources/cdap-unit-test-base/src/main (No such file or directory)
```

This blocks local testing. This PR fixes this issue by adding a dummy directory with a `.gitignore` file inside.

The alternative is to remove the compilation steps for this directory, but, if we were to do that and were to add new classes in the main directory in the future, we would need to re-add those compilation steps. This method ensures the build functions without resorting to removing the compilation entirely.

We also need to add a file inside of the empty directory because git [does not allow empty directories](https://stackoverflow.com/questions/115983/how-do-i-add-an-empty-directory-to-a-git-repository).