### PR TITLE
Add metrics for wrangler directives usage in pipeline runs

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -977,6 +977,9 @@ public final class Constants {
 
       //For scheduler
       public static final String SCHEDULE = "sch";
+
+      // For wrangler directives
+      public static final String DIRECTIVE = "dir";
     }
 
     /**

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsQueryHelper.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/MetricsQueryHelper.java
@@ -124,6 +124,9 @@ public class MetricsQueryHelper {
 
       // put schedule job related tag
       .put(Constants.Metrics.Tag.SCHEDULE, "schedule")
+
+      // put directives related tag
+      .put(Constants.Metrics.Tag.DIRECTIVE, "directive")
       .build();
 
     tagNameToHuman = mapping;

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricStore.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricStore.java
@@ -87,6 +87,7 @@ public class DefaultMetricStore implements MetricStore {
   private static final String BY_COMPONENT = "component";
   private static final String BY_SCHEDULE = "schedule";
   private static final String BY_ONLY_COMPONENT = "only_component";
+  private static final String BY_DIRECTIVE = "directive";
   private static final Map<String, AggregationAlias> AGGREGATIONS_ALIAS_DIMENSIONS =
     ImmutableMap.of(BY_WORKFLOW,
                     new AggregationAlias(ImmutableMap.of(Constants.Metrics.Tag.RUN_ID,
@@ -207,6 +208,12 @@ public class DefaultMetricStore implements MetricStore {
     aggs.put(BY_ONLY_COMPONENT, new DefaultAggregation(
       ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.COMPONENT),
       ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.COMPONENT)));
+
+    // Directives:
+    aggs.put(BY_DIRECTIVE, new DefaultAggregation(
+      ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP, Constants.Metrics.Tag.DIRECTIVE),
+      ImmutableList.of(Constants.Metrics.Tag.NAMESPACE, Constants.Metrics.Tag.APP, Constants.Metrics.Tag.DIRECTIVE)
+    ));
 
     AGGREGATIONS = Collections.unmodifiableMap(aggs);
   }


### PR DESCRIPTION
Add new metric tag to aggregate and query based on Wrangler directive name.