### PR TITLE
Added runtime supports for Java 11 environment

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/ConfigActivator.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/ConfigActivator.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.conf;
+
+import java.util.function.Predicate;
+
+/**
+ * An interface for testing configuration activation.
+ */
+public interface ConfigActivator extends Predicate<String> {
+
+  /**
+   * Returns the name of the activation supported by this {@link ConfigActivator}.
+   */
+  String getActivationName();
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/JavaVersionConfigActivator.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/JavaVersionConfigActivator.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.conf;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * This class is copied from the {@code JdkVersionProfileActivator} class in the
+ * <a href="https://github.com/apache/maven">Maven repo</a>
+ * for configuration activation based on java version.
+ */
+public final class JavaVersionConfigActivator implements ConfigActivator {
+
+  private static final Pattern FILTER_1 = Pattern.compile("[^\\d._-]");
+  private static final Pattern FILTER_2 = Pattern.compile("[._-]");
+  private static final Pattern FILTER_3 = Pattern.compile("\\."); // used for split now
+
+
+  @Override
+  public boolean test(String value) {
+    return isJavaVersionCompatible(value, System.getProperty("java.version"));
+  }
+
+  @Override
+  public String getActivationName() {
+    return "jdk";
+  }
+
+  private static boolean isJavaVersionCompatible(String requiredJdkRange,
+      String currentJavaVersion) {
+    if (requiredJdkRange.startsWith("!")) {
+      return !currentJavaVersion.startsWith(requiredJdkRange.substring(1));
+    } else if (isRange(requiredJdkRange)) {
+      return isInRange(currentJavaVersion, getRange(requiredJdkRange));
+    } else {
+      return currentJavaVersion.startsWith(requiredJdkRange);
+    }
+  }
+
+  private static boolean isRange(String value) {
+    return value.startsWith("[") || value.startsWith("(");
+  }
+
+  private static boolean isInRange(String value, List<RangeValue> range) {
+    int leftRelation = getRelationOrder(value, range.get(0), true);
+
+    if (leftRelation == 0) {
+      return true;
+    }
+
+    if (leftRelation < 0) {
+      return false;
+    }
+
+    return getRelationOrder(value, range.get(1), false) <= 0;
+  }
+
+  private static int getRelationOrder(String value, RangeValue rangeValue, boolean isLeft) {
+    if (rangeValue.value.length() <= 0) {
+      return isLeft ? 1 : -1;
+    }
+
+    value = FILTER_1.matcher(value).replaceAll("");
+
+    List<String> valueTokens = new ArrayList<>(Arrays.asList(FILTER_2.split(value)));
+    List<String> rangeValueTokens = new ArrayList<>(
+        Arrays.asList(FILTER_3.split(rangeValue.value)));
+
+    addZeroTokens(valueTokens, 3);
+    addZeroTokens(rangeValueTokens, 3);
+
+    for (int i = 0; i < 3; i++) {
+      int x = Integer.parseInt(valueTokens.get(i));
+      int y = Integer.parseInt(rangeValueTokens.get(i));
+      if (x < y) {
+        return -1;
+      } else if (x > y) {
+        return 1;
+      }
+    }
+    if (!rangeValue.closed) {
+      return isLeft ? -1 : 1;
+    }
+    return 0;
+  }
+
+  private static void addZeroTokens(List<String> tokens, int max) {
+    while (tokens.size() < max) {
+      tokens.add("0");
+    }
+  }
+
+  private static List<RangeValue> getRange(String range) {
+    List<RangeValue> ranges = new ArrayList<>();
+
+    for (String token : range.split(",")) {
+      if (token.startsWith("[")) {
+        ranges.add(new RangeValue(token.replace("[", ""), true));
+      } else if (token.startsWith("(")) {
+        ranges.add(new RangeValue(token.replace("(", ""), false));
+      } else if (token.endsWith("]")) {
+        ranges.add(new RangeValue(token.replace("]", ""), true));
+      } else if (token.endsWith(")")) {
+        ranges.add(new RangeValue(token.replace(")", ""), false));
+      } else if (token.length() <= 0) {
+        ranges.add(new RangeValue("", false));
+      }
+    }
+    if (ranges.size() < 2) {
+      ranges.add(new RangeValue("99999999", false));
+    }
+    return ranges;
+  }
+
+  private static class RangeValue {
+
+    private final String value;
+    private final boolean closed;
+
+    RangeValue(String value, boolean closed) {
+      this.value = value.trim();
+      this.closed = closed;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/lang/ClassPathResources.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/lang/ClassPathResources.java
@@ -16,23 +16,19 @@
 
 package io.cdap.cdap.common.lang;
 
-import com.google.common.base.Function;
-import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 import io.cdap.cdap.common.internal.guava.ClassPath;
+import io.cdap.cdap.common.internal.guava.ClassPath.ClassInfo;
 import io.cdap.cdap.common.internal.guava.ClassPath.ResourceInfo;
-import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.twill.api.ClassAcceptor;
 import org.apache.twill.internal.utils.Dependencies;
 import org.slf4j.Logger;
@@ -44,21 +40,6 @@ import org.slf4j.LoggerFactory;
 public final class ClassPathResources {
 
   private static final Logger LOG = LoggerFactory.getLogger(ClassPathResources.class);
-
-  public static final Function<ClassPath.ClassInfo, String> CLASS_INFO_TO_CLASS_NAME =
-      new Function<ClassPath.ClassInfo, String>() {
-        @Override
-        public String apply(ClassPath.ClassInfo input) {
-          return input.getName();
-        }
-      };
-  public static final Function<ClassPath.ResourceInfo, String> RESOURCE_INFO_TO_RESOURCE_NAME =
-      new Function<ClassPath.ResourceInfo, String>() {
-        @Override
-        public String apply(ClassPath.ResourceInfo input) {
-          return input.getResourceName();
-        }
-      };
 
   /**
    * Returns the base set of resources needed to load the specified {@link Class} using the
@@ -75,14 +56,14 @@ public final class ClassPathResources {
     ClassPath classPath = getClassPath(classLoader, classz);
 
     // Add everything in the classpath as visible resources
-    Set<String> result = Sets.newHashSet(Iterables.transform(classPath.getResources(),
-        RESOURCE_INFO_TO_RESOURCE_NAME));
+    Set<String> result = classPath.getResources().stream()
+        .map(ResourceInfo::getResourceName)
+        .collect(Collectors.toSet());
     // Trace dependencies for all classes in the classpath
-    findClassDependencies(
-        classLoader, Iterables.transform(classPath.getAllClasses(), CLASS_INFO_TO_CLASS_NAME),
+    return findClassDependencies(
+        classLoader,
+        classPath.getAllClasses().stream().map(ClassInfo::getName).collect(Collectors.toList()),
         result);
-
-    return result;
   }
 
   /**
@@ -98,26 +79,6 @@ public final class ClassPathResources {
   public static Set<ClassPath.ResourceInfo> getClassPathResources(ClassLoader classLoader,
       Class<?> cls) throws IOException {
     return getClassPath(classLoader, cls).getResources();
-  }
-
-  /**
-   * Returns a Set containing all bootstrap classpaths as defined in the {@code sun.boot.class.path}
-   * property.
-   */
-  public static Set<String> getBootstrapClassPaths() {
-    // Get the bootstrap classpath. This is for exclusion while tracing class dependencies.
-    Set<String> bootstrapPaths = new HashSet<>();
-    for (String classpath : Splitter.on(File.pathSeparatorChar)
-        .split(System.getProperty("sun.boot.class.path"))) {
-      File file = new File(classpath);
-      bootstrapPaths.add(file.getAbsolutePath());
-      try {
-        bootstrapPaths.add(file.getCanonicalPath());
-      } catch (IOException e) {
-        // Ignore the exception and proceed.
-      }
-    }
-    return Collections.unmodifiableSet(bootstrapPaths);
   }
 
   /**
@@ -139,71 +100,95 @@ public final class ClassPathResources {
     }
   }
 
-  static ClassAcceptor createClassAcceptor(final ClassLoader classLoader,
-      final Collection<String> result) {
-    final Set<String> bootstrapClassPaths = getBootstrapClassPaths();
-    final Set<URL> classPathSeen = Sets.newHashSet();
-    return new ClassAcceptor() {
-      @Override
-      public boolean accept(String className, URL classUrl, URL classPathUrl) {
-        // Ignore bootstrap classes
-        if (bootstrapClassPaths.contains(classPathUrl.getFile())) {
-          return false;
-        }
+  /**
+   * Returns a {@link URLClassLoader} for loading classes provided the JVM platform.
+   */
+  private static URLClassLoader getPlatformClassLoader() {
+    ClassLoader platformClassloader;
+    try {
+      // For Java11+, there is a ClassLoader.getPlatformClassLoader() method to get
+      // the platform classloader.
+      //noinspection JavaReflectionMemberAccess
+      platformClassloader = (ClassLoader) ClassLoader.class.getMethod("getPlatformClassLoader")
+          .invoke(null);
+    } catch (Exception e) {
+      // For Java8, the parent of the system classloader is the
+      // platform classloader (bootstrap + ext classloader)
+      platformClassloader = ClassLoader.getSystemClassLoader().getParent();
+    }
+    // Always warp it with a URLClassLoader to simplify handling of
+    // the potential `null` parent classloader in the Java 8 case.
+    return new URLClassLoader(new URL[0], platformClassloader);
+  }
 
-        // Should ignore classes from SLF4J implementation, otherwise it will includes logback lib, which shouldn't be
-        // visible through the program classloader.
-        if (className.startsWith("org.slf4j.impl.")) {
-          return false;
-        }
+  static ClassAcceptor createClassAcceptor(ClassLoader classLoader, Collection<String> result)
+      throws IOException {
+    try (URLClassLoader platformClassloader = getPlatformClassLoader()) {
+      Set<URL> classPathSeen = new HashSet<>();
+      return new ClassAcceptor() {
+        @Override
+        public boolean accept(String className, URL classUrl, URL classPathUrl) {
 
-        // Ignore classes with incompatible Java specification version in multi-release jars.
-        // See https://docs.oracle.com/javase/10/docs/specs/jar/jar.html#multi-release-jar-files for details.
-        if (className.startsWith("META-INF.versions.")) {
-          // Get current Java specification version
-          // See https://docs.oracle.com/en/java/javase/12/docs/api/java.base/java/lang/System.html#getProperties().
-          String javaSpecVersion = System.getProperty("java.specification.version")
-              .replaceFirst("^1[.]", "");
-          int version = 0;
-          try {
-            version = Integer.parseInt(javaSpecVersion);
-          } catch (NumberFormatException e) {
-            throw new IllegalStateException(
-                String.format("Failed to parse Java specification version string %s",
-                    javaSpecVersion), e);
-          }
-          if (version < 9) {
-            // Per JAR spec, classes for Java 8 and below will not be versioned.
+          // Ignore platform classes
+          if (platformClassloader.getResource(className.replace('.', '/') + ".class") != null) {
             return false;
           }
-          // Check if the specification version matches the dependency version
-          try {
-            int classVersion = Integer.parseInt(className.split("[.]")[2]);
-            if (version < classVersion) {
+
+          // Should ignore classes from SLF4J implementation, otherwise it will include logback lib,
+          // which shouldn't be visible through the program classloader.
+          if (className.startsWith("org.slf4j.impl.")) {
+            return false;
+          }
+
+          // Ignore classes with incompatible Java specification version in multi-release jars.
+          // See https://docs.oracle.com/javase/10/docs/specs/jar/jar.html#multi-release-jar-files
+          // for details.
+          if (className.startsWith("META-INF.versions.")) {
+            // Get current Java specification version
+            // See https://docs.oracle.com/en/java/javase/12/docs/api/java.base/java/lang/System.html#getProperties().
+            String javaSpecVersion = System.getProperty("java.specification.version")
+                .replaceFirst("^1[.]", "");
+            int version;
+            try {
+              version = Integer.parseInt(javaSpecVersion);
+            } catch (NumberFormatException e) {
+              throw new IllegalStateException(
+                  String.format("Failed to parse Java specification version string %s",
+                      javaSpecVersion), e);
+            }
+            if (version < 9) {
+              // Per JAR spec, classes for Java 8 and below will not be versioned.
               return false;
             }
-          } catch (NumberFormatException e) {
-            // If the class version fails to parse, allow it through.
-            LOG.debug("Failed to parse multi-release versioned dependency class '%s'", className);
+            // Check if the specification version matches the dependency version
+            try {
+              int classVersion = Integer.parseInt(className.split("[.]")[2]);
+              if (version < classVersion) {
+                return false;
+              }
+            } catch (NumberFormatException e) {
+              // If the class version fails to parse, allow it through.
+              LOG.debug("Failed to parse multi-release versioned dependency class '{}'", className);
+            }
           }
-        }
 
-        if (!classPathSeen.add(classPathUrl)) {
+          if (!classPathSeen.add(classPathUrl)) {
+            return true;
+          }
+
+          // Add all resources in the given class path
+          try {
+            ClassPath classPath = ClassPath.from(classPathUrl.toURI(), classLoader);
+            for (ClassPath.ResourceInfo resourceInfo : classPath.getResources()) {
+              result.add(resourceInfo.getResourceName());
+            }
+          } catch (Exception e) {
+            // If fail to get classes/resources from the classpath, ignore this classpath.
+          }
           return true;
         }
-
-        // Add all resources in the given class path
-        try {
-          ClassPath classPath = ClassPath.from(classPathUrl.toURI(), classLoader);
-          for (ClassPath.ResourceInfo resourceInfo : classPath.getResources()) {
-            result.add(resourceInfo.getResourceName());
-          }
-        } catch (Exception e) {
-          // If fail to get classes/resources from the classpath, ignore this classpath.
-        }
-        return true;
-      }
-    };
+      };
+    }
   }
 
   /**
@@ -244,7 +229,7 @@ public final class ClassPathResources {
         return URI.create(path.substring(0, path.indexOf("!/"))).toURL();
       }
     } catch (MalformedURLException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     throw new IllegalStateException("Unsupported class URL: " + resourceURL);
   }

--- a/cdap-common/src/main/resources/META-INF/services/io.cdap.cdap.common.conf.ConfigActivator
+++ b/cdap-common/src/main/resources/META-INF/services/io.cdap.cdap.common.conf.ConfigActivator
@@ -1,0 +1,17 @@
+#
+# Copyright © 2023 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+io.cdap.cdap.common.conf.JavaVersionConfigActivator

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -248,12 +248,31 @@
   <property>
     <name>twill.jvm.gc.opts</name>
     <value>-XX:+UseG1GC -verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M</value>
+    <activation>
+      <jdk>(,9)</jdk>
+    </activation>
     <description>
       Java garbage collection options for all Apache Twill containers;
       "&lt;LOG_DIR&gt;" is the location of the log directory in the
       container; note that the special characters are replaced with entity
       equivalents so they can be included in the XML
     </description>
+  </property>
+
+  <property>
+    <name>twill.jvm.gc.opts</name>
+    <value>-XX:+UseG1GC -verbose:gc -Xlog:gc*:file=&lt;LOG_DIR&gt;/gc.log:time,level,tags:filecount=10,filesize=1M</value>
+    <activation>
+      <jdk>[9,)</jdk>
+    </activation>
+    <description>
+      Java garbage collection options for all Apache Twill containers in Java 9
+      or above environment.
+      "&lt;LOG_DIR&gt;" is the location of the log directory in the
+      container; note that the special characters are replaced with entity
+      equivalents so they can be included in the XML
+    </description>
+
   </property>
 
   <property>

--- a/cdap-common/src/test/java/io/cdap/cdap/common/conf/TestConfigActivator.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/conf/TestConfigActivator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.conf;
+
+/**
+ * A {@link ConfigActivator} for testing. It only parses the activation value as a boolean
+ * as the activation result.
+ */
+public class TestConfigActivator implements ConfigActivator {
+
+  @Override
+  public String getActivationName() {
+    return "test";
+  }
+
+  @Override
+  public boolean test(String s) {
+    return Boolean.parseBoolean(s);
+  }
+}

--- a/cdap-common/src/test/resources/META-INF/services/io.cdap.cdap.common.conf.ConfigActivator
+++ b/cdap-common/src/test/resources/META-INF/services/io.cdap.cdap.common.conf.ConfigActivator
@@ -1,0 +1,17 @@
+#
+# Copyright © 2023 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+io.cdap.cdap.common.conf.TestConfigActivator

--- a/cdap-common/src/test/resources/test-default.xml
+++ b/cdap-common/src/test/resources/test-default.xml
@@ -33,4 +33,20 @@
         </description>
     </property>
 
+    <property>
+        <name>conf.test.activate</name>
+        <value>1</value>
+        <activation>
+            <test>false</test>
+        </activation>
+    </property>
+
+    <property>
+        <name>conf.test.activate</name>
+        <value>2</value>
+        <activation>
+            <test>true</test>
+        </activation>
+    </property>
+
 </configuration>

--- a/cdap-common/src/test/resources/test-override.xml
+++ b/cdap-common/src/test/resources/test-override.xml
@@ -23,4 +23,12 @@
             B
         </description>
     </property>
+
+    <property>
+        <name>conf.test.activate</name>
+        <value>3</value>
+        <activation>
+            <test>true</test>
+        </activation>
+    </property>
 </configuration>

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -346,7 +346,7 @@
           <version>${project.version}</version>
           <scope>provided</scope>
         </dependency>
-	<dependency>
+        <dependency>
           <groupId>io.cdap.cdap</groupId>
           <artifactId>cdap-securestore-ext-gcp-secretstore</artifactId>
           <version>${project.version}</version>
@@ -899,6 +899,15 @@
           <artifactId>cdap-kubernetes</artifactId>
           <version>${project.version}</version>
           <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>log4j-over-slf4j</artifactId>
+          <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
         </dependency>
       </dependencies>
 

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
@@ -25,11 +25,8 @@ import io.cdap.cdap.common.lang.ClassLoaders;
 import io.cdap.cdap.common.lang.FilterClassLoader;
 import io.cdap.cdap.common.logging.StandardOutErrorRedirector;
 import io.cdap.cdap.common.logging.common.UncaughtExceptionHandler;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.bridge.SLF4JBridgeHandler;
-
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -43,9 +40,13 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 /**
- * This class launches Spark YARN containers with classes loaded through the {@link SparkContainerClassLoader}.
+ * This class launches Spark YARN containers with classes loaded through the
+ * {@link SparkContainerClassLoader}.
  */
 public final class SparkContainerLauncher {
 
@@ -65,16 +66,18 @@ public final class SparkContainerLauncher {
   };
 
   /**
-   * Main method is used as the entrypoint to launch classes in Kubernetes images.
-   * The first argument should be the name of the class to delegate to, which must have a main method.
-   * Every other argument will be passed into the delegate main method.
+   * Main method is used as the entrypoint to launch classes in Kubernetes images. The first
+   * argument should be the name of the class to delegate to, which must have a main method. Every
+   * other argument will be passed into the delegate main method.
    */
   public static void main(String[] args) throws Exception {
-    launch(args[0], args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0], false, "k8s");
+    launch(args[0], args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0],
+        false, "k8s");
   }
 
   /**
-   * Launches the given main class. The main class will be loaded through the {@link SparkContainerClassLoader}.
+   * Launches the given main class. The main class will be loaded through the
+   * {@link SparkContainerClassLoader}.
    *
    * @param mainClassName the main class to launch
    * @param args arguments for the main class
@@ -84,26 +87,36 @@ public final class SparkContainerLauncher {
   }
 
   /**
-   * Launches the given main class. The main class will be loaded through the {@link SparkContainerClassLoader}.
+   * Launches the given main class. The main class will be loaded through the
+   * {@link SparkContainerClassLoader}.
    *
    * @param mainClassName the main class to launch
    * @param args arguments for the main class
    * @param removeMainClass whether to remove the jar for the main class from the classloader
-   * @param masterEnvName name of the MasterEnvironment used to submit the Spark job. This will be used to setup
-   *   bindings for service discovery and other CDAP capabilities. If null, the default Hadoop implementations will
-   *   be used.
+   * @param masterEnvName name of the MasterEnvironment used to submit the Spark job. This will
+   *     be used to setup bindings for service discovery and other CDAP capabilities. If null, the
+   *     default Hadoop implementations will be used.
    */
   public static void launch(String mainClassName, String[] args, boolean removeMainClass,
-                            @Nullable String masterEnvName) throws Exception {
+      @Nullable String masterEnvName) throws Exception {
     Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler());
+
+    Set<URL> urls = new LinkedHashSet<>();
+    for (String path : System.getProperty("java.class.path").split(File.pathSeparator)) {
+      urls.add(Paths.get(path).toRealPath().toUri().toURL());
+    }
+
     ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
-    Set<URL> urls = ClassLoaders.getClassLoaderURLs(systemClassLoader, new LinkedHashSet<URL>());
 
     // Remove the URL that contains the given main classname to avoid infinite recursion.
     // This is needed because we generate a class with the same main classname in order to intercept the main()
     // method call from the container launch script.
     if (removeMainClass) {
-      urls.remove(getURLByClass(systemClassLoader, mainClassName));
+      URL urlByClass = getURLByClass(systemClassLoader, mainClassName);
+      if (!urls.remove(urlByClass)) {
+        urls.forEach(url -> LOG.info("URL: {}", url));
+        throw new Exception("Failed to remove url " + urlByClass + " for class " + mainClassName);
+      }
     }
 
     // Remove the first scala from the set of classpath. This ensure the one from Spark is used for spark
@@ -117,13 +130,14 @@ public final class SparkContainerLauncher {
     ClassLoader parentClassLoader = new FilterClassLoader(systemClassLoader, KAFKA_FILTER);
 
     boolean rewriteCheckpointTempFileName = Boolean.parseBoolean(
-      System.getProperty(SparkRuntimeUtils.STREAMING_CHECKPOINT_REWRITE_ENABLED, "false"));
+        System.getProperty(SparkRuntimeUtils.STREAMING_CHECKPOINT_REWRITE_ENABLED, "false"));
 
     // Creates the SparkRunnerClassLoader for class rewriting and it will be used for the rest of the execution.
     // Use the extension classloader as the parent instead of the system classloader because
     // Spark classes are in the system classloader which we want to rewrite.
-    ClassLoader classLoader = new SparkContainerClassLoader(urls.toArray(new URL[0]), parentClassLoader,
-                                                            rewriteCheckpointTempFileName);
+    ClassLoader classLoader = new SparkContainerClassLoader(urls.toArray(new URL[0]),
+        parentClassLoader,
+        rewriteCheckpointTempFileName);
 
     // Sets the context classloader and launch the actual Spark main class.
     Thread.currentThread().setContextClassLoader(classLoader);
@@ -135,18 +149,21 @@ public final class SparkContainerLauncher {
     // Install the JUL to SLF4J Bridge
     try {
       classLoader.loadClass(SLF4JBridgeHandler.class.getName())
-        .getDeclaredMethod("install")
-        .invoke(null);
+          .getDeclaredMethod("install")
+          .invoke(null);
     } catch (Exception e) {
       // Log the error and continue
-      log(logger, "warn", "Failed to invoke SLF4JBridgeHandler.install() required for jul-to-slf4j bridge", e);
+      log(logger, "warn",
+          "Failed to invoke SLF4JBridgeHandler.install() required for jul-to-slf4j bridge", e);
     }
 
     // Get the SparkRuntimeContext to initialize all necessary services and logging context
     // Need to do it using the SparkRunnerClassLoader through reflection.
-    Class<?> sparkRuntimeContextProviderClass = classLoader.loadClass(SparkRuntimeContextProvider.class.getName());
+    Class<?> sparkRuntimeContextProviderClass = classLoader.loadClass(
+        SparkRuntimeContextProvider.class.getName());
     if (masterEnvName != null) {
-      sparkRuntimeContextProviderClass.getMethod("setMasterEnvName", String.class).invoke(null, masterEnvName);
+      sparkRuntimeContextProviderClass.getMethod("setMasterEnvName", String.class)
+          .invoke(null, masterEnvName);
     }
     Object sparkRuntimeContext = sparkRuntimeContextProviderClass.getMethod("get").invoke(null);
 
@@ -160,8 +177,8 @@ public final class SparkContainerLauncher {
       if (!isPySpark()) {
         // Invoke StandardOutErrorRedirector.redirectToLogger()
         classLoader.loadClass(StandardOutErrorRedirector.class.getName())
-          .getDeclaredMethod("redirectToLogger", String.class)
-          .invoke(null, mainClassName);
+            .getDeclaredMethod("redirectToLogger", String.class)
+            .invoke(null, mainClassName);
       }
 
       // Force setting the system property CDAP_LOG_DIR to <LOG_DIR>. This is to workaround bug in Spark 1.2
@@ -175,7 +192,8 @@ public final class SparkContainerLauncher {
       Runnable stopGatewayServer = startGatewayServerIfNeeded(classLoader, logger);
       try {
         log(logger, "info", "Launch main class {}.main({})", mainClassName, Arrays.toString(args));
-        classLoader.loadClass(mainClassName).getMethod("main", String[].class).invoke(null, new Object[]{args});
+        classLoader.loadClass(mainClassName).getMethod("main", String[].class)
+            .invoke(null, new Object[]{args});
         log(logger, "info", "Main method returned {}", mainClassName);
       } finally {
         stopGatewayServer.run();
@@ -184,7 +202,8 @@ public final class SparkContainerLauncher {
       // LOG the exception since this exception will be propagated back to JVM
       // and kill the main thread (hence the JVM process).
       // If we don't log it here as ERROR, it will be logged by UncaughtExceptionHandler as DEBUG level
-      log(logger, "error", "Exception raised when calling {}.main(String[]) method", mainClassName, t);
+      log(logger, "error", "Exception raised when calling {}.main(String[]) method",
+          mainClassName, t);
       throw t;
     } finally {
       if (sparkRuntimeContext instanceof Closeable) {
@@ -228,7 +247,8 @@ public final class SparkContainerLauncher {
     // Otherwise start the gateway server using reflection. Also write the port number to a local file
     try {
       final Object server = classLoader.loadClass(SparkPythonUtil.class.getName())
-        .getMethod("startPy4jGateway", Path.class).invoke(null, Paths.get(System.getProperty("user.dir")));
+          .getMethod("startPy4jGateway", Path.class)
+          .invoke(null, Paths.get(System.getProperty("user.dir")));
 
       return new Runnable() {
         @Override
@@ -241,7 +261,9 @@ public final class SparkContainerLauncher {
         }
       };
     } catch (Exception e) {
-      log(logger, "warn", "Failed to start Py4j GatewayServer. No CDAP functionality will be available in executor", e);
+      log(logger, "warn",
+          "Failed to start Py4j GatewayServer. No CDAP functionality will be available in executor",
+          e);
       return noopRunnable;
     }
   }
@@ -251,8 +273,8 @@ public final class SparkContainerLauncher {
   }
 
   /**
-   * Removes extra classpath containing the given class that is not from the spark library loaded from the
-   * given {@link ClassLoader} if there are multiple files containing the given class.
+   * Removes extra classpath containing the given class that is not from the spark library loaded
+   * from the given {@link ClassLoader} if there are multiple files containing the given class.
    *
    * @param classLoader the {@link ClassLoader} for finding the jar containing the given class
    * @param className the class to look for
@@ -260,9 +282,10 @@ public final class SparkContainerLauncher {
    * @throws IOException if failed to lookup the class location
    */
   private static void removeNonSparkJar(ClassLoader classLoader,
-                                        String className, Set<URL> urls) throws IOException, URISyntaxException {
+      String className, Set<URL> urls) throws IOException, URISyntaxException {
     URL sparkConfURL = getURLByClass(classLoader, SPARK_CONF_CLASS_NAME);
-    List<URL> classURLs = Collections.list(classLoader.getResources(className.replace('.', '/') + ".class"));
+    List<URL> classURLs = Collections.list(
+        classLoader.getResources(className.replace('.', '/') + ".class"));
 
     if (classURLs.size() <= 1) {
       return;
@@ -285,13 +308,14 @@ public final class SparkContainerLauncher {
 
   private static Object createLogger(ClassLoader classLoader) throws Exception {
     return classLoader.loadClass(LoggerFactory.class.getName())
-      .getMethod("getLogger", Class.class)
-      .invoke(null, SparkContainerLauncher.class);
+        .getMethod("getLogger", Class.class)
+        .invoke(null, SparkContainerLauncher.class);
   }
 
-  private static void log(Object logger, String level, String message, Object...args) {
+  private static void log(Object logger, String level, String message, Object... args) {
     try {
-      logger.getClass().getMethod(level, String.class, Object[].class).invoke(logger, message, args);
+      logger.getClass().getMethod(level, String.class, Object[].class)
+          .invoke(logger, message, args);
     } catch (Exception e) {
       // ignore
     }

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
     <jetty8.version>8.1.15.v20140411</jetty8.version>
     <jline.version>2.12</jline.version>
     <junit.version>4.11</junit.version>
+    <log4j2.slf4j.version>2.20.0</log4j2.slf4j.version>
     <pragmatists.version>1.0.5</pragmatists.version>
     <kafka.version>0.10.2.2</kafka.version>
     <leveldb.version>0.12</leveldb.version>
@@ -208,6 +209,11 @@
         <groupId>org.slf4j</groupId>
         <artifactId>log4j-over-slf4j</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-to-slf4j</artifactId>
+        <version>${log4j2.slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This PR contains three main changes

1.  Added support for configuration activation based on JVM version.
     Support a new `activation` element in the cConf xml to conditionally select a particular configuration value. This is needed since the JVM takes different parameters for GC options in different JVM versions.
2.  Make class loading compatible with Java 11.
     This change is to replace System ClassLoader.getURLs() usage to parse from the `java.class.path` property since the system classloader is no longer an instance of `URLClassLoader`. Also, removed the usage of `sun.boot.class.path` property since it is removed in Java 11. It is replaced by checking class loadability from the platform classloader.
3.  Make it works in GCP dataproc Spark 3 environment by setting the event log compression correctly.
