### PR TITLE
CDAP-20483: Use workdir for git cloning and add sizelimit

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerService.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.api.service.worker.RunnableTask;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.TaskWorker;
 import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.discovery.ResolvingDiscoverable;
 import io.cdap.cdap.common.discovery.URIScheme;
@@ -42,7 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Launches an HTTP server for receiving and handling {@link RunnableTask}
+ * Launches an HTTP server for receiving and handling {@link RunnableTask}.
  */
 public class TaskWorkerService extends AbstractIdleService {
 
@@ -61,6 +62,13 @@ public class TaskWorkerService extends AbstractIdleService {
       MetricsCollectionService metricsCollectionService,
       CommonNettyHttpServiceFactory commonNettyHttpServiceFactory) {
     this.discoveryService = discoveryService;
+
+    // set workdir location in cConf
+    // workdir location is unique per task worker and accessible via env var
+    String workDir = System.getenv("CDAP_LOCAL_DIR");
+    if (workDir != null) {
+      cConf.set(TaskWorker.WORK_DIR, workDir);
+    }
 
     NettyHttpService.Builder builder = commonNettyHttpServiceFactory.builder(
             Constants.Service.TASK_WORKER)

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -462,9 +462,11 @@ public final class Constants {
     /**
      * Task worker container configurations.
      */
+    public static final String WORK_DIR = "task.worker.work.dir";
     public static final String LOCAL_DATA_DIR = "task.worker.local.data.dir";
     public static final String CONTAINER_DISK_SIZE_GB = "task.worker.container.disk.size.gb";
     public static final String CONTAINER_MEMORY_MB = "task.worker.container.memory.mb";
+    public static final String CONTAINER_WORKDIR_SIZE_MB = "task.worker.container.workdir.size.mb";
     public static final String CONTAINER_CORES = "task.worker.container.num.cores";
     public static final String CONTAINER_CPU_MULTIPLIER = "task.worker.container.cpu.multiplier";
     public static final String CONTAINER_MEMORY_MULTIPLIER = "task.worker.container.memory.multiplier";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5122,6 +5122,14 @@
   </property>
 
   <property>
+    <name>task.worker.container.workdir.size.mb</name>
+    <value>5000</value>
+    <description>
+      Size of the workdir volume for the task worker.
+    </description>
+  </property>
+
+  <property>
     <name>task.worker.container.kill.after.request.count</name>
     <value>100</value>
     <description>

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillPreparer.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillPreparer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.spi.twill;
+
+
+import org.apache.twill.api.TwillPreparer;
+
+/**
+ * An extension of TwillPreparer used to add extra functionalities for CDAP.
+ */
+public interface ExtendedTwillPreparer extends TwillPreparer {
+
+  /**
+   * Set size limit for workdir volume in kube twill application which is an emptydir.
+   *
+   * @param sizeLimitInMB volume size limit in MB
+   */
+  ExtendedTwillPreparer setWorkdirSizeLimit(int sizeLimitInMB);
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManager.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/RepositoryManager.java
@@ -149,7 +149,7 @@ public class RepositoryManager implements AutoCloseable {
     RefreshableCredentialsProvider credentialsProvider;
     try {
       credentialsProvider = new AuthenticationStrategyProvider(
-          sourceControlConfig.getNamespaceID(),
+          sourceControlConfig.getNamespaceId(),
           secureStore)
           .get(sourceControlConfig.getRepositoryConfig())
           .getCredentialsProvider();

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/SourceControlConfig.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/SourceControlConfig.java
@@ -29,25 +29,29 @@ import java.util.Objects;
  */
 public class SourceControlConfig {
 
-  private final String namespaceID;
+  private final String namespaceId;
   // Path where local git repositories are stored.
   private final Path localReposClonePath;
   private final int gitCommandTimeoutSeconds;
   private final RepositoryConfig repositoryConfig;
 
-  public SourceControlConfig(NamespaceId namespaceID, RepositoryConfig repositoryConfig,
+  public SourceControlConfig(NamespaceId namespaceId, RepositoryConfig repositoryConfig,
       CConfiguration cConf) {
-    this.namespaceID = namespaceID.getNamespace();
+    this.namespaceId = namespaceId.getNamespace();
     this.repositoryConfig = repositoryConfig;
-    String gitCloneDirectory = cConf.get(
-        Constants.SourceControlManagement.GIT_REPOSITORIES_CLONE_DIRECTORY_PATH);
     this.gitCommandTimeoutSeconds = cConf.getInt(
         Constants.SourceControlManagement.GIT_COMMAND_TIMEOUT_SECONDS);
-    this.localReposClonePath = Paths.get(gitCloneDirectory, "namespace", this.namespaceID);
+    // if local dir is set use it for cloned storage
+    // for task workers it would use emptydir volume
+    String defaultCloneDir = cConf.get(Constants.SourceControlManagement.GIT_REPOSITORIES_CLONE_DIRECTORY_PATH);
+    String workDir = cConf.get(Constants.TaskWorker.WORK_DIR);
+    String gitCloneDirectory = workDir == null
+        ? defaultCloneDir : String.format("%s/source-control", workDir);
+    this.localReposClonePath = Paths.get(gitCloneDirectory, "namespace", this.namespaceId);
   }
 
-  public String getNamespaceID() {
-    return namespaceID;
+  public String getNamespaceId() {
+    return namespaceId;
   }
 
   public Path getLocalReposClonePath() {
@@ -71,15 +75,15 @@ public class SourceControlConfig {
       return false;
     }
     SourceControlConfig that = (SourceControlConfig) o;
-    return gitCommandTimeoutSeconds == that.gitCommandTimeoutSeconds && namespaceID.equals(
-        that.namespaceID)
+    return gitCommandTimeoutSeconds == that.gitCommandTimeoutSeconds && namespaceId.equals(
+        that.namespaceId)
         && localReposClonePath.equals(that.localReposClonePath) && repositoryConfig.equals(
         that.repositoryConfig);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(namespaceID, localReposClonePath, gitCommandTimeoutSeconds,
+    return Objects.hash(namespaceId, localReposClonePath, gitCommandTimeoutSeconds,
         repositoryConfig);
   }
 }


### PR DESCRIPTION
- For git cloning use workdir volume if available otherwise use tmp
- Add sizelimit for workdir volume. This is a soft limit. Kubernetes will periodically check the directory size and eject the pod if the limit is breached. 

Testing: 
- Manual test with taskworker enabled [x]
- Manual test with taskworker disabled [x]
