### PR TITLE
[CDAP-20386] Reset to remote branch on repeated git clone

### DIFF
--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManager.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManager.java
@@ -28,15 +28,28 @@ import io.cdap.cdap.proto.sourcecontrol.RemoteRepositoryValidationException;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigValidationException;
 import io.cdap.cdap.sourcecontrol.operationrunner.SourceControlException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.CommitCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.LsRemoteCommand;
 import org.eclipse.jgit.api.PushCommand;
+import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.TransportException;
+import org.eclipse.jgit.errors.MissingObjectException;
 import org.eclipse.jgit.internal.storage.dfs.InMemoryRepository;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
@@ -46,44 +59,40 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.PushResult;
+import org.eclipse.jgit.transport.RemoteConfig;
 import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.Date;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.Supplier;
-import javax.annotation.Nullable;
-
 /**
- * A git repository manager that is responsible for handling interfacing with git. It provides version control
- * operations. This is not thread safe.
+ * A git repository manager that is responsible for handling interfacing with
+ * git. It provides version control operations. This is not thread safe.
  */
 public class RepositoryManager implements AutoCloseable {
-  private static final Logger LOG = LoggerFactory.getLogger(RepositoryManager.class);
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      RepositoryManager.class);
   private final SourceControlConfig sourceControlConfig;
   private final RefreshableCredentialsProvider credentialsProvider;
   private Git git;
-  // We clone the repository inside a randomly named directory to prevent multiple repository managers for the
-  // same namespace from interfering with each other.
+  // We clone the repository inside a randomly named directory to prevent
+  // multiple repository managers for the same namespace from interfering with
+  // each other.
   private final String randomDirectoryName;
 
