### PR TITLE
[CDAP-20501] Separate netty configs for task worker and system worker

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerService.java
@@ -84,9 +84,9 @@ public class SystemWorkerService extends AbstractIdleService {
             Constants.Service.SYSTEM_WORKER)
         .setHost(cConf.get(Constants.SystemWorker.ADDRESS))
         .setPort(cConf.getInt(Constants.SystemWorker.PORT))
-        .setExecThreadPoolSize(cConf.getInt(Constants.TaskWorker.EXEC_THREADS))
-        .setBossThreadPoolSize(cConf.getInt(Constants.TaskWorker.BOSS_THREADS))
-        .setWorkerThreadPoolSize(cConf.getInt(Constants.TaskWorker.WORKER_THREADS))
+        .setExecThreadPoolSize(cConf.getInt(Constants.SystemWorker.EXEC_THREADS))
+        .setBossThreadPoolSize(cConf.getInt(Constants.SystemWorker.BOSS_THREADS))
+        .setWorkerThreadPoolSize(cConf.getInt(Constants.SystemWorker.WORKER_THREADS))
         .setChannelPipelineModifier(new ChannelPipelineModifier() {
           @Override
           public void modify(ChannelPipeline pipeline) {

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -521,6 +521,9 @@ public final class Constants {
      */
     public static final String ADDRESS = "system.worker.bind.address";
     public static final String PORT = "system.worker.bind.port";
+    public static final String EXEC_THREADS = "system.worker.exec.threads";
+    public static final String BOSS_THREADS = "system.worker.boss.threads";
+    public static final String WORKER_THREADS = "system.worker.worker.threads";
     public static final String REQUEST_LIMIT = "system.worker.request.limit";
     public static final String METRIC_PREFIX = "task.worker.";
   }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5274,6 +5274,30 @@
   </property>
 
   <property>
+    <description>
+      The number of worker threads in the system worker.
+    </description>
+    <name>system.worker.worker.threads</name>
+    <value>${task.worker.worker.threads}</value>
+  </property>
+
+  <property>
+    <description>
+      The number of executor threads for the system worker.
+    </description>
+    <name>system.worker.exec.threads</name>
+    <value>${task.worker.exec.threads}</value>
+  </property>
+
+  <property>
+    <description>
+      The number of boss threads for the system worker.
+    </description>
+    <name>system.worker.boss.threads</name>
+    <value>${task.worker.boss.threads}</value>
+  </property>
+
+  <property>
     <name>system.worker.request.limit</name>
     <value>10</value>
     <description>


### PR DESCRIPTION
Why: currently system.worker and task.workers use the same configs to setup their netty. Thus, we cannot tune system.worker configs alone. 
This PR separates the configs so system.worker netty configs can be tuned separately. 