### PR TITLE
 [CDAP-19611] Kill tethered pipeline runs stuck in STOPPING state

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -109,6 +109,7 @@ public interface Store {
    *
    * @param id run id of the program
    * @param twillRunId Twill run id
+   * @param runTime start timestamp in seconds
    * @param sourceId id of the source of program run status, which is proportional to the timestamp of
    *                 when the current program run status is reached
    */

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramNotificationSubscriberService.java
@@ -446,7 +446,7 @@ class ProgramNotificationSingleTopicSubscriberService extends AbstractNotificati
         break;
       case RUNNING:
         long logicalStartTimeSecs = getTimeSeconds(notification.getProperties(),
-                                                   ProgramOptionConstants.LOGICAL_START_TIME);
+                                                   ProgramOptionConstants.LOGICAL_START_TIME, -1);
         if (logicalStartTimeSecs == -1) {
           LOG.warn("Ignore program running notification for program {} without {} specified, {}",
                    programRunId, ProgramOptionConstants.LOGICAL_START_TIME, notification);
@@ -461,7 +461,7 @@ class ProgramNotificationSingleTopicSubscriberService extends AbstractNotificati
         break;
       case SUSPENDED:
         long suspendTime = getTimeSeconds(notification.getProperties(),
-                                          ProgramOptionConstants.SUSPEND_TIME);
+                                          ProgramOptionConstants.SUSPEND_TIME, -1);
         // since we are adding suspend time recently, there might be old suspended notifications for which time
         // can be -1.
         recordedRunRecord = appMetadataStore.recordProgramSuspend(programRunId, messageIdBytes, suspendTime);
@@ -469,21 +469,23 @@ class ProgramNotificationSingleTopicSubscriberService extends AbstractNotificati
         break;
       case RESUMING:
         long resumeTime = getTimeSeconds(notification.getProperties(),
-                                         ProgramOptionConstants.RESUME_TIME);
-        // since we are adding suspend time recently, there might be old suspended notifications for which time
+                                         ProgramOptionConstants.RESUME_TIME, -1);
+        // since we are adding resume time recently, there might be old resumed notifications for which time
         // can be -1.
         recordedRunRecord = appMetadataStore.recordProgramResumed(programRunId, messageIdBytes, resumeTime);
         writeToHeartBeatTable(recordedRunRecord, resumeTime, programHeartbeatTable);
         break;
       case STOPPING:
         Map<String, String> notificationProperties = notification.getProperties();
