### PR TITLE
fix(CDAP-20515): throw SourceControlException if the repository exists but is not initialized

### DIFF
--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManager.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManager.java
@@ -460,6 +460,7 @@ public class RepositoryManager implements AutoCloseable {
    *
    * @return The commit ID for the head.
    * @throws IOException when git is unable to resolve head.
+   * @throws SourceControlException if the repository is not initialized.
    */
   @VisibleForTesting
   ObjectId resolveHead() throws IOException {
@@ -467,7 +468,15 @@ public class RepositoryManager implements AutoCloseable {
       throw new IllegalStateException(
           "Call cloneRemote() before getting HEAD.");
     }
-    return git.getRepository().resolve(Constants.HEAD);
+
+    ObjectId commitObjectId = git.getRepository().resolve(Constants.HEAD);
+
+    if (commitObjectId == null) {
+      throw new SourceControlException(
+          "Failed to resolve Git HEAD. Please make sure the repository is initialized.");
+    }
+
+    return commitObjectId;
   }
 
   /**


### PR DESCRIPTION
fix(CDAP-20515): throw exception if the repository exists but is empty