### PR TITLE
[CDAP-19539] Fail tethering profile creation if peer name is invalid

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringConf.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringConf.java
@@ -42,6 +42,7 @@ public class TetheringConf {
     String tetheredInstanceName = getString(properties, TETHERED_INSTANCE_PROPERTY);
     String tetheredNamespace = getString(properties, TETHERED_NAMESPACE_PROPERTY);
     EntityId.ensureValidNamespace(tetheredNamespace);
+    EntityId.ensureValidId("tetheredInstanceName", tetheredInstanceName);
     return new TetheringConf(tetheredInstanceName, tetheredNamespace);
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManagerTest.java
@@ -217,4 +217,14 @@ public class TetheringRuntimeJobManagerTest {
     // Validation should fail because the tethering status is not yet accepted
     runtimeJobManager.checkTetheredConnection(TETHERED_INSTANCE_NAME, TETHERED_INSTANCE_NAME);
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testTetheringProfileWithInvalidPeerName() {
+    Map<String, String> properties = ImmutableMap.of(TetheringConf.TETHERED_INSTANCE_PROPERTY,
+                                                     // invalid space character in instance name
+                                                     " myinstance",
+                                                     TetheringConf.TETHERED_NAMESPACE_PROPERTY,
+                                                     TETHERED_NAMESPACE_NAME);
+    TetheringConf.fromProperties(properties);
+  }
 }


### PR DESCRIPTION
If the peer name is entered incorrectly (e.g: with whitespace characters), pipelines runs using the profile fail with a confusing error message about invalid topic name.
Fix: fail tethering profile creation with a meaningful error.

![image](https://user-images.githubusercontent.com/2873805/219237356-d42d624e-cb83-4a99-91a1-5ce5909b1d15.png)
