### PR TITLE
Turning LCM flag on

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -352,11 +352,11 @@ public interface Store {
    * Return a list of program specifications that are deleted comparing the specification in the store with the
    * spec that is passed.
    *
-   * @param id                   ApplicationId
+   * @param appRef               ApplicationReference
    * @param specification        Application specification
    * @return                     List of ProgramSpecifications that are deleted
    */
-  List<ProgramSpecification> getDeletedProgramSpecifications(ApplicationId id,
+  List<ProgramSpecification> getDeletedProgramSpecifications(ApplicationReference appRef,
                                                              ApplicationSpecification specification);
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
@@ -70,7 +70,7 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
   @Override
   public void process(ApplicationDeployable appSpec) throws Exception {
     List<ProgramSpecification> deletedSpecs = store.getDeletedProgramSpecifications(
-        appSpec.getApplicationId(),
+        appSpec.getApplicationId().getAppReference(),
         appSpec.getSpecification());
 
     // TODO: this should also delete logs and run records (or not?), and do it for all program types [CDAP-2187]

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -559,11 +559,11 @@ public class DefaultStore implements Store {
 
   // todo: this method should be moved into DeletedProgramHandlerState, bad design otherwise
   @Override
-  public List<ProgramSpecification> getDeletedProgramSpecifications(ApplicationId id,
+  public List<ProgramSpecification> getDeletedProgramSpecifications(ApplicationReference appRef,
       ApplicationSpecification appSpec) {
 
     ApplicationMeta existing = TransactionRunners.run(transactionRunner, context -> {
-      return getAppMetadataStore(context).getApplication(id);
+      return getAppMetadataStore(context).getLatest(appRef);
     });
 
     List<ProgramSpecification> deletedProgramSpecs = Lists.newArrayList();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -740,8 +740,9 @@ public abstract class AppFabricTestBase {
   }
 
   protected void deleteApp(ApplicationId app, int expectedResponseCode) throws Exception {
+    // Changing to non version specific app deletion - since version specific app deletion isn't supported after LCM.
     HttpResponse response = doDelete(getVersionedAPIPath(
-      String.format("/apps/%s/versions/%s", app.getApplication(), app.getVersion()), app.getNamespace()));
+      String.format("/apps/%s", app.getApplication()), app.getNamespace()));
     assertResponseCode(expectedResponseCode, response);
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/ProgramLifecycleHttpHandlerTest.java
@@ -1212,7 +1212,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
 
     ApplicationId defaultAppId = TEST_NAMESPACE_META2.getNamespaceId().app(AppWithSchedule.NAME);
     Assert.assertEquals(200, deploy(defaultAppId, request).getResponseCode());
-    ApplicationDetail appDetails = getAppDetails(defaultAppId.getNamespace(), defaultAppId.getApplication());
 
     List<ScheduleDetail> actualSchedules = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
                                                          defaultAppId.getApplication());
@@ -1224,7 +1223,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
       new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, true);
 
     Assert.assertEquals(200, deploy(defaultAppId, request).getResponseCode());
-    appDetails = getAppDetails(defaultAppId.getNamespace(), defaultAppId.getApplication());
 
     actualSchedules = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
                                     defaultAppId.getApplication());
@@ -1235,7 +1233,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     request = new AppRequest<>(
       new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, false);
     Assert.assertEquals(200, deploy(defaultAppId, request).getResponseCode());
-    appDetails = getAppDetails(defaultAppId.getNamespace(), defaultAppId.getApplication());
 
     // schedule should not be updated
     actualSchedules = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
@@ -1247,7 +1244,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     request = new AppRequest<>(
       new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, false);
     Assert.assertEquals(200, deploy(defaultAppId, request).getResponseCode());
-    appDetails = getAppDetails(defaultAppId.getNamespace(), defaultAppId.getApplication());
 
     actualSchedules = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
                                     defaultAppId.getApplication());
@@ -1258,7 +1254,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     request = new AppRequest<>(
       new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, true);
     Assert.assertEquals(200, deploy(defaultAppId, request).getResponseCode());
-    appDetails = getAppDetails(defaultAppId.getNamespace(), defaultAppId.getApplication());
 
     actualSchedules = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
                                     defaultAppId.getApplication());
