### PR TITLE
[CDAP-20431] Cache application_jar in GCS using hash appended name

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RuntimeJobTwillPreparer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RuntimeJobTwillPreparer.java
@@ -20,6 +20,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.Gson;
 import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.utils.HashUtils;
+import io.cdap.cdap.common.utils.ProjectInfo;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.internal.app.runtime.distributed.runtimejob.DefaultRuntimeJobInfo;
 import io.cdap.cdap.proto.id.ProgramRunId;
@@ -44,6 +46,7 @@ import org.apache.twill.api.TwillRunnable;
 import org.apache.twill.api.TwillSpecification;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
+import org.apache.twill.internal.Constants;
 import org.apache.twill.internal.DefaultLocalFile;
 import org.apache.twill.internal.JvmOptions;
 import org.apache.twill.internal.TwillRuntimeSpecification;
@@ -63,77 +66,41 @@ class RuntimeJobTwillPreparer extends AbstractRuntimeTwillPreparer {
   private final Map<String, Location> secretFiles;
   private final Supplier<RuntimeJobManager> jobManagerSupplier;
   private final ProgramOptions programOptions;
+  private final boolean artifactsComputeHash;
+  private final boolean artifactsComputeHashSnapshot;
+  private final int artifactsComputeHashTimeBucketDays;
 
-  RuntimeJobTwillPreparer(CConfiguration cConf, Configuration hConf,
-      TwillSpecification twillSpec, ProgramRunId programRunId,
-      ProgramOptions programOptions, Map<String, Location> secretFiles,
-      LocationCache locationCache, LocationFactory locationFactory,
-      TwillControllerFactory controllerFactory, Supplier<RuntimeJobManager> jobManagerSupplier) {
-    super(cConf, hConf, twillSpec, programRunId, programOptions, locationCache, locationFactory,
+  RuntimeJobTwillPreparer(
+      CConfiguration cConf,
+      Configuration hConf,
+      TwillSpecification twillSpec,
+      ProgramRunId programRunId,
+      ProgramOptions programOptions,
+      Map<String, Location> secretFiles,
+      LocationCache locationCache,
+      LocationFactory locationFactory,
+      TwillControllerFactory controllerFactory,
+      Supplier<RuntimeJobManager> jobManagerSupplier) {
+    super(
+        cConf,
+        hConf,
+        twillSpec,
+        programRunId,
+        programOptions,
+        locationCache,
+        locationFactory,
         controllerFactory);
     this.secretFiles = secretFiles;
     this.jobManagerSupplier = jobManagerSupplier;
     this.programOptions = programOptions;
-  }
-
-  @Override
-  protected void launch(TwillRuntimeSpecification twillRuntimeSpec,
-      RuntimeSpecification runtimeSpec,
-      JvmOptions jvmOptions, Map<String, String> environments, Map<String, LocalFile> localFiles,
-      TimeoutChecker timeoutChecker) throws Exception {
-    try (RuntimeJobManager jobManager = jobManagerSupplier.get()) {
-      timeoutChecker.throwIfTimeout();
-      Map<String, LocalFile> localizeFiles = new HashMap<>(localFiles);
-      for (Map.Entry<String, Location> secretFile : secretFiles.entrySet()) {
-        Location secretFileLocation = secretFile.getValue();
-        localizeFiles.put(secretFile.getKey(),
-            new DefaultLocalFile(secretFile.getKey(),
-                secretFileLocation.toURI(),
-                secretFileLocation.lastModified(),
-                secretFileLocation.length(),
-                false, null));
-      }
-
-      RuntimeJobInfo runtimeJobInfo = createRuntimeJobInfo(runtimeSpec, localizeFiles,
-          jvmOptions.getRunnableExtraOptions(runtimeSpec.getName()));
-      LOG.info("Starting runnable {} for runId {} with job manager.", runtimeSpec.getName(),
-          getProgramRunId());
-      // launch job using job manager
-      jobManager.launch(runtimeJobInfo);
-    }
-  }
-
-  private RuntimeJobInfo createRuntimeJobInfo(RuntimeSpecification runtimeSpec,
-      Map<String, LocalFile> localFiles, String jvmOpts) {
-
-    Map<String, String> jvmProperties = parseJvmProperties(jvmOpts);
-    LOG.info("JVM properties {}", jvmProperties);
-
-    Collection<? extends LocalFile> files =
-        Stream.concat(localFiles.values().stream(), runtimeSpec.getLocalFiles().stream())
-            .collect(Collectors.toList());
-
-    Collection<LocalFile> resultingFiles = new ArrayList<>();
-
-    Set<String> cacheableFiles;
-    if (programOptions.getArguments().hasOption(ProgramOptionConstants.CACHEABLE_FILES)) {
-      cacheableFiles =
-          GSON.fromJson(
-              programOptions.getArguments().getOption(ProgramOptionConstants.CACHEABLE_FILES),
-              Set.class);
-    } else {
-      cacheableFiles = new HashSet<>();
-    }
-
-    for (LocalFile f : files) {
-      if (!cacheableFiles.contains(f.getName())) {
-        resultingFiles.add(f);
-      } else {
-        resultingFiles.add(new CacheableLocalFile(f));
-      }
-    }
-
-    return new DefaultRuntimeJobInfo(getProgramRunId(), resultingFiles, jvmProperties);
+    this.artifactsComputeHash =
+        cConf.getBoolean(io.cdap.cdap.common.conf.Constants.AppFabric.ARTIFACTS_COMPUTE_HASH);
+    this.artifactsComputeHashSnapshot =
+        cConf.getBoolean(
+            io.cdap.cdap.common.conf.Constants.AppFabric.ARTIFACTS_COMPUTE_HASH_SNAPSHOT);
+    this.artifactsComputeHashTimeBucketDays =
+        cConf.getInt(
+            io.cdap.cdap.common.conf.Constants.AppFabric.ARTIFACTS_COMPUTE_HASH_TIME_BUCKET_DAYS);
   }
 
   /**
@@ -177,5 +144,100 @@ class RuntimeJobTwillPreparer extends AbstractRuntimeTwillPreparer {
       idx = jvmOpts.indexOf("-D", endIdx);
     }
     return jvmProperties;
+  }
+
+  @Override
+  protected void launch(
+      TwillRuntimeSpecification twillRuntimeSpec,
+      RuntimeSpecification runtimeSpec,
+      JvmOptions jvmOptions,
+      Map<String, String> environments,
+      Map<String, LocalFile> localFiles,
+      TimeoutChecker timeoutChecker)
+      throws Exception {
+    try (RuntimeJobManager jobManager = jobManagerSupplier.get()) {
+      timeoutChecker.throwIfTimeout();
+      Map<String, LocalFile> localizeFiles = new HashMap<>(localFiles);
+      for (Map.Entry<String, Location> secretFile : secretFiles.entrySet()) {
+        Location secretFileLocation = secretFile.getValue();
+        localizeFiles.put(
+            secretFile.getKey(),
+            new DefaultLocalFile(
+                secretFile.getKey(),
+                secretFileLocation.toURI(),
+                secretFileLocation.lastModified(),
+                secretFileLocation.length(),
+                false,
+                null));
+      }
+
+      RuntimeJobInfo runtimeJobInfo =
+          createRuntimeJobInfo(
+              runtimeSpec,
+              localizeFiles,
+              jvmOptions.getRunnableExtraOptions(runtimeSpec.getName()));
+      LOG.info(
+          "Starting runnable {} for runId {} with job manager.",
+          runtimeSpec.getName(),
+          getProgramRunId());
+      // launch job using job manager
+      jobManager.launch(runtimeJobInfo);
+    }
+  }
+
+  @Override
+  String getApplicationJarLocalizedName(String hashVal) {
+    ProjectInfo.Version cdapVersion = ProjectInfo.getVersion();
+    String computedHashVal = hashVal;
+    if (artifactsComputeHash && (artifactsComputeHashSnapshot || !cdapVersion.isSnapshot())) {
+      if (artifactsComputeHashTimeBucketDays > 0) {
+        computedHashVal =
+            HashUtils.timeBucketHash(
+                hashVal, artifactsComputeHashTimeBucketDays, System.currentTimeMillis());
+      }
+    }
+    return String.format("application_%s.jar", computedHashVal);
+  }
+
+  private RuntimeJobInfo createRuntimeJobInfo(
+      RuntimeSpecification runtimeSpec, Map<String, LocalFile> localFiles, String jvmOpts) {
+
+    Map<String, String> jvmProperties = parseJvmProperties(jvmOpts);
+    LOG.info("JVM properties {}", jvmProperties);
+    Map<String, String> runtimeJobArguments = new HashMap<>();
+    String applicationJarLocalizedName = localFiles.get(Constants.Files.APPLICATION_JAR).getName();
+    // The applicationJarLocalizedName is passed in runtimeJobArguments will be used by
+    // runtimeJobManager while launching the job so that it can be added in classpath in
+    // runner cluster.
+    runtimeJobArguments.put(Constants.Files.APPLICATION_JAR, applicationJarLocalizedName);
+
+    Collection<? extends LocalFile> files =
+        Stream.concat(localFiles.values().stream(), runtimeSpec.getLocalFiles().stream())
+            .collect(Collectors.toList());
+
+    Collection<LocalFile> resultingFiles = new ArrayList<>();
+
+    Set<String> cacheableFiles;
+    if (programOptions.getArguments().hasOption(ProgramOptionConstants.CACHEABLE_FILES)) {
+      cacheableFiles =
+          GSON.fromJson(
+              programOptions.getArguments().getOption(ProgramOptionConstants.CACHEABLE_FILES),
+              Set.class);
+    } else {
+      cacheableFiles = new HashSet<>();
+    }
+    // Add application jar to cacheable files to reuse it across launches.
+    cacheableFiles.add(applicationJarLocalizedName);
+
+    for (LocalFile f : files) {
+      if (!cacheableFiles.contains(f.getName())) {
+        resultingFiles.add(f);
+      } else {
+        resultingFiles.add(new CacheableLocalFile(f));
+      }
+    }
+
+    return new DefaultRuntimeJobInfo(
+        getProgramRunId(), resultingFiles, jvmProperties, runtimeJobArguments);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJobInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJobInfo.java
@@ -35,18 +35,26 @@ public class DefaultRuntimeJobInfo implements RuntimeJobInfo {
   private final Collection<? extends LocalFile> files;
   private final Map<String, String> jvmProperties;
 
+  private final Map<String, String> arguments;
+
 
   public DefaultRuntimeJobInfo(ProgramRunId programRunId, Collection<? extends LocalFile> files,
       Map<String, String> jvmProperties) {
+    this(programRunId, files, jvmProperties, Collections.emptyMap());
+  }
+
+  public DefaultRuntimeJobInfo(ProgramRunId programRunId, Collection<? extends LocalFile> files,
+                               Map<String, String> jvmProperties, Map<String, String> arguments) {
     this.info = new ProgramRunInfo.Builder()
-        .setNamespace(programRunId.getNamespace())
-        .setApplication(programRunId.getApplication())
-        .setVersion(programRunId.getVersion())
-        .setProgramType(programRunId.getType().name())
-        .setProgram(programRunId.getProgram())
-        .setRun(programRunId.getRun()).build();
+      .setNamespace(programRunId.getNamespace())
+      .setApplication(programRunId.getApplication())
+      .setVersion(programRunId.getVersion())
+      .setProgramType(programRunId.getType().name())
+      .setProgram(programRunId.getProgram())
+      .setRun(programRunId.getRun()).build();
     this.files = Collections.unmodifiableCollection(new ArrayList<>(files));
     this.jvmProperties = Collections.unmodifiableMap(new LinkedHashMap<>(jvmProperties));
+    this.arguments = Collections.unmodifiableMap(arguments);
   }
 
   @Override
@@ -67,5 +75,10 @@ public class DefaultRuntimeJobInfo implements RuntimeJobInfo {
   @Override
   public Map<String, String> getJvmProperties() {
     return jvmProperties;
+  }
+
+  @Override
+  public Map<String, String> getArguments() {
+    return arguments;
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/utils/HashUtils.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/utils/HashUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.utils;
+
+import java.util.concurrent.TimeUnit;
+
+/** Utility class for Hash-related operations. */
+public class HashUtils {
+
+  /**
+   * Returns timed bucketed hash value. Therefore, for a given hash, result is identical as long as
+   * call to this method has happened within the given window. This method also uses a jitter based
+   * on provided hash to reduce likelihood of two time bucket with different hashes to be identical.
+   * For a given n as the jitter chosen from 0 to window-1, time bucket windows will be as follows:
+   * [window -n, 2*window -n), [2*window -n , 3*window -n), ... The beginning of an above time
+   * bucket window which currentTime lies in uniquely identifies the time bucket window for the
+   * given hash.
+   *
+   * @param hash value that needs to be time bucketed.
+   * @param window in days
+   * @param currentTime current time in millisecond
+   */
+  public static String timeBucketHash(String hash, int window, long currentTime) {
+    // jitter is used to avoid having identical time bucket windows for different keys
+    long jitter = TimeUnit.DAYS.toMillis(hash.hashCode() % window);
+    long windowMillis = TimeUnit.DAYS.toMillis(window);
+
+    long nextBucket = (currentTime / windowMillis) * windowMillis + windowMillis - jitter;
+    return String.format("%s_%s", hash, nextBucket);
+  }
+}

--- a/cdap-common/src/test/java/io/cdap/cdap/common/utils/HashUtilsTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/utils/HashUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 Cask Data, Inc.
+ * Copyright © 2023 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,15 +14,16 @@
  * the License.
  */
 
-package io.cdap.cdap.internal.app.deploy;
+package io.cdap.cdap.common.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
-import org.junit.Test;
 
-public class InMemoryProgramRunDispatcherTest {
+public class HashUtilsTest {
 
   @Test
   public void testTimeBucketHash() {
@@ -32,8 +33,8 @@ public class InMemoryProgramRunDispatcherTest {
     Set<String> results2 = new HashSet<>();
     long dayInMilliSec = TimeUnit.DAYS.toMillis(1);
     for (int i = 0; i < 15; i++) {
-      results1.add(InMemoryProgramRunDispatcher.timeBucketHash("hash1", window, currentTime + (i * dayInMilliSec)));
-      results2.add(InMemoryProgramRunDispatcher.timeBucketHash("hash2", window, currentTime + (i * dayInMilliSec)));
+      results1.add(HashUtils.timeBucketHash("hash1", window, currentTime + (i * dayInMilliSec)));
+      results2.add(HashUtils.timeBucketHash("hash2", window, currentTime + (i * dayInMilliSec)));
     }
 
     // for 15 days window, we should have maximum 2 time buckets

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocJobMain.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocJobMain.java
@@ -69,6 +69,10 @@ public class DataprocJobMain {
       throw new RuntimeException(
           "Missing --" + SPARK_COMPAT + " argument for the spark compat version");
     }
+    if (!arguments.containsKey(Constants.Files.APPLICATION_JAR)) {
+      throw new RuntimeException(
+        String.format("Missing --%s argument for the application jar name", Constants.Files.APPLICATION_JAR));
+    }
 
     Thread.setDefaultUncaughtExceptionHandler(
         (t, e) -> LOG.error("Uncaught exception from thread {}", t, e));
@@ -86,6 +90,7 @@ public class DataprocJobMain {
 
     String runtimeJobClassName = arguments.get(RUNTIME_JOB_CLASS).iterator().next();
     String sparkCompat = arguments.get(SPARK_COMPAT).iterator().next();
+    String applicationJarLocalizedName = arguments.get(Constants.Files.APPLICATION_JAR).iterator().next();
 
     ClassLoader cl = DataprocJobMain.class.getClassLoader();
     if (!(cl instanceof URLClassLoader)) {
@@ -94,7 +99,7 @@ public class DataprocJobMain {
 
     // create classpath from resources, application and twill jars
     URL[] urls = getClasspath((URLClassLoader) cl, Arrays.asList(Constants.Files.RESOURCES_JAR,
-        Constants.Files.APPLICATION_JAR,
+        applicationJarLocalizedName,
         Constants.Files.TWILL_JAR));
     Arrays.stream(urls).forEach(url -> LOG.debug("Classpath URL: {}", url));
 

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobInfo.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobInfo.java
@@ -51,4 +51,11 @@ public interface RuntimeJobInfo {
   default Map<String, String> getJvmProperties() {
     return Collections.emptyMap();
   }
+
+  /**
+   * Returns a set of arguments for process that runs the {@link RuntimeJob}.
+   */
+  default Map<String, String> getArguments() {
+    return Collections.emptyMap();
+  }
 }


### PR DESCRIPTION
Why:
- When we run an `all-action-plugins` pipeline, the `application.jar` does not contain spark jars required by the pipeline which proves that the `application.jar` is not constant throughout the cdap version and can change per pipeline structure.

- Hence, caching it similarly like `artifacts_jar` with time bucket hashing.

- Also added cdap version to the `application.jar` hasher since it calculates the md5 using only class names which can be same in different cdap versions and we can end up using older jar from GCS.

- Passed `applicationJarLocalizedName` in the runtime arguments of `DataprocJob` for it to be accessible in `DataprocJobMain`.

- `RemoteExecutionTwillPreparer` still uses the constant name `application.jar`.