-  public RepositoryManager(SecureStore secureStore,
-                           CConfiguration cConf,
-                           NamespaceId namespace,
-                           RepositoryConfig repoConfig) {
-    this.sourceControlConfig = new SourceControlConfig(namespace, repoConfig, cConf);
+  public RepositoryManager(final SecureStore secureStore,
+      final CConfiguration cConf,
+      final NamespaceId namespace,
+      final RepositoryConfig repoConfig) {
+    this.sourceControlConfig = new SourceControlConfig(namespace, repoConfig,
+        cConf);
     try {
-      this.credentialsProvider = new AuthenticationStrategyProvider(namespace.getNamespace(), secureStore)
-        .get(repoConfig)
-        .getCredentialsProvider();
+      this.credentialsProvider = new AuthenticationStrategyProvider(
+          namespace.getNamespace(),
+          secureStore)
+          .get(repoConfig)
+          .getCredentialsProvider();
     } catch (AuthenticationStrategyNotFoundException e) {
       // This is not expected as only valid auth configs will be stored.
       throw new RuntimeException(e);
@@ -92,14 +101,16 @@ public class RepositoryManager implements AutoCloseable {
   }
 
   /**
-   * Returns the base path in the git repo to store CDAP applications. If an optional Path prefix is provided in the
-   * repository configuration, the returned path includes it.
+   * Returns the base path in the git repo to store CDAP applications. If an
+   * optional Path prefix is provided in the repository configuration, the
+   * returned path includes it.
    *
    * @return the path for the repository base directory.
    */
   public Path getBasePath() {
     Path localRepoPath = getRepositoryRoot();
-    String pathPrefix = sourceControlConfig.getRepositoryConfig().getPathPrefix();
+    String pathPrefix = sourceControlConfig.getRepositoryConfig()
+        .getPathPrefix();
     if (Strings.isNullOrEmpty(pathPrefix)) {
       return localRepoPath;
     }
@@ -107,13 +118,15 @@ public class RepositoryManager implements AutoCloseable {
   }
 
   /**
-   * Gets the relative path of a file in git repository based on the user configured path prefix.
+   * Gets the relative path of a file in git repository based on the user
+   * configured path prefix.
    *
    * @param fileName The filename
    * @return the relative {@link Path}
    */
-  public Path getFileRelativePath(String fileName) {
-    String pathPrefix = sourceControlConfig.getRepositoryConfig().getPathPrefix();
+  public Path getFileRelativePath(final String fileName) {
+    String pathPrefix = sourceControlConfig.getRepositoryConfig()
+        .getPathPrefix();
     if (Strings.isNullOrEmpty(pathPrefix)) {
       return Paths.get(fileName);
     }
@@ -123,65 +136,86 @@ public class RepositoryManager implements AutoCloseable {
   /**
    * Validates the provided configuration.
    *
-   * @param secureStore         A secure store for fetching credentials if required.
+   * @param secureStore         A secure store for fetching credentials if
+   *                            required.
    * @param sourceControlConfig Configuration for source control operations.
-   * @throws RepositoryConfigValidationException when provided repository configuration is invalid.
+   * @throws RepositoryConfigValidationException when provided repository
+   *                                             configuration is invalid.
    */
-  public static void validateConfig(SecureStore secureStore, SourceControlConfig sourceControlConfig)
-    throws RemoteRepositoryValidationException {
+  public static void validateConfig(final SecureStore secureStore,
+      final SourceControlConfig sourceControlConfig)
+      throws RemoteRepositoryValidationException {
     RepositoryConfig config = sourceControlConfig.getRepositoryConfig();
     RefreshableCredentialsProvider credentialsProvider;
     try {
-      credentialsProvider = new AuthenticationStrategyProvider(sourceControlConfig.getNamespaceID(), secureStore)
-        .get(sourceControlConfig.getRepositoryConfig())
-        .getCredentialsProvider();
+      credentialsProvider = new AuthenticationStrategyProvider(
+          sourceControlConfig.getNamespaceID(),
+          secureStore)
+          .get(sourceControlConfig.getRepositoryConfig())
+          .getCredentialsProvider();
     } catch (AuthenticationStrategyNotFoundException e) {
       throw new RepositoryConfigValidationException(e.getMessage(), e);
     }
     try {
       credentialsProvider.refresh();
     } catch (AuthenticationConfigException e) {
-      throw new RepositoryConfigValidationException("Failed to get authentication credentials: " + e.getMessage(), e);
+      throw new RepositoryConfigValidationException(
+          "Failed to get authentication credentials: " + e.getMessage(), e);
     } catch (IOException e) {
-      throw new RemoteRepositoryValidationException("Internal error: " + e.getMessage(), e);
+      throw new RemoteRepositoryValidationException(
+          "Internal error: " + e.getMessage(), e);
     }
     // Try fetching heads in the remote repository.
     try (Git git = Git.wrap(new InMemoryRepository.Builder().build())) {
       LsRemoteCommand cmd =
-        createCommand(git::lsRemote, sourceControlConfig, credentialsProvider).setRemote(config.getLink())
-          .setHeads(true)
-          .setTags(false);
+          createCommand(git::lsRemote, sourceControlConfig,
+              credentialsProvider).setRemote(
+                  config.getLink())
+              .setHeads(true)
+              .setTags(false);
       validateDefaultBranch(cmd.callAsMap(), config.getDefaultBranch());
     } catch (TransportException e) {
-      throw new RepositoryConfigValidationException("Failed to connect with remote repository: " + e.getMessage(), e);
+      throw new RepositoryConfigValidationException(
+          "Failed to connect with remote repository: " + e.getMessage(), e);
     } catch (GitAPIException e) {
-      throw new RepositoryConfigValidationException("Failed to list remotes in remote repository: " + e.getMessage(),
-                                                    e);
+      throw new RepositoryConfigValidationException(
+          "Failed to list remotes in remote repository: " + e.getMessage(),
+          e);
     } catch (Exception e) {
-      Throwables.propagateIfInstanceOf(e, RepositoryConfigValidationException.class);
-      throw new RemoteRepositoryValidationException("Failed to list remotes in remote repository.", e);
+      Throwables.propagateIfInstanceOf(e,
+          RepositoryConfigValidationException.class);
+      throw new RemoteRepositoryValidationException(
+          "Failed to list remotes in remote repository.",
+          e);
     }
   }
 
   /**
-   * Commits and pushes the changes of a given file under the repository root path.
+   * Commits and pushes the changes of a given file under the repository root
+   * path.
    *
-   * @param commitMeta  Details for the commit including author, committer and commit message
-   * @param fileChanged The relative path to repository root where the file is updated
+   * @param commitMeta  Details for the commit including author, committer and
+   *                    commit message
+   * @param fileChanged The relative path to repository root where the file is
+   *                    updated
    * @return the hash of the written file.
    * @throws GitAPIException          when the underlying git commands fail
-   * @throws NoChangesToPushException when there's no file changes for the commit
-   * @throws SourceControlException when failed to get the fileHash before push, or the {@link PushResult} status is
-   * not OK
+   * @throws NoChangesToPushException when there's no file changes for the
+   *                                  commit
+   * @throws SourceControlException   when failed to get the fileHash before
+   *                                  push, or the {@link PushResult} status is
+   *                                  not OK
    */
-  public String commitAndPush(CommitMeta commitMeta, Path fileChanged)
-    throws NoChangesToPushException, GitAPIException {
+  public String commitAndPush(final CommitMeta commitMeta,
+      final Path fileChanged)
+      throws NoChangesToPushException, GitAPIException {
     validateInitialized();
 
     // if the status is clean skip
     Status preStageStatus = git.status().call();
     if (preStageStatus.isClean()) {
-      throw new NoChangesToPushException("No changes have been made for the applications to push.");
+      throw new NoChangesToPushException(
+          "No changes have been made for the applications to push.");
     }
 
     git.add().addFilepattern(fileChanged.toString()).call();
@@ -192,21 +226,29 @@ public class RepositoryManager implements AutoCloseable {
     try {
       fileHash = getFileHash(fileChanged, commit);
     } catch (IOException e) {
-      throw new SourceControlException(String.format("Failed to get fileHash for %s", fileChanged), e);
+      throw new SourceControlException(
+          String.format("Failed to get fileHash for %s", fileChanged),
+          e);
     }
 
     if (fileHash == null) {
-      throw new SourceControlException(String.format("Failed to get fileHash for %s, because the path is not " +
-                                                     "found in Git tree", fileChanged));
+      throw new SourceControlException(
+          String.format(
+              "Failed to get fileHash for %s, because the path is not "
+                  + "found in Git tree", fileChanged));
     }
 
-    PushCommand pushCommand = createCommand(git::push, sourceControlConfig, credentialsProvider);
+    PushCommand pushCommand = createCommand(git::push, sourceControlConfig,
+        credentialsProvider);
     Iterable<PushResult> pushResults = pushCommand.call();
 
     for (PushResult result : pushResults) {
       for (RemoteRefUpdate rru : result.getRemoteUpdates()) {
-        if (rru.getStatus() != RemoteRefUpdate.Status.OK && rru.getStatus() != RemoteRefUpdate.Status.UP_TO_DATE) {
-          throw new SourceControlException(String.format("Push failed for %s: %s", fileChanged, rru.getStatus()));
+        if (rru.getStatus() != RemoteRefUpdate.Status.OK
+            && rru.getStatus() != RemoteRefUpdate.Status.UP_TO_DATE) {
+          throw new SourceControlException(
+              String.format("Push failed for %s: %s", fileChanged,
+                  rru.getStatus()));
         }
       }
     }
@@ -214,73 +256,55 @@ public class RepositoryManager implements AutoCloseable {
     return fileHash;
   }
 
-  private CommitCommand getCommitCommand(CommitMeta commitMeta) {
+  private CommitCommand getCommitCommand(final CommitMeta commitMeta) {
     // We only set email
     PersonIdent author = new PersonIdent(commitMeta.getAuthor(), "");
-    PersonIdent authorWithDate = new PersonIdent(author, new Date(commitMeta.getTimestampMillis()));
+    PersonIdent authorWithDate = new PersonIdent(author,
+        new Date(commitMeta.getTimestampMillis()));
 
     PersonIdent committer = new PersonIdent(commitMeta.getCommitter(), "");
 
-    return git.commit().setAuthor(authorWithDate).setCommitter(committer).setMessage(commitMeta.getMessage());
+    return git.commit().setAuthor(authorWithDate).setCommitter(committer)
+        .setMessage(commitMeta.getMessage());
   }
 
   /**
-   * Returns the <a href="https://git-scm.com/docs/git-hash-object">Git Hash</a>
-   * of the requested file path in the provided commit. It is the caller's responsibility to handle paths that refer
-   * to directories or symlinks.
-   *
-   * @param relativePath The path relative to the repository base path (returned by
-   *                     {@link RepositoryManager#getRepositoryRoot()}) on the filesystem.
-   * @param commitHash   The commit ID hash for which to get the file hash.
-   * @return The git file hash of the requested file.
-   * @throws IOException           when file or commit isn't found, there are circular symlinks or other file IO
-   *                               errors.
-   * @throws NotFoundException     when the file isn't committed to Git.
-   * @throws IllegalStateException when {@link RepositoryManager#cloneRemote()} isn't called before this.
-   */
-  public String getFileHash(Path relativePath, String commitHash) throws IOException, NotFoundException,
-    GitAPIException {
-    validateInitialized();
-    ObjectId commitId = ObjectId.fromString(commitHash);
-
-    // Each commit points to a tree that contains the files/directories as nodes. The ObjectId (hashes) of the nodes
-    // represent the state of a file at that commit.
-    try (RevWalk walk = new RevWalk(git.getRepository())) {
-      String hash = getFileHash(relativePath, walk.parseCommit(commitId));
-      if (hash == null) {
-        throw new NotFoundException("File not found in Git revision tree.");
-      }
-      return hash;
-    }
-  }
-
-  /**
-   * Initializes the Git repository by cloning remote. This method doesn't re-clone if the remote has already been
-   * cloned earlier.
+   * Initializes the Git repository by cloning remote. If the repository is
+   * already cloned, it resets the git repository to the state in the remote.
+   * All local changes will be lost.
    *
    * @return the commit ID of the present HEAD.
    * @throws GitAPIException               when a Git operation fails.
    * @throws IOException                   when file or network I/O fails.
-   * @throws AuthenticationConfigException when there is a failure while fetching authentication credentials for Git.
+   * @throws AuthenticationConfigException when there is a failure while
+   *                                       fetching authentication credentials
+   *                                       for Git.
    */
-  public String cloneRemote() throws IOException, AuthenticationConfigException, GitAPIException {
+  public String cloneRemote()
+      throws IOException, AuthenticationConfigException, GitAPIException {
+    credentialsProvider.refresh();
     if (git != null) {
-      return resolveHead().getName();
+      return resetToCleanBranch(git.getRepository().getBranch());
     }
     // Clean up the directory if it already exists.
     deletePathIfExists(getRepositoryRoot());
-    RepositoryConfig repositoryConfig = sourceControlConfig.getRepositoryConfig();
-    credentialsProvider.refresh();
+    RepositoryConfig repositoryConfig = sourceControlConfig
+        .getRepositoryConfig();
     CloneCommand command =
-      createCommand(Git::cloneRepository).setURI(repositoryConfig.getLink()).setDirectory(getRepositoryRoot().toFile());
+        createCommand(Git::cloneRepository).setURI(repositoryConfig.getLink())
+            .setDirectory(getRepositoryRoot().toFile());
     String branch = getBranchRefName(repositoryConfig.getDefaultBranch());
     if (branch != null) {
-      command.setBranchesToClone(Collections.singleton((branch))).setBranch(branch);
+      command.setBranchesToClone(Collections.singleton((branch)))
+          .setBranch(branch);
     }
     git = command.call();
     return resolveHead().getName();
   }
 
+  /**
+   * Closes the repository manager and frees resources.
+   */
   @Override
   public void close() {
     if (git != null) {
@@ -290,24 +314,80 @@ public class RepositoryManager implements AutoCloseable {
     try {
       deletePathIfExists(getRepositoryRoot());
     } catch (IOException e) {
-      LOG.warn("Failed to close the RepositoryManager, there may be leftover files", e);
+      LOG.warn(
+          "Failed to close the RepositoryManager, there may be leftover files",
+          e);
     }
   }
 
   /**
+   * Returns the root directory path where the git repo is cloned.
+   *
    * @return the absolute path for repository root
    */
   public Path getRepositoryRoot() {
-    return sourceControlConfig.getLocalReposClonePath().resolve(randomDirectoryName);
+    return sourceControlConfig.getLocalReposClonePath()
+        .resolve(randomDirectoryName);
   }
 
-  private <C extends TransportCommand> C createCommand(Supplier<C> creator) {
+  /**
+   * Returns the <a href="https://git-scm.com/docs/git-hash-object">Git Hash</a>
+   * of the requested file path in the provided commit. It is the caller's
+   * responsibility to handle paths that refer to directories or symlinks.
+   *
+   * @param relativePath The path relative to the repository base path (returned
+   *                     by {@link RepositoryManager#getRepositoryRoot()}) on
+   *                     the filesystem.
+   * @param commitHash   The commit ID hash for which to get the file hash.
+   * @return The git file hash of the requested file.
+   * @throws IOException           when file or commit isn't found, there are
+   *                               circular symlinks or other file IO errors.
+   * @throws NotFoundException     when the file isn't committed to Git.
+   * @throws IllegalStateException when {@link RepositoryManager#cloneRemote()}
+   *                               isn't called before this.
+   */
+  public String getFileHash(final Path relativePath, final String commitHash)
+      throws IOException, NotFoundException,
+      GitAPIException {
+    validateInitialized();
+    ObjectId commitId = ObjectId.fromString(commitHash);
+
+    // Each commit points to a tree that contains the files/directories as
+    // nodes. The ObjectId (hashes) of the nodes represent the state of a
+    // file at that commit.
+    RevCommit commit = getRevCommit(commitId, true);
+    String hash = getFileHash(relativePath, commit);
+    if (hash == null) {
+      throw new NotFoundException("File not found in Git revision tree.");
+    }
+    return hash;
+  }
+
+  @Nullable
+  private String getFileHash(final Path relativePath, final RevCommit commit)
+      throws IOException,
+      GitAPIException {
+    // Find the node representing the exact file path in the tree.
+    try (TreeWalk walk = TreeWalk.forPath(git.getRepository(),
+        relativePath.toString(),
+        commit.getTree())) {
+      if (walk == null) {
+        LOG.warn("Path {} not found in Git tree", relativePath);
+        return null;
+      }
+      return walk.getObjectId(0).getName();
+    }
+  }
+
+  private <C extends TransportCommand> C createCommand(
+      final Supplier<C> creator) {
     return createCommand(creator, sourceControlConfig, credentialsProvider);
   }
 
-  private static <C extends TransportCommand> C createCommand(Supplier<C> creator,
-                                                              SourceControlConfig sourceControlConfig,
-                                                              CredentialsProvider credentialsProvider) {
+  private static <C extends TransportCommand> C createCommand(
+      final Supplier<C> creator,
+      final SourceControlConfig sourceControlConfig,
+      final CredentialsProvider credentialsProvider) {
     C command = creator.get();
     command.setCredentialsProvider(credentialsProvider);
     command.setTimeout(sourceControlConfig.getGitCommandTimeoutSeconds());
@@ -321,15 +401,31 @@ public class RepositoryManager implements AutoCloseable {
    * @return the ref name for the branch or Null if the branch name is null.
    */
   @Nullable
-  private static String getBranchRefName(@Nullable String branch) {
+  private static String getBranchRefName(final @Nullable String branch) {
     if (Strings.isNullOrEmpty(branch)) {
       return null;
     }
     return "refs/heads/" + branch;
   }
 
-  private static void validateDefaultBranch(Map<String, Ref> refs, @Nullable String defaultBranchName) throws
-    RepositoryConfigValidationException {
+  /**
+   * Returns the remote branch ref name for a given branch name.
+   *
+   * @param branch name without refs/head prefix.
+   * @param remoteName name of the git remote.
+   * @return the ref name for the remote branch.
+   */
+  private static String getRemoteBranchRefName(final String branch,
+      final String remoteName) {
+    if (Strings.isNullOrEmpty(branch)) {
+      return null;
+    }
+    return String.format("refs/remotes/%s/%s", remoteName, branch);
+  }
+
+  private static void validateDefaultBranch(final Map<String, Ref> refs,
+      final @Nullable String defaultBranchName) throws
+      RepositoryConfigValidationException {
     // If default branch is not provided, skip validation.
     if (getBranchRefName(defaultBranchName) == null) {
       return;
@@ -337,8 +433,9 @@ public class RepositoryManager implements AutoCloseable {
     // Check if default branch exists.
     if (refs.get(getBranchRefName(defaultBranchName)) == null) {
       throw new RepositoryConfigValidationException(String.format(
-        "Default branch not found in remote repository. Ensure branch '%s' already exists.",
-        defaultBranchName));
+          "Default branch not found in remote repository."
+              + " Ensure branch '%s' already exists.",
+          defaultBranchName));
     }
   }
 
@@ -347,33 +444,106 @@ public class RepositoryManager implements AutoCloseable {
    */
   private void validateInitialized() {
     if (git == null) {
-      throw new IllegalStateException("Initialize source control manager before performing operation.");
+      throw new IllegalStateException(
+          "Initialize source control manager before performing operation.");
     }
   }
 
-  private static void deletePathIfExists(Path path) throws IOException {
+  private static void deletePathIfExists(final Path path) throws IOException {
     if (Files.exists(path)) {
       DirUtils.deleteDirectoryContents(path.toFile());
     }
   }
 
+  /**
+   * Returns the commit ID for the present head.
+   *
+   * @return The commit ID for the head.
+   * @throws IOException when git is unable to resolve head.
+   */
   @VisibleForTesting
   ObjectId resolveHead() throws IOException {
     if (git == null) {
-      throw new IllegalStateException("Call cloneRemote() before getting HEAD.");
+      throw new IllegalStateException(
+          "Call cloneRemote() before getting HEAD.");
     }
     return git.getRepository().resolve(Constants.HEAD);
   }
 
-  @Nullable
-  private String getFileHash(Path relativePath, RevCommit commit) throws IOException {
-    // Find the node representing the exact file path in the tree.
-    try (TreeWalk walk = TreeWalk.forPath(git.getRepository(), relativePath.toString(), commit.getTree())) {
-      if (walk == null) {
-        LOG.warn("Path {} not found in Git tree", relativePath);
-        return null;
+  /**
+   * Gets the {@link RevCommit} for a {@link ObjectId} from the local git
+   * repository.
+   *
+   * @param commitId               the ID of the commit to be fetched.
+   * @param fetchCommitsIfRequired Whether to fetch commits from remote
+   *                               repository when commit isn't found locally.
+   * @return the {@link RevCommit}
+   * @throws IOException     when the commit for the provided commitId isn't
+   *                         found.
+   * @throws GitAPIException when there are failures while fetching commits from
+   *                         the remote.
+   */
+  private RevCommit getRevCommit(final ObjectId commitId,
+      final boolean fetchCommitsIfRequired)
+      throws IOException,
+      GitAPIException {
+    try (RevWalk walk = new RevWalk(git.getRepository())) {
+      return walk.parseCommit(commitId);
+    } catch (MissingObjectException e) {
+      if (!fetchCommitsIfRequired) {
+        throw e;
       }
-      return walk.getObjectId(0).getName();
+      LOG.warn(
+          "Commit {} not found in local repository, "
+              + "fetching commits from remote",
+          commitId.getName());
+      fetchRemote(getOrigin());
+      // set fetchCommitsIfRequired as false to prevent fetching commits
+      // indefinitely.
+      return getRevCommit(commitId, false);
     }
+  }
+
+  /**
+   * Gets the {@link RemoteConfig} for the single remote that is being tracked.
+   *
+   * @return the {@link RemoteConfig} for origin.
+   */
+  private RemoteConfig getOrigin() throws GitAPIException {
+    List<RemoteConfig> remoteConfigs = git.remoteList().call();
+    if (remoteConfigs.size() != 1) {
+      throw new IllegalStateException(
+          String.format("%s remotes found for git repository, expected 1.",
+              remoteConfigs.size()));
+    }
+    return remoteConfigs.get(0);
+  }
+
+  /**
+   * Fetched commits from the remote.
+   *
+   * @param remote the remote to fetch.
+   */
+  private void fetchRemote(final RemoteConfig remote) throws GitAPIException {
+    createCommand(git::fetch).setRefSpecs(remote.getFetchRefSpecs()).call();
+  }
+
+  /**
+   * Does a <a href="https://git-scm.com/docs/git-reset"> hard reset </a> to the
+   * remote branch being tracked.
+   *
+   * @param remoteBranchName branch to reset to.
+   * @return the commit ID of the new head.
+   */
+  private String resetToCleanBranch(final String remoteBranchName)
+      throws IOException, GitAPIException {
+    RemoteConfig origin = getOrigin();
+    fetchRemote(origin);
+    git.reset()
+        .setMode(ResetCommand.ResetType.HARD)
+        .setRef(getRemoteBranchRefName(remoteBranchName, origin.getName()))
+        .call();
+    git.clean().setCleanDirectories(true).setIgnore(true).call();
+    return resolveHead().getName();
   }
 }

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
@@ -52,39 +52,48 @@ import org.mockito.MockitoAnnotations;
  * Tests for {@link  RepositoryManager}.
  */
 public class RepositoryManagerTest extends SourceControlTestBase {
+
   @Mock
   private SecureStore secureStore;
   private CConfiguration cConf;
   public LocalGitServer gitServer = getGitServer();
   @Rule
-  public RuleChain chain = RuleChain.outerRule(baseTempFolder).around(gitServer);
+  public RuleChain chain = RuleChain.outerRule(baseTempFolder)
+      .around(gitServer);
 
   @Before
   public void beforeEach() throws Exception {
     MockitoAnnotations.initMocks(this);
     Mockito.when(secureStore.get(NAMESPACE, TOKEN_NAME))
-      .thenReturn(new SecureStoreData(null, MOCK_TOKEN.getBytes(StandardCharsets.UTF_8)));
+        .thenReturn(new SecureStoreData(null,
+            MOCK_TOKEN.getBytes(StandardCharsets.UTF_8)));
     cConf = CConfiguration.create();
-    cConf.setInt(Constants.SourceControlManagement.GIT_COMMAND_TIMEOUT_SECONDS, GIT_COMMAND_TIMEOUT);
-    cConf.set(Constants.SourceControlManagement.GIT_REPOSITORIES_CLONE_DIRECTORY_PATH,
-              baseTempFolder.newFolder("repository").getAbsolutePath());
+    cConf.setInt(Constants.SourceControlManagement.GIT_COMMAND_TIMEOUT_SECONDS,
+        GIT_COMMAND_TIMEOUT);
+    cConf.set(
+        Constants.SourceControlManagement.GIT_REPOSITORIES_CLONE_DIRECTORY_PATH,
+        baseTempFolder.newFolder("repository").getAbsolutePath());
   }
 
   @Test
   public void testValidateIncorrectKeyName() throws Exception {
     String serverUrl = gitServer.getServerUrl();
-    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
-      .setLink(serverUrl + "ignored")
-      .setDefaultBranch("develop")
-      .setAuthType(AuthType.PAT)
-      .setTokenName(TOKEN_NAME + "invalid")
-      .build();
-    SourceControlConfig sourceControlConfig = new SourceControlConfig(new NamespaceId(NAMESPACE), config, cConf);
+    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(
+            Provider.GITHUB)
+        .setLink(serverUrl + "ignored")
+        .setDefaultBranch("develop")
+        .setAuthType(AuthType.PAT)
+        .setTokenName(TOKEN_NAME + "invalid")
+        .build();
+    SourceControlConfig sourceControlConfig = new SourceControlConfig(
+        new NamespaceId(NAMESPACE),
+        config, cConf);
     try {
       RepositoryManager.validateConfig(secureStore, sourceControlConfig);
       Assert.fail();
     } catch (RepositoryConfigValidationException e) {
-      Assert.assertTrue(e.getMessage().contains("Failed to get authentication credentials"));
+      Assert.assertTrue(
+          e.getMessage().contains("Failed to get authentication credentials"));
     }
   }
 
@@ -92,7 +101,8 @@ public class RepositoryManagerTest extends SourceControlTestBase {
   public void testValidateInvalidToken() throws Exception {
     SourceControlConfig sourceControlConfig = getSourceControlConfig();
     Mockito.when(secureStore.get(NAMESPACE, TOKEN_NAME))
-      .thenReturn(new SecureStoreData(null, "invalid-token".getBytes(StandardCharsets.UTF_8)));
+        .thenReturn(new SecureStoreData(null,
+            "invalid-token".getBytes(StandardCharsets.UTF_8)));
     try {
       RepositoryManager.validateConfig(secureStore, sourceControlConfig);
       Assert.fail();
@@ -104,30 +114,37 @@ public class RepositoryManagerTest extends SourceControlTestBase {
   @Test
   public void testValidateInvalidBranchName() throws Exception {
     String serverUrl = gitServer.getServerUrl();
-    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
-      .setLink(serverUrl + "ignored")
-      .setDefaultBranch("develop-invalid")
-      .setAuthType(AuthType.PAT)
-      .setTokenName(TOKEN_NAME)
-      .build();
-    SourceControlConfig sourceControlConfig = new SourceControlConfig(new NamespaceId(NAMESPACE), config, cConf);
+    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(
+            Provider.GITHUB)
+        .setLink(serverUrl + "ignored")
+        .setDefaultBranch("develop-invalid")
+        .setAuthType(AuthType.PAT)
+        .setTokenName(TOKEN_NAME)
+        .build();
+    SourceControlConfig sourceControlConfig = new SourceControlConfig(
+        new NamespaceId(NAMESPACE),
+        config, cConf);
     try {
       RepositoryManager.validateConfig(secureStore, sourceControlConfig);
       Assert.fail();
     } catch (RepositoryConfigValidationException e) {
-      Assert.assertTrue(e.getMessage().contains("Default branch not found in remote repository"));
+      Assert.assertTrue(e.getMessage()
+          .contains("Default branch not found in remote repository"));
     }
   }
 
   @Test
   public void testValidateNullBranchName() throws Exception {
     String serverUrl = gitServer.getServerUrl();
-    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
-      .setLink(serverUrl + "ignored")
-      .setAuthType(AuthType.PAT)
-      .setTokenName(TOKEN_NAME)
-      .build();
-    SourceControlConfig sourceControlConfig = new SourceControlConfig(new NamespaceId(NAMESPACE), config, cConf);
+    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(
+            Provider.GITHUB)
+        .setLink(serverUrl + "ignored")
+        .setAuthType(AuthType.PAT)
+        .setTokenName(TOKEN_NAME)
+        .build();
+    SourceControlConfig sourceControlConfig = new SourceControlConfig(
+        new NamespaceId(NAMESPACE),
+        config, cConf);
     RepositoryManager.validateConfig(secureStore, sourceControlConfig);
   }
 
@@ -149,10 +166,10 @@ public class RepositoryManagerTest extends SourceControlTestBase {
     String expectedHash = getGitStyleHash(fileContents);
     Assert.assertEquals(expectedHash, fileHash);
     // Change the file, but don't commit. The hash should remain the same.
-    Files.write(manager.getBasePath().resolve(fileName), "change 1".getBytes(StandardCharsets.UTF_8));
+    Files.write(manager.getBasePath().resolve(fileName),
+        "change 1".getBytes(StandardCharsets.UTF_8));
     fileHash = manager.getFileHash(path, manager.resolveHead().getName());
     Assert.assertEquals(expectedHash, fileHash);
-    manager.close();
     // Change the file contents and commit, the hash should also change.
     addFileToGit(path, "change 2", gitServer);
     commitId = manager.cloneRemote();
@@ -161,10 +178,11 @@ public class RepositoryManagerTest extends SourceControlTestBase {
   }
 
   @Test(expected = NotFoundException.class)
-  public void testGetFileHashInvlidPath() throws Exception {
-    try (RepositoryManager manager = getRepositoryManager();) {
+  public void testGetFileHashInvalidPath() throws Exception {
+    try (RepositoryManager manager = getRepositoryManager()) {
       String commitId = manager.cloneRemote();
-      manager.getFileHash(Paths.get("data-pipelines", "pipeline.json"), commitId);
+      manager.getFileHash(Paths.get("data-pipelines", "pipeline.json"),
+          commitId);
     }
   }
 
@@ -183,19 +201,22 @@ public class RepositoryManagerTest extends SourceControlTestBase {
     String hash = manager.getFileHash(path, commitId);
     // Change file contents, but don't commit.
     Path absoluteRepoPath = manager.getRepositoryRoot().resolve(path);
-    Files.write(absoluteRepoPath, fileContents2.getBytes(StandardCharsets.UTF_8));
+    Files.write(absoluteRepoPath,
+        fileContents2.getBytes(StandardCharsets.UTF_8));
     // Check the file hash of the link, it should be unchanged.
     Assert.assertEquals(hash, manager.getFileHash(path, commitId));
     // Check that working directory changes are still present.
-    Assert.assertEquals(new String(Files.readAllBytes(absoluteRepoPath), StandardCharsets.UTF_8), fileContents2);
-    manager.close();
+    Assert.assertEquals(new String(Files.readAllBytes(absoluteRepoPath),
+            StandardCharsets.UTF_8),
+        fileContents2);
     // Commit the symlink change.
     addFileToGit(path, fileContents2, gitServer);
     manager.cloneRemote();
     // Check the file hash at previous commit.
     Assert.assertEquals(hash, manager.getFileHash(path, commitId));
     // Check the file hash at head.
-    Assert.assertNotEquals(hash, manager.getFileHash(path, manager.resolveHead().getName()));
+    Assert.assertNotEquals(hash,
+        manager.getFileHash(path, manager.resolveHead().getName()));
     manager.close();
   }
 
@@ -213,12 +234,37 @@ public class RepositoryManagerTest extends SourceControlTestBase {
     }
   }
 
+  @Test
+  public void testCloneUntrackedFiles() throws Exception {
+    try (RepositoryManager manager = getRepositoryManager()) {
+      manager.cloneRemote();
+      Path path = manager.getRepositoryRoot().resolve("my-file.txt");
+      Files.write(path, "abc".getBytes(StandardCharsets.UTF_8));
+      Assert.assertTrue(Files.exists(path));
+      manager.cloneRemote();
+      Assert.assertFalse(Files.exists(path));
+    }
+  }
+
+  @Test
+  public void testFetchNewCommitForFileHash() throws Exception {
+    try (RepositoryManager manager = getRepositoryManager()) {
+      manager.cloneRemote();
+      String fileName = "pipeline.json";
+      Path path = Paths.get(fileName);
+      String contents = "{name: pipeline}";
+      RevCommit commit = addFileToGit(path, contents, gitServer);
+      Assert.assertEquals(manager.getFileHash(path, commit.getName()),
+          getGitStyleHash(contents));
+    }
+  }
+
   private RepositoryConfig.Builder getRepositoryConfigBuilder() {
     return new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
-      .setLink(gitServer.getServerUrl() + "ignored")
-      .setDefaultBranch("develop")
-      .setAuthType(AuthType.PAT)
-      .setTokenName(TOKEN_NAME);
+        .setLink(gitServer.getServerUrl() + "ignored")
+        .setDefaultBranch("develop")
+        .setAuthType(AuthType.PAT)
+        .setTokenName(TOKEN_NAME);
   }
 
   /**
@@ -227,7 +273,9 @@ public class RepositoryManagerTest extends SourceControlTestBase {
    * @return the {@link SourceControlConfig}.
    */
   private SourceControlConfig getSourceControlConfig() {
-    return new SourceControlConfig(new NamespaceId(NAMESPACE), getRepositoryConfigBuilder().build(), cConf);
+    return new SourceControlConfig(new NamespaceId(NAMESPACE),
+        getRepositoryConfigBuilder().build(),
+        cConf);
   }
 
   /**
@@ -236,27 +284,32 @@ public class RepositoryManagerTest extends SourceControlTestBase {
    * @return the {@link RepositoryManager}.
    */
   private RepositoryManager getRepositoryManager() {
-    return new RepositoryManager(secureStore, cConf, new NamespaceId(NAMESPACE), getRepositoryConfigBuilder().build());
+    return new RepositoryManager(secureStore, cConf, new NamespaceId(NAMESPACE),
+        getRepositoryConfigBuilder().build());
   }
 
   @Test
   public void testCommitAndPushSuccess() throws Exception {
     String serverUrl = gitServer.getServerUrl();
-    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
-      .setLink(serverUrl + "ignored")
-      .setDefaultBranch("develop")
-      .setAuthType(AuthType.PAT)
-      .setTokenName(TOKEN_NAME)
-      .build();
+    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(
+            Provider.GITHUB)
+        .setLink(serverUrl + "ignored")
+        .setDefaultBranch("develop")
+        .setAuthType(AuthType.PAT)
+        .setTokenName(TOKEN_NAME)
+        .build();
 
-    try (RepositoryManager manager = new RepositoryManager(secureStore, cConf, new NamespaceId(NAMESPACE), config)) {
+    try (RepositoryManager manager = new RepositoryManager(secureStore, cConf,
+        new NamespaceId(NAMESPACE), config)) {
       manager.cloneRemote();
-      CommitMeta commitMeta = new CommitMeta("author", "committer", 100, "message");
+      CommitMeta commitMeta = new CommitMeta("author", "committer", 100,
+          "message");
       Path filePath = manager.getBasePath().resolve("file1");
       String fileContent = "content";
 
       Files.write(filePath, fileContent.getBytes(StandardCharsets.UTF_8));
-      manager.commitAndPush(commitMeta, manager.getBasePath().relativize(filePath));
+      manager.commitAndPush(commitMeta,
+          manager.getBasePath().relativize(filePath));
       verifyCommit(filePath, fileContent, commitMeta);
     }
   }
@@ -264,16 +317,19 @@ public class RepositoryManagerTest extends SourceControlTestBase {
   @Test(expected = SourceControlException.class)
   public void testCommitAndPushSourceControlFailure() throws Exception {
     String serverUrl = gitServer.getServerUrl();
-    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
-      .setLink(serverUrl + "ignored")
-      .setDefaultBranch("develop")
-      .setAuthType(AuthType.PAT)
-      .setTokenName(TOKEN_NAME)
-      .build();
+    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(
+            Provider.GITHUB)
+        .setLink(serverUrl + "ignored")
+        .setDefaultBranch("develop")
+        .setAuthType(AuthType.PAT)
+        .setTokenName(TOKEN_NAME)
+        .build();
 
-    try (RepositoryManager manager = new RepositoryManager(secureStore, cConf, new NamespaceId(NAMESPACE), config)) {
+    try (RepositoryManager manager = new RepositoryManager(secureStore, cConf,
+        new NamespaceId(NAMESPACE), config)) {
       manager.cloneRemote();
-      CommitMeta commitMeta = new CommitMeta("author", "committer", 100, "message");
+      CommitMeta commitMeta = new CommitMeta("author", "committer", 100,
+          "message");
       Path filePath = manager.getBasePath().resolve("file1");
       String fileContent = "content";
 
@@ -286,17 +342,20 @@ public class RepositoryManagerTest extends SourceControlTestBase {
   public void testCommitAndPushNoChangeSuccess() throws Exception {
     String pathPrefix = "prefix";
     String serverUrl = gitServer.getServerUrl();
-    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
-      .setLink(serverUrl + "ignored")
-      .setDefaultBranch("develop")
-      .setPathPrefix(pathPrefix)
-      .setAuthType(AuthType.PAT)
-      .setTokenName(TOKEN_NAME)
-      .build();
+    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(
+            Provider.GITHUB)
+        .setLink(serverUrl + "ignored")
+        .setDefaultBranch("develop")
+        .setPathPrefix(pathPrefix)
+        .setAuthType(AuthType.PAT)
+        .setTokenName(TOKEN_NAME)
+        .build();
 
-    try (RepositoryManager manager = new RepositoryManager(secureStore, cConf, new NamespaceId(NAMESPACE), config)) {
+    try (RepositoryManager manager = new RepositoryManager(secureStore, cConf,
+        new NamespaceId(NAMESPACE), config)) {
       manager.cloneRemote();
-      CommitMeta commitMeta = new CommitMeta("author", "committer", 100, "message");
+      CommitMeta commitMeta = new CommitMeta("author", "committer", 100,
+          "message");
       manager.commitAndPush(commitMeta, Paths.get(pathPrefix));
 
       verifyNoCommit();
@@ -306,50 +365,63 @@ public class RepositoryManagerTest extends SourceControlTestBase {
   @Test(expected = GitAPIException.class)
   public void testCommitAndPushFails() throws Exception {
     String serverUrl = gitServer.getServerUrl();
-    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(Provider.GITHUB)
-      .setLink(serverUrl + "ignored")
-      .setDefaultBranch("develop")
-      .setAuthType(AuthType.PAT)
-      .setTokenName(TOKEN_NAME)
-      .build();
+    RepositoryConfig config = new RepositoryConfig.Builder().setProvider(
+            Provider.GITHUB)
+        .setLink(serverUrl + "ignored")
+        .setDefaultBranch("develop")
+        .setAuthType(AuthType.PAT)
+        .setTokenName(TOKEN_NAME)
+        .build();
 
-    try (RepositoryManager manager = new RepositoryManager(secureStore, cConf, new NamespaceId(NAMESPACE), config)) {
+    try (RepositoryManager manager = new RepositoryManager(secureStore, cConf,
+        new NamespaceId(NAMESPACE), config)) {
       manager.cloneRemote();
-      CommitMeta commitMeta = new CommitMeta("author", "committer", 100, "message");
+      CommitMeta commitMeta = new CommitMeta("author", "committer", 100,
+          "message");
       Path filePath = manager.getBasePath().resolve("file1");
       String fileContent = "content";
 
       Files.write(filePath, fileContent.getBytes(StandardCharsets.UTF_8));
       gitServer.after();
-      manager.commitAndPush(commitMeta, manager.getBasePath().relativize(filePath));
+      manager.commitAndPush(commitMeta,
+          manager.getBasePath().relativize(filePath));
     }
   }
 
   private void verifyNoCommit() throws GitAPIException, IOException {
-    Path tempDirPath = baseTempFolder.newFolder("temp-local-git-verify").toPath();
+    Path tempDirPath = baseTempFolder.newFolder("temp-local-git-verify")
+        .toPath();
     Git localGit = getClonedGit(tempDirPath, gitServer);
     List<RevCommit> commits =
-      StreamSupport.stream(localGit.log().all().call().spliterator(), false).collect(Collectors.toList());
+        StreamSupport.stream(localGit.log().all().call().spliterator(), false)
+            .collect(Collectors.toList());
     Assert.assertEquals(1, commits.size());
   }
 
-  private void verifyCommit(Path pathFromRepoRoot, String expectedContent, CommitMeta commitMeta) throws
-    GitAPIException, IOException {
-    Path tempDirPath = baseTempFolder.newFolder("temp-local-git-verify").toPath();
+  private void verifyCommit(Path pathFromRepoRoot, String expectedContent,
+      CommitMeta commitMeta)
+      throws
+      GitAPIException, IOException {
+    Path tempDirPath = baseTempFolder.newFolder("temp-local-git-verify")
+        .toPath();
     Git localGit = getClonedGit(tempDirPath, gitServer);
     Path filePath = tempDirPath.resolve(pathFromRepoRoot);
 
-    String actualContent = new String(Files.readAllBytes(filePath), StandardCharsets.UTF_8);
+    String actualContent = new String(Files.readAllBytes(filePath),
+        StandardCharsets.UTF_8);
     Assert.assertEquals(expectedContent, actualContent);
 
     List<RevCommit> commits =
-      StreamSupport.stream(localGit.log().all().call().spliterator(), false).collect(Collectors.toList());
+        StreamSupport.stream(localGit.log().all().call().spliterator(), false)
+            .collect(Collectors.toList());
     Assert.assertEquals(2, commits.size());
     RevCommit latestCommit = commits.get(0);
 
     Assert.assertEquals(latestCommit.getFullMessage(), commitMeta.getMessage());
-    Assert.assertEquals(commitMeta.getAuthor(), latestCommit.getAuthorIdent().getName());
-    Assert.assertEquals(commitMeta.getCommitter(), latestCommit.getCommitterIdent().getName());
+    Assert.assertEquals(commitMeta.getAuthor(),
+        latestCommit.getAuthorIdent().getName());
+    Assert.assertEquals(commitMeta.getCommitter(),
+        latestCommit.getCommitterIdent().getName());
 
     localGit.close();
     DirUtils.deleteDirectoryContents(tempDirPath.toFile());


### PR DESCRIPTION
[CDAP-20386](https://cdap.atlassian.net/browse/CDAP-20386)

On calling repeated calls to `RepositoryManager#clone()`, do a hard reset to remote branch.

## Tests
Two unit tests were already calling `manager.close()` followed by `manager.cloneRemote()` to get changes in the remote repo, the close call has been removed and the tests are passing.

[CDAP-20386]: https://cdap.atlassian.net/browse/CDAP-20386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