### PR TITLE
CDAP-20114 avoid setting owner refs for user jobs

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -678,7 +678,8 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
   /**
    * Creates a {@link V1ObjectMeta} for the given resource type.
    */
-  private V1ObjectMeta createResourceMetadata(Type resourceType, String runnableName,
+  @VisibleForTesting
+  V1ObjectMeta createResourceMetadata(Type resourceType, String runnableName,
       long startTimeoutMillis,
       boolean runtimeCleanupDisabled) {
     String resourceName = getResourceName(twillSpec.getName(), twillRunId,
@@ -700,8 +701,11 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
           Boolean.TRUE.toString());
     }
 
-    // OwnerReference must be in same namespace as object
-    if (kubeNamespace.equals(programRuntimeNamespace)) {
+    // Only set owner reference if preparing an app in the system namespace.
+    // For user program runs, we don't want owner references. Owner reference will mean that
+    // a deletion of the system worker that launched the run (happens on app-fabric restart)
+    // will cause the k8s job to also be deleted
+    if (isSystemNamespace(cdapRuntimeNamespace) && kubeNamespace.equals(programRuntimeNamespace)) {
       objectMetaBuilder.withOwnerReferences(podInfo.getOwnerReferences());
     }
     return objectMetaBuilder.build();

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
@@ -20,11 +20,15 @@ import io.cdap.cdap.master.environment.k8s.PodInfo;
 import io.cdap.cdap.master.spi.MasterOptionConstants;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentRunnable;
+import io.kubernetes.client.openapi.models.V1Job;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1OwnerReference;
 import io.kubernetes.client.openapi.models.V1PodSecurityContext;
 import io.kubernetes.client.openapi.models.V1ResourceRequirements;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.twill.api.AbstractTwillRunnable;
 import org.apache.twill.api.ResourceSpecification;
@@ -172,6 +176,31 @@ public class KubeTwillPreparerTest {
     V1ResourceRequirements gotResourceRequirements = preparer.createResourceRequirements(resourceSpecification);
     Assert.assertEquals("1", gotResourceRequirements.getRequests().get("cpu").toSuffixedString());
     Assert.assertEquals("100Mi", gotResourceRequirements.getRequests().get("memory").toSuffixedString());
+  }
+
+  @Test
+  public void testOwnerReferencesNotSetOnUserRuns() throws Exception {
+    V1OwnerReference ownerReference = new V1OwnerReference()
+        .apiVersion("apps/v1")
+        .kind("ReplicaSet")
+        .name("system-worker");
+    PodInfo podInfo = new PodInfo("test-pod-name", "test-pod-dir", "test-label-file.txt",
+        "test-name-file.txt", "test-pod-uid", "test-uid-file.txt", "test-namespace-file.txt",
+        "test-pod-namespace", Collections.emptyMap(), Collections.singletonList(ownerReference),
+        "test-pod-service-account", "test-pod-runtime-class",
+        Collections.emptyList(), "test-pod-container-label", "test-pod-container-image",
+        Collections.emptyList(), Collections.emptyList(), new V1PodSecurityContext(),
+        "test-pod-image-pull-policy");
+
+    KubeTwillPreparer preparer = new KubeTwillPreparer(createMasterEnvironmentContext(),
+        null, "default", podInfo, createTwillSpecification(),
+        null, null, null, null, null);
+    Map<String, String> config = new HashMap<>();
+    config.put(MasterOptionConstants.RUNTIME_NAMESPACE, "ns1");
+    preparer.withConfiguration(config);
+
+    V1ObjectMeta objectMeta = preparer.createResourceMetadata(V1Job.class, "runnable", 0, true);
+    Assert.assertNull(objectMeta.getOwnerReferences());
   }
 
   @Test


### PR DESCRIPTION
Don't set owner references for user program runs to avoid deleting those jobs when app-fabric gets restarted.