### PR TITLE
feat(CDAP-20243): Add repository config CRUD API 

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -72,6 +72,7 @@ import io.cdap.cdap.gateway.handlers.ProfileHttpHandler;
 import io.cdap.cdap.gateway.handlers.ProgramLifecycleHttpHandler;
 import io.cdap.cdap.gateway.handlers.ProgramLifecycleHttpHandlerInternal;
 import io.cdap.cdap.gateway.handlers.ProvisionerHttpHandler;
+import io.cdap.cdap.gateway.handlers.SourceControlManagementHttpHandler;
 import io.cdap.cdap.gateway.handlers.TransactionHttpHandler;
 import io.cdap.cdap.gateway.handlers.UsageHandler;
 import io.cdap.cdap.gateway.handlers.VersionHandler;
@@ -400,6 +401,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       handlerBinder.addBinding().to(UsageHandler.class);
       handlerBinder.addBinding().to(InstanceOperationHttpHandler.class);
       handlerBinder.addBinding().to(NamespaceHttpHandler.class);
+      handlerBinder.addBinding().to(SourceControlManagementHttpHandler.class);
       handlerBinder.addBinding().to(AppLifecycleHttpHandler.class);
       handlerBinder.addBinding().to(AppLifecycleHttpHandlerInternal.class);
       handlerBinder.addBinding().to(ProgramLifecycleHttpHandler.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -79,7 +79,6 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     responder.sendJson(HttpResponseStatus.OK, GSON.toJson(ns));
   }
 
-
   @PUT
   @Path("/namespaces/{namespace-id}/properties")
   @AuditPolicy(AuditDetail.REQUEST_BODY)

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/SourceControlManagementHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/SourceControlManagementHttpHandler.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.security.AuditDetail;
+import io.cdap.cdap.common.security.AuditPolicy;
+import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import io.cdap.cdap.internal.app.services.SourceControlManagementService;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.sourcecontrol.InvalidRepositoryConfigException;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigRequest;
+import io.cdap.cdap.proto.sourcecontrol.SetRepositoryResponse;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * {@link io.cdap.http.HttpHandler} for source control management.
+ */
+@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}/repository")
+public class SourceControlManagementHttpHandler extends AbstractAppFabricHttpHandler {
+  private final SourceControlManagementService sourceControlService;
+  private static final Gson GSON = new Gson();
+
+  @Inject
+  SourceControlManagementHttpHandler(SourceControlManagementService sourceControlService) {
+    this.sourceControlService = sourceControlService;
+  }
+
+  @PUT
+  @Path("/")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void setRepository(FullHttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId) throws Exception {
+    NamespaceId namespace = validateNamespaceId(namespaceId);
+    RepositoryConfigRequest repoRequest = getRepositoryConfigRequest(request);
+
+    if (repoRequest == null || repoRequest.getRepository() == null) {
+      responder.sendJson(HttpResponseStatus.BAD_REQUEST,
+                         GSON.toJson(new SetRepositoryResponse("Repository configuration cannot be null.")));
+    }
+
+    if (repoRequest.shouldTest()) {
+      // TODO: CDAP-20252, add the validate logic once the SourceControlManager module is ready
+    }
+
+    try {
+      repoRequest.getRepository().validate();
+    } catch (InvalidRepositoryConfigException e) {
+      responder.sendJson(HttpResponseStatus.BAD_REQUEST, GSON.toJson(new SetRepositoryResponse(e)));
+    }
+
+    sourceControlService.setRepository(namespace, repoRequest.getRepository());
+    responder.sendJson(HttpResponseStatus.OK,
+                       GSON.toJson(
+                         new SetRepositoryResponse(
+                           String.format("Updated repository configuration for namespace '%s'.", namespaceId))));
+  }
+
+  @GET
+  @Path("/")
+  public void getRepository(FullHttpRequest request, HttpResponder responder,
+                            @PathParam("namespace-id") String namespaceId) throws Exception {
+    NamespaceId namespace = validateNamespaceId(namespaceId);
+    RepositoryConfig repository = sourceControlService.getRepository(namespace);
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(repository));
+  }
+
+  @DELETE
+  @Path("/")
+  public void deleteRepository(FullHttpRequest request, HttpResponder responder,
+                               @PathParam("namespace-id") String namespaceId) throws Exception {
+    sourceControlService.deleteRepository(validateNamespaceId(namespaceId));
+    responder.sendString(HttpResponseStatus.OK, String.format("Deleted repository configuration for namespace '%s'.",
+                                                              namespaceId));
+  }
+
+  private NamespaceId validateNamespaceId(String namespaceId) throws BadRequestException {
+    try {
+      return new NamespaceId(namespaceId);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e.getMessage(), e);
+    }
+  }
+
+  private RepositoryConfigRequest getRepositoryConfigRequest(FullHttpRequest request) throws BadRequestException {
+    try {
+      return parseBody(request, RepositoryConfigRequest.class);
+    } catch (JsonSyntaxException e) {
+      throw new BadRequestException("Invalid request body: " + e.getMessage(), e);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/namespace/DefaultNamespaceResourceDeleter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/namespace/DefaultNamespaceResourceDeleter.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.config.PreferencesService;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
+import io.cdap.cdap.internal.app.services.SourceControlManagementService;
 import io.cdap.cdap.internal.profile.ProfileService;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.proto.NamespaceMeta;
@@ -53,6 +54,7 @@ public class DefaultNamespaceResourceDeleter implements NamespaceResourceDeleter
   private final DatasetFramework dsFramework;
   private final MetricsSystemClient metricsSystemClient;
   private final ApplicationLifecycleService applicationLifecycleService;
+  private final SourceControlManagementService sourceControlService;
   private final ArtifactRepository artifactRepository;
   private final StorageProviderNamespaceAdmin storageProviderNamespaceAdmin;
   private final MessagingService messagingService;
@@ -63,6 +65,7 @@ public class DefaultNamespaceResourceDeleter implements NamespaceResourceDeleter
                                   DatasetFramework dsFramework,
                                   MetricsSystemClient metricsSystemClient,
                                   ApplicationLifecycleService applicationLifecycleService,
+                                  SourceControlManagementService sourceControlService,
                                   ArtifactRepository artifactRepository,
                                   StorageProviderNamespaceAdmin storageProviderNamespaceAdmin,
                                   MessagingService messagingService, ProfileService profileService) {
@@ -72,6 +75,7 @@ public class DefaultNamespaceResourceDeleter implements NamespaceResourceDeleter
     this.dsFramework = dsFramework;
     this.metricsSystemClient = metricsSystemClient;
     this.applicationLifecycleService = applicationLifecycleService;
+    this.sourceControlService = sourceControlService;
     this.artifactRepository = artifactRepository;
     this.storageProviderNamespaceAdmin = storageProviderNamespaceAdmin;
     this.messagingService = messagingService;
@@ -84,6 +88,8 @@ public class DefaultNamespaceResourceDeleter implements NamespaceResourceDeleter
 
     // Delete Preferences associated with this namespace
     preferencesService.deleteProperties(namespaceId);
+    // Delete Source Control repository configuration
+    sourceControlService.deleteRepository(namespaceId);
     // Delete all applications
     applicationLifecycleService.removeAll(namespaceId);
     // Delete datasets and modules

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.NamespaceNotFoundException;
+import io.cdap.cdap.common.RepositoryNotFoundException;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.proto.sourcecontrol.InvalidRepositoryConfigException;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
+import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
+import io.cdap.cdap.spi.data.StructuredTableContext;
+import io.cdap.cdap.spi.data.TableNotFoundException;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import io.cdap.cdap.store.NamespaceTable;
+import io.cdap.cdap.store.RepositoryTable;
+
+/**
+ * Service that manages source control for repositories and applications.
+ * It exposes repository CRUD apis and source control tasks that do pull/pull/list applications in linked repository.
+ */
+public class SourceControlManagementService {
+
+  private final AccessEnforcer accessEnforcer;
+  private final AuthenticationContext authenticationContext;
+  private final TransactionRunner transactionRunner;
+
+  @Inject
+  public SourceControlManagementService(TransactionRunner transactionRunner,
+                                        AccessEnforcer accessEnforcer,
+                                        AuthenticationContext authenticationContext) {
+    this.transactionRunner = transactionRunner;
+    this.accessEnforcer = accessEnforcer;
+    this.authenticationContext = authenticationContext;
+  }
+
+  private RepositoryTable getRepositoryTable(StructuredTableContext context) throws TableNotFoundException {
+    return new RepositoryTable(context);
+  }
+
+  private NamespaceTable getNamespaceTable(StructuredTableContext context) throws TableNotFoundException {
+    return new NamespaceTable(context);
+  }
+
+  public void setRepository(NamespaceId namespace, RepositoryConfig repository)
+    throws NamespaceNotFoundException, InvalidRepositoryConfigException {
+    accessEnforcer.enforce(namespace, authenticationContext.getPrincipal(), StandardPermission.UPDATE);
+
+    TransactionRunners.run(transactionRunner, context -> {
+      NamespaceTable nsTable = getNamespaceTable(context);
+      if (nsTable.get(namespace) == null) {
+        throw new NamespaceNotFoundException(namespace);
+      }
+
+      RepositoryTable repoTable = getRepositoryTable(context);
+      repoTable.create(namespace, repository);
+    }, NamespaceNotFoundException.class);
+  }
+
+  public void deleteRepository(NamespaceId namespace) {
+    accessEnforcer.enforce(namespace, authenticationContext.getPrincipal(), StandardPermission.DELETE);
+    
+    TransactionRunners.run(transactionRunner, context -> {
+      RepositoryTable repoTable = getRepositoryTable(context);
+      repoTable.delete(namespace);
+    });
+  }
+
+  public RepositoryConfig getRepository(NamespaceId namespace) throws RepositoryNotFoundException {
+    accessEnforcer.enforce(namespace, authenticationContext.getPrincipal(), StandardPermission.GET);
+    
+    return TransactionRunners.run(transactionRunner, context -> {
+      RepositoryTable table = getRepositoryTable(context);
+      RepositoryConfig repository = table.get(namespace);
+      if (repository == null) {
+        throw new RepositoryNotFoundException(namespace);
+      }
+
+      return repository;
+    }, RepositoryNotFoundException.class);
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SourceControlManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SourceControlManagementServiceTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services;
+
+import io.cdap.cdap.common.NamespaceNotFoundException;
+import io.cdap.cdap.common.RepositoryNotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.namespace.NamespaceAdmin;
+import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.sourcecontrol.AuthType;
+import io.cdap.cdap.proto.sourcecontrol.Provider;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class SourceControlManagementServiceTest extends AppFabricTestBase {
+  private static CConfiguration cConf;
+  private static NamespaceAdmin namespaceAdmin;
+  private static SourceControlManagementService sourceControlService;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    cConf = createBasicCConf();
+    initializeAndStartServices(cConf);
+    namespaceAdmin = getInjector().getInstance(NamespaceAdmin.class);
+    sourceControlService = getInjector().getInstance(SourceControlManagementService.class);
+  }
+
+
+  @Test
+  public void testSetRepoConfig() throws Exception {
+    String namespace = "custompaceNamespace";
+    NamespaceId namespaceId = new NamespaceId(namespace);
+    RepositoryConfig namespaceRepo = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
+      .setLink("example.com").setDefaultBranch("develop").setAuthType(AuthType.PAT)
+      .setTokenName("token").setUsername("user").build();
+    
+    try {
+      sourceControlService.setRepository(namespaceId, namespaceRepo);
+      Assert.fail();
+    } catch (NamespaceNotFoundException e) {
+      // no-op
+      // Setting repository will fail since the namespace does not exist
+    }
+
+    // Create namespace and repository should succeed
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespace).build());
+    sourceControlService.setRepository(namespaceId, namespaceRepo);
+    Assert.assertEquals(namespaceRepo, sourceControlService.getRepository(namespaceId));
+
+    RepositoryConfig newRepositoryConfig = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
+      .setLink("another.example.com").setDefaultBranch("master").setAuthType(AuthType.PAT)
+      .setTokenName("another.token").setUsername("another.user").build();
+    sourceControlService.setRepository(namespaceId, newRepositoryConfig);
+
+    // Verify repository updated
+    Assert.assertEquals(newRepositoryConfig, sourceControlService.getRepository(namespaceId));
+
+    //clean up
+    namespaceAdmin.delete(namespaceId);
+
+    try {
+      sourceControlService.getRepository(namespaceId);
+      Assert.fail();
+    } catch (RepositoryNotFoundException e) {
+      // no-op
+    }
+  }
+
+  @Test
+  public void testDeleteRepoConfig() throws Exception {
+    String namespace = "custompaceNamespace";
+    NamespaceId namespaceId = new NamespaceId(namespace);
+    RepositoryConfig namespaceRepo = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
+      .setLink("example.com").setDefaultBranch("develop").setAuthType(AuthType.PAT)
+      .setTokenName("token").setUsername("user").build();
+    try {
+      sourceControlService.setRepository(namespaceId, namespaceRepo);
+      Assert.fail();
+    } catch (NamespaceNotFoundException e) {
+      // no-op
+      // Setting repository will fail since the namespace does not exist
+    }
+
+    // Create namespace and repository should succeed
+    namespaceAdmin.create(new NamespaceMeta.Builder().setName(namespace).build());
+    sourceControlService.setRepository(namespaceId, namespaceRepo);
+    
+    Assert.assertEquals(namespaceRepo, sourceControlService.getRepository(namespaceId));
+
+    // Delete repository and verify it's deleted
+    sourceControlService.deleteRepository(namespaceId);
+    
+    try {
+      sourceControlService.getRepository(namespaceId);
+      Assert.fail();
+    } catch (RepositoryNotFoundException e) {
+      // no-op
+    }
+
+    //clean up
+    namespaceAdmin.delete(namespaceId);
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -1452,6 +1452,19 @@ public abstract class AppFabricTestBase {
                  GSON.toJson(meta));
   }
 
+  protected HttpResponse setRepository(String id, String repoString) throws Exception {
+    return doPut(String.format("%s/namespaces/%s/repository", Constants.Gateway.API_VERSION_3, id), repoString);
+  }
+
+  protected HttpResponse getRepository(String name) throws Exception {
+    Preconditions.checkArgument(name != null, "namespace name cannot be null");
+    return doGet(String.format("%s/namespaces/%s/repository", Constants.Gateway.API_VERSION_3, name));
+  }
+
+  protected HttpResponse deleteRepository(String name) throws Exception {
+    return doDelete(String.format("%s/namespaces/%s/repository", Constants.Gateway.API_VERSION_3, name));
+  }
+
   protected String getPreferenceURI() {
     return "";
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/SourceControlManagementHttpHandlerTests.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/SourceControlManagementHttpHandlerTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services.http.handlers;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.gateway.handlers.SourceControlManagementHttpHandler;
+import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.proto.sourcecontrol.AuthType;
+import io.cdap.cdap.proto.sourcecontrol.Provider;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigRequest;
+import io.cdap.common.http.HttpResponse;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link SourceControlManagementHttpHandler}
+ */
+public class SourceControlManagementHttpHandlerTests extends AppFabricTestBase {
+  
+  private static final String NAME = "test";
+  private static final Gson GSON = new Gson();
+
+  private void assertResponseCode(int expected, HttpResponse response) {
+    Assert.assertEquals(expected, response.getResponseCode());
+  }
+
+  private RepositoryConfig readGetRepositoryResponse(HttpResponse response) {
+    return readResponse(response, RepositoryConfig.class);
+  }
+
+  @Test
+  public void testNamespaceRepository() throws Exception {
+    // verify the repository does not exist at the beginning
+    HttpResponse response = getRepository(NAME);
+    assertResponseCode(404, response);
+
+    // Set repository config
+    RepositoryConfig namespaceRepo = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
+      .setLink("example.com").setDefaultBranch("develop").setAuthType(AuthType.PAT)
+      .setTokenName("token").setUsername("user").build();
+
+    // Assert the namespace does not exist
+    response = setRepository(NAME, createRepoRequestString(namespaceRepo));
+    assertResponseCode(404, response);
+
+    // Create the NS
+    assertResponseCode(200, createNamespace(NAME));
+
+    // Set and verify the repository
+    response = setRepository(NAME, createRepoRequestString(namespaceRepo));
+    assertResponseCode(200, response);
+
+    response = getRepository(NAME);
+    RepositoryConfig repository = readGetRepositoryResponse(response);
+    Assert.assertEquals(namespaceRepo, repository);
+
+    RepositoryConfig newRepoConfig = new RepositoryConfig.Builder(namespaceRepo)
+      .setTokenName("a new token name")
+      .setLink("a new link").build();
+    
+    response = setRepository(NAME, createRepoRequestString(newRepoConfig));
+    assertResponseCode(200, response);
+    response = getRepository(NAME);
+    repository = readGetRepositoryResponse(response);
+
+    // verify that the repo config has been updated
+    Assert.assertEquals(newRepoConfig, repository);
+
+    // Delete the repository
+    assertResponseCode(200, deleteRepository(NAME));
+    assertResponseCode(404, getRepository(NAME));
+
+    // cleanup
+    response = deleteNamespace(NAME);
+    assertResponseCode(200, response);
+  }
+
+  private String createRepoRequestString(RepositoryConfig namespaceRepo) {
+    return GSON.toJson(new RepositoryConfigRequest(namespaceRepo));
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/RepositoryNotFoundException.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/RepositoryNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2019 Cask Data, Inc.
+ * Copyright © 2023 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,12 +14,23 @@
  * the License.
  */
 
+package io.cdap.cdap.common;
 
-package io.cdap.cdap.gateway.router;
+import io.cdap.cdap.proto.id.NamespaceId;
 
 /**
- * Expected number of paths annotated with {@link io.cdap.cdap.common.security.AuditPolicy}
+ * Thrown when a namespace repository configuration is not found in CDAP.
  */
-public final class ExpectedNumberOfAuditPolicyPaths {
-  public static final int EXPECTED_PATH_NUMBER = 46;
+public class RepositoryNotFoundException extends NotFoundException  {
+
+  private final NamespaceId namespace;
+
+  public RepositoryNotFoundException(NamespaceId id) {
+    super(String.format("The repository configuration of namespace %s is not found.", id));
+    this.namespace = id;
+  }
+
+  public NamespaceId getNamespace() {
+    return namespace;
+  }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/RepositoryTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/RepositoryTable.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.store;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+import io.cdap.cdap.spi.data.StructuredRow;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.StructuredTableContext;
+import io.cdap.cdap.spi.data.TableNotFoundException;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.Fields;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * Dataset for namespace repository. It does not wrap its operations in a transaction.
+ * It is up to the caller to decide what operations belong in a transaction.
+ */
+public class RepositoryTable {
+  private static final Gson GSON = new Gson();
+
+  private final StructuredTable table;
+
+  public RepositoryTable(StructuredTableContext context) throws TableNotFoundException {
+    this.table = context.getTable(StoreDefinition.NamespaceStore.REPOSITORIES);
+  }
+
+  /**
+   * Create the repository configuration
+   *
+   * @param id the namespace id
+   * @param config the source control repository configuration for the namespace
+   */
+  public void create(NamespaceId id, RepositoryConfig config) throws IOException {
+    Field<String> namespaceField = Fields.stringField(StoreDefinition.NamespaceStore.NAMESPACE_FIELD,
+                                                      id.getNamespace());
+    Field<String> configField = Fields.stringField(StoreDefinition.NamespaceStore.REPOSITORY_CONFIGURATION_FIELD,
+                                                   GSON.toJson(config));
+    table.upsert(Arrays.asList(namespaceField, configField));
+  }
+
+  /**
+   *
+   * @param id the namespace id
+   * @return {@link RepositoryConfig} the repository configuration
+   */
+  @Nullable
+  public RepositoryConfig get(NamespaceId id) throws IOException {
+    return table.read(Collections.singleton(Fields.stringField(StoreDefinition.NamespaceStore.NAMESPACE_FIELD,
+                                                               id.getEntityName())))
+      .map(this::getRepositoryConfig)
+      .orElse(null);
+  }
+
+  /**
+   * Delete the repository configuration for this namespace
+   *
+   * @param id id of the namespace
+   */
+  public void delete(NamespaceId id) throws IOException {
+    table.delete(Collections.singleton(Fields.stringField(StoreDefinition.NamespaceStore.NAMESPACE_FIELD,
+                                                          id.getEntityName())));
+  }
+
+  @Nullable
+  private RepositoryConfig getRepositoryConfig(StructuredRow row) {
+    return Optional.ofNullable(row.getString(StoreDefinition.NamespaceStore.REPOSITORY_CONFIGURATION_FIELD))
+      .map(field -> GSON.fromJson(field, RepositoryConfig.class))
+      .orElse(null);
+  }
+}

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
@@ -91,9 +91,11 @@ public final class StoreDefinition {
    */
   public static final class NamespaceStore {
     public static final StructuredTableId NAMESPACES = new StructuredTableId("namespaces");
+    public static final StructuredTableId REPOSITORIES = new StructuredTableId("repositories");
 
     public static final String NAMESPACE_FIELD = "namespace";
     public static final String NAMESPACE_METADATA_FIELD = "namespace_metadata";
+    public static final String REPOSITORY_CONFIGURATION_FIELD = "config";
 
     public static final StructuredTableSpecification NAMESPACE_TABLE_SPEC =
       new StructuredTableSpecification.Builder()
@@ -103,8 +105,17 @@ public final class StoreDefinition {
         .withPrimaryKeys(NAMESPACE_FIELD)
         .build();
 
+    public static final StructuredTableSpecification REPOSITORY_TABLE_SPEC =
+      new StructuredTableSpecification.Builder()
+        .withId(REPOSITORIES)
+        .withFields(Fields.stringType(NAMESPACE_FIELD),
+                    Fields.stringType(REPOSITORY_CONFIGURATION_FIELD))
+        .withPrimaryKeys(NAMESPACE_FIELD)
+        .build();
+
     public static void create(StructuredTableAdmin tableAdmin) throws IOException {
       createIfNotExists(tableAdmin, NAMESPACE_TABLE_SPEC);
+      createIfNotExists(tableAdmin, REPOSITORY_TABLE_SPEC);
     }
   }
 

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/AuthConfig.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/AuthConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.sourcecontrol;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Auth Configuration for the linked repository
+ */
+public class AuthConfig {
+  private final AuthType type;
+  private final String tokenName;
+  private final String username;
+
+  public AuthConfig(AuthType authType, String tokenName, @Nullable String username) {
+    this.type = authType;
+    this.tokenName = tokenName;
+    this.username = username;
+  }
+
+  public AuthType getType() {
+    return type;
+  }
+
+  public String getTokenName() {
+    return tokenName;
+  }
+
+  @Nullable
+  public String getUsername() {
+    return username;
+  }
+
+  public boolean isValid() {
+    return type != null && tokenName != null;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AuthConfig that = (AuthConfig) o;
+    return Objects.equals(type, that.type) &&
+      Objects.equals(tokenName, that.tokenName) &&
+      Objects.equals(username, that.username);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, tokenName, username);
+  }
+
+  @Override
+  public String toString() {
+    return "Auth{" +
+      "type=" + type +
+      ", tokenName=" + tokenName +
+      ", username=" + username +
+      '}';
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/AuthType.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/AuthType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2019 Cask Data, Inc.
+ * Copyright © 2023 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,12 +14,11 @@
  * the License.
  */
 
-
-package io.cdap.cdap.gateway.router;
+package io.cdap.cdap.proto.sourcecontrol;
 
 /**
- * Expected number of paths annotated with {@link io.cdap.cdap.common.security.AuditPolicy}
+ * Auth Type Enums.
  */
-public final class ExpectedNumberOfAuditPolicyPaths {
-  public static final int EXPECTED_PATH_NUMBER = 46;
+public enum AuthType {
+  PAT;
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/InvalidRepositoryConfigException.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/InvalidRepositoryConfigException.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.sourcecontrol;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Throw an exception when the RepositoryConfig is invalid.
+ */
+public class InvalidRepositoryConfigException extends RuntimeException {
+  private final List<RepositoryValidationFailure> failures;
+
+  public InvalidRepositoryConfigException(Collection<RepositoryValidationFailure> failures) {
+    super(generateMessage(failures));
+    this.failures = Collections.unmodifiableList(new ArrayList<>(failures));
+  }
+
+  public InvalidRepositoryConfigException(String message) {
+    super(message);
+    this.failures = Collections.unmodifiableList(new ArrayList<>());
+  }
+
+  /**
+   * Returns a list of repository validation failures.
+   */
+  public List<RepositoryValidationFailure> getFailures() {
+    return failures;
+  }
+
+  private static String generateMessage(Collection<RepositoryValidationFailure> failures) {
+    String errorMessage = failures.isEmpty() ? "" : failures.iterator().next().getMessage();
+    
+    return String.format("Errors while validating repository configuration: %s", errorMessage);
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/Provider.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/Provider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2019 Cask Data, Inc.
+ * Copyright © 2023 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,12 +14,11 @@
  * the License.
  */
 
-
-package io.cdap.cdap.gateway.router;
+package io.cdap.cdap.proto.sourcecontrol;
 
 /**
- * Expected number of paths annotated with {@link io.cdap.cdap.common.security.AuditPolicy}
+ * The Provider Enum.
  */
-public final class ExpectedNumberOfAuditPolicyPaths {
-  public static final int EXPECTED_PATH_NUMBER = 46;
+public enum Provider {
+  GITHUB;
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfig.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfig.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.sourcecontrol;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Represents the repository configuration of a namespace. This class needs to be GSON serializable.
+ */
+public class RepositoryConfig {
+  private final Provider provider;
+  private final String link;
+  private final String defaultBranch;
+  private final String pathPrefix;
+  private final AuthConfig auth;
+
+  private RepositoryConfig(Provider provider, String link, String defaultBranch, AuthConfig authConfig,
+                           @Nullable String pathPrefix) {
+    this.provider = provider;
+    this.link = link;
+    this.defaultBranch = defaultBranch;
+    this.auth = authConfig;
+    this.pathPrefix = pathPrefix;
+  }
+
+  public Provider getProvider() {
+    return provider;
+  }
+
+  public String getLink() {
+    return link;
+  }
+
+  public String getDefaultBranch() {
+    return defaultBranch;
+  }
+  
+  @Nullable
+  public String getPathPrefix() {
+    return pathPrefix;
+  }
+
+  public AuthConfig getAuth() {
+    return auth;
+  }
+
+  public void validate() {
+    Collection<RepositoryValidationFailure> failures = new ArrayList<>();
+
+    if (provider == null) {
+      failures.add(new RepositoryValidationFailure("'provider' field cannot be null."));
+    }
+
+    if (link == null) {
+      failures.add(new RepositoryValidationFailure("'link' field cannot be null."));
+    }
+
+    if (defaultBranch == null) {
+      failures.add(new RepositoryValidationFailure("'defaultBranch' field cannot be null."));
+    }
+
+    if (auth == null) {
+      failures.add(new RepositoryValidationFailure("'auth' field cannot be null."));
+    } else if (!auth.isValid()) {
+      failures.add(new RepositoryValidationFailure("'type' and 'tokenName' field in 'auth' object cannot be null."));
+    }
+
+    if (!failures.isEmpty()) {
+      throw new InvalidRepositoryConfigException(failures);
+    }
+  }
+
+  /**
+   * Builder used to build {@link RepositoryConfig}
+   */
+  public static final class Builder {
+    private Provider provider;
+    private String link;
+    private String defaultBranch;
+    private String pathPrefix;
+    private AuthType authType;
+    private String tokenName;
+    private String username;
+
+    public Builder() {
+      // no-op
+    }
+
+    public Builder(RepositoryConfig repoConfig) {
+      this.provider = repoConfig.getProvider();
+      this.link = repoConfig.getLink();
+      this.defaultBranch = repoConfig.getDefaultBranch();
+      this.pathPrefix = repoConfig.getPathPrefix();
+      if (repoConfig.getAuth() != null) {
+        this.authType = repoConfig.getAuth().getType();
+        this.tokenName = repoConfig.getAuth().getTokenName();
+        this.username = repoConfig.getAuth().getUsername();
+      }
+    }
+
+    public Builder setProvider(Provider provider) {
+      this.provider = provider;
+      return this;
+    }
+
+    public Builder setLink(String link) {
+      this.link = link;
+      return this;
+    }
+
+    public Builder setDefaultBranch(String defaultBranch) {
+      this.defaultBranch = defaultBranch;
+      return this;
+    }
+
+    public Builder setPathPrefix(String pathPrefix) {
+      this.pathPrefix = pathPrefix;
+      return this;
+    }
+
+    public Builder setAuthType(AuthType authType) {
+      this.authType = authType;
+      return this;
+    }
+
+    public Builder setTokenName(String tokenName) {
+      this.tokenName = tokenName;
+      return this;
+    }
+    
+    public Builder setUsername(String username) {
+      this.username = username;
+      return this;
+    }
+
+    public RepositoryConfig build() {
+      RepositoryConfig repoConfig = new RepositoryConfig(provider, link, defaultBranch,
+                                                         new AuthConfig(authType, tokenName, username), pathPrefix);
+      repoConfig.validate();
+      return repoConfig;
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RepositoryConfig that = (RepositoryConfig) o;
+    return Objects.equals(provider, that.provider) &&
+      Objects.equals(link, that.link) &&
+      Objects.equals(defaultBranch, that.defaultBranch) &&
+      Objects.equals(auth, that.auth) &&
+      Objects.equals(pathPrefix, that.pathPrefix);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(provider, link, defaultBranch, auth, pathPrefix);
+  }
+
+  @Override
+  public String toString() {
+    return "RepositoryConfig{" +
+      "provider=" + provider +
+      ", link=" + link +
+      ", defaultBranch=" + defaultBranch +
+      ", auth=" + auth +
+      ", pathPrefix=" + pathPrefix +
+      '}';
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfigRequest.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfigRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.sourcecontrol;
+
+/**
+ * The request class to set or test repository configuration.
+ */
+public class RepositoryConfigRequest {
+  private final boolean test;
+  private final RepositoryConfig repository;
+
+  public RepositoryConfigRequest(RepositoryConfig repository, boolean validate) {
+    this.repository = repository;
+    this.test = validate;
+  }
+
+  public RepositoryConfigRequest(RepositoryConfig repository) {
+    this.repository = repository;
+    this.test = false;
+  }
+
+  public boolean shouldTest() {
+    return test;
+  }
+
+  public RepositoryConfig getRepository() {
+    return repository;
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RepositoryValidationFailure.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RepositoryValidationFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2017-2019 Cask Data, Inc.
+ * Copyright © 2023 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,12 +14,19 @@
  * the License.
  */
 
-
-package io.cdap.cdap.gateway.router;
+package io.cdap.cdap.proto.sourcecontrol;
 
 /**
- * Expected number of paths annotated with {@link io.cdap.cdap.common.security.AuditPolicy}
+ * Class that handles Repository Configuration validation failure.
  */
-public final class ExpectedNumberOfAuditPolicyPaths {
-  public static final int EXPECTED_PATH_NUMBER = 46;
+public class RepositoryValidationFailure {
+  private final String message;
+
+  public RepositoryValidationFailure(String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/SetRepositoryResponse.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/SetRepositoryResponse.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.sourcecontrol;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * The HTTP Response class for setting repository configuration.
+ */
+public class SetRepositoryResponse {
+  private final Collection<RepositoryValidationFailure> errors;
+  private final String message;
+
+  public SetRepositoryResponse(InvalidRepositoryConfigException e) {
+    this.errors = Collections.unmodifiableList(new ArrayList<>(e.getFailures()));
+    this.message = e.getMessage();
+  }
+
+  public SetRepositoryResponse(String message) {
+    this.errors = Collections.unmodifiableList(new ArrayList<>());
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public Collection<RepositoryValidationFailure> getErrors() {
+    return errors;
+  }
+}

--- a/cdap-proto/src/test/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfigTest.java
+++ b/cdap-proto/src/test/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfigTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.sourcecontrol;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for RepositoryConfig class
+ */
+public class RepositoryConfigTest {
+  private static final Provider PROVIDER = Provider.GITHUB;
+  private static final String LINK = "example.com";
+  private static final String DEFAULT_BRANCH = "develop";
+  private static final AuthType AUTH_TYPE = AuthType.PAT;
+  private static final String TOKEN_NAME = "token";
+  private static final String USERNAME = "user";
+
+
+  @Test
+  public void testValidRepositoryConfig() {
+    RepositoryConfig repo = new RepositoryConfig.Builder().setProvider(PROVIDER)
+      .setLink(LINK).setDefaultBranch(DEFAULT_BRANCH).setAuthType(AUTH_TYPE)
+      .setTokenName(TOKEN_NAME).setUsername(USERNAME).build();
+
+    Assert.assertEquals(PROVIDER, repo.getProvider());
+    Assert.assertEquals(LINK, repo.getLink());
+    Assert.assertEquals(DEFAULT_BRANCH, repo.getDefaultBranch());
+    Assert.assertEquals(AUTH_TYPE, repo.getAuth().getType());
+    Assert.assertEquals(TOKEN_NAME, repo.getAuth().getTokenName());
+    Assert.assertEquals(USERNAME, repo.getAuth().getUsername());
+  }
+
+  @Test
+  public void testInvalidProvider() {
+
+    try {
+      new RepositoryConfig.Builder().setProvider(null)
+        .setLink(LINK).setDefaultBranch(DEFAULT_BRANCH).setAuthType(AUTH_TYPE)
+        .setTokenName(TOKEN_NAME).setUsername(USERNAME).build();
+      Assert.fail();
+    } catch (InvalidRepositoryConfigException e) {
+      Assert.assertEquals(1, e.getFailures().size());
+      Assert.assertEquals("'provider' field cannot be null.",
+                          e.getFailures().get(0).getMessage());
+    }
+  }
+
+  @Test
+  public void testInvalidLink() {
+
+    try {
+      new RepositoryConfig.Builder().setProvider(PROVIDER)
+        .setLink(null).setDefaultBranch(DEFAULT_BRANCH).setAuthType(AUTH_TYPE)
+        .setTokenName(TOKEN_NAME).setUsername(USERNAME).build();
+      Assert.fail();
+    } catch (InvalidRepositoryConfigException e) {
+      Assert.assertEquals(1, e.getFailures().size());
+      Assert.assertEquals("'link' field cannot be null.",
+                          e.getFailures().get(0).getMessage());
+    }
+  }
+
+  @Test
+  public void testInvalidDefaultBranch() {
+
+    try {
+      new RepositoryConfig.Builder().setProvider(PROVIDER)
+        .setLink(LINK).setDefaultBranch(null).setAuthType(AUTH_TYPE)
+        .setTokenName(TOKEN_NAME).setUsername(USERNAME).build();
+      Assert.fail();
+    } catch (InvalidRepositoryConfigException e) {
+      Assert.assertEquals(1, e.getFailures().size());
+      Assert.assertEquals("'defaultBranch' field cannot be null.",
+                          e.getFailures().get(0).getMessage());
+    }
+  }
+
+  @Test
+  public void testInvalidAuthType() {
+
+    try {
+      new RepositoryConfig.Builder().setProvider(PROVIDER)
+        .setLink(LINK).setDefaultBranch(DEFAULT_BRANCH).setAuthType(null)
+        .setTokenName(TOKEN_NAME).setUsername(USERNAME).build();
+      Assert.fail();
+    } catch (InvalidRepositoryConfigException e) {
+      Assert.assertEquals(1, e.getFailures().size());
+      Assert.assertEquals("'type' and 'tokenName' field in 'auth' object cannot be null.",
+                          e.getFailures().get(0).getMessage());
+    }
+  }
+
+  @Test
+  public void testInvalidTokenName() {
+
+    try {
+      new RepositoryConfig.Builder().setProvider(PROVIDER)
+        .setLink(LINK).setDefaultBranch(DEFAULT_BRANCH).setAuthType(AUTH_TYPE)
+        .setTokenName(null).setUsername(USERNAME).build();
+      Assert.fail();
+    } catch (InvalidRepositoryConfigException e) {
+      Assert.assertEquals(1, e.getFailures().size());
+      Assert.assertEquals("'type' and 'tokenName' field in 'auth' object cannot be null.",
+                          e.getFailures().get(0).getMessage());
+    }
+  }
+
+  @Test
+  public void testMultipleInvalidFields() {
+
+    try {
+      new RepositoryConfig.Builder().setProvider(null)
+        .setLink(null).setDefaultBranch(DEFAULT_BRANCH).setAuthType(null)
+        .setTokenName(TOKEN_NAME).setUsername(USERNAME).build();
+      Assert.fail();
+    } catch (InvalidRepositoryConfigException e) {
+      Assert.assertEquals(3, e.getFailures().size());
+    }
+  }
+}


### PR DESCRIPTION
WHAT:
1. Add `repositories` table to store SCM repository configuration
2. Add `PUT/GET/DELETE  /namespaces/{namespace-id}/repository` CRUD APIs in SourceControlHttpHandler

Example request body of `PUT /namespaces/{namespace-id}/repository `:
```
{
  "provider": "GITHUB",
  "link": "example.com",
  "defaultBranch": "develop",
  "pathPrefix": "testnamespace/",
  "auth": {
    "type": "PAT",
    "tokenName": "testnamespace.source.control.management.access.token.SOMETOKEN",
    "username": "user"
  }
}
```
