### PR TITLE
fix(CDAP-20361): the GET /appdetail api should return the requested versions

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -406,12 +406,12 @@ public interface Store {
                            BiConsumer<ApplicationId, ApplicationMeta> consumer);
 
   /**
-   * Returns a Map of {@link ApplicationSpecification} for the given set of {@link ApplicationId}.
+   * Returns a Map of {@link ApplicationMeta} for the given set of {@link ApplicationId}.
    *
    * @param ids the list of application ids to get the specs
-   * @return collection of application specs. For applications that don't exist, there will be no entry in the result.
+   * @return collection of application metas. For applications that don't exist, there will be no entry in the result.
    */
-  Map<ApplicationId, ApplicationSpecification> getApplications(Collection<ApplicationId> ids);
+  Map<ApplicationId, ApplicationMeta> getApplications(Collection<ApplicationId> ids);
 
   /**
    * Returns a map of latest programIds given programReferences

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -781,10 +781,9 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public Map<ApplicationId, ApplicationSpecification> getApplications(Collection<ApplicationId> ids) {
+  public Map<ApplicationId, ApplicationMeta> getApplications(Collection<ApplicationId> ids) {
     return TransactionRunners.run(transactionRunner, context -> {
-      return getAppMetadataStore(context).getApplicationsForAppIds(ids).entrySet().stream()
-        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getSpec()));
+      return getAppMetadataStore(context).getApplicationsForAppIds(ids);
     });
   }
 


### PR DESCRIPTION
## What
1. The GET /appdetail API was broken by mapping `-SNAPSHOT` to latest version change at appMetaStore in LCM, we should fix this by correctly return requested versions
2. Fixing it also benefits SCM work in the pushApps flow


Note that we're deprecating the `GET /appdetail API` in 6.9.0. Fixing it is more for SCM work