### PR TITLE
Fixing updateAll and deleteAll spi methods

### DIFF
--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
@@ -445,11 +445,7 @@ public final class NoSqlStructuredTable implements StructuredTable {
         Collection<Field<?>> primaryKeys = iterator.next().getPrimaryKeys();
         List<Field<?>> fieldsToUpdate = Stream.concat(primaryKeys.stream(), fields.stream())
           .collect(Collectors.toList());
-        Put put = updateFieldsToBytes(fieldsToUpdate);
-        // Put will not have values if a row is not being updated
-        if (!put.getValues().isEmpty()) {
-          table.put(put);
-        }
+        table.put(convertFieldsToBytes(fieldsToUpdate));
       }
     }
   }

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTable.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTable.java
@@ -355,8 +355,7 @@ public class SpannerStructuredTable implements StructuredTable {
 
   @Override
   public void deleteAll(Range range) throws InvalidFieldException {
-    fieldValidator.validatePrimaryKeys(range.getBegin(), true);
-    fieldValidator.validatePrimaryKeys(range.getEnd(), true);
+    fieldValidator.validateScanRange(range);
 
     Map<String, Value> parameters = new HashMap<>();
     String condition = getRangeWhereClause(range, parameters);


### PR DESCRIPTION
Make updateAll upsert fields instead of updating existing fields. Edge case: null columns can be updated this way.

Make deleteAll spanner implementation relax primary key range restriction.