### PR TITLE
Revert "CDAP-20216: Stop DefaultRuntimeJob in case of failure in any core services +  Don't retry in case of 400/404 error during RuntimeClientService shutdown "

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
@@ -148,7 +148,6 @@ import org.apache.twill.api.TwillRunner;
 import org.apache.twill.common.Threads;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
-import org.apache.twill.internal.ServiceListenerAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.bridge.SLF4JBridgeHandler;
@@ -283,33 +282,6 @@ public class DefaultRuntimeJob implements RuntimeJob {
       try (Program program = createProgram(cConf, programRunner, programDescriptor, programOpts)) {
         ProgramController controller = programRunner.run(program, programOpts);
         controllerFuture.complete(controller);
-
-        // Failure of any core service can leave the program in an orphaned state
-        // One example is RuntimeClientService failure when CDAP instance is deleted
-        // In such situations runtime job should be stopped to free up resources (CDAP-20216)
-        for (Service service : coreServices) {
-          service.addListener(new ServiceListenerAdapter() {
-            @Override
-            public void failed(Service.State from, Throwable failure) {
-              LOG.error("Core service {} failed, prev state {}, terminating program run",
-                        service, from, failure);
-              try {
-                LOG.error("Forcefully terminating program run {}", programRunId);
-                controller.kill();
-              } catch (Exception e) {
-                LOG.error("Error in terminating program run", e);
-                // Fallback in case controller could not be stopped
-                try {
-                  programStateWriter.error(programRunId, failure);
-                } catch (Exception ex) {
-                  LOG.error("Error in updating program state to error", ex);
-                }
-                programCompletion.completeExceptionally(failure);
-              }
-            }
-          }, Threads.SAME_THREAD_EXECUTOR);
-        }
-
         runtimeClientService.onProgramStopRequested(terminateTs -> {
           long timeout = TimeUnit.SECONDS.toMillis(terminateTs - STOP_PROPAGATION_DELAY_SECS)
               - System.currentTimeMillis();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientService.java
@@ -28,7 +28,6 @@ import io.cdap.cdap.api.messaging.TopicNotFoundException;
 import io.cdap.cdap.api.retry.RetryableException;
 import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.GoneException;
-import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.logging.LogSamplers;
@@ -225,7 +224,7 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
      * @throws GoneException if run already finished
      */
     long publishMessages()
-        throws TopicNotFoundException, IOException, BadRequestException, GoneException, NotFoundException {
+        throws TopicNotFoundException, IOException, BadRequestException, GoneException {
       long currentTimeMillis = System.currentTimeMillis();
 
       // Not too publish more than necessary in one topic.
@@ -277,7 +276,7 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
      * RuntimeClient}.
      */
     protected void processMessages(Iterator<Message> iterator)
-        throws IOException, BadRequestException, GoneException, NotFoundException {
+        throws IOException, BadRequestException, GoneException {
       runtimeClient.sendMessages(programRunId, topicId, iterator);
     }
 
@@ -303,8 +302,7 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
           while (publishMessages() == 0) {
             LOG.trace("Continue processing final messages for {}", topicId.getTopic());
           }
-        }, getRetryStrategy(), t -> !(t instanceof GoneException || t instanceof NotFoundException
-          || t instanceof BadRequestException));
+        }, getRetryStrategy(), t -> !(t instanceof GoneException));
       } catch (TopicNotFoundException | BadRequestException e) {
         // This shouldn't happen. If it does, it must be some bug in the system and there is no way to recover from it.
         // So just log the cause for debugging.
@@ -313,9 +311,6 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
         LOG.warn(
             "Failed to publish final messages on topic {} since the run is already marked completed",
             topicId, e);
-      } catch (NotFoundException e) {
-        LOG.error(
-          "Failed to publish final messages on topic {} since the run cannot be found", topicId, e);
       } catch (Exception e) {
         LOG.error("Retry exhausted when trying to publish message on close for topic {}", topicId,
             e);
@@ -345,7 +340,7 @@ public class RuntimeClientService extends AbstractRetryableScheduledService {
 
     @Override
     protected void processMessages(Iterator<Message> iterator)
-        throws IOException, BadRequestException, GoneException, NotFoundException {
+        throws IOException, BadRequestException, GoneException {
       List<Message> message = StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0),
               false)
           .collect(Collectors.toList());


### PR DESCRIPTION
Reverts cdapio/cdap#14994 as the change is targeted for 6.9.1