### PR TITLE
CDAP-20308 - Add http connection and read timeout properties for task worker pods.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteConfigurator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteConfigurator.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.api.service.worker.RunnableTaskRequest;
 import io.cdap.cdap.app.deploy.ConfigResponse;
 import io.cdap.cdap.app.deploy.Configurator;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.RemoteTaskExecutor;
@@ -36,6 +37,7 @@ import io.cdap.cdap.internal.app.runtime.artifact.ApplicationClassCodec;
 import io.cdap.cdap.internal.app.runtime.artifact.RequirementsCodec;
 import io.cdap.cdap.internal.app.worker.ConfiguratorTask;
 import io.cdap.cdap.internal.io.SchemaTypeAdapter;
+import io.cdap.common.http.HttpRequestConfig;
 
 import java.nio.charset.StandardCharsets;
 
@@ -58,8 +60,11 @@ public class RemoteConfigurator implements Configurator {
                             @Assisted AppDeploymentInfo deploymentInfo,
                             RemoteClientFactory remoteClientFactory) {
     this.deploymentInfo = deploymentInfo;
+    int connectTimeout = cConf.getInt(Constants.TaskWorker.CONFIGURATOR_HTTP_CLIENT_CONNECTION_TIMEOUT_MS);
+    int readTimeout = cConf.getInt(Constants.TaskWorker.CONFIGURATOR_HTTP_CLIENT_READ_TIMEOUT_MS);
+    HttpRequestConfig httpRequestConfig = new HttpRequestConfig(connectTimeout, readTimeout, false);
     this.remoteTaskExecutor = new RemoteTaskExecutor(cConf, metricsCollectionService, remoteClientFactory,
-        RemoteTaskExecutor.Type.TASK_WORKER);
+        RemoteTaskExecutor.Type.TASK_WORKER, httpRequestConfig);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicSystemHttpServiceContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/http/BasicSystemHttpServiceContext.java
@@ -55,6 +55,7 @@ import io.cdap.cdap.spi.data.table.StructuredTableId;
 import io.cdap.cdap.spi.data.transaction.TransactionException;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TxRunnable;
+import io.cdap.common.http.HttpRequestConfig;
 import org.apache.tephra.TransactionSystemClient;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
@@ -107,8 +108,11 @@ public class BasicSystemHttpServiceContext extends BasicHttpServiceContext imple
     this.preferencesFetcher = preferencesFetcher;
     this.cConf = cConf;
     this.contextAccessEnforcer = contextAccessEnforcer;
+    int connectTimeout = cConf.getInt(Constants.TaskWorker.SYSTEMAPP_HTTP_CLIENT_CONNECTION_TIMEOUT_MS);
+    int readTimeout = cConf.getInt(Constants.TaskWorker.SYSTEMAPP_HTTP_CLIENT_READ_TIMEOUT_MS);
+    HttpRequestConfig httpRequestConfig = new HttpRequestConfig(connectTimeout, readTimeout, false);
     this.remoteTaskExecutor = new RemoteTaskExecutor(cConf, metricsCollectionService, remoteClientFactory,
-        RemoteTaskExecutor.Type.TASK_WORKER);
+        RemoteTaskExecutor.Type.TASK_WORKER, httpRequestConfig);
     this.namespaceQueryAdmin = namespaceQueryAdmin;
   }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -470,6 +470,15 @@ public final class Constants {
     public static final String CONTAINER_DISK_READONLY = "task.worker.container.disk.readonly";
     public static final String CONTAINER_JVM_OPTS = "task.worker.container.jvm.opts";
 
+    public static final String CONFIGURATOR_HTTP_CLIENT_READ_TIMEOUT_MS =
+      "task.worker.configurator.http.client.read.timeout.ms";
+    public static final String CONFIGURATOR_HTTP_CLIENT_CONNECTION_TIMEOUT_MS =
+      "task.worker.configurator.http.client.connection.timeout.ms";
+    public static final String SYSTEMAPP_HTTP_CLIENT_READ_TIMEOUT_MS =
+      "task.worker.systemapp.http.client.read.timeout.ms";
+    public static final String SYSTEMAPP_HTTP_CLIENT_CONNECTION_TIMEOUT_MS =
+      "task.worker.systemapp.http.client.connection.timeout.ms";
+
     /**
      * Task worker http handler configuration
      */

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4932,6 +4932,54 @@
     </description>
   </property>
 
+  <property>
+    <name>task.worker.http.client.read.timeout.ms</name>
+    <value>120000</value>
+    <description>
+      Read timeout default in milliseconds for task worker HTTP requests.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.http.client.connection.timeout.ms</name>
+    <value>60000</value>
+    <description>
+      Connection timeout default in milliseconds for task worker HTTP requests.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.configurator.http.client.read.timeout.ms</name>
+    <value>${task.worker.http.client.read.timeout.ms}</value>
+    <description>
+      Read timeout in milliseconds for configurator task HTTP requests.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.configurator.http.client.connection.timeout.ms</name>
+    <value>${task.worker.http.client.connection.timeout.ms}</value>
+    <description>
+      Connection timeout in milliseconds for configurator task HTTP requests.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.systemapp.http.client.read.timeout.ms</name>
+    <value>${task.worker.http.client.read.timeout.ms}</value>
+    <description>
+      Read timeout in milliseconds for system app tasks HTTP requests.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.systemapp.http.client.connection.timeout.ms</name>
+    <value>${task.worker.http.client.connection.timeout.ms}</value>
+    <description>
+      Connection timeout in milliseconds for system app tasks HTTP requests.
+    </description>
+  </property>
+
   <!-- System pods Configuration  -->
   <property>
     <name>system.worker.program.twill.controller.start.seconds</name>


### PR DESCRIPTION
CDAP-20308 : 
- Added `http.client.read.timeout` and `http.client.connection.timeout` specific for task worker pods. 
- This applies for application deployment and system app operations like validations from Studio , Wrangler operations like connection management.
