### PR TITLE
Fix field-level lineage for multi-plugins

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/lineage/Origin.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/lineage/Origin.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.lineage;
+
+import javax.annotation.Nullable;
+
+/**
+ * Represents the Origin for a field.
+ */
+public final class Origin {
+  private final String stageOperation;
+  private final String marker;
+
+  @Nullable
+  public String getMarker() {
+    return marker;
+  }
+
+  /**
+   * Creates a new instance.
+   *
+   * @param stageOperation stage name followed by "." followed by operation name
+   * @param marker only useful in case of multi-sources/multi-sinks
+   */
+  public Origin(String stageOperation, @Nullable String marker) {
+    this.stageOperation = stageOperation;
+    this.marker = marker;
+  }
+
+  public String getStageOperation() {
+    return stageOperation;
+  }
+}


### PR DESCRIPTION
Currently, to find the origin for a field in the write operation, we only keep track of the "operation name" as the source. But in case of multi-source/multi-sink plugins, the operation name alone will not be helpful to find the correct origin. For such cases we look for a "tag" that is emitted by such plugins which refers to the asset(could be a table, sObject, etc) to help us identify the correct origin for the field.

Below scenarios were tested:
1. Multi-db source to BigQuery multi-sink pipeline where the tables has duplicate column names(e.g. all 3 tables used had a column called 'id')
2. Multi-db source to BigQuery multi-sink pipeline where the tables did not have duplicate column names
3. Single source to single sink pipeline with a transformation plugin in between(wrangler)

Jira: https://cdap.atlassian.net/browse/CDAP-20442