### PR TITLE
Add default language capability to relational transform context

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/StandardSQLCapabilities.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/engine/sql/StandardSQLCapabilities.java
@@ -19,15 +19,24 @@ package io.cdap.cdap.etl.api.engine.sql;
 import io.cdap.cdap.etl.api.relational.Capability;
 
 /**
- * Defines capabilities for SQL Engine factories
+ * Defines capabilities for SQL Engine factories.
  */
+@SuppressWarnings({"abbreviationAsWordInName"})
 public enum StandardSQLCapabilities implements Capability {
   /**
-   * Defines that factory implements SQL92 language
+   * Defines that factory implements SQL92 language.
    */
   SQL92,
   /**
-   * Defines that factory implements support for BigQuery specific language
+   * Defines that factory implements support for BigQuery specific language.
    */
-  BIGQUERY
+  BIGQUERY,
+  /**
+   * Defines that factory implements support for Postgres SQL dialect.
+   */
+  POSTGRES,
+  /**
+   * Defines that factory implements support for Spark SQL dialect.
+   */
+  SPARK
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/RelationalTranformContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/RelationalTranformContext.java
@@ -18,32 +18,39 @@ package io.cdap.cdap.etl.api.relational;
 
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.feature.FeatureFlagsProvider;
+import java.util.Collection;
 import java.util.Set;
 
 /**
  * This interface provides sql engine, input relation(s) and a way to set tranformation results to a
- * {@link RelationalTransform#transform(RelationalTranformContext)} call
+ * {@link RelationalTransform#transform(RelationalTranformContext)} call.
  */
 public interface RelationalTranformContext extends FeatureFlagsProvider {
 
   /**
-   * @return relational engine to be used for tranformation
+   * Gets the relational engine to be used for the transformation.
+   *
+   * @return relational engine to be used for transformation
    */
   Engine getEngine();
 
   /**
+   * Gets the relation corresponding to the given input.
+   *
    * @param inputStage input name
    * @return relation corresponding to the given input
    */
   Relation getInputRelation(String inputStage);
 
   /**
+   * Gets the set of all relation names in the input.
+   *
    * @return set of all input relation names
    */
   Set<String> getInputRelationNames();
 
   /**
-   * Gets schema for input stage
+   * Gets schema for input stage.
    *
    * @param inputStage input name
    * @return relation corresponding to the given input
@@ -51,19 +58,35 @@ public interface RelationalTranformContext extends FeatureFlagsProvider {
   Schema getInputSchema(String inputStage);
 
   /**
-   * Gets the output schema for this transform context
+   * Gets the output schema for this transform context.
    *
    * @return output schema
    */
   Schema getOutputSchema();
 
   /**
-   * sets the primary output relation for the transform
+   * Sets the primary output relation for the transform.
+   *
+   * @param outputRelation the output relation
    */
   void setOutputRelation(Relation outputRelation);
 
   /**
+   * Sets the output relation corresponding to an output stage.
    *
+   * @param portName name of output stage
+   * @param outputDataSet output relation
    */
   void setOutputRelation(String portName, Relation outputDataSet);
+
+  /**
+   * Provides a list of capabilities that plugins must use to locate an ExpressionFactory to parse user-entered
+   * expressions.
+   *
+   * @return the list of languages supported by default as a list of {@link Capability}s.
+   */
+  default Collection<Capability> getDefaultLanguageCapabilityList() {
+    throw new UnsupportedOperationException("Default language capabilities are not supported for this relation "
+            + "transform context.");
+  }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BasicRelationalTransformContext.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BasicRelationalTransformContext.java
@@ -18,10 +18,13 @@ package io.cdap.cdap.etl.spark.batch;
 
 import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.api.feature.FeatureFlagsProvider;
+import io.cdap.cdap.etl.api.engine.sql.StandardSQLCapabilities;
+import io.cdap.cdap.etl.api.relational.Capability;
 import io.cdap.cdap.etl.api.relational.Engine;
 import io.cdap.cdap.etl.api.relational.Relation;
 import io.cdap.cdap.etl.api.relational.RelationalTranformContext;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -92,5 +95,9 @@ public class BasicRelationalTransformContext implements RelationalTranformContex
 
   public Relation getOutputRelation() {
     return outputRelation;
+  }
+
+  public Collection<Capability> getDefaultLanguageCapabilityList() {
+    return Collections.singleton(StandardSQLCapabilities.POSTGRES);
   }
 }


### PR DESCRIPTION
This PR adds a way to list default language capabilities for a relational transform context and implements it in `BasicRelationalTransformContext` to return a `POSTGRES` capability. 