### PR TITLE
[CDAP-20436] Metrics aggregation in RuntimeClientService

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/MetricsMessageAggregator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/MetricsMessageAggregator.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.common.collect.Iterators;
+import com.google.common.reflect.TypeToken;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.data.schema.UnsupportedTypeException;
+import io.cdap.cdap.api.messaging.Message;
+import io.cdap.cdap.api.metrics.MetricValue;
+import io.cdap.cdap.api.metrics.MetricValues;
+import io.cdap.cdap.common.io.BinaryDecoder;
+import io.cdap.cdap.common.io.BinaryEncoder;
+import io.cdap.cdap.common.io.DatumReader;
+import io.cdap.cdap.common.io.DatumWriter;
+import io.cdap.cdap.common.io.StringCachingDecoder;
+import io.cdap.cdap.common.utils.ResettableByteArrayInputStream;
+import io.cdap.cdap.internal.io.DatumReaderFactory;
+import io.cdap.cdap.internal.io.DatumWriterFactory;
+import io.cdap.cdap.internal.io.SchemaGenerator;
+import io.cdap.cdap.metrics.collect.AggregatedMetricsEmitter;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An aggregator for metrics that aggregates metrics on 2 levels.
+ * <ol>
+ *   <li>Combine metrics across all {@link MetricValues} with the same tags, retaining the latest timestamp.</li>
+ *   <li>Inside each {@link MetricValues}, combine {@link MetricValue} with the same name.</li>
+ * </ol>
+ */
+class MetricsMessageAggregator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      MetricsMessageAggregator.class);
+
+  private final Map<String, String> cachemap;
+  private final ResettableByteArrayInputStream decodingInputStream;
+  private final StringCachingDecoder decoder;
+  private final DatumReader<MetricValues> reader;
+  private final Schema schema;
+  private final ByteArrayOutputStream encodeOutputStream;
+  private final BinaryEncoder encoder;
+  private final DatumWriter<MetricValues> recordWriter;
+  private final long aggregationWindowSeconds;
+
+  MetricsMessageAggregator(SchemaGenerator schemaGenerator,
+      DatumWriterFactory writerFactory, DatumReaderFactory readerFactory,
+      long aggregationWindowSeconds) {
+    TypeToken<MetricValues> metricValueType = TypeToken.of(MetricValues.class);
+    try {
+      this.schema = schemaGenerator.generate(metricValueType.getType());
+    } catch (UnsupportedTypeException e) {
+      throw new RuntimeException("Failed to generate schema for MetricValues",
+          e);
+    }
+    this.reader = readerFactory.create(metricValueType, schema);
+    this.recordWriter = writerFactory.create(metricValueType, schema);
+    this.cachemap = new HashMap<>();
+    this.decodingInputStream = new ResettableByteArrayInputStream();
+    this.decoder = new StringCachingDecoder(
+        new BinaryDecoder(decodingInputStream), cachemap);
+    this.encodeOutputStream = new ByteArrayOutputStream(1024);
+    this.encoder = new BinaryEncoder(encodeOutputStream);
+    this.aggregationWindowSeconds = Math.max(1, aggregationWindowSeconds);
+  }
+
+  public Iterator<Message> aggregate(Iterator<Message> input) {
+    if (!input.hasNext()) {
+      return input;
+    }
+    cachemap.clear();
+
+    Map<MetricsMapKey, MetricsAggregator> aggregated = new HashMap<>();
+    long currentTimestamp =
+        System.currentTimeMillis() / TimeUnit.SECONDS.toMillis(1);
+    // MetricValues will be aggregated across windows of size
+    // "aggregationWindowSeconds". We align the current time to the end of the
+    // last widow. This is done since in most cases, it is expected that all
+    // the MetricValues were emitted very recently. The offset ensures
+    // the last window completely lies in the past and maximizes the chance
+    // that all metrics lie within it.
+    long offset = (currentTimestamp % aggregationWindowSeconds) + 1;
+    Message[] lastMessage = new Message[1];
+    try {
+      input.forEachRemaining(message -> {
+        // Decode the metrics.
+        // Keep track of the last message ID as TopicRelayers need it to fetch
+        // messages in the next iteration.
+        lastMessage[0] = message;
+        decodingInputStream.reset(message.getPayload());
+        MetricValues values;
+        try {
+          values = reader.read(decoder, schema);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+        addToAggregatedValues(aggregated, offset, values);
+      });
+    } catch (Exception e) {
+      LOG.warn(
+          "Failed to decode metric message. Returning partially aggregated values.",
+          e);
+      return Iterators.concat(
+          getIteratorFromAggregatedMetrics(aggregated, lastMessage[0].getId()),
+          Collections.singleton(lastMessage[0]).iterator(), input);
+    }
+
+    return getIteratorFromAggregatedMetrics(aggregated, lastMessage[0].getId());
+  }
+
+  private Iterator<Message> getIteratorFromAggregatedMetrics(
+      Map<MetricsMapKey, MetricsAggregator> aggregated, String messageId) {
+    return aggregated.entrySet().stream().map(this::getMetricValues)
+        .map(metricValues -> encodeMetricValues(metricValues, messageId))
+        .iterator();
+  }
+
+  private void addToAggregatedValues(
+      Map<MetricsMapKey, MetricsAggregator> aggregated, long offset,
+      MetricValues values) {
+    long timestamp = values.getTimestamp();
+    long roundedTimestamp = getRoundedTimestamp(timestamp, offset);
+    MetricsAggregator metricsAggregator = aggregated.computeIfAbsent(
+        new MetricsMapKey(values.getTags(), roundedTimestamp),
+        t -> new MetricsAggregator());
+
+    for (MetricValue metric : values.getMetrics()) {
+      metricsAggregator.addMetric(metric, timestamp);
+    }
+  }
+
+  private MetricValues getMetricValues(
+      Entry<MetricsMapKey, MetricsAggregator> entry) {
+    return entry.getValue().getAggregateMetricValues(
+        entry.getKey().getTags(), entry.getKey().getRoundedTimestamp());
+  }
+
+  private Message encodeMetricValues(MetricValues metricValues,
+      String lastMessageId) {
+    encodeOutputStream.reset();
+    try {
+      recordWriter.encode(metricValues, encoder);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Failed to encode metric to message payload.", e);
+    }
+    byte[] payload = encodeOutputStream.toByteArray();
+    return new Message() {
+      @Override
+      public String getId() {
+        // TopicRelayers keep track of the last message ID
+        // to fetch messages in the next iteration.
+        // Message IDs are generated by the messaging service.
+        // Return the last message ID before aggregation every time.
+        return lastMessageId;
+      }
+
+      @Override
+      public byte[] getPayload() {
+        return payload;
+      }
+    };
+  }
+
+  private long getRoundedTimestamp(long timestamp, long offset) {
+    return (Math.max(timestamp - offset, 0) / aggregationWindowSeconds)
+        * aggregationWindowSeconds;
+  }
+
+  /**
+   * The key for aggregating {@link MetricValues}. Only values with the same key
+   * will be merged.
+   */
+  private static class MetricsMapKey {
+
+    private final Map<String, String> tags;
+    private final long roundedTimestamp;
+
+    private MetricsMapKey(Map<String, String> tags, long roundedTimestamp) {
+      this.tags = tags;
+      this.roundedTimestamp = roundedTimestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof MetricsMapKey)) {
+        return false;
+      }
+      MetricsMapKey input = (MetricsMapKey) o;
+      return roundedTimestamp == input.roundedTimestamp && tags.equals(
+          input.tags);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(tags, roundedTimestamp);
+    }
+
+    public Map<String, String> getTags() {
+      return tags;
+    }
+
+    public long getRoundedTimestamp() {
+      return roundedTimestamp;
+    }
+  }
+
+  /**
+   * Aggregator for {@link MetricValue}s. Users can add {@link MetricValue}s one
+   * by one and get the resulting {@link MetricValues} once all the metrics are
+   * added.
+   */
+  private static class MetricsAggregator {
+
+    private final Collection<MetricValue> metrics;
+    private final Map<String, AggregatedMetric> aggregatedMetricsMap;
+
+    private MetricsAggregator() {
+      this.metrics = new ArrayList<>();
+      this.aggregatedMetricsMap = new HashMap<>();
+    }
+
+    public void addMetric(MetricValue metric, long timestamp) {
+      switch (metric.getType()) {
+        case GAUGE:
+        case COUNTER:
+          aggregatedMetricsMap.computeIfAbsent(metric.getName(),
+              AggregatedMetric::new).addMetric(metric, timestamp);
+          break;
+        default:
+          // Don't know how to aggregate other metric types, so store them without aggregation.
+          metrics.add(metric);
+      }
+    }
+
+    public MetricValues getAggregateMetricValues(Map<String, String> tags,
+        long timestamp) {
+      aggregatedMetricsMap.values().stream()
+          .map(AggregatedMetric::emit)
+          .forEach(metrics::add);
+      return new MetricValues(tags, timestamp, metrics);
+    }
+  }
+
+  /**
+   * A class to obtain an aggregated {@link MetricValue} after adding them one
+   * by one.
+   */
+  private static class AggregatedMetric {
+
+    private final AggregatedMetricsEmitter emitter;
+    private long timestamp;
+
+    private AggregatedMetric(String metricName) {
+      this.emitter = new AggregatedMetricsEmitter(metricName);
+      this.timestamp = 0;
+    }
+
+    public void addMetric(MetricValue metric, long timestamp) {
+      this.timestamp = Math.max(timestamp, this.timestamp);
+      switch (metric.getType()) {
+        case GAUGE:
+          if (this.timestamp == timestamp) {
+            emitter.gauge(metric.getValue());
+          }
+          break;
+        case COUNTER:
+          emitter.increment(metric.getValue());
+          break;
+        default:
+          throw new IllegalArgumentException(
+              String.format("Can't aggregate metric type %s",
+                  metric.getType()));
+      }
+    }
+
+    public MetricValue emit() {
+      return emitter.emit();
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Cask Data, Inc.
+ * Copyright © 2020-2023 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -30,6 +30,7 @@ import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.GoneException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.RuntimeMonitor;
 import io.cdap.cdap.common.logging.LogSamplers;
 import io.cdap.cdap.common.logging.Loggers;
 import io.cdap.cdap.common.service.AbstractRetryableScheduledService;
@@ -37,6 +38,9 @@ import io.cdap.cdap.common.service.Retries;
 import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.common.service.RetryStrategy;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.internal.io.DatumReaderFactory;
+import io.cdap.cdap.internal.io.DatumWriterFactory;
+import io.cdap.cdap.internal.io.SchemaGenerator;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
 import io.cdap.cdap.messaging.data.MessageId;
@@ -61,16 +65,18 @@ import java.util.function.LongConsumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A service that periodically relay messages from local TMS to the runtime server. This service
- * runs in the remote runtime.
+ * A service that periodically relay messages from local TMS to the runtime
+ * server. This service runs in the remote runtime.
  */
 public class RuntimeClientService extends AbstractRetryableScheduledService {
 
-  private static final Logger LOG = LoggerFactory.getLogger(RuntimeClientService.class);
+  private static final Logger LOG = LoggerFactory.getLogger(
+      RuntimeClientService.class);
   private static final Logger OUTAGE_LOG = Loggers.sampling(
       LOG, LogSamplers.all(LogSamplers.skipFirstN(5),
           LogSamplers.limitRate(TimeUnit.SECONDS.toMillis(30))));
@@ -86,18 +92,28 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
   private final AtomicLong programFinishTime;
 
   @Inject
-  RuntimeClientService(CConfiguration cConf, MessagingService messagingService,
-      RuntimeClient runtimeClient, ProgramRunId programRunId) {
-    super(RetryStrategies.fromConfiguration(cConf, Constants.Service.RUNTIME_MONITOR_RETRY_PREFIX));
+  RuntimeClientService(CConfiguration cConf,
+      MessagingService messagingService,
+      RuntimeClient runtimeClient,
+      ProgramRunId programRunId,
+      SchemaGenerator schemaGenerator,
+      DatumWriterFactory writerFactory,
+      DatumReaderFactory readerFactory) {
+    super(RetryStrategies.fromConfiguration(cConf,
+        Constants.Service.RUNTIME_MONITOR_RETRY_PREFIX));
     this.messagingContext = new MultiThreadMessagingContext(messagingService);
     this.pollTimeMillis = cConf.getLong(Constants.RuntimeMonitor.POLL_TIME_MS);
-    this.gracefulShutdownMillis = cConf.getLong(Constants.RuntimeMonitor.GRACEFUL_SHUTDOWN_MS);
+    this.gracefulShutdownMillis = cConf.getLong(
+        Constants.RuntimeMonitor.GRACEFUL_SHUTDOWN_MS);
     this.programRunId = programRunId;
     this.runtimeClient = runtimeClient;
     this.fetchLimit = cConf.getInt(Constants.RuntimeMonitor.BATCH_SIZE);
     this.programFinishTime = new AtomicLong(-1L);
     this.topicRelayers = RuntimeMonitors.createTopicNameList(cConf)
-        .stream().map(name -> createTopicRelayer(cConf, name)).collect(Collectors.toList());
+        .stream()
+        .map(name -> createTopicRelayer(cConf, name, schemaGenerator,
+            writerFactory, readerFactory))
+        .collect(Collectors.toList());
   }
 
   @Override
@@ -119,7 +135,9 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
       if ((nextPollDelay == pollTimeMillis
           && now - (gracefulShutdownMillis >> 1) > getProgramFinishTime())
           || (now - gracefulShutdownMillis > getProgramFinishTime())) {
-        LOG.debug("Program {} terminated. Shutting down runtime client service.", programRunId);
+        LOG.debug(
+            "Program {} terminated. Shutting down runtime client service.",
+            programRunId);
         stop();
       }
     }
@@ -136,24 +154,27 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
   @Override
   protected void doShutdown() throws Exception {
     // Keep polling until it sees the program completion
-    RetryStrategy retryStrategy = RetryStrategies.timeLimit(gracefulShutdownMillis,
+    RetryStrategy retryStrategy = RetryStrategies.timeLimit(
+        gracefulShutdownMillis,
         TimeUnit.MILLISECONDS,
         getRetryStrategy());
     Retries.runWithRetries(() -> {
-      for (TopicRelayer topicRelayer : topicRelayers) {
-        topicRelayer.prepareClose();
-      }
-      if (getProgramFinishTime() < 0) {
-        throw new RetryableException("Program completion is not yet observed");
-      }
-    }, retryStrategy, t -> t instanceof IOException || t instanceof RetryableException);
+          for (TopicRelayer topicRelayer : topicRelayers) {
+            topicRelayer.prepareClose();
+          }
+          if (getProgramFinishTime() < 0) {
+            throw new RetryableException("Program completion is not yet observed");
+          }
+        }, retryStrategy,
+        t -> t instanceof IOException || t instanceof RetryableException);
 
     // Close all the TopicRelay, which will flush out all pending messages
     for (TopicRelayer topicRelayer : topicRelayers) {
       Retries.callWithRetries((Retries.Callable<Void, IOException>) () -> {
-        topicRelayer.close();
-        return null;
-      }, getRetryStrategy(), t -> t instanceof IOException || t instanceof RetryableException);
+            topicRelayer.close();
+            return null;
+          }, getRetryStrategy(),
+          t -> t instanceof IOException || t instanceof RetryableException);
     }
   }
 
