### PR TITLE
feat(CDAP-20248): Handler and service code for pulling and deploying application

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -423,6 +423,13 @@ public interface Store {
   void setAppSourceControlMeta(ApplicationId appId, SourceControlMeta sourceControlMeta);
 
   /**
+   * Get source control metadata of provided application.
+   * @param appRef the application reference
+   * @return {@link SourceControlMeta}
+   */
+  SourceControlMeta getAppSourceControlMeta(ApplicationReference appRef);
+
+  /**
    * Returns a map of latest programIds given programReferences
    *
    * @param references the list of programReferences to get the latest programIds

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
 import org.apache.twill.filesystem.Location;
 
 import javax.annotation.Nullable;
@@ -55,6 +56,8 @@ public class AppDeploymentInfo {
   @Nullable
   private final ChangeDetail changeDetail;
   @Nullable
+  private final SourceControlMeta sourceControlMeta;
+  @Nullable
   private final ApplicationSpecification deployedApplicationSpec;
   private final boolean isUpgrade;
 
@@ -81,6 +84,7 @@ public class AppDeploymentInfo {
       .setUpdateSchedules(other.updateSchedules)
       .setRuntimeInfo(other.runtimeInfo)
       .setChangeDetail(other.changeDetail)
+      .setSourceControlMeta(other.sourceControlMeta)
       .setIsUpgrade(other.isUpgrade)
       .setDeployedApplicationSpec(other.deployedApplicationSpec);
   }
@@ -89,8 +93,8 @@ public class AppDeploymentInfo {
                             ApplicationClass applicationClass, @Nullable String appName, @Nullable String appVersion,
                             @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal,
                             boolean updateSchedules, @Nullable AppDeploymentRuntimeInfo runtimeInfo,
-                            @Nullable ChangeDetail changeDetail, boolean isUpgrade,
-                            @Nullable ApplicationSpecification deployedApplicationSpec) {
+                            @Nullable ChangeDetail changeDetail, @Nullable SourceControlMeta sourceControlMeta,
+                            boolean isUpgrade, @Nullable ApplicationSpecification deployedApplicationSpec) {
     this.artifactId = artifactId;
     this.artifactLocation = artifactLocation;
     this.namespaceId = namespaceId;
@@ -102,6 +106,7 @@ public class AppDeploymentInfo {
     this.applicationClass = applicationClass;
     this.runtimeInfo = runtimeInfo;
     this.changeDetail = changeDetail;
+    this.sourceControlMeta = sourceControlMeta;
     this.isUpgrade = isUpgrade;
     this.deployedApplicationSpec = deployedApplicationSpec;
   }
@@ -193,6 +198,11 @@ public class AppDeploymentInfo {
     return changeDetail;
   }
 
+  @Nullable
+  public SourceControlMeta getSourceControlMeta() {
+    return sourceControlMeta;
+  }
+
   /**
    * Returns true if the deploy event type is an upgrade.
    */
@@ -226,6 +236,8 @@ public class AppDeploymentInfo {
     private AppDeploymentRuntimeInfo runtimeInfo;
     @Nullable
     private ChangeDetail changeDetail;
+    @Nullable
+    private SourceControlMeta sourceControlMeta;
     @Nullable
     private ApplicationSpecification deployedApplicationSpec;
     private boolean isUpgrade;
@@ -296,6 +308,11 @@ public class AppDeploymentInfo {
       return this;
     }
 
+    public Builder setSourceControlMeta(@Nullable SourceControlMeta sourceControlMeta) {
+      this.sourceControlMeta = sourceControlMeta;
+      return this;
+    }
+
     public Builder setIsUpgrade(boolean isUpgrade) {
       this.isUpgrade = isUpgrade;
       return this;
@@ -321,7 +338,7 @@ public class AppDeploymentInfo {
       }
       return new AppDeploymentInfo(artifactId, artifactLocation, namespaceId, applicationClass,
                                    appName, appVersion, configString, ownerPrincipal, updateSchedules, runtimeInfo,
-                                   changeDetail, isUpgrade, deployedApplicationSpec);
+                                   changeDetail, sourceControlMeta, isUpgrade, deployedApplicationSpec);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.proto.artifact.ChangeDetail;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 import org.apache.twill.filesystem.Location;
 
@@ -53,9 +54,9 @@ public class ApplicationDeployable {
   private final boolean updateSchedules;
   @Nullable
   private final ChangeDetail changeDetail;
+  @Nullable
+  private final SourceControlMeta sourceControlMeta;
   private final boolean isUpgrade;
-
-  //TODO: CDAP-20248, add SourceControlMeta when we do pull and deploy
 
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
                                ApplicationId applicationId, ApplicationSpecification specification,
@@ -64,7 +65,7 @@ public class ApplicationDeployable {
                                ApplicationClass applicationClass) {
     this(artifactId, artifactLocation, applicationId, specification, existingAppSpec, applicationDeployScope,
          applicationClass, null, true, Collections.emptyList(), Collections.emptyMap(),
-         null, false);
+         null, null, false);
   }
 
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
@@ -76,7 +77,7 @@ public class ApplicationDeployable {
                                boolean updateSchedules,
                                Collection<StructuredTableSpecification> systemTables,
                                Map<MetadataScope, Metadata> metadata, @Nullable ChangeDetail changeDetail,
-                               boolean isUpgrade) {
+                               @Nullable SourceControlMeta sourceControlMeta, boolean isUpgrade) {
     this.artifactId = artifactId;
     this.artifactLocation = artifactLocation;
     this.applicationId = applicationId;
@@ -89,6 +90,7 @@ public class ApplicationDeployable {
     this.applicationClass = applicationClass;
     this.metadata = metadata;
     this.changeDetail = changeDetail;
+    this.sourceControlMeta = sourceControlMeta;
     this.isUpgrade = isUpgrade;
   }
 
@@ -183,5 +185,13 @@ public class ApplicationDeployable {
    */
   public boolean isUpgrade() {
     return isUpgrade;
+  }
+
+  /**
+   * Returns the source control metadata
+   */
+  @Nullable
+  public SourceControlMeta getSourceControlMeta() {
+    return sourceControlMeta;
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
@@ -66,7 +66,7 @@ public class ApplicationRegistrationStage extends AbstractStage<ApplicationWithP
       store.getAllAppVersionsAppIds(applicationId.getAppReference());
     boolean ownerAdded = addOwnerIfRequired(input, allAppVersionsAppIds);
     ApplicationMeta appMeta = new ApplicationMeta(applicationSpecification.getName(), input.getSpecification(),
-                                                  input.getChangeDetail());
+                                                  input.getChangeDetail(), input.getSourceControlMeta());
     try {
       int editCount = store.addApplication(input.getApplicationId(), appMeta);
       // increment metric : event.deploy.upgrade.count

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
@@ -36,7 +36,7 @@ public class ApplicationWithPrograms extends ApplicationDeployable {
           applicationDeployable.getApplicationClass(), applicationDeployable.getOwnerPrincipal(),
           applicationDeployable.canUpdateSchedules(), applicationDeployable.getSystemTables(),
           applicationDeployable.getMetadata(), applicationDeployable.getChangeDetail(),
-          applicationDeployable.isUpgrade());
+          applicationDeployable.getSourceControlMeta(), applicationDeployable.isUpgrade());
     this.programDescriptors = ImmutableList.copyOf(programDescriptors);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
@@ -123,6 +123,6 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
                                    ApplicationDeployScope.USER, deploymentInfo.getApplicationClass(),
                                    deploymentInfo.getOwnerPrincipal(), deploymentInfo.canUpdateSchedules(),
                                    appSpecInfo.getSystemTables(), metadatas, deploymentInfo.getChangeDetail(),
-                                   deploymentInfo.isUpgrade()));
+                                   deploymentInfo.getSourceControlMeta(), deploymentInfo.isUpgrade()));
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
@@ -188,7 +188,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
     try {
       LOG.debug("Deploying preview application for {}", programId);
       applicationLifecycleService.deployApp(preview.getParent(), preview.getApplication(), preview.getVersion(),
-                                            artifactSummary, config, request.getChange(),
+                                            artifactSummary, config, request.getChange(), null,
                                             NOOP_PROGRAM_TERMINATOR, null, request.canUpdateSchedules(),
                                             true, userProps);
     } catch (Exception e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -796,6 +796,14 @@ public class DefaultStore implements Store {
   }
 
   @Override
+  @Nullable
+  public SourceControlMeta getAppSourceControlMeta(ApplicationReference appRef) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      return getAppMetadataStore(context).getAppSourceControlMeta(appRef);
+    });
+  }
+
+  @Override
   public Map<ProgramReference, ProgramId> getPrograms(Collection<ProgramReference> references) {
     return TransactionRunners.run(transactionRunner, context -> {
       return getAppMetadataStore(context).filterProgramsExistence(references).stream()

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/executor/AppCreator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/executor/AppCreator.java
@@ -65,7 +65,7 @@ public class AppCreator extends BaseStepExecutor<AppCreator.Arguments> {
 
     try {
       appLifecycleService.deployApp(appRef.getParent(), appRef.getApplication(), ApplicationId.DEFAULT_VERSION,
-                                    artifactSummary, configString, arguments.getChange(), x -> { },
+                                    artifactSummary, configString, arguments.getChange(), null, x -> { },
                                     ownerPrincipalId, arguments.canUpdateSchedules(), false,
                                     Collections.emptyMap());
     } catch (NotFoundException | UnauthorizedException | InvalidArtifactException e) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
@@ -308,7 +308,7 @@ class CapabilityApplier {
     String configString = application.getConfig() == null ? null : GSON.toJson(application.getConfig());
     applicationLifecycleService
       .deployApp(applicationReference.getParent(), applicationReference.getApplication(), ApplicationId.DEFAULT_VERSION,
-                 application.getArtifact(), configString, null, NOOP_PROGRAM_TERMINATOR,
+                 application.getArtifact(), configString, null, null, NOOP_PROGRAM_TERMINATOR,
                  null, null, false, Collections.emptyMap());
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
@@ -116,7 +116,7 @@ public class SystemAppEnableExecutor {
 
     try {
       return appLifecycleService.deployApp(appId.getParent(), appId.getApplication(), appId.getVersion(),
-                                           artifactSummary, configString, null, x -> { },
+                                           artifactSummary, configString, null, null, x -> { },
                                            ownerPrincipalId, arguments.canUpdateSchedules(), false,
                                            Collections.emptyMap());
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
@@ -121,7 +121,7 @@ public class SystemProgramManagementServiceTest extends AppFabricTestBase {
     artifactRepository.addArtifact(artifactId, appJarFile);
     ArtifactSummary summary = new ArtifactSummary(artifactId.getName(), artifactId.getVersion().getVersion(),
                                                   ArtifactScope.SYSTEM);
-    applicationLifecycleService.deployApp(NamespaceId.SYSTEM, APP_NAME, VERSION, summary, null, null,
+    applicationLifecycleService.deployApp(NamespaceId.SYSTEM, APP_NAME, VERSION, summary, null, null, null,
                                           programId -> {
                                             // no-op
                                           }, null, false, false, Collections.emptyMap());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -1474,6 +1474,12 @@ public abstract class AppFabricTestBase {
                                 appRef.getNamespace(), appRef.getApplication()), GSON.toJson(request));
   }
 
+  protected HttpResponse pullApplication(ApplicationReference appRef) throws Exception {
+    return doPost(String.format("%s/namespaces/%s/repository/apps/%s/pull",
+                                Constants.Gateway.API_VERSION_3,
+                                appRef.getNamespace(), appRef.getApplication()));
+  }
+
   protected String getPreferenceURI() {
     return "";
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/SourceControlManagementHttpHandlerTests.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/SourceControlManagementHttpHandlerTests.java
@@ -22,6 +22,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.security.store.SecureStore;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.NotFoundException;
@@ -33,6 +34,7 @@ import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
 import io.cdap.cdap.internal.app.services.SourceControlManagementService;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
 import io.cdap.cdap.metadata.MetadataSubscriberService;
+import io.cdap.cdap.proto.ApplicationRecord;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.sourcecontrol.AuthConfig;
 import io.cdap.cdap.proto.sourcecontrol.AuthType;
@@ -43,12 +45,17 @@ import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigValidationException;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryMeta;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryValidationFailure;
 import io.cdap.cdap.proto.sourcecontrol.SetRepositoryResponse;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
+import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
+import io.cdap.cdap.sourcecontrol.NoChangesToPullException;
 import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
+import io.cdap.cdap.sourcecontrol.operationrunner.PullFailureException;
 import io.cdap.cdap.sourcecontrol.operationrunner.PushAppResponse;
+import io.cdap.cdap.sourcecontrol.operationrunner.PushFailureException;
 import io.cdap.cdap.sourcecontrol.operationrunner.SourceControlOperationRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.common.http.HttpResponse;
@@ -275,18 +282,17 @@ public class SourceControlManagementHttpHandlerTests extends AppFabricTestBase {
   public void testPushAppSucceeds() throws Exception {
     Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp", "version1");
 
-    // Push two applications to linked repository
-    String commitMessage = "push two apps";
+    // Push one application to linked repository
+    String commitMessage = "push one app";
     PushAppResponse expectedAppResponse = new PushAppResponse(appId1.getId(), appId1.getVersion(),
                                                               appId1.getId() + " hash");
     Mockito.doReturn(expectedAppResponse).when(sourceControlService)
       .pushApp(Mockito.any(), Mockito.eq(commitMessage));
-
-    // Assert two app are pushed and updated with source control metadata
     HttpResponse response = pushApplication(NamespaceId.DEFAULT.appReference(appId1.getId()), commitMessage);
+
+    // Assert the app is pushed
     assertResponseCode(200, response);
     PushAppResponse result = readResponse(response, PushAppResponse.class);
-
     Assert.assertEquals(result, expectedAppResponse);
   }
 
@@ -294,13 +300,13 @@ public class SourceControlManagementHttpHandlerTests extends AppFabricTestBase {
   public void testPushAppNotFound() throws Exception {
     Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp", "version1");
 
-    // Push two applications to linked repository
-    String commitMessage = "push two apps";
+    // Push one application to linked repository
+    String commitMessage = "push one app";
     Mockito.doThrow(new NotFoundException("apps not found")).when(sourceControlService)
       .pushApp(Mockito.any(), Mockito.eq(commitMessage));
-
-    // Assert two app are pushed and updated with source control metadata
     HttpResponse response = pushApplication(NamespaceId.DEFAULT.appReference(appId1.getId()), commitMessage);
+
+    // Assert the app is not found
     assertResponseCode(404, response);
     Assert.assertEquals(response.getResponseBodyAsString(), "apps not found");
   }
@@ -309,16 +315,119 @@ public class SourceControlManagementHttpHandlerTests extends AppFabricTestBase {
   public void testPushAppNoChange() throws Exception {
     Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp", "version1");
 
-    // Push two applications to linked repository
-    String commitMessage = "push two apps";
-
+    // Push one application to linked repository
+    String commitMessage = "push one app";
     Mockito.doThrow(new NoChangesToPushException("No changes for apps to push")).when(sourceControlService)
       .pushApp(Mockito.any(), Mockito.eq(commitMessage));
-
-    // Assert two app are pushed and updated with source control metadata
     HttpResponse response = pushApplication(NamespaceId.DEFAULT.appReference(appId1.getId()), commitMessage);
+
+    // Assert the error that app has no changes to push
     assertResponseCode(400, response);
     Assert.assertTrue(response.getResponseBodyAsString().contains("No changes for apps to push"));
+  }
+
+  @Test
+  public void testPushAppPushFailureException() throws Exception {
+    Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp", "version1");
+
+    // Push one application to linked repository
+    String commitMessage = "push one app";
+    Mockito.doThrow(new PushFailureException("Failed to push app")).when(sourceControlService)
+      .pushApp(Mockito.any(), Mockito.eq(commitMessage));
+    HttpResponse response = pushApplication(NamespaceId.DEFAULT.appReference(appId1.getId()), commitMessage);
+
+    // Assert the PushFailureException
+    assertResponseCode(500, response);
+    Assert.assertTrue(response.getResponseBodyAsString().contains("Failed to push app"));
+  }
+
+  @Test
+  public void testPushAppInvalidAuthenticationConfig() throws Exception {
+    Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp", "version1");
+
+    // Push one application to linked repository
+    String commitMessage = "push one app";
+    Mockito.doThrow(new AuthenticationConfigException("Repository config not valid")).when(sourceControlService)
+      .pushApp(Mockito.any(), Mockito.eq(commitMessage));
+    HttpResponse response = pushApplication(NamespaceId.DEFAULT.appReference(appId1.getId()), commitMessage);
+
+    // Assert the AuthenticationConfigException
+    assertResponseCode(400, response);
+    Assert.assertTrue(response.getResponseBodyAsString().contains("Repository config not valid"));
+  }
+
+  @Test
+  public void testPullAppSucceeds() throws Exception {
+    Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp", "version1");
+
+    // Pull one application from linked repository
+    SourceControlMeta meta = new SourceControlMeta("fileHash");
+    ApplicationRecord expectedAppResponse = new ApplicationRecord(new ArtifactSummary("name", "version"),
+                                                                  appId1.getId(), appId1.getVersion(), "",
+                                                                  null, null, meta);
+    Mockito.doReturn(expectedAppResponse).when(sourceControlService).pullAndDeploy(Mockito.any());
+    HttpResponse response = pullApplication(NamespaceId.DEFAULT.appReference(appId1.getId()));
+
+    // Assert one app is pulled and deployed
+    assertResponseCode(200, response);
+    ApplicationRecord result = readResponse(response, ApplicationRecord.class);
+    Assert.assertEquals(result, expectedAppResponse);
+  }
+
+  @Test
+  public void testPullAppNotFound() throws Exception {
+    Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp", "version1");
+
+    // Pull one application from linked repository
+    Mockito.doThrow(new NotFoundException("app ConfigApp not found"))
+      .when(sourceControlService).pullAndDeploy(Mockito.any());
+    HttpResponse response = pullApplication(NamespaceId.DEFAULT.appReference(appId1.getId()));
+
+    // Assert the app is not found
+    assertResponseCode(404, response);
+    Assert.assertEquals(response.getResponseBodyAsString(), "app ConfigApp not found");
+  }
+
+  @Test
+  public void testPullAppNoChange() throws Exception {
+    Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp", "version1");
+
+    // Push two applications to linked repository
+    Mockito.doThrow(new NoChangesToPullException("No changes for app to pull"))
+      .when(sourceControlService).pullAndDeploy(Mockito.any());
+    HttpResponse response = pullApplication(NamespaceId.DEFAULT.appReference(appId1.getId()));
+
+    // Assert the app is not changed
+    assertResponseCode(200, response);
+    Assert.assertTrue(response.getResponseBodyAsString().contains("No changes for app to pull"));
+  }
+
+  @Test
+  public void testPullAppInvalidAuthenticationConfig() throws Exception {
+    Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp", "version1");
+
+    // Pull one application from repository
+    Mockito.doThrow(new AuthenticationConfigException("Repo configuration is invalid"))
+      .when(sourceControlService).pullAndDeploy(Mockito.any());
+    HttpResponse response = pullApplication(NamespaceId.DEFAULT.appReference(appId1.getId()));
+
+    // Assert the AuthenticationConfigException
+    assertResponseCode(400, response);
+    Assert.assertTrue(response.getResponseBodyAsString().contains("Repo configuration is invalid"));
+  }
+
+  @Test
+  public void testPullAppPullFailureException() throws Exception {
+    Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp", "version1");
+
+    // Pull one application from repository
+    Mockito.doThrow(new PullFailureException("Failed to pull application", new Exception()))
+      .when(sourceControlService).pullAndDeploy(Mockito.any());
+    HttpResponse response = pullApplication(NamespaceId.DEFAULT.appReference(appId1.getId()));
+
+    // Assert the pull failure
+    assertResponseCode(500, response);
+    Assert.assertTrue(response.getResponseBodyAsString().contains("Failed to pull application"));
   }
 
   private String buildRepoRequestString(Provider provider, String link, String defaultBranch,

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -937,9 +937,9 @@ public abstract class AppMetadataStoreTest {
       TransactionRunners.run(transactionRunner, context -> {
         AppMetadataStore store = AppMetadataStore.create(context);
         store.writeApplication(NamespaceId.DEFAULT.getNamespace(), appName, ApplicationId.DEFAULT_VERSION, appSpec,
-                               new ChangeDetail(null, null, null, creationTimeMillis));
+                               new ChangeDetail(null, null, null, creationTimeMillis), null);
         store.writeApplication(NamespaceId.SYSTEM.getNamespace(), appName, ApplicationId.DEFAULT_VERSION, appSpec,
-                               new ChangeDetail(null, null, null, creationTimeMillis));
+                               new ChangeDetail(null, null, null, creationTimeMillis), null);
       });
     }
     TransactionRunners.run(transactionRunner, context -> {
@@ -976,7 +976,7 @@ public abstract class AppMetadataStoreTest {
       TransactionRunners.run(transactionRunner, context -> {
         AppMetadataStore store = AppMetadataStore.create(context);
         store.writeApplication(NamespaceId.DEFAULT.getNamespace(), appName, ApplicationId.DEFAULT_VERSION, appSpec,
-                               new ChangeDetail(null, null, null, creationTimeMillis));
+                               new ChangeDetail(null, null, null, creationTimeMillis), null);
       });
     }
 
@@ -1006,7 +1006,7 @@ public abstract class AppMetadataStoreTest {
       TransactionRunners.run(transactionRunner, context -> {
         AppMetadataStore store = AppMetadataStore.create(context);
         store.writeApplication(NamespaceId.DEFAULT.getNamespace(), appName, ApplicationId.DEFAULT_VERSION, appSpec,
-                               new ChangeDetail(null, null, null, creationTimeMillis));
+                               new ChangeDetail(null, null, null, creationTimeMillis), null);
       });
     }
 
@@ -1129,7 +1129,7 @@ public abstract class AppMetadataStoreTest {
         AppMetadataStore store = AppMetadataStore.create(context);
         store.writeApplication(NamespaceId.DEFAULT.getNamespace(),
                                defaultAppName, ApplicationId.DEFAULT_VERSION, appSpec,
-                               new ChangeDetail(null, null, null, creationTimeMillis));
+                               new ChangeDetail(null, null, null, creationTimeMillis), null);
       });
 
       String cdapAppName = "test" + (2 * i + 1);
@@ -1137,7 +1137,7 @@ public abstract class AppMetadataStoreTest {
         AppMetadataStore store = AppMetadataStore.create(context);
         store.writeApplication(NamespaceId.CDAP.getNamespace(),
                                cdapAppName, ApplicationId.DEFAULT_VERSION, appSpec,
-                               new ChangeDetail(null, null, null, creationTimeMillis));
+                               new ChangeDetail(null, null, null, creationTimeMillis), null);
       });
     }
 
@@ -1167,7 +1167,7 @@ public abstract class AppMetadataStoreTest {
         AppMetadataStore store = AppMetadataStore.create(context);
         store.writeApplication(NamespaceId.DEFAULT.getNamespace(),
             defaultAppName, ApplicationId.DEFAULT_VERSION, appSpec,
-                               new ChangeDetail(null, null, null, creationTimeMillis));
+                               new ChangeDetail(null, null, null, creationTimeMillis), null);
       });
 
       String cdapAppName = "test" + (2 * i + 1);
@@ -1175,7 +1175,7 @@ public abstract class AppMetadataStoreTest {
         AppMetadataStore store = AppMetadataStore.create(context);
         store.writeApplication(NamespaceId.CDAP.getNamespace(),
             cdapAppName, ApplicationId.DEFAULT_VERSION, appSpec,
-                               new ChangeDetail(null, null, null, creationTimeMillis));
+                               new ChangeDetail(null, null, null, creationTimeMillis), null);
       });
     }
 

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/ApplicationRecord.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/ApplicationRecord.java
@@ -159,7 +159,7 @@ public class ApplicationRecord {
       ", version='" + version + '\'' +
       ", description='" + description + '\'' +
       ", artifact=" + artifact +
-      ", ownerPrincipal=" + ownerPrincipal + '\'' +
+      ", ownerPrincipal='" + ownerPrincipal + '\'' +
       ", change=" + change +
       ", sourceControlMeta=" + sourceControlMeta +
       '}';

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/SourceControlMeta.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/SourceControlMeta.java
@@ -17,17 +17,21 @@
 package io.cdap.cdap.proto.sourcecontrol;
 
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * The source control metadata for an application.
  */
 public class SourceControlMeta {
+
+  @Nullable
   private final String fileHash;
 
-  public SourceControlMeta(String fileHash) {
+  public SourceControlMeta(@Nullable String fileHash) {
     this.fileHash = fileHash;
   }
 
+  @Nullable
   public String getFileHash() {
     return fileHash;
   }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/NoChangesToPullException.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/NoChangesToPullException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol;
+
+/**
+ * Exception thrown when there's no changes for the pulled application
+ */
+public class NoChangesToPullException extends Exception {
+  public NoChangesToPullException(String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
## What

This PR adds the http handler and service layer of SCM application pull&deploy flow. A lot of code is borrowed from `io.cdap.cdap.gateway.handlers.AppLifecycleHttpHandler` and we re-sued the deploy code of `io.cdap.cdap.internal.app.services.ApplicationLifecycleService#deployApp`. The operation runner `pull` (PR: https://github.com/cdapio/cdap/pull/14928) is left as the placeholder to make this PR more readable and concentrated