### PR TITLE
[CDAP-20482] Disable hooks in RepositoryManager

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.internal.provision.ProvisioningService;
 import io.cdap.cdap.internal.sysapp.SystemAppManagementService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
+import io.cdap.cdap.sourcecontrol.operationrunner.SourceControlOperationRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.spi.data.transaction.TxCallable;
@@ -80,6 +81,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final ProvisioningService provisioningService;
   private final BootstrapService bootstrapService;
   private final SystemAppManagementService systemAppManagementService;
+  private final SourceControlOperationRunner sourceControlOperationRunner;
   private final CConfiguration cConf;
   private final SConfiguration sConf;
   private final boolean sslEnabled;
@@ -113,7 +115,8 @@ public class AppFabricServer extends AbstractIdleService {
       SystemAppManagementService systemAppManagementService,
       TransactionRunner transactionRunner,
       RunRecordMonitorService runRecordCounterService,
-      CommonNettyHttpServiceFactory commonNettyHttpServiceFactory) {
+      CommonNettyHttpServiceFactory commonNettyHttpServiceFactory,
+      SourceControlOperationRunner sourceControlOperationRunner) {
     this.hostname = hostname;
     this.discoveryService = discoveryService;
     this.handlers = handlers;
@@ -136,6 +139,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.transactionRunner = transactionRunner;
     this.runRecordCounterService = runRecordCounterService;
     this.commonNettyHttpServiceFactory = commonNettyHttpServiceFactory;
+    this.sourceControlOperationRunner = sourceControlOperationRunner;
   }
 
   /**
@@ -158,7 +162,8 @@ public class AppFabricServer extends AbstractIdleService {
             runRecordCorrectorService.start(),
             programRunStatusMonitorService.start(),
             coreSchedulerService.start(),
-            runRecordCounterService.start()
+            runRecordCounterService.start(),
+            sourceControlOperationRunner.start()
         )
     ).get();
 
@@ -214,6 +219,7 @@ public class AppFabricServer extends AbstractIdleService {
     programRunStatusMonitorService.stopAndWait();
     provisioningService.stopAndWait();
     runRecordCounterService.stopAndWait();
+    sourceControlOperationRunner.stopAndWait();
   }
 
   private Cancellable startHttpService(NettyHttpService httpService) throws Exception {

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/SecureSystemReader.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/SecureSystemReader.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+import org.eclipse.jgit.lib.Config;
+import org.eclipse.jgit.storage.file.FileBasedConfig;
+import org.eclipse.jgit.util.FS;
+import org.eclipse.jgit.util.SystemReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link SystemReader} that disables features and hides properties to ensure
+ * user code isn't executed accidentally.
+ */
+public class SecureSystemReader extends SystemReader {
+
+  private static final String HOSTNAME = "cdap.io";
+  private static final Logger LOG = LoggerFactory.getLogger(
+      SecureSystemReader.class);
+  // ALLOWED_SYSTEM_PROPERTIES stores properties that are essential for git to
+  // work.
+  private static final Set<String> REQUIRED_SYSTEM_PROPERTIES = Collections.singleton(
+      "os.name");
+
+  private final Config gitConfig;
+  private final SystemReader delegate;
+
+  private SecureSystemReader(SystemReader delegate) {
+    this.delegate = delegate;
+    this.gitConfig = new Config();
+    this.gitConfig.setString("core", null, "hooksPath", "/dev/null");
+  }
+
+  @Override
+  public String getHostname() {
+    return HOSTNAME;
+  }
+
+  @Override
+  public String getenv(String s) {
+    return null;
+  }
+
+  @Override
+  public String getProperty(String s) {
+    // Restrict access to environment variables which are used by Git.
+    // Environment variables such as GIT_DIR can be used to make jgit read
+    // configuration from different directories on the file system.
+    // Git uses default values of most properties that can be configured using
+    // environment variables. Values which are required are read through the
+    // delegate.
+    if (REQUIRED_SYSTEM_PROPERTIES.contains(s)) {
+      return delegate.getProperty(s);
+    }
+    return null;
+  }
+
+  @Override
+  public FileBasedConfig openUserConfig(Config config, FS fs) {
+    return new EmptyConfig(gitConfig, null, fs);
+  }
+
+  @Override
+  public FileBasedConfig openSystemConfig(Config config, FS fs) {
+    return new EmptyConfig(gitConfig, null, fs);
+  }
+
+  @Override
+  public FileBasedConfig openJGitConfig(Config config, FS fs) {
+    return new EmptyConfig(gitConfig, null, fs);
+  }
+
+  @Override
+  public long getCurrentTime() {
+    return delegate.getCurrentTime();
+  }
+
+  @Override
+  public int getTimezone(long l) {
+    return delegate.getTimezone(l);
+  }
+
+  /**
+   * Sets a {@link SecureSystemReader} as the {@link SystemReader} used by Jgit.
+   */
+  public static void setAsSystemReader() {
+    SystemReader currentSystemReader = SystemReader.getInstance();
+    if (currentSystemReader instanceof SecureSystemReader) {
+      return;
+    }
+    LOG.info("Setting SecureSystemReader for Git.");
+    SystemReader.setInstance(new SecureSystemReader(currentSystemReader));
+  }
+
+  @VisibleForTesting
+  SystemReader getDelegate() {
+    return delegate;
+  }
+
+  /**
+   * A {@link FileBasedConfig} that can't be updated.
+   */
+  private static class EmptyConfig extends FileBasedConfig {
+
+    EmptyConfig(Config base, File cfgLocation, FS fs) {
+      super(base, cfgLocation, fs);
+    }
+
+    @Override
+    public void load() {
+      // no-op
+    }
+
+    @Override
+    public void save() {
+      // no-op
+    }
+
+    @Override
+    public boolean isOutdated() {
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return "EmptyConfig";
+    }
+  }
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/InMemorySourceControlOperationRunner.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/InMemorySourceControlOperationRunner.java
@@ -16,10 +16,12 @@
 
 package io.cdap.cdap.sourcecontrol.operationrunner;
 
+import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
 import io.cdap.cdap.common.utils.DirUtils;
@@ -31,6 +33,7 @@ import io.cdap.cdap.sourcecontrol.CommitMeta;
 import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
 import io.cdap.cdap.sourcecontrol.RepositoryManager;
 import io.cdap.cdap.sourcecontrol.RepositoryManagerFactory;
+import io.cdap.cdap.sourcecontrol.SecureSystemReader;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileWriter;
@@ -49,7 +52,9 @@ import org.slf4j.LoggerFactory;
  * In-Memory implementation for {@link SourceControlOperationRunner}.
  * Runs all git operation inside calling service.
  */
-public class InMemorySourceControlOperationRunner implements SourceControlOperationRunner {
+@Singleton
+public class InMemorySourceControlOperationRunner extends
+    AbstractIdleService implements SourceControlOperationRunner {
   // Gson for decoding request
   private static final Gson DECODE_GSON =
     new GsonBuilder().registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory()).create();
@@ -259,6 +264,16 @@ public class InMemorySourceControlOperationRunner implements SourceControlOperat
       return Files.isRegularFile(file.toPath(), LinkOption.NOFOLLOW_LINKS) // only allow regular files
           && FileUtils.getExtension(file.getName()).equalsIgnoreCase("json"); // filter json extension
     };
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    SecureSystemReader.setAsSystemReader();
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    // No-op.
   }
 }
 

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunner.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunner.java
@@ -16,8 +16,10 @@
 
 package io.cdap.cdap.sourcecontrol.operationrunner;
 
