### PR TITLE
Fix EndPointFieldDeserializer in the case where a field is dropped in a pipeline

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/lineage/field/EndPoint.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/lineage/field/EndPoint.java
@@ -29,7 +29,9 @@ import javax.annotation.Nullable;
  * program runs.
  */
 public class EndPoint {
+  @Nullable
   private final String namespace;
+  @Nullable
   private final String name;
   private final Map<String, String> properties;
 
@@ -49,7 +51,9 @@ public class EndPoint {
 
   /**
    * @return the namespace name if it is explicitly provided while creating this EndPoint,
-   * otherwise {@code null} is returned
+   * otherwise {@code null} is returned. Also, in the case where in a pipeline
+   * a field is dropped, the dropped EndPointField is mapped to a blank EndPointField with
+   * namespace set to null.
    */
   @Nullable
   public String getNamespace() {
@@ -58,7 +62,10 @@ public class EndPoint {
 
   /**
    * @return the name of the {@link EndPoint}
+   * Name can be null in the case where in a pipeline a field is dropped,
+   * and the dropped EndPointField is mapped to a blank EndPointField with name set to null.
    */
+  @Nullable
   public String getName() {
     return name;
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/metadata/MetadataConsumerSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/metadata/MetadataConsumerSubscriberService.java
@@ -286,15 +286,13 @@ public class MetadataConsumerSubscriberService extends AbstractMessagingSubscrib
     }
 
     private LineageInfo getLineageInfoForConsumer(FieldLineageInfo lineage, long startTimeMs, long endTimeMs) {
-      Map<EndPointField, Set<EndPointField>> incomingSummary = lineage.getIncomingSummary();
-      Map<EndPointField, Set<EndPointField>> outgoingSummary = lineage.getOutgoingSummary();
       return LineageInfo.builder()
         .setStartTimeMs(startTimeMs)
         .setEndTimeMs(endTimeMs)
         .setSources(lineage.getSources().stream().map(this::getAssetForEndpoint).collect(Collectors.toSet()))
         .setTargets(lineage.getDestinations().stream().map(this::getAssetForEndpoint).collect(Collectors.toSet()))
-        .setTargetToSources(getAssetsMapFromEndpointFieldsMap(incomingSummary))
-        .setSourceToTargets(getAssetsMapFromEndpointFieldsMap(outgoingSummary))
+        .setTargetToSources(getAssetsMapFromEndpointFieldsMap(lineage.getIncomingSummary()))
+        .setSourceToTargets(getAssetsMapFromEndpointFieldsMap(lineage.getOutgoingSummary()))
         .build();
     }
 
@@ -313,6 +311,7 @@ public class MetadataConsumerSubscriberService extends AbstractMessagingSubscrib
       return endPointFieldSetMap.entrySet().stream()
         .collect(Collectors.toMap(entry -> getAssetForEndpoint(entry.getKey().getEndPoint()),
                                   entry -> entry.getValue().stream()
+                                    .filter(EndPointField::isValid)
                                     .map(endPointField ->
                                            getAssetForEndpoint(endPointField.getEndPoint()))
                                     .collect(Collectors.toSet()),

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/field/EndPointField.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/field/EndPointField.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.data2.metadata.lineage.field;
 import io.cdap.cdap.api.lineage.field.EndPoint;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Represent a single field along with the EndPoint to which it belongs to.
@@ -28,7 +29,7 @@ public class EndPointField {
   private final String field;
   private transient Integer hashCode;
 
-  public EndPointField(EndPoint endPoint, String field) {
+  public EndPointField(EndPoint endPoint, @Nullable String field) {
     this.endPoint = endPoint;
     this.field = field;
   }
@@ -68,5 +69,23 @@ public class EndPointField {
       "endPoint=" + endPoint +
       ", field='" + field + '\'' +
       '}';
+  }
+
+  /**
+   * Checks for validity of an EndPointField.
+   *
+   * If in a pipeline a field is dropped, the source EndPointField corresponding to
+   * the dropped field maps to an empty EndPointField of the form
+   * `EndPointField{endPoint=EndPoint{namespace='null', name='null', properties='{}'}, field='null'}`.
+   * This method can be used to scan for such EndPointFields.
+   *
+   * @return true if an EndPointField is valid, false otherwise
+   */
+  public boolean isValid() {
+    return endPoint != null &&
+      endPoint.getName() != null &&
+      endPoint.getNamespace() != null &&
+      !endPoint.getProperties().isEmpty() &&
+      field != null;
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/field/EndpointFieldDeserializer.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/metadata/lineage/field/EndpointFieldDeserializer.java
@@ -21,11 +21,13 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 import io.cdap.cdap.api.lineage.field.EndPoint;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -42,7 +44,8 @@ public class EndpointFieldDeserializer implements JsonDeserializer<EndPointField
                                    JsonDeserializationContext context) throws JsonParseException {
     JsonObject obj = json.getAsJsonObject();
     EndPoint endPoint = context.deserialize(obj.getAsJsonObject("endPoint"), EndPoint.class);
-    String field = obj.getAsJsonPrimitive("field").getAsString();
+    String field = Optional.ofNullable(obj.getAsJsonPrimitive("field"))
+      .map(JsonPrimitive::getAsString).orElse(null);
 
     EndPointField endPointField = new EndPointField(endPoint, field);
     return endpointFields.computeIfAbsent(endPointField, k -> endPointField);


### PR DESCRIPTION
Jira: https://cdap.atlassian.net/browse/CDAP-20272

If a pipeline with wrangler has drop column directive, in field-level lineage the dropped column is mapped to a blank EndpointField of the format `EndPointField{endPoint=EndPoint{namespace='null', name='null', properties='{}'}, field='null'}`.
This causes the deserializer to throw a NullPointerException.

To fix this
1. Guard against null fields in the deserializer
2. Add a method in `EndPointField` to check for such fields and have the callers use them if needed.
3. Add this check in MetadataConsumerSubscriberService while parsing FieldLineageInfo(MetadataSubscriberService does not require such checks and renders the UI for field-lineage correctly)

Additionally the writer to the TMS should be fixed to not write such records. Tracking jira - https://cdap.atlassian.net/browse/CDAP-20330