### PR TITLE
Add new RunRecordTimeToLiveService

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -75,6 +75,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final ProgramNotificationSubscriberService programNotificationSubscriberService;
   private final ProgramStopSubscriberService programStopSubscriberService;
   private final RunRecordCorrectorService runRecordCorrectorService;
+  private final RunRecordTimeToLiveService runRecordTimeToLiveService;
   private final ProgramRunStatusMonitorService programRunStatusMonitorService;
   private final RunRecordMonitorService runRecordCounterService;
   private final CoreSchedulerService coreSchedulerService;
@@ -116,6 +117,7 @@ public class AppFabricServer extends AbstractIdleService {
       TransactionRunner transactionRunner,
       RunRecordMonitorService runRecordCounterService,
       CommonNettyHttpServiceFactory commonNettyHttpServiceFactory,
+      RunRecordTimeToLiveService runRecordTimeToLiveService,
       SourceControlOperationRunner sourceControlOperationRunner) {
     this.hostname = hostname;
     this.discoveryService = discoveryService;
@@ -138,6 +140,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.systemAppManagementService = systemAppManagementService;
     this.transactionRunner = transactionRunner;
     this.runRecordCounterService = runRecordCounterService;
+    this.runRecordTimeToLiveService = runRecordTimeToLiveService;
     this.commonNettyHttpServiceFactory = commonNettyHttpServiceFactory;
     this.sourceControlOperationRunner = sourceControlOperationRunner;
   }
@@ -163,6 +166,7 @@ public class AppFabricServer extends AbstractIdleService {
             programRunStatusMonitorService.start(),
             coreSchedulerService.start(),
             runRecordCounterService.start(),
+            runRecordTimeToLiveService.start(),
             sourceControlOperationRunner.start()
         )
     ).get();
