### PR TITLE
[CDAP-19610] TetheringAgent: track program updates for each peer

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -2053,6 +2053,16 @@ public class AppMetadataStore {
     getSubscriberStateTable().upsert(keys);
   }
 
+  /**
+   * Deletes the topic's last fetched message id for the given subscriber.
+   *
+   * @param topic the topic name
+   * @param subscriber the subscriber name
+   */
+  public void deleteSubscriberState(String topic, String subscriber) throws IOException {
+    getSubscriberStateTable().delete(getSubscriberKeys(topic, subscriber));
+  }
+
   @VisibleForTesting
   Set<RunId> getRunningInRangeForStatus(String statusKey, long startTimeInSecs,
                                         long endTimeInSecs) throws IOException {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/SubscriberState.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/SubscriberState.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tracks the last message id received from and sent to each tethered peer.
+ */
+public class SubscriberState {
+  // Id of the last program status update message that was sent to each tethered peer.
+  private final Map<String, String> lastMessageIdsSent;
+  // Id of the last control message received from each tethered peer.
+  private final Map<String, String> lastMessageIdsReceived;
+
+  public SubscriberState() {
+    lastMessageIdsSent = new HashMap<>();
+    lastMessageIdsReceived = new HashMap<>();
+  }
+
+  /**
+   * Sets the last message id sent to a tethered peer.
+   * @param peer peer name
+   * @param  messageId message id
+   */
+  void setLastMessageIdSent(String peer, String messageId) {
+    lastMessageIdsSent.put(peer, messageId);
+  }
+
+  /**
+   * Sets the last message id received from a tethered peer.
+   * @param peer peer name
+   * @param  messageId message id
+   */
+  void setLastMessageIdReceived(String peer, String messageId) {
+    lastMessageIdsReceived.put(peer, messageId);
+  }
+
+  /**
+   * Returns the last message id sent to a tethered peer.
+   * @param peer peer name
+   */
+  public String getLastMessageIdSent(String peer) {
+    return lastMessageIdsSent.get(peer);
+  }
+
+  /**
+   * Returns the last message id received from a tethered peer.
+   * @param peer peer name
+   */
+  public String getLastMessageIdReceived(String peer) {
+    return lastMessageIdsReceived.get(peer);
+  }
+
+  /**
+   * Returns last message ids sent to each tethered peer.
+   */
+  public Map<String, String> getLastMessageIdsSent() {
+    return lastMessageIdsSent;
+  }
+
+  /**
+   * Returns last message ids received from each tethered peer.
+   */
+  public Map<String, String> getLastMessageIdsReceived() {
+    return lastMessageIdsReceived;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringClient.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringClient.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.internal.tethering;
 
+import com.google.common.base.Strings;
 import com.google.common.net.HttpHeaders;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -116,6 +117,9 @@ public final class TetheringClient {
                                         peerUri, content);
     if (resp.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
       String body = resp.getResponseBodyAsString(StandardCharsets.UTF_8);
+      if (Strings.isNullOrEmpty(body)) {
+        throw new NotFoundException(String.format("Peer %s was not found", peerInfo.getName()));
+      }
       try {
         return GSON.fromJson(body, TetheringControlResponseV2.class);
       } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringClientHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringClientHandler.java
@@ -17,13 +17,17 @@
 package io.cdap.cdap.internal.tethering;
 
 import com.google.gson.Gson;
+import io.cdap.cdap.api.messaging.TopicAlreadyExistsException;
 import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.NamespaceNotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.messaging.TopicMetadata;
 import io.cdap.cdap.proto.id.InstanceId;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.TopicId;
 import io.cdap.cdap.proto.security.InstancePermission;
 import io.cdap.cdap.security.spi.authenticator.RemoteAuthenticator;
 import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
@@ -32,9 +36,13 @@ import io.cdap.http.HttpResponder;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.elasticsearch.common.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -46,22 +54,28 @@ import javax.ws.rs.Path;
  */
 @Path(Constants.Gateway.API_VERSION_3)
 public class TetheringClientHandler extends AbstractHttpHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(TetheringClientHandler.class);
   private static final Gson GSON = new Gson();
 
   private final TetheringStore store;
   private final ContextAccessEnforcer contextAccessEnforcer;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
   private final TetheringClient tetheringClient;
+  private final MessagingService messagingService;
+  private final String programStateTopicPrefix;
 
   @Inject
   TetheringClientHandler(CConfiguration cConf, TetheringStore store, ContextAccessEnforcer contextAccessEnforcer,
                          NamespaceQueryAdmin namespaceQueryAdmin,
                          @Named(TetheringAgentService.REMOTE_TETHERING_AUTHENTICATOR)
-                           RemoteAuthenticator remoteAuthenticator) {
+                           RemoteAuthenticator remoteAuthenticator,
+                         MessagingService messagingService) {
     this.store = store;
     this.contextAccessEnforcer = contextAccessEnforcer;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.tetheringClient = new TetheringClient(remoteAuthenticator, cConf);
+    this.messagingService = messagingService;
+    this.programStateTopicPrefix = cConf.get(Constants.Tethering.PROGRAM_STATE_TOPIC_PREFIX);
   }
 
   /**
@@ -82,6 +96,7 @@ public class TetheringClientHandler extends AbstractHttpHandler {
                                      TetheringStatus.PENDING, peerMetadata, System.currentTimeMillis());
     tetheringClient.createTethering(peerInfo);
     store.addPeer(peerInfo);
+    createPeerProgramStatusTopic(peerInfo.getName());
     responder.sendStatus(HttpResponseStatus.OK);
   }
 
@@ -91,6 +106,18 @@ public class TetheringClientHandler extends AbstractHttpHandler {
       if (!namespaceQueryAdmin.exists(namespaceId)) {
         throw new NamespaceNotFoundException(namespaceId);
       }
+    }
+  }
+
+  private void createPeerProgramStatusTopic(String peer) throws IOException {
+    TopicId topic = new TopicId(NamespaceId.SYSTEM.getNamespace(),
+                                programStateTopicPrefix + peer);
+    try {
+      messagingService.createTopic(new TopicMetadata(topic, Collections.emptyMap()));
+    } catch (TopicAlreadyExistsException ex) {
+      // no-op
+    } catch (IOException e) {
+      LOG.warn("Failed to create topic {}", topic.getTopic(), e);
     }
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringProgramEventPublisher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringProgramEventPublisher.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.api.messaging.Message;
+import io.cdap.cdap.api.messaging.MessageFetcher;
+import io.cdap.cdap.api.messaging.MessagePublisher;
+import io.cdap.cdap.api.messaging.TopicAlreadyExistsException;
+import io.cdap.cdap.api.messaging.TopicNotFoundException;
+import io.cdap.cdap.api.retry.RetryableException;
+import io.cdap.cdap.app.runtime.Arguments;
+import io.cdap.cdap.app.runtime.ProgramOptions;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.service.AbstractRetryableScheduledService;
+import io.cdap.cdap.common.service.Retries;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
+import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.internal.app.runtime.codec.ArgumentsCodec;
+import io.cdap.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
+import io.cdap.cdap.internal.app.runtime.monitor.RuntimeProgramStatusSubscriberService;
+import io.cdap.cdap.internal.app.store.AppMetadataStore;
+import io.cdap.cdap.logging.gateway.handlers.ProgramRunRecordFetcher;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.messaging.TopicMetadata;
+import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
+import io.cdap.cdap.proto.Notification;
+import io.cdap.cdap.proto.RunRecord;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.id.TopicId;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+
+/**
+ * Reads program status messages from TMS and writes to them to peer specific topics.
+ * {@link TetheringAgentService} is responsible for reading status messages from the peer specific topics and
+ * sending updates to the respective peers.
+ */
+public class TetheringProgramEventPublisher extends AbstractRetryableScheduledService  {
+  private static final Logger LOG = LoggerFactory.getLogger(TetheringProgramEventPublisher.class);
+  private static final Gson GSON = ApplicationSpecificationAdapter.addTypeAdapters(new GsonBuilder())
+    .registerTypeAdapter(Arguments.class, new ArgumentsCodec())
+    .registerTypeAdapter(ProgramOptions.class, new ProgramOptionsCodec())
+    .create();
+  static final String SUBSCRIBER = "tether.agent";
+
+  private final TetheringStore store;
+  private final MessagingService messagingService;
+  private final MessageFetcher messageFetcher;
+  private final MessagePublisher messagePublisher;
+  private final ProgramRunRecordFetcher runRecordFetcher;
+  private final TransactionRunner transactionRunner;
+  private final String programUpdateTopic;
+  private final int programUpdateFetchSize;
+  private final String programStateTopicPrefix;
+  private final long pollInterval;
+
+  // Tracks id of last program status update message that was processed.
+  private String lastProgramUpdateMessageId;
+
+  @Inject
+  TetheringProgramEventPublisher(CConfiguration cConf, TetheringStore store, MessagingService messagingService,
+                                 ProgramRunRecordFetcher programRunRecordFetcher, TransactionRunner transactionRunner) {
+    super(RetryStrategies.fromConfiguration(cConf, "tethering.agent."));
+    this.store = store;
+    this.messagingService = messagingService;
+    this.messageFetcher = new MultiThreadMessagingContext(messagingService).getMessageFetcher();
+    this.messagePublisher = new MultiThreadMessagingContext(messagingService).getMessagePublisher();
+    this.runRecordFetcher = programRunRecordFetcher;
+    this.transactionRunner = transactionRunner;
+    this.programUpdateTopic = cConf.get(Constants.AppFabric.PROGRAM_STATUS_RECORD_EVENT_TOPIC);
+    this.programUpdateFetchSize = cConf.getInt(Constants.AppFabric.STATUS_EVENT_FETCH_SIZE);
+    this.programStateTopicPrefix = cConf.get(Constants.Tethering.PROGRAM_STATE_TOPIC_PREFIX);
+    // TetheringAgentService reads messages published by TetheringProgramEventPublisher, so use the same
+    // poll interval here
+    this.pollInterval = TimeUnit.SECONDS.toMillis(cConf.getLong(Constants.Tethering.CONNECTION_INTERVAL));
+  }
+
+  @Override
+  protected void doStartUp() {
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
+      lastProgramUpdateMessageId = appMetadataStore.retrieveSubscriberState(programUpdateTopic, SUBSCRIBER);
+      if (lastProgramUpdateMessageId == null) {
+        // Initialize subscriber based on last message fetched by RuntimeProgramStatusSubscriberService.
+        // This is to avoid fetching existing program history from before TetheringAgent was added
+        String messageId = appMetadataStore.retrieveSubscriberState(programUpdateTopic,
+                                                                    RuntimeProgramStatusSubscriberService.SUBSCRIBER);
+        appMetadataStore.persistSubscriberState(programUpdateTopic, SUBSCRIBER, messageId);
+        lastProgramUpdateMessageId = messageId;
+      }
+    });
+  }
+
+  @Override
+  protected long runTask() throws IOException {
+    List<PeerInfo> peers = store.getPeers().stream()
+      // Ignore peers that are not in ACCEPTED state.
+      .filter(p -> p.getTetheringStatus() == TetheringStatus.ACCEPTED)
+      .collect(Collectors.toList());
+
+    PeerProgramUpdates peerProgramUpdates = getPeerProgramUpdates();
+    persistNotifications(peerProgramUpdates, peers);
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
+      appMetadataStore.persistSubscriberState(programUpdateTopic,
+                                              SUBSCRIBER,
+                                              lastProgramUpdateMessageId);
+
+    });
+
+    return pollInterval;
+  }
+
+  /**
+   * Returns program status updates for tethered peers.
+   */
+  private PeerProgramUpdates getPeerProgramUpdates() {
+    Map<String, List<Notification>> peerToNotifications = new HashMap<>();
+    String lastMessageId = lastProgramUpdateMessageId;
+    try (CloseableIterator<Message> iterator = messageFetcher.fetch(NamespaceId.SYSTEM.getNamespace(),
+                                                                    programUpdateTopic,
+                                                                    programUpdateFetchSize,
+                                                                    lastProgramUpdateMessageId)) {
+      while (iterator.hasNext()) {
+        Message message = iterator.next();
+        Notification notification = message.decodePayload(r -> GSON.fromJson(r, Notification.class));
+        if (notification.getNotificationType() != Notification.Type.PROGRAM_STATUS) {
+          continue;
+        }
+        Map<String, String> properties = notification.getProperties();
+        String programRunId = properties.get(ProgramOptionConstants.PROGRAM_RUN_ID);
+        try {
+          RunRecord runRecord = runRecordFetcher.getRunRecordMeta(GSON.fromJson(programRunId, ProgramRunId.class));
+          if (runRecord.getPeerName() == null) {
+            continue;
+          }
+          String programStatus = properties.get(ProgramOptionConstants.PROGRAM_STATUS);
+          LOG.debug("Received message for peer {} about program run {} in state {}",
+                    runRecord.getPeerName(), programRunId, programStatus);
+          peerToNotifications.computeIfAbsent(runRecord.getPeerName(), n -> new ArrayList<>()).add(notification);
+        } catch (NotFoundException | IOException e) {
+          LOG.error("Unable to fetch runRecord for programRunId {}", programRunId, e);
+        }
+
+        lastMessageId = message.getId();
+      }
+    } catch (Exception e) {
+      LOG.error("Exception when fetching program updates. Will retry again during next poll", e);
+    }
+    return new PeerProgramUpdates(peerToNotifications, lastMessageId);
+  }
+
+  private void persistNotifications(PeerProgramUpdates peerProgramUpdates, List<PeerInfo> peers) throws IOException {
+    for (PeerInfo peer: peers) {
+      String peerName = peer.getName();
+      List<String> notifications = peerProgramUpdates.peerToNotifications.getOrDefault(peerName, new ArrayList<>())
+        .stream().map(n -> GSON.toJson(n)).collect(Collectors.toList());
+      publishMessages(programStateTopicPrefix + peerName, notifications);
+    }
+    lastProgramUpdateMessageId = peerProgramUpdates.lastMessageId;
+  }
+
+  private void publishMessages(String topic, List<String> messages) throws IOException {
+    if (messages.isEmpty()) {
+      return;
+    }
+    Retries.runWithRetries(() -> {
+      try {
+        messagePublisher.publish(NamespaceId.SYSTEM.getNamespace(), topic,
+                                 messages.toArray(new String[0]));
+      } catch (TopicNotFoundException e) {
+        // Create the topic if it doesn't exist and retry publish
+        createTopicIfNeeded(new TopicId(NamespaceId.SYSTEM.getNamespace(), topic));
+        throw new RetryableException(e);
+      }
+    }, RetryStrategies.limit(1, RetryStrategies.fixDelay(1, TimeUnit.SECONDS)));
+  }
+
+  private void createTopicIfNeeded(TopicId topicId) throws IOException {
+    try {
+      messagingService.createTopic(new TopicMetadata(topicId, Collections.emptyMap()));
+      LOG.debug("Created topic {}", topicId.getTopic());
+    } catch (TopicAlreadyExistsException ex) {
+      // no-op
+    }
+  }
+
+  /**
+   * Program status notifications for tethered peers.
+   */
+  private static class PeerProgramUpdates {
+    // List of notifications for each tethered peer
+    private final Map<String, List<Notification>> peerToNotifications;
+    // Last message id read from TMS
+    private final String lastMessageId;
+
+    private PeerProgramUpdates(Map<String, List<Notification>> peerToNotifications, String lastMessageId) {
+      this.peerToNotifications = peerToNotifications;
+      this.lastMessageId = lastMessageId;
+    }
+  }
+
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringServerHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringServerHandler.java
@@ -88,7 +88,7 @@ public class TetheringServerHandler extends AbstractHttpHandler {
     this.store = store;
     this.messagingService = messagingService;
     this.messagingContext = new MultiThreadMessagingContext(messagingService);
-    this.topicPrefix = cConf.get(Constants.Tethering.TOPIC_PREFIX);
+    this.topicPrefix = cConf.get(Constants.Tethering.CLIENT_TOPIC_PREFIX);
     this.contextAccessEnforcer = contextAccessEnforcer;
     this.programStatePublisher = programStatePublisher;
   }
@@ -217,6 +217,10 @@ public class TetheringServerHandler extends AbstractHttpHandler {
       TopicId topicId = new TopicId(NamespaceId.SYSTEM.getNamespace(),
                                     topicPrefix + peer);
       createTopicIfNeeded(topicId);
+    } else {
+      // Recreate topic if the client deletes and recreates tethering.
+      LOG.debug("Peer {} exists, recreating tethering topic", peer);
+      deleteTopicForPeer(peer);
     }
     responder.sendStatus(HttpResponseStatus.OK);
   }
