### PR TITLE
[Cherry-pick][CDAP-20298] Sometimes runtime client don't shutdown nicely because it tries to publish messages after run is completed

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeHandler.java
@@ -97,7 +97,7 @@ public class RuntimeHandler extends AbstractHttpHandler {
     this.logsTopicPrefix = cConf.get(Constants.Logging.TMS_TOPIC_PREFIX);
     this.eventLogsEnabled = cConf.getBoolean(Constants.AppFabric.SPARK_EVENT_LOGS_ENABLED);
     this.eventLogsBaseLocation = locationFactory.create(cConf.get(Constants.AppFabric.SPARK_EVENT_LOGS_DIR));
-    this.allowedTopics = new HashSet<>(RuntimeMonitors.createTopicConfigs(cConf).values());
+    this.allowedTopics = new HashSet<>(RuntimeMonitors.createTopicNameList(cConf));
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeMonitors.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeMonitors.java
@@ -39,7 +39,7 @@ import java.net.ProxySelector;
 import java.net.URI;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -53,10 +53,10 @@ public final class RuntimeMonitors {
   private static final Logger LOG = LoggerFactory.getLogger(RuntimeMonitors.class);
 
   /**
-   * Creates a map from topic configuration name to the actual TMS topic based on the list of topic configuration names
+   * Creates a properly ordered list of TMS topic names based on the list of topic configuration names
    * specified by the {@link Constants.RuntimeMonitor#TOPICS_CONFIGS} key.
    */
-  public static Map<String, String> createTopicConfigs(CConfiguration cConf) {
+  public static List<String> createTopicNameList(CConfiguration cConf) {
     return cConf.getTrimmedStringCollection(Constants.RuntimeMonitor.TOPICS_CONFIGS).stream().flatMap(key -> {
       int idx = key.lastIndexOf(':');
       if (idx < 0) {
@@ -87,7 +87,7 @@ public final class RuntimeMonitors {
       topic.getKey().startsWith(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC) ? 2 :
       topic.getKey().startsWith(Constants.Logging.TMS_TOPIC_PREFIX) ? 1 :
       0
-    )).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (v1, v2) -> v1, LinkedHashMap::new));
+    )).map(e -> e.getValue()).collect(Collectors.toList());
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeRequestValidator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeRequestValidator.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.runtime.monitor;
 
 import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.GoneException;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.netty.handler.codec.http.HttpRequest;
 
@@ -33,8 +34,9 @@ public interface RuntimeRequestValidator {
    * @param programRunId the program run id where the request is coming from
    * @param request the http request from the program runtime
    * @throws BadRequestException if the request is not valid
+   * @throws GoneException if the run already finished
    * @throws AccessException if the request doesn't have a valid Authorization header
    */
   ProgramRunInfo getProgramRunStatus(ProgramRunId programRunId, HttpRequest request)
-    throws BadRequestException, AccessException;
+    throws BadRequestException, AccessException, GoneException;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingHandler.java
@@ -22,6 +22,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.io.Closeables;
 import com.google.inject.Inject;
 import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.GoneException;
 import io.cdap.cdap.common.ServiceException;
 import io.cdap.cdap.common.ServiceUnavailableException;
 import io.cdap.cdap.common.conf.Constants;
@@ -182,10 +183,11 @@ public class RuntimeServiceRoutingHandler extends AbstractHttpHandler {
    * Opens a {@link HttpURLConnection} to the given service for the given program run.
    *
    * @throws BadRequestException if the request for service routing is not valid
+   * @throws GoneException if the run already finished
    */
   private HttpURLConnection openConnection(HttpRequest request, String namespace, String app,
                                            String version, String programType, String program, String run,
-                                           String service) throws BadRequestException {
+                                           String service) throws BadRequestException, GoneException {
     ApplicationId appId = new NamespaceId(namespace).app(app, version);
     ProgramRunId programRunId = new ProgramRunId(appId,
                                                  ProgramType.valueOfCategoryName(programType, BadRequestException::new),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidatorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/DirectRuntimeRequestValidatorTest.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.GoneException;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -139,7 +140,7 @@ public class DirectRuntimeRequestValidatorTest {
   }
 
   @Test
-  public void testValid() throws BadRequestException {
+  public void testValid() throws BadRequestException, GoneException {
     ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").spark("spark").run(RunIds.generate());
 
     // Insert the run
@@ -163,7 +164,7 @@ public class DirectRuntimeRequestValidatorTest {
   }
 
   @Test (expected = BadRequestException.class)
-  public void testInvalid() throws BadRequestException {
+  public void testInvalid() throws BadRequestException, GoneException {
     ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").spark("spark").run(RunIds.generate());
 
     // Validation should fail
@@ -174,7 +175,7 @@ public class DirectRuntimeRequestValidatorTest {
   }
 
   @Test (expected = UnauthorizedException.class)
-  public void testUnauthorized() throws BadRequestException {
+  public void testUnauthorized() throws BadRequestException, GoneException {
     ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").spark("spark").run(RunIds.generate());
 
     RuntimeRequestValidator validator = new DirectRuntimeRequestValidator(cConf, txRunner,
@@ -189,8 +190,8 @@ public class DirectRuntimeRequestValidatorTest {
     validator.getProgramRunStatus(programRunId, new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/"));
   }
 
-  @Test (expected = BadRequestException.class)
-  public void testNotRunning() throws BadRequestException {
+  @Test (expected = GoneException.class)
+  public void testNotRunning() throws BadRequestException, GoneException {
     ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").spark("spark").run(RunIds.generate());
 
     // Insert a completed run
@@ -213,7 +214,7 @@ public class DirectRuntimeRequestValidatorTest {
   }
 
   @Test
-  public void testFetcher() throws BadRequestException {
+  public void testFetcher() throws BadRequestException, GoneException {
     ArtifactId artifactId = new ArtifactId("test", new ArtifactVersion("1.0"), ArtifactScope.USER);
     ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").spark("spark").run(RunIds.generate());
     ProgramRunStatus programRunStatus = ProgramRunStatus.RUNNING;
@@ -246,7 +247,7 @@ public class DirectRuntimeRequestValidatorTest {
   }
 
   @Test
-  public void testValidProgramInStoppingState() throws BadRequestException {
+  public void testValidProgramInStoppingState() throws BadRequestException, GoneException {
     ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").spark("spark").run(RunIds.generate());
 
     // Insert the run

--- a/cdap-common/src/main/java/io/cdap/cdap/common/GoneException.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/GoneException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common;
+
+import io.cdap.cdap.api.common.HttpErrorStatusProvider;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Indicates that object is gone (e.g. moved into finished / deleted status)
+ */
+public class GoneException extends Exception implements HttpErrorStatusProvider {
+  public GoneException() {
+  }
+
+  public GoneException(String message) {
+    super(message);
+  }
+
+  @Override
+  public int getStatusCode() {
+    return HttpResponseStatus.GONE.code();
+  }
+}


### PR DESCRIPTION
Ensure proper topic order is retained in the runtime client and even if a message is sent into a completed run it does not get into 1h retry loop.

Cherry-pick of https://github.com/cdapio/cdap/pull/14880