### PR TITLE
[CDAP-20285] Filter out $repl_$init.class from compiled JARs

### DIFF
--- a/cdap-unit-test/src/test/java/io/cdap/cdap/spark/SparkTest.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/spark/SparkTest.java
@@ -164,8 +164,6 @@ public class SparkTest extends TestFrameworkTestBase {
   }
 
   @Test
-  @Ignore
-  // TODO: CDAP-20285 - fix test
   public void testDynamicSpark() throws Exception {
     ApplicationManager appManager = deploy(TestSparkApp.class);
 


### PR DESCRIPTION
Newer versions of scala will silently fail to add the JAR to classpath if the jar contains any classes which conflict with any existing classes in the classpath. This change preemptively fixes a bug with `SparkTest.testDynamicSpark` which will occur when switching to using spark3. 