### PR TITLE
feat(CDAP-20250): push app to linked repository

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -144,6 +144,7 @@ import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.impersonation.UnsupportedUGIProvider;
 import io.cdap.cdap.security.store.SecureStoreHandler;
+import io.cdap.cdap.sourcecontrol.SourceControlModule;
 import io.cdap.http.HttpHandler;
 import org.quartz.SchedulerException;
 import org.quartz.core.JobRunShellFactory;
@@ -180,6 +181,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new CapabilityModule(),
                            new NamespaceAdminModule().getInMemoryModules(),
                            new ConfigStoreModule(),
+                           new SourceControlModule(),
                            new EntityVerifierModule(),
                            BootstrapModules.getInMemoryModule(),
                            new AbstractModule() {
@@ -219,6 +221,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new CapabilityModule(),
                            new NamespaceAdminModule().getStandaloneModules(),
                            new ConfigStoreModule(),
+                           new SourceControlModule(),
                            new EntityVerifierModule(),
                            new ProvisionerModule(),
                            BootstrapModules.getFileBasedModule(),
@@ -271,6 +274,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                            new CapabilityModule(),
                            new NamespaceAdminModule().getDistributedModules(),
                            new ConfigStoreModule(),
+                           new SourceControlModule(),
                            new EntityVerifierModule(),
                            new ProvisionerModule(),
                            BootstrapModules.getFileBasedModule(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -48,6 +48,7 @@ import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.WorkflowId;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
 import org.apache.twill.api.RunId;
 
 import java.io.IOException;
@@ -412,6 +413,13 @@ public interface Store {
    * @return collection of application metas. For applications that don't exist, there will be no entry in the result.
    */
   Map<ApplicationId, ApplicationMeta> getApplications(Collection<ApplicationId> ids);
+
+  /**
+   * Update an applications with provided SourceControlMeta.
+   * @param appId the application ID
+   * @param sourceControlMeta the source control metadata of the application synced with linked repository.
+   */
+  void setAppSourceControlMeta(ApplicationId appId, SourceControlMeta sourceControlMeta);
 
   /**
    * Returns a map of latest programIds given programReferences

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -784,7 +784,7 @@ public class AppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       deployedApp.getApplicationId().getVersion(),
       deployedApp.getSpecification().getDescription(),
       Optional.ofNullable(deployedApp.getOwnerPrincipal()).map(KerberosPrincipalId::getPrincipal).orElse(null),
-      deployedApp.getChangeDetail());
+      deployedApp.getChangeDetail(), null);
   }
 
   private BodyConsumer deployApplication(final HttpResponder responder,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
@@ -54,6 +54,8 @@ public class ApplicationDeployable {
   @Nullable
   private final ChangeDetail changeDetail;
 
+  //TODO: CDAP-20248, add SourceControlMeta when we do pull and deploy
+
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
                                ApplicationId applicationId, ApplicationSpecification specification,
                                @Nullable ApplicationSpecification existingAppSpec,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -106,6 +106,7 @@ import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.security.AccessPermission;
 import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
 import io.cdap.cdap.scheduler.Scheduler;
 import io.cdap.cdap.security.impersonation.EntityImpersonator;
 import io.cdap.cdap.security.impersonation.Impersonator;
@@ -300,7 +301,8 @@ public class ApplicationLifecycleService extends AbstractIdleService {
       for (Map.Entry<ApplicationId, ApplicationMeta> entry : list) {
         ApplicationDetail applicationDetail = ApplicationDetail.fromSpec(entry.getValue().getSpec(),
                                                                          owners.get(entry.getKey()),
-                                                                         entry.getValue().getChange());
+                                                                         entry.getValue().getChange(),
+                                                                         entry.getValue().getSourceControlMeta());
 
         try {
           capabilityReader.checkAllEnabled(entry.getValue().getSpec());
@@ -333,16 +335,23 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     }
     String ownerPrincipal = ownerAdmin.getOwnerPrincipal(appId);
     return enforceApplicationDetailAccess(appId, ApplicationDetail.fromSpec(appMeta.getSpec(), ownerPrincipal,
-                                                                            appMeta.getChange()));
+                                                                            appMeta.getChange(),
+                                                                            appMeta.getSourceControlMeta()));
+  }
+
+  public ApplicationDetail getLatestAppDetail(ApplicationReference appRef) throws IOException, NotFoundException {
+    return getLatestAppDetail(appRef, true);
   }
 
   /**
    * Get details about the latest version of the specified application
    *
    * @param appRef the application reference
+   * @param getSourceControlMeta the boolean indicating if we return {@link SourceControlMeta}
    * @return detail about the latest version of the specified application
    */
-  public ApplicationDetail getLatestAppDetail(ApplicationReference appRef) throws IOException, NotFoundException {
+  public ApplicationDetail getLatestAppDetail(ApplicationReference appRef, boolean getSourceControlMeta)
+    throws IOException, NotFoundException {
     ApplicationMeta appMeta = store.getLatest(appRef);
     if (appMeta == null || appMeta.getSpec() == null) {
       throw new ApplicationNotFoundException(appRef);
@@ -351,7 +360,9 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     ApplicationId appId = appRef.app(appMeta.getSpec().getAppVersion());
     String ownerPrincipal = ownerAdmin.getOwnerPrincipal(appId);
     return enforceApplicationDetailAccess(appId, ApplicationDetail.fromSpec(appMeta.getSpec(), ownerPrincipal,
-                                                                            appMeta.getChange()));
+                                                                            appMeta.getChange(),
+                                                                            getSourceControlMeta ?
+                                                                              appMeta.getSourceControlMeta() : null));
   }
 
   /**
@@ -368,14 +379,14 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     Set<ApplicationId> filterIds = appIds.stream().filter(visibleIds::contains).collect(Collectors.toSet());
     Map<ApplicationId, ApplicationMeta> appMetas = store.getApplications(filterIds);
     Map<ApplicationId, String> principals = ownerAdmin.getOwnerPrincipals(filterIds);
-
-    return appMetas.entrySet().stream()
-             .collect(Collectors.toMap(
-               Entry::getKey,
-               entry -> ApplicationDetail.fromSpec(entry.getValue().getSpec(),
-                                                   principals.get(entry.getKey()),
-                                                   entry.getValue().getChange())
-             ));
+    
+    return appMetas.entrySet().stream().collect(Collectors.toMap(
+      Entry::getKey,
+      entry -> ApplicationDetail.fromSpec(entry.getValue().getSpec(),
+                                          principals.get(entry.getKey()),
+                                          entry.getValue().getChange(),
+                                          entry.getValue().getSourceControlMeta())
+    ));
   }
 
   /**
@@ -401,7 +412,8 @@ public class ApplicationLifecycleService extends AbstractIdleService {
       }
       try {
         ApplicationDetail applicationDetail = enforceApplicationDetailAccess(
-          appId, ApplicationDetail.fromSpec(appMeta.getSpec(), null, appMeta.getChange()));
+          appId, ApplicationDetail.fromSpec(appMeta.getSpec(), null,
+                                            appMeta.getChange(), appMeta.getSourceControlMeta()));
         // Add a directory for the namespace
         if (namespaces.add(appId.getParent())) {
           ZipEntry entry = new ZipEntry(appId.getNamespace() + "/");
@@ -1256,7 +1268,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
   }
 
   /**
-   * Enforces nessesary access on {@link ApplicationDetail}.
+   * Enforces necessary access on {@link ApplicationDetail}.
    */
   private ApplicationDetail enforceApplicationDetailAccess(ApplicationId appId,
                                                            ApplicationDetail applicationDetail) throws AccessException {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/ApplicationMeta.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/ApplicationMeta.java
@@ -20,6 +20,7 @@ import com.google.common.base.Objects;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.proto.artifact.ChangeDetail;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
 
 import javax.annotation.Nullable;
 
@@ -33,11 +34,19 @@ public class ApplicationMeta {
   private final ApplicationSpecification spec;
   @Nullable
   private final ChangeDetail change;
+  @Nullable
+  private final SourceControlMeta sourceControlMeta;
 
-  public ApplicationMeta(String id, ApplicationSpecification spec, @Nullable ChangeDetail change) {
+  public ApplicationMeta(String id, ApplicationSpecification spec,
+                         @Nullable ChangeDetail change, @Nullable SourceControlMeta sourceControlMeta) {
     this.id = id;
     this.spec = spec;
     this.change = change;
+    this.sourceControlMeta = sourceControlMeta;
+  }
+
+  public ApplicationMeta(String id, ApplicationSpecification spec, @Nullable ChangeDetail change) {
+    this(id, spec, change, null);
   }
 
   public String getId() {
@@ -53,12 +62,18 @@ public class ApplicationMeta {
     return change;
   }
 
+  @Nullable
+  public SourceControlMeta getSourceControlMeta() {
+    return sourceControlMeta;
+  }
+
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
       .add("id", id)
       .add("spec", ADAPTER.toJson(spec))
       .add("change", change)
+      .add("sourceControlMeta", sourceControlMeta)
       .toString();
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -63,6 +63,7 @@ import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.proto.id.WorkflowId;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.cdap.spi.data.SortOrder;
 import io.cdap.cdap.spi.data.StructuredTableContext;
@@ -784,6 +785,13 @@ public class DefaultStore implements Store {
   public Map<ApplicationId, ApplicationMeta> getApplications(Collection<ApplicationId> ids) {
     return TransactionRunners.run(transactionRunner, context -> {
       return getAppMetadataStore(context).getApplicationsForAppIds(ids);
+    });
+  }
+
+  @Override
+  public void setAppSourceControlMeta(ApplicationId appId, SourceControlMeta sourceControlMeta) {
+    TransactionRunners.run(transactionRunner, context -> {
+      getAppMetadataStore(context).setAppSourceControlMeta(appId, sourceControlMeta);
     });
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SourceControlManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SourceControlManagementServiceTest.java
@@ -16,20 +16,36 @@
 
 package io.cdap.cdap.internal.app.services;
 
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+import io.cdap.cdap.ConfigTestApp;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.common.NamespaceNotFoundException;
+import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.RepositoryNotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.metadata.MetadataSubscriberService;
+import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.sourcecontrol.AuthType;
 import io.cdap.cdap.proto.sourcecontrol.Provider;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryMeta;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
+import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
+import io.cdap.cdap.security.impersonation.UGIProvider;
+import io.cdap.cdap.sourcecontrol.operationrunner.PushAppResponse;
+import io.cdap.cdap.sourcecontrol.operationrunner.PushFailureException;
+import io.cdap.cdap.sourcecontrol.operationrunner.SourceControlOperationRunner;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * Tests for {@link SourceControlManagementService}
@@ -38,6 +54,8 @@ public class SourceControlManagementServiceTest extends AppFabricTestBase {
   private static CConfiguration cConf;
   private static NamespaceAdmin namespaceAdmin;
   private static SourceControlManagementService sourceControlService;
+  private static final SourceControlOperationRunner mockSourceControlOperationRunner =
+    Mockito.mock(SourceControlOperationRunner.class);
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -45,6 +63,17 @@ public class SourceControlManagementServiceTest extends AppFabricTestBase {
     initializeAndStartServices(cConf);
     namespaceAdmin = getInjector().getInstance(NamespaceAdmin.class);
     sourceControlService = getInjector().getInstance(SourceControlManagementService.class);
+  }
+
+  protected static void initializeAndStartServices(CConfiguration cConf) throws Exception {
+    initializeAndStartServices(cConf, new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(UGIProvider.class).to(CurrentUGIProvider.class);
+        bind(MetadataSubscriberService.class).in(Scopes.SINGLETON);
+        bind(SourceControlOperationRunner.class).toInstance(mockSourceControlOperationRunner);
+      }
+    });
   }
 
   @Test
@@ -113,7 +142,6 @@ public class SourceControlManagementServiceTest extends AppFabricTestBase {
 
     RepositoryMeta repoMeta = sourceControlService.getRepositoryMeta(namespaceId);
     Assert.assertEquals(namespaceRepo, repoMeta.getConfig());
-    Assert.assertNotNull(repoMeta.getUpdatedTimeMillis());
 
     // Delete repository and verify it's deleted
     sourceControlService.deleteRepository(namespaceId);
@@ -127,5 +155,120 @@ public class SourceControlManagementServiceTest extends AppFabricTestBase {
 
     //clean up
     namespaceAdmin.delete(namespaceId);
+  }
+
+  @Test
+  public void testPushAppSucceeds() throws Exception {
+    // Deploy one application in default namespace
+    Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp");
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "appWithConfig", "1.0.0-SNAPSHOT");
+    addAppArtifact(artifactId, ConfigTestApp.class);
+
+    ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("abc", "def");
+    deploy(appId1, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId()), config));
+
+    // Set the repository config
+    String namespace = Id.Namespace.DEFAULT.getId();
+    NamespaceId namespaceId = new NamespaceId(namespace);
+    RepositoryConfig namespaceRepo = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
+      .setLink("example.com").setDefaultBranch("develop").setAuthType(AuthType.PAT)
+      .setTokenName("token").setUsername("user").build();
+    sourceControlService.setRepository(namespaceId, namespaceRepo);
+    
+    PushAppResponse expectedAppResponse = new PushAppResponse(appId1.getId(), appId1.getVersion(),
+                                                              appId1.getId() + " hash");
+
+    Mockito.doReturn(expectedAppResponse)
+      .when(mockSourceControlOperationRunner).push(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+
+    // Assert the result is as expected
+    PushAppResponse result = sourceControlService.pushApp(namespaceId.appReference(appId1.getId()), "some commit");
+
+    Assert.assertEquals(result, expectedAppResponse);
+
+    // Assert the source control meta field is updated
+    ApplicationDetail appDetail = getAppDetails(Id.Namespace.DEFAULT.getId(), appId1.getId());
+    SourceControlMeta metaFromPushResult = new SourceControlMeta(result.getFileHash());
+    Assert.assertEquals(appDetail.getSourceControlMeta(), metaFromPushResult);
+
+    // Cleanup
+    deleteApp(appId1, 200);
+    deleteArtifact(artifactId, 200);
+    sourceControlService.deleteRepository(namespaceId);
+  }
+
+  @Test
+  public void testPushAppsRepoNotFoundException() throws Exception {
+    // Deploy one application in default namespace
+    Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp");
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "appWithConfig", "1.0.0-SNAPSHOT");
+    addAppArtifact(artifactId, ConfigTestApp.class);
+
+    ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("abc", "def");
+    deploy(appId1, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId()), config));
+    ApplicationDetail appDetail = getAppDetails(Id.Namespace.DEFAULT.getId(), appId1.getId());
+
+    // Do not set the repository config
+    NamespaceId namespaceId = new NamespaceId(Id.Namespace.DEFAULT.getId());
+
+    PushAppResponse expectedAppResponse = new PushAppResponse(appId1.getId(), appId1.getVersion(),
+                                                              appId1.getId() + " hash");
+
+    Mockito.doReturn(expectedAppResponse)
+      .when(mockSourceControlOperationRunner).push(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+
+    // Assert the result is as expected
+    try {
+      sourceControlService.pushApp(namespaceId.appReference(appId1.getId()), "some commit");
+      Assert.fail();
+    } catch (RepositoryNotFoundException e) {
+      // no-op
+    }
+    
+    // Cleanup
+    deleteApp(appId1, 200);
+    deleteArtifact(artifactId, 200);
+  }
+
+  @Test(expected = NotFoundException.class)
+  public void testPushAppsApplicationNotFoundException() throws Exception {
+    NamespaceId namespaceId = new NamespaceId(Id.Namespace.DEFAULT.getId());
+    sourceControlService.pushApp(namespaceId.appReference("appNotFound"), "some commit");
+  }
+
+  @Test
+  public void testPushAppsPushFailureException() throws Exception {
+    // Deploy one application in default namespace
+    Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp");
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "appWithConfig", "1.0.0-SNAPSHOT");
+    addAppArtifact(artifactId, ConfigTestApp.class);
+
+    ConfigTestApp.ConfigClass config = new ConfigTestApp.ConfigClass("abc", "def");
+    deploy(appId1, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId()), config));
+    ApplicationDetail appDetail = getAppDetails(Id.Namespace.DEFAULT.getId(), appId1.getId());
+
+    // Do not set the repository config
+    NamespaceId namespaceId = new NamespaceId(Id.Namespace.DEFAULT.getId());
+    RepositoryConfig namespaceRepo = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
+      .setLink("example.com").setDefaultBranch("develop").setAuthType(AuthType.PAT)
+      .setTokenName("token").setUsername("user").build();
+
+    // Set the repository config
+    sourceControlService.setRepository(namespaceId, namespaceRepo);
+
+    Mockito.doThrow(new PushFailureException("push apps failed", new Exception()))
+      .when(mockSourceControlOperationRunner).push(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+
+    // Assert the result is as expected
+    try {
+      sourceControlService.pushApp(namespaceId.appReference(appId1.getId()), "some commit");
+      Assert.fail();
+    } catch (PushFailureException e) {
+      // no-op
+    }
+
+    // Cleanup
+    deleteApp(appId1, 200);
+    deleteArtifact(artifactId, 200);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -100,6 +100,7 @@ import io.cdap.cdap.proto.ScheduleDetail;
 import io.cdap.cdap.proto.ScheduledRuntime;
 import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -107,6 +108,7 @@ import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.profile.Profile;
+import io.cdap.cdap.proto.sourcecontrol.PushAppRequest;
 import io.cdap.cdap.runtime.spi.profile.ProfileStatus;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
 import io.cdap.cdap.scheduler.Scheduler;
@@ -1463,6 +1465,13 @@ public abstract class AppFabricTestBase {
 
   protected HttpResponse deleteRepository(String name) throws Exception {
     return doDelete(String.format("%s/namespaces/%s/repository", Constants.Gateway.API_VERSION_3, name));
+  }
+
+  protected HttpResponse pushApplication(ApplicationReference appRef, String commitMessage) throws Exception {
+    PushAppRequest request = new PushAppRequest(commitMessage);
+    return doPost(String.format("%s/namespaces/%s/repository/apps/%s/push",
+                                Constants.Gateway.API_VERSION_3,
+                                appRef.getNamespace(), appRef.getApplication()), GSON.toJson(request));
   }
 
   protected String getPreferenceURI() {

--- a/cdap-client-tests/src/test/java/io/cdap/cdap/client/ApplicationClientTestRun.java
+++ b/cdap-client-tests/src/test/java/io/cdap/cdap/client/ApplicationClientTestRun.java
@@ -313,16 +313,19 @@ public class ApplicationClientTestRun extends ClientTestBase {
       Set<ApplicationRecord> apps = Sets.newHashSet(appClient.list(NamespaceId.DEFAULT, "fake", null));
       Set<ApplicationRecord> expected = ImmutableSet.of(
         new ApplicationRecord(new ArtifactSummary("fake", "1.0.0-SNAPSHOT"), appId1.getApplication(),
-                              fakeAppDetail2.getAppVersion(), "", null, fakeAppDetail2.getChange()),
+                              fakeAppDetail2.getAppVersion(), "", null,
+                              fakeAppDetail2.getChange(), appId3Detail.getSourceControlMeta()),
         new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT"), appId2.getApplication(),
-                              appId2Detail.getAppVersion(), "", null, appId2Detail.getChange())
+                              appId2Detail.getAppVersion(), "", null,
+                              appId2Detail.getChange(), appId2Detail.getSourceControlMeta())
       );
       Assert.assertEquals(expected, apps);
 
       apps = Sets.newHashSet(appClient.list(NamespaceId.DEFAULT, "otherfake", null));
       expected = ImmutableSet.of(
         new ApplicationRecord(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT"), appId3.getApplication(),
-                              appId3Detail.getAppVersion(), "", null, appId3Detail.getChange())
+                              appId3Detail.getAppVersion(), "", null,
+                              appId3Detail.getChange(), appId3Detail.getSourceControlMeta())
       );
       Assert.assertEquals(expected, apps);
 
@@ -330,11 +333,14 @@ public class ApplicationClientTestRun extends ClientTestBase {
       apps = Sets.newHashSet(appClient.list(NamespaceId.DEFAULT, ImmutableSet.of("fake", "otherfake"), null));
       expected = ImmutableSet.of(
         new ApplicationRecord(new ArtifactSummary("fake", "1.0.0-SNAPSHOT"), appId1.getApplication(),
-                              fakeAppDetail2.getAppVersion(), "", null, fakeAppDetail2.getChange()),
+                              fakeAppDetail2.getAppVersion(), "", null,
+                              fakeAppDetail2.getChange(), fakeAppDetail2.getSourceControlMeta()),
         new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT"), appId2.getApplication(),
-                              appId2Detail.getAppVersion(), "", null, appId2Detail.getChange()),
+                              appId2Detail.getAppVersion(), "", null,
+                              appId2Detail.getChange(), appId2Detail.getSourceControlMeta()),
         new ApplicationRecord(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT"), appId3.getApplication(),
-                              appId3Detail.getAppVersion(), "", null, appId3Detail.getChange())
+                              appId3Detail.getAppVersion(), "", null,
+                              appId3Detail.getChange(), appId3Detail.getSourceControlMeta())
       );
       Assert.assertEquals(expected, apps);
 