@@ -172,8 +193,8 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
   /**
    * Accepts a Runnable and passes it to RuntimeClient
    *
-   * @param stopper a {@link LongConsumer} with the termination timestamp in seconds as the
-   *     argument
+   * @param stopper a {@link LongConsumer} with the termination timestamp in
+   *                seconds as the argument
    */
   public void onProgramStopRequested(LongConsumer stopper) {
     runtimeClient.onProgramStopRequested(stopper);
@@ -182,14 +203,35 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
   /**
    * Creates an instance of {@link TopicRelayer} based on the topic.
    */
-  private TopicRelayer createTopicRelayer(CConfiguration cConf, String topic) {
+  private TopicRelayer createTopicRelayer(CConfiguration cConf,
+      String topic,
+      SchemaGenerator schemaGenerator,
+      DatumWriterFactory writerFactory,
+      DatumReaderFactory readerFactory) {
     TopicId topicId = NamespaceId.SYSTEM.topic(topic);
 
-    String programStatusTopic = cConf.get(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC);
+    String programStatusTopic = cConf.get(
+        Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC);
     if (topic.matches("^" + Pattern.quote(programStatusTopic) + "[0-9]*$")) {
-      return new ProgramStatusTopicRelayer(topicId);
+      return new ProgramStatusTopicRelayer(topicId, pollTimeMillis);
     }
-    return new TopicRelayer(topicId);
+    String metricsTopic = cConf.get(Constants.Metrics.TOPIC_PREFIX);
+    // If metrics aggregation is enabled, we need a larger poll interval because
+    // polling at a faster rate than the metrics publishing rate will decrease
+    // the benefit of aggregation.
+    if (cConf.getBoolean(Constants.RuntimeMonitor.METRICS_AGGREGATION_ENABLED)
+        &&
+        topic.startsWith(metricsTopic)) {
+      return new TopicRelayer(topicId,
+          cConf.getLong(RuntimeMonitor.METRICS_AGGREGATION_POLL_TIME_MS),
+          new MetricsMessageAggregator(
+              schemaGenerator,
+              writerFactory,
+              readerFactory,
+              cConf.getLong(
+                  Constants.RuntimeMonitor.METRICS_AGGREGATION_WINDOW_SECONDS)));
+    }
+    return new TopicRelayer(topicId, pollTimeMillis, null);
   }
 
   /**
@@ -201,13 +243,17 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
         LogSamplers.limitRate(TimeUnit.SECONDS.toMillis(30)));
 
     protected final TopicId topicId;
+    private final MetricsMessageAggregator messageAggregator;
+    protected final long pollTimeMillis;
     private String lastMessageId;
     private long nextPublishTimeMillis;
     private int totalPublished;
 
-
-    TopicRelayer(TopicId topicId) {
+    TopicRelayer(TopicId topicId, long pollTimeMillis,
+        @Nullable MetricsMessageAggregator messageAggregator) {
+      this.pollTimeMillis = pollTimeMillis;
       this.topicId = topicId;
+      this.messageAggregator = messageAggregator;
     }
 
     public TopicId getTopicId() {
@@ -215,19 +261,21 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
     }
 
     /**
-     * Fetches messages from the {@link MessagingContext} and publish them using {@link
-     * RuntimeClient}.
+     * Fetches messages from the {@link MessagingContext} and publish them using
+     * {@link RuntimeClient}.
      *
      * @return delay in milliseconds till the next poll
-     * @throws TopicNotFoundException if the TMS topic to fetch from does not exist
-     * @throws IOException if failed to read from TMS or write to RuntimeClient
-     * @throws GoneException if run already finished
+     * @throws TopicNotFoundException if the TMS topic to fetch from does not
+     *                                exist
+     * @throws IOException            if failed to read from TMS or write to
+     *                                RuntimeClient
+     * @throws GoneException          if run already finished
      */
     long publishMessages()
         throws TopicNotFoundException, IOException, BadRequestException, GoneException {
       long currentTimeMillis = System.currentTimeMillis();
 
-      // Not too publish more than necessary in one topic.
+      // Not to publish more than necessary in one topic.
       // This method might get called more than once even before the next publish time is hit.
       if (currentTimeMillis < nextPublishTimeMillis) {
         return nextPublishTimeMillis - currentTimeMillis;
@@ -238,16 +286,21 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
               topicId.getTopic(),
               fetchLimit,
               lastMessageId)) {
+        Iterator<Message> messageIterator = iterator;
+        if (messageAggregator != null) {
+          messageIterator = messageAggregator.aggregate(iterator);
+        }
         AtomicInteger messageCount = new AtomicInteger();
-        if (iterator.hasNext()) {
+        if (messageIterator.hasNext()) {
           String[] messageId = new String[1];
+          Iterator<Message> finalMessageIterator = messageIterator;
           processMessages(new AbstractIterator<Message>() {
             @Override
             protected Message computeNext() {
-              if (!iterator.hasNext()) {
+              if (!finalMessageIterator.hasNext()) {
                 return endOfData();
               }
-              Message message = iterator.next();
+              Message message = finalMessageIterator.next();
               messageId[0] = message.getId();
               messageCount.incrementAndGet();
               return message;
@@ -257,7 +310,8 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
           // Update the lastMessageId if sendMessages succeeded
           lastMessageId = messageId[0] == null ? lastMessageId : messageId[0];
           totalPublished += messageCount.get();
-          progressLog.trace("Processed in total {} messages on topic {}", totalPublished, topicId);
+          progressLog.trace("Processed in total {} messages on topic {}",
+              totalPublished, topicId);
         }
 
         // If we fetched all messages, then delay the next poll by pollTimeMillis.
@@ -272,8 +326,8 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
     }
 
     /**
-     * Processes the give list of {@link Message}. By default it sends them through the {@link
-     * RuntimeClient}.
+     * Processes the give list of {@link Message}. By default it sends them
+     * through the {@link RuntimeClient}.
      */
     protected void processMessages(Iterator<Message> iterator)
         throws IOException, BadRequestException, GoneException {
@@ -281,9 +335,10 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
     }
 
     /**
-     * Prepare to close by sending out all messages except final program status.
+     * Prepare to close by sending out all messages except final program
+     * status.
      */
-    public void prepareClose() throws IOException {
+    public void prepareClose() {
       forcePoll();
     }
 
@@ -300,40 +355,45 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
         // Retry on all errors
         Retries.runWithRetries(() -> {
           while (publishMessages() == 0) {
-            LOG.trace("Continue processing final messages for {}", topicId.getTopic());
+            LOG.trace("Continue processing final messages for {}",
+                topicId.getTopic());
           }
         }, getRetryStrategy(), t -> !(t instanceof GoneException));
       } catch (TopicNotFoundException | BadRequestException e) {
         // This shouldn't happen. If it does, it must be some bug in the system and there is no way to recover from it.
         // So just log the cause for debugging.
-        LOG.error("Failed to publish messages on close for topic {}", topicId, e);
+        LOG.error("Failed to publish messages on close for topic {}", topicId,
+            e);
       } catch (GoneException e) {
         LOG.warn(
             "Failed to publish final messages on topic {} since the run is already marked completed",
             topicId, e);
       } catch (Exception e) {
-        LOG.error("Retry exhausted when trying to publish message on close for topic {}", topicId,
+        LOG.error(
+            "Retry exhausted when trying to publish message on close for topic {}",
+            topicId,
             e);
       }
     }
   }
 
   /**
-   * A {@link TopicRelayer} specifically for handling program state events. We need special handling
-   * for program state to delay the relaying of terminal program status to give a grace period for
-   * messages in other topics to send out.
+   * A {@link TopicRelayer} specifically for handling program state events. We
+   * need special handling for program state to delay the relaying of terminal
+   * program status to give a grace period for messages in other topics to send
+   * out.
    */
   private class ProgramStatusTopicRelayer extends TopicRelayer {
 
     private final List<Message> lastProgramStateMessages;
     /**
-     * Tell if program finish was detected by this relayer. In this case we hold off sending final
-     * status messages
+     * Tell if program finish was detected by this relayer. In this case we hold
+     * off sending final status messages
      */
     private boolean detectedProgramFinish;
 
-    ProgramStatusTopicRelayer(TopicId topicId) {
-      super(topicId);
+    ProgramStatusTopicRelayer(TopicId topicId, long pollTimeMillis) {
+      super(topicId, pollTimeMillis, null);
       this.lastProgramStateMessages = new LinkedList<>();
       LOG.trace("Watching for status messages in topic {}", topicId.getTopic());
     }
@@ -341,7 +401,8 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
     @Override
     protected void processMessages(Iterator<Message> iterator)
         throws IOException, BadRequestException, GoneException {
-      List<Message> message = StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0),
+      List<Message> message = StreamSupport.stream(
+              Spliterators.spliteratorUnknownSize(iterator, 0),
               false)
           .collect(Collectors.toList());
 
@@ -349,7 +410,8 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
         long finishTime = findProgramFinishTime(message);
         if (finishTime >= 0) {
           detectedProgramFinish = true;
-          LOG.trace("Detected program {} finish time {} in topic {}", programRunId, finishTime,
+          LOG.trace("Detected program {} finish time {} in topic {}",
+              programRunId, finishTime,
               topicId.getTopic());
         }
         programFinishTime.compareAndSet(-1L, finishTime);
@@ -382,20 +444,24 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
         try {
           LOG.debug("Sending {} program completion messages to {}",
               lastProgramStateMessages.size(), topicId);
-          Retries.runWithRetries(() -> super.processMessages(lastProgramStateMessages.iterator()),
-              getRetryStrategy(), t -> t instanceof IOException || t instanceof RetryableException);
+          Retries.runWithRetries(
+              () -> super.processMessages(lastProgramStateMessages.iterator()),
+              getRetryStrategy(),
+              t -> t instanceof IOException || t instanceof RetryableException);
         } catch (BadRequestException e) {
           // This shouldn't happen. If it does, that means the server thinks this program is no longer running.
           // The best we can do is to log here, even the log won't be collected by CDAP, but it will be retained
           // on the cluster.
-          LOG.warn("Bad request when program state messages to runtime server: {}",
+          LOG.warn(
+              "Bad request when program state messages to runtime server: {}",
               lastProgramStateMessages, e);
         } catch (GoneException e) {
           LOG.warn(
               "Failed to publish program state messages to {} since the run id already marked completed",
               topicId, e);
         } catch (Exception e) {
-          LOG.error("Failed to send program state messages to runtime server: {}",
+          LOG.error(
+              "Failed to send program state messages to runtime server: {}",
               lastProgramStateMessages, e);
         }
         lastProgramStateMessages.clear();
@@ -403,21 +469,24 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
     }
 
     /**
-     * Returns the time where the program finished, meaning it reaches one of the terminal states.
-     * If the given list of {@link Message} doesn't contain such information, {@code -1L} is
-     * returned.
+     * Returns the time where the program finished, meaning it reaches one of
+     * the terminal states. If the given list of {@link Message} doesn't contain
+     * such information, {@code -1L} is returned.
      */
     private long findProgramFinishTime(List<Message> messages) {
       for (Message message : messages) {
         Notification notification = message.decodePayload(
             r -> GSON.fromJson(r, Notification.class));
-        if (notification.getNotificationType() != Notification.Type.PROGRAM_STATUS) {
+        if (notification.getNotificationType()
+            != Notification.Type.PROGRAM_STATUS) {
           continue;
         }
 
         Map<String, String> properties = notification.getProperties();
-        String programRun = properties.get(ProgramOptionConstants.PROGRAM_RUN_ID);
-        String programStatus = properties.get(ProgramOptionConstants.PROGRAM_STATUS);
+        String programRun = properties.get(
+            ProgramOptionConstants.PROGRAM_RUN_ID);
+        String programStatus = properties.get(
+            ProgramOptionConstants.PROGRAM_STATUS);
 
         if (programRun == null || programStatus == null) {
           continue;
@@ -425,17 +494,20 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
 
         // Only match the program state change for the program run it is monitoring
         // For Workflow case, there could be multiple state changes for programs running inside the workflow.
-        ProgramRunId messageRunId = GSON.fromJson(programRun, ProgramRunId.class);
+        ProgramRunId messageRunId = GSON.fromJson(programRun,
+            ProgramRunId.class);
         if (!programRunId.equals(messageRunId)) {
           continue;
         }
 
         if (ProgramRunStatus.isEndState(programStatus)) {
           try {
-            return Long.parseLong(properties.get(ProgramOptionConstants.END_TIME));
+            return Long.parseLong(
+                properties.get(ProgramOptionConstants.END_TIME));
           } catch (Exception e) {
             // END_TIME should be a valid long. In case there is any problem, use the timestamp in the message ID
-            return new MessageId(Bytes.fromHexString(message.getId())).getPublishTimestamp();
+            return new MessageId(
+                Bytes.fromHexString(message.getId())).getPublishTimestamp();
           }
         }
       }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/MetricsMessageAggregatorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/MetricsMessageAggregatorTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2020-2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.common.reflect.TypeToken;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.data.schema.UnsupportedTypeException;
+import io.cdap.cdap.api.messaging.Message;
+import io.cdap.cdap.api.metrics.MetricType;
+import io.cdap.cdap.api.metrics.MetricValues;
+import io.cdap.cdap.common.guice.IOModule;
+import io.cdap.cdap.common.io.BinaryDecoder;
+import io.cdap.cdap.common.io.BinaryEncoder;
+import io.cdap.cdap.common.io.DatumReader;
+import io.cdap.cdap.common.io.DatumWriter;
+import io.cdap.cdap.common.io.Encoder;
+import io.cdap.cdap.common.io.StringCachingDecoder;
+import io.cdap.cdap.common.utils.ResettableByteArrayInputStream;
+import io.cdap.cdap.internal.io.DatumReaderFactory;
+import io.cdap.cdap.internal.io.DatumWriterFactory;
+import io.cdap.cdap.internal.io.SchemaGenerator;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import org.bouncycastle.util.Strings;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link MetricsMessageAggregator}
+ */
+public class MetricsMessageAggregatorTest {
+
+  private MetricsMessageAggregator aggregator;
+  private Injector injector;
+
+  @Before
+  public void beforeTest() {
+    injector = Guice.createInjector(new IOModule());
+    aggregator = new MetricsMessageAggregator(
+        injector.getInstance(SchemaGenerator.class),
+        injector.getInstance(DatumWriterFactory.class),
+        injector.getInstance(DatumReaderFactory.class), 1);
+  }
+
+  @Test
+  public void testAggregateDecodingFailure() throws UnsupportedTypeException {
+    Map<String, String> tags = new HashMap<>();
+    tags.put("key1", "value1");
+    MetricValues metric = new MetricValues(tags, "metric1", 0, 1,
+        MetricType.COUNTER);
+    TypeToken<MetricValues> metricValueType = TypeToken.of(MetricValues.class);
+    Schema schema = injector.getInstance(SchemaGenerator.class)
+        .generate(metricValueType.getType());
+    byte[] encodedMetric = encodeMetricValues(metric,
+        injector.getInstance(DatumWriterFactory.class)
+            .create(TypeToken.of(MetricValues.class), schema));
+    byte[] invalidPayload = "message".getBytes(StandardCharsets.UTF_8);
+
+    Iterator<Message> input = Arrays.asList(new Message[]{
+            getMessage(encodedMetric, "1"),
+            getMessage(encodedMetric, "2"),
+            getMessage(invalidPayload, "3"),
+            getMessage(encodedMetric, "4")})
+        .iterator();
+
+    DatumReader<MetricValues> reader = injector.getInstance(
+            DatumReaderFactory.class)
+        .create(metricValueType, schema);
+    Iterator<Message> result = aggregator.aggregate(input);
+    Message current = result.next();
+    Assert.assertEquals("3", current.getId());
+    Assert.assertEquals(2,
+        decodeMetricValues(current.getPayload(), reader, schema).getMetrics()
+            .iterator().next().getValue());
+
+    current = result.next();
+    Assert.assertEquals("3", current.getId());
+    Assert.assertEquals("message",
+        Strings.fromUTF8ByteArray(current.getPayload()));
+
+    current = result.next();
+    Assert.assertEquals("4", current.getId());
+    Assert.assertEquals(1,
+        decodeMetricValues(current.getPayload(), reader, schema).getMetrics()
+            .iterator().next().getValue());
+    Assert.assertFalse(result.hasNext());
+  }
+
+  private Message getMessage(byte[] payload, String id) {
+    return new Message() {
+      @Override
+      public String getId() {
+        return id;
+      }
+
+      @Override
+      public byte[] getPayload() {
+        return payload;
+      }
+    };
+  }
+
+  public static byte[] encodeMetricValues(MetricValues metricValues,
+      DatumWriter<MetricValues> writer) {
+    ByteArrayOutputStream encOs = new ByteArrayOutputStream(1024);
+    Encoder enc = new BinaryEncoder(encOs);
+    try {
+      writer.encode(metricValues, enc);
+      return encOs.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static MetricValues decodeMetricValues(byte[] bytes,
+      DatumReader<MetricValues> reader, Schema schema) {
+    HashMap<String, String> cachemap = new HashMap<>();
+    ResettableByteArrayInputStream decOs = new ResettableByteArrayInputStream();
+    StringCachingDecoder decoder = new StringCachingDecoder(
+        new BinaryDecoder(decOs), cachemap);
+    decOs.reset(bytes);
+    try {
+      return reader.read(decoder, schema);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 Cask Data, Inc.
+ * Copyright © 2020-2023 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,17 +17,22 @@
 package io.cdap.cdap.internal.app.runtime.monitor;
 
 import com.google.common.base.Throwables;
+import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Service;
 import com.google.gson.Gson;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.api.messaging.Message;
 import io.cdap.cdap.api.messaging.MessageFetcher;
 import io.cdap.cdap.api.messaging.MessagePublisher;
 import io.cdap.cdap.api.messaging.MessagingContext;
+import io.cdap.cdap.api.metrics.MetricType;
+import io.cdap.cdap.api.metrics.MetricValue;
+import io.cdap.cdap.api.metrics.MetricValues;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.guice.RuntimeServerModule;
 import io.cdap.cdap.app.runtime.ProgramStateWriter;
@@ -35,15 +40,22 @@ import io.cdap.cdap.common.GoneException;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.RuntimeMonitor;
 import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
+import io.cdap.cdap.common.io.DatumReader;
+import io.cdap.cdap.common.io.DatumWriter;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.internal.app.program.MessagingProgramStatePublisher;
 import io.cdap.cdap.internal.app.program.MessagingProgramStateWriter;
 import io.cdap.cdap.internal.app.program.ProgramStatePublisher;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.internal.io.DatumReaderFactory;
+import io.cdap.cdap.internal.io.DatumWriterFactory;
+import io.cdap.cdap.internal.io.SchemaGenerator;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
 import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
@@ -54,9 +66,13 @@ import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Spliterators;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -64,6 +80,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.apache.twill.discovery.DiscoveryService;
@@ -85,17 +102,21 @@ public class RuntimeClientServiceTest {
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
   private static final int PROGRAM_STATUS_EVENT_TEST_PARTITIONS = 10;
+  private static final int METRICS_TEST_PARTITIONS = 2;
 
   // The cConf value for the runtime monitor topic configs to have two topics, and one has to be program status event
   // This is for testing the RuntimeClientService handling of program status correctly
   private static final String TOPIC_CONFIGS_VALUE =
-    Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC
-      + "," + Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC + ":" + PROGRAM_STATUS_EVENT_TEST_PARTITIONS
-      + "," + Constants.Metadata.MESSAGING_TOPIC
-      + "," + Constants.Audit.TOPIC;
+      Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC
+          + "," + Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC + ":"
+          + PROGRAM_STATUS_EVENT_TEST_PARTITIONS
+          + "," + Constants.Metadata.MESSAGING_TOPIC
+          + "," + Constants.Metrics.TOPIC_PREFIX + ":" + METRICS_TEST_PARTITIONS
+          + "," + Constants.Audit.TOPIC;
 
   private static final ProgramRunId PROGRAM_RUN_ID =
-    NamespaceId.DEFAULT.app("app").workflow("workflow").run(RunIds.generate());
+      NamespaceId.DEFAULT.app("app").workflow("workflow")
+          .run(RunIds.generate());
   private static final Gson GSON = new Gson();
 
   private List<String> topicNames;
@@ -112,56 +133,63 @@ public class RuntimeClientServiceTest {
   private ProgramStatePublisher clientProgramStatePublisher;
 
   private AtomicBoolean runCompleted = new AtomicBoolean(false);
+  private Injector clientInjector;
 
   @Before
   public void beforeTest() throws Exception {
     CConfiguration cConf = CConfiguration.create();
 
-    cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR,
+        TEMP_FOLDER.newFolder().getAbsolutePath());
     cConf.set(Constants.RuntimeMonitor.TOPICS_CONFIGS, TOPIC_CONFIGS_VALUE);
-    cConf.setInt(Constants.AppFabric.PROGRAM_STATUS_EVENT_NUM_PARTITIONS, PROGRAM_STATUS_EVENT_TEST_PARTITIONS);
+    cConf.setInt(Constants.AppFabric.PROGRAM_STATUS_EVENT_NUM_PARTITIONS,
+        PROGRAM_STATUS_EVENT_TEST_PARTITIONS);
 
     topicNames = RuntimeMonitors.createTopicNameList(cConf);
     Pattern statusTopicRegex = Pattern.compile(
-      "^" + Pattern.quote(cConf.get(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC)) + "[0-9]*$");
+        "^" + Pattern.quote(
+            cConf.get(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC))
+            + "[0-9]*$");
     nonStatusTopicNames = topicNames.stream()
-      .filter(name -> !statusTopicRegex.matcher(name).matches())
-      .collect(Collectors.toList());
+        .filter(name -> !statusTopicRegex.matcher(name).matches())
+        .collect(Collectors.toList());
 
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
 
     // Injector for the server side
     Injector injector = Guice.createInjector(
-      new ConfigModule(cConf),
-      new LocalLocationModule(),
-      new MessagingServerRuntimeModule().getInMemoryModules(),
-      new AuthenticationContextModules().getNoOpModule(),
-      new AuthorizationEnforcementModule().getNoOpModules(),
-      new RuntimeServerModule() {
-        @Override
-        protected void bindRequestValidator() {
-          bind(RuntimeRequestValidator.class).toInstance(
-            (programRunId, request) -> {
-              if (runCompleted.get()) {
-                throw new GoneException();
-              }
-              return new ProgramRunInfo(ProgramRunStatus.RUNNING);
-            });
-        }
+        new ConfigModule(cConf),
+        new LocalLocationModule(),
+        new MessagingServerRuntimeModule().getInMemoryModules(),
+        new AuthenticationContextModules().getNoOpModule(),
+        new AuthorizationEnforcementModule().getNoOpModules(),
+        new RuntimeServerModule() {
+          @Override
+          protected void bindRequestValidator() {
+            bind(RuntimeRequestValidator.class).toInstance(
+                (programRunId, request) -> {
+                  if (runCompleted.get()) {
+                    throw new GoneException();
+                  }
+                  return new ProgramRunInfo(ProgramRunStatus.RUNNING);
+                });
+          }
 
-        @Override
-        protected void bindLogProcessor() {
-          bind(RemoteExecutionLogProcessor.class).toInstance(payloads -> { });
+          @Override
+          protected void bindLogProcessor() {
+            bind(RemoteExecutionLogProcessor.class).toInstance(payloads -> {
+            });
+          }
+        },
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(MetricsCollectionService.class).to(
+                NoOpMetricsCollectionService.class);
+            bind(DiscoveryService.class).toInstance(discoveryService);
+            bind(DiscoveryServiceClient.class).toInstance(discoveryService);
+          }
         }
-      },
-      new AbstractModule() {
-        @Override
-        protected void configure() {
-          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
-          bind(DiscoveryService.class).toInstance(discoveryService);
-          bind(DiscoveryServiceClient.class).toInstance(discoveryService);
-        }
-      }
     );
 
     messagingService = injector.getInstance(MessagingService.class);
@@ -174,9 +202,12 @@ public class RuntimeClientServiceTest {
 
     // Injector for the client side
     clientCConf = CConfiguration.create();
-    clientCConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
-    clientCConf.set(Constants.RuntimeMonitor.TOPICS_CONFIGS, TOPIC_CONFIGS_VALUE);
-    clientCConf.setInt(Constants.AppFabric.PROGRAM_STATUS_EVENT_NUM_PARTITIONS, PROGRAM_STATUS_EVENT_TEST_PARTITIONS);
+    clientCConf.set(Constants.CFG_LOCAL_DATA_DIR,
+        TEMP_FOLDER.newFolder().getAbsolutePath());
+    clientCConf.set(Constants.RuntimeMonitor.TOPICS_CONFIGS,
+        TOPIC_CONFIGS_VALUE);
+    clientCConf.setInt(Constants.AppFabric.PROGRAM_STATUS_EVENT_NUM_PARTITIONS,
+        PROGRAM_STATUS_EVENT_TEST_PARTITIONS);
 
     // Shorten the poll delay and grace period to speed up testing of program terminate state handling
     clientCConf.setLong(Constants.RuntimeMonitor.POLL_TIME_MS, 200);
@@ -184,36 +215,41 @@ public class RuntimeClientServiceTest {
     // Use smaller batch size so that fetches is broken into multiple fetches
     clientCConf.setInt(Constants.RuntimeMonitor.BATCH_SIZE, 1);
 
-    injector = Guice.createInjector(
-      new ConfigModule(clientCConf),
-      RemoteAuthenticatorModules.getNoOpModule(),
-      new MessagingServerRuntimeModule().getInMemoryModules(),
-      new AuthorizationEnforcementModule().getNoOpModules(),
-      new AuthenticationContextModules().getNoOpModule(),
-      new AbstractModule() {
-        @Override
-        protected void configure() {
-          bind(ProgramStatePublisher.class).to(MessagingProgramStatePublisher.class);
-          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
-          bind(DiscoveryService.class).toInstance(discoveryService);
-          bind(DiscoveryServiceClient.class).toInstance(discoveryService);
-          bind(ProgramRunId.class).toInstance(PROGRAM_RUN_ID);
+    clientInjector = Guice.createInjector(
+        new ConfigModule(clientCConf),
+        RemoteAuthenticatorModules.getNoOpModule(),
+        new MessagingServerRuntimeModule().getInMemoryModules(),
+        new AuthorizationEnforcementModule().getNoOpModules(),
+        new AuthenticationContextModules().getNoOpModule(),
+        new IOModule(),
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(ProgramStatePublisher.class).to(
+                MessagingProgramStatePublisher.class);
+            bind(MetricsCollectionService.class).to(
+                NoOpMetricsCollectionService.class);
+            bind(DiscoveryService.class).toInstance(discoveryService);
+            bind(DiscoveryServiceClient.class).toInstance(discoveryService);
+            bind(ProgramRunId.class).toInstance(PROGRAM_RUN_ID);
+          }
         }
-      }
     );
 
-    clientMessagingService = injector.getInstance(MessagingService.class);
+    clientMessagingService = clientInjector.getInstance(MessagingService.class);
     if (clientMessagingService instanceof Service) {
       ((Service) clientMessagingService).startAndWait();
     }
-    clientProgramStatePublisher = injector.getInstance(ProgramStatePublisher.class);
-    runtimeClientService = injector.getInstance(RuntimeClientService.class);
-    runtimeClientService.startAndWait();
+    clientProgramStatePublisher = clientInjector.getInstance(
+        ProgramStatePublisher.class);
   }
 
   @After
   public void afterTest() {
-    runtimeClientService.stopAndWait();
+    if (runtimeClientService != null) {
+      runtimeClientService.stopAndWait();
+    }
+    runtimeClientService = null;
     if (clientMessagingService instanceof Service) {
       ((Service) clientMessagingService).stopAndWait();
     }
@@ -226,83 +262,223 @@ public class RuntimeClientServiceTest {
 
   @Test
   public void testBasicRelay() throws Exception {
+    runtimeClientService = clientInjector.getInstance(
+        RuntimeClientService.class);
+    runtimeClientService.startAndWait();
     // Send some messages to multiple topics in the client side TMS, they should get replicated to the server side TMS.
-    MessagingContext messagingContext = new MultiThreadMessagingContext(clientMessagingService);
+    MessagingContext messagingContext = new MultiThreadMessagingContext(
+        clientMessagingService);
     MessagePublisher messagePublisher = messagingContext.getDirectMessagePublisher();
-    ProgramStateWriter programStateWriter = new MessagingProgramStateWriter(clientProgramStatePublisher);
+    ProgramStateWriter programStateWriter = new MessagingProgramStateWriter(
+        clientProgramStatePublisher);
 
     // For program status event topic, we need to send valid program status event because
     // the RuntimeClientService will decode it to watch for program termination
     programStateWriter.running(PROGRAM_RUN_ID, null);
 
     for (String topic : nonStatusTopicNames) {
-      messagePublisher.publish(NamespaceId.SYSTEM.getNamespace(), topic, "msg" + topic, "msg" + topic);
+      messagePublisher.publish(NamespaceId.SYSTEM.getNamespace(), topic,
+          "msg" + topic, "msg" + topic);
     }
 
     // Extract the program run status from the Notification
-    MessagingContext serverMessagingContext = new MultiThreadMessagingContext(messagingService);
+    MessagingContext serverMessagingContext = new MultiThreadMessagingContext(
+        messagingService);
     waitForStatus(serverMessagingContext, ProgramRunStatus.RUNNING);
 
     for (String topic : nonStatusTopicNames) {
       Tasks.waitFor(Arrays.asList("msg" + topic, "msg" + topic),
-                    () -> fetchMessages(serverMessagingContext, topic, 10, null)
-                      .stream().map(Message::getPayloadAsString).collect(Collectors.toList()),
-                    5, TimeUnit.SECONDS);
+          () -> fetchMessages(serverMessagingContext, topic, 10, null)
+              .stream().map(Message::getPayloadAsString)
+              .collect(Collectors.toList()),
+          5, TimeUnit.SECONDS);
     }
 
     for (String topic : nonStatusTopicNames) {
       Tasks.waitFor(Arrays.asList("msg" + topic, "msg" + topic),
-                    () -> fetchMessages(serverMessagingContext, topic, 10, null)
-                      .stream().map(Message::getPayloadAsString).collect(Collectors.toList()),
-                    5, TimeUnit.SECONDS);
+          () -> fetchMessages(serverMessagingContext, topic, 10, null)
+              .stream().map(Message::getPayloadAsString)
+              .collect(Collectors.toList()),
+          5, TimeUnit.SECONDS);
     }
 
     // Writes a program terminate message to unblock stopping of the client service
     programStateWriter.completed(PROGRAM_RUN_ID);
   }
 
+  @Test
+  public void testRelayWithAggregation() throws Exception {
+    TypeToken<MetricValues> metricValueType = TypeToken.of(MetricValues.class);
+    Schema schema = clientInjector.getInstance(SchemaGenerator.class).generate(
+        metricValueType.getType());
+    // Use larger batch size so that fetches have enough metrics to aggregate.
+    clientCConf.setInt(Constants.RuntimeMonitor.BATCH_SIZE, 10);
+    clientCConf.setBoolean(Constants.RuntimeMonitor.METRICS_AGGREGATION_ENABLED,
+        true);
+    clientCConf.setLong(
+        Constants.RuntimeMonitor.METRICS_AGGREGATION_WINDOW_SECONDS, 10);
+    clientCConf.setLong(RuntimeMonitor.METRICS_AGGREGATION_POLL_TIME_MS, 200);
+
+    runtimeClientService = clientInjector.getInstance(
+        RuntimeClientService.class);
+    runtimeClientService.startAndWait();
+    Map<String, String> tags = new HashMap<>();
+    tags.put("key1", "value1");
+    tags.put("key2", "value2");
+    tags = Collections.unmodifiableMap(tags);
+
+    long aggregationWindowSize = 10;
+    // Metrics will be split into two windows:
+    // 1. [currentTime - windowSize + 1, currentTime]
+    // 2. [currentTime - 2 * windowSize + 1, currentTime - windowSize]
+    long currentTimestamp = System.currentTimeMillis() / 1000;
+    long windowStartTime = currentTimestamp - 2 * aggregationWindowSize + 1;
+
+    MetricValues counter1 = new MetricValues(tags, "metric1",
+        windowStartTime + 2, 1,
+        MetricType.COUNTER);
+    MetricValues counter2 = new MetricValues(tags, "metric1",
+        windowStartTime + 3, 2,
+        MetricType.COUNTER);
+    // counter3 should not be aggregated with other metrics due to the large time difference.
+    MetricValues counter3 = new MetricValues(tags, "metric1", currentTimestamp,
+        1, MetricType.COUNTER);
+
+    MetricValues gauge1 = new MetricValues(tags, "metric2", windowStartTime + 4,
+        1,
+        MetricType.GAUGE);
+    MetricValues gauge2 = new MetricValues(tags, "metric2", windowStartTime + 5,
+        2,
+        MetricType.GAUGE);
+
+    DatumWriter<MetricValues> writer = clientInjector.getInstance(
+        DatumWriterFactory.class).create(metricValueType, schema);
+    List<byte[]> payloads = Stream.of(counter1, counter2, counter3, gauge1,
+            gauge2)
+        .map(
+            (MetricValues m) -> MetricsMessageAggregatorTest.encodeMetricValues(
+                m, writer))
+        .collect(Collectors.toList());
+    String topic = clientCConf.get(Constants.Metrics.TOPIC_PREFIX) + "0";
+
+    MessagingContext messagingContext = new MultiThreadMessagingContext(
+        clientMessagingService);
+    MessagePublisher messagePublisher = messagingContext.getDirectMessagePublisher();
+    messagePublisher.publish(NamespaceId.SYSTEM.getNamespace(), topic,
+        payloads.iterator());
+
+    ProgramStateWriter programStateWriter = new MessagingProgramStateWriter(
+        clientProgramStatePublisher);
+
+    // For program status event topic, we need to send valid program status event because
+    // the RuntimeClientService will decode it to watch for program termination
+    programStateWriter.running(PROGRAM_RUN_ID, null);
+    MessagingContext serverMessagingContext = new MultiThreadMessagingContext(
+        messagingService);
+    waitForStatus(serverMessagingContext, ProgramRunStatus.RUNNING);
+
+    Map<String, String> finalTags = tags;
+    DatumReader<MetricValues> reader = clientInjector.getInstance(
+            DatumReaderFactory.class)
+        .create(metricValueType, schema);
+    Tasks.waitFor(true, () -> {
+      List<MetricValues> metricsList =
+          fetchMessages(serverMessagingContext, topic, 10, null)
+              .stream()
+              .map(
+                  (Message m) -> MetricsMessageAggregatorTest.decodeMetricValues(
+                      m.getPayload(), reader,
+                      schema))
+              .collect(Collectors.toList());
+      try {
+        metricsList.sort(
+            (m1, m2) -> (int) (m1.getTimestamp() - m2.getTimestamp()));
+        Assert.assertEquals(2, metricsList.size());
+        MetricValues metricValues = metricsList.get(0);
+        Assert.assertEquals(metricValues.getTags(), finalTags);
+        List<MetricValue> values = new ArrayList<>(metricValues.getMetrics());
+        Assert.assertEquals(2, values.size());
+        values.sort(Comparator.comparing(MetricValue::getName));
+
+        Assert.assertEquals(3, values.get(0).getValue());
+        Assert.assertEquals(MetricType.COUNTER, values.get(0).getType());
+
+        Assert.assertEquals(2, values.get(1).getValue());
+        Assert.assertEquals(MetricType.GAUGE, values.get(1).getType());
+
+        metricValues = metricsList.get(1);
+        values = new ArrayList<>(metricValues.getMetrics());
+        Assert.assertEquals(metricValues.getTags(), finalTags);
+        Assert.assertEquals(1, values.get(0).getValue());
+        Assert.assertEquals(MetricType.COUNTER, values.get(0).getType());
+        return true;
+      } catch (AssertionError e) {
+        return false;
+      }
+    }, 5, TimeUnit.SECONDS);
+
+    // Writes a program terminate message to unblock stopping of the client service
+    programStateWriter.completed(PROGRAM_RUN_ID);
+  }
+
   /**
-   * Test for {@link RuntimeClientService} that will terminate itself when seeing program completed message.
+   * Test for {@link RuntimeClientService} that will terminate itself when
+   * seeing program completed message.
    */
   @Test
   public void testProgramTerminate() throws Exception {
-    MessagingContext messagingContext = new MultiThreadMessagingContext(clientMessagingService);
+    runtimeClientService = clientInjector.getInstance(
+        RuntimeClientService.class);
+    runtimeClientService.startAndWait();
+    MessagingContext messagingContext = new MultiThreadMessagingContext(
+        clientMessagingService);
     MessagePublisher messagePublisher = messagingContext.getDirectMessagePublisher();
 
-    ProgramStateWriter programStateWriter = new MessagingProgramStateWriter(clientProgramStatePublisher);
+    ProgramStateWriter programStateWriter = new MessagingProgramStateWriter(
+        clientProgramStatePublisher);
 
     // Send a terminate program state first, wait for the service sees the state change,
     // then publish messages to other topics.
     programStateWriter.completed(PROGRAM_RUN_ID);
-    Tasks.waitFor(true, () -> runtimeClientService.getProgramFinishTime() >= 0, 2, TimeUnit.SECONDS);
+    Tasks.waitFor(true, () -> runtimeClientService.getProgramFinishTime() >= 0,
+        2, TimeUnit.SECONDS);
 
     for (String topic : nonStatusTopicNames) {
-      List<String> payloads = Arrays.asList("msg" + topic, "msg" + topic, "msg" + topic);
+      List<String> payloads = Arrays.asList("msg" + topic, "msg" + topic,
+          "msg" + topic);
       messagePublisher.publish(NamespaceId.SYSTEM.getNamespace(), topic,
-                               StandardCharsets.UTF_8, payloads.iterator());
+          StandardCharsets.UTF_8, payloads.iterator());
     }
 
     // The client service should get stopped by itself.
     Tasks.waitFor(Service.State.TERMINATED, () -> runtimeClientService.state(),
-                  clientCConf.getLong(Constants.RuntimeMonitor.GRACEFUL_SHUTDOWN_MS) + 2000, TimeUnit.MILLISECONDS);
+        clientCConf.getLong(Constants.RuntimeMonitor.GRACEFUL_SHUTDOWN_MS)
+            + 2000, TimeUnit.MILLISECONDS);
 
     // All messages should be sent after the runtime client service stopped
-    MessagingContext serverMessagingContext = new MultiThreadMessagingContext(messagingService);
+    MessagingContext serverMessagingContext = new MultiThreadMessagingContext(
+        messagingService);
     for (String topic : nonStatusTopicNames) {
       Tasks.waitFor(Arrays.asList("msg" + topic, "msg" + topic, "msg" + topic),
-                    () -> fetchMessages(serverMessagingContext, topic, 10, null)
-                      .stream().map(Message::getPayloadAsString).collect(Collectors.toList()),
-                    5, TimeUnit.SECONDS);
+          () -> fetchMessages(serverMessagingContext, topic, 10, null)
+              .stream().map(Message::getPayloadAsString)
+              .collect(Collectors.toList()),
+          5, TimeUnit.SECONDS);
     }
     waitForStatus(serverMessagingContext, ProgramRunStatus.COMPLETED);
   }
 
   /**
-   * Test for {@link RuntimeClientService} that will block termination until a program completed mess
+   * Test for {@link RuntimeClientService} that will block termination until a
+   * program completed mess
    */
   @Test(timeout = 10000L)
   public void testRuntimeClientStop() throws Exception {
-    ProgramStateWriter programStateWriter = new MessagingProgramStateWriter(clientProgramStatePublisher);
+    runtimeClientService = clientInjector.getInstance(
+        RuntimeClientService.class);
+    runtimeClientService.startAndWait();
+    ProgramStateWriter programStateWriter = new MessagingProgramStateWriter(
+        clientProgramStatePublisher);
 
     ListenableFuture<Service.State> stopFuture = runtimeClientService.stop();
     try {
@@ -322,14 +498,19 @@ public class RuntimeClientServiceTest {
    */
   @Test(timeout = 10000L)
   public void testExternalStop() throws Exception {
-    ProgramStateWriter programStateWriter = new MessagingProgramStateWriter(clientProgramStatePublisher);
-    MessagingContext messagingContext = new MultiThreadMessagingContext(clientMessagingService);
+    runtimeClientService = clientInjector.getInstance(
+        RuntimeClientService.class);
+    runtimeClientService.startAndWait();
+    ProgramStateWriter programStateWriter = new MessagingProgramStateWriter(
+        clientProgramStatePublisher);
+    MessagingContext messagingContext = new MultiThreadMessagingContext(
+        clientMessagingService);
     MessagePublisher messagePublisher = messagingContext.getDirectMessagePublisher();
 
     //Validate proper topic order as it's important for not to loose messages
     Assert.assertEquals(
-      "Topics must be in proper order to ensure status messages are sent out last",
-      topicNames, runtimeClientService.getTopicNames());
+        "Topics must be in proper order to ensure status messages are sent out last",
+        topicNames, runtimeClientService.getTopicNames());
 
     //Mark run as externally stopped
     runCompleted.set(true);
@@ -337,7 +518,7 @@ public class RuntimeClientServiceTest {
     //Publish a message
     String topic = nonStatusTopicNames.get(0);
     messagePublisher.publish(NamespaceId.SYSTEM.getNamespace(), topic,
-                             "msg1" + topic, "msg2" + topic);
+        "msg1" + topic, "msg2" + topic);
 
     ListenableFuture<Service.State> stopFuture = runtimeClientService.stop();
     try {
@@ -352,32 +533,37 @@ public class RuntimeClientServiceTest {
     stopFuture.get();
   }
 
-  private List<Message> fetchMessages(MessagingContext messagingContext, String topic, int limit,
-                                      @Nullable String lastMessageId) {
+  private List<Message> fetchMessages(MessagingContext messagingContext,
+      String topic, int limit,
+      @Nullable String lastMessageId) {
     try {
       MessageFetcher messageFetcher = messagingContext.getMessageFetcher();
-      try (CloseableIterator<Message> iterator = messageFetcher.fetch(NamespaceId.SYSTEM.getNamespace(),
-                                                                      topic, limit, lastMessageId)) {
-        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false)
-          .collect(Collectors.toList());
+      try (CloseableIterator<Message> iterator = messageFetcher.fetch(
+          NamespaceId.SYSTEM.getNamespace(),
+          topic, limit, lastMessageId)) {
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(iterator, 0), false)
+            .collect(Collectors.toList());
       }
     } catch (Exception e) {
       throw Throwables.propagate(e);
     }
   }
 
-  private void waitForStatus(MessagingContext serverMessagingContext, ProgramRunStatus status)
-    throws TimeoutException, InterruptedException, ExecutionException {
+  private void waitForStatus(MessagingContext serverMessagingContext,
+      ProgramRunStatus status)
+      throws TimeoutException, InterruptedException, ExecutionException {
 
     Tasks.waitFor(Collections.singletonList(status),
-                  () -> topicNames.stream().filter(
-                      topic -> !nonStatusTopicNames.contains(topic)
-                    ).flatMap(topic ->
-                                fetchMessages(serverMessagingContext, topic, 10, null).stream()
-                                  .map(Message::getPayloadAsString)
-                                  .map(s -> GSON.fromJson(s, Notification.class))
-                                  .map(n -> n.getProperties().get(ProgramOptionConstants.PROGRAM_STATUS))
-                                  .map(ProgramRunStatus::valueOf))
-                    .collect(Collectors.toList()), 5, TimeUnit.SECONDS);
+        () -> topicNames.stream().filter(
+                topic -> !nonStatusTopicNames.contains(topic)
+            ).flatMap(topic ->
+                fetchMessages(serverMessagingContext, topic, 10, null).stream()
+                    .map(Message::getPayloadAsString)
+                    .map(s -> GSON.fromJson(s, Notification.class))
+                    .map(n -> n.getProperties()
+                        .get(ProgramOptionConstants.PROGRAM_STATUS))
+                    .map(ProgramRunStatus::valueOf))
+            .collect(Collectors.toList()), 5, TimeUnit.SECONDS);
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1275,6 +1275,11 @@ public final class Constants {
     // Configuration key for the service proxy password. It is only used within a runtime cluster.
     public static final String SERVICE_PROXY_PASSWORD = "app.program.runtime.service.proxy.password";
     public static final String SERVICE_PROXY_PASSWORD_FILE = "cdap.service.proxy.secret";
+    public static final String METRICS_AGGREGATION_ENABLED = "app.program.runtime.monitor.metrics.aggregation.enabled";
+    public static final String METRICS_AGGREGATION_WINDOW_SECONDS =
+        "app.program.runtime.monitor.metrics.aggregation.window.secs";
+    public static final String  METRICS_AGGREGATION_POLL_TIME_MS =
+        "app.program.runtime.monitor.metrics.aggregation.polltime.ms";
   }
 
   /**

--- a/cdap-common/src/main/java/io/cdap/cdap/common/utils/ResettableByteArrayInputStream.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/utils/ResettableByteArrayInputStream.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.utils;
+
+import io.cdap.cdap.api.common.Bytes;
+import java.io.ByteArrayInputStream;
+
+/**
+ * A {@link ByteArrayInputStream} that can reset its byte buffer.
+ */
+public class ResettableByteArrayInputStream extends ByteArrayInputStream {
+
+  public ResettableByteArrayInputStream() {
+    super(Bytes.EMPTY_BYTE_ARRAY);
+  }
+
+  /**
+   * Sets the buffer and resets internal counters.
+   *
+   * @param buf the new buffer
+   */
+  public void reset(byte[] buf) {
+    this.buf = buf;
+    this.pos = 0;
+    this.count = buf.length;
+    this.mark = 0;
+  }
+}

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3190,6 +3190,32 @@
     </description>
   </property>
 
+  <property>
+    <name>app.program.runtime.monitor.metrics.aggregation.enabled</name>
+    <value>false</value>
+    <description>
+      Whether to enable metrics aggregation in runtime client service.
+    </description>
+  </property>
+
+  <property>
+    <name>app.program.runtime.monitor.metrics.aggregation.window.secs</name>
+    <value>5</value>
+    <description>
+      When metrics aggregation in runtime client service is enabled, this property controls the max time difference
+      between two metrics which can be aggregated.
+    </description>
+  </property>
+
+  <property>
+    <name>app.program.runtime.monitor.metrics.aggregation.polltime.ms</name>
+    <value>5000</value>
+    <description>
+      Polling time in milliseconds to poll updates from a runtime when metrics aggregation is enabled.
+      This enables setting longer poll intervals to have better aggregation of metrics.
+    </description>
+  </property>
+
   <!-- Operational Statistics Configuration -->
 
   <property>

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/collect/AggregatedMetricsEmitter.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/collect/AggregatedMetricsEmitter.java
@@ -24,8 +24,7 @@ import org.slf4j.LoggerFactory;
  * {@link MetricsEmitter} that aggregates  values for a metric during collection and emit the
  * aggregated value when emit.
  */
-final class AggregatedMetricsEmitter implements MetricsEmitter {
-
+public final class AggregatedMetricsEmitter implements MetricsEmitter {
   private static final Logger LOG = LoggerFactory.getLogger(AggregatedMetricsEmitter.class);
 
   private final String name;
@@ -34,7 +33,7 @@ final class AggregatedMetricsEmitter implements MetricsEmitter {
   private MetricType metricType = MetricType.COUNTER;
   private Distribution distribution;
 
-  AggregatedMetricsEmitter(String name) {
+  public AggregatedMetricsEmitter(String name) {
     if (name == null || name.isEmpty()) {
       LOG.warn("Creating emmitter with " + (name == null ? "null" : "empty") + " name, ");
     }


### PR DESCRIPTION
[CDAP-20436](https://cdap.atlassian.net/browse/CDAP-20436)

This change adds an option to aggregate metrics messages in RuntimeClientService that runs in the remote cluster. This option is turned off by default. The aggregation aims at reducing the metrics with duplicate tags and names emitted by multiple spark executors. This makes the number of metrics emitted by a CDAP application independent of the number of spark executors.

This change also enables setting separate TMS poling intervals for metrics/non-metrics topic relayers. This is done to increase aggregation efficiency because metrics are published by processes every 5 seconds by default and TopicRelayers poll TMS every 2 seconds. TopicRelayers for non-metrics topic (eg: Logs, program status events) continue to poll at normal intervals.

[CDAP-20436]: https://cdap.atlassian.net/browse/CDAP-20436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