### PR TITLE
[CDAP-20457] KubeTwillPreparer: dont' overwrite global JVM opts

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -204,6 +204,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
   private String workloadIdentityServiceAccount;
   private boolean runtimeCleanupDisabled;
   private String cdapRuntimeNamespace;
+  private StringBuilder globalJvmOptions;
 
   KubeTwillPreparer(MasterEnvironmentContext masterEnvContext, ApiClient apiClient,
       String kubeNamespace,
@@ -262,6 +263,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
         confTTLStr);
     this.workloadIdentityPool = cConf.get(KubeMasterEnvironment.WORKLOAD_IDENTITY_POOL);
     this.cdapRuntimeNamespace = null;
+    this.globalJvmOptions = new StringBuilder();
   }
 
   @Override
@@ -442,9 +444,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
 
   @Override
   public TwillPreparer setJVMOptions(String options) {
-    for (String runnable : runnables) {
-      setJVMOptions(runnable, options);
-    }
+    globalJvmOptions = new StringBuilder(options);
     return this;
   }
 
@@ -456,9 +456,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
 
   @Override
   public TwillPreparer addJVMOptions(String options) {
-    for (String runnable : runnableJVMOptions.keySet()) {
-      runnableJVMOptions.get(runnable).append(JAVA_OPTS_DELIM).append(options);
-    }
+    globalJvmOptions.append(JAVA_OPTS_DELIM).append(options);
     return this;
   }
 
@@ -1251,8 +1249,9 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
     RuntimeSpecification mainRuntimeSpec = getMainRuntimeSpecification(runtimeSpecs);
     String runnableName = mainRuntimeSpec.getName();
     environs.putAll(environments.get(runnableName));
+    String jvmOpts = globalJvmOptions.toString() + JAVA_OPTS_DELIM + runnableJVMOptions.get(runnableName).toString();
     // Add JVM options to environment.
-    environs.put(JAVA_OPTS_KEY, runnableJVMOptions.get(runnableName).toString());
+    environs.put(JAVA_OPTS_KEY, jvmOpts);
     // Add workload identity environment variable if applicable.
     if (workloadIdentityEnabled && WorkloadIdentityUtil.shouldMountWorkloadIdentity(
         cdapInstallNamespace,
@@ -1278,7 +1277,7 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
       // Add all environments for the runnable
       environs.putAll(environments.get(name));
       // Add JVM options to environment.
-      environs.put(JAVA_OPTS_KEY, runnableJVMOptions.get(name).toString());
+      environs.put(JAVA_OPTS_KEY, jvmOpts);
       mounts = addSecreteVolMountIfNeeded(spec, volumeMounts);
       containers.add(
           createContainer(name, podInfo.getContainerImage(), podInfo.getImagePullPolicy(), workDir,


### PR DESCRIPTION
`KubeTwillPreparer` does not handle jvm opts correctly - we should keep track of global options and per-runnable options separately. The global options should be applied to all runnables. See https://github.com/cdapio/twill/blob/v1.2.0/twill-api/src/main/java/org/apache/twill/api/TwillPreparer.java#L78-L111.

This bug in `KubeTwillPreparer` was exposed by #14566 when we added a [setJvmOptions(runnable, options)](https://github.com/cdapio/cdap/pull/14566/files#diff-1d9250edb34f2515d9681c61f8e57ee7e60ce40921f52539a7869be4cde4aaf5R356) in `DistributedProgramRunner`.