@@ -342,16 +348,19 @@ public class ApplicationClientTestRun extends ClientTestBase {
       apps = Sets.newHashSet(appClient.list(NamespaceId.DEFAULT, (String) null, "0.1.0-SNAPSHOT"));
       expected = ImmutableSet.of(new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT"),
                                                        appId2.getApplication(), appId2Detail.getAppVersion(),
-                                                       "", null, appId2Detail.getChange())
+                                                       "", null,
+                                                       appId2Detail.getChange(), appId2Detail.getSourceControlMeta())
       );
       Assert.assertEquals(expected, apps);
 
       apps = Sets.newHashSet(appClient.list(NamespaceId.DEFAULT, (String) null, "1.0.0-SNAPSHOT"));
       expected = ImmutableSet.of(
         new ApplicationRecord(new ArtifactSummary("fake", "1.0.0-SNAPSHOT"), appId1.getApplication(),
-                              fakeAppDetail2.getAppVersion(), "", null, fakeAppDetail2.getChange()),
+                              fakeAppDetail2.getAppVersion(), "", null,
+                              fakeAppDetail2.getChange(), fakeAppDetail2.getSourceControlMeta()),
         new ApplicationRecord(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT"), appId3.getApplication(),
-                              appId3Detail.getAppVersion(), "", null, appId3Detail.getChange())
+                              appId3Detail.getAppVersion(), "", null,
+                              appId3Detail.getChange(), appId3Detail.getSourceControlMeta())
       );
       Assert.assertEquals(expected, apps);
 
