### PR TITLE
CDAP-20216: Stop DefaultRuntimeJob in case of failure in any core services +  Don't retry in case of 400/404 error during RuntimeClientService shutdown 

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClient.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClient.java
@@ -23,6 +23,7 @@ import com.google.inject.Inject;
 import io.cdap.cdap.api.messaging.Message;
 import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.GoneException;
+import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.ServiceUnavailableException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
@@ -101,7 +102,7 @@ public class RuntimeClient {
    */
   public void sendMessages(ProgramRunId programRunId,
       TopicId topicId, Iterator<Message> messages)
-      throws IOException, BadRequestException, GoneException {
+      throws IOException, BadRequestException, GoneException, NotFoundException {
 
     if (!NamespaceId.SYSTEM.equals(topicId.getNamespaceId())) {
       throw new IllegalArgumentException("Only topic in the system namespace is supported");
@@ -181,7 +182,7 @@ public class RuntimeClient {
       try (OutputStream os = urlConn.getOutputStream()) {
         Files.copy(eventFile.toPath(), os);
         throwIfError(programRunId, urlConn);
-      } catch (BadRequestException | GoneException e) {
+      } catch (BadRequestException | GoneException | NotFoundException e) {
         // Just treat bad request as IOException since it won't be retriable
         throw new IOException(e);
       }
@@ -226,7 +227,7 @@ public class RuntimeClient {
    * if it is not 200.
    */
   private void throwIfError(ProgramRunId programRunId,
-      HttpURLConnection urlConn) throws IOException, BadRequestException, GoneException {
+      HttpURLConnection urlConn) throws IOException, BadRequestException, GoneException, NotFoundException {
     int responseCode = urlConn.getResponseCode();
     if (responseCode == HttpURLConnection.HTTP_OK) {
       return;
@@ -243,6 +244,8 @@ public class RuntimeClient {
           throw new ServiceUnavailableException(Constants.Service.RUNTIME, errorMsg);
         case HttpURLConnection.HTTP_GONE:
           throw new GoneException(errorMsg);
+        case HttpURLConnection.HTTP_NOT_FOUND:
+          throw new NotFoundException(errorMsg);
       }
 
       throw new IOException(


### PR DESCRIPTION
https://cdap.atlassian.net/browse/CDAP-20216

- **Stop DefaultRuntimeJob in case of failure of any core service** - One example is RuntimeClientService failure when CDAP instance is deleted or in some cases when replication capability is disabled while replication job is running. The Runtime Job keeps running in an orphaned state and consumes resources.
- **Don't retry http 400/404 when RuntimeClientService is shutting down** - RuntimeClientService takes atleast 4 x `system.runtime.monitor.retry.policy.max.time.secs` (1 hour) time to stop. This happens when retries are exhausted after `system.runtime.monitor.retry.policy.max.time.secs`,  [RuntimeClientService.shutdown()](https://github.com/cdapio/cdap/blob/9e01e699c0e111677d0bb6e607b860bba704aac8/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java#L138) takes atleast 3 x system.runtime.monitor.retry.policy.max.time.secs due to retries for closing topic relayers in case of 404 error (cdap instance is deleted) or 400 (run record is deleted). This change is similar to https://github.com/cdapio/cdap/pull/14880 for not retrying GoneException (http 410) when run record is in terminated state.

### Testing
- Checked it's difficult to write unit test for DefaultRuntimeJob.run() in it's current state as it has hardcoded dependency on files being present at relative path on file system (e.g. program.options.json).
- Verified following scenarios
  - Delete cdap instance while replication job is running on Dataproc    
  - Persistently kill runtime service while replication job is running on Dataproc 

### Logs
<details>
  <summary>
    Logs
  </summary>
<code>
2023-03-20 11:09:05,115 - ERROR [RuntimeClientService:i.c.c.i.a.r.d.r.DefaultRuntimeJob@292] - Core service RuntimeClientService [FAILED] failed, prev state RUNNING, terminating program run
java.io.IOException: Failed to send message for program run program_run:default.attpt4runtimefix3.-SNAPSHOT.worker.DeltaWorker.66fdebe3-c70e-11ed-ac4d-a659ba290a46 to https://r-runtime3-sumj-test-cdf-6-8-dot-r.datafusion-dev.googleusercontent.com:443/v3Internal/runtime/namespaces/default/apps/attpt4runtimefix3/versions/-SNAPSHOT/workers/DeltaWorker/runs/66fdebe3-c70e-11ed-ac4d-a659ba290a46/topics/metrics6. Respond code: 502. Error: unknown error
	at io.cdap.cdap.internal.app.runtime.monitor.RuntimeClient.throwIfError(RuntimeClient.java:252)
	at io.cdap.cdap.internal.app.runtime.monitor.RuntimeClient.sendMessages(RuntimeClient.java:130)
	at io.cdap.cdap.internal.app.runtime.monitor.RuntimeClientService$TopicRelayer.processMessages(RuntimeClientService.java:281)
	at io.cdap.cdap.internal.app.runtime.monitor.RuntimeClientService$TopicRelayer.publishMessages(RuntimeClientService.java:245)
	at io.cdap.cdap.internal.app.runtime.monitor.RuntimeClientService.runTask(RuntimeClientService.java:108)
	at io.cdap.cdap.common.service.AbstractRetryableScheduledService.runOneIteration(AbstractRetryableScheduledService.java:167)
	at com.google.common.util.concurrent.AbstractScheduledService$1$1.run(AbstractScheduledService.java:170)
	at com.google.common.util.concurrent.AbstractScheduledService$CustomScheduler$ReschedulableCallable.call(AbstractScheduledService.java:355)
	at com.google.common.util.concurrent.AbstractScheduledService$CustomScheduler$ReschedulableCallable.call(AbstractScheduledService.java:321)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
	Suppressed: io.cdap.cdap.api.retry.RetriesExhaustedException: Retries exhausted after 54 failures and 60755 ms.
		at io.cdap.cdap.common.service.AbstractRetryableScheduledService.runOneIteration(AbstractRetryableScheduledService.java:184)
		... 9 common frames omitted
2023-03-20 11:09:05,294 - ERROR [RuntimeClientService:i.c.c.i.a.r.d.r.DefaultRuntimeJob@295] - Forcefully terminating program run program_run:default.attpt4runtimefix3.-SNAPSHOT.worker.DeltaWorker.66fdebe3-c70e-11ed-ac4d-a659ba290a46
2023-03-20 11:09:05,455 - INFO  [RuntimeClientService:o.a.t.y.YarnTwillController@206] - Killing application worker.default.attpt4runtimefix3.DeltaWorker application_1679289688443_0007
2023-03-20 11:09:51,023 - INFO  [zk-client-EventThread:o.a.t.y.YarnTwillController@231] - Failed to access application worker.default.attpt4runtimefix3.DeltaWorker application_1679289688443_0007 live node in ZK, resort to polling. Failure reason: KeeperErrorCode = NoNode for /instances/dfa126c9-fc27-406f-847a-bcf91177441f
2023-03-20 11:09:51,046 - INFO  [worker.default.attpt4runtimefix3.DeltaWorker-application_1679289688443_0007-yarn-poller:o.a.t.y.YarnTwillController@303] - Yarn application worker.default.attpt4runtimefix3.DeltaWorker application_1679289688443_0007 completed. Shutting down controller.
2023-03-20 11:09:51,068 - INFO  [ STOPPING:i.c.c.i.a.r.d.AbstractTwillProgramController@77] - Twill program terminated: program_run:default.attpt4runtimefix3.-SNAPSHOT.worker.DeltaWorker.66fdebe3-c70e-11ed-ac4d-a659ba290a46, twill runId: dfa126c9-fc27-406f-847a-bcf91177441f, status: KILLED
2023-03-20 11:09:51,125 - DEBUG [main:i.c.c.l.a.LogAppenderInitializer@137] - Stopping log appender TMSLogAppender
2023-03-20 11:09:51,132 - DEBUG [main:i.c.c.i.a.r.d.r.DefaultRuntimeJob@632] - Stopping core service ProfileMetricService [RUNNING]
2023-03-20 11:09:51,135 - DEBUG [main:i.c.c.i.a.r.d.r.DefaultRuntimeJob@632] - Stopping core service RuntimeClientService [FAILED]
2023-03-20 11:09:51,136 - WARN  [main:i.c.c.i.a.r.d.r.DefaultRuntimeJob@636] - Exception raised when stopping service RuntimeClientService [FAILED] during program termination.
com.google.common.util.concurrent.UncheckedExecutionException: java.lang.Exception: Service failed while running
	at com.google.common.util.concurrent.Futures.wrapAndThrowUnchecked(Futures.java:1015)
	at com.google.common.util.concurrent.Futures.getUnchecked(Futures.java:1001)
	at com.google.common.util.concurrent.AbstractService.stopAndWait(AbstractService.java:225)
	at com.google.common.util.concurrent.AbstractScheduledService.stopAndWait(AbstractScheduledService.java:300)
	at io.cdap.cdap.internal.app.runtime.distributed.runtimejob.DefaultRuntimeJob.stopCoreServices(DefaultRuntimeJob.java:634)
	at io.cdap.cdap.internal.app.runtime.distributed.runtimejob.DefaultRuntimeJob.run(DefaultRuntimeJob.java:377)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at io.cdap.cdap.runtime.spi.runtimejob.DataprocJobMain.main(DataprocJobMain.java:142)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.google.cloud.hadoop.services.agent.job.shim.HadoopRunClassShim.main(HadoopRunClassShim.java:19)
Caused by: java.lang.Exception: Service failed while running
	at com.google.common.util.concurrent.AbstractService$1.failed(AbstractService.java:123)
	at com.google.common.util.concurrent.AbstractService$6$1.run(AbstractService.java:444)
	at com.google.common.util.concurrent.MoreExecutors$SameThreadExecutorService.execute(MoreExecutors.java:262)
	at com.google.common.util.concurrent.AbstractService$ListenerExecutorPair.execute(AbstractService.java:470)
	at com.google.common.util.concurrent.AbstractService$6.run(AbstractService.java:442)
	at com.google.common.util.concurrent.AbstractService.executeListeners(AbstractService.java:369)
	at com.google.common.util.concurrent.AbstractService.notifyFailed(AbstractService.java:313)
	at com.google.common.util.concurrent.AbstractScheduledService$1$1.run(AbstractScheduledService.java:178)
	at com.google.common.util.concurrent.AbstractScheduledService$CustomScheduler$ReschedulableCallable.call(AbstractScheduledService.java:355)
	at com.google.common.util.concurrent.AbstractScheduledService$CustomScheduler$ReschedulableCallable.call(AbstractScheduledService.java:321)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.io.IOException: Failed to send message for program run program_run:default.attpt4runtimefix3.-SNAPSHOT.worker.DeltaWorker.66fdebe3-c70e-11ed-ac4d-a659ba290a46 to https://r-runtime3-sumj-test-cdf-6-8-dot-r.datafusion-dev.googleusercontent.com:443/v3Internal/runtime/namespaces/default/apps/attpt4runtimefix3/versions/-SNAPSHOT/workers/DeltaWorker/runs/66fdebe3-c70e-11ed-ac4d-a659ba290a46/topics/metrics6. Respond code: 502. Error: unknown error
	at io.cdap.cdap.internal.app.runtime.monitor.RuntimeClient.throwIfError(RuntimeClient.java:252)
	at io.cdap.cdap.internal.app.runtime.monitor.RuntimeClient.sendMessages(RuntimeClient.java:130)
	at io.cdap.cdap.internal.app.runtime.monitor.RuntimeClientService$TopicRelayer.processMessages(RuntimeClientService.java:281)
	at io.cdap.cdap.internal.app.runtime.monitor.RuntimeClientService$TopicRelayer.publishMessages(RuntimeClientService.java:245)
	at io.cdap.cdap.internal.app.runtime.monitor.RuntimeClientService.runTask(RuntimeClientService.java:108)
	at io.cdap.cdap.common.service.AbstractRetryableScheduledService.runOneIteration(AbstractRetryableScheduledService.java:167)
	at com.google.common.util.concurrent.AbstractScheduledService$1$1.run(AbstractScheduledService.java:170)
	... 8 common frames omitted
	Suppressed: io.cdap.cdap.api.retry.RetriesExhaustedException: Retries exhausted after 54 failures and 60755 ms.
		at io.cdap.cdap.common.service.AbstractRetryableScheduledService.runOneIteration(AbstractRetryableScheduledService.java:184)
		... 9 common frames omitted
2023-03-20 11:09:51,138 - DEBUG [main:i.c.c.i.a.r.d.r.DefaultRuntimeJob@632] - Stopping core service MessagingMetricsCollectionService [RUNNING]
2023-03-20 11:09:51,145 - DEBUG [main:i.c.c.i.a.r.d.r.DefaultRuntimeJob@632] - Stopping core service MessagingHttpService [RUNNING]
2023-03-20 11:09:51,148 - DEBUG [MessagingHttpService STOPPING:i.c.c.i.a.r.d.r.RemoteExecutionDiscoveryService@148] - Update discoverable messaging.service with address messaging.service:0 and payload https://
2023-03-20 11:09:51,149 - INFO  [MessagingHttpService STOPPING:i.c.h.NettyHttpService@258] - Stopping HTTP Service messaging.service
2023-03-20 11:09:51,188 - INFO  [MessagingHttpService STOPPING:i.c.c.m.s.MessagingHttpService@121] - Messaging HTTP server stopped
2023-03-20 11:09:51,189 - DEBUG [main:i.c.c.i.a.r.d.r.DefaultRuntimeJob@632] - Stopping core service CoreMessagingService [RUNNING]
2023-03-20 11:09:51,201 - INFO  [CoreMessagingService STOPPING:i.c.c.m.s.CoreMessagingService@260] - Core Messaging Service stopped
2023-03-20 11:09:51,201 - DEBUG [main:i.c.c.i.a.r.d.r.DefaultRuntimeJob@632] - Stopping core service LogAppenderLoaderService [RUNNING]
2023-03-20 11:09:51,332 INFO runtimejob.DataprocJobMain: Invoking destroy() on io.cdap.cdap.runtime.spi.runtimejob.DataprocRuntimeEnvironment
2023-03-20 11:09:51,356 INFO runtimejob.DataprocJobMain: Runtime job completed.
</code>
</details>