-        long stoppingTsSecs = getTimeSeconds(notificationProperties, ProgramOptionConstants.STOPPING_TIME);
-        if (stoppingTsSecs == -1L) {
+        long stoppingTsSecs = getTimeSeconds(notificationProperties, ProgramOptionConstants.STOPPING_TIME,
+                                             -1);
+        if (stoppingTsSecs == -1) {
           LOG.warn("Ignore program stopping notification for program {} without {} specified, {}",
                    programRunId, ProgramOptionConstants.STOPPING_TIME, notification);
           return;
         }
-        long terminateTsSecs = getTimeSeconds(notificationProperties, ProgramOptionConstants.TERMINATE_TIME);
+        long terminateTsSecs = getTimeSeconds(notificationProperties, ProgramOptionConstants.TERMINATE_TIME,
+                                              Long.MAX_VALUE);
         recordedRunRecord = appMetadataStore.recordProgramStopping(programRunId, messageIdBytes, stoppingTsSecs,
                                                                    terminateTsSecs);
         writeToHeartBeatTable(recordedRunRecord, stoppingTsSecs, programHeartbeatTable);
@@ -555,7 +557,7 @@ class ProgramNotificationSingleTopicSubscriberService extends AbstractNotificati
                                                   List<Runnable> runnables) throws Exception {
     Map<String, String> properties = notification.getProperties();
 
-    long endTimeSecs = getTimeSeconds(properties, ProgramOptionConstants.END_TIME);
+    long endTimeSecs = getTimeSeconds(properties, ProgramOptionConstants.END_TIME, -1);
     if (endTimeSecs == -1) {
       LOG.warn("Ignore program {} notification for program {} without end time specified, {}",
                programRunStatus.name().toLowerCase(), programRunId, notification);
@@ -705,7 +707,7 @@ class ProgramNotificationSingleTopicSubscriberService extends AbstractNotificati
     ProgramOptions programOptions = ProgramOptions.fromNotification(notification, GSON);
     String userId = properties.get(ProgramOptionConstants.USER_ID);
 
-    long endTs = getTimeSeconds(properties, ProgramOptionConstants.CLUSTER_END_TIME);
+    long endTs = getTimeSeconds(properties, ProgramOptionConstants.CLUSTER_END_TIME, -1);
     ProgramDescriptor programDescriptor =
       GSON.fromJson(properties.get(ProgramOptionConstants.PROGRAM_DESCRIPTOR), ProgramDescriptor.class);
     switch (clusterStatus) {
@@ -801,11 +803,12 @@ class ProgramNotificationSingleTopicSubscriberService extends AbstractNotificati
    *
    * @param properties the properties map
    * @param option the key to lookup in the properties map
-   * @return the time in seconds, or -1 if not found
+   * @param defaultValue the default value to return if there is no such property.
+   * @return the time in seconds, or {@code defaultValue} if not found
    */
-  private long getTimeSeconds(Map<String, String> properties, String option) {
+  private long getTimeSeconds(Map<String, String> properties, String option, long defaultValue) {
     String timeString = properties.get(option);
-    return (timeString == null) ? -1L : TimeUnit.MILLISECONDS.toSeconds(Long.parseLong(timeString));
+    return (timeString == null) ? defaultValue : TimeUnit.MILLISECONDS.toSeconds(Long.parseLong(timeString));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorService.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.runtime.ProgramRuntimeService;
 import io.cdap.cdap.app.runtime.ProgramRuntimeService.RuntimeInfo;
+import io.cdap.cdap.app.runtime.ProgramStateWriter;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -62,23 +63,29 @@ public class ProgramRunStatusMonitorService extends AbstractRetryableScheduledSe
   private final int txBatchSize;
   private final long intervalMillis;
   private final long terminateTimeBufferSecs;
+  private final long tetheredProgramTerminateTimeSecs;
   private final int numThreads;
   private ExecutorService executorService;
   private final MetricsCollectionService metricsCollectionService;
+  private final ProgramStateWriter programStateWriter;
 
   @Inject
   ProgramRunStatusMonitorService(CConfiguration cConf, Store store, ProgramRuntimeService runtimeService,
-                                 MetricsCollectionService metricsCollectionService) {
-    this(cConf, store, runtimeService, metricsCollectionService,
+                                 MetricsCollectionService metricsCollectionService,
+                                 ProgramStateWriter programStateWriter) {
+    this(cConf, store, runtimeService, metricsCollectionService, programStateWriter,
          cConf.getInt(Constants.AppFabric.PROGRAM_TERMINATOR_TX_BATCH_SIZE),
          cConf.getLong(Constants.AppFabric.PROGRAM_TERMINATOR_INTERVAL_SECS),
-         cConf.getLong(Constants.AppFabric.PROGRAM_TERMINATE_TIME_BUFFER_SECS));
+         cConf.getLong(Constants.AppFabric.PROGRAM_TERMINATE_TIME_BUFFER_SECS),
+         cConf.getLong(Constants.AppFabric.TETHERED_PROGRAM_TERMINATE_TIME_SECS));
   }
 
   @VisibleForTesting
   ProgramRunStatusMonitorService(CConfiguration cConf, Store store, ProgramRuntimeService runtimeService,
-                                 MetricsCollectionService metricsCollectionService, int txBatchSize,
-                                 long specifiedIntervalSecs, long terminateTimeBufferSecs) {
+                                 MetricsCollectionService metricsCollectionService,
+                                 ProgramStateWriter programStateWriter, int txBatchSize,
+                                 long specifiedIntervalSecs, long terminateTimeBufferSecs,
+                                 long tetheredProgramTerminateTimeSecs) {
     super(RetryStrategies.fromConfiguration(cConf, Constants.Service.RUNTIME_MONITOR_RETRY_PREFIX));
     this.store = store;
     this.runtimeService = runtimeService;
@@ -92,6 +99,8 @@ public class ProgramRunStatusMonitorService extends AbstractRetryableScheduledSe
     this.terminateTimeBufferSecs = terminateTimeBufferSecs;
     this.numThreads = cConf.getInt(Constants.AppFabric.PROGRAM_KILL_THREADS);
     this.metricsCollectionService = metricsCollectionService;
+    this.programStateWriter = programStateWriter;
+    this.tetheredProgramTerminateTimeSecs = tetheredProgramTerminateTimeSecs;
   }
 
   @Override
@@ -146,14 +155,19 @@ public class ProgramRunStatusMonitorService extends AbstractRetryableScheduledSe
         break;
       }
       for (RunRecordDetail record : stoppingRuns.values()) {
+        String provisionerName = SystemArguments.getProfileProvisioner(record.getSystemArgs());
+        ProgramRunId programRunId = record.getProgramRunId();
         // If this run was initiated by this CDAP instance to run on another instance, it will use the tethering
         // provisioner. The instance that actually runs it on the other side will have a non-null peer name.
-        String provisionerName = SystemArguments.getProfileProvisioner(record.getSystemArgs());
         if (record.getPeerName() == null && TetheringProvisioner.TETHERING_NAME.equals(provisionerName)) {
+          LOG.info("Forcing the termination of tethered program run {} as it should have stopped at {} ",
+                   programRunId, record.getTerminateTs());
+          programScannedForTermination.add(programRunId);
+          programStateWriter.killed(programRunId);
+          emitForceTerminatedRunsMetric(programRunId, record);
           continue;
         }
 
-        ProgramRunId programRunId = record.getProgramRunId();
         programScannedForTermination.add(programRunId);
         RuntimeInfo runtimeInfo = runtimeService.lookup(programRunId.getParent(),
                                                         RunIds.fromString(programRunId.getRun()));
@@ -177,7 +191,25 @@ public class ProgramRunStatusMonitorService extends AbstractRetryableScheduledSe
         return false;
       }
       Long terminateTime = record.getTerminateTs();
-      return terminateTime != null && terminateTime <= currentTimeInSecs;
+      Long stoppingTime = record.getStoppingTs();
+      if (terminateTime == null) {
+        // should not happen when state is STOPPING
+        return false;
+      }
+      String provisionerName = SystemArguments.getProfileProvisioner(record.getSystemArgs());
+      // If this run was initiated by this CDAP instance to run on another instance, it will use the tethering
+      // provisioner. The instance that actually runs it on the other side will have a non-null peer name.
+      if (record.getPeerName() == null && TetheringProvisioner.TETHERING_NAME.equals(provisionerName)) {
+        if (stoppingTime == null) {
+          // should not happen when state is STOPPING
+          return false;
+        }
+        // Give additional grace period (= tetheredProgramTerminateTimeSecs) for tethered programs running on another
+        // instance to terminate.
+        return currentTimeInSecs - tetheredProgramTerminateTimeSecs > stoppingTime &&
+          terminateTime <= currentTimeInSecs;
+      }
+      return terminateTime <= currentTimeInSecs;
     };
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramStopSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramStopSubscriberService.java
@@ -26,7 +26,6 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.utils.ImmutablePair;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
-import io.cdap.cdap.internal.app.runtime.monitor.RuntimeProgramStatusSubscriberService;
 import io.cdap.cdap.internal.app.store.AppMetadataStore;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.messaging.MessagingService;
@@ -48,7 +47,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ProgramStopSubscriberService extends AbstractNotificationSubscriberService {
   private static final String SUBSCRIBER = "program.stopper";
-  private static final Logger LOG = LoggerFactory.getLogger(RuntimeProgramStatusSubscriberService.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ProgramStopSubscriberService.class);
   private static final Gson GSON = new Gson();
   private final ProgramRuntimeService programRuntimeService;
   private final ProgramStateWriter programStateWriter;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramRunStatusMonitorServiceTest.java
@@ -26,10 +26,13 @@ import io.cdap.cdap.api.metrics.MetricStore;
 import io.cdap.cdap.api.metrics.MetricTimeSeries;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.guice.ClusterMode;
+import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.app.runtime.AbstractProgramRuntimeService;
 import io.cdap.cdap.app.runtime.NoOpProgramStateWriter;
 import io.cdap.cdap.app.runtime.ProgramController;
+import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.app.runtime.ProgramRuntimeService;
+import io.cdap.cdap.app.runtime.ProgramStateWriter;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -45,6 +48,7 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.profile.Profile;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -118,11 +122,13 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
       }
     };
     ProgramRunStatusMonitorService programRunStatusMonitorService
-      = new ProgramRunStatusMonitorService(cConf, store, testService, metricsCollectionService, 5, 3, 2);
+      = new ProgramRunStatusMonitorService(cConf, store, testService,
+                                           metricsCollectionService, new NoOpProgramStateWriter(),
+                                           5, 3, 2, 2);
     programRunStatusMonitorService.startAndWait();
     Assert.assertEquals(1, latch.getCount());
     programRunStatusMonitorService.terminatePrograms();
-    latch.await(10, TimeUnit.SECONDS);
+    Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
     MetricStore metricStore = getInjector().getInstance(MetricStore.class);
     ProfileId myProfile = NamespaceId.SYSTEM.profile("native");
     Tasks.waitFor(true, () -> getMetric(metricStore, wfId, myProfile, new HashMap<>(),
@@ -152,6 +158,97 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
       return 0;
     }
     return timeValues.get(0).getValue();
+  }
+
+  @Test
+  public void testStoppingLocalTetheredProgramsBeyondTerminateTimeAreKilled() throws Exception {
+    AtomicInteger sourceId = new AtomicInteger(0);
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
+    // Set up a workflow for a tethered program in Stopping state. This program is run in tethered mode on
+    // behalf of a remote instance.
+    Map<String, String> wfSystemArg = ImmutableMap.of(
+      ProgramOptionConstants.CLUSTER_MODE, ClusterMode.ISOLATED.name(),
+      SystemArguments.PROFILE_NAME, ProfileId.NATIVE.getScopedName(),
+      SystemArguments.PROFILE_PROVISIONER, Profile.NATIVE.getProvisioner().getName(),
+      ProgramOptionConstants.PEER_NAME, "peer");
+    ProgramRunId wfId = NamespaceId.DEFAULT.app("test").workflow("testWF").run(randomRunId());
+    store.setProvisioning(wfId, Collections.emptyMap(), wfSystemArg,
+                          Bytes.toBytes(sourceId.getAndIncrement()), artifactId);
+    store.setProvisioned(wfId, 0, Bytes.toBytes(sourceId.getAndIncrement()));
+    store.setStart(wfId, null, Collections.emptyMap(), Bytes.toBytes(sourceId.getAndIncrement()));
+    store.setRunning(wfId, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()), null,
+                     Bytes.toBytes(sourceId.getAndIncrement()));
+    long currentTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    store.setStopping(wfId, Bytes.toBytes(sourceId.getAndIncrement()), currentTimeInSecs, currentTimeInSecs);
+    CountDownLatch latch = new CountDownLatch(1);
+    ProgramRuntimeService testService = new AbstractProgramRuntimeService(
+      cConf, null, new NoOpProgramStateWriter(), null) {
+
+      @Override
+      protected boolean isDistributed() {
+        return false;
+      }
+
+      @Nullable
+      public RuntimeInfo lookup(ProgramId programId, RunId runId) {
+        return getRuntimeInfo(programId, latch);
+      }
+    };
+    ProgramRunStatusMonitorService programRunStatusMonitorService
+      = new ProgramRunStatusMonitorService(cConf, store, testService,
+                                           metricsCollectionService, new NoOpProgramStateWriter(),
+                                           5, 3, 2, 2);
+    programRunStatusMonitorService.startAndWait();
+    Assert.assertEquals(1, latch.getCount());
+    programRunStatusMonitorService.terminatePrograms();
+    Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+    MetricStore metricStore = getInjector().getInstance(MetricStore.class);
+    ProfileId myProfile = NamespaceId.SYSTEM.profile("native");
+    Tasks.waitFor(true, () -> getMetric(metricStore, wfId, myProfile, new HashMap<>(),
+                                        SYSTEM_METRIC_PREFIX +
+                                          Constants.Metrics.Program.PROGRAM_FORCE_TERMINATED_RUNS) > 0,
+                  10, TimeUnit.SECONDS);
+    metricStore.deleteAll();
+  }
+
+  @Test
+  public void testStoppingRemoteTetheredProgramsBeyondTerminateTimeAreKilled() throws Exception {
+    AtomicInteger sourceId = new AtomicInteger(0);
+    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
+    // Set up a workflow for a tethered program in Stopping state. This program is run on a remote instance.
+    Map<String, String> wfSystemArg = ImmutableMap.of(
+      ProgramOptionConstants.CLUSTER_MODE, ClusterMode.ISOLATED.name(),
+      SystemArguments.PROFILE_NAME, NamespaceId.SYSTEM.profile("tethering-profile").getScopedName(),
+      SystemArguments.PROFILE_PROVISIONER, TetheringProvisioner.TETHERING_NAME);
+    ProgramRunId wfId = NamespaceId.DEFAULT.app("test").workflow("testWF").run(randomRunId());
+    store.setProvisioning(wfId, Collections.emptyMap(), wfSystemArg,
+                          Bytes.toBytes(sourceId.getAndIncrement()), artifactId);
+    store.setProvisioned(wfId, 0, Bytes.toBytes(sourceId.getAndIncrement()));
+    store.setStart(wfId, null, Collections.emptyMap(), Bytes.toBytes(sourceId.getAndIncrement()));
+    long currentTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+    long runningTimeInSecs = currentTimeInSecs - 100;
+    long stoppingTimeInSecs = currentTimeInSecs - 50;
+    long terminateTimeInSecs = currentTimeInSecs - 10;
+    store.setRunning(wfId, runningTimeInSecs, null,
+                     Bytes.toBytes(sourceId.getAndIncrement()));
+    store.setStopping(wfId, Bytes.toBytes(sourceId.getAndIncrement()), stoppingTimeInSecs, terminateTimeInSecs);
+    CountDownLatch latch = new CountDownLatch(1);
+    ProgramRuntimeService testService = getInjector().getInstance(ProgramRuntimeService.class);
+    ProgramStateWriter psw = getProgramStateWriter(latch);
+    ProgramRunStatusMonitorService programRunStatusMonitorService
+      = new ProgramRunStatusMonitorService(cConf, store, testService, metricsCollectionService, psw,
+                                           5, 3, 2, 2);
+    programRunStatusMonitorService.startAndWait();
+    Assert.assertEquals(1, latch.getCount());
+    programRunStatusMonitorService.terminatePrograms();
+    Assert.assertTrue(latch.await(10, TimeUnit.SECONDS));
+    MetricStore metricStore = getInjector().getInstance(MetricStore.class);
+    ProfileId myProfile = NamespaceId.SYSTEM.profile("tethering-profile");
+    Tasks.waitFor(true, () -> getMetric(metricStore, wfId, myProfile, new HashMap<>(),
+                                        SYSTEM_METRIC_PREFIX +
+                                          Constants.Metrics.Program.PROGRAM_FORCE_TERMINATED_RUNS) > 0,
+                  10, TimeUnit.SECONDS);
+    metricStore.deleteAll();
   }
 
   @Test
@@ -188,7 +285,9 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
       }
     };
     ProgramRunStatusMonitorService programRunStatusMonitorService
