### PR TITLE
fix(CDAP-20412): get the fileHash after commit but before push, avoid empty filHash in db

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
@@ -233,7 +233,6 @@ public class SourceControlManagementService {
     PullAppResponse<?> pullResponse = sourceControlOperationRunner.pull(appRef, repoConfig);
 
     if (latestMeta != null &&
-      latestMeta.getFileHash() != null &&
       latestMeta.getFileHash().equals(pullResponse.getApplicationFileHash())) {
       throw new NoChangesToPullException(String.format("Pipeline deployment was not successful because there is " +
                                                          "no new change for the pulled application: %s", appRef));

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/SourceControlMeta.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/SourceControlMeta.java
@@ -17,21 +17,18 @@
 package io.cdap.cdap.proto.sourcecontrol;
 
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 /**
  * The source control metadata for an application.
  */
 public class SourceControlMeta {
 
-  @Nullable
   private final String fileHash;
 
-  public SourceControlMeta(@Nullable String fileHash) {
+  public SourceControlMeta(String fileHash) {
     this.fileHash = fileHash;
   }
 
-  @Nullable
   public String getFileHash() {
     return fileHash;
   }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/PushAppResponse.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/PushAppResponse.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.sourcecontrol.operationrunner;
 
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 /**
  * Encapsulates the information generated from a single application push
@@ -25,10 +24,9 @@ import javax.annotation.Nullable;
 public class PushAppResponse {
   private final String name;
   private final String version;
-  @Nullable
   private final String fileHash;
 
-  public PushAppResponse(String name, String version, @Nullable String fileHash) {
+  public PushAppResponse(String name, String version, String fileHash) {
     this.name = name;
     this.version = version;
     this.fileHash = fileHash;
@@ -38,7 +36,6 @@ public class PushAppResponse {
     return name;
   }
 
-  @Nullable
   public String getFileHash() {
     return fileHash;
   }


### PR DESCRIPTION
## What 

Currently in the push app flow, we get the fileHash after git push. If getting fileHash throws IOException, we don’t send back error but just log the warning since the push actually succeeded, and the fileHash is not stored back in DB. 

We should instead parse the fileHash before git push, so that if it errors out, we stop git push and throw exception. This way we always get a solid fileHash in DB