### PR TITLE
[CDAP-20110] Spark program types should be run as k8s job

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -976,10 +976,11 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
     Map<Type, AppResourceWatcherThread<?>> typeMap = new HashMap<>();
     // Batch jobs are k8s jobs, and streaming pipelines are k8s deployments
     typeMap.put(V1Job.class, AppResourceWatcherThread.createJobWatcher(namespace, selector, apiClientFactory));
-    typeMap.put(V1Deployment.class,
-                AppResourceWatcherThread.createDeploymentWatcher(namespace, selector, apiClientFactory));
-    // We only create statefulsets in the system namespace, so only add watchers for them in that namespace
+    // We only create deployments and statefulsets in the system namespace,
+    // so only add watchers for them in that namespace
     if (namespace.equals(kubeNamespace)) {
+      typeMap.put(V1Deployment.class,
+                  AppResourceWatcherThread.createDeploymentWatcher(namespace, selector, apiClientFactory));
       typeMap.put(V1StatefulSet.class,
                   AppResourceWatcherThread.createStatefulSetWatcher(namespace, selector, apiClientFactory));
     }

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkTwillRunnable.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkTwillRunnable.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.internal.app.runtime.ProgramRunners;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.distributed.AbstractProgramTwillRunnable;
 import io.cdap.cdap.internal.app.spark.SparkCompatReader;
+import io.cdap.cdap.master.spi.twill.Completable;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import org.apache.hadoop.conf.Configuration;
@@ -41,6 +42,7 @@ import org.apache.twill.api.TwillRunnable;
 /**
  * A {@link TwillRunnable} wrapper for {@link ProgramRunner} that runs spark.
  */
+@Completable
 public class SparkTwillRunnable extends AbstractProgramTwillRunnable<ProgramRunner> {
 
   public SparkTwillRunnable(String name) {


### PR DESCRIPTION
We run as k8s job if the twill runnable class has a `Completable` [annotation](https://github.com/cdapio/cdap/blob/develop/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java#L617)