-      = new ProgramRunStatusMonitorService(cConf, store, testService, metricsCollectionService, 5, 3, 2);
+      = new ProgramRunStatusMonitorService(cConf, store, testService,
+                                           metricsCollectionService, new NoOpProgramStateWriter(),
+                                           5, 3, 2, 2);
     Assert.assertEquals(1, latch.getCount());
     Assert.assertTrue(programRunStatusMonitorService.terminatePrograms().isEmpty());
   }
@@ -224,44 +323,9 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
       }
     };
     ProgramRunStatusMonitorService programRunStatusMonitorService
-      = new ProgramRunStatusMonitorService(cConf, store, testService, metricsCollectionService, 5, 3, 2);
-    Assert.assertEquals(1, latch.getCount());
-    Assert.assertTrue(programRunStatusMonitorService.terminatePrograms().isEmpty());
-  }
-
-  @Test
-  public void testTetheredRunsAreSkipped() {
-    AtomicInteger sourceId = new AtomicInteger(0);
-    ArtifactId artifactId = NamespaceId.DEFAULT.artifact("testArtifact", "1.0").toApiArtifactId();
-    // set up a workflow for a program in Stopping state
-    Map<String, String> wfSystemArg = ImmutableMap.of(
-      ProgramOptionConstants.CLUSTER_MODE, ClusterMode.ISOLATED.name(),
-      SystemArguments.PROFILE_PROVISIONER, TetheringProvisioner.TETHERING_NAME);
-    ProgramRunId wfId = NamespaceId.DEFAULT.app("test").workflow("testWF").run(randomRunId());
-    store.setProvisioning(wfId, Collections.emptyMap(), wfSystemArg,
-                          Bytes.toBytes(sourceId.getAndIncrement()), artifactId);
-    store.setProvisioned(wfId, 0, Bytes.toBytes(sourceId.getAndIncrement()));
-    store.setStart(wfId, null, Collections.emptyMap(), Bytes.toBytes(sourceId.getAndIncrement()));
-    store.setRunning(wfId, TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis()), null,
-                     Bytes.toBytes(sourceId.getAndIncrement()));
-    long currentTimeInSecs = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
-    store.setStopping(wfId, Bytes.toBytes(sourceId.getAndIncrement()), currentTimeInSecs, currentTimeInSecs);
-    CountDownLatch latch = new CountDownLatch(1);
-    ProgramRuntimeService testService = new AbstractProgramRuntimeService(
-      cConf, null, new NoOpProgramStateWriter(), null) {
-
-      @Override
-      protected boolean isDistributed() {
-        return false;
-      }
-
-      @Nullable
-      public RuntimeInfo lookup(ProgramId programId, RunId runId) {
-        return getRuntimeInfo(programId, latch);
-      }
-    };
-    ProgramRunStatusMonitorService programRunStatusMonitorService
-      = new ProgramRunStatusMonitorService(cConf, store, testService, metricsCollectionService, 5, 3, 2);
+      = new ProgramRunStatusMonitorService(cConf, store, testService, metricsCollectionService,
+                                           new NoOpProgramStateWriter(),
+                                           5, 3, 2, 2);
     Assert.assertEquals(1, latch.getCount());
     Assert.assertTrue(programRunStatusMonitorService.terminatePrograms().isEmpty());
   }
