### PR TITLE
fix(CDAP-20318): return in the catch block of setRepository, otherwise it still sets the repo wrongly

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/SourceControlManagementHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/SourceControlManagementHttpHandler.java
@@ -74,6 +74,7 @@ public class SourceControlManagementHttpHandler extends AbstractAppFabricHttpHan
       repoRequest.getRepository().validate();
     } catch (InvalidRepositoryConfigException e) {
       responder.sendJson(HttpResponseStatus.BAD_REQUEST, GSON.toJson(new SetRepositoryResponse(e)));
+      return;
     }
 
     sourceControlService.setRepository(namespace, repoRequest.getRepository());

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/AuthConfig.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/AuthConfig.java
@@ -47,7 +47,7 @@ public class AuthConfig {
   }
 
   public boolean isValid() {
-    return type != null && tokenName != null;
+    return type != null && tokenName != null && !tokenName.equals("");
   }
 
   @Override

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfig.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfig.java
@@ -65,21 +65,18 @@ public class RepositoryConfig {
     Collection<RepositoryValidationFailure> failures = new ArrayList<>();
 
     if (provider == null) {
-      failures.add(new RepositoryValidationFailure("'provider' field cannot be null."));
+      failures.add(new RepositoryValidationFailure("'provider' field cannot be null or empty."));
     }
 
-    if (link == null) {
-      failures.add(new RepositoryValidationFailure("'link' field cannot be null."));
-    }
-
-    if (defaultBranch == null) {
-      failures.add(new RepositoryValidationFailure("'defaultBranch' field cannot be null."));
+    if (link == null || link.equals("")) {
+      failures.add(new RepositoryValidationFailure("'link' field cannot be null or empty."));
     }
 
     if (auth == null) {
-      failures.add(new RepositoryValidationFailure("'auth' field cannot be null."));
+      failures.add(new RepositoryValidationFailure("'auth' field cannot be null or empty."));
     } else if (!auth.isValid()) {
-      failures.add(new RepositoryValidationFailure("'type' and 'tokenName' field in 'auth' object cannot be null."));
+      failures.add(new RepositoryValidationFailure("'type' and 'tokenName' field in 'auth' object " +
+                                                     "cannot be null or empty."));
     }
 
     if (!failures.isEmpty()) {

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfigRequest.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfigRequest.java
@@ -23,9 +23,9 @@ public class RepositoryConfigRequest {
   private final boolean test;
   private final RepositoryConfig repository;
 
-  public RepositoryConfigRequest(RepositoryConfig repository, boolean validate) {
+  public RepositoryConfigRequest(RepositoryConfig repository, boolean test) {
     this.repository = repository;
-    this.test = validate;
+    this.test = test;
   }
 
   public RepositoryConfigRequest(RepositoryConfig repository) {

--- a/cdap-proto/src/test/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfigTest.java
+++ b/cdap-proto/src/test/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfigTest.java
@@ -47,7 +47,6 @@ public class RepositoryConfigTest {
 
   @Test
   public void testInvalidProvider() {
-
     try {
       new RepositoryConfig.Builder().setProvider(null)
         .setLink(LINK).setDefaultBranch(DEFAULT_BRANCH).setAuthType(AUTH_TYPE)
@@ -55,14 +54,13 @@ public class RepositoryConfigTest {
       Assert.fail();
     } catch (InvalidRepositoryConfigException e) {
       Assert.assertEquals(1, e.getFailures().size());
-      Assert.assertEquals("'provider' field cannot be null.",
+      Assert.assertEquals("'provider' field cannot be null or empty.",
                           e.getFailures().get(0).getMessage());
     }
   }
 
   @Test
   public void testInvalidLink() {
-
     try {
       new RepositoryConfig.Builder().setProvider(PROVIDER)
         .setLink(null).setDefaultBranch(DEFAULT_BRANCH).setAuthType(AUTH_TYPE)
@@ -70,29 +68,13 @@ public class RepositoryConfigTest {
       Assert.fail();
     } catch (InvalidRepositoryConfigException e) {
       Assert.assertEquals(1, e.getFailures().size());
-      Assert.assertEquals("'link' field cannot be null.",
-                          e.getFailures().get(0).getMessage());
-    }
-  }
-
-  @Test
-  public void testInvalidDefaultBranch() {
-
-    try {
-      new RepositoryConfig.Builder().setProvider(PROVIDER)
-        .setLink(LINK).setDefaultBranch(null).setAuthType(AUTH_TYPE)
-        .setTokenName(TOKEN_NAME).setUsername(USERNAME).build();
-      Assert.fail();
-    } catch (InvalidRepositoryConfigException e) {
-      Assert.assertEquals(1, e.getFailures().size());
-      Assert.assertEquals("'defaultBranch' field cannot be null.",
+      Assert.assertEquals("'link' field cannot be null or empty.",
                           e.getFailures().get(0).getMessage());
     }
   }
 
   @Test
   public void testInvalidAuthType() {
-
     try {
       new RepositoryConfig.Builder().setProvider(PROVIDER)
         .setLink(LINK).setDefaultBranch(DEFAULT_BRANCH).setAuthType(null)
@@ -100,14 +82,13 @@ public class RepositoryConfigTest {
       Assert.fail();
     } catch (InvalidRepositoryConfigException e) {
       Assert.assertEquals(1, e.getFailures().size());
-      Assert.assertEquals("'type' and 'tokenName' field in 'auth' object cannot be null.",
+      Assert.assertEquals("'type' and 'tokenName' field in 'auth' object cannot be null or empty.",
                           e.getFailures().get(0).getMessage());
     }
   }
 
   @Test
   public void testInvalidTokenName() {
-
     try {
       new RepositoryConfig.Builder().setProvider(PROVIDER)
         .setLink(LINK).setDefaultBranch(DEFAULT_BRANCH).setAuthType(AUTH_TYPE)
@@ -115,14 +96,13 @@ public class RepositoryConfigTest {
       Assert.fail();
     } catch (InvalidRepositoryConfigException e) {
       Assert.assertEquals(1, e.getFailures().size());
-      Assert.assertEquals("'type' and 'tokenName' field in 'auth' object cannot be null.",
+      Assert.assertEquals("'type' and 'tokenName' field in 'auth' object cannot be null or empty.",
                           e.getFailures().get(0).getMessage());
     }
   }
 
   @Test
   public void testMultipleInvalidFields() {
-
     try {
       new RepositoryConfig.Builder().setProvider(null)
         .setLink(null).setDefaultBranch(DEFAULT_BRANCH).setAuthType(null)


### PR DESCRIPTION
## What

Should return in the catch block of `InvalidRepositoryConfigException` inside setRepository code