### PR TITLE
[CDAP-20458] Improve run record monitor

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -563,7 +563,7 @@
 
   <property>
     <name>run.record.monitor.cleanup.interval.seconds</name>
-    <value>300</value>
+    <value>60</value>
     <description>
       Cleanup interval (in seconds) in which run record monitor service cleanup
       logic runs to delete old entries.


### PR DESCRIPTION
This PR improves run record monitor by 

1. Emitting flowcontrol.running metrics when cleanup thread is running
2. Reduces cleanup thread default frequency to 60 second 
3. Improves synchronization block by allowing to emit metrics concurrently to achieve better latency when starting new pipelines 