### PR TITLE
[CDAP-20387] Separate subscriber transaction size from subscriber fetch size

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AbstractNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AbstractNotificationSubscriberService.java
@@ -51,6 +51,18 @@ public abstract class AbstractNotificationSubscriberService extends
       MessagingService messagingService,
       MetricsCollectionService metricsCollectionService,
       TransactionRunner transactionRunner) {
+    this(name, cConf, topicName, fetchSize, emptyFetchDelayMillis, messagingService,
+        metricsCollectionService,
+        transactionRunner, fetchSize);
+  }
+
+  protected AbstractNotificationSubscriberService(String name, CConfiguration cConf,
+      String topicName,
+      int fetchSize, long emptyFetchDelayMillis,
+      MessagingService messagingService,
+      MetricsCollectionService metricsCollectionService,
+      TransactionRunner transactionRunner,
+      int txSize) {
     super(NamespaceId.SYSTEM.topic(topicName), fetchSize,
         cConf.getInt(TxConstants.Manager.CFG_TX_TIMEOUT),
         emptyFetchDelayMillis,
@@ -61,7 +73,8 @@ public abstract class AbstractNotificationSubscriberService extends
             Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace(),
             Constants.Metrics.Tag.TOPIC, topicName,
             Constants.Metrics.Tag.CONSUMER, name
-        )));
+        )),
+        txSize);
     this.name = name;
     this.messagingContext = new MultiThreadMessagingContext(messagingService);
     this.transactionRunner = transactionRunner;

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -221,7 +221,10 @@ public final class Constants {
     public static final String BOSS_THREADS = "app.boss.threads";
     public static final String WORKER_THREADS = "app.worker.threads";
     public static final String APP_SCHEDULER_QUEUE = "apps.scheduler.queue";
+    public static final String PROGRAM_STATUS_EVENT_TX_SEPARATION = "app.program.status.event.tx.separation";
     public static final String STATUS_EVENT_FETCH_SIZE = "app.program.status.event.fetch.size";
+
+    public static final String STATUS_EVENT_TX_SIZE = "app.program.status.event.tx.size";
     public static final String STATUS_EVENT_POLL_DELAY_MILLIS = "app.program.status.event.poll.delay.millis";
     public static final String MAPREDUCE_JOB_CLIENT_CONNECT_MAX_RETRIES = "mapreduce.jobclient.connect.max.retries";
     public static final String MAPREDUCE_INCLUDE_CUSTOM_CLASSES = "mapreduce.include.custom.format.classes";

--- a/cdap-common/src/main/java/io/cdap/cdap/common/utils/TimeBoundIterator.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/utils/TimeBoundIterator.java
@@ -38,12 +38,13 @@ public class TimeBoundIterator<T> extends AbstractIterator<T> {
     this(delegate, timeBoundMillis, new Stopwatch());
   }
 
-  @VisibleForTesting
-  TimeBoundIterator(Iterator<T> delegate, long timeBoundMillis, Stopwatch stopwatch) {
+  public TimeBoundIterator(Iterator<T> delegate, long timeBoundMillis, Stopwatch stopwatch) {
     this.delegate = delegate;
     this.timeBoundMillis = timeBoundMillis;
     this.stopwatch = stopwatch;
-    this.stopwatch.start();
+    if (!this.stopwatch.isRunning()) {
+      this.stopwatch.start();
+    }
   }
 
   @Override

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -694,11 +694,31 @@
   </property>
 
   <property>
+    <name>app.program.status.event.tx.separation</name>
+    <value>false</value>
+    <description>
+      if true, ProgramNotificationSubscriberService will go shouldRunInSeparateTx to
+      see if certain messages need to run in a separate transaction.
+      This is usually not needed, unless scale is extremely high, which in turn may result
+      in transactions being deadlock with program.status.event.topic.num.partitions is greater than 1.
+    </description>
+  </property>
+
+  <property>
     <name>app.program.status.event.fetch.size</name>
     <value>100</value>
     <description>
       Maximum number of events to fetch from the messaging system in each processing cycle for
       program status update events
+    </description>
+  </property>
+
+  <property>
+    <name>app.program.status.event.tx.size</name>
+    <value>${app.program.status.event.fetch.size}</value>
+    <description>
+      Maximum number of events to process in one transaction when messages are fetched from the messaging system
+      in each processing cycle for program status update events
     </description>
   </property>
 

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/subscriber/AbstractMessagingPollingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/subscriber/AbstractMessagingPollingService.java
@@ -227,6 +227,10 @@ public abstract class AbstractMessagingPollingService<T> extends AbstractRetryab
     return 0L;
   }
 
+  int getFetchSize() {
+    return fetchSize;
+  }
+
   /**
    * Returns the publish time encoded in the given message id.
    *


### PR DESCRIPTION
Why: with the introduction of multiple partitions for ProgramNotificationSubscriberService, and since transaction size is identical to TMS fetch size, multiple concurrent big transactions try to modify DB concurrently which may cause deadlocks. 

This PR, separates txn size from subscriber fetch size so we can still fetch large number of messages from TMS, but can process them in smaller transaction sizes. 