### PR TITLE
[CDAP-20316] Remove broker.id properties when creating Kafka servers to allow auto-generation of broker IDs

### DIFF
--- a/cdap-common/src/test/java/io/cdap/cdap/common/guice/KafkaClientModuleTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/guice/KafkaClientModuleTest.java
@@ -220,7 +220,6 @@ public class KafkaClientModuleTest {
   private EmbeddedKafkaServer createKafkaServer(String zkConnectStr, File dir) throws Exception {
     // Don't set port, EmbeddedKafkaServer will find a ephemeral port.
     Properties properties = new Properties();
-    properties.setProperty("broker.id", "1");
     properties.setProperty("num.network.threads", "2");
     properties.setProperty("num.io.threads", "2");
     properties.setProperty("socket.send.buffer.bytes", "1048576");

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/kafka/KafkaTester.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/kafka/KafkaTester.java
@@ -191,7 +191,6 @@ public class KafkaTester extends ExternalResource {
 
   private Properties generateKafkaConfig() throws IOException {
     Properties properties = new Properties();
-    properties.setProperty("broker.id", "1");
     properties.setProperty("host.name", InetAddress.getLoopbackAddress().getHostAddress());
     properties.setProperty("port", "0");
     properties.setProperty("num.network.threads", "2");

--- a/cdap-kafka/src/main/java/io/cdap/cdap/kafka/run/KafkaServerMain.java
+++ b/cdap-kafka/src/main/java/io/cdap/cdap/kafka/run/KafkaServerMain.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.kafka.run;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import com.google.common.net.InetAddresses;
 import com.google.common.util.concurrent.Service;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
@@ -111,12 +110,6 @@ public class KafkaServerMain extends DaemonMain {
       }
     }
 
-    if (kafkaProperties.getProperty("broker.id") == null) {
-      int brokerId = generateBrokerId(address);
-      LOG.info(String.format("Initializing server with broker id %d", brokerId));
-      kafkaProperties.setProperty("broker.id", Integer.toString(brokerId));
-    }
-
     if (kafkaProperties.getProperty("zookeeper.connect") == null) {
       kafkaProperties.setProperty("zookeeper.connect", zkConnectStr);
     }
@@ -161,14 +154,5 @@ public class KafkaServerMain extends DaemonMain {
       prop.setProperty(trimmedKey, value);
     }
     return prop;
-  }
-
-  private static int generateBrokerId(InetAddress address) {
-    LOG.info("Generating broker ID with address {}", address);
-    try {
-      return Math.abs(InetAddresses.coerceToInteger(address));
-    } catch (Exception e) {
-      throw Throwables.propagate(e);
-    }
   }
 }


### PR DESCRIPTION
See [CDAP-20316](https://cdap.atlassian.net/browse/CDAP-20316).

[CDAP-20316]: https://cdap.atlassian.net/browse/CDAP-20316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