### PR TITLE
CDAP-20375: Start event publish manager after task worker.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -35,7 +35,6 @@ import io.cdap.cdap.common.metrics.MetricsReporterHook;
 import io.cdap.cdap.common.security.HttpsEnabler;
 import io.cdap.cdap.internal.app.store.AppMetadataStore;
 import io.cdap.cdap.internal.bootstrap.BootstrapService;
-import io.cdap.cdap.internal.events.EventPublishManager;
 import io.cdap.cdap.internal.provision.ProvisioningService;
 import io.cdap.cdap.internal.sysapp.SystemAppManagementService;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -85,7 +84,6 @@ public class AppFabricServer extends AbstractIdleService {
   private final SConfiguration sConf;
   private final boolean sslEnabled;
   private final TransactionRunner transactionRunner;
-  private final EventPublishManager eventPublishManager;
 
   private Cancellable cancelHttpService;
   private Set<HttpHandler> handlers;
@@ -114,7 +112,6 @@ public class AppFabricServer extends AbstractIdleService {
       BootstrapService bootstrapService,
       SystemAppManagementService systemAppManagementService,
       TransactionRunner transactionRunner,
-      EventPublishManager eventPublishManager,
       RunRecordMonitorService runRecordCounterService,
       CommonNettyHttpServiceFactory commonNettyHttpServiceFactory) {
     this.hostname = hostname;
@@ -137,7 +134,6 @@ public class AppFabricServer extends AbstractIdleService {
     this.bootstrapService = bootstrapService;
     this.systemAppManagementService = systemAppManagementService;
     this.transactionRunner = transactionRunner;
-    this.eventPublishManager = eventPublishManager;
     this.runRecordCounterService = runRecordCounterService;
     this.commonNettyHttpServiceFactory = commonNettyHttpServiceFactory;
   }
@@ -162,7 +158,6 @@ public class AppFabricServer extends AbstractIdleService {
             runRecordCorrectorService.start(),
             programRunStatusMonitorService.start(),
             coreSchedulerService.start(),
-            eventPublishManager.start(),
             runRecordCounterService.start()
         )
     ).get();
@@ -218,7 +213,6 @@ public class AppFabricServer extends AbstractIdleService {
     runRecordCorrectorService.stopAndWait();
     programRunStatusMonitorService.stopAndWait();
     provisioningService.stopAndWait();
-    eventPublishManager.stopAndWait();
     runRecordCounterService.stopAndWait();
   }
 

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -78,7 +78,7 @@ import org.apache.twill.zookeeper.ZKClientService;
 public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions> {
 
   /**
-   * Main entry point
+   * Main entry point.
    */
   public static void main(String[] args) throws Exception {
     main(AppFabricServiceMain.class, args);
@@ -133,7 +133,7 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
       List<? super AutoCloseable> closeableResources,
       MasterEnvironment masterEnv, MasterEnvironmentContext masterEnvContext,
       EnvironmentOptions options) {
-    CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    final CConfiguration cConf = injector.getInstance(CConfiguration.class);
     closeableResources.add(injector.getInstance(AccessControllerInstantiator.class));
     services.add(injector.getInstance(OperationalStatsService.class));
     services.add(injector.getInstance(SecureStoreService.class));

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -52,6 +52,7 @@ import io.cdap.cdap.internal.app.namespace.StorageProviderNamespaceAdmin;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.internal.app.worker.TaskWorkerServiceLauncher;
 import io.cdap.cdap.internal.app.worker.system.SystemWorkerServiceLauncher;
+import io.cdap.cdap.internal.events.EventPublishManager;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.messaging.guice.MessagingClientModule;
@@ -164,6 +165,9 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
     if (cConf.getBoolean(SystemWorker.POOL_ENABLE)) {
       services.add(injector.getInstance(SystemWorkerServiceLauncher.class));
     }
+
+    // Event publisher could rely on task workers for token generated for security enabled deployments
+    services.add(injector.getInstance(EventPublishManager.class));
 
     // Adds the master environment tasks
     masterEnv.getTasks()

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -69,6 +69,7 @@ import io.cdap.cdap.gateway.router.RouterModules;
 import io.cdap.cdap.internal.app.runtime.monitor.RuntimeServer;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerService;
+import io.cdap.cdap.internal.events.EventPublishManager;
 import io.cdap.cdap.logging.LoggingUtil;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.framework.LogPipelineLoader;
@@ -153,6 +154,7 @@ public class StandaloneMain {
   private final MetadataStorage metadataStorage;
   private final RuntimeServer runtimeServer;
   private final ArtifactLocalizerService artifactLocalizerService;
+  private final EventPublishManager eventPublishManager;
 
   private ExternalAuthenticationServer externalAuthenticationServer;
 
@@ -184,6 +186,7 @@ public class StandaloneMain {
     runtimeServer = injector.getInstance(RuntimeServer.class);
     cConf.setInt(Constants.ArtifactLocalizer.PORT, 0);
     artifactLocalizerService = injector.getInstance(ArtifactLocalizerService.class);
+    eventPublishManager = injector.getInstance(EventPublishManager.class);
 
     if (cConf.getBoolean(Constants.Transaction.TX_ENABLED)) {
       txService = injector.getInstance(InMemoryTransactionService.class);
@@ -297,6 +300,7 @@ public class StandaloneMain {
     operationalStatsService.startAndWait();
     secureStoreService.startAndWait();
     supportBundleInternalService.startAndWait();
+    eventPublishManager.startAndWait();
 
     String protocol = sslEnabled ? "https" : "http";
     int dashboardPort = sslEnabled
@@ -334,6 +338,7 @@ public class StandaloneMain {
       previewRunnerManager.stopAndWait();
       previewHttpServer.stopAndWait();
       artifactLocalizerService.stopAndWait();
+      eventPublishManager.stopAndWait();
       // app fabric will also stop all programs
       appFabricServer.stopAndWait();
       runtimeServer.stopAndWait();

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -146,7 +146,7 @@ public class StandaloneMain {
   private final OperationalStatsService operationalStatsService;
   private final TwillRunnerService remoteExecutionTwillRunnerService;
   private final MetadataSubscriberService metadataSubscriberService;
-  private final LevelDBTableService levelDBTableService;
+  private final LevelDBTableService levelDbTableService;
   private final SecureStoreService secureStoreService;
   private final SupportBundleInternalService supportBundleInternalService;
   private final PreviewHttpServer previewHttpServer;
@@ -164,7 +164,7 @@ public class StandaloneMain {
 
     injector = Guice.createInjector(modules);
 
-    levelDBTableService = injector.getInstance(LevelDBTableService.class);
+    levelDbTableService = injector.getInstance(LevelDBTableService.class);
     messagingService = injector.getInstance(MessagingService.class);
     accessControllerInstantiator = injector.getInstance(AccessControllerInstantiator.class);
     router = injector.getInstance(NettyRouter.class);
@@ -369,7 +369,7 @@ public class StandaloneMain {
       logAppenderInitializer.close();
       accessControllerInstantiator.close();
       metadataStorage.close();
-      levelDBTableService.close();
+      levelDbTableService.close();
     } catch (Throwable e) {
       halt = true;
       LOG.error("Exception during shutdown", e);
@@ -399,6 +399,12 @@ public class StandaloneMain {
     }
   }
 
+  /**
+   * Main method for standalone instance.
+   *
+   * @param args String args.
+   * @throws Exception Any exception.
+   */
   public static void main(String[] args) throws Exception {
     // Includes logging extension jars as part of the system classpath.
     // It is needed to support custom appenders loaded from those extension jars.
@@ -468,9 +474,9 @@ public class StandaloneMain {
     if (OSDetector.isWindows()) {
       // not set anywhere by the project, expected to be set from IDEs if running from the project instead of sdk
       // hadoop.dll is at cdap-unit-test\src\main\resources\hadoop.dll for some reason
-      String hadoopDLLPath = System.getProperty("hadoop.dll.path");
-      if (hadoopDLLPath != null) {
-        System.load(hadoopDLLPath);
+      String hadoopDllPath = System.getProperty("hadoop.dll.path");
+      if (hadoopDllPath != null) {
+        System.load(hadoopDllPath);
       } else {
         // this is where it is when the standalone sdk is built
         String userDir = System.getProperty("user.dir");


### PR DESCRIPTION
[CDAP-20375](https://cdap.atlassian.net/browse/CDAP-20375) Problem:
For security enabled instances, event publisher extensions need to request a task worker endpoint for token with appropriate access permissions. Starting the event publish manager in the `AppFabricServer` causes the initialization of these extensions to fail since the task workers are started only after `AppFabricServer` finishes starting. 

Fix:
Move the starting of event publish manager after task worker. Event publishers need to retry to account for startup time for task workers.

See https://github.com/cdapio/events-writer-extension/pull/29 for ext changes.

[CDAP-20375]: https://cdap.atlassian.net/browse/CDAP-20375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