### PR TITLE
CDAP-20326 Add SCM list apps handler and implementation

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -1479,6 +1479,10 @@ public abstract class AppFabricTestBase {
                                 appRef.getNamespace(), appRef.getApplication()));
   }
 
+  protected HttpResponse listApplicationsFromRepository(String namespace) throws Exception {
+    return doGet(String.format("%s/namespaces/%s/repository/apps", Constants.Gateway.API_VERSION_3, namespace));
+  }
+
   protected String getPreferenceURI() {
     return "";
   }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunner.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunner.java
@@ -28,15 +28,17 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.internal.remote.RemoteTaskExecutor;
 import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
 import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
 import io.cdap.cdap.sourcecontrol.worker.PushAppTask;
 import io.cdap.common.http.HttpRequestConfig;
-import java.nio.charset.StandardCharsets;
-import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import javax.inject.Inject;
 
 /**
  * Remote implementation for {@link SourceControlOperationRunner}.
@@ -60,8 +62,8 @@ public class RemoteSourceControlOperationRunner implements SourceControlOperatio
   }
 
   @Override
-  public PushAppResponse push(PushAppContext pushAppContext)
-    throws PushFailureException, NoChangesToPushException, AuthenticationConfigException {
+  public PushAppResponse push(PushAppContext pushAppContext) throws NoChangesToPushException,
+    AuthenticationConfigException {
     try {
       RunnableTaskRequest request =
         RunnableTaskRequest.getBuilder(PushAppTask.class.getName()).withParam(GSON.toJson(pushAppContext)).build();
@@ -85,16 +87,22 @@ public class RemoteSourceControlOperationRunner implements SourceControlOperatio
         throw new AuthenticationConfigException(exceptionMessage, cause);
       }
 
-      throw new PushFailureException(exceptionMessage, cause);
+      throw new SourceControlException(exceptionMessage, cause);
     } catch (Exception ex) {
-      throw new PushFailureException(ex.getMessage(), ex);
+      throw new SourceControlException(ex.getMessage(), ex);
     }
   }
 
   @Override
-  public PullAppResponse<?> pull(ApplicationReference appRef, RepositoryConfig repoConfig)
-    throws PullFailureException, NotFoundException, AuthenticationConfigException {
+  public PullAppResponse<?> pull(ApplicationReference appRef, RepositoryConfig repoConfig) throws NotFoundException,
+    AuthenticationConfigException {
     // TODO: CDAP-20356, pull application in task worker
     throw new UnsupportedOperationException("Not implemented");
   }
+
+  @Override
+  public RepositoryAppsResponse list(NamespaceId namespace, RepositoryConfig repoConfig)
+    throws AuthenticationConfigException, NotFoundException {
+    // TODO: CDAP-20357, list applications in task worker
+    throw new UnsupportedOperationException("Not implemented");  }
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/RepositoryApp.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/RepositoryApp.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol.operationrunner;
+
+import java.util.Objects;
+
+/**
+ * Response class encapsulating information for a single applications found in repository
+ */
+public class RepositoryApp {
+  private final String name;
+  private final String fileHash;
+
+  public RepositoryApp(String name, String fileHash) {
+    this.name = name;
+    this.fileHash = fileHash;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getFileHash() {
+    return fileHash;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RepositoryApp that = (RepositoryApp) o;
+    return Objects.equals(name, that.name) &&
+      Objects.equals(fileHash, that.fileHash);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, fileHash);
+  }
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/RepositoryAppsResponse.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/RepositoryAppsResponse.java
@@ -16,11 +16,21 @@
 
 package io.cdap.cdap.sourcecontrol.operationrunner;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
- * Exception thrown when push operation fails in operation runner. Encapsulates all underlying exceptions.
+ * Response class encapsulating information about a list of applications found in repository
  */
-public class PullFailureException extends Exception {
-  public PullFailureException(String message, Exception cause) {
-    super(message, cause);
+public class RepositoryAppsResponse {
+  private final List<RepositoryApp> apps;
+
+  public RepositoryAppsResponse(List<RepositoryApp> apps) {
+    this.apps = Collections.unmodifiableList(new ArrayList<>(apps));
+  }
+
+  public List<RepositoryApp> getApps() {
+    return apps;
   }
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/SourceControlException.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/SourceControlException.java
@@ -17,19 +17,17 @@
 package io.cdap.cdap.sourcecontrol.operationrunner;
 
 /**
- * Exception thrown when push operation fails in operation runner.
- * Encapsulates all underlying exceptions.
+ * Exception thrown when source control operation fails in runner.
+ * Encapsulates some underlying exceptions.
+ * Should be subclassed for common root-causes
  */
-public class PushFailureException extends Exception {
-  public PushFailureException(String message, Exception cause) {
+// TODO https://cdap.atlassian.net/browse/CDAP-20410 Classify and make suberrors based on root causes
+public class SourceControlException extends RuntimeException {
+  public SourceControlException(String message, Throwable cause) {
     super(message, cause);
   }
 
-  public PushFailureException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
-  public PushFailureException(String message) {
+  public SourceControlException(String message) {
     super(message);
   }
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/SourceControlOperationRunner.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/SourceControlOperationRunner.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.sourcecontrol.operationrunner;
 
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
 import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
@@ -28,12 +29,13 @@ import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
 public interface SourceControlOperationRunner {
   /**
    * @param pushAppContext {@link PushAppContext} pf the application to be pushed
-   * @return {@link PushAppResponse} file-paths and file-hashes for the updated configs.
-   * @throws PushFailureException when the push operation fails for any unexpected reason.
-   * @throws NoChangesToPushException when the there's no change for the application to push.
-   * @throws AuthenticationConfigException when the repository configuration is invalid.
+   * @return file-paths and file-hashes for the updated configs.
+   * @throws NoChangesToPushException      if there is no effective changes on the config file to commit
+   * @throws AuthenticationConfigException when there is an error while creating the authentication credentials to
+   *                                       call remote Git.
+   * @throws SourceControlException when the push operation fails for any other reason.
    */
-  PushAppResponse push(PushAppContext pushAppContext) throws PushFailureException, NoChangesToPushException,
+  PushAppResponse push(PushAppContext pushAppContext) throws NoChangesToPushException,
     AuthenticationConfigException;
 
   /**
@@ -41,12 +43,22 @@ public interface SourceControlOperationRunner {
    *
    * @param appRef The {@link ApplicationReference} of the application to pull from
    * @return the details of the pulled application.
-   * @throws PullFailureException          when the operation fails for any reason.
    * @throws NotFoundException             when the requested application is not found in the Git repository.
    * @throws AuthenticationConfigException when there is an error while creating the authentication credentials to
    *                                       call remote Git.
    * @throws IllegalArgumentException      when the fetched application json or file path is invalid.
+   * @throws SourceControlException when the operation fails for any other reason.
    */
-  PullAppResponse<?> pull(ApplicationReference appRef, RepositoryConfig repoConfig) throws PullFailureException,
-    NotFoundException, AuthenticationConfigException;
+  PullAppResponse<?> pull(ApplicationReference appRef, RepositoryConfig repoConfig) throws NotFoundException,
+    AuthenticationConfigException;
+
+  /**
+   * @return Name and git-file-hashes for the detected config files.
+   * @throws AuthenticationConfigException when there is an error while creating the authentication credentials to
+   *                                       call remote Git.
+   * @throws NotFoundException when the given path-prefix is missing in the repository.
+   * @throws SourceControlException when the list operation fails for any other reason.
+   */
+  RepositoryAppsResponse list(NamespaceId namespace, RepositoryConfig repoConfig) throws AuthenticationConfigException,
+    NotFoundException;
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/worker/PushAppTask.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/worker/PushAppTask.java
@@ -25,13 +25,13 @@ import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
 import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
 import io.cdap.cdap.sourcecontrol.operationrunner.PushAppContext;
 import io.cdap.cdap.sourcecontrol.operationrunner.PushAppResponse;
-import io.cdap.cdap.sourcecontrol.operationrunner.PushFailureException;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * The task that pushes an application to linked repository.
@@ -50,7 +50,7 @@ public class PushAppTask extends SourceControlTask implements RunnableTask {
 
   @Override
   public void run(RunnableTaskContext context)
-    throws AuthenticationConfigException, PushFailureException, NoChangesToPushException, IOException {
+    throws AuthenticationConfigException, NoChangesToPushException, IOException {
     PushAppContext pushContext = GSON.fromJson(context.getParam(), PushAppContext.class);
 
     LOG.info("Pushing application {} in worker.", pushContext.getAppToPush().getName());

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
@@ -28,16 +28,7 @@ import io.cdap.cdap.proto.sourcecontrol.AuthType;
 import io.cdap.cdap.proto.sourcecontrol.Provider;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigValidationException;
-import io.cdap.cdap.sourcecontrol.operationrunner.PushFailureException;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
+import io.cdap.cdap.sourcecontrol.operationrunner.SourceControlException;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -51,6 +42,16 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * Tests for {@link  RepositoryManager}.
@@ -324,8 +325,8 @@ public class RepositoryManagerTest {
     }
   }
 
-  @Test(expected = PushFailureException.class)
-  public void testCommitAndPushFailureException() throws Exception {
+  @Test(expected = SourceControlException.class)
+  public void testCommitAndPushSourceControlFailure() throws Exception {
     String serverURL = gitServer.getServerURL();
     RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
       .setLink(serverURL + "ignored")

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunnerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunnerTest.java
@@ -49,8 +49,6 @@ import io.cdap.http.ChannelPipelineModifier;
 import io.cdap.http.NettyHttpService;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpContentDecompressor;
-import java.util.ArrayList;
-import java.util.UUID;
 import org.apache.twill.discovery.InMemoryDiscoveryService;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -60,6 +58,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
+
+import java.util.ArrayList;
+import java.util.UUID;
 
 /**
  * Tests for {@link RemoteSourceControlOperationRunner}
@@ -181,7 +182,7 @@ public class RemoteSourceControlOperationRunnerTest {
     Assert.assertEquals(pushResponse.getVersion(), mockAppDetails.getAppVersion());
   }
 
-  @Test(expected = PushFailureException.class)
+  @Test(expected = SourceControlException.class)
   public void testRemoteSourceControlOperationRunnerPushFailureException() throws Exception {
     // Get the actual repo config
     String serverURL = gitServer.getServerURL();


### PR DESCRIPTION
### Description
This PR adds capability to list application configs found in linked repository.
Currently 
- We only look at files directly under given path-prefix (if not given root of the repository). 
- We only consider json files
- The filename is taken as application name by convention

Current testing shows the api latency is split into cloning and fetching hashes evenly. The hashing performance would significantly improve once the changes in [https://github.com/cdapio/cdap/pull/14928](url) is merged.

### Testing
- Unit ✅ 
- Manual ✅ 
<img width="890" alt="Screenshot 2023-02-27 at 10 17 50 AM" src="https://user-images.githubusercontent.com/25403205/221476722-a61cf659-8d13-4fe6-bdfb-55aa829ffc11.png">
