### PR TITLE
CDAP-20504 remove duplicate calls for secure store

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/security/store/SecureStore.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/security/store/SecureStore.java
@@ -37,7 +37,8 @@ public interface SecureStore {
   List<SecureStoreMetadata> list(String namespace) throws Exception;
 
   /**
-   * Returns the data stored in the secure store.
+   * Returns the secret and its metadata for the given namespace and name.
+   * Use {@link #getData(String, String)} if the metadata is not required.
    *
    * @param namespace The namespace that this key belongs to
    * @param name Name of the data element
@@ -46,4 +47,30 @@ public interface SecureStore {
    * @throws Exception if the specified namespace or name does not exist
    */
   SecureStoreData get(String namespace, String name) throws Exception;
+
+  /**
+   * Returns the metadata for the secret.
+   *
+   * @param namespace The namespace that this key belongs to
+   * @param name Name of the data element
+   * @return Metadata for the securely stored data associated with the name
+   * @throws IOException If there was a problem reading from the store
+   * @throws Exception if the specified namespace or name does not exist
+   */
+  default SecureStoreMetadata getMetadata(String namespace, String name) throws Exception {
+    return get(namespace, name).getMetadata();
+  }
+
+  /**
+   * Returns the secret data.
+   *
+   * @param namespace The namespace that this key belongs to
+   * @param name Name of the data element
+   * @return The securely stored data associated with the name
+   * @throws IOException If there was a problem reading from the store
+   * @throws Exception if the specified namespace or name does not exist
+   */
+  default byte[] getData(String namespace, String name) throws Exception {
+    return get(namespace, name).get();
+  }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/AbstractContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/AbstractContext.java
@@ -526,6 +526,16 @@ public abstract class AbstractContext extends AbstractServiceDiscoverer
   }
 
   @Override
+  public SecureStoreMetadata getMetadata(String namespace, String name) throws Exception {
+    return Retries.callWithRetries(() -> secureStore.getMetadata(namespace, name), retryStrategy);
+  }
+
+  @Override
+  public byte[] getData(String namespace, String name) throws Exception {
+    return Retries.callWithRetries(() -> secureStore.getData(namespace, name), retryStrategy);
+  }
+
+  @Override
   public void execute(final TxRunnable runnable) throws TransactionFailureException {
     execute(runnable, false);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/batch/MapReduceLifecycleContext.java
@@ -323,6 +323,16 @@ public class MapReduceLifecycleContext<KEY, VALUE> implements MapReduceTaskConte
   }
 
   @Override
+  public SecureStoreMetadata getMetadata(String namespace, String name) throws Exception {
+    return delegate.getMetadata(namespace, name);
+  }
+
+  @Override
+  public byte[] getData(String namespace, String name) throws Exception {
+    return delegate.getData(namespace, name);
+  }
+
+  @Override
   public void execute(TxRunnable runnable) throws TransactionFailureException {
     throw new TransactionFailureException(
         "Attempted to start a transaction within a MapReduce transaction");

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/DefaultSystemAppTaskContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/DefaultSystemAppTaskContext.java
@@ -183,6 +183,16 @@ public class DefaultSystemAppTaskContext extends AbstractServiceDiscoverer imple
   }
 
   @Override