@@ -289,6 +293,10 @@ public class TetheringServerHandler extends AbstractHttpHandler {
     } catch (PeerNotFoundException e) {
       // Peer doesn't exist, nothing to do here
     }
+    deleteTopicForPeer(peer);
+  }
+
+  private void deleteTopicForPeer(String peer) throws IOException {
     TopicId topic = new TopicId(NamespaceId.SYSTEM.getNamespace(),
                                 topicPrefix + peer);
     try {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManager.java
@@ -88,7 +88,7 @@ public class TetheringRuntimeJobManager implements RuntimeJobManager {
     this.messagePublisher = new MultiThreadMessagingContext(messagingService).getMessagePublisher();
     this.tetheringStore = tetheringStore;
     this.topicId = new TopicId(NamespaceId.SYSTEM.getNamespace(),
-                               cConf.get(Constants.Tethering.TOPIC_PREFIX) + tetheredInstanceName);
+                               cConf.get(Constants.Tethering.CLIENT_TOPIC_PREFIX) + tetheredInstanceName);
     this.locationFactory = locationFactory;
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringServerHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringServerHandlerTest.java
@@ -145,7 +145,7 @@ public class TetheringServerHandlerTest {
   public static void setup() throws IOException {
     cConf = CConfiguration.create();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
-    topicPrefix = cConf.get(Constants.Tethering.TOPIC_PREFIX);
+    topicPrefix = cConf.get(Constants.Tethering.CLIENT_TOPIC_PREFIX);
     injector = Guice.createInjector(
       new ConfigModule(cConf),
       new SystemDatasetRuntimeModule().getInMemoryModules(),
@@ -208,7 +208,8 @@ public class TetheringServerHandlerTest {
       .setHttpHandlers(
         new TetheringServerHandler(cConf, tetheringStore, messagingService, contextAccessEnforcer,
                                    messagingProgramStatePublisher),
-        new TetheringHandler(cConf, tetheringStore, messagingService, profileService)).build();
+        new TetheringHandler(cConf, tetheringStore, messagingService, profileService))
+      .build();
     service.start();
     config = ClientConfig.builder()
       .setConnectionConfig(
@@ -417,7 +418,7 @@ public class TetheringServerHandlerTest {
 
     // Queue up a couple of messages for the peer
     MessagePublisher publisher = new MultiThreadMessagingContext(messagingService).getMessagePublisher();
-    String topicPrefix = cConf.get(Constants.Tethering.TOPIC_PREFIX);
+    String topicPrefix = cConf.get(Constants.Tethering.CLIENT_TOPIC_PREFIX);
     String topic = topicPrefix + "xyz";
     TetheringLaunchMessage launchMessage = new TetheringLaunchMessage.Builder()
       .addFileNames(DistributedProgramRunner.LOGBACK_FILE_NAME)
@@ -479,7 +480,7 @@ public class TetheringServerHandlerTest {
     TetheringControlMessage controlMessage = new TetheringControlMessage(TetheringControlMessage.Type.KEEPALIVE,
                                                                          new byte[0]);
     MessagePublisher publisher = new MultiThreadMessagingContext(messagingService).getMessagePublisher();
-    String topicPrefix = cConf.get(Constants.Tethering.TOPIC_PREFIX);
+    String topicPrefix = cConf.get(Constants.Tethering.CLIENT_TOPIC_PREFIX);
     String topic = topicPrefix + "xyz";
     publisher.publish(NamespaceId.SYSTEM.getNamespace(), topic, GSON.toJson(controlMessage));
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManagerTest.java
@@ -103,7 +103,7 @@ public class TetheringRuntimeJobManagerTest {
   @BeforeClass
   public static void setUp() throws IOException, TopicAlreadyExistsException, PeerAlreadyExistsException {
     CConfiguration cConf = CConfiguration.create();
-    cConf.set(Constants.Tethering.TOPIC_PREFIX, "prefix-");
+    cConf.set(Constants.Tethering.CLIENT_TOPIC_PREFIX, "prefix-");
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
@@ -139,7 +139,7 @@ public class TetheringRuntimeJobManagerTest {
     tetheringStore.addPeer(peerInfo);
     TetheringConf conf = TetheringConf.fromProperties(PROPERTIES);
     topicId = new TopicId(NamespaceId.SYSTEM.getNamespace(),
-                          cConf.get(Constants.Tethering.TOPIC_PREFIX) + TETHERED_INSTANCE_NAME);
+                          cConf.get(Constants.Tethering.CLIENT_TOPIC_PREFIX) + TETHERED_INSTANCE_NAME);
     messagingService.createTopic(new TopicMetadata(topicId, Collections.emptyMap()));
     messageFetcher = new MultiThreadMessagingContext(messagingService).getMessageFetcher();
     runtimeJobManager = new TetheringRuntimeJobManager(conf, cConf, messagingService, tetheringStore,

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1956,7 +1956,11 @@ public final class Constants {
     /**
      * Prefix of per-client TMS topic used on the tethering server.
      */
-    public static final String TOPIC_PREFIX = "tethering.topic.prefix";
+    public static final String CLIENT_TOPIC_PREFIX = "tethering.topic.prefix";
+    /**
+     * Prefix of program state TMS topic used on the tethering client.
+     */
+    public static final String PROGRAM_STATE_TOPIC_PREFIX = "tethering.program.state.topic.prefix";
     /**
      * Interval for connecting to the server.
      */

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5358,6 +5358,14 @@
   </property>
 
   <property>
+    <name>tethering.program.state.topic.prefix</name>
+    <value>tether_program_state_</value>
+    <description>
+      TMS topic prefix used on tethering client that contains program status updates for the peer
+    </description>
+  </property>
+
+  <property>
     <name>tethering.client.connection.timeout.ms</name>
     <value>${http.client.connection.timeout.ms}</value>
     <description>

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/TetheringAgentServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/TetheringAgentServiceMain.java
@@ -35,6 +35,7 @@ import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.internal.app.store.StoreProgramRunRecordFetcher;
 import io.cdap.cdap.internal.tethering.TetheringAgentService;
+import io.cdap.cdap.internal.tethering.TetheringProgramEventPublisher;
 import io.cdap.cdap.logging.gateway.handlers.ProgramRunRecordFetcher;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
@@ -80,6 +81,8 @@ public class TetheringAgentServiceMain extends AbstractServiceMain<EnvironmentOp
         protected void configure() {
           bind(TetheringAgentService.class).in(Scopes.SINGLETON);
           expose(TetheringAgentService.class);
+          bind(TetheringProgramEventPublisher.class).in(Scopes.SINGLETON);
+          expose(TetheringProgramEventPublisher.class);
           bind(ProgramRunRecordFetcher.class).to(StoreProgramRunRecordFetcher.class).in(Scopes.SINGLETON);
           expose(ProgramRunRecordFetcher.class);
         }
@@ -96,6 +99,7 @@ public class TetheringAgentServiceMain extends AbstractServiceMain<EnvironmentOp
       services.add(zkBinding.getProvider().get());
     }
     services.add(injector.getInstance(TetheringAgentService.class));
+    services.add(injector.getInstance(TetheringProgramEventPublisher.class));
   }
 
   @Nullable


### PR DESCRIPTION
- Store program updates for each peer in a separate TMS topic. This ensures that we don't lose updates if the peer becomes unreachable.
- Delete peer specific TMS topics when tethering is deleted.