### PR TITLE
fix(CDAP-20417): enforce commit message in push flow

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/SourceControlManagementHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/SourceControlManagementHttpHandler.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.gateway.handlers;
 
+import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
@@ -157,7 +158,7 @@ public class SourceControlManagementHttpHandler extends AbstractAppFabricHttpHan
     } catch (AuthenticationConfigException e) {
       responder.sendJson(HttpResponseStatus.BAD_REQUEST, e.getMessage());
     } catch (NoChangesToPushException e) {
-      responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
+      responder.sendString(HttpResponseStatus.OK, e.getMessage());
     } catch (PushFailureException e) {
       responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
     }
@@ -187,11 +188,18 @@ public class SourceControlManagementHttpHandler extends AbstractAppFabricHttpHan
   }
 
   private PushAppRequest validateAndGetAppsRequest(FullHttpRequest request) throws BadRequestException {
+    PushAppRequest appRequest;
     try {
-      return parseBody(request, PushAppRequest.class);
+      appRequest = parseBody(request, PushAppRequest.class);
     } catch (JsonSyntaxException e) {
       throw new BadRequestException("Invalid request body: " + e.getMessage());
     }
+
+    if (appRequest == null || Strings.isNullOrEmpty(appRequest.getCommitMessage())) {
+      throw new BadRequestException("Please specify commit message in the request body.");
+    }
+
+    return appRequest;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
@@ -57,12 +57,10 @@ import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.store.NamespaceTable;
 import io.cdap.cdap.store.RepositoryTable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.Optional;
-import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Service that manages source control for repositories and applications.
@@ -154,14 +152,14 @@ public class SourceControlManagementService {
   /**
    * The method to push an application to linked repository
    * @param appRef {@link ApplicationReference}
-   * @param commitMessage optional commit message from user
+   * @param commitMessage enforced commit message from user
    * @return {@link PushAppResponse}
    * @throws NotFoundException if the application is not found or the repository config is not found
    * @throws IOException if {@link ApplicationLifecycleService} fails to get the adminOwner store
    * @throws PushFailureException if {@link SourceControlOperationRunner} fails to push
    * @throws NoChangesToPushException if there's no change of the application between namespace and linked repository
    */
-  public PushAppResponse pushApp(ApplicationReference appRef, @Nullable String commitMessage)
+  public PushAppResponse pushApp(ApplicationReference appRef, String commitMessage)
     throws NotFoundException, IOException, PushFailureException,
            NoChangesToPushException, AuthenticationConfigException {
     // TODO: CDAP-20396 RepositoryConfig is currently only accessible from the service layer

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/SourceControlManagementHttpHandlerTests.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/SourceControlManagementHttpHandlerTests.java
@@ -296,6 +296,19 @@ public class SourceControlManagementHttpHandlerTests extends AppFabricTestBase {
   }
 
   @Test
+  public void testPushAppInvalidRequest() throws Exception {
+    Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp", "version1");
+    // Push empty commit message
+    String commitMessage = "";
+    HttpResponse response = pushApplication(NamespaceId.DEFAULT.appReference(appId1.getId()), commitMessage);
+
+    // Assert the response
+    assertResponseCode(400, response);
+    Assert.assertEquals(response.getResponseBodyAsString(),
+        "Please specify commit message in the request body.");
+  }
+
+  @Test
   public void testPushAppNotFound() throws Exception {
     Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp", "version1");
 
@@ -321,7 +334,7 @@ public class SourceControlManagementHttpHandlerTests extends AppFabricTestBase {
     HttpResponse response = pushApplication(NamespaceId.DEFAULT.appReference(appId1.getId()), commitMessage);
 
     // Assert the error that app has no changes to push
-    assertResponseCode(400, response);
+    assertResponseCode(200, response);
     Assert.assertTrue(response.getResponseBodyAsString().contains("No changes for apps to push"));
   }
 

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/PushAppRequest.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/PushAppRequest.java
@@ -16,8 +16,6 @@
 
 package io.cdap.cdap.proto.sourcecontrol;
 
-import javax.annotation.Nullable;
-
 /**
  * The request class to push an application to linked git repository.
  */
@@ -28,7 +26,6 @@ public class PushAppRequest {
     this.commitMessage = commitMessage;
   }
 
-  @Nullable
   public String getCommitMessage() {
     return commitMessage;
   }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManager.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManager.java
@@ -191,7 +191,7 @@ public class RepositoryManager implements AutoCloseable {
     try {
       fileHash = getFileHash(fileChanged, commit);
     } catch (IOException e) {
-      throw new PushFailureException(String.format("Failed to get fileHash for %s before push", fileChanged), e);
+      throw new PushFailureException(String.format("Failed to get fileHash for %s", fileChanged), e);
     }
 
     if (fileHash == null) {


### PR DESCRIPTION
## What

1. Enforce commit message in push flow
2. Return 200 for NoChangesToPush, since it's not actually bacd request, but more like idempotent repeated PUT