@@ -344,6 +408,57 @@ public class ProgramRunStatusMonitorServiceTest extends AppFabricTestBase {
       @Override
       public ListenableFuture<ProgramController> command(String name, Object value) {
         return null;
+      }
+    };
+  }
+
+  private ProgramStateWriter getProgramStateWriter(CountDownLatch latch) {
+    return new ProgramStateWriter() {
+      @Override
+      public void start(ProgramRunId programRunId, ProgramOptions programOptions, @Nullable String twillRunId,
+                        ProgramDescriptor programDescriptor) {
+        // no-op
+      }
+
+      @Override
+      public void running(ProgramRunId programRunId, @Nullable String twillRunId) {
+        // no-op
+      }
+
+      @Override
+      public void stop(ProgramRunId programRunId, int gracefulShutdownSecs) {
+        // no-op
+      }
+
+      @Override
+      public void completed(ProgramRunId programRunId) {
+        // no-op
+      }
+
+      @Override
+      public void killed(ProgramRunId programRunId) {
+        latch.countDown();
+      }
+
+      @Override
+      public void error(ProgramRunId programRunId, Throwable failureCause) {
+        // no-op
+      }
+
+      @Override
+      public void suspend(ProgramRunId programRunId) {
+        // no-op
+      }
+
+      @Override
+      public void resume(ProgramRunId programRunId) {
+        // no-op
+      }
+
+      @Override
+      public void reject(ProgramRunId programRunId, ProgramOptions programOptions, ProgramDescriptor programDescriptor,
+                         String userId, Throwable cause) {
+        // no-op
       }
     };
   }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -233,6 +233,8 @@ public final class Constants {
       = "app.program.local.dataset.deleter.initial.delay";
     public static final String PROGRAM_TERMINATOR_INTERVAL_SECS = "app.program.terminator.interval.secs";
     public static final String PROGRAM_TERMINATE_TIME_BUFFER_SECS = "app.program.terminate.time.buffer.secs";
+    public static final String TETHERED_PROGRAM_TERMINATE_TIME_SECS
+      = "app.program.terminate.tethered.time.buffer.secs";
     public static final String PROGRAM_TERMINATOR_TX_BATCH_SIZE = "app.program.terminator.tx.batch.size";
     public static final String ARTIFACTS_COMPUTE_HASH = "app.artifact.compute.hash";
     public static final String ARTIFACTS_COMPUTE_HASH_TIME_BUCKET_DAYS = "app.artifact.compute.hash.time.bucket.days";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -639,6 +639,16 @@
   </property>
 
   <property>
+    <name>app.program.terminate.tethered.time.buffer.secs</name>
+    <value>3600</value>
+    <description>
+      Interval in seconds of how much buffer time is given to tethered programs
+      running on another CDAP instace to allow them to stop on their own before
+      issuing a hard kill
+    </description>
+  </property>
+
+  <property>
     <name>app.program.terminator.tx.batch.size</name>
     <value>1000</value>
     <description>


### PR DESCRIPTION
Fixed ProgramRunStatusMonitorService to stop tethered programs running on another instance that are stuck in STOPPING state.
Also fixed ProgramNotificationSubscriberService to set a default terminate timestamp of Long.MAX_VALUE instead of -1.