### PR TITLE
[CDAP-20535] Removed exception when LinearRelationalTransform stages contain more than 2 inputs.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/LinearRelationalTransform.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/relational/LinearRelationalTransform.java
@@ -29,14 +29,12 @@ public interface LinearRelationalTransform extends RelationalTransform {
    * Relation)}.
    *
    * @param context tranformation context with engine, input and output parameters
-   * @return true
+   * @return true if the number of input relations is 1. False otherwise.
    */
   default boolean transform(RelationalTranformContext context) {
     Set<String> names = context.getInputRelationNames();
     if (names.size() != 1) {
-      throw new IllegalArgumentException(
-          "Plugin " + getClass().getName() + " supports only single input and got "
-              + names.size() + ": " + names);
+      return false;
     }
     context.setOutputRelation(
         transform(context, context.getInputRelation(names.iterator().next())));


### PR DESCRIPTION
This removes failures caused by the **GROUP BY** and **DEDUPLICATE** with multiple inputs with the new Spark SQL Engine.

This ensures those plugins execute as Spark plugins.

