### PR TITLE
fix(CDAP-20354): return correct errors for remote repo validation

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/SourceControlManagementHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/SourceControlManagementHttpHandler.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.features.Feature;
 import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import io.cdap.cdap.internal.app.services.SourceControlManagementService;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.sourcecontrol.RemoteRepositoryValidationException;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigRequest;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigValidationException;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryMeta;
@@ -81,6 +82,9 @@ public class SourceControlManagementHttpHandler extends AbstractAppFabricHttpHan
       responder.sendJson(HttpResponseStatus.OK, GSON.toJson(repoMeta));
     } catch (RepositoryConfigValidationException e) {
       responder.sendJson(HttpResponseStatus.BAD_REQUEST, GSON.toJson(new SetRepositoryResponse(e)));
+    } catch (RemoteRepositoryValidationException e) {
+      responder.sendJson(HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                         GSON.toJson(new SetRepositoryResponse(e.getMessage())));
     }
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
@@ -23,8 +23,8 @@ import io.cdap.cdap.common.RepositoryNotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.proto.sourcecontrol.RemoteRepositoryValidationException;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
-import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigValidationException;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryMeta;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
@@ -36,8 +36,6 @@ import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.store.NamespaceTable;
 import io.cdap.cdap.store.RepositoryTable;
-
-import java.io.IOException;
 
 /**
  * Service that manages source control for repositories and applications.
@@ -111,12 +109,8 @@ public class SourceControlManagementService {
     }, RepositoryNotFoundException.class);
   }
 
-  public void validateRepository(NamespaceId namespace, RepositoryConfig repoConfig) {
-    try {
-      RepositoryManager.validateConfig(secureStore, new SourceControlConfig(namespace, repoConfig, cConf));
-    } catch (IOException e) {
-      // TODO: CDAP-20354, throw correct non-400 validation errors
-      throw new RepositoryConfigValidationException("Internal error: " + e.getMessage(), e);
-    }
+  public void validateRepository(NamespaceId namespace, RepositoryConfig repoConfig)
+    throws RemoteRepositoryValidationException {
+    RepositoryManager.validateConfig(secureStore, new SourceControlConfig(namespace, repoConfig, cConf));
   }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RemoteRepositoryValidationException.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RemoteRepositoryValidationException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.sourcecontrol;
+
+/**
+ * Throw an exception when the validation of connecting to a remote repository fails.
+ */
+public class RemoteRepositoryValidationException extends Exception {
+  public RemoteRepositoryValidationException(String message) {
+    super(message);
+  }
+
+  public RemoteRepositoryValidationException(String message, Exception cause) {
+    super(message, cause);
+  }
+}

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
@@ -78,7 +78,7 @@ public class RepositoryManagerTest {
   }
 
   @Test
-  public void testValidateIncorrectKeyName() throws IOException {
+  public void testValidateIncorrectKeyName() throws Exception {
     String serverURL = gitServer.getServerURL();
     RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
       .setLink(serverURL + "ignored")
@@ -87,14 +87,12 @@ public class RepositoryManagerTest {
       .setTokenName(GITHUB_TOKEN_NAME + "invalid")
       .build();
     SourceControlConfig sourceControlConfig = new SourceControlConfig(new NamespaceId(NAMESPACE), config, cConf);
-    boolean exceptionCaught = false;
     try {
       RepositoryManager.validateConfig(secureStore, sourceControlConfig);
+      Assert.fail();
     } catch (RepositoryConfigValidationException e) {
-      exceptionCaught = true;
       Assert.assertTrue(e.getMessage().contains("Failed to get authentication credentials"));
     }
-    Assert.assertTrue(exceptionCaught);
   }
 
   @Test
@@ -102,18 +100,16 @@ public class RepositoryManagerTest {
     SourceControlConfig sourceControlConfig = getSourceControlConfig();
     Mockito.when(secureStore.get(NAMESPACE, GITHUB_TOKEN_NAME))
       .thenReturn(new SecureStoreData(null, "invalid-token".getBytes(StandardCharsets.UTF_8)));
-    boolean exceptionCaught = false;
     try {
       RepositoryManager.validateConfig(secureStore, sourceControlConfig);
+      Assert.fail();
     } catch (RepositoryConfigValidationException e) {
-      exceptionCaught = true;
       Assert.assertTrue(e.getMessage().contains("not authorized"));
     }
-    Assert.assertTrue(exceptionCaught);
   }
 
   @Test
-  public void testValidateInvalidBranchName() throws IOException {
+  public void testValidateInvalidBranchName() throws Exception {
     String serverURL = gitServer.getServerURL();
     RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
       .setLink(serverURL + "ignored")
@@ -122,18 +118,16 @@ public class RepositoryManagerTest {
       .setTokenName(GITHUB_TOKEN_NAME)
       .build();
     SourceControlConfig sourceControlConfig = new SourceControlConfig(new NamespaceId(NAMESPACE), config, cConf);
-    boolean exceptionCaught = false;
     try {
       RepositoryManager.validateConfig(secureStore, sourceControlConfig);
+      Assert.fail();
     } catch (RepositoryConfigValidationException e) {
-      exceptionCaught = true;
       Assert.assertTrue(e.getMessage().contains("Default branch not found in remote repository"));
     }
-    Assert.assertTrue(exceptionCaught);
   }
 
   @Test
-  public void testValidateNullBranchName() throws IOException {
+  public void testValidateNullBranchName() throws Exception {
     String serverURL = gitServer.getServerURL();
     RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
       .setLink(serverURL + "ignored")
@@ -145,7 +139,7 @@ public class RepositoryManagerTest {
   }
 
   @Test
-  public void testValidateSuccess() throws IOException {
+  public void testValidateSuccess() throws Exception {
     RepositoryManager.validateConfig(secureStore, getSourceControlConfig());
   }
 


### PR DESCRIPTION
## What 
`SourceControlManagementService#validateRepository` is throwing `RepositoryConfigValidationException` which is captured by handler and returns 400 bad request. This is not correct since there might be some other errors like internet connection issue, wrong passwords errors which do not fall into the 400 category. Instead we created a new `RemoteRepositoryValidationException` and return 500 for unknown errors