### PR TITLE
Initial GCP Secret Manager Secure Store implementation

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -346,6 +346,12 @@
           <version>${project.version}</version>
           <scope>provided</scope>
         </dependency>
+	<dependency>
+          <groupId>io.cdap.cdap</groupId>
+          <artifactId>cdap-securestore-ext-gcp-secretstore</artifactId>
+          <version>${project.version}</version>
+          <scope>provided</scope>
+        </dependency>
         <dependency>
           <groupId>io.cdap.cdap</groupId>
           <artifactId>cdap-authenticator-ext-gcp</artifactId>
@@ -663,6 +669,27 @@
                     <resource>
                       <directory>
                         ${project.parent.basedir}/cdap-securestore-ext-cloudkms/target/libexec/
+                      </directory>
+                      <includes>
+                        <include>*.jar</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+
+	      <execution>
+                <id>copy-securestore-ext-gcp-secretstore</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <outputDirectory>${stage.securestores.ext.dir}/gcp-secretstore</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>
+                        ${project.parent.basedir}/cdap-securestore-ext-gcp-secretstore/target/libexec/
                       </directory>
                       <includes>
                         <include>*.jar</include>

--- a/cdap-securestore-ext-gcp-secretstore/pom.xml
+++ b/cdap-securestore-ext-gcp-secretstore/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2023 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>cdap</artifactId>
+    <groupId>io.cdap.cdap</groupId>
+    <version>6.9.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>cdap-securestore-ext-gcp-secretstore</artifactId>
+  <name>CDAP Google Cloud Secret Store Secure Store Extension</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <google.cloud.secretmanager.version>2.8.0</google.cloud.secretmanager.version>
+    <guava.version>31.1-jre</guava.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-securestore-spi</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-secretmanager</artifactId>
+      <version>${google.cloud.secretmanager.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+      <version>2.10.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.9.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>dist</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>copy-dependencies</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <outputDirectory>${project.build.directory}/libexec</outputDirectory>
+                  <overWriteReleases>false</overWriteReleases>
+                  <overWriteSnapshots>false</overWriteSnapshots>
+                  <overWriteIfNewer>true</overWriteIfNewer>
+                  <prependGroupId>true</prependGroupId>
+                  <silent>true</silent>
+                  <includeScope>runtime</includeScope>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.4</version>
+            <executions>
+              <execution>
+                <id>jar</id>
+                <phase>prepare-package</phase>
+                <configuration combine.self="override">
+                  <outputDirectory>${project.build.directory}/libexec</outputDirectory>
+                  <finalName>${project.groupId}.${project.build.finalName}</finalName>
+                </configuration>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/CloudSecretManagerClient.java
+++ b/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/CloudSecretManagerClient.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.securestore.gcp.cloudsecretmanager;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.rpc.ApiException;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.secretmanager.v1.AddSecretVersionRequest;
+import com.google.cloud.secretmanager.v1.CreateSecretRequest;
+import com.google.cloud.secretmanager.v1.ListSecretsRequest;
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient.ListSecretsPage;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
+import com.google.cloud.secretmanager.v1.SecretPayload;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.FieldMask;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.Optional;
+
+/** Client for <a href="https://cloud.google.com/secret-manager">Google Cloud Secret Manager</a> */
+public class CloudSecretManagerClient {
+  private static final Logger LOG = LoggerFactory.getLogger(CloudSecretManagerClient.class);
+  /**
+   * Property that, if set, overrides which GCP project to use rather than the default (see
+   * https://github.com/googleapis/google-cloud-java#specifying-a-project-id for default behavior).
+   */
+  private static final String PROJECT_ID = "project.id";
+  /**
+   * Property that, if set, overrides which service account to authorize as rather than the default
+   * (see https://github.com/googleapis/google-cloud-java#authentication for default behavior)
+   */
+  private static final String SERVICE_ACCOUNT_FILE = "service.account.file";
+
+  private final SecretManagerServiceClient secretManager;
+  // GCP project resource name e.g. "project/my-project-id".
+  private final String projectResourceName;
+
+  /** Throws IOException if the underlying {@link SecretManagerServiceClient} fails to be created. */
+  public CloudSecretManagerClient(Map<String, String> properties) throws IOException {
+    String projectId =
+      properties.containsKey(PROJECT_ID)
+        ? properties.get(PROJECT_ID)
+        : ServiceOptions.getDefaultProjectId();
+    this.secretManager = createClient(properties);
+    this.projectResourceName = "projects/" + projectId;
+  }
+
+  /**
+   * Creates a new secret, throwing if the secret already exists.
+   *
+   * @throws ApiException if Google API call fails.
+   */
+  public void createSecret(WrappedSecret wrappedSecret) {
+    CreateSecretRequest request =
+      CreateSecretRequest.newBuilder()
+        .setParent(projectResourceName)
+        .setSecretId(
+          getSecretId(
+            wrappedSecret.getNamespace(), wrappedSecret.getCdapSecretMetadata().getName()))
+        .setSecret(wrappedSecret.getGcpSecret(getSecretResourceName(wrappedSecret)))
+        .build();
+
+    secretManager.createSecret(request);
+  }
+
+  /**
+   * Adds a new secret payload to the provided secret.
+   *
+   * @throws ApiException if Google API call fails.
+   */
+  public void addSecretVersion(WrappedSecret wrappedSecret, byte[] data) {
+    SecretPayload secretPayload =
+      SecretPayload.newBuilder().setData(ByteString.copyFrom(data)).build();
+    AddSecretVersionRequest addSecretReq =
+      AddSecretVersionRequest.newBuilder()
+        .setParent(getSecretResourceName(wrappedSecret))
+        .setPayload(secretPayload)
+        .build();
+
+    secretManager.addSecretVersion(addSecretReq);
+  }
+
+  /**
+   * Returns the secrets in the specified namespace. Does not fetch their secret payloads. Iterates
+   * over all pages.
+   *
+   * @throws ApiException if Google API call fails.
+   */
+  public ImmutableList<WrappedSecret> listSecrets(String namespace) {
+    ListSecretsRequest request =
+      ListSecretsRequest.newBuilder()
+        .setFilter("annotations.cdap_namespace=" + namespace)
+        .setParent(projectResourceName)
+        .build();
+
+    ImmutableList.Builder<WrappedSecret> secrets = ImmutableList.builder();
+    for (ListSecretsPage page : secretManager.listSecrets(request).iteratePages()) {
+      for (Secret secret : page.getResponse().getSecretsList()) {
+        try {
+          secrets.add(WrappedSecret.fromGcpSecret(secret));
+        } catch (InvalidSecretException e) {
+          // Log and ignore parse failures.
+          LOG.error("Failed to parse secret.", e);
+        }
+      }
+    }
+    return secrets.build();
+  }
+
+  /**
+   * Fetches the latest secret payload associated with the specified secret.
+   *
+   * @throws ApiException if Google API call fails.
+   */
+  public byte[] getSecretData(WrappedSecret secret) {
+    return secretManager
+      .accessSecretVersion(String.format("%s/versions/latest", getSecretResourceName(secret)))
+      .getPayload()
+      .getData()
+      .toByteArray();
+  }
+
+  /**
+   * Returns the secret metadata for the specified secret. Does not fetch its secret payload.
+   *
+   * @throws ApiException if Google API call fails.
+   * @throws InvalidSecretException if parsing the JSON-encoded annotations fails.
+   */
+  public WrappedSecret getSecret(String namespace, String name) throws InvalidSecretException {
+    return WrappedSecret.fromGcpSecret(
+      secretManager.getSecret(getSecretResourceName(namespace, name)));
+  }
+
+  /**
+   * Computes the new annotations for {@link wrappedSecret} and performs an update operation on the
+   * corresponding GCP secret to match the newly computed properties.
+   *
+   * @throws ApiException if Google API call fails.
+   */
+  public void updateSecret(WrappedSecret wrappedSecret) {
+    // Update all fields.
+    secretManager.updateSecret(
+      wrappedSecret.getGcpSecret(getSecretResourceName(wrappedSecret)),
+      FieldMask.newBuilder().addPaths("annotations").build());
+  }
+
+  /**
+   * Deletes the specified secret.
+   *
+   * @throws ApiException if Google API call fails.
+   */
+  public void deleteSecret(String namespace, String name) {
+    secretManager.deleteSecret(getSecretResourceName(namespace, name));
+  }
+
+  public void destroy() {
+    secretManager.close();
+  }
+
+  /** Returns the GCP resource name for the specified WrappedSecret. */
+  private String getSecretResourceName(WrappedSecret secret) {
+    return getSecretResourceName(secret.getNamespace(), secret.getCdapSecretMetadata().getName());
+  }
+
+  private String getSecretResourceName(String namespace, String name) {
+    return String.format("%s/secrets/%s", projectResourceName, getSecretId(namespace, name));
+  }
+
+  /**
+   * Computes the secret ID, returning an ID guaranteed to be shorter than 255 characters (the
+   * Secret Manager limit) and guaranteed to be prefixed with "cdap-" to allow the use of IAM
+   * conditionals to widely grant or revoke access to secrets created by this client.
+   */
+  private static String getSecretId(String namespace, String name) {
+    return String.format("cdap-%s-%s", hashLongName(namespace), hashLongName(name));
+  }
+
+  /**
+   * Returns {@code input} unmodified if it is at most 120 characters long, otherwise returns the
+   * first 56 characters and appends a hex-encoded sha256 hash of the entire name (120 characters
+   * total).
+   */
+  private static String hashLongName(String input) {
+    if (input.length() <= 120) {
+      return input;
+    }
+    try {
+      byte[] hash =
+        MessageDigest.getInstance("SHA-256").digest(input.getBytes(StandardCharsets.UTF_8));
+      StringBuilder hexString = new StringBuilder();
+      for (byte b : hash) {
+        hexString.append(String.format("%02X", b));
+      }
+      return input.substring(0, 30) + hexString.toString();
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("Unable to generate SHA-256 hash", e);
+    }
+  }
+
+  private static SecretManagerServiceClient createClient(Map<String, String> properties) throws IOException {
+    SecretManagerServiceSettings.Builder settings = SecretManagerServiceSettings.newBuilder();
+
+    createCredentialsProvider(properties)
+      .ifPresent(
+        (credentials) -> {
+          settings.setCredentialsProvider(credentials);
+        });
+    return SecretManagerServiceClient.create(settings.build());
+  }
+
+  /**
+   * Returns a CredentialProvider if a service account file is configured in {@code properties},
+   * otherwise returns empty.
+   */
+  private static Optional<CredentialsProvider> createCredentialsProvider(Map<String, String> properties)
+      throws IOException {
+    String serviceAccountContents = properties.getOrDefault(SERVICE_ACCOUNT_FILE, "");
+    if (serviceAccountContents.isEmpty()) {
+      return Optional.empty();
+    }
+    GoogleCredentials credentials =
+      GoogleCredentials.fromStream(new ByteArrayInputStream(serviceAccountContents.getBytes()));
+
+    return Optional.of(FixedCredentialsProvider.create(credentials));
+  }
+}

--- a/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/GcpSecretManager.java
+++ b/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/GcpSecretManager.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.securestore.gcp.cloudsecretmanager;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.common.annotations.VisibleForTesting;
+import io.cdap.cdap.securestore.spi.SecretManager;
+import io.cdap.cdap.securestore.spi.SecretManagerContext;
+import io.cdap.cdap.securestore.spi.SecretNotFoundException;
+import io.cdap.cdap.securestore.spi.secret.Secret;
+import io.cdap.cdap.securestore.spi.secret.SecretMetadata;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/**
+ * SecretManager implementation backed by GCP's service also called "Secret Manager"
+ * https://cloud.google.com/secret-manager
+ *
+ * <p>This implementation doesn't store any infromation within the CDAP database and instead stores
+ * the credentials entirely inside GCP Secret Manager -- this allows credentials to be shared
+ * between multiple CDAP instances without additional coordination.
+ *
+ * <p>Due to Secret Manager annotation <a
+ * href="https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets#Secret">limitations</a>
+ * the total size of metadata associated with any given secret cannot exceed 16 KiB.
+ */
+public class GcpSecretManager implements SecretManager {
+  private static final String PROVIDER_NAME = "gcp-secretmanager";
+
+  private CloudSecretManagerClient client;
+
+  @Override
+  public String getName() {
+    return PROVIDER_NAME;
+  }
+
+  @Override
+  public void initialize(SecretManagerContext context) throws IOException {
+    this.client = new CloudSecretManagerClient(context.getProperties());
+  }
+
+  @VisibleForTesting
+  void initialize(CloudSecretManagerClient client) {
+    this.client = client;
+  }
+
+  @Override
+  public void store(String namespace, Secret secret) throws IOException {
+    WrappedSecret wrappedSecret = WrappedSecret.fromMetadata(namespace, secret.getMetadata());
+
+    try {
+      Secret existingSecret = get(namespace, secret.getMetadata().getName());
+      // 'update' only if 'get' request succeeds, otherwise 'create'.
+      client.updateSecret(wrappedSecret);
+
+      // Add a new secret version only if the secret payload has changed.
+      if (!Arrays.equals(existingSecret.getData(), secret.getData())) {
+        client.addSecretVersion(wrappedSecret, secret.getData());
+      }
+    } catch (SecretNotFoundException unused) {
+      try {
+        client.createSecret(wrappedSecret);
+        client.addSecretVersion(wrappedSecret, secret.getData());
+      } catch (ApiException e) {
+        throw new IOException("Secret Manager create API call failed", e);
+      }
+    } catch (ApiException e) {
+      // Note: 'get' already has a handler for ApiExceptions.
+      throw new IOException("Secret Manager update API call failed", e);
+    }
+  }
+
+  @Override
+  public Secret get(String namespace, String name) throws SecretNotFoundException, IOException {
+    try {
+      WrappedSecret wrappedSecret = client.getSecret(namespace, name);
+      byte[] secretData = client.getSecretData(wrappedSecret);
+      return new Secret(secretData, wrappedSecret.getCdapSecretMetadata());
+    } catch (ApiException e) {
+      if (e.getStatusCode().getCode() == StatusCode.Code.NOT_FOUND) {
+        throw new SecretNotFoundException(namespace, name);
+      }
+      throw new IOException("Secret Manager get API call failed", e);
+    } catch (InvalidSecretException e) {
+      throw new IOException("Failed to parse secret", e);
+    }
+  }
+
+  @Override
+  public Collection<SecretMetadata> list(String namespace) throws IOException {
+    try {
+      return client.listSecrets(namespace).stream()
+        .map(WrappedSecret::getCdapSecretMetadata)
+        .collect(Collectors.toList());
+    } catch (ApiException e) {
+      throw new IOException("Secret Manager list API call failed", e);
+    }
+  }
+
+  @Override
+  public void delete(String namespace, String name) throws SecretNotFoundException, IOException {
+    try {
+      client.deleteSecret(namespace, name);
+    } catch (ApiException e) {
+      throw new IOException("Secret Manager delete API call failed", e);
+    }
+  }
+
+  @Override
+  public void destroy(SecretManagerContext context) {
+    client.destroy();
+  }
+}

--- a/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/InvalidSecretException.java
+++ b/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/InvalidSecretException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.securestore.gcp.cloudsecretmanager;
+
+/** Exception thrown when failing to create a {@link WrappedSecret} when reading from an input. */
+public final class InvalidSecretException extends Exception {
+  public InvalidSecretException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/WrappedSecret.java
+++ b/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/WrappedSecret.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.securestore.gcp.cloudsecretmanager;
+
+import com.google.cloud.secretmanager.v1.Replication;
+import com.google.cloud.secretmanager.v1.Replication.Automatic;
+import com.google.cloud.secretmanager.v1.Secret;
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.protobuf.util.Timestamps;
+import io.cdap.cdap.securestore.spi.secret.SecretMetadata;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Wrapper around a {@link io.cdap.cdap.securestore.spi.secret.SecretMetadata} which allows it to
+ * easily be converted a GCP SecretManager {@link com.google.cloud.secretmanager.v1.Secret} and
+ * back.
+ *
+ * <p>Does not contain the underlying secret payload.
+ */
+public final class WrappedSecret {
+  private static final Gson GSON = new Gson();
+  private static final Type PROP_MAP_TYPE = new TypeToken<Map<String, String>>() { }.getType();
+
+  private final String namespace;
+  private final SecretMetadata secretMetadata;
+
+  private WrappedSecret(String namespace, SecretMetadata secretMetadata) {
+    this.namespace = namespace;
+    this.secretMetadata = secretMetadata;
+  }
+
+  /** Constructs a new WrappedSecret from a CDAP Secret. */
+  public static WrappedSecret fromMetadata(String namespace, SecretMetadata metadata) {
+    return new WrappedSecret(namespace, metadata);
+  }
+
+  /**
+   * Constructs a new WrappedSecret from a GCP Secret Manager secret, throwing an
+   * {@link InvalidSecretException} if the secret cannot be parsed.
+   */
+  public static WrappedSecret fromGcpSecret(Secret secret) throws InvalidSecretException {
+    String namespace = getNamespace(secret);
+    SecretMetadata metadata = toSecretMetadata(secret);
+    return new WrappedSecret(namespace, metadata);
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public SecretMetadata getCdapSecretMetadata() {
+    return secretMetadata;
+  }
+
+  /**
+   * Returns a new GCP {@link Secret} representing the underlying SecretMetadata.
+   *
+   * @param resourceName Value to set for the "name" field needed for update operations.
+   */
+  public Secret getGcpSecret(String resourceName) {
+    return Secret.newBuilder()
+      // Set replication policy to automatic (as opposed to user-managed) and do not specify a
+      // CMEK (use google-managed key).
+      .setReplication(Replication.newBuilder().setAutomatic(Automatic.getDefaultInstance()))
+      .setName(resourceName)
+      .putAnnotations("cdap_namespace", namespace)
+      .putAnnotations("cdap_secret_name", secretMetadata.getName())
+      .putAnnotations("cdap_description", Optional.ofNullable(secretMetadata.getDescription()).orElse(""))
+      .putAnnotations("cdap_props", serializeProps(secretMetadata.getProperties()))
+      .build();
+  }
+
+  private static SecretMetadata toSecretMetadata(Secret secret) throws InvalidSecretException {
+    return new SecretMetadata(
+      secret.getAnnotationsOrDefault("cdap_secret_name", ""),
+      secret.getAnnotationsOrDefault("cdap_description", ""),
+      Timestamps.toMillis(secret.getCreateTime()),
+      deserializeProps(secret.getAnnotationsOrDefault("cdap_props", "{}")));
+  }
+
+  private static String getNamespace(Secret secret) {
+    return secret.getAnnotationsOrDefault("cdap_namespace", "");
+  }
+
+  private static String serializeProps(Map<String, String> input) {
+    return GSON.toJson(input);
+  }
+
+  /**
+   * Parses {@code input} as JSON and returns the corresponding map, throwing an {@link InvalidSecretException}
+   * if parsing input fails.
+   */
+  private static Map<String, String> deserializeProps(String input) throws InvalidSecretException {
+    try {
+      return GSON.fromJson(input, PROP_MAP_TYPE);
+    } catch (JsonSyntaxException e) {
+      throw new InvalidSecretException("Failed to parse cdap_props", e);
+    }
+  }
+}

--- a/cdap-securestore-ext-gcp-secretstore/src/main/resources/META-INF/services/io.cdap.cdap.securestore.spi.SecretManager
+++ b/cdap-securestore-ext-gcp-secretstore/src/main/resources/META-INF/services/io.cdap.cdap.securestore.spi.SecretManager
@@ -1,0 +1,17 @@
+#
+# Copyright © 2023 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+io.cdap.cdap.securestore.gcp.cloudsecretmanager.GcpSecretManager

--- a/cdap-securestore-ext-gcp-secretstore/src/test/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/GcpSecretManagerTest.java
+++ b/cdap-securestore-ext-gcp-secretstore/src/test/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/GcpSecretManagerTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.securestore.gcp.cloudsecretmanager;
+
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.securestore.spi.SecretNotFoundException;
+import io.cdap.cdap.securestore.spi.secret.Secret;
+import io.cdap.cdap.securestore.spi.secret.SecretMetadata;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
+
+public class GcpSecretManagerTest {
+  @Rule
+  public final MockitoRule mockito = MockitoJUnit.rule();
+
+  private static final String NAMESPACE = "test_namespace";
+
+  @Mock
+  private CloudSecretManagerClient client;
+
+  private GcpSecretManager secretManager;
+
+  @Before
+  public void setUp() {
+    secretManager = new GcpSecretManager();
+    secretManager.initialize(client);
+  }
+
+  @Test
+  public void store_create() throws Exception {
+    ApiException exception = createApiException(Code.NOT_FOUND);
+    when(client.getSecret(ArgumentMatchers.any(), ArgumentMatchers.any())).thenThrow(exception);
+
+    secretManager.store(NAMESPACE, createSecret("example"));
+
+    verify(client, times(1)).createSecret(ArgumentMatchers.any());
+    verify(client, times(1)).addSecretVersion(ArgumentMatchers.any(), ArgumentMatchers.any());
+    verify(client, times(0)).updateSecret(ArgumentMatchers.any());
+  }
+
+  @Test
+  public void store_updateMetadataOnly() throws Exception {
+    byte[] payload = "Foo".getBytes();
+    SecretMetadata metadata = createMetadata("example");
+    when(client.getSecret(ArgumentMatchers.any(), ArgumentMatchers.any()))
+      .thenReturn(WrappedSecret.fromMetadata(NAMESPACE, metadata));
+    when(client.getSecretData(ArgumentMatchers.any())).thenReturn(payload);
+
+    // Metadata [potentially] updated, payload remains the same.
+    secretManager.store(NAMESPACE, new Secret(payload, metadata));
+
+    // Update, not create called. No secret version added.
+    verify(client, times(0)).createSecret(ArgumentMatchers.any());
+    verify(client, times(1)).updateSecret(ArgumentMatchers.any());
+    verify(client, times(0)).addSecretVersion(ArgumentMatchers.any(), ArgumentMatchers.any());
+  }
+
+  @Test
+  public void store_updatePayload() throws Exception {
+    byte[] oldPayload = "Foo".getBytes();
+    byte[] newPayload = "Bar".getBytes();
+    SecretMetadata metadata = createMetadata("example");
+    when(client.getSecret(ArgumentMatchers.any(), ArgumentMatchers.any()))
+      .thenReturn(WrappedSecret.fromMetadata(NAMESPACE, metadata));
+    when(client.getSecretData(ArgumentMatchers.any())).thenReturn(oldPayload);
+
+    secretManager.store(NAMESPACE, new Secret(newPayload, metadata));
+
+    // Update called, secret version added.
+    verify(client, times(1)).updateSecret(ArgumentMatchers.any());
+    verify(client, times(1)).addSecretVersion(ArgumentMatchers.any(), eq(newPayload));
+  }
+
+  @Test
+  public void store_exception() throws Exception {
+    ApiException exception = createApiException(Code.PERMISSION_DENIED);
+    when(client.getSecret(ArgumentMatchers.any(), ArgumentMatchers.any()))
+      .thenThrow(exception);
+
+    assertThrows(IOException.class, () -> secretManager.store(NAMESPACE, createSecret("example")));
+  }
+
+  @Test
+  public void get_success() throws Exception {
+    byte[] payload = "example".getBytes();
+    SecretMetadata metadata = createMetadata("example");
+    when(client.getSecret(ArgumentMatchers.any(), ArgumentMatchers.any()))
+      .thenReturn(WrappedSecret.fromMetadata(NAMESPACE, metadata));
+    when(client.getSecretData(ArgumentMatchers.any())).thenReturn(payload);
+
+    Secret secret = secretManager.get(NAMESPACE, "example");
+
+    assertArrayEquals(payload, secret.getData());
+  }
+
+  @Test
+  public void get_notFoundError() throws Exception {
+    ApiException exception = createApiException(Code.NOT_FOUND);
+    when(client.getSecret(ArgumentMatchers.any(), ArgumentMatchers.any())).thenThrow(exception);
+
+    assertThrows(SecretNotFoundException.class, () -> secretManager.get(NAMESPACE, "example"));
+  }
+
+  @Test
+  public void get_otherError() throws Exception {
+    ApiException exception = createApiException(Code.PERMISSION_DENIED);
+    when(client.getSecret(ArgumentMatchers.any(), ArgumentMatchers.any())).thenThrow(exception);
+
+    assertThrows(IOException.class, () -> secretManager.get(NAMESPACE, "example"));
+  }
+
+  @Test
+  public void list_success() throws Exception {
+    SecretMetadata item1 = createMetadata("example1");
+    SecretMetadata item2 = createMetadata("example2");
+    when(client.listSecrets(ArgumentMatchers.any())).thenReturn(
+      ImmutableList.of(
+        WrappedSecret.fromMetadata(NAMESPACE, item1),
+        WrappedSecret.fromMetadata(NAMESPACE, item2)));
+
+    ImmutableList<SecretMetadata> list = ImmutableList.copyOf(secretManager.list(NAMESPACE));
+
+    assertEquals(ImmutableList.of(item1, item2), list);
+  }
+
+  @Test
+  public void list_wrapsApiExceptions() throws Exception {
+    ApiException exception = createApiException(Code.PERMISSION_DENIED);
+    when(client.listSecrets(ArgumentMatchers.any())).thenThrow(exception);
+
+    assertThrows(IOException.class, () -> secretManager.list(NAMESPACE));
+  }
+
+  @Test
+  public void delete_wrapsApiExceptions() throws Exception {
+    ApiException exception = createApiException(Code.PERMISSION_DENIED);
+    doThrow(exception).when(client).deleteSecret(ArgumentMatchers.any(), ArgumentMatchers.any());
+
+    assertThrows(IOException.class, () -> secretManager.delete(NAMESPACE, "example"));
+  }
+
+  private static Secret createSecret(String name) {
+    return new Secret(name.getBytes(), createMetadata(name));
+  }
+
+  private static SecretMetadata createMetadata(String name) {
+    return new SecretMetadata(name, "Fake description", 0, ImmutableMap.of());
+  }
+
+  private static ApiException createApiException(Code code) {
+    return new ApiException(new RuntimeException("Fake Exception"), createStatusCode(code), true);
+  }
+
+  private static StatusCode createStatusCode(Code code) {
+    return new StatusCode() {
+      @Override
+      public Code getCode() {
+        return code;
+      }
+
+      @Override
+      public Object getTransportCode() {
+        throw new RuntimeException("unimplemented");
+      }
+    };
+  }
+}

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -440,6 +440,12 @@
           <version>${project.version}</version>
           <scope>provided</scope>
         </dependency>
+	<dependency>
+          <groupId>io.cdap.cdap</groupId>
+          <artifactId>cdap-securestore-ext-gcp-secretstore</artifactId>
+          <version>${project.version}</version>
+          <scope>provided</scope>
+        </dependency>
         <!-- dependencies on system apps to be built before standalone -->
         <dependency>
           <groupId>io.cdap.cdap</groupId>
@@ -644,6 +650,13 @@
                     <resource>
                       <directory>${project.parent.basedir}/cdap-securestore-ext-cloudkms/target/libexec</directory>
                       <targetPath>ext/securestores/gcp-cloudkms</targetPath>
+                      <includes>
+                        <include>*.jar</include>
+                      </includes>
+                    </resource>
+		    <resource>
+                      <directory>${project.parent.basedir}/cdap-securestore-ext-gcp-secretstore/target/libexec</directory>
+                      <targetPath>ext/securestores/gcp-secretstore</targetPath>
                       <includes>
                         <include>*.jar</include>
                       </includes>

--- a/pom.xml
+++ b/pom.xml
@@ -2716,6 +2716,7 @@
         <module>cdap-runtime-ext-remote-hadoop</module>
         <module>cdap-runtime-spi</module>
         <module>cdap-securestore-ext-cloudkms</module>
+	<module>cdap-securestore-ext-gcp-secretstore</module>
         <module>cdap-securestore-spi</module>
         <module>cdap-support-bundle</module>
         <module>cdap-operational-stats-core</module>


### PR DESCRIPTION
 * Adds a new (CDAP) Secret Manager implementation which uses (GCP) Secret Manager as the backing store for secrets
   * This implementation allows secrets to easily be shared between CDAP instances.