### PR TITLE
[CDAP-20343] Implement RepositoryManager#getFileHash()

### DIFF
--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManager.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManager.java
@@ -16,9 +16,11 @@
 
 package io.cdap.cdap.sourcecontrol;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigValidationException;
@@ -29,37 +31,50 @@ import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.internal.storage.dfs.InMemoryRepository;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 /**
  * A git repository manager that is responsible for handling interfacing with git. It provides version control
- * operations.
+ * operations. This is not thread safe.
  */
 public class RepositoryManager implements AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(RepositoryManager.class);
   private final SourceControlConfig sourceControlConfig;
   private final RefreshableCredentialsProvider credentialsProvider;
   private Git git;
+  // We clone the repository inside a randomly named directory to prevent multiple repository managers for the
+  // same namespace from interfering with each other.
+  private final String randomDirectoryName;
 
   public RepositoryManager(SecureStore secureStore, SourceControlConfig sourceControlConfig) {
     this.sourceControlConfig = sourceControlConfig;
     try {
-      this.credentialsProvider = new AuthenticationStrategyProvider(sourceControlConfig.getNamespaceID(),
-                                                                    secureStore)
+      this.credentialsProvider = new AuthenticationStrategyProvider(sourceControlConfig.getNamespaceID(), secureStore)
         .get(sourceControlConfig.getRepositoryConfig())
         .getCredentialsProvider();
     } catch (AuthenticationStrategyNotFoundException e) {
       // This is not expected as only valid auth configs will be stored.
       throw new RuntimeException(e);
     }
+    this.randomDirectoryName = UUID.randomUUID().toString();
   }
 
   /**
@@ -69,7 +84,7 @@ public class RepositoryManager implements AutoCloseable {
    * @return the path for the repository base directory.
    */
   public Path getBasePath() {
-    Path localRepoPath = sourceControlConfig.getLocalRepoPath();
+    Path localRepoPath = getRepositoryRoot();
     String pathPrefix = sourceControlConfig.getRepositoryConfig().getPathPrefix();
     if (pathPrefix == null) {
       return localRepoPath;
@@ -91,8 +106,7 @@ public class RepositoryManager implements AutoCloseable {
     RepositoryConfig config = sourceControlConfig.getRepositoryConfig();
     RefreshableCredentialsProvider credentialsProvider;
     try {
-      credentialsProvider = new AuthenticationStrategyProvider(sourceControlConfig.getNamespaceID(),
-                                                               secureStore)
+      credentialsProvider = new AuthenticationStrategyProvider(sourceControlConfig.getNamespaceID(), secureStore)
         .get(sourceControlConfig.getRepositoryConfig())
         .getCredentialsProvider();
     } catch (AuthenticationStrategyNotFoundException e) {
@@ -122,27 +136,86 @@ public class RepositoryManager implements AutoCloseable {
   }
 
   /**
-   * Initializes the Git repository by cloning remote.
+   * Returns the <a href="https://git-scm.com/docs/git-hash-object">Git Hash</a>
+   * of the requested file path in the provided commit. For symlinks, it returns the hash of
+   * the target file. This ensures that the file hash of a symlink is equal to the hash of the target file. It
+   * doesn't return the hash for directories. If the directory contains symlinks, we can't depend on the
+   * directory hash to ensure the contents are unchanged.
    *
+   * @param relativePath The path relative to the repository base path (returned by
+   *                     {@link RepositoryManager#getRepositoryRoot()}) on the filesystem.
+   * @param commitHash   The commit ID hash for which to get the file hash.
+   * @return The git file hash of the requested file.
+   * @throws IOException              when file or commit isn't found, there are circular symlinks or other file IO
+   *                                  errors.
+   * @throws IllegalArgumentException when the provided file isn't a regular file, eg: directory.
+   * @throws NotFoundException        when the file isn't committed to Git.
+   * @throws IllegalStateException    when {@link RepositoryManager#cloneRemote()} isn't called before this.
+   */
+  public String getFileHash(Path relativePath, String commitHash) throws IOException, NotFoundException,
+    GitAPIException {
+    validateInitialized();
+    // Save changes before checking out the requested commit.
+    ObjectId previousCommit = resolveHead();
+    // Stash changes in current working directory. Stash ID will be null if working directory is clean.
+    RevCommit stashID = git.stashCreate().setIncludeUntracked(true).call();
+
+    try {
+      ObjectId commitId = ObjectId.fromString(commitHash);
+      // Each commit points to a tree that contains the files/directories as nodes. The ObjectId (hashes) of the nodes
+      // represent the state of a file at that commit.
+      RevCommit commit = new RevWalk(git.getRepository()).parseCommit(commitId);
+      // Checkout the requested commit.
+      git.checkout().setName(commitHash).call();
+
+      // Git considers symlinks as separate files. So the hash of the symlink will be different from the target file.
+      // Resolve path in case of symlinks. This ensures the hash of the target file is returned.
+      Path realPath = getRepositoryRoot().resolve(relativePath).toRealPath();
+      // We should not be comparing hashes of directories. If the directory contains symlinks, we can't depend on the
+      // directory hash to ensure the contents are unchanged.
+      if (!Files.isRegularFile(realPath)) {
+        throw new IllegalArgumentException(String.format("Path %s doesn't refer to a regular file.",
+                                                         realPath.toAbsolutePath()));
+      }
+      Path realRelativePath = getRepositoryRoot().relativize(realPath);
+      // Find the node representing the exact file path in the tree.
+      TreeWalk walk = TreeWalk.forPath(git.getRepository(), realRelativePath.toString(), commit.getTree());
+      if (walk == null) {
+        throw new NotFoundException("File not found in Git revision tree.");
+      }
+      return walk.getObjectId(0).getName();
+    } finally {
+      // Restore the changes to working directory.
+      git.checkout().setName(previousCommit.getName()).call();
+      popStash(stashID);
+    }
+  }
+
+  /**
+   * Initializes the Git repository by cloning remote. This method doesn't re-clone if the remote has already been
+   * cloned earlier.
+   *
+   * @return the commit ID of the present HEAD.
    * @throws GitAPIException               when a Git operation fails.
    * @throws IOException                   when file or network I/O fails.
    * @throws AuthenticationConfigException when there is a failure while fetching authentication credentials for Git.
    */
-  public void cloneRemote() throws Exception {
+  public String cloneRemote() throws Exception {
     if (git != null) {
-      return;
+      return resolveHead().getName();
     }
     // Clean up the directory if it already exists.
-    deletePathIfExists(sourceControlConfig.getLocalRepoPath());
+    deletePathIfExists(getRepositoryRoot());
     RepositoryConfig repositoryConfig = sourceControlConfig.getRepositoryConfig();
     credentialsProvider.refresh();
-    CloneCommand command = createCommand(Git::cloneRepository).setURI(repositoryConfig.getLink())
-      .setDirectory(sourceControlConfig.getLocalRepoPath().toFile());
+    CloneCommand command =
+      createCommand(Git::cloneRepository).setURI(repositoryConfig.getLink()).setDirectory(getRepositoryRoot().toFile());
     String branch = getBranchRefName(repositoryConfig.getDefaultBranch());
     if (branch != null) {
       command.setBranchesToClone(Collections.singleton((branch))).setBranch(branch);
     }
     git = command.call();
+    return resolveHead().getName();
   }
 
   @Override
@@ -151,7 +224,14 @@ public class RepositoryManager implements AutoCloseable {
       git.close();
     }
     git = null;
-    deletePathIfExists(sourceControlConfig.getLocalRepoPath());
+    deletePathIfExists(getRepositoryRoot());
+  }
+
+  /**
+   * @return the absolute path for repository root
+   */
+  public Path getRepositoryRoot() {
+    return sourceControlConfig.getLocalReposClonePath().resolve(randomDirectoryName);
   }
 
   private <C extends TransportCommand> C createCommand(Supplier<C> creator) {
@@ -209,4 +289,35 @@ public class RepositoryManager implements AutoCloseable {
       DirUtils.deleteDirectoryContents(path.toFile());
     }
   }
+
+  @VisibleForTesting
+  ObjectId resolveHead() throws IOException {
+    if (git == null) {
+      throw new IllegalStateException("Call cloneRemote() before getting HEAD.");
+    }
+    return git.getRepository().resolve(Constants.HEAD);
+  }
+
+  /**
+   * Pops the stash with the given rev commit.
+   */
+  private void popStash(@Nullable RevCommit stashID) throws GitAPIException {
+    if (stashID == null) {
+      LOG.debug("Pop stash called with null stashID, nothing will be popped.");
+      return;
+    }
+    // pop the stash.
+    git.stashApply().setStashRef(stashID.getName()).setRestoreUntracked(true).call();
+    Collection<RevCommit> stashes = git.stashList().call();
+    int stashIndex = 0;
+    for (RevCommit stash : stashes) {
+      if (stash.equals(stashID)) {
+        git.stashDrop().setStashRef(stashIndex).call();
+        return;
+      }
+      stashIndex++;
+    }
+    LOG.warn("Couldn't find Git stash with ID {} to drop. Ignoring missing stash.", stashID.getName());
+  }
+
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/SourceControlConfig.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/SourceControlConfig.java
@@ -30,8 +30,8 @@ import java.util.Objects;
  */
 public class SourceControlConfig {
   private final String namespaceID;
-  // Path where local git repository is stored.
-  private final Path localRepoPath;
+  // Path where local git repositories are stored.
+  private final Path localReposClonePath;
   private final int gitCommandTimeoutSeconds;
   private final RepositoryConfig repositoryConfig;
 
@@ -40,15 +40,15 @@ public class SourceControlConfig {
     this.repositoryConfig = repositoryConfig;
     String gitCloneDirectory = cConf.get(Constants.SourceControlManagement.GIT_REPOSITORIES_CLONE_DIRECTORY_PATH);
     this.gitCommandTimeoutSeconds = cConf.getInt(Constants.SourceControlManagement.GIT_COMMAND_TIMEOUT_SECONDS);
-    this.localRepoPath = Paths.get(gitCloneDirectory, "namespace", this.namespaceID);
+    this.localReposClonePath = Paths.get(gitCloneDirectory, "namespace", this.namespaceID);
   }
 
   public String getNamespaceID() {
     return namespaceID;
   }
 
-  public Path getLocalRepoPath() {
-    return localRepoPath;
+  public Path getLocalReposClonePath() {
+    return localReposClonePath;
   }
 
   public int getGitCommandTimeoutSeconds() {
@@ -69,11 +69,11 @@ public class SourceControlConfig {
     }
     SourceControlConfig that = (SourceControlConfig) o;
     return gitCommandTimeoutSeconds == that.gitCommandTimeoutSeconds && namespaceID.equals(that.namespaceID) &&
-      localRepoPath.equals(that.localRepoPath) && repositoryConfig.equals(that.repositoryConfig);
+      localReposClonePath.equals(that.localReposClonePath) && repositoryConfig.equals(that.repositoryConfig);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(namespaceID, localRepoPath, gitCommandTimeoutSeconds, repositoryConfig);
+    return Objects.hash(namespaceID, localReposClonePath, gitCommandTimeoutSeconds, repositoryConfig);
   }
 }

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/LocalGitServer.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/LocalGitServer.java
@@ -92,7 +92,7 @@ public class LocalGitServer extends ExternalResource {
     testGit = Git.init().setDirectory(testRepoDir).call();
 
     // We need to initialize history by committing before switching branches.
-    Files.write(testGit.getRepository().getDirectory().toPath().resolve("abc.txt"), "content".getBytes());
+    Files.write(testRepoDir.toPath().resolve("abc.txt"), "content".getBytes());
     testGit.add().addFilepattern(".").call();
     testGit.commit().setMessage("main_message").call();
     testGit.checkout().setCreateBranch(true).setName(branchName).call();

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
@@ -16,15 +16,20 @@
 
 package io.cdap.cdap.sourcecontrol;
 
+import com.google.common.hash.Hashing;
 import io.cdap.cdap.api.security.store.SecureStore;
 import io.cdap.cdap.api.security.store.SecureStoreData;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.sourcecontrol.AuthType;
 import io.cdap.cdap.proto.sourcecontrol.Provider;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigValidationException;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,6 +42,9 @@ import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.UUID;
 
 /**
@@ -48,6 +56,7 @@ public class RepositoryManagerTest {
   private static final String MOCK_TOKEN = UUID.randomUUID().toString();
   private static final String NAMESPACE = "namespace1";
   private static final String GITHUB_TOKEN_NAME = "github-pat";
+  private static final int GIT_COMMAND_TIMEOUT = 2;
   @Mock
   private SecureStore secureStore;
   private CConfiguration cConf;
@@ -63,7 +72,7 @@ public class RepositoryManagerTest {
     Mockito.when(secureStore.get(NAMESPACE, GITHUB_TOKEN_NAME))
       .thenReturn(new SecureStoreData(null, MOCK_TOKEN.getBytes(StandardCharsets.UTF_8)));
     cConf = CConfiguration.create();
-    cConf.setInt(Constants.SourceControlManagement.GIT_COMMAND_TIMEOUT_SECONDS, 2);
+    cConf.setInt(Constants.SourceControlManagement.GIT_COMMAND_TIMEOUT_SECONDS, GIT_COMMAND_TIMEOUT);
     cConf.set(Constants.SourceControlManagement.GIT_REPOSITORIES_CLONE_DIRECTORY_PATH,
               tempFolder.newFolder("repository").getAbsolutePath());
   }
@@ -90,17 +99,7 @@ public class RepositoryManagerTest {
 
   @Test
   public void testValidateInvalidToken() throws Exception {
-    String serverURL = gitServer.getServerURL();
-    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
-      .setLink(serverURL + "ignored")
-      .setDefaultBranch("develop")
-      .setAuthType(AuthType.PAT)
-      .setTokenName(GITHUB_TOKEN_NAME)
-      .build();
-    SourceControlConfig sourceControlConfig = new SourceControlConfig(new NamespaceId(NAMESPACE), config, cConf);
-    // Validation should succeed with correct credentials.
-    RepositoryManager.validateConfig(secureStore, sourceControlConfig);
-    // Validation should fail with incorrect credentials.
+    SourceControlConfig sourceControlConfig = getSourceControlConfig();
     Mockito.when(secureStore.get(NAMESPACE, GITHUB_TOKEN_NAME))
       .thenReturn(new SecureStoreData(null, "invalid-token".getBytes(StandardCharsets.UTF_8)));
     boolean exceptionCaught = false;
@@ -147,14 +146,235 @@ public class RepositoryManagerTest {
 
   @Test
   public void testValidateSuccess() throws IOException {
-    String serverURL = gitServer.getServerURL();
-    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
-      .setLink(serverURL + "ignored")
+    RepositoryManager.validateConfig(secureStore, getSourceControlConfig());
+  }
+
+  @Test
+  public void testGetFileHashSuccess() throws Exception {
+    String fileName = "pipeline.json";
+    Path path = Paths.get(fileName);
+    String fileContents = "{name: pipeline}";
+    addFileToGit(path, fileContents);
+    RepositoryManager manager = getRepositoryManager();
+    String commitID = manager.cloneRemote();
+    String fileHash = manager.getFileHash(path, commitID);
+
+    String expectedHash = getGitStyleHash(fileContents);
+    Assert.assertEquals(expectedHash, fileHash);
+    // Change the file, but don't commit. The hash should remain the same.
+    Files.write(manager.getBasePath().resolve(fileName), "change 1".getBytes(StandardCharsets.UTF_8));
+    fileHash = manager.getFileHash(path, manager.resolveHead().getName());
+    Assert.assertEquals(expectedHash, fileHash);
+    manager.close();
+    // Change the file contents and commit, the hash should also change.
+    addFileToGit(path, "change 2");
+    commitID = manager.cloneRemote();
+    fileHash = manager.getFileHash(path, commitID);
+    Assert.assertNotEquals(fileHash, expectedHash);
+    manager.close();
+  }
+
+  @Test
+  public void testGetFileHashChangedFile() throws Exception {
+    // Add two files to git.
+    String fileName1 = "file1.json";
+    String fileContents1 = "abc";
+    String fileName2 = "file2.json";
+    String fileContents2 = "def";
+    addFileToGit(Paths.get(fileName1), fileContents1);
+    addFileToGit(Paths.get(fileName2), fileContents2);
+    // Add a symlink pointing to file1.
+    String symlinkFileName = "link.json";
+    Path symlinkPath = Paths.get(symlinkFileName);
+    addSymbolicLinkToGit(symlinkPath, Paths.get(fileName1));
+    // check file hash of link.
+    RepositoryManager manager = getRepositoryManager();
+    manager.cloneRemote();
+    String commitID = manager.resolveHead().getName();
+    String hash = manager.getFileHash(symlinkPath, commitID);
+    // Change the symlink to point to file 2, but don't commit.
+    Path absoluteLinkPath = manager.getRepositoryRoot().resolve(symlinkFileName);
+    Path absoluteTargetPath = manager.getRepositoryRoot().resolve(fileName2);
+    Files.delete(absoluteLinkPath);
+    Files.createSymbolicLink(absoluteLinkPath, absoluteLinkPath.getParent().relativize(absoluteTargetPath));
+    // Check the file hash of the link, it should be unchanged.
+    Assert.assertEquals(hash, manager.getFileHash(symlinkPath, commitID));
+    // Check that working directory changes are still present.
+    Assert.assertEquals(absoluteLinkPath.toRealPath(), absoluteTargetPath);
+    manager.close();
+    // Commit the symlink change.
+    addSymbolicLinkToGit(symlinkPath, Paths.get(fileName2));
+    manager.cloneRemote();
+    // Check the file hash at previous commit.
+    Assert.assertEquals(hash, manager.getFileHash(symlinkPath, commitID));
+    // Check the file hash at head.
+    Assert.assertNotEquals(hash, manager.getFileHash(symlinkPath, manager.resolveHead().getName()));
+    manager.close();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGetFileHashDirectory() throws Exception {
+    String fileName = "pipeline.json";
+    String dirName = "data-pipelines";
+    // Add a regular file inside a directory.
+    Path regularFilePath = Paths.get(dirName, fileName);
+    addFileToGit(regularFilePath, "{name: pipeline}");
+    RepositoryManager manager = getRepositoryManager();
+    String commitID = manager.cloneRemote();
+    try {
+      manager.getFileHash(Paths.get(dirName), commitID);
+    } finally {
+      manager.close();
+    }
+  }
+
+  @Test(expected = IOException.class)
+  public void testGetFileHashInvalidCommitID() throws Exception {
+    String fileName = "pipeline.json";
+    Path path = Paths.get(fileName);
+    addFileToGit(path, "{name: pipeline}");
+    RepositoryManager manager = getRepositoryManager();
+    manager.cloneRemote();
+    try {
+      manager.getFileHash(path, "7edf45b8cab741caf657e71bd30464860fa56789");
+    } finally {
+      manager.close();
+    }
+  }
+
+  @Test
+  public void testGetFileHashSymlinks() throws Exception {
+    String fileName = "pipeline.json";
+    // Add a regular file inside a directory.
+    Path regularFilePath = Paths.get(fileName);
+    String contents = "{name: pipeline}";
+    addFileToGit(regularFilePath, contents);
+    // Add a symbolic link.
+    Path symlinkDirectory = Paths.get("cdap", "applications");
+    String symLinkFileName1 = "pipeline-link-1.json";
+    String symLinkFileName2 = "pipeline-link-2.json";
+    Path symlinkPath1 = symlinkDirectory.resolve(symLinkFileName1);
+    addSymbolicLinkToGit(symlinkPath1, regularFilePath);
+    // Create a symbolic link to a symbolic link (a->b->c).
+    Path symlinkPath2 = symlinkDirectory.resolve(symLinkFileName2);
+    addSymbolicLinkToGit(symlinkPath2, symlinkPath1);
+
+    RepositoryConfig repositoryConfig = getRepositoryConfigBuilder().setPathPrefix("cdap/applications").build();
+    SourceControlConfig sourceControlConfig =
+      new SourceControlConfig(new NamespaceId(NAMESPACE), repositoryConfig, cConf);
+    RepositoryManager manager = new RepositoryManager(secureStore, sourceControlConfig);
+    String commitID = manager.cloneRemote();
+    String expectedHash = getGitStyleHash(contents);
+    // The hash of the original file, and both the symlinks should be equal.
+    Assert.assertEquals(manager.getFileHash(symlinkPath1, commitID), expectedHash);
+    Assert.assertEquals(manager.getFileHash(symlinkPath2, commitID), expectedHash);
+    manager.close();
+  }
+
+  private RepositoryConfig.Builder getRepositoryConfigBuilder() {
+    return new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
+      .setLink(gitServer.getServerURL() + "ignored")
       .setDefaultBranch("develop")
       .setAuthType(AuthType.PAT)
-      .setTokenName(GITHUB_TOKEN_NAME)
-      .build();
-    SourceControlConfig sourceControlConfig = new SourceControlConfig(new NamespaceId(NAMESPACE), config, cConf);
-    RepositoryManager.validateConfig(secureStore, sourceControlConfig);
+      .setTokenName(GITHUB_TOKEN_NAME);
+  }
+
+  /**
+   * Creates a valid {@link SourceControlConfig}.
+   *
+   * @return the {@link SourceControlConfig}.
+   */
+  private SourceControlConfig getSourceControlConfig() {
+    return new SourceControlConfig(new NamespaceId(NAMESPACE), getRepositoryConfigBuilder().build(), cConf);
+  }
+
+  /**
+   * Creates a valid {@link RepositoryManager}.
+   *
+   * @return the {@link RepositoryManager}.
+   */
+  private RepositoryManager getRepositoryManager() {
+    return new RepositoryManager(secureStore, getSourceControlConfig());
+  }
+
+  /**
+   * Clones the Git repository hosted by the {@link LocalGitServer}.
+   *
+   * @param dir the directory to clone the repository in.
+   * @return the cloned {@link Git} object.
+   */
+  private Git getClonedGit(Path dir) throws GitAPIException {
+    return Git.cloneRepository()
+      .setURI(gitServer.getServerURL() + "ignored")
+      .setDirectory(dir.toFile())
+      .setBranch(DEFAULT_BRANCH_NAME)
+      .setTimeout(GIT_COMMAND_TIMEOUT)
+      .setCredentialsProvider(new UsernamePasswordCredentialsProvider(GIT_SERVER_USERNAME, MOCK_TOKEN))
+      .call();
+  }
+
+  /**
+   * Adds a file to the git repository hosted by the {@link LocalGitServer}.
+   *
+   * @param relativePath path relative to git repo root.
+   * @param contents     the contents of the file.
+   */
+  private void addFileToGit(Path relativePath, String contents) throws GitAPIException, IOException {
+    Path tempDirPath = tempFolder.newFolder("temp-local-git").toPath();
+    Git localGit = getClonedGit(tempDirPath);
+    Path absolutePath = tempDirPath.resolve(relativePath);
+    // Create parent directories if they don't exist.
+    Files.createDirectories(absolutePath.getParent());
+    Files.write(absolutePath, contents.getBytes(StandardCharsets.UTF_8));
+    localGit.add().addFilepattern(".").call();
+    localGit.commit().setMessage("Adding " + relativePath).call();
+    localGit.push()
+      .setTimeout(GIT_COMMAND_TIMEOUT)
+      .setCredentialsProvider(new UsernamePasswordCredentialsProvider(GIT_SERVER_USERNAME, MOCK_TOKEN))
+      .call();
+    localGit.close();
+    DirUtils.deleteDirectoryContents(tempDirPath.toFile());
+  }
+
+  /**
+   * Adds a symbolic link to the git repository hosted by the {@link LocalGitServer}. This overwrites the link file
+   * if it already exists.
+   *
+   * @param relativeLinkPath   relative path to create the symlink.
+   * @param relativeTargetPath relative path to an existing file in the Git repository.
+   */
+  private void addSymbolicLinkToGit(Path relativeLinkPath, Path relativeTargetPath) throws GitAPIException,
+    IOException {
+    Path tempDirPath = tempFolder.newFolder("temp-local-git").toPath();
+    Git localGit = getClonedGit(tempDirPath);
+    Path absoluteTargetPath = tempDirPath.resolve(relativeTargetPath);
+    Path absoluteLinkPath = tempDirPath.resolve(relativeLinkPath);
+    // Create parent directories for the link if they don't exist.
+    Files.createDirectories(absoluteLinkPath.getParent());
+    if (Files.exists(absoluteLinkPath)) {
+      Files.delete(absoluteLinkPath);
+    }
+    // Create a relative link so that it remains valid irrespective of where the repository is cloned.
+    Files.createSymbolicLink(absoluteLinkPath, absoluteLinkPath.getParent().relativize(absoluteTargetPath));
+    localGit.add().addFilepattern(".").call();
+    localGit.commit().setMessage("Adding Symbolic link: " + relativeTargetPath).call();
+    localGit.push()
+      .setTimeout(GIT_COMMAND_TIMEOUT)
+      .setCredentialsProvider(new UsernamePasswordCredentialsProvider(GIT_SERVER_USERNAME, MOCK_TOKEN))
+      .call();
+    localGit.close();
+    DirUtils.deleteDirectoryContents(tempDirPath.toFile());
+  }
+
+  /**
+   * Calculates the hash for provided file contents in a similar way to Git.
+   */
+  private String getGitStyleHash(String fileContents) {
+    // Git prefixes the object with "blob ", followed by the length (as a human-readable integer), followed by a NUL
+    // character and takes the sha1 hash to find the file hash.
+    // See https://stackoverflow.com/a/7225329.
+    return Hashing.sha1()
+      .hashString("blob " + fileContents.length() + "\0" + fileContents, StandardCharsets.UTF_8)
+      .toString();
   }
 }


### PR DESCRIPTION
[CDAP-20343](https://cdap.atlassian.net/browse/CDAP-20343)
A file hash is stored in DB for quickly comparing the version of pipeline pushed to Git by CDAP. We need to retrieve the hash from Git’s metadata for the same. The Git file has remains the same irrespective of branch, commit ID, create time, author etc.

[CDAP-20343]: https://cdap.atlassian.net/browse/CDAP-20343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