### PR TITLE
fix(CDAP-20411): Inject DiscoveryService in RunnableTask and avoid calling MasterEnvironments

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTaskModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/ConfiguratorTaskModule.java
@@ -16,18 +16,13 @@ package io.cdap.cdap.internal.app.worker;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
-import io.cdap.cdap.common.guice.SupplierProviderBridge;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepositoryReader;
-import io.cdap.cdap.master.environment.MasterEnvironments;
-import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.UGIProvider;
-import org.apache.twill.discovery.DiscoveryService;
-import org.apache.twill.discovery.DiscoveryServiceClient;
 
 /**
  * ConfiguratorTaskModule specifies the binding for a {@link io.cdap.cdap.internal.app.worker.ConfiguratorTask}
@@ -36,17 +31,9 @@ public class ConfiguratorTaskModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    MasterEnvironment masterEnv = MasterEnvironments.getMasterEnvironment();
-    bind(DiscoveryService.class)
-      .toProvider(new SupplierProviderBridge<>(masterEnv.getDiscoveryServiceSupplier()));
-    bind(DiscoveryServiceClient.class)
-      .toProvider(new SupplierProviderBridge<>(masterEnv.getDiscoveryServiceClientSupplier()));
-
     bind(PluginFinder.class).to(RemoteWorkerPluginFinder.class);
     bind(UGIProvider.class).to(CurrentUGIProvider.class);
-
     bind(ArtifactRepositoryReader.class).to(RemoteArtifactRepositoryReader.class).in(Scopes.SINGLETON);
-
     bind(ArtifactRepository.class).to(RemoteArtifactRepository.class);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerService.java
@@ -35,6 +35,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.HttpContentDecompressor;
 import org.apache.twill.common.Cancellable;
 import org.apache.twill.discovery.DiscoveryService;
+import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +58,7 @@ public class TaskWorkerService extends AbstractIdleService {
   TaskWorkerService(CConfiguration cConf,
                     SConfiguration sConf,
                     DiscoveryService discoveryService,
+                    DiscoveryServiceClient discoveryServiceClient,
                     MetricsCollectionService metricsCollectionService,
                     CommonNettyHttpServiceFactory commonNettyHttpServiceFactory) {
     this.discoveryService = discoveryService;
@@ -73,7 +75,9 @@ public class TaskWorkerService extends AbstractIdleService {
           pipeline.addAfter("compressor", "decompressor", new HttpContentDecompressor());
         }
       })
-      .setHttpHandlers(new TaskWorkerHttpHandlerInternal(cConf, this::stopService, metricsCollectionService));
+      .setHttpHandlers(new TaskWorkerHttpHandlerInternal(cConf, discoveryService,
+                                                         discoveryServiceClient, this::stopService,
+                                                         metricsCollectionService));
 
     if (cConf.getBoolean(Constants.Security.SSL.INTERNAL_ENABLED)) {
       new HttpsEnabler().configureKeyStore(cConf, sConf).enable(builder);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/ConfiguratorTaskTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/ConfiguratorTaskTest.java
@@ -18,21 +18,15 @@ package io.cdap.cdap.internal.app.worker;
 
 import com.google.inject.Injector;
 import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.internal.app.runtime.distributed.MockMasterEnvironment;
-import io.cdap.cdap.master.environment.MasterEnvironments;
-import io.cdap.cdap.master.spi.environment.MasterEnvironment;
+import org.apache.twill.discovery.InMemoryDiscoveryService;
 import org.junit.Test;
 
 public class ConfiguratorTaskTest {
   @Test
-  public void testConfiguratorTaskInjector() throws Exception {
-    MasterEnvironment masterEnvironment = new MockMasterEnvironment();
-    masterEnvironment.initialize(null);
-    MasterEnvironment tmpMasterEnv = MasterEnvironments.setMasterEnvironment(masterEnvironment);
+  public void testConfiguratorTaskInjector()  {
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
 
-    Injector injector = ConfiguratorTask.createInjector(CConfiguration.create());
+    Injector injector = ConfiguratorTask.createInjector(CConfiguration.create(), discoveryService, discoveryService);
     injector.getInstance(ConfiguratorTask.ConfiguratorTaskRunner.class);
-
-    MasterEnvironments.setMasterEnvironment(tmpMasterEnv);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/SystemAppTaskTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/SystemAppTaskTest.java
@@ -24,12 +24,11 @@ import io.cdap.cdap.internal.app.runtime.artifact.ArtifactManagerFactory;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
-import io.cdap.cdap.internal.app.runtime.distributed.MockMasterEnvironment;
-import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.apache.twill.discovery.InMemoryDiscoveryService;
 import org.junit.Test;
 
 /**
@@ -39,9 +38,8 @@ public class SystemAppTaskTest {
 
   @Test
   public void testInjector() {
-    MasterEnvironments.setMasterEnvironment(new MockMasterEnvironment());
-
-    Injector injector = SystemAppTask.createInjector(CConfiguration.create());
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
+    Injector injector = SystemAppTask.createInjector(CConfiguration.create(), discoveryService, discoveryService);
 
     injector.getInstance(ArtifactRepositoryReader.class);
     injector.getInstance(ArtifactRepository.class);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerMetricsTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerMetricsTest.java
@@ -84,7 +84,8 @@ public class TaskWorkerMetricsTest {
     };
 
     mockMetricsCollector.startAndWait();
-    taskWorkerService = new TaskWorkerService(cConf, sConf, new InMemoryDiscoveryService(),
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
+    taskWorkerService = new TaskWorkerService(cConf, sConf, discoveryService, discoveryService,
                                               mockMetricsCollector,
                                               new CommonNettyHttpServiceFactory(cConf, mockMetricsCollector));
     taskWorkerStateFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceTest.java
@@ -88,8 +88,9 @@ public class TaskWorkerServiceTest {
     CConfiguration cConf = createCConf();
     SConfiguration sConf = createSConf();
 
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     TaskWorkerService taskWorkerService = new TaskWorkerService(
-      cConf, sConf, new InMemoryDiscoveryService(), metricsCollectionService,
+      cConf, sConf, discoveryService, discoveryService, metricsCollectionService,
       new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
     serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);
     // start the service
@@ -112,8 +113,9 @@ public class TaskWorkerServiceTest {
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 1);
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 5);
 
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     TaskWorkerService taskWorkerService = new TaskWorkerService(
-      cConf, sConf, new InMemoryDiscoveryService(), metricsCollectionService,
+      cConf, sConf, discoveryService, discoveryService, metricsCollectionService,
       new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
     serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);
     // start the service
@@ -130,8 +132,9 @@ public class TaskWorkerServiceTest {
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 10);
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 2);
 
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     TaskWorkerService taskWorkerService = new TaskWorkerService(
-      cConf, sConf, new InMemoryDiscoveryService(), metricsCollectionService,
+      cConf, sConf, discoveryService, discoveryService, metricsCollectionService,
       new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
     serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);
     // start the service
@@ -163,8 +166,9 @@ public class TaskWorkerServiceTest {
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 2);
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 0);
 
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     TaskWorkerService taskWorkerService = new TaskWorkerService(
-      cConf, sConf, new InMemoryDiscoveryService(), metricsCollectionService,
+      cConf, sConf, discoveryService, discoveryService, metricsCollectionService,
       new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
     serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);
     // start the service

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceTest.java
@@ -104,15 +104,16 @@ public class SystemWorkerServiceTest extends AppFabricTestBase {
     );
 
     SConfiguration sConf = createSConf();
-
-    SystemWorkerService service = new SystemWorkerService(cConf, sConf, new InMemoryDiscoveryService(),
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
+    SystemWorkerService service = new SystemWorkerService(cConf, sConf, discoveryService,
                                                           metricsCollectionService, new CommonNettyHttpServiceFactory(
                                                             cConf, metricsCollectionService),
                                                           injector.getInstance(TokenManager.class),
                                                           new NoopTwillRunnerService(),
                                                           new NoopTwillRunnerService(),
                                                           getInjector().getInstance(ProvisioningService.class),
-                                                          Guice.createInjector(new RunnableTaskModule(cConf)),
+                                                          Guice.createInjector(
+                                                            new RunnableTaskModule(discoveryService, discoveryService)),
                                                           new AuthenticationTestContext(), new NoOpAccessController());
     service.startAndWait();
     this.systemWorkerService = service;

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RunnableTaskLauncher.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RunnableTaskLauncher.java
@@ -21,6 +21,9 @@ import com.google.inject.Injector;
 import io.cdap.cdap.api.service.worker.RunnableTask;
 import io.cdap.cdap.api.service.worker.RunnableTaskContext;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.guice.ConfigModule;
+import org.apache.twill.discovery.DiscoveryService;
+import org.apache.twill.discovery.DiscoveryServiceClient;
 
 /**
  * RunnableTaskLauncher launches a {@link RunnableTask} by loading its class and calling its run method.
@@ -28,8 +31,13 @@ import io.cdap.cdap.common.conf.CConfiguration;
 public class RunnableTaskLauncher {
   private final Injector injector;
 
-  public RunnableTaskLauncher(CConfiguration cConf) {
-    injector = Guice.createInjector(new RunnableTaskModule(cConf));
+  public RunnableTaskLauncher(CConfiguration cConf,
+                              DiscoveryService discoveryService,
+                              DiscoveryServiceClient discoveryServiceClient) {
+    injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new RunnableTaskModule(discoveryService, discoveryServiceClient)
+    );
   }
 
   /**

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RunnableTaskModule.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RunnableTaskModule.java
@@ -17,21 +17,26 @@
 package io.cdap.cdap.common.internal.remote;
 
 import com.google.inject.AbstractModule;
-import io.cdap.cdap.common.conf.CConfiguration;
+import org.apache.twill.discovery.DiscoveryService;
+import org.apache.twill.discovery.DiscoveryServiceClient;
 
 /**
  * Module for Runnable tasks.
  */
 public class RunnableTaskModule extends AbstractModule {
 
-  private final CConfiguration cConf;
+  private final DiscoveryService discoveryService;
+  private final DiscoveryServiceClient discoveryServiceClient;
 
-  public RunnableTaskModule(CConfiguration cConf) {
-    this.cConf = cConf;
+  public RunnableTaskModule(DiscoveryService discoveryService,
+                            DiscoveryServiceClient discoveryServiceClient) {
+    this.discoveryService = discoveryService;
+    this.discoveryServiceClient = discoveryServiceClient;
   }
 
   @Override
   protected void configure() {
-    bind(CConfiguration.class).toInstance(cConf);
+    bind(DiscoveryService.class).toInstance(discoveryService);
+    bind(DiscoveryServiceClient.class).toInstance(discoveryServiceClient);
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
@@ -40,6 +40,8 @@ import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.twill.common.Threads;
+import org.apache.twill.discovery.DiscoveryService;
+import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,10 +93,11 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
    */
   private final AtomicBoolean mustRestart = new AtomicBoolean(false);
 
-  public TaskWorkerHttpHandlerInternal(CConfiguration cConf, Consumer<String> stopper,
+  public TaskWorkerHttpHandlerInternal(CConfiguration cConf, DiscoveryService discoveryService,
+                                       DiscoveryServiceClient discoveryServiceClient, Consumer<String> stopper,
                                        MetricsCollectionService metricsCollectionService) {
     int killAfterRequestCount = cConf.getInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 0);
-    this.runnableTaskLauncher = new RunnableTaskLauncher(cConf);
+    this.runnableTaskLauncher = new RunnableTaskLauncher(cConf, discoveryService, discoveryServiceClient);
     this.metricsCollectionService = metricsCollectionService;
     this.metadataServiceEndpoint = cConf.get(Constants.TaskWorker.METADATA_SERVICE_END_POINT);
     this.taskCompletionConsumer = (succeeded, taskDetails) -> {

--- a/cdap-common/src/test/java/io/cdap/cdap/common/internal/remote/RemoteTaskExecutorTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/internal/remote/RemoteTaskExecutorTest.java
@@ -65,9 +65,10 @@ public class RemoteTaskExecutorTest {
     cConf = CConfiguration.create();
     discoveryService = new InMemoryDiscoveryService();
     remoteClientFactory = new RemoteClientFactory(discoveryService, new NoOpInternalAuthenticator());
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     httpService = new CommonNettyHttpServiceBuilder(cConf, "test", new NoOpMetricsCollectionService())
       .setHttpHandlers(
-        new TaskWorkerHttpHandlerInternal(cConf, className -> {
+        new TaskWorkerHttpHandlerInternal(cConf, discoveryService, discoveryService, className -> {
         }, new NoOpMetricsCollectionService())
       )
       .setChannelPipelineModifier(new ChannelPipelineModifier() {

--- a/cdap-common/src/test/java/io/cdap/cdap/common/internal/remote/RunnableTaskLauncherTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/internal/remote/RunnableTaskLauncherTest.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.api.service.worker.RunnableTask;
 import io.cdap.cdap.api.service.worker.RunnableTaskContext;
 import io.cdap.cdap.api.service.worker.RunnableTaskRequest;
 import io.cdap.cdap.common.conf.CConfiguration;
+import org.apache.twill.discovery.InMemoryDiscoveryService;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,7 +42,9 @@ public class RunnableTaskLauncherTest {
     RunnableTaskRequest request = RunnableTaskRequest.getBuilder(TestRunnableTask.class.getName()).
       withParam(want).build();
 
-    RunnableTaskLauncher launcher = new RunnableTaskLauncher(CConfiguration.create());
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
+    RunnableTaskLauncher launcher = new RunnableTaskLauncher(CConfiguration.create(),
+                                                             discoveryService, discoveryService);
     RunnableTaskContext context = new RunnableTaskContext(request);
     launcher.launchRunnableTask(context);
 


### PR DESCRIPTION
## What

Currently all worker `RunnableTask`s are calling `MasterEnvironments` to fetch the `DiscoveryService` and we cannot decouple task worker implementation from appFabric...
`DiscoveryService` should instead be injected in `RunnableTaskLauncher` and `RunnableTask`s should not be aware of `MasterEnvironments`.