@@ -219,6 +223,7 @@ public class AppFabricServer extends AbstractIdleService {
     programRunStatusMonitorService.stopAndWait();
     provisioningService.stopAndWait();
     runRecordCounterService.stopAndWait();
+    runRecordTimeToLiveService.stopAndWait();
     sourceControlOperationRunner.stopAndWait();
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/RunRecordTimeToLiveService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/RunRecordTimeToLiveService.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.internal.app.store.AppMetadataStore;
+import io.cdap.cdap.spi.data.transaction.TransactionException;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service which periodically scans the database tables for run records which should be deleted per
+ * the global time to live value.
+ *
+ * <p>Does not run if no TTL is configured or a TTL of 0 is specified.
+ */
+public final class RunRecordTimeToLiveService extends AbstractIdleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RunRecordTimeToLiveService.class);
+
+  private final TransactionRunner transactionRunner;
+  private final boolean isEnabled;
+  private final Duration ttlMaxAge;
+  private final Duration checkFrequency;
+  private final Duration initialDelay;
+  private final Clock clock;
+
+  private ScheduledExecutorService service;
+
+  @Inject
+  RunRecordTimeToLiveService(CConfiguration cConf, TransactionRunner transactionRunner) {
+    // Negative TTLs do not make sense, treat as 0.
+    this.ttlMaxAge =
+        Duration.ofDays(Math.max(cConf.getInt(Constants.AppFabric.RUN_DATA_CLEANUP_TTL_DAYS), 0));
+    this.isEnabled = !this.ttlMaxAge.isZero();
+    // Delay should be at least 1 hour to ensure it isn't infinitely running.
+    this.checkFrequency =
+        Duration.ofHours(
+            Math.max(cConf.getInt(Constants.AppFabric.RUN_DATA_CLEANUP_TTL_FREQUENCY_HOURS), 1));
+    // Negative delays do not make sense, treat as 0.
+    this.initialDelay =
+        Duration.ofMinutes(
+            Math.max(
+                cConf.getInt(Constants.AppFabric.RUN_DATA_CLEANUP_TTL_INITIAL_DELAY_MINUTES), 0));
+
+    this.transactionRunner = transactionRunner;
+    this.clock = Clock.systemUTC();
+  }
+
+  @Override
+  protected void startUp() {
+    if (!isEnabled) {
+      LOG.info("No TTL configured, skipping starting RunRecordTimeToLiveService");
+      return;
+    }
+
+    service =
+        Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder().setNameFormat("Run Record TTL janitor").build());
+
+    service.scheduleAtFixedRate(
+        () -> doCleanup(),
+        initialDelay.getSeconds(),
+        checkFrequency.getSeconds(),
+        TimeUnit.SECONDS);
+  }
+
+  @Override
+  protected void shutDown() {
+    if (!isEnabled) {
+      // no-op because no services were started.
+      return;
+    }
+    LOG.info("Stopping RunRecordTimeToLiveService");
+
+    service.shutdownNow();
+  }
+
+  private void doCleanup() {
+    Instant endDate = Instant.now(clock).minus(ttlMaxAge);
+    LOG.info("Doing scheduled cleanup, deleting all run records before {}", endDate);
+
+    try {
+      transactionRunner.run(
+          context -> {
+            AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
+
+            appMetadataStore.deleteCompletedRunsStartedBefore(endDate);
+          });
+    } catch (TransactionException e) {
+      LOG.error("Failed to clean up old records", e);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -70,6 +70,7 @@ import io.cdap.cdap.store.StoreDefinition;
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.reflect.Type;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1820,6 +1821,18 @@ public class AppMetadataStore {
       }
       return null;
     }
+  }
+
+  /**
+   * Deletes all completed run records with a start time before {@code timeUpperBound}, throwing
+   * {@code IOException} if the delete operation fails.
+   */
+  public void deleteCompletedRunsStartedBefore(Instant timeUpperBound) throws IOException {
+    ImmutableList<Field<?>> keyPrefixFields = ImmutableList.of(
+            Fields.stringField(StoreDefinition.AppMetadataStore.RUN_STATUS, TYPE_RUN_RECORD_COMPLETED));
+
+    getRunRecordsTable()
+        .deleteAll(createRunRecordScanRange(keyPrefixFields, 0L, timeUpperBound.getEpochSecond()));
   }
 
   /**

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -266,6 +266,11 @@ public final class Constants {
       "run.record.monitor.cleanup.interval.seconds";
     public static final String PROGRAM_LAUNCH_THREADS = "app.program.launch.threads";
     public static final String PROGRAM_KILL_THREADS = "app.program.kill.threads";
+    public static final String RUN_DATA_CLEANUP_TTL_DAYS = "app.run.records.ttl.days";
+    public static final String RUN_DATA_CLEANUP_TTL_FREQUENCY_HOURS =
+        "app.run.records.ttl.frequency.hours";
+    public static final String RUN_DATA_CLEANUP_TTL_INITIAL_DELAY_MINUTES =
+        "app.run.records.ttl.initial.delay.minutes";
 
     // A boolean value cConf entry to tell whether a ProgramRunner is running remotely (i.e. not inside app-fabric)
     // This config is not present in the cdap-default.xml as it is only set internally by CDAP.

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -589,6 +589,38 @@
   </property>
 
   <property>
+    <name>app.run.records.ttl.days</name>
+    <value>0</value>
+    <description>
+      Amount of time (in days) to retain run records for old job runs.
+      This TTL is retroactive and applies to all runs regardless of what this
+      value was when the run was started.
+      Zero or negative values will cause run records to be retained indefinitely
+      and disable this feature.
+    </description>
+  </property>
+
+  <property>
+    <name>app.run.records.ttl.frequency.hours</name>
+    <value>12</value>
+    <description>
+      How frequently (in hours) to check for and delete old run records.
+      Will always wait at least 1 hour. This value is ignored if
+      app.run.records.table.ttl.days is set to zero.
+    </description>
+  </property>
+
+  <property>
+    <name>app.run.records.ttl.initial.delay.minutes</name>
+    <value>10</value>
+    <description>
+      How long (in minutes) to wait after initial start to initially scan for
+      old run records to delete. This value is ignored if
+      app.run.records.table.ttl.days is set to zero.
+    </description>
+  </property>
+
+  <property>
     <name>app.program.max.start.seconds</name>
     <value>300</value>
     <description>


### PR DESCRIPTION
 * Adds new periodic task which deletes run records older than a configurable number of days
 * Use cases:
   * Help reduce database growth over time.
   * Implement data retention policies.
 * This service does nothing if the new property `app.run.records.table.ttl.age.days` is unset or set to 0