### PR TITLE
[CDAP-20509]Added caching before pushing to relational stages to prevent reprocessing when running in the Spark engine

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSQLEngineAdapter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSQLEngineAdapter.java
@@ -827,7 +827,9 @@ public class BatchSQLEngineAdapter implements Closeable {
       // Push all stages that need to be pushed to execute this aggregation
       input.forEach((name, collection) -> {
         if (!exists(name)) {
-          push(name, stageSpec.getInputSchemas().get(name), collection);
+          // Cache input dataset to prevent reprocessing and metrics skew.
+          SparkCollection<Object> cachedCollection = collection.cache();
+          push(name, stageSpec.getInputSchemas().get(name), cachedCollection);
         }
       });
 


### PR DESCRIPTION
This avoids the metrics skew issue reported in https://cdap.atlassian.net/browse/CDAP-20509