### PR TITLE
CDAP-20380: fix macro in nested fields

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginInstantiator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginInstantiator.java
@@ -333,7 +333,11 @@ public class PluginInstantiator implements Closeable {
               trackingMacroEvaluator.reset();
               Map<String, String> substitutedChildMap = new HashMap<>();
               childMap.forEach((name, value) -> {
+                if (!pluginPropertyFieldMap.containsKey(name)) {
+                  return;
+                }
                 macroParser.parse(value);
+
                 substitutedChildMap.put(name, getOriginalOrDefaultValue(
                   value, name, pluginPropertyFieldMap.get(name).getType(), trackingMacroEvaluator));
               });


### PR DESCRIPTION
BigQuery preview using macro in connections failed with NPE because the bigquery connection contains some fields that are not in bigquery source, i.e, showHiddenDatasets. This will fix the NPE by skipping the fields that are not in the plugin spec