### PR TITLE
CDAP-20445 reduce unactionable logging

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/metadata/MetadataConsumerSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/metadata/MetadataConsumerSubscriberService.java
@@ -193,7 +193,6 @@ public class MetadataConsumerSubscriberService extends
       // Intellij would warn here that the condition is always false - because the switch above covers all cases.
       // But if there is ever an unexpected message, we can't throw exception, that would leave the message there.
       if (processor == null) {
-        LOG.warn("Unsupported metadata message type {}. Message ignored.", message.getType());
         continue;
       }
       try {

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTable.java
@@ -71,7 +71,7 @@ public final class NoSqlStructuredTable implements StructuredTable {
 
   private static final Logger LOG = LoggerFactory.getLogger(NoSqlStructuredTable.class);
   private static final Logger LOG_RATE_LIMITED =
-      Loggers.sampling(LOG, LogSamplers.limitRate(TimeUnit.SECONDS.toMillis(10L)));
+      Loggers.sampling(LOG, LogSamplers.limitRate(TimeUnit.MINUTES.toMillis(5L)));
   private final IndexedTable table;
   private final StructuredTableSchema schema;
   private final FieldValidator fieldValidator;


### PR DESCRIPTION
Removed a warning log in MetadataConsumerSubscriberService when reading a message that is not about field lineage, since it is expected behavior and not a problem.

Reduced the frequency of the warning message about nosql performance. When running on nosql, it would fill up the logs, making it difficult to find more valuable information.