@@ -359,7 +368,8 @@ public class ApplicationClientTestRun extends ClientTestBase {
       apps = Sets.newHashSet(appClient.list(NamespaceId.DEFAULT, "fake", "0.1.0-SNAPSHOT"));
       expected = ImmutableSet.of(new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT"),
                                                        appId2.getApplication(), appId2Detail.getAppVersion(),
-                                                       "", null, appId2Detail.getChange()));
+                                                       "", null,
+                                                       appId2Detail.getChange(), appId2Detail.getSourceControlMeta()));
       Assert.assertEquals(expected, apps);
     } finally {
       //appClient.deleteAll(NamespaceId.DEFAULT);

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
@@ -390,6 +390,7 @@ public final class StoreDefinition {
     public static final String CHANGE_SUMMARY_FIELD = "change_summary";
     public static final String AUTHOR_FIELD = "author";
     public static final String LATEST_FIELD = "latest";
+    public static final String SOURCE_CONTROL_META = "source_control_metadata";
     public static final String PROGRAM_TYPE_FIELD = "program_type";
     public static final String PROGRAM_FIELD = "program";
     public static final String RUN_FIELD = "run";
@@ -416,7 +417,8 @@ public final class StoreDefinition {
                     Fields.longType(CREATION_TIME_FIELD),
                     Fields.stringType(AUTHOR_FIELD),
                     Fields.stringType(CHANGE_SUMMARY_FIELD),
-                    Fields.booleanType(LATEST_FIELD))
+                    Fields.booleanType(LATEST_FIELD),
+                    Fields.stringType(SOURCE_CONTROL_META))
         .withPrimaryKeys(NAMESPACE_FIELD, APPLICATION_FIELD, VERSION_FIELD)
         .withIndexes(LATEST_FIELD, CREATION_TIME_FIELD)
         .build();

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/ApplicationDetail.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/ApplicationDetail.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.plugin.Plugin;
 import io.cdap.cdap.internal.dataset.DatasetCreationSpec;
 import io.cdap.cdap.proto.artifact.ChangeDetail;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +39,8 @@ public class ApplicationDetail {
   private final String description;
   @Nullable
   private final ChangeDetail change;
+  @Nullable
+  private final SourceControlMeta sourceControlMeta;
   private final String configuration;
   private final List<DatasetDetail> datasets;
   private final List<ProgramRecord> programs;
@@ -50,6 +53,7 @@ public class ApplicationDetail {
                            String appVersion,
                            String description,
                            @Nullable ChangeDetail change,
+                           @Nullable SourceControlMeta sourceControlMeta,
                            String configuration,
                            List<DatasetDetail> datasets,
                            List<ProgramRecord> programs,
@@ -60,6 +64,7 @@ public class ApplicationDetail {
     this.appVersion = appVersion;
     this.description = description;
     this.change = change;
+    this.sourceControlMeta = sourceControlMeta;
     this.configuration = configuration;
     this.datasets = datasets;
     this.programs = programs;
@@ -88,6 +93,11 @@ public class ApplicationDetail {
     return change;
   }
 
+  @Nullable
+  public SourceControlMeta getSourceControlMeta() {
+    return sourceControlMeta;
+  }
+
   public List<DatasetDetail> getDatasets() {
     return datasets;
   }
@@ -110,7 +120,8 @@ public class ApplicationDetail {
   }
 
   public static ApplicationDetail fromSpec(ApplicationSpecification spec, @Nullable String ownerPrincipal,
-                                           @Nullable ChangeDetail change) {
+                                           @Nullable ChangeDetail change,
+                                           @Nullable SourceControlMeta sourceControlMeta) {
     // Adding owner, creation time and change summary description fields to the app detail
 
     List<ProgramRecord> programs = new ArrayList<>();
@@ -141,17 +152,17 @@ public class ApplicationDetail {
     }
 
     List<PluginDetail> plugins = new ArrayList<>();
-    for (Map.Entry<String, Plugin> pluginEnty : spec.getPlugins().entrySet()) {
-      plugins.add(new PluginDetail(pluginEnty.getKey(),
-                                   pluginEnty.getValue().getPluginClass().getName(),
-                                   pluginEnty.getValue().getPluginClass().getType()));
+    for (Map.Entry<String, Plugin> pluginEntry : spec.getPlugins().entrySet()) {
+      plugins.add(new PluginDetail(pluginEntry.getKey(),
+                                   pluginEntry.getValue().getPluginClass().getName(),
+                                   pluginEntry.getValue().getPluginClass().getType()));
     }
     // this is only required if there are old apps lying around that failed to get upgrading during
     // the upgrade to v3.2 for some reason. In those cases artifact id will be null until they re-deploy the app.
     // in the meantime, we don't want this api call to null pointer exception.
     ArtifactSummary summary = spec.getArtifactId() == null ?
       new ArtifactSummary(spec.getName(), null) : ArtifactSummary.from(spec.getArtifactId());
-    return new ApplicationDetail(spec.getName(), spec.getAppVersion(), spec.getDescription(), change,
+    return new ApplicationDetail(spec.getName(), spec.getAppVersion(), spec.getDescription(), change, sourceControlMeta,
                                  spec.getConfiguration(), datasets, programs, plugins, summary, ownerPrincipal);
   }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/ApplicationRecord.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/ApplicationRecord.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.proto;
 import com.google.gson.annotations.SerializedName;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.proto.artifact.ChangeDetail;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
 
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -36,14 +37,19 @@ public class ApplicationRecord {
   private final String ownerPrincipal;
   @Nullable
   private final ChangeDetail change;
+  @Nullable
+  private final SourceControlMeta sourceControlMeta;
 
   public ApplicationRecord(ApplicationDetail detail) {
     this(detail.getArtifact(), detail.getName(),
-         detail.getAppVersion(), detail.getDescription(), detail.getOwnerPrincipal(), detail.getChange());
+         detail.getAppVersion(), detail.getDescription(),
+         detail.getOwnerPrincipal(), detail.getChange(),
+         detail.getSourceControlMeta());
   }
 
   public ApplicationRecord(ArtifactSummary artifact, String name, String version, String description,
-                           @Nullable String ownerPrincipal, @Nullable ChangeDetail change) {
+                           @Nullable String ownerPrincipal, @Nullable ChangeDetail change,
+                           @Nullable SourceControlMeta sourceControlMeta) {
     this.type = "App";
     this.artifact = artifact;
     this.name = name;
@@ -51,6 +57,7 @@ public class ApplicationRecord {
     this.version = version;
     this.ownerPrincipal = ownerPrincipal;
     this.change = change;
+    this.sourceControlMeta = sourceControlMeta;
   }
 
   public ArtifactSummary getArtifact() {
@@ -83,6 +90,11 @@ public class ApplicationRecord {
     return change;
   }
 
+  @Nullable
+  public SourceControlMeta getSourceControlMeta() {
+    return sourceControlMeta;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -100,12 +112,13 @@ public class ApplicationRecord {
       Objects.equals(description, that.description) &&
       Objects.equals(artifact, that.artifact) &&
       Objects.equals(ownerPrincipal, that.ownerPrincipal) &&
-      Objects.equals(change, that.change);
+      Objects.equals(change, that.change) &&
+      Objects.equals(sourceControlMeta, that.sourceControlMeta);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, name, version, description, artifact, ownerPrincipal, change);
+    return Objects.hash(type, name, version, description, artifact, ownerPrincipal, change, sourceControlMeta);
   }
 
   @Override
@@ -118,6 +131,7 @@ public class ApplicationRecord {
       ", artifact=" + artifact +
       ", ownerPrincipal=" + ownerPrincipal + '\'' +
       ", change=" + change +
+      ", sourceControlMeta=" + sourceControlMeta +
       '}';
   }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/PushAppRequest.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/PushAppRequest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.sourcecontrol;
+
+import javax.annotation.Nullable;
+
+/**
+ * The request class to push an application to linked git repository.
+ */
+public class PushAppRequest {
+  private final String commitMessage;
+
+  public PushAppRequest(String commitMessage) {
+    this.commitMessage = commitMessage;
+  }
+
+  @Nullable
+  public String getCommitMessage() {
+    return commitMessage;
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/SourceControlMeta.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/SourceControlMeta.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.sourcecontrol;
+
+import java.util.Objects;
+
+/**
+ * The source control metadata for an application.
+ */
+public class SourceControlMeta {
+  private final String fileHash;
+
+  public SourceControlMeta(String fileHash) {
+    this.fileHash = fileHash;
+  }
+
+  public String getFileHash() {
+    return fileHash;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SourceControlMeta that = (SourceControlMeta) o;
+
+    return Objects.equals(fileHash, that.fileHash);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fileHash);
+  }
+
+  @Override
+  public String toString() {
+    return "SourceControlMeta{" +
+             "fileHash='" + fileHash + '\'' +
+             '}';
+  }
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/CommitMeta.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/CommitMeta.java
@@ -23,13 +23,13 @@ import java.util.Objects;
  */
 public class CommitMeta {
   private final String author;
-  private final String commiter;
+  private final String committer;
   private final long timestampMillis;
   private final String message;
 
-  public CommitMeta(String author, String commiter, long timestampMillis, String message) {
+  public CommitMeta(String author, String committer, long timestampMillis, String message) {
     this.author = author;
-    this.commiter = commiter;
+    this.committer = committer;
     this.timestampMillis = timestampMillis;
     this.message = message;
   }
@@ -38,8 +38,8 @@ public class CommitMeta {
     return author;
   }
 
-  public String getCommiter() {
-    return commiter;
+  public String getCommitter() {
+    return committer;
   }
 
   public long getTimestampMillis() {
@@ -59,12 +59,12 @@ public class CommitMeta {
       return false;
     }
     CommitMeta that = (CommitMeta) o;
-    return timestampMillis == that.timestampMillis && author.equals(that.author) && commiter.equals(that.commiter) &&
+    return timestampMillis == that.timestampMillis && author.equals(that.author) && committer.equals(that.committer) &&
       message.equals(that.message);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(author, commiter, timestampMillis, message);
+    return Objects.hash(author, committer, timestampMillis, message);
   }
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/NoChangesToPushException.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/NoChangesToPushException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol;
+
+/**
+ * Exception thrown when there's no changes needed to push to linked repository
+ */
+public class NoChangesToPushException extends Exception {
+  public NoChangesToPushException(String message) {
+    super(message);
+  }
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManagerFactory.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManagerFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+
+/**
+ * The default implementation for RepositoryManagerFactory
+ */
+public class RepositoryManagerFactory {
+
+  private final SecureStore secureStore;
+  private final CConfiguration cConf;
+
+  @Inject
+  RepositoryManagerFactory(SecureStore secureStore, CConfiguration cConf) {
+    this.secureStore = secureStore;
+    this.cConf = cConf;
+  }
+
+  public RepositoryManager create(NamespaceId namespace, RepositoryConfig repoConfig) {
+    return new RepositoryManager(secureStore, cConf, namespace, repoConfig);
+  }
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/SourceControlModule.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/SourceControlModule.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+import io.cdap.cdap.sourcecontrol.operationrunner.InMemorySourceControlOperationRunner;
+import io.cdap.cdap.sourcecontrol.operationrunner.SourceControlOperationRunner;
+
+/**
+ *  Guice module for source control management classes.
+ */
+public class SourceControlModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    // TODO: CDAP-20322 add the remoteSourceControlOperationRunner
+    bind(SourceControlOperationRunner.class).to(InMemorySourceControlOperationRunner.class).in(Scopes.SINGLETON);
+  }
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/UnexpectedRepositoryChangesException.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/UnexpectedRepositoryChangesException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol;
+
+/**
+ * Exception thrown when we find changes other than added files
+ */
+public class UnexpectedRepositoryChangesException extends Exception {
+  public UnexpectedRepositoryChangesException(String message) {
+    super(message);
+  }
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/InMemorySourceControlOperationRunner.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/InMemorySourceControlOperationRunner.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol.operationrunner;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Inject;
+import io.cdap.cdap.proto.ApplicationDetail;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
+import io.cdap.cdap.sourcecontrol.CommitMeta;
+import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
+import io.cdap.cdap.sourcecontrol.RepositoryManager;
+import io.cdap.cdap.sourcecontrol.RepositoryManagerFactory;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * In-Memory implementation for {@link SourceControlOperationRunner}.
+ * Runs all git operation inside calling service.
+ */
+public class InMemorySourceControlOperationRunner implements SourceControlOperationRunner {
+  private final RepositoryManagerFactory repoManagerFactory;
+  private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+  private static final Logger LOG = LoggerFactory.getLogger(InMemorySourceControlOperationRunner.class);
+
+  @Inject
+  InMemorySourceControlOperationRunner(RepositoryManagerFactory repoManagerFactory) {
+    this.repoManagerFactory = repoManagerFactory;
+  }
+
+  @Override
+  public PushAppResponse push(NamespaceId namespace, RepositoryConfig repoConfig,
+                              ApplicationDetail appToPush, CommitMeta commitDetails)
+    throws PushFailureException, NoChangesToPushException, AuthenticationConfigException {
+    RepositoryManager repositoryManager = repoManagerFactory.create(namespace, repoConfig);
+    try {
+      try {
+        repositoryManager.cloneRemote();
+      } catch (GitAPIException | IOException e) {
+        throw new PushFailureException(String.format("Failed to clone remote repository: %s", e.getMessage()), e);
+      }
+
+      LOG.info("Pushing application configs for : {}", appToPush);
+
+      //TODO: CDAP-20371, Add retry logic here in case the head at remote moved while we are doing push
+      return writeAppDetailAndPush(repositoryManager, appToPush, commitDetails);
+    } finally {
+      try {
+        repositoryManager.close();
+      } catch (IOException e) {
+        LOG.warn("Failed to close the RepositoryManager, there may be leftover files", e);
+      }
+    }
+  }
+
+  /**
+   * Atomic operation of writing application and push, return the push response.
+   *
+   * @param repositoryManager {@link RepositoryManager} to conduct git operations
+   * @param appToPush         {@link ApplicationDetail} to push
+   * @param commitDetails     {@link CommitMeta} from user input
+   * @return {@link PushAppResponse}
+   * @throws NoChangesToPushException if there's no change between the application in namespace and git repository
+   * @throws PushFailureException     for failures while writing config file or doing git operations
+   */
+  private PushAppResponse writeAppDetailAndPush(RepositoryManager repositoryManager,
+                                                ApplicationDetail appToPush,
+                                                CommitMeta commitDetails)
+    throws NoChangesToPushException, PushFailureException {
+    try {
+      // Creates the base directory if it does not exist. This method does not throw an exception if the directory
+      // already exists. This is for the case that the repo is new and user configured prefix path.
+      Files.createDirectories(repositoryManager.getBasePath());
+    } catch (IOException e) {
+      throw new PushFailureException("Failed to create repository base directory", e);
+    }
+
+    String configFileName = generateConfigFileName(appToPush.getName());
+
+    Path appRelativePath = repositoryManager.getFileRelativePath(configFileName);
+    Path filePathToWrite = validateAppConfigRelativePath(repositoryManager, appRelativePath);
+    // Opens the file for writing, creating the file if it doesn't exist,
+    // or truncating an existing regular-file to a size of 0
+    try (FileWriter writer = new FileWriter(filePathToWrite.toString())) {
+      GSON.toJson(appToPush, writer);
+    } catch (IOException e) {
+      throw new PushFailureException(
+        String.format("Failed to write application config to path %s", appRelativePath), e);
+    }
+
+    LOG.debug("Wrote application configs for {} in file {}", appToPush.getName(), appRelativePath);
+
+    try {
+      // TODO: CDAP-20383, handle NoChangesToPushException
+      //  Define the case that the application to push does not have any changes
+      String gitFileHash = repositoryManager.commitAndPush(commitDetails, appRelativePath);
+      return new PushAppResponse(appToPush.getName(), appToPush.getAppVersion(), gitFileHash);
+    } catch (GitAPIException e) {
+      throw new PushFailureException(String.format("Failed to push config to git: %s", e.getMessage()), e);
+    }
+  }
+
+  /**
+   * Generate config file name from app name.
+   * Currently, it only adds `.json` as extension with app name being the filename.
+   *
+   * @param appName Name of the application
+   * @return The file name we want to store application config in
+   */
+  private String generateConfigFileName(String appName) {
+    return String.format("%s.json", appName);
+  }
+
+  /**
+   * Validates if the resolved path is not a symbolic link and not a directory.
+   *
+   * @param repositoryManager the RepositoryManager
+   * @param appRelativePath   the relative {@link Path} of the application to write to
+   * @return A valid application config file relative path
+   */
+  private Path validateAppConfigRelativePath(RepositoryManager repositoryManager,
+                                             Path appRelativePath)
+    throws PushFailureException {
+    Path filePath = repositoryManager.getRepositoryRoot().resolve(appRelativePath);
+    if (Files.isSymbolicLink(filePath)) {
+      throw new PushFailureException(String.format("Cannot push %s to the remote repository because it already " +
+                                                     "exists as a symbolic link. Symbolic links are not allowed.",
+                                                   appRelativePath));
+    }
+    if (Files.isDirectory(filePath)) {
+      throw new PushFailureException(String.format("Cannot push %s to the remote repository because it already " +
+                                                     "exists as a directory.", appRelativePath));
+    }
+    return filePath;
+  }
+}
+

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/PushAppResponse.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/PushAppResponse.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol.operationrunner;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Encapsulates the information generated from a single application push
+ */
+public class PushAppResponse {
+  private final String name;
+  private final String version;
+  @Nullable
+  private final String fileHash;
+
+  public PushAppResponse(String name, String version, @Nullable String fileHash) {
+    this.name = name;
+    this.version = version;
+    this.fileHash = fileHash;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Nullable
+  public String getFileHash() {
+    return fileHash;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PushAppResponse that = (PushAppResponse) o;
+    return Objects.equals(name, that.name) &&
+      Objects.equals(version, that.version) &&
+      Objects.equals(fileHash, that.fileHash);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, version, fileHash);
+  }
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/PushFailureException.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/PushFailureException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol.operationrunner;
+
+/**
+ * Exception thrown when push operation fails in operation runner.
+ * Encapsulates all underlying exceptions.
+ */
+public class PushFailureException extends Exception {
+  public PushFailureException(String message, Exception cause) {
+    super(message, cause);
+  }
+
+  public PushFailureException(String message) {
+    super(message);
+  }
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/SourceControlOperationRunner.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/SourceControlOperationRunner.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol.operationrunner;
+
+import io.cdap.cdap.proto.ApplicationDetail;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
+import io.cdap.cdap.sourcecontrol.CommitMeta;
+import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
+
+/**
+ * An interface encapsulating all operations needed for source control management
+ */
+public interface SourceControlOperationRunner {
+  /**
+   * @param appToPush {@link ApplicationDetail} to be pushed
+   * @param commitDetails Details of commit author, committer and message
+   * @return file-paths and file-hashes for the updated configs.
+   * @throws PushFailureException when the push operation fails for any reason.
+   */
+  PushAppResponse push(NamespaceId namespace, RepositoryConfig repoConfig,
+                       ApplicationDetail appToPush, CommitMeta commitDetails)
+    throws PushFailureException, NoChangesToPushException, AuthenticationConfigException;
+}

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigValidationException;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.junit.Assert;
 import org.junit.Before;
@@ -45,7 +46,10 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Tests for {@link  RepositoryManager}.
@@ -254,9 +258,7 @@ public class RepositoryManagerTest {
     addSymbolicLinkToGit(symlinkPath2, symlinkPath1);
 
     RepositoryConfig repositoryConfig = getRepositoryConfigBuilder().setPathPrefix("cdap/applications").build();
-    SourceControlConfig sourceControlConfig =
-      new SourceControlConfig(new NamespaceId(NAMESPACE), repositoryConfig, cConf);
-    RepositoryManager manager = new RepositoryManager(secureStore, sourceControlConfig);
+    RepositoryManager manager = new RepositoryManager(secureStore, cConf, new NamespaceId(NAMESPACE), repositoryConfig);
     String commitID = manager.cloneRemote();
     String expectedHash = getGitStyleHash(contents);
     // The hash of the original file, and both the symlinks should be equal.
@@ -288,7 +290,7 @@ public class RepositoryManagerTest {
    * @return the {@link RepositoryManager}.
    */
   private RepositoryManager getRepositoryManager() {
-    return new RepositoryManager(secureStore, getSourceControlConfig());
+    return new RepositoryManager(secureStore, cConf, new NamespaceId(NAMESPACE), getRepositoryConfigBuilder().build());
   }
 
   /**
@@ -371,4 +373,102 @@ public class RepositoryManagerTest {
       .hashString("blob " + fileContents.length() + "\0" + fileContents, StandardCharsets.UTF_8)
       .toString();
   }
+
+  @Test
+  public void testCommitAndPushSuccess() throws Exception {
+    String serverURL = gitServer.getServerURL();
+    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
+      .setLink(serverURL + "ignored")
+      .setDefaultBranch("develop")
+      .setAuthType(AuthType.PAT)
+      .setTokenName(GITHUB_TOKEN_NAME)
+      .build();
+
+    try (RepositoryManager manager = new RepositoryManager(secureStore, cConf,
+                                                           new NamespaceId(NAMESPACE), config)) {
+      manager.cloneRemote();
+      CommitMeta commitMeta = new CommitMeta("author", "committer", 100, "message");
+      Path filePath = manager.getBasePath().resolve("file1");
+      String fileContent = "content";
+
+      Files.write(filePath, fileContent.getBytes(StandardCharsets.UTF_8));
+      manager.commitAndPush(commitMeta, manager.getBasePath().relativize(filePath));
+      verifyCommit(filePath, fileContent, commitMeta);
+    }
+  }
+
+  @Test(expected = NoChangesToPushException.class)
+  public void testCommitAndPushNoChangeSuccess() throws Exception {
+    String pathPrefix = "prefix";
+    String serverURL = gitServer.getServerURL();
+    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
+      .setLink(serverURL + "ignored")
+      .setDefaultBranch("develop")
+      .setPathPrefix(pathPrefix)
+      .setAuthType(AuthType.PAT)
+      .setTokenName(GITHUB_TOKEN_NAME)
+      .build();
+
+    try (RepositoryManager manager = new RepositoryManager(secureStore, cConf, new NamespaceId(NAMESPACE), config)) {
+      manager.cloneRemote();
+      CommitMeta commitMeta = new CommitMeta("author", "committer", 100, "message");
+      manager.commitAndPush(commitMeta, Paths.get(pathPrefix));
+
+      verifyNoCommit();
+    }
+  }
+
+  @Test(expected = GitAPIException.class)
+  public void testCommitAndPushFails() throws Exception {
+    String serverURL = gitServer.getServerURL();
+    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
+      .setLink(serverURL + "ignored")
+      .setDefaultBranch("develop")
+      .setAuthType(AuthType.PAT)
+      .setTokenName(GITHUB_TOKEN_NAME)
+      .build();
+
+    try (RepositoryManager manager = new RepositoryManager(secureStore, cConf,
+                                                           new NamespaceId(NAMESPACE), config)) {
+      manager.cloneRemote();
+      CommitMeta commitMeta = new CommitMeta("author", "committer", 100, "message");
+      Path filePath = manager.getBasePath().resolve("file1");
+      String fileContent = "content";
+
+      Files.write(filePath, fileContent.getBytes(StandardCharsets.UTF_8));
+      gitServer.after();
+      manager.commitAndPush(commitMeta, manager.getBasePath().relativize(filePath));
+    }
+  }
+
+  private void verifyNoCommit() throws GitAPIException, IOException {
+    Path tempDirPath = tempFolder.newFolder("temp-local-git-verify").toPath();
+    Git localGit = getClonedGit(tempDirPath);
+    List<RevCommit> commits = StreamSupport.stream(localGit.log().all().call().spliterator(), false).
+      collect(Collectors.toList());
+    Assert.assertEquals(1, commits.size());
+  }
+
+  private void verifyCommit(Path pathFromRepoRoot, String expectedContent, CommitMeta commitMeta)
+    throws GitAPIException, IOException {
+    Path tempDirPath = tempFolder.newFolder("temp-local-git-verify").toPath();
+    Git localGit = getClonedGit(tempDirPath);
+    Path filePath = tempDirPath.resolve(pathFromRepoRoot);
+
+    String actualContent = new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
+    Assert.assertEquals(expectedContent, actualContent);
+
+    List<RevCommit> commits = StreamSupport.stream(localGit.log().all().call().spliterator(), false)
+      .collect(Collectors.toList());
+    Assert.assertEquals(2, commits.size());
+    RevCommit latestCommit = commits.get(0);
+
+    Assert.assertEquals(latestCommit.getFullMessage(), commitMeta.getMessage());
+    Assert.assertEquals(commitMeta.getAuthor(), latestCommit.getAuthorIdent().getName());
+    Assert.assertEquals(commitMeta.getCommitter(), latestCommit.getCommitterIdent().getName());
+
+    localGit.close();
+    DirUtils.deleteDirectoryContents(tempDirPath.toFile());
+  }
+
 }

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/operationrunner/InMemorySourceControlOperationRunnerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/operationrunner/InMemorySourceControlOperationRunnerTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol.operationrunner;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.proto.ApplicationDetail;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.sourcecontrol.AuthType;
+import io.cdap.cdap.proto.sourcecontrol.Provider;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
+import io.cdap.cdap.sourcecontrol.CommitMeta;
+import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
+import io.cdap.cdap.sourcecontrol.RepositoryManager;
+import io.cdap.cdap.sourcecontrol.RepositoryManagerFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+
+public class InMemorySourceControlOperationRunnerTest {
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  private static final ApplicationDetail testAppDetails = new ApplicationDetail(
+    "app1", "v1", "description1", null, null, "conf1", new ArrayList<>(),
+    new ArrayList<>(), new ArrayList<>(), null, null);
+  private static final String pathPrefix = "pathPrefix";
+  private static final RepositoryConfig testRepoConfig = new RepositoryConfig.Builder()
+    .setProvider(Provider.GITHUB)
+    .setLink("ignored")
+    .setDefaultBranch("develop")
+    .setPathPrefix(pathPrefix)
+    .setAuthType(AuthType.PAT)
+    .setTokenName("GITHUB_TOKEN_NAME")
+    .build();
+  private static final CommitMeta testCommit = new CommitMeta("author1", "committer1", 123, "message1");
+  private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+  private static final NamespaceId NAMESPACE = NamespaceId.DEFAULT;
+
+  private InMemorySourceControlOperationRunner operationRunner;
+  private RepositoryManager mockRepositoryManager;
+
+  @Before
+  public void setUp() throws Exception {
+    RepositoryManagerFactory mockRepositoryManagerFactory = Mockito.mock(RepositoryManagerFactory.class);
+    this.mockRepositoryManager = Mockito.mock(RepositoryManager.class);
+    Mockito.doReturn(mockRepositoryManager).when(mockRepositoryManagerFactory).create(Mockito.any(), Mockito.any());
+    Mockito.doReturn("commit hash").when(mockRepositoryManager).cloneRemote();
+    this.operationRunner = new InMemorySourceControlOperationRunner(mockRepositoryManagerFactory);
+    Path appRelativePath = Paths.get(pathPrefix, testAppDetails.getName() + ".json");
+    Mockito.doReturn(appRelativePath).when(mockRepositoryManager).getFileRelativePath(Mockito.any());
+  }
+
+  private boolean verifyConfigFileContent(Path repoDirPath) throws IOException {
+    String fileData = new String(Files.readAllBytes(
+      repoDirPath.resolve(String.format("%s.json", testAppDetails.getName()))), StandardCharsets.UTF_8);
+    return fileData.equals(GSON.toJson(testAppDetails));
+  }
+
+  @Test
+  public void testPushSuccess() throws Exception {
+    Path tmpRepoDirPath = TMP_FOLDER.newFolder().toPath();
+    Path baseRepoDirPath = tmpRepoDirPath.resolve(pathPrefix);
+
+    Mockito.doReturn(tmpRepoDirPath).when(mockRepositoryManager).getRepositoryRoot();
+    Mockito.doReturn(baseRepoDirPath).when(mockRepositoryManager).getBasePath();
+    Mockito.doReturn("file Hash").when(mockRepositoryManager).commitAndPush(Mockito.anyObject(),
+                                                                            Mockito.any());
+
+    operationRunner.push(NAMESPACE, testRepoConfig, testAppDetails, testCommit);
+
+    Assert.assertTrue(verifyConfigFileContent(baseRepoDirPath));
+  }
+
+  @Test(expected = PushFailureException.class)
+  public void testPushFailedToCreateDirectory() throws Exception {
+    // Setting the repo dir as file causing failure in Files.createDirectories
+    Path tmpRepoDirPath = TMP_FOLDER.newFile().toPath();
+    Path baseRepoDirPath = tmpRepoDirPath.resolve(pathPrefix);
+
+    Mockito.doReturn(tmpRepoDirPath).when(mockRepositoryManager).getRepositoryRoot();
+    Mockito.doReturn(baseRepoDirPath).when(mockRepositoryManager).getBasePath();
+
+    operationRunner.push(NAMESPACE, testRepoConfig, testAppDetails, testCommit);
+  }
+
+  @Test(expected = PushFailureException.class)
+  public void testPushFailedToWriteFile() throws Exception {
+    Path tmpRepoDirPath = TMP_FOLDER.newFolder().toPath();
+    Path baseRepoDirPath = tmpRepoDirPath.resolve(pathPrefix);
+    // creating a directory where validateAppConfigRelativePath should throw PushFailureException
+    Files.createDirectories(baseRepoDirPath.resolve(testAppDetails.getName() + ".json"));
+
+    Mockito.doReturn(tmpRepoDirPath).when(mockRepositoryManager).getRepositoryRoot();
+    Mockito.doReturn(baseRepoDirPath).when(mockRepositoryManager).getBasePath();
+
+    operationRunner.push(NAMESPACE, testRepoConfig, testAppDetails, testCommit);
+  }
+
+  @Test(expected = PushFailureException.class)
+  public void testPushFailedInvalidSymlinkPath() throws Exception {
+    Path tmpRepoDirPath = TMP_FOLDER.newFolder().toPath();
+    Path baseRepoDirPath = tmpRepoDirPath.resolve(pathPrefix);
+
+    Mockito.doReturn(tmpRepoDirPath).when(mockRepositoryManager).getRepositoryRoot();
+    Mockito.doReturn(baseRepoDirPath).when(mockRepositoryManager).getBasePath();
+    Mockito.doReturn("file Hash").when(mockRepositoryManager).commitAndPush(Mockito.anyObject(),
+                                                                            Mockito.any());
+
+    Path target = tmpRepoDirPath.resolve("target");
+    Files.createDirectories(baseRepoDirPath);
+    Files.createFile(target);
+    Files.createSymbolicLink(baseRepoDirPath.resolve("app1.json"), target);
+    operationRunner.push(NAMESPACE, testRepoConfig, testAppDetails, testCommit);
+  }
+
+  @Test(expected = AuthenticationConfigException.class)
+  public void testPushFailedToClone() throws Exception {
+    Mockito.doThrow(new AuthenticationConfigException("config not exists")).when(mockRepositoryManager).cloneRemote();
+    operationRunner.push(NAMESPACE, testRepoConfig, testAppDetails, testCommit);
+  }
+
+  @Test(expected = NoChangesToPushException.class)
+  public void testPushNoChanges() throws Exception {
+    Path tmpRepoDirPath = TMP_FOLDER.newFolder().toPath();
+    Path baseRepoDirPath = tmpRepoDirPath.resolve(pathPrefix);
+
+    Mockito.doReturn(tmpRepoDirPath).when(mockRepositoryManager).getRepositoryRoot();
+    Mockito.doReturn(baseRepoDirPath).when(mockRepositoryManager).getBasePath();
+    Mockito.doThrow(new NoChangesToPushException("no changes to push"))
+      .when(mockRepositoryManager).commitAndPush(Mockito.any(), Mockito.any());
+    operationRunner.push(NAMESPACE, testRepoConfig, testAppDetails, testCommit);
+  }
+}


### PR DESCRIPTION
## What
1. Added the pushApp endpoint in SCM http handler
2. It's a joint effort PR with @samdgupi 's https://github.com/cdapio/cdap/pull/14900


Example:
API: `namespaces/<ns>/repository/apps/<app-id>/push`
Request:
```
{
  "commitMessage": "testing push apps DataFusionQuickstart_edit_new_name"
}
```

Response: 
```
{
  "name": "DataFusionQuickstart_edit_new_name",
  "version": "848bdde6-937c-11ed-a08f-000000140577",
  "fileHash": "06cfb766ba2b361cd38cfd839319fa662734df25"
}
```