### PR TITLE
[CDAP-20535] Updated LinearRelationalTransform to support multiple input relations.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/DelegatingMultiRelation.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/DelegatingMultiRelation.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+import io.cdap.cdap.etl.api.aggregation.DeduplicateAggregationDefinition;
+import io.cdap.cdap.etl.api.aggregation.GroupByAggregationDefinition;
+import io.cdap.cdap.etl.api.aggregation.WindowAggregationDefinition;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation of {@link Relation} which takes multiple relations and delegates operations to all of them.
+ */
+public class DelegatingMultiRelation implements Relation {
+
+  List<Relation> delegates;
+
+  private DelegatingMultiRelation(List<Relation> delegates) {
+    this.delegates = delegates;
+  }
+
+  @Override
+  public boolean isValid() {
+    return delegates.stream().allMatch(Relation::isValid);
+  }
+
+  @Override
+  public String getValidationError() {
+    return delegates.stream().map(Relation::getValidationError).collect(Collectors.joining(";"));
+  }
+
+  @Override
+  public Relation setColumn(String column, Expression value) {
+    return new DelegatingMultiRelation(delegates.stream()
+                               .map(d -> d.setColumn(column, value))
+                               .collect(Collectors.toList()));
+  }
+
+  @Override
+  public Relation dropColumn(String column) {
+    return new DelegatingMultiRelation(delegates.stream()
+                               .map(d -> d.dropColumn(column))
+                               .collect(Collectors.toList()));
+  }
+
+  @Override
+  public Relation select(Map<String, Expression> columns) {
+    return new DelegatingMultiRelation(delegates.stream()
+                               .map(d -> d.select(columns))
+                               .collect(Collectors.toList()));
+  }
+
+  @Override
+  public Relation filter(Expression filter) {
+    return new DelegatingMultiRelation(delegates.stream()
+                               .map(d -> d.filter(filter))
+                               .collect(Collectors.toList()));
+  }
+
+  @Override
+  public Relation groupBy(GroupByAggregationDefinition aggregationDefinition) {
+    return new DelegatingMultiRelation(delegates.stream()
+                               .map(d -> d.groupBy(aggregationDefinition))
+                               .collect(Collectors.toList()));
+  }
+
+  @Override
+  public Relation window(WindowAggregationDefinition aggregationDefinition) {
+    return new DelegatingMultiRelation(delegates.stream()
+                               .map(d -> d.window(aggregationDefinition))
+                               .collect(Collectors.toList()));
+  }
+
+  @Override
+  public Relation deduplicate(DeduplicateAggregationDefinition aggregationDefinition) {
+    return new DelegatingMultiRelation(delegates.stream()
+                               .map(d -> d.deduplicate(aggregationDefinition))
+                               .collect(Collectors.toList()));
+  }
+
+  public List<Relation> getDelegates() {
+    return delegates;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  static class Builder {
+    List<Relation> delegates;
+
+    private Builder() {
+      this.delegates = new ArrayList<>();
+    }
+
+    public void addRelation(Relation relation) {
+      this.delegates.add(relation);
+    }
+
+    public DelegatingMultiRelation build() {
+      return new DelegatingMultiRelation( this.delegates);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/LinearRelationalTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/LinearRelationalTransform.java
@@ -29,14 +29,12 @@ public interface LinearRelationalTransform extends RelationalTransform {
    * Relation)}.
    *
    * @param context tranformation context with engine, input and output parameters
-   * @return true
+   * @return true if the number of input relations is 1. False otherwise.
    */
   default boolean transform(RelationalTranformContext context) {
     Set<String> names = context.getInputRelationNames();
     if (names.size() != 1) {
-      throw new IllegalArgumentException(
-          "Plugin " + getClass().getName() + " supports only single input and got "
-              + names.size() + ": " + names);
+      return false;
     }
     context.setOutputRelation(
         transform(context, context.getInputRelation(names.iterator().next())));

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/LinearRelationalTransformCapabilities.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/LinearRelationalTransformCapabilities.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.relational;
+
+public enum LinearRelationalTransformCapabilities implements Capability {
+  /**
+ * Set if {@link LinearRelationalTransform#transform(RelationalTranformContext) can handle multiple input stages}
+ */
+  CAN_HANDLE_MULTIPLE_INPUTS;
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/relation/SparkSQLRelation.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/relation/SparkSQLRelation.java
@@ -128,7 +128,7 @@ public class SparkSQLRelation implements Relation {
                     SELECT,
                     getColumnAliasCSV(columnExpMap),
                     FROM,
-                    this.datasetName)
+                    "relational_transform_stage")
     );
 
     if (filterCondition != null && !filterCondition.isEmpty()) {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/batch/relation/SparkSQLRelationTest.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/batch/relation/SparkSQLRelationTest.java
@@ -45,9 +45,10 @@ public class SparkSQLRelationTest {
     SparkSQLRelation actualRelation =
       (SparkSQLRelation) baseSQLRelation.setColumn("c", factory.compile("a+b"));
 
-    SparkSQLRelation expectedRelation = new SparkSQLRelation("testDataset",
-                                                     Arrays.asList("a", "b", "c"),
-                                                     "SELECT a AS a , b AS b , a+b AS c FROM testDataset");
+    SparkSQLRelation expectedRelation =
+      new SparkSQLRelation("testDataset",
+                           Arrays.asList("a", "b", "c"),
+                           "SELECT a AS a , b AS b , a+b AS c FROM relational_transform_stage");
 
     Assert.assertTrue(expectedRelation.equals(actualRelation));
   }
@@ -55,9 +56,10 @@ public class SparkSQLRelationTest {
   @Test
   public void testDropColumn() {
     SparkSQLRelation actualRelation = (SparkSQLRelation) baseSQLRelation.dropColumn("b");
-    SparkSQLRelation expectedRelation = new SparkSQLRelation("testDataset",
-                                                             Arrays.asList("a"),
-                                                             "SELECT a AS a FROM testDataset");
+    SparkSQLRelation expectedRelation =
+      new SparkSQLRelation("testDataset",
+                           Arrays.asList("a"),
+                           "SELECT a AS a FROM relational_transform_stage");
     Assert.assertTrue(expectedRelation.equals(actualRelation));
   }
 
@@ -68,20 +70,22 @@ public class SparkSQLRelationTest {
     selectColumns.put("new_b", factory.compile("b"));
 
     SparkSQLRelation actualRelation = (SparkSQLRelation) baseSQLRelation.select(selectColumns);
-    SparkSQLRelation expectedRelation = new SparkSQLRelation("testDataset",
-                                                             Arrays.asList("new_a", "new_b"),
-                                                             "SELECT a AS new_a , b AS new_b FROM " +
-                                                               "testDataset");
+    SparkSQLRelation expectedRelation =
+      new SparkSQLRelation("testDataset",
+                           Arrays.asList("new_a", "new_b"),
+                           "SELECT a AS new_a , b AS new_b FROM " +
+                             "relational_transform_stage");
     Assert.assertTrue(expectedRelation.equals(actualRelation));
   }
 
   @Test
   public void testFilter() {
     SparkSQLRelation actualRelation = (SparkSQLRelation) baseSQLRelation.filter(factory.compile("a > 2"));
-    SparkSQLRelation expectedRelation = new SparkSQLRelation("testDataset",
-                                                             Arrays.asList("a", "b"),
-                                                             "SELECT a AS a , b AS b FROM testDataset " +
-                                                               "WHERE a > 2");
+    SparkSQLRelation expectedRelation =
+      new SparkSQLRelation("testDataset",
+                           Arrays.asList("a", "b"),
+                           "SELECT a AS a , b AS b FROM relational_transform_stage " +
+                             "WHERE a > 2");
     Assert.assertEquals(expectedRelation.getSqlStatement(), actualRelation.getSqlStatement());
   }
 }


### PR DESCRIPTION
Engines can use a new capability to signal that they support multiple input relational transform stages.

The Spark SQL Engine is able to quickly combine input stages (using the dataframe union operation).

Since Spark is the fallback engine, this ensures relational transform stages will always be able to execute in Spark.