@@ -1270,7 +1265,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     request = new AppRequest<>(
       new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, false);
     Assert.assertEquals(200, deploy(defaultAppId, request).getResponseCode());
-    appDetails = getAppDetails(defaultAppId.getNamespace(), defaultAppId.getApplication());
 
     actualSchedules = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
                                     defaultAppId.getApplication());
@@ -1281,7 +1275,6 @@ public class ProgramLifecycleHttpHandlerTest extends AppFabricTestBase {
     request = new AppRequest<>(
       new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion()), config, null, null, true);
     Assert.assertEquals(200, deploy(defaultAppId, request).getResponseCode());
-    appDetails = getAppDetails(defaultAppId.getNamespace(), defaultAppId.getApplication());
 
     actualSchedules = listSchedules(TEST_NAMESPACE_META2.getNamespaceId().getNamespace(),
                                     defaultAppId.getApplication());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/DefaultStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/DefaultStoreTest.java
@@ -70,6 +70,7 @@ import io.cdap.cdap.proto.RunCountResult;
 import io.cdap.cdap.proto.WorkflowNodeStateDetail;
 import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.Ids;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProfileId;
@@ -574,7 +575,8 @@ public abstract class DefaultStoreTest {
     AbstractApplication newApp = new AppWithNoServices();
 
     // get the delete program specs after deploying AppWithNoServices
-    List<ProgramSpecification> programSpecs = store.getDeletedProgramSpecifications(appId, Specifications.from(newApp));
+    List<ProgramSpecification> programSpecs = store.getDeletedProgramSpecifications(appId.getAppReference(),
+                                                                                    Specifications.from(newApp));
 
     //verify the result.
     Assert.assertEquals(1, programSpecs.size());
@@ -890,14 +892,14 @@ public abstract class DefaultStoreTest {
     Assert.assertEquals(6, specsToBeVerified.size());
 
     // Check the diff with the same app - re-deployment scenario where programs are not removed.
-    List<ProgramSpecification> deletedSpecs = store.getDeletedProgramSpecifications(appId, spec);
+    List<ProgramSpecification> deletedSpecs = store.getDeletedProgramSpecifications(appId.getAppReference(), spec);
     Assert.assertEquals(0, deletedSpecs.size());
 
     //Get the spec for app that contains no programs.
     spec = Specifications.from(new NoProgramsApp());
 
     //Get the deleted program specs by sending a spec with same name as AllProgramsApp but with no programs
-    deletedSpecs = store.getDeletedProgramSpecifications(appId, spec);
+    deletedSpecs = store.getDeletedProgramSpecifications(appId.getAppReference(), spec);
     Assert.assertEquals(6, deletedSpecs.size());
 
     for (ProgramSpecification specification : deletedSpecs) {
@@ -1039,7 +1041,7 @@ public abstract class DefaultStoreTest {
     spec = Specifications.from(new DefaultStoreTestApp());
 
     //Get the deleted program specs by sending a spec with same name as AllProgramsApp but with no programs
-    List<ProgramSpecification> deletedSpecs = store.getDeletedProgramSpecifications(appId, spec);
+    List<ProgramSpecification> deletedSpecs = store.getDeletedProgramSpecifications(appId.getAppReference(), spec);
     Assert.assertEquals(2, deletedSpecs.size());
 
     for (ProgramSpecification specification : deletedSpecs) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/io/cdap/cdap/etl/tool/UpgradeTool.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-tools/src/main/java/io/cdap/cdap/etl/tool/UpgradeTool.java
@@ -93,7 +93,7 @@ public class UpgradeTool {
 
   private Set<ApplicationId> upgrade(NamespaceId namespace) throws Exception {
     Set<ApplicationId> upgraded = new HashSet<>();
-    for (ApplicationRecord appRecord : appClient.list(namespace, Upgrader.ARTIFACT_NAMES, null)) {
+    for (ApplicationRecord appRecord : appClient.list(namespace, Upgrader.ARTIFACT_NAMES, null, null)) {
       ApplicationId appId = namespace.app(appRecord.getName());
       if (upgrade(appId)) {
         upgraded.add(appId);

--- a/cdap-cli-tests/src/test/java/io/cdap/cdap/cli/CLIMainTest.java
+++ b/cdap-cli-tests/src/test/java/io/cdap/cdap/cli/CLIMainTest.java
@@ -52,6 +52,7 @@ public class CLIMainTest extends CLITestBase {
   @AfterClass
   public static void tearDownClass() throws Exception {
     programClient.stopAll(NamespaceId.DEFAULT);
+    // Introduced in LCM: Deletion of app - removes all it's versions
     testCommandOutputContains(cli, "delete app " + FakeApp.NAME, "Successfully deleted app");
   }
 

--- a/cdap-cli-tests/src/test/java/io/cdap/cdap/cli/CLITestBase.java
+++ b/cdap-cli-tests/src/test/java/io/cdap/cdap/cli/CLITestBase.java
@@ -239,8 +239,7 @@ public abstract class CLITestBase {
 
   @Test
   public void testList() throws Exception {
-    testCommandOutputContains("list app versions " + FakeApp.NAME, V1_SNAPSHOT);
-    testCommandOutputContains("list app versions " + FakeApp.NAME, ApplicationId.DEFAULT_VERSION);
+    // Introducing in LCM : App versions are not explicit
     testCommandOutputContains("list dataset instances", FakeApp.DS_NAME);
   }
 

--- a/cdap-cli/src/main/java/io/cdap/cdap/cli/command/app/DeleteAppCommand.java
+++ b/cdap-cli/src/main/java/io/cdap/cdap/cli/command/app/DeleteAppCommand.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.cli.english.Article;
 import io.cdap.cdap.cli.english.Fragment;
 import io.cdap.cdap.cli.util.AbstractAuthCommand;
 import io.cdap.cdap.client.ApplicationClient;
-import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.common.cli.Arguments;
 import java.io.PrintStream;
@@ -45,9 +44,6 @@ public class DeleteAppCommand extends AbstractAuthCommand {
   @Override
   public void perform(Arguments arguments, PrintStream output) throws Exception {
     ApplicationId appId = parseApplicationId(arguments);
-    ApplicationDetail appDetail = appClient.get(appId);
-    appId = new ApplicationId(appId.getNamespace(), appId.getApplication(),
-        appDetail.getAppVersion());
     appClient.delete(appId);
     output.printf("Successfully deleted application '%s.%s'\n", appId.getEntityName(),
         appId.getVersion());
@@ -55,15 +51,11 @@ public class DeleteAppCommand extends AbstractAuthCommand {
 
   @Override
   public String getPattern() {
-    return String.format("delete app <%s> [version <%s>]", ArgumentName.APP,
-        ArgumentName.APP_VERSION);
+    return String.format("delete app <%s>", ArgumentName.APP);
   }
 
   @Override
   public String getDescription() {
-    return String.format(
-        "Deletes %s with an optional version. If version is not provided, default version '%s' "
-            + "will be used.", Fragment.of(Article.A, ElementType.APP.getName()),
-        ApplicationId.DEFAULT_VERSION);
+    return String.format("Deletes %s.", Fragment.of(Article.A, ElementType.APP.getName()));
   }
 }

--- a/cdap-cli/src/main/java/io/cdap/cdap/cli/command/app/ListAppsCommand.java
+++ b/cdap-cli/src/main/java/io/cdap/cdap/cli/command/app/ListAppsCommand.java
@@ -57,19 +57,16 @@ public class ListAppsCommand extends AbstractAuthCommand {
       }
     }
     Table table = Table.builder()
-        .setHeader("id", "appVersion", "description", "artifactName", "artifactVersion",
-            "artifactScope", "principal")
-        .setRows(appClient.list(cliConfig.getCurrentNamespace(), artifactNames, artifactVersion),
-            new RowMaker<ApplicationRecord>() {
-              @Override
-              public List<?> makeRow(ApplicationRecord object) {
-                return Lists.newArrayList(object.getName(), object.getAppVersion(),
-                    object.getDescription(),
-                    object.getArtifact().getName(), object.getArtifact().getVersion(),
-                    object.getArtifact().getScope(),
-                    object.getOwnerPrincipal());
-              }
-            }).build();
+      .setHeader("id", "appVersion", "description", "artifactName", "artifactVersion", "artifactScope", "principal")
+      .setRows(appClient.list(cliConfig.getCurrentNamespace(), artifactNames, artifactVersion, null),
+        new RowMaker<ApplicationRecord>() {
+          @Override
+          public List<?> makeRow(ApplicationRecord object) {
+            return Lists.newArrayList(object.getName(), object.getAppVersion(), object.getDescription(),
+              object.getArtifact().getName(), object.getArtifact().getVersion(), object.getArtifact().getScope(),
+              object.getOwnerPrincipal());
+          }
+        }).build();
     cliConfig.getTableRenderer().render(cliConfig, output, table);
   }
 

--- a/cdap-client/src/main/java/io/cdap/cdap/client/ProgramClient.java
+++ b/cdap-client/src/main/java/io/cdap/cdap/client/ProgramClient.java
@@ -612,11 +612,9 @@ public class ProgramClient {
    *     gateway server
    */
   public Map<String, String> getRuntimeArgs(ProgramId program)
-      throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
-
-    String path = String.format("apps/%s/versions/%s/%s/%s/runtimeargs",
-        program.getApplication(), program.getVersion(),
-        program.getType().getCategoryName(), program.getProgram());
+    throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
+    String path = String.format("apps/%s/%s/%s/runtimeargs",
+                                program.getApplication(), program.getType().getCategoryName(), program.getProgram());
     URL url = config.resolveNamespacedURLV3(program.getNamespaceId(), path);
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
         HttpURLConnection.HTTP_NOT_FOUND);
@@ -638,11 +636,9 @@ public class ProgramClient {
    *     gateway server
    */
   public void setRuntimeArgs(ProgramId program, Map<String, String> runtimeArgs)
-      throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
-
-    String path = String.format("apps/%s/versions/%s/%s/%s/runtimeargs",
-        program.getApplication(), program.getVersion(),
-        program.getType().getCategoryName(), program.getProgram());
+    throws IOException, UnauthenticatedException, ProgramNotFoundException, UnauthorizedException {
+    String path = String.format("apps/%s/%s/%s/runtimeargs",
+                                program.getApplication(), program.getType().getCategoryName(), program.getProgram());
     URL url = config.resolveNamespacedURLV3(program.getNamespaceId(), path);
     HttpRequest request = HttpRequest.put(url).withBody(GSON.toJson(runtimeArgs)).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(),

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5493,7 +5493,7 @@
 
   <property>
     <name>feature.lifecycle.management.edit.enabled</name>
-    <value>false</value>
+    <value>true</value>
     <description>
       Enables Design-time Lifecycle Management for applications.
     </description>


### PR DESCRIPTION
For 6.9.0 LCM is GA - turning the FF on in this PR.

Refactoring tests because : 
Delete /version api is disabled in LCM
tests referencing runtime args are using /version API
GET /apps returns all versions of the apps, unless latest filter is set to "true".