+import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.inject.Singleton;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.api.service.worker.RemoteExecutionException;
 import io.cdap.cdap.api.service.worker.RemoteTaskException;
@@ -42,7 +44,9 @@ import org.slf4j.LoggerFactory;
  * Remote implementation for {@link SourceControlOperationRunner}.
  * Runs all git operation inside task worker.
  */
-public class RemoteSourceControlOperationRunner implements SourceControlOperationRunner {
+@Singleton
+public class RemoteSourceControlOperationRunner extends
+    AbstractIdleService implements SourceControlOperationRunner {
 
   private static final Gson GSON = new GsonBuilder().create();
 
@@ -163,5 +167,15 @@ public class RemoteSourceControlOperationRunner implements SourceControlOperatio
     if (propagateType.isOfClass(exceptionClass)) {
       throw propagateType.createException(exceptionMessage, cause);
     }
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    // no-op.
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    // no-op.
   }
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/SourceControlOperationRunner.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/SourceControlOperationRunner.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.sourcecontrol.operationrunner;
 
+import com.google.common.util.concurrent.Service;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
 import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
@@ -23,7 +24,7 @@ import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
 /**
  * An interface encapsulating all operations needed for source control management.
  */
-public interface SourceControlOperationRunner {
+public interface SourceControlOperationRunner extends Service {
   /**
    * Push an application config to remote git repository.
    *

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/worker/ListAppsTask.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/worker/ListAppsTask.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.sourcecontrol.worker;
 
 import com.google.gson.Gson;
 import com.google.inject.Inject;
-import io.cdap.cdap.api.service.worker.RunnableTask;
 import io.cdap.cdap.api.service.worker.RunnableTaskContext;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -35,7 +34,7 @@ import org.slf4j.LoggerFactory;
 /**
  * The task that lists applications found in linked repository.
  */
-public class ListAppsTask extends SourceControlTask implements RunnableTask  {
+public class ListAppsTask extends SourceControlTask {
   private static final Gson GSON = new Gson();
   private static final Logger LOG = LoggerFactory.getLogger(ListAppsTask.class);
 
@@ -47,7 +46,7 @@ public class ListAppsTask extends SourceControlTask implements RunnableTask  {
   }
 
   @Override
-  public void run(RunnableTaskContext context) throws IOException, AuthenticationConfigException, NotFoundException {
+  public void doRun(RunnableTaskContext context) throws IOException, AuthenticationConfigException, NotFoundException {
     NamespaceRepository nameSpaceRepository = GSON.fromJson(context.getParam(), NamespaceRepository.class);
 
     LOG.trace("Listing applications for namespace {} in task worker.", nameSpaceRepository.getNamespaceId());

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/worker/PullAppTask.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/worker/PullAppTask.java
@@ -18,22 +18,20 @@ package io.cdap.cdap.sourcecontrol.worker;
 
 import com.google.gson.Gson;
 import com.google.inject.Inject;
-import io.cdap.cdap.api.service.worker.RunnableTask;
 import io.cdap.cdap.api.service.worker.RunnableTaskContext;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
 import io.cdap.cdap.sourcecontrol.operationrunner.PulAppOperationRequest;
 import io.cdap.cdap.sourcecontrol.operationrunner.PullAppResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
-public class PullAppTask extends SourceControlTask implements RunnableTask {
+public class PullAppTask extends SourceControlTask {
   private static final Gson GSON = new Gson();
   private static final Logger LOG = LoggerFactory.getLogger(PullAppTask.class);
 
@@ -45,7 +43,7 @@ public class PullAppTask extends SourceControlTask implements RunnableTask {
   }
 
   @Override
-  public void run(RunnableTaskContext context)
+  public void doRun(RunnableTaskContext context)
     throws AuthenticationConfigException, IOException, NotFoundException {
     PulAppOperationRequest pulAppOperationRequest = GSON.fromJson(context.getParam(), PulAppOperationRequest.class);
 

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/worker/PushAppTask.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/worker/PushAppTask.java
@@ -18,25 +18,23 @@ package io.cdap.cdap.sourcecontrol.worker;
 
 import com.google.gson.Gson;
 import com.google.inject.Inject;
-import io.cdap.cdap.api.service.worker.RunnableTask;
 import io.cdap.cdap.api.service.worker.RunnableTaskContext;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
 import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
 import io.cdap.cdap.sourcecontrol.operationrunner.PushAppOperationRequest;
 import io.cdap.cdap.sourcecontrol.operationrunner.PushAppResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-
 /**
  * The task that pushes an application to linked repository.
  */
-public class PushAppTask extends SourceControlTask implements RunnableTask {
+public class PushAppTask extends SourceControlTask {
 
   private static final Gson GSON = new Gson();
   private static final Logger LOG = LoggerFactory.getLogger(PushAppTask.class);
@@ -49,7 +47,7 @@ public class PushAppTask extends SourceControlTask implements RunnableTask {
   }
 
   @Override
-  public void run(RunnableTaskContext context)
+  public void doRun(RunnableTaskContext context)
     throws AuthenticationConfigException, NoChangesToPushException, IOException {
     PushAppOperationRequest pushAppOperationRequest = GSON.fromJson(context.getParam(), PushAppOperationRequest.class);
 

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/worker/SourceControlTask.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/worker/SourceControlTask.java
@@ -18,6 +18,8 @@ package io.cdap.cdap.sourcecontrol.worker;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import io.cdap.cdap.api.service.worker.RunnableTask;
+import io.cdap.cdap.api.service.worker.RunnableTaskContext;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
@@ -29,9 +31,9 @@ import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 
 /**
- * The abstract class that creates the {@link InMemorySourceControlOperationRunner}
+ * The abstract class that creates the {@link InMemorySourceControlOperationRunner}.
  */
-abstract class SourceControlTask {
+abstract class SourceControlTask implements RunnableTask {
 
   protected final InMemorySourceControlOperationRunner inMemoryOperationRunner;
 
@@ -47,4 +49,12 @@ abstract class SourceControlTask {
     );
     inMemoryOperationRunner = injector.getInstance(InMemorySourceControlOperationRunner.class);
   }
+
+  @Override
+  public void run(RunnableTaskContext context) throws Exception {
+    inMemoryOperationRunner.startAndWait();
+    doRun(context);
+  }
+
+  protected abstract void doRun(RunnableTaskContext context) throws Exception;
 }

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunnerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunnerTest.java
@@ -50,6 +50,7 @@ import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
 import io.cdap.cdap.sourcecontrol.CommitMeta;
 import io.cdap.cdap.sourcecontrol.LocalGitServer;
 import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
+import io.cdap.cdap.sourcecontrol.SecureSystemReader;
 import io.cdap.cdap.sourcecontrol.SourceControlTestBase;
 import io.cdap.http.ChannelPipelineModifier;
 import io.cdap.http.NettyHttpService;
@@ -62,6 +63,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.twill.discovery.InMemoryDiscoveryService;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -130,7 +132,7 @@ public class RemoteSourceControlOperationRunnerTest extends SourceControlTestBas
     FileSecureStoreService fileSecureStoreService = new FileSecureStoreService(cConf, sConf, namespaceClient,
                                                                                FileSecureStoreService.CURRENT_CODEC
                                                                                  .newInstance());
-    
+
     httpService = new CommonNettyHttpServiceBuilder(cConf, "test", new NoOpMetricsCollectionService())
       .setHttpHandlers(
         new TaskWorkerHttpHandlerInternal(cConf, discoveryService, discoveryService, className -> {
@@ -180,6 +182,8 @@ public class RemoteSourceControlOperationRunnerTest extends SourceControlTestBas
       new RemoteSourceControlOperationRunner(cConf, metricsCollectionService, remoteClientFactory);
 
     PushAppResponse pushResponse = operationRunner.push(mockPushContext);
+    // Verify SecureSystemReader is being used.
+    Assert.assertTrue(SystemReader.getInstance() instanceof SecureSystemReader);
 
     // Assert the pushed app in response
     Assert.assertEquals(pushResponse.getName(), mockAppDetails.getName());
@@ -254,6 +258,8 @@ public class RemoteSourceControlOperationRunnerTest extends SourceControlTestBas
     addFileToGit(configFilePath, TEST_APP_SPEC, gitServer);
 
     PullAppResponse<?> response = operationRunner.pull(mockPullRequest);
+    // Verify SecureSystemReader is being used.
+    Assert.assertTrue(SystemReader.getInstance() instanceof SecureSystemReader);
 
     // validate pull response
     AppRequest<?> appRequest = response.getAppRequest();
@@ -326,6 +332,8 @@ public class RemoteSourceControlOperationRunnerTest extends SourceControlTestBas
     addFileToGit(configFile2, TEST_APP_SPEC, gitServer);
 
     RepositoryAppsResponse response = operationRunner.list(testNamespaceRepository);
+    // Verify SecureSystemReader is being used.
+    Assert.assertTrue(SystemReader.getInstance() instanceof SecureSystemReader);
     List<RepositoryApp> apps = response.getApps().stream()
       .sorted(Comparator.comparing(RepositoryApp::getName)).collect(Collectors.toList());
 


### PR DESCRIPTION
# [CDAP-20482](https://cdap.atlassian.net/browse/CDAP-20482)

This change makes RepositoryManager always use a git config provided in a file. The provided git config disables git hooks to prevent accidental execution of git hooks.

[CDAP-20482]: https://cdap.atlassian.net/browse/CDAP-20482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