### PR TITLE
CDAP-20430 return unevaluated properties in validation call

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineServiceTest.java
@@ -67,12 +67,6 @@ import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
@@ -83,6 +77,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 
 /**
  * Tests for the data pipeline service.
@@ -201,39 +200,6 @@ public class DataPipelineServiceTest extends HydratorTestBase {
     // test it can still pass validation
     actual = sendRequest(new StageValidationRequest(stage, Collections.emptyList(), true));
     Assert.assertTrue(actual.getFailures().isEmpty());
-  }
-
-  @Test
-  public void testMacroResolutionFromProperties() throws Exception {
-    // StringValueFilterTransform checks that the field exists in the input schema
-    String stageName = "tx";
-    Map<String, String> properties = new HashMap<>();
-    properties.put("field", "x");
-    properties.put("value", "${someProperty}");
-    ETLStage stage = new ETLStage(stageName, new ETLPlugin(StringValueFilterTransform.NAME, Transform.PLUGIN_TYPE,
-                                                           properties));
-    Schema inputSchema = Schema.recordOf("x", Schema.Field.of("x", Schema.of(Schema.Type.STRING)));
-
-    // Set the preference value in the store
-    getPreferencesService().setProperties(NamespaceId.DEFAULT, Collections.singletonMap("someProperty", "someValue"));
-
-    // This call should include the resolved value for Field
-    StageValidationRequest requestBody1 =
-      new StageValidationRequest(stage, Collections.singletonList(new StageSchema("input", inputSchema)),
-                                 true);
-    StageValidationResponse actual1 = sendRequest(requestBody1);
-    Assert.assertTrue(actual1.getFailures().isEmpty());
-    Assert.assertNotNull(actual1.getSpec().getPlugin());
-    Assert.assertEquals("someValue", actual1.getSpec().getPlugin().getProperties().get("value"));
-
-    // This call should NOT include the resolved value for Field
-    StageValidationRequest requestBody2 =
-      new StageValidationRequest(stage, Collections.singletonList(new StageSchema("input", inputSchema)),
-                                 false);
-    StageValidationResponse actual2 = sendRequest(requestBody2);
-    Assert.assertTrue(actual2.getFailures().isEmpty());
-    Assert.assertNotNull(actual2.getSpec().getPlugin());
-    Assert.assertEquals("${someProperty}", actual2.getSpec().getPlugin().getProperties().get("value"));
   }
 
   @Test

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/service/ValidationUtilsTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/service/ValidationUtilsTest.java
@@ -45,12 +45,13 @@ import java.util.Map;
  */
 public class ValidationUtilsTest {
 
-  private static final FeatureFlagsProvider MOCK_FEATURE_FLAGS_PROVIDER = new FeatureFlagsProvider() {
-  };
+  private static final FeatureFlagsProvider MOCK_FEATURE_FLAGS_PROVIDER =
+      new FeatureFlagsProvider() { };
 
   @Test
   public void testValidateNoException() {
-    Schema testSchema = Schema.recordOf("a", Schema.Field.of("a", Schema.of(Schema.Type.STRING)));
+    Schema testSchema = Schema.recordOf("a",
+        Schema.Field.of("a", Schema.of(Schema.Type.STRING)));
     StageSchema testStageSchema = new StageSchema("source", testSchema);
     ETLStage etlStage = new ETLStage("source", MockSource.getPlugin("testtable"));
     StageValidationRequest validationRequest = new StageValidationRequest(
@@ -65,7 +66,8 @@ public class ValidationUtilsTest {
 
   @Test
   public void testValidateException() {
-    Schema testSchema = Schema.recordOf("a", Schema.Field.of("a", Schema.of(Schema.Type.STRING)));
+    Schema testSchema = Schema.recordOf("a",
+        Schema.Field.of("a", Schema.of(Schema.Type.STRING)));
     StageSchema testStageSchema = new StageSchema("source", testSchema);
     ETLStage etlStage = new ETLStage("source", MockSource.getPlugin(null));
     StageValidationRequest validationRequest = new StageValidationRequest(
@@ -79,8 +81,9 @@ public class ValidationUtilsTest {
   }
 
   @Test
-  public void testMacroSubstitution() {
-    Schema testSchema = Schema.recordOf("a", Schema.Field.of("a", Schema.of(Schema.Type.STRING)));
+  public void testMacroSubstitutionNotReturned() {
+    Schema testSchema = Schema.recordOf("a",
+        Schema.Field.of("a", Schema.of(Schema.Type.STRING)));
     StageSchema testStageSchema = new StageSchema("source", testSchema);
     ETLStage etlStage = new ETLStage("source", MockSource.getPlugin("@{tName}"));
     StageValidationRequest validationRequest = new StageValidationRequest(
@@ -97,37 +100,40 @@ public class ValidationUtilsTest {
         return propertiesCopy;
       }, MOCK_FEATURE_FLAGS_PROVIDER);
     Assert.assertTrue(stageValidationResponse.getFailures().isEmpty());
-    Assert.assertEquals(testtable, stageValidationResponse.getSpec().getPlugin().getProperties().get("tableName"));
+    Assert.assertEquals("@{tName}",
+        stageValidationResponse.getSpec().getPlugin().getProperties().get("tableName"));
   }
 
   //Mock PluginConfigurer
   private PluginConfigurer getPluginConfigurer(PluginClass pluginClass) {
     return new PluginConfigurer() {
       @Override
-      public <T> T usePlugin(String pluginType, String pluginName, String pluginId, PluginProperties properties,
-                             PluginSelector selector) {
+      public <T> T usePlugin(String pluginType, String pluginName, String pluginId,
+          PluginProperties properties, PluginSelector selector) {
         String tableName = properties.getProperties().get("tableName");
         if (tableName == null || tableName.isEmpty()) {
-          throw new InvalidPluginConfigException(pluginClass, Collections.singleton("tableName"), new HashSet<>());
+          throw new InvalidPluginConfigException(pluginClass, Collections.singleton("tableName"),
+              new HashSet<>());
         }
         MockSource.Config config = new MockSource.Config();
         MockSource.ConnectionConfig connectionConfig = new MockSource.ConnectionConfig();
         String schema = properties.getProperties().get("schema");
         String sleep = properties.getProperties().get("sleepInMillis");
         connectionConfig.setTableName(tableName);
-        config.setConfig(connectionConfig, schema, null, sleep == null ? null : Long.parseLong(sleep));
+        config.setConfig(connectionConfig, schema, null,
+            sleep == null ? null : Long.parseLong(sleep));
         return (T) new MockSource(config);
       }
 
       @Override
       public <T> Class<T> usePluginClass(String pluginType, String pluginName, String pluginId,
-                                         PluginProperties properties, PluginSelector selector) {
+          PluginProperties properties, PluginSelector selector) {
         return null;
       }
 
       @Override
       public Map<String, String> evaluateMacros(Map<String, String> properties,
-                                                MacroEvaluator evaluator, MacroParserOptions options) throws
+          MacroEvaluator evaluator, MacroParserOptions options) throws
         InvalidMacroException {
         return null;
       }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/spec/StageSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/spec/StageSpec.java
@@ -189,8 +189,8 @@ public class StageSpec implements Serializable {
   public static class Builder {
 
     private final String name;
-    private final PluginSpec plugin;
     private final boolean isSplitter;
+    private PluginSpec plugin;
     private Map<String, Schema> inputSchemas;
     private Map<String, Schema> portSchemas;
     private Map<String, Port> outputs;
@@ -238,6 +238,12 @@ public class StageSpec implements Serializable {
       if (port != null) {
         this.portSchemas.put(port, outputSchema);
       }
+      return this;
+    }
+
+    public Builder setPluginProperties(Map<String, String> properties) {
+      this.plugin = new PluginSpec(plugin.getType(), plugin.getName(), new HashMap<>(properties),
+          plugin.getArtifact());
       return this;
     }
 
@@ -343,8 +349,10 @@ public class StageSpec implements Serializable {
 
     if (newMaxPreviewRecords < stageSpec.getMaxPreviewRecords()) {
       LOG.warn(
-          "Max preview records exceeds allowed limit. Setting maximum preview records to {} instead of {} ",
-          newMaxPreviewRecords, stageSpec.maxPreviewRecords);
+          "Max preview records exceeds allowed limit. Setting maximum preview records to {} instead"
+              + " of {} ",
+          newMaxPreviewRecords,
+          stageSpec.maxPreviewRecords);
     }
     return new StageSpec(stageSpec.name, stageSpec.plugin, stageSpec.inputSchemas,
         stageSpec.outputSchema,


### PR DESCRIPTION
Fix the stage validation call to return macro unevaluated properties to prevent secure macro values from being returned.