### PR TITLE
CDAP-20493 remove avro usage in data-pipeline app

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline3_2.12/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline3_2.12/pom.xml
@@ -54,6 +54,10 @@
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-lang3</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkSQLEngine.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SparkSQLEngine.java
@@ -45,7 +45,6 @@ import io.cdap.cdap.etl.spark.batch.relation.SparkSQLExpressionFactory;
 import io.cdap.cdap.etl.spark.batch.relation.SparkSQLPullProducer;
 import io.cdap.cdap.etl.spark.batch.relation.SparkSQLPushConsumer;
 import io.cdap.cdap.etl.spark.batch.relation.SparkSQLRelation;
-import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.spark.sql.Dataset;
@@ -65,7 +64,7 @@ import java.util.stream.Collectors;
  * Spark SQLEngine implementation, where compatible ANSI SQL in the given transformation will
  * run in Spark SQL over a Dataset.
  */
-public class SparkSQLEngine extends BatchSQLEngine<LongWritable, GenericData.Record, StructuredRecord, NullWritable>
+public class SparkSQLEngine extends BatchSQLEngine<Object, Object, Object, Object>
   implements Engine {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkSQLEngine.class);


### PR DESCRIPTION
Remove GenericData from SparkSQLEngine since its not being used anyway. This fixes unit test issues in downstream projects that happen due to classloading conflicts, where the program classloader would define some avro classes that would clash with avro usage in the plugin.