### PR TITLE
CDAP-19729 : Enable upgrade for Datastream apps using state store.

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationUpdateContext.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/app/ApplicationUpdateContext.java
@@ -77,5 +77,11 @@ public interface ApplicationUpdateContext {
   List<ArtifactId> getPluginArtifacts(String pluginType, String pluginName,
                                       @Nullable ArtifactVersionRange pluginRange, int limit) throws Exception;
 
+  /**
+   * Returns the current app spec.
+   *
+   * @return {@link ApplicationSpecification}
+   */
+  ApplicationSpecification getApplicationSpecification();
 }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultApplicationUpdateContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/DefaultApplicationUpdateContext.java
@@ -40,6 +40,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import io.cdap.cdap.api.Config;
 import io.cdap.cdap.api.app.ApplicationConfigUpdateAction;
+import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.app.ApplicationUpdateContext;
 import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.api.artifact.ArtifactScope;
@@ -86,12 +87,13 @@ public class DefaultApplicationUpdateContext implements ApplicationUpdateContext
   private final NamespaceId namespaceId;
   private final Set<ArtifactScope> allowedArtifactScopes;
   private final boolean allowSnapshot;
+  private final ApplicationSpecification appSpec;
 
   public DefaultApplicationUpdateContext(NamespaceId namespaceId, ApplicationId applicationId,
                                          ArtifactId applicationArtifactId, ArtifactRepository artifactRepository,
                                          String configString, List<ApplicationConfigUpdateAction> updateActions,
                                          Set<ArtifactScope> allowedArtifactScopes,
-                                         boolean allowSnapshot) {
+                                         boolean allowSnapshot, ApplicationSpecification appSpec) {
     this.namespaceId = namespaceId;
     this.applicationId = applicationId;
     this.artifactRepository = artifactRepository;
@@ -100,6 +102,7 @@ public class DefaultApplicationUpdateContext implements ApplicationUpdateContext
     this.updateActions = Collections.unmodifiableList(new ArrayList<>(updateActions));
     this.allowedArtifactScopes = Collections.unmodifiableSet(allowedArtifactScopes);
     this.allowSnapshot = allowSnapshot;
+    this.appSpec = appSpec;
   }
 
   @Override
@@ -143,6 +146,11 @@ public class DefaultApplicationUpdateContext implements ApplicationUpdateContext
       candidates.addAll(getScopedPluginArtifacts(pluginType, pluginName, scope, pluginRange, limit));
     }
     return candidates;
+  }
+
+  @Override
+  public ApplicationSpecification getApplicationSpecification() {
+    return appSpec;
   }
 
   private List<ArtifactId> getScopedPluginArtifacts(String pluginType, String pluginName,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -694,7 +694,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     DefaultApplicationUpdateContext updateContext =
       new DefaultApplicationUpdateContext(appId.getParent(), appId, artifactDetail.getDescriptor().getArtifactId(),
                                           artifactRepository, appSpec.getConfiguration(), updateActions,
-                                          allowedArtifactScopes, allowSnapshot);
+                                          allowedArtifactScopes, allowSnapshot, appSpec);
 
     try (CloseableClassLoader artifactClassLoader =
       artifactRepository.createArtifactClassLoader(artifactDetail.getDescriptor(),

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsPipelineSpecGenerator.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.api.DatasetConfigurer;
+import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.app.RuntimeConfigurer;
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.feature.FeatureFlagsProvider;
@@ -88,10 +89,7 @@ public class DataStreamsPipelineSpecGenerator
 
     String pipelineId = UUID.randomUUID().toString();
     if (runtimeConfigurer != null && runtimeConfigurer.getDeployedApplicationSpec() != null) {
-      SparkSpecification sparkSpec =
-        runtimeConfigurer.getDeployedApplicationSpec().getSpark().get(DataStreamsSparkLauncher.NAME);
-      DataStreamsPipelineSpec spec = GSON.fromJson(sparkSpec.getProperty(Constants.PIPELINEID),
-                                                   DataStreamsPipelineSpec.class);
+      DataStreamsPipelineSpec spec = getDataStreamsPipelineSpec(runtimeConfigurer.getDeployedApplicationSpec());
       pipelineId = spec.getPipelineId();
     }
 
@@ -106,6 +104,17 @@ public class DataStreamsPipelineSpecGenerator
     //Configure retries
     configureRetries(specBuilder);
     return specBuilder.build();
+  }
+
+  /**
+   * Extract and return {@link DataStreamsPipelineSpec} from the {@link ApplicationSpecification}.
+   * @param deployedApplicationSpec
+   * @return {@link DataStreamsPipelineSpec}
+   */
+  static DataStreamsPipelineSpec getDataStreamsPipelineSpec(ApplicationSpecification deployedApplicationSpec) {
+    SparkSpecification sparkSpec =
+      deployedApplicationSpec.getSpark().get(DataStreamsSparkLauncher.NAME);
+    return GSON.fromJson(sparkSpec.getProperty(Constants.PIPELINEID), DataStreamsPipelineSpec.class);
   }
 
   @VisibleForTesting

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/DataStreamsConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/DataStreamsConfig.java
@@ -17,8 +17,10 @@
 package io.cdap.cdap.etl.proto.v2;
 
 import io.cdap.cdap.api.Resources;
+import io.cdap.cdap.api.app.ApplicationUpdateContext;
 import io.cdap.cdap.etl.proto.Connection;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -125,6 +127,25 @@ public final class DataStreamsConfig extends ETLConfig {
 
   public static Builder builder() {
     return new Builder();
+  }
+
+  /**
+   * Updates the configuration for all stages using the provided ApplicationUpdateContext
+   * @param applicationUpdateContext
+   * @return The updated {@link DataStreamsConfig}
+   * @throws Exception
+   */
+  public DataStreamsConfig updateConfig(ApplicationUpdateContext applicationUpdateContext) throws Exception {
+    Set<ETLStage> updatedStages = new HashSet<>();
+    // Upgrade all stages.
+    for (ETLStage stage : getStages()) {
+      updatedStages.add(stage.updateStage(applicationUpdateContext));
+    }
+
+    return new DataStreamsConfig(updatedStages, connections, resources, driverResources, clientResources,
+                                 stageLoggingEnabled, processTimingEnabled, batchInterval, isUnitTest,
+                                 disableCheckpoints, checkpointDir, numOfRecordsPreview, stopGracefully,
+                                 properties);
   }
 
   /**


### PR DESCRIPTION
[CDAP-19729] Enable upgrade for Datastream apps using state store. 

[CDAP-19729]: https://cdap.atlassian.net/browse/CDAP-19729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