### PR TITLE
[CDAP-20146] Cherry-Pick 6.7 Force system workers to reset security context upon verifying permissions to launch a task

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerHttpHandlerInternal.java
@@ -30,6 +30,11 @@ import io.cdap.cdap.internal.app.worker.RunnableTaskLauncher;
 import io.cdap.cdap.internal.app.worker.TaskDetails;
 import io.cdap.cdap.proto.BasicThrowable;
 import io.cdap.cdap.proto.codec.BasicThrowableCodec;
+import io.cdap.cdap.proto.id.InstanceId;
+import io.cdap.cdap.proto.security.ApplicationPermission;
+import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
+import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
+import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.BodyProducer;
 import io.cdap.http.HttpHandler;
@@ -76,12 +81,17 @@ public class SystemWorkerHttpHandlerInternal extends AbstractHttpHandler {
   private final AtomicInteger requestProcessedCount = new AtomicInteger(0);
 
   private final MetricsCollectionService metricsCollectionService;
+  private final AuthenticationContext authenticationContext;
+  private final AccessEnforcer internalAccessEnforcer;
 
   public SystemWorkerHttpHandlerInternal(CConfiguration cConf, MetricsCollectionService metricsCollectionService,
-                                         Injector injector) {
+                                         Injector injector, AuthenticationContext authenticationContext,
+                                         AccessEnforcer internalAccessEnforcer) {
     this.runnableTaskLauncher = new RunnableTaskLauncher(injector);
     this.metricsCollectionService = metricsCollectionService;
     this.requestLimit = cConf.getInt(Constants.SystemWorker.REQUEST_LIMIT);
+    this.authenticationContext = authenticationContext;
+    this.internalAccessEnforcer = internalAccessEnforcer;
   }
 
   private void emitMetrics(TaskDetails taskDetails) {
@@ -96,6 +106,12 @@ public class SystemWorkerHttpHandlerInternal extends AbstractHttpHandler {
   @POST
   @Path("/run")
   public void run(FullHttpRequest request, HttpResponder responder) {
+    // Perform a permission check to ensure the caller is part of the system, then unset the SecurityRequestContext to
+    // force the system worker to use its system context.
+    internalAccessEnforcer.enforce(InstanceId.SELF, authenticationContext.getPrincipal(),
+                                   ApplicationPermission.EXECUTE);
+    SecurityRequestContext.reset();
+
     if (requestProcessedCount.incrementAndGet() > requestLimit) {
       responder.sendStatus(HttpResponseStatus.TOO_MANY_REQUESTS);
       return;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerTwillRunnable.java
@@ -157,7 +157,7 @@ public class SystemWorkerTwillRunnable extends AbstractTwillRunnable {
       new MessagingClientModule(),
       new ExploreClientModule(),
       new AuthorizationModule(),
-      new AuthorizationEnforcementModule().getDistributedModules(),
+      new AuthorizationEnforcementModule().getMasterModule(),
       Modules.override(new AppFabricServiceRuntimeModule(cConf).getDistributedModules())
         .with(new AbstractModule() {
           @Override

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceTest.java
@@ -37,8 +37,10 @@ import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
 import io.cdap.cdap.internal.app.worker.RunnableTaskModule;
 import io.cdap.cdap.internal.provision.ProvisioningService;
 import io.cdap.cdap.proto.BasicThrowable;
-import io.cdap.cdap.security.auth.FileBasedKeyManager;
+import io.cdap.cdap.security.auth.TokenManager;
+import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
 import io.cdap.cdap.security.guice.FileBasedCoreSecurityModule;
+import io.cdap.cdap.security.spi.authorization.NoOpAccessController;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
@@ -106,11 +108,12 @@ public class SystemWorkerServiceTest extends AppFabricTestBase {
     SystemWorkerService service = new SystemWorkerService(cConf, sConf, new InMemoryDiscoveryService(),
                                                           metricsCollectionService, new CommonNettyHttpServiceFactory(
                                                             cConf, metricsCollectionService),
-                                                          injector.getInstance(FileBasedKeyManager.class),
+                                                          injector.getInstance(TokenManager.class),
                                                           new NoopTwillRunnerService(),
                                                           new NoopTwillRunnerService(),
                                                           getInjector().getInstance(ProvisioningService.class),
-                                                          Guice.createInjector(new RunnableTaskModule(cConf)));
+                                                          Guice.createInjector(new RunnableTaskModule(cConf)),
+                                                          new AuthenticationTestContext(), new NoOpAccessController());
     service.startAndWait();
     this.systemWorkerService = service;
   }


### PR DESCRIPTION
Cherry-pick of #14918 