### PR TITLE
[CDAP-20341] Make PAT auth strategy fetch credentials lazily and improve exception handling

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigValidationException;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryMeta;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
@@ -35,6 +36,8 @@ import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.store.NamespaceTable;
 import io.cdap.cdap.store.RepositoryTable;
+
+import java.io.IOException;
 
 /**
  * Service that manages source control for repositories and applications.
@@ -109,7 +112,11 @@ public class SourceControlManagementService {
   }
 
   public void validateRepository(NamespaceId namespace, RepositoryConfig repoConfig) {
-    // TODO: CDAP-20354, throw correct non-400 validation errors
-    RepositoryManager.validateConfig(secureStore, new SourceControlConfig(namespace, repoConfig, cConf));
+    try {
+      RepositoryManager.validateConfig(secureStore, new SourceControlConfig(namespace, repoConfig, cConf));
+    } catch (IOException e) {
+      // TODO: CDAP-20354, throw correct non-400 validation errors
+      throw new RepositoryConfigValidationException("Internal error: " + e.getMessage(), e);
+    }
   }
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/AuthenticationConfigException.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/AuthenticationConfigException.java
@@ -24,4 +24,8 @@ public class AuthenticationConfigException extends Exception {
   public AuthenticationConfigException(String message, Exception cause) {
     super(message, cause);
   }
+
+  public AuthenticationConfigException(String message) {
+    super(message);
+  }
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/AuthenticationStrategy.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/AuthenticationStrategy.java
@@ -16,10 +16,6 @@
 
 package io.cdap.cdap.sourcecontrol;
 
-import io.cdap.cdap.api.security.store.SecureStore;
-import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
-import org.eclipse.jgit.transport.CredentialsProvider;
-
 /**
  * Interface to provide authentication objects used by JGit for different
  * {@link io.cdap.cdap.proto.sourcecontrol.Provider}s and {@link io.cdap.cdap.proto.sourcecontrol.AuthType}s.
@@ -28,13 +24,7 @@ public interface AuthenticationStrategy {
   /**
    * Returns a credential provider for authenticating with a remote git repository.
    *
-   * @param store       a {@link SecureStore} to fetch credentials
-   * @param config      Configuration for the remote repository.
-   * @param namespaceId The namespace information for fetching credentials from secure store.
    * @return a Credential provider to be used with all git commands.
-   * @throws AuthenticationConfigException when there are problems creating the credential provider for the provided
-   *                                       config.
    */
-  CredentialsProvider getCredentialsProvider(SecureStore store, RepositoryConfig config, String namespaceId) throws
-    AuthenticationConfigException;
+  RefreshableCredentialsProvider getCredentialsProvider();
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/AuthenticationStrategyProvider.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/AuthenticationStrategyProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol;
+
+import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.proto.sourcecontrol.AuthType;
+import io.cdap.cdap.proto.sourcecontrol.Provider;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+
+/**
+ * Provides an {@link AuthenticationStrategy}.
+ */
+public class AuthenticationStrategyProvider {
+  private final String namespaceID;
+  private final SecureStore secureStore;
+
+  public AuthenticationStrategyProvider(String namespaceID, SecureStore secureStore) {
+    this.namespaceID = namespaceID;
+    this.secureStore = secureStore;
+  }
+
+  /**
+   * Returns an {@link AuthenticationStrategy} for the given Git repository provider and auth type.
+   *
+   * @return an instance of {@link  AuthenticationStrategy}.
+   * @throws AuthenticationStrategyNotFoundException when the corresponding {@link AuthenticationStrategy} is not found.
+   */
+  AuthenticationStrategy get(RepositoryConfig repoConfig) throws
+    AuthenticationStrategyNotFoundException {
+    if (repoConfig.getProvider() == Provider.GITHUB) {
+      if (repoConfig.getAuth().getType() == AuthType.PAT) {
+        return new GitPATAuthenticationStrategy(secureStore, repoConfig, namespaceID);
+      }
+    }
+    throw new AuthenticationStrategyNotFoundException(String.format("No strategy found for provider %s and type %s.",
+                                                                    repoConfig.getProvider(),
+                                                                    repoConfig.getAuth().getType()));
+  }
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/GitPATAuthenticationStrategy.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/GitPATAuthenticationStrategy.java
@@ -16,11 +16,16 @@
 
 package io.cdap.cdap.sourcecontrol;
 
+import com.google.common.base.Throwables;
 import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.api.security.store.SecureStoreData;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
-import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.errors.UnsupportedCredentialItem;
+import org.eclipse.jgit.transport.CredentialItem;
+import org.eclipse.jgit.transport.URIish;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -28,17 +33,68 @@ import java.nio.charset.StandardCharsets;
  */
 public class GitPATAuthenticationStrategy implements AuthenticationStrategy {
   private static final String GITHUB_PAT_USERNAME = "oauth2";
+  private final SecureStorePasswordProvider credentialsProvider;
+
+  public GitPATAuthenticationStrategy(SecureStore secureStore, RepositoryConfig config, String namespaceId) {
+    this.credentialsProvider =
+      new SecureStorePasswordProvider(secureStore, GITHUB_PAT_USERNAME, config.getAuth().getTokenName(), namespaceId);
+  }
 
   @Override
-  public CredentialsProvider getCredentialsProvider(SecureStore store,
-                                                    RepositoryConfig config,
-                                                    String namespaceId) throws AuthenticationConfigException {
-    try {
-      byte[] bytes = store.get(namespaceId, config.getAuth().getTokenName()).get();
-      String token = new String(bytes, StandardCharsets.UTF_8);
-      return new UsernamePasswordCredentialsProvider(GITHUB_PAT_USERNAME, token);
-    } catch (Exception e) {
-      throw new AuthenticationConfigException("Failed to get auth token from secure store", e);
+  public RefreshableCredentialsProvider getCredentialsProvider() {
+    return credentialsProvider;
+  }
+
+  /**
+   * A class that wraps a {@link UsernamePasswordCredentialsProvider} but fetches password from a {@link SecureStore}.
+   */
+  private static class SecureStorePasswordProvider extends RefreshableCredentialsProvider {
+    private final SecureStore secureStore;
+    private final String username;
+    private final String passwordKeyName;
+    private final String namespaceID;
+    private String password;
+
+    SecureStorePasswordProvider(SecureStore secureStore, String username, String passwordKeyName, String namespaceID) {
+      this.secureStore = secureStore;
+      this.username = username;
+      this.passwordKeyName = passwordKeyName;
+      this.namespaceID = namespaceID;
+    }
+
+    @Override
+    public void refresh() throws IOException, AuthenticationConfigException {
+      SecureStoreData data;
+      try {
+        data = secureStore.get(namespaceID, passwordKeyName);
+      } catch (Exception e) {
+        Throwables.propagateIfInstanceOf(e, IOException.class);
+        throw new AuthenticationConfigException("Failed to get password from secure store", e);
+      }
+      if (data == null) {
+        throw new AuthenticationConfigException(String.format("Password with key name %s not found in secure store",
+                                                              passwordKeyName));
+      }
+      password = new String(data.get(), StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public boolean isInteractive() {
+      return false;
+    }
+
+    @Override
+    public boolean supports(CredentialItem... credentialItems) {
+      return new UsernamePasswordCredentialsProvider("", "").supports(credentialItems);
+    }
+
+    @Override
+    public boolean get(URIish urIish, CredentialItem... credentialItems) throws UnsupportedCredentialItem {
+      if (password == null) {
+        throw new IllegalStateException(
+          "Password not fetched from secure store. Refresh credentials before getting them.");
+      }
+      return new UsernamePasswordCredentialsProvider(username, password).get(urIish, credentialItems);
     }
   }
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RefreshableCredentialsProvider.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RefreshableCredentialsProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol;
+
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.URIish;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * A {@link CredentialsProvider} that can refresh its credentials.
+ */
+public abstract class RefreshableCredentialsProvider extends CredentialsProvider {
+  /**
+   * Refresh or fetches the authentication credentials. Users must call refresh
+   * at lest once before using {@link RefreshableCredentialsProvider#get(URIish, List)} to ensure
+   * credentials from a remote service are initialized.
+   *
+   * @throws AuthenticationConfigException when the provided configuration is invalid.
+   * @throws IOException                   when there are network errors while refreshing the credentials.
+   */
+  abstract void refresh() throws AuthenticationConfigException, IOException;
+}


### PR DESCRIPTION
Changes:
1. GitPATAuthStrategy now returns a CredentialsProvider that fetches credentials from secure store only when required. Now RepositoryMaanger can store the credentialsProvider instead of getting it from auth strategy. See https://github.com/cdapio/cdap/pull/14886#discussion_r1099762770
2. Add GitAPIException message in validation exception to make message more useful for users.