### PR TITLE
[CDAP-19500] add retries for macro evaluation and correctly close the client

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java
@@ -109,6 +109,9 @@ abstract class AbstractServiceRetryableMacroEvaluator implements MacroEvaluator 
     validateResponseCode(serviceName, urlConn);
     try (Reader reader = new InputStreamReader(urlConn.getInputStream(), StandardCharsets.UTF_8)) {
       return CharStreams.toString(reader);
+    } catch (IOException e) {
+      // IOExceptions are retryable for idempotent operations.
+      throw new RetryableException(e);
     } finally {
       urlConn.disconnect();
     }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -400,6 +400,10 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
     if (client != null) {
       client.close();
     }
+    ClusterControllerClient clusterControllerClient = this.clusterControllerClient;
+    if (clusterControllerClient != null) {
+      clusterControllerClient.close();
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes:
```
Caused by: java.net.SocketTimeoutException: Read timed out
	at io.cdap.cdap.etl.common.AbstractServiceRetryableMacroEvaluator.validateAndRetrieveContent(AbstractServiceRetryableMacroEvaluator.java:110)
```
```
2023-01-29 07:58:00,734 - ERROR [runtime-scheduler-9:i.g.i.ManagedChannelOrphanWrapper@159] - *~*~*~ Channel ManagedChannelImpl{logId=33, target=us-east1-dataproc.googleapis.com:443} was not shutdown properly!!! ~*~*~*
    Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
java.lang.RuntimeException: ManagedChannel allocation site
	at io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference.<init>(ManagedChannelOrphanWrapper.java:93)
	at io.cdap.cdap.runtime.spi.runtimejob.DataprocRuntimeJobManager.getClusterControllerClient(DataprocRuntimeJobManager.java:227)
```