+  public SecureStoreMetadata getMetadata(String namespace, String name) throws Exception {
+    return Retries.callWithRetries(() -> secureStore.getMetadata(namespace, name), retryStrategy);
+  }
+
+  @Override
+  public byte[] getData(String namespace, String name) throws Exception {
+    return Retries.callWithRetries(() -> secureStore.getData(namespace, name), retryStrategy);
+  }
+
+  @Override
   public void close() {
     try {
       try {

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/condition/BasicConditionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/condition/BasicConditionContext.java
@@ -128,6 +128,16 @@ public class BasicConditionContext extends AbstractStageContext implements Condi
   }
 
   @Override
+  public SecureStoreMetadata getMetadata(String namespace, String name) throws Exception {
+    return context.getMetadata(namespace, name);
+  }
+
+  @Override
+  public byte[] getData(String namespace, String name) throws Exception {
+    return context.getData(namespace, name);
+  }
+
+  @Override
   public void put(String namespace, String name, String data, @Nullable String description,
       Map<String, String> properties) throws Exception {
     context.getAdmin().put(namespace, name, data, description, properties);

--- a/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/customaction/BasicActionContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-batch/src/main/java/io/cdap/cdap/etl/batch/customaction/BasicActionContext.java
@@ -80,6 +80,16 @@ public class BasicActionContext extends AbstractStageContext implements ActionCo
   }
 
   @Override
+  public SecureStoreMetadata getMetadata(String namespace, String name) throws Exception {
+    return context.getMetadata(namespace, name);
+  }
+
+  @Override
+  public byte[] getData(String namespace, String name) throws Exception {
+    return context.getData(namespace, name);
+  }
+
+  @Override
   public void put(String namespace, String name, String data, @Nullable String description,
       Map<String, String> properties) throws Exception {
     context.getAdmin().put(namespace, name, data, description, properties);

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/SecureStoreMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/SecureStoreMacroEvaluator.java
@@ -54,7 +54,7 @@ public class SecureStoreMacroEvaluator implements MacroEvaluator {
           "Macro '" + FUNCTION_NAME + "' should have exactly 1 argument");
     }
     try {
-      return Bytes.toString(secureStore.get(namespace, args[0]).get());
+      return Bytes.toString(secureStore.getData(namespace, args[0]));
     } catch (Exception e) {
       throw new InvalidMacroException(
           "Failed to resolve macro '" + FUNCTION_NAME + "(" + args[0] + ")'", e);

--- a/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/CloudSecretManagerClient.java
+++ b/cdap-securestore-ext-gcp-secretstore/src/main/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/CloudSecretManagerClient.java
@@ -138,9 +138,10 @@ public class CloudSecretManagerClient {
    *
    * @throws ApiException if Google API call fails.
    */
-  public byte[] getSecretData(WrappedSecret secret) {
+  public byte[] getSecretData(String namespace, String name) {
+    String resourceName = getSecretResourceName(namespace, name);
     return secretManager
-      .accessSecretVersion(String.format("%s/versions/latest", getSecretResourceName(secret)))
+      .accessSecretVersion(String.format("%s/versions/latest", resourceName))
       .getPayload()
       .getData()
       .toByteArray();
@@ -158,7 +159,7 @@ public class CloudSecretManagerClient {
   }
 
   /**
-   * Computes the new annotations for {@link wrappedSecret} and performs an update operation on the
+   * Computes the new annotations for {@link WrappedSecret} and performs an update operation on the
    * corresponding GCP secret to match the newly computed properties.
    *
    * @throws ApiException if Google API call fails.

--- a/cdap-securestore-ext-gcp-secretstore/src/test/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/GcpSecretManagerTest.java
+++ b/cdap-securestore-ext-gcp-secretstore/src/test/java/io/cdap/cdap/securestore/gcp/cloudsecretmanager/GcpSecretManagerTest.java
@@ -78,7 +78,7 @@ public class GcpSecretManagerTest {
     SecretMetadata metadata = createMetadata("example");
     when(client.getSecret(ArgumentMatchers.any(), ArgumentMatchers.any()))
       .thenReturn(WrappedSecret.fromMetadata(NAMESPACE, metadata));
-    when(client.getSecretData(ArgumentMatchers.any())).thenReturn(payload);
+    when(client.getSecretData(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(payload);
 
     // Metadata [potentially] updated, payload remains the same.
     secretManager.store(NAMESPACE, new Secret(payload, metadata));
@@ -96,7 +96,8 @@ public class GcpSecretManagerTest {
     SecretMetadata metadata = createMetadata("example");
     when(client.getSecret(ArgumentMatchers.any(), ArgumentMatchers.any()))
       .thenReturn(WrappedSecret.fromMetadata(NAMESPACE, metadata));
-    when(client.getSecretData(ArgumentMatchers.any())).thenReturn(oldPayload);
+    when(client.getSecretData(ArgumentMatchers.any(), ArgumentMatchers.any()))
+        .thenReturn(oldPayload);
 
     secretManager.store(NAMESPACE, new Secret(newPayload, metadata));
 
@@ -120,7 +121,7 @@ public class GcpSecretManagerTest {
     SecretMetadata metadata = createMetadata("example");
     when(client.getSecret(ArgumentMatchers.any(), ArgumentMatchers.any()))
       .thenReturn(WrappedSecret.fromMetadata(NAMESPACE, metadata));
-    when(client.getSecretData(ArgumentMatchers.any())).thenReturn(payload);
+    when(client.getSecretData(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(payload);
 
     Secret secret = secretManager.get(NAMESPACE, "example");
 

--- a/cdap-securestore-spi/src/main/java/io/cdap/cdap/securestore/spi/SecretManager.java
+++ b/cdap-securestore-spi/src/main/java/io/cdap/cdap/securestore/spi/SecretManager.java
@@ -67,6 +67,40 @@ public interface SecretManager {
   Secret get(String namespace, String name) throws SecretNotFoundException, IOException;
 
   /**
+   * Returns securely stored secret without its metadata. Use {@link #get(String, String)} if
+   * both the secret and its metadata are needed. Implementations should implement this method
+   * instead of relying on the default if the underlying system requires different calls to
+   * get the secret itself and its metadata.
+   *
+   * @param namespace the namespace that this secret belongs to
+   * @param name the name of the secret
+   * @return the sensitive data
+   * @throws SecretNotFoundException if the secret is not present in the namespace
+   * @throws IOException if unable to retrieve the secret
+   */
+  default byte[] getData(String namespace, String name)
+      throws SecretNotFoundException, IOException {
+    return get(namespace, name).getData();
+  }
+
+  /**
+   * Returns metadata about the securely stored secret. Use {@link #get(String, String)} if both the
+   * secret and its metadata are needed. Implementations should implement this method
+   * instead of relying on the default if the underlying system requires different calls to
+   * get the secret itself and its metadata.
+   *
+   * @param namespace the namespace that this secret belongs to
+   * @param name the name of the secret
+   * @return the metadata for the secret
+   * @throws SecretNotFoundException if the secret is not present in the namespace
+   * @throws IOException if unable to retrieve the secret
+   */
+  default SecretMetadata getMetadata(String namespace, String name)
+      throws SecretNotFoundException, IOException {
+    return get(namespace, name).getMetadata();
+  }
+
+  /**
    * Returns {@link Collection} of metadata of all the secrets in the provided namespace.
    *
    * @param namespace the namespace that secrets belong to

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/DefaultAuthorizationContext.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/DefaultAuthorizationContext.java
@@ -212,6 +212,16 @@ public class DefaultAuthorizationContext implements AuthorizationContext {
   }
 
   @Override
+  public SecureStoreMetadata getMetadata(String namespace, String name) throws Exception {
+    return delegateSecureStore.getMetadata(namespace, name);
+  }
+
+  @Override
+  public byte[] getData(String namespace, String name) throws Exception {
+    return delegateSecureStore.getData(namespace, name);
+  }
+
+  @Override
   public boolean namespaceExists(String namespace) throws IOException {
     return delegateAdmin.namespaceExists(namespace);
   }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/guice/preview/PreviewSecureStore.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/guice/preview/PreviewSecureStore.java
@@ -45,6 +45,16 @@ public class PreviewSecureStore implements SecureStore, SecureStoreManager {
   }
 
   @Override
+  public SecureStoreMetadata getMetadata(String namespace, String name) throws Exception {
+    return delegate.getMetadata(namespace, name);
+  }
+
+  @Override
+  public byte[] getData(String namespace, String name) throws Exception {
+    return delegate.getData(namespace, name);
+  }
+
+  @Override
   public void put(String namespace, String name, String data, @Nullable String description,
       Map<String, String> properties) throws Exception {
     //TODO put data in in-mempry map

--- a/cdap-security/src/main/java/io/cdap/cdap/security/store/DefaultSecureStoreService.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/store/DefaultSecureStoreService.java
@@ -91,6 +91,22 @@ public class DefaultSecureStoreService extends AbstractIdleService implements Se
     return secureStoreService.get(namespace, name);
   }
 
+  @Override
+  public SecureStoreMetadata getMetadata(String namespace, String name) throws Exception {
+    Principal principal = authenticationContext.getPrincipal();
+    SecureKeyId secureKeyId = new SecureKeyId(namespace, name);
+    accessEnforcer.enforce(secureKeyId, principal, StandardPermission.GET);
+    return secureStoreService.getMetadata(namespace, name);
+  }
+
+  @Override
+  public byte[] getData(String namespace, String name) throws Exception {
+    Principal principal = authenticationContext.getPrincipal();
+    SecureKeyId secureKeyId = new SecureKeyId(namespace, name);
+    accessEnforcer.enforce(secureKeyId, principal, StandardPermission.GET);
+    return secureStoreService.getData(namespace, name);
+  }
+
   /**
    * Puts the user provided data in the secure store, if the user has admin access to the key.
    *

--- a/cdap-security/src/main/java/io/cdap/cdap/security/store/SecureStoreHandler.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/store/SecureStoreHandler.java
@@ -22,8 +22,8 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.security.store.SecureStore;
-import io.cdap.cdap.api.security.store.SecureStoreData;
 import io.cdap.cdap.api.security.store.SecureStoreManager;
+import io.cdap.cdap.api.security.store.SecureStoreMetadata;
 import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.security.AuditDetail;
@@ -114,7 +114,7 @@ public class SecureStoreHandler extends AbstractHttpHandler {
       @PathParam("namespace-id") String namespace,
       @PathParam("key-name") String name) throws Exception {
     SecureKeyId secureKeyId = new SecureKeyId(namespace, name);
-    httpResponder.sendByteArray(HttpResponseStatus.OK, secureStore.get(namespace, name).get(),
+    httpResponder.sendByteArray(HttpResponseStatus.OK, secureStore.getData(namespace, name),
         new DefaultHttpHeaders().set(HttpHeaderNames.CONTENT_TYPE, "text/plain;charset=utf-8"));
   }
 
@@ -123,8 +123,8 @@ public class SecureStoreHandler extends AbstractHttpHandler {
   public void getMetadata(HttpRequest httpRequest, HttpResponder httpResponder,
       @PathParam("namespace-id") String namespace,
       @PathParam("key-name") String name) throws Exception {
-    SecureStoreData secureStoreData = secureStore.get(namespace, name);
-    httpResponder.sendJson(HttpResponseStatus.OK, GSON.toJson(secureStoreData.getMetadata()));
+    SecureStoreMetadata metadata = secureStore.getMetadata(namespace, name);
+    httpResponder.sendJson(HttpResponseStatus.OK, GSON.toJson(metadata));
   }
 
   @Path("/")

--- a/cdap-security/src/main/java/io/cdap/cdap/security/store/secretmanager/SecretManagerSecureStoreService.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/store/secretmanager/SecretManagerSecureStoreService.java
@@ -117,6 +117,28 @@ public class SecretManagerSecureStoreService extends AbstractIdleService impleme
   }
 
   @Override
+  public SecureStoreMetadata getMetadata(String namespace, String name) throws Exception {
+    validate(namespace);
+    try {
+      SecretMetadata metadata = secretManager.getMetadata(namespace, name);
+      return new SecureStoreMetadata(metadata.getName(), metadata.getDescription(),
+          metadata.getCreationTimeMs(), metadata.getProperties());
+    } catch (SecretNotFoundException e) {
+      throw new SecureKeyNotFoundException(new SecureKeyId(namespace, name), e);
+    }
+  }
+
+  @Override
+  public byte[] getData(String namespace, String name) throws Exception {
+    validate(namespace);
+    try {
+      return secretManager.getData(namespace, name);
+    } catch (SecretNotFoundException e) {
+      throw new SecureKeyNotFoundException(new SecureKeyId(namespace, name), e);
+    }
+  }
+
+  @Override
   public void put(String namespace, String name, String data, @Nullable String description,
       Map<String, String> properties) throws Exception {
     validate(namespace);

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/GitPatAuthenticationStrategy.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/GitPatAuthenticationStrategy.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.sourcecontrol;
 
 import com.google.common.base.Throwables;
 import io.cdap.cdap.api.security.store.SecureStore;
-import io.cdap.cdap.api.security.store.SecureStoreData;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -76,9 +75,9 @@ public class GitPatAuthenticationStrategy implements AuthenticationStrategy {
 
     @Override
     public void refresh() throws IOException, AuthenticationConfigException {
-      SecureStoreData data;
+      byte[] data;
       try {
-        data = secureStore.get(namespaceId, passwordKeyName);
+        data = secureStore.getData(namespaceId, passwordKeyName);
       } catch (Exception e) {
         Throwables.propagateIfInstanceOf(e, IOException.class);
         throw new AuthenticationConfigException("Failed to get password from secure store", e);
@@ -88,7 +87,7 @@ public class GitPatAuthenticationStrategy implements AuthenticationStrategy {
             String.format("Password with key name %s not found in secure store",
                 passwordKeyName));
       }
-      password = new String(data.get(), StandardCharsets.UTF_8);
+      password = new String(data, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.sourcecontrol;
 
 import io.cdap.cdap.api.security.store.SecureStore;
-import io.cdap.cdap.api.security.store.SecureStoreData;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
@@ -68,9 +67,8 @@ public class RepositoryManagerTest extends SourceControlTestBase {
   @Before
   public void beforeEach() throws Exception {
     MockitoAnnotations.initMocks(this);
-    Mockito.when(secureStore.get(NAMESPACE, PASSWORD_NAME))
-        .thenReturn(new SecureStoreData(null,
-            MOCK_TOKEN.getBytes(StandardCharsets.UTF_8)));
+    Mockito.when(secureStore.getData(NAMESPACE, PASSWORD_NAME))
+        .thenReturn(MOCK_TOKEN.getBytes(StandardCharsets.UTF_8));
     cConf = CConfiguration.create();
     cConf.setInt(Constants.SourceControlManagement.GIT_COMMAND_TIMEOUT_SECONDS,
         GIT_COMMAND_TIMEOUT);
@@ -108,9 +106,8 @@ public class RepositoryManagerTest extends SourceControlTestBase {
   @Test
   public void testValidateInvalidToken() throws Exception {
     SourceControlConfig sourceControlConfig = getSourceControlConfig();
-    Mockito.when(secureStore.get(NAMESPACE, PASSWORD_NAME))
-        .thenReturn(new SecureStoreData(null,
-            "invalid-token".getBytes(StandardCharsets.UTF_8)));
+    Mockito.when(secureStore.getData(NAMESPACE, PASSWORD_NAME))
+        .thenReturn("invalid-token".getBytes(StandardCharsets.UTF_8));
     try {
       RepositoryManager.validateConfig(secureStore, sourceControlConfig);
       Assert.fail();

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/BasicSparkClientContext.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/BasicSparkClientContext.java
@@ -334,6 +334,16 @@ final class BasicSparkClientContext implements SparkClientContext {
   }
 
   @Override
+  public SecureStoreMetadata getMetadata(String namespace, String name) throws Exception {
+    return sparkRuntimeContext.getMetadata(namespace, name);
+  }
+
+  @Override
+  public byte[] getData(String namespace, String name) throws Exception {
+    return sparkRuntimeContext.getData(namespace, name);
+  }
+
+  @Override
   public ProgramState getState() {
     return state;
   }

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkSecureStore.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkSecureStore.java
@@ -19,7 +19,6 @@ package io.cdap.cdap.app.runtime.spark;
 import io.cdap.cdap.api.security.store.SecureStore;
 import io.cdap.cdap.api.security.store.SecureStoreData;
 import io.cdap.cdap.api.security.store.SecureStoreMetadata;
-
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -57,6 +56,16 @@ public class SparkSecureStore implements SecureStore, Externalizable {
   @Override
   public SecureStoreData get(String namespace, String name) throws Exception {
     return delegate.get(namespace, name);
+  }
+
+  @Override
+  public SecureStoreMetadata getMetadata(String namespace, String name) throws Exception {
+    return delegate.getMetadata(namespace, name);
+  }
+
+  @Override
+  public byte[] getData(String namespace, String name) throws Exception {
+    return delegate.getData(namespace, name);
   }
 
   @Override

--- a/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
+++ b/cdap-spark-core-base/src/main/scala/io/cdap/cdap/app/runtime/spark/DefaultJavaSparkExecutionContext.scala
@@ -16,35 +16,25 @@
 
 package io.cdap.cdap.app.runtime.spark
 
-import io.cdap.cdap.api.Admin
-import io.cdap.cdap.api.ServiceDiscoverer
-import io.cdap.cdap.api.TxRunnable
+import io.cdap.cdap.api.{Admin, ServiceDiscoverer, TxRunnable}
 import io.cdap.cdap.api.app.ApplicationSpecification
 import io.cdap.cdap.api.data.batch.Split
 import io.cdap.cdap.api.lineage.field.Operation
 import io.cdap.cdap.api.messaging.MessagingContext
-import io.cdap.cdap.api.metadata.Metadata
-import io.cdap.cdap.api.metadata.MetadataEntity
-import io.cdap.cdap.api.metadata.MetadataScope
+import io.cdap.cdap.api.metadata.{Metadata, MetadataEntity, MetadataScope}
 import io.cdap.cdap.api.metrics.Metrics
 import io.cdap.cdap.api.plugin.PluginContext
 import io.cdap.cdap.api.preview.DataTracer
 import io.cdap.cdap.api.schedule.TriggeringScheduleInfo
-import io.cdap.cdap.api.security.store.SecureStore
-import io.cdap.cdap.api.security.store.SecureStoreData
-import io.cdap.cdap.api.security.store.SecureStoreMetadata
-import io.cdap.cdap.api.spark.JavaSparkExecutionContext
-import io.cdap.cdap.api.spark.SparkExecutionContext
-import io.cdap.cdap.api.spark.SparkSpecification
+import io.cdap.cdap.api.security.store.{SecureStore, SecureStoreData, SecureStoreMetadata}
+import io.cdap.cdap.api.spark.{JavaSparkExecutionContext, SparkExecutionContext, SparkSpecification}
 import io.cdap.cdap.api.spark.dynamic.SparkInterpreter
-import io.cdap.cdap.api.workflow.WorkflowInfo
-import io.cdap.cdap.api.workflow.WorkflowToken
+import io.cdap.cdap.api.workflow.{WorkflowInfo, WorkflowToken}
 import org.apache.spark.api.java.JavaPairRDD
 import org.apache.twill.api.RunId
 
 import java.io.IOException
-import java.lang
-import java.util
+import java.{lang, util}
 import scala.collection.JavaConversions._
 import scala.reflect.ClassTag
 
@@ -143,6 +133,16 @@ class DefaultJavaSparkExecutionContext(sec: SparkExecutionContext) extends JavaS
   @throws[IOException]
   override def get(namespace: String, name: String): SecureStoreData = {
     return sec.getSecureStore.get(namespace, name)
+  }
+
+  @throws[IOException]
+  override def getMetadata(namespace: String, name: String): SecureStoreMetadata = {
+    return sec.getSecureStore.getMetadata(namespace, name)
+  }
+
+  @throws[IOException]
+  override def getData(namespace: String, name: String): Array[Byte] = {
+    return sec.getSecureStore.getData(namespace, name)
   }
 
   /**


### PR DESCRIPTION
Enhanced the SecretManager and SecureStore APIs to have separate methods to get the actual secret content and the secret metadata. This matches the REST API, which already has separate endpoints for the data and metadata, and removes the need to make two calls whenever just one piece of information is needed.

This also increases the usability of SecretManager implementations that use a system that has different quotas for fetching metadata and secret content, like the GCP SecretManager.