### PR TITLE
CDAP-20500 add launch mode to dataproc provisioners

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramOptionConstants.java
@@ -189,4 +189,9 @@ public final class ProgramOptionConstants {
    * This is needed for running tethered programs
    */
   public static final String PROGRAM_RESOURCE_URI = "programResourceUri";
+
+  /**
+   * Option for the {@link io.cdap.cdap.runtime.spi.runtimejob.LaunchMode} for the run.
+   */
+  public static final String LAUNCH_MODE = "launchMode";
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RuntimeJobTwillPreparer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/remote/RuntimeJobTwillPreparer.java
@@ -40,6 +40,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.LocalFile;
+import org.apache.twill.api.ResourceSpecification;
 import org.apache.twill.api.RuntimeSpecification;
 import org.apache.twill.api.TwillPreparer;
 import org.apache.twill.api.TwillRunnable;
@@ -237,7 +238,9 @@ class RuntimeJobTwillPreparer extends AbstractRuntimeTwillPreparer {
       }
     }
 
+    ResourceSpecification resourceSpecification = runtimeSpec.getResourceSpecification();
     return new DefaultRuntimeJobInfo(
-        getProgramRunId(), resultingFiles, jvmProperties, runtimeJobArguments);
+        getProgramRunId(), resultingFiles, jvmProperties, runtimeJobArguments,
+        resourceSpecification.getVirtualCores(), resourceSpecification.getMemorySize());
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
@@ -33,6 +33,7 @@ import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.name.Names;
+import com.google.inject.util.Modules;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.artifact.ApplicationClass;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
@@ -40,7 +41,7 @@ import io.cdap.cdap.app.deploy.ConfigResponse;
 import io.cdap.cdap.app.deploy.Configurator;
 import io.cdap.cdap.app.guice.ClusterMode;
 import io.cdap.cdap.app.guice.DefaultProgramRunnerFactory;
-import io.cdap.cdap.app.guice.RemoteExecutionDiscoveryModule;
+import io.cdap.cdap.app.guice.DistributedProgramContainerModule;
 import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.app.program.Programs;
@@ -50,12 +51,11 @@ import io.cdap.cdap.app.runtime.ProgramOptions;
 import io.cdap.cdap.app.runtime.ProgramRunner;
 import io.cdap.cdap.app.runtime.ProgramRunnerFactory;
 import io.cdap.cdap.app.runtime.ProgramRuntimeProvider;
+import io.cdap.cdap.app.runtime.ProgramRuntimeProvider.Mode;
 import io.cdap.cdap.app.runtime.ProgramStateWriter;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.discovery.ResolvingDiscoverable;
-import io.cdap.cdap.common.guice.ConfigModule;
-import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.lang.jar.BundleJarUtil;
 import io.cdap.cdap.common.lang.jar.ClassLoaderFolder;
@@ -71,9 +71,6 @@ import io.cdap.cdap.internal.app.deploy.InMemoryConfigurator;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentRuntimeInfo;
 import io.cdap.cdap.internal.app.deploy.pipeline.AppSpecInfo;
-import io.cdap.cdap.internal.app.program.MessagingProgramStatePublisher;
-import io.cdap.cdap.internal.app.program.MessagingProgramStateWriter;
-import io.cdap.cdap.internal.app.program.ProgramStatePublisher;
 import io.cdap.cdap.internal.app.runtime.AbstractListener;
 import io.cdap.cdap.internal.app.runtime.BasicArguments;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
@@ -86,6 +83,7 @@ import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepositoryReader;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteIsolatedPluginFinder;
+import io.cdap.cdap.internal.app.runtime.batch.MapReduceProgramRunner;
 import io.cdap.cdap.internal.app.runtime.codec.ArgumentsCodec;
 import io.cdap.cdap.internal.app.runtime.codec.ProgramOptionsCodec;
 import io.cdap.cdap.internal.app.runtime.distributed.DistributedMapReduceProgramRunner;
@@ -96,27 +94,23 @@ import io.cdap.cdap.internal.app.runtime.monitor.RuntimeClientService;
 import io.cdap.cdap.internal.app.runtime.monitor.RuntimeMonitors;
 import io.cdap.cdap.internal.app.runtime.monitor.ServiceSocksProxyInfo;
 import io.cdap.cdap.internal.app.runtime.monitor.TrafficRelayServer;
+import io.cdap.cdap.internal.app.runtime.workflow.WorkflowProgramRunner;
 import io.cdap.cdap.internal.profile.ProfileMetricService;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.appender.loader.LogAppenderLoaderService;
 import io.cdap.cdap.logging.context.LoggingContextHelper;
-import io.cdap.cdap.logging.guice.TMSLogAppenderModule;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
 import io.cdap.cdap.messaging.server.MessagingHttpService;
-import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.runtime.spi.RuntimeMonitorType;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
+import io.cdap.cdap.runtime.spi.runtimejob.LaunchMode;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJob;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobEnvironment;
-import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
-import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
-import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
-import io.cdap.cdap.security.impersonation.UGIProvider;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
@@ -144,10 +138,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.twill.api.ServiceAnnouncer;
 import org.apache.twill.api.TwillRunner;
+import org.apache.twill.common.Cancellable;
 import org.apache.twill.common.Threads;
 import org.apache.twill.filesystem.Location;
-import org.apache.twill.filesystem.LocationFactory;
 import org.apache.twill.internal.ServiceListenerAdapter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -185,11 +181,21 @@ public class DefaultRuntimeJob implements RuntimeJob {
     ProgramOptions programOpts = readJsonFile(
         new File(DistributedProgramRunner.PROGRAM_OPTIONS_FILE_NAME),
         ProgramOptions.class);
+
+    Map<String, String> enhancedSystemArgs = new HashMap<>(programOpts.getArguments().asMap());
+    LaunchMode launchMode = runtimeJobEnv.getLaunchMode();
+    enhancedSystemArgs.put(ProgramOptionConstants.LAUNCH_MODE, launchMode.name());
+    // in client mode, need to add host to the system arguments
+    if (launchMode == LaunchMode.CLIENT) {
+      enhancedSystemArgs.put(ProgramOptionConstants.HOST,
+          InetAddress.getLocalHost().getCanonicalHostName());
+    }
+    Arguments systemArgs = new BasicArguments(enhancedSystemArgs);
+    programOpts = new SimpleProgramOptions(programOpts.getProgramId(),
+        systemArgs, programOpts.getUserArguments(), programOpts.isDebug());
     ProgramRunId programRunId = programOpts.getProgramId()
         .run(ProgramRunners.getRunId(programOpts));
     ProgramId programId = programRunId.getParent();
-
-    Arguments systemArgs = programOpts.getArguments();
 
     // Setup logging context for the program
     LoggingContextAccessor.setLoggingContext(
@@ -514,58 +520,67 @@ public class DefaultRuntimeJob implements RuntimeJob {
       ProgramRunId programRunId,
       ProgramOptions programOpts) {
     List<Module> modules = new ArrayList<>();
-    modules.add(new ConfigModule(cConf));
+    // doesn't make sense to run a service program in isolated mode
+    ServiceAnnouncer serviceAnnouncer = new ServiceAnnouncer() {
+      @Override
+      public Cancellable announce(String s, int i) {
+        throw new UnsupportedOperationException("Services are not supported in remote jobs");
+      }
 
-    RuntimeMonitorType runtimeMonitorType = SystemArguments.getRuntimeMonitorType(cConf,
-        programOpts);
-    modules.add(RuntimeMonitors.getRemoteAuthenticatorModule(runtimeMonitorType, programOpts));
-
-    modules.add(new IOModule());
-    modules.add(new TMSLogAppenderModule());
-    modules.add(new RemoteExecutionDiscoveryModule());
-    modules.add(new AuthorizationEnforcementModule().getDistributedModules());
-    modules.add(new AuthenticationContextModules().getProgramContainerModule(cConf));
-    modules.add(new MetricsClientRuntimeModule().getDistributedModules());
-    modules.add(new MessagingServerRuntimeModule().getStandaloneModules());
+      @Override
+      public Cancellable announce(String s, int i, byte[] bytes) {
+        throw new UnsupportedOperationException("Services are not supported in remote jobs");
+      }
+    };
+    // module for running programs, except with MessagingServer bindings
+    // instead of MessagingClient. This is because this class runs a local MessagingService
+    // that the actual program will write to, while the RuntimeClientService relays the messages
+    // back to the actual system messaging service.
+    Module programModule = Modules.override(new DistributedProgramContainerModule(
+        cConf, new Configuration(), programRunId, programOpts, serviceAnnouncer))
+        .with(new MessagingServerRuntimeModule().getStandaloneModules());
+    modules.add(programModule);
 
     modules.add(new AbstractModule() {
       @Override
       protected void configure() {
         bind(ClusterMode.class).toInstance(ClusterMode.ISOLATED);
-        bind(UGIProvider.class).to(CurrentUGIProvider.class).in(Scopes.SINGLETON);
 
-        // Bindings from the environment
+        // Bindings from the environment for program runners
         bind(TwillRunner.class).annotatedWith(Constants.AppFabric.ProgramRunner.class)
             .toInstance(runtimeJobEnv.getTwillRunner());
-        bind(LocationFactory.class).toInstance(runtimeJobEnv.getLocationFactory());
 
         MapBinder<ProgramType, ProgramRunner> defaultProgramRunnerBinder = MapBinder.newMapBinder(
             binder(), ProgramType.class, ProgramRunner.class);
 
-        bind(ProgramRuntimeProvider.Mode.class).toInstance(ProgramRuntimeProvider.Mode.DISTRIBUTED);
+        if (runtimeJobEnv.getLaunchMode() == LaunchMode.CLIENT) {
+          bind(ProgramRuntimeProvider.Mode.class).toInstance(Mode.LOCAL);
+          defaultProgramRunnerBinder.addBinding(ProgramType.MAPREDUCE)
+              .to(MapReduceProgramRunner.class);
+          defaultProgramRunnerBinder.addBinding(ProgramType.WORKFLOW)
+              .to(WorkflowProgramRunner.class);
+        } else {
+          bind(ProgramRuntimeProvider.Mode.class).toInstance(Mode.DISTRIBUTED);
+          defaultProgramRunnerBinder.addBinding(ProgramType.MAPREDUCE)
+              .to(DistributedMapReduceProgramRunner.class);
+          defaultProgramRunnerBinder.addBinding(ProgramType.WORKFLOW)
+              .to(DistributedWorkflowProgramRunner.class);
+          defaultProgramRunnerBinder.addBinding(ProgramType.WORKER)
+              .to(DistributedWorkerProgramRunner.class);
+        }
         bind(ProgramRunnerFactory.class).annotatedWith(Constants.AppFabric.ProgramRunner.class)
             .to(DefaultProgramRunnerFactory.class).in(Scopes.SINGLETON);
-        bind(ProgramStatePublisher.class).to(MessagingProgramStatePublisher.class)
-            .in(Scopes.SINGLETON);
-        bind(ProgramStateWriter.class).to(MessagingProgramStateWriter.class).in(Scopes.SINGLETON);
 
-        defaultProgramRunnerBinder.addBinding(ProgramType.MAPREDUCE)
-            .to(DistributedMapReduceProgramRunner.class);
-        defaultProgramRunnerBinder.addBinding(ProgramType.WORKFLOW)
-            .to(DistributedWorkflowProgramRunner.class);
-        defaultProgramRunnerBinder.addBinding(ProgramType.WORKER)
-            .to(DistributedWorkerProgramRunner.class);
         bind(ProgramRunnerFactory.class).to(DefaultProgramRunnerFactory.class).in(Scopes.SINGLETON);
 
         bind(ProgramRunId.class).toInstance(programRunId);
-        bind(RuntimeMonitorType.class).toInstance(runtimeMonitorType);
 
+        // needed for app-spec regeneration
         install(
             new FactoryModuleBuilder()
                 .implement(Configurator.class, InMemoryConfigurator.class)
                 .build(ConfiguratorFactory.class)
         );
-
         bind(String.class)
             .annotatedWith(Names.named(RemoteIsolatedPluginFinder.ISOLATED_PLUGIN_DIR))
             .toInstance(programOpts.getArguments().getOption(ProgramOptionConstants.PLUGIN_DIR,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJobInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJobInfo.java
@@ -36,15 +36,12 @@ public class DefaultRuntimeJobInfo implements RuntimeJobInfo {
   private final Map<String, String> jvmProperties;
 
   private final Map<String, String> arguments;
-
-
-  public DefaultRuntimeJobInfo(ProgramRunId programRunId, Collection<? extends LocalFile> files,
-      Map<String, String> jvmProperties) {
-    this(programRunId, files, jvmProperties, Collections.emptyMap());
-  }
+  private final int virtualCores;
+  private final int memoryMb;
 
   public DefaultRuntimeJobInfo(ProgramRunId programRunId, Collection<? extends LocalFile> files,
-                               Map<String, String> jvmProperties, Map<String, String> arguments) {
+      Map<String, String> jvmProperties, Map<String, String> arguments,
+      int virtualCores, int memoryMb) {
     this.info = new ProgramRunInfo.Builder()
       .setNamespace(programRunId.getNamespace())
       .setApplication(programRunId.getApplication())
@@ -55,6 +52,8 @@ public class DefaultRuntimeJobInfo implements RuntimeJobInfo {
     this.files = Collections.unmodifiableCollection(new ArrayList<>(files));
     this.jvmProperties = Collections.unmodifiableMap(new LinkedHashMap<>(jvmProperties));
     this.arguments = Collections.unmodifiableMap(arguments);
+    this.virtualCores = virtualCores;
+    this.memoryMb = memoryMb;
   }
 
   @Override
@@ -80,5 +79,15 @@ public class DefaultRuntimeJobInfo implements RuntimeJobInfo {
   @Override
   public Map<String, String> getArguments() {
     return arguments;
+  }
+
+  @Override
+  public int getVirtualCores() {
+    return virtualCores;
+  }
+
+  @Override
+  public int getMemoryMb() {
+    return memoryMb;
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJobTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJobTest.java
@@ -19,20 +19,26 @@ package io.cdap.cdap.internal.app.runtime.distributed.runtimejob;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import io.cdap.cdap.app.runtime.Arguments;
+import io.cdap.cdap.app.runtime.ProgramRunner;
+import io.cdap.cdap.app.runtime.ProgramRunnerFactory;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.twill.NoopTwillRunnerService;
+import io.cdap.cdap.internal.app.deploy.ConfiguratorFactory;
 import io.cdap.cdap.internal.app.runtime.BasicArguments;
 import io.cdap.cdap.internal.app.runtime.SimpleProgramOptions;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
+import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import io.cdap.cdap.runtime.spi.provisioner.Cluster;
 import io.cdap.cdap.runtime.spi.provisioner.ClusterStatus;
 import io.cdap.cdap.runtime.spi.provisioner.Node;
+import io.cdap.cdap.runtime.spi.runtimejob.LaunchMode;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobEnvironment;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.twill.api.TwillRunner;
@@ -51,39 +57,61 @@ public class DefaultRuntimeJobTest {
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
   @Test
-  public void testInjector() throws Exception {
+  public void testClusterModeInjector() throws Exception {
+    testInjector(LaunchMode.CLUSTER);
+  }
+
+  @Test
+  public void testClientModeInjector() throws Exception {
+    testInjector(LaunchMode.CLIENT);
+  }
+
+  private void testInjector(LaunchMode launchMode) throws IOException {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().toString());
 
     LocationFactory locationFactory = new LocalLocationFactory(TEMP_FOLDER.newFile());
 
     DefaultRuntimeJob defaultRuntimeJob = new DefaultRuntimeJob();
-    Arguments systemArgs = new BasicArguments(Collections.singletonMap(SystemArguments.PROFILE_NAME, "test"));
-    Node node = new Node("test", Node.Type.MASTER, "127.0.0.1", System.currentTimeMillis(), Collections.emptyMap());
-    Cluster cluster = new Cluster("test", ClusterStatus.RUNNING, Collections.singleton(node), Collections.emptyMap());
-    ProgramRunId programRunId = NamespaceId.DEFAULT.app("app").workflow("workflow").run(RunIds.generate());
-    SimpleProgramOptions programOpts = new SimpleProgramOptions(programRunId.getParent(), systemArgs,
-                                                                new BasicArguments());
+    Arguments systemArgs =
+        new BasicArguments(Collections.singletonMap(SystemArguments.PROFILE_NAME, "test"));
+    Node node = new Node("test", Node.Type.MASTER, "127.0.0.1", System.currentTimeMillis(),
+        Collections.emptyMap());
+    Cluster cluster = new Cluster("test", ClusterStatus.RUNNING, Collections.singleton(node),
+        Collections.emptyMap());
+    ProgramRunId programRunId =
+        NamespaceId.DEFAULT.app("app").workflow("workflow").run(RunIds.generate());
+    SimpleProgramOptions programOpts = new SimpleProgramOptions(programRunId.getParent(),
+        systemArgs, new BasicArguments());
 
-    Injector injector = Guice.createInjector(defaultRuntimeJob.createModules(new RuntimeJobEnvironment() {
+    Injector injector = Guice.createInjector(defaultRuntimeJob.createModules(
+        new RuntimeJobEnvironment() {
 
-      @Override
-      public LocationFactory getLocationFactory() {
-        return locationFactory;
-      }
+          @Override
+          public LocationFactory getLocationFactory() {
+            return locationFactory;
+          }
 
-      @Override
-      public TwillRunner getTwillRunner() {
-        return new NoopTwillRunnerService();
-      }
+          @Override
+          public TwillRunner getTwillRunner() {
+            return new NoopTwillRunnerService();
+          }
 
-      @Override
-      public Map<String, String> getProperties() {
-        return Collections.emptyMap();
-      }
-    }, cConf, programRunId, programOpts));
+          @Override
+          public Map<String, String> getProperties() {
+            return Collections.emptyMap();
+          }
+
+          @Override
+          public LaunchMode getLaunchMode() {
+            return launchMode;
+          }
+        }, cConf, programRunId, programOpts));
 
     injector.getInstance(LogAppenderInitializer.class);
     defaultRuntimeJob.createCoreServices(injector, systemArgs, cluster);
+    injector.getInstance(ConfiguratorFactory.class);
+    ProgramRunnerFactory programRunnerFactory = injector.getInstance(ProgramRunnerFactory.class);
+    programRunnerFactory.create(ProgramType.WORKFLOW);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManagerTest.java
@@ -251,8 +251,7 @@ public class TetheringRuntimeJobManagerTest {
                                                  DistributedProgramRunner.APP_SPEC_FILE_NAME);
 
     RuntimeJobInfo runtimeJobInfo = new DefaultRuntimeJobInfo(programRunId,
-                                                              localFiles,
-                                                              Collections.emptyMap());
+        localFiles, Collections.emptyMap(), Collections.emptyMap(), 0, 0);
     TetheringLaunchMessage payload = runtimeJobManager.createLaunchPayload(runtimeJobInfo);
     Assert.assertEquals(TETHERED_NAMESPACE_NAME, payload.getRuntimeNamespace());
     Assert.assertEquals(localFilenames, payload.getFiles().keySet());

--- a/cdap-client/src/main/java/io/cdap/cdap/client/SecureStoreClient.java
+++ b/cdap-client/src/main/java/io/cdap/cdap/client/SecureStoreClient.java
@@ -43,7 +43,6 @@ import java.util.List;
  * Provides ways to get/set Secure keys.
  */
 public class SecureStoreClient {
-
   private static final Gson GSON = new Gson();
   private static final String SECURE_KEYS = "securekeys";
 

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocJobMain.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocJobMain.java
@@ -50,6 +50,7 @@ public class DataprocJobMain {
   public static final String SPARK_COMPAT = "sparkCompat";
   public static final String ARCHIVE = "archive";
   public static final String PROPERTY_PREFIX = "prop";
+  public static final String LAUNCH_MODE = "launchMode";
 
   private static final Logger LOG = LoggerFactory.getLogger(DataprocJobMain.class);
 
@@ -69,6 +70,10 @@ public class DataprocJobMain {
     if (!arguments.containsKey(SPARK_COMPAT)) {
       throw new RuntimeException(
           "Missing --" + SPARK_COMPAT + " argument for the spark compat version");
+    }
+    if (!arguments.containsKey(LAUNCH_MODE)) {
+      throw new RuntimeException(
+          "Missing -- " + LAUNCH_MODE + " argument for the launch mode");
     }
     if (!arguments.containsKey(Constants.Files.APPLICATION_JAR)) {
       throw new RuntimeException(
@@ -94,6 +99,7 @@ public class DataprocJobMain {
     String sparkCompat = arguments.get(SPARK_COMPAT).iterator().next();
     String applicationJarLocalizedName = arguments.get(Constants.Files.APPLICATION_JAR).iterator()
         .next();
+    String launchMode = arguments.get(LAUNCH_MODE).iterator().next();
 
     // create classpath from resources, application and twill jars
     URL[] urls = getClasspath(Arrays.asList(Constants.Files.RESOURCES_JAR,
@@ -117,9 +123,11 @@ public class DataprocJobMain {
 
       try {
         // call initialize() method on dataprocEnvClass
-        Method initializeMethod = dataprocEnvClass.getMethod("initialize", String.class);
-        LOG.info("Invoking initialize() on {} with {}", dataprocEnvClassName, sparkCompat);
-        initializeMethod.invoke(newDataprocEnvInstance, sparkCompat);
+        Method initializeMethod = dataprocEnvClass.getMethod("initialize", String.class,
+            String.class);
+        LOG.info("Invoking initialize() on {} with {}, {}",
+            dataprocEnvClassName, sparkCompat, launchMode);
+        initializeMethod.invoke(newDataprocEnvInstance, sparkCompat, launchMode);
 
         // call run() method on runtimeJobClass
         Class<?> runEnvCls = newCL.loadClass(RuntimeJobEnvironment.class.getName());

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeEnvironment.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeEnvironment.java
@@ -57,14 +57,16 @@ public class DataprocRuntimeEnvironment implements RuntimeJobEnvironment {
   private TwillRunnerService yarnTwillRunnerService;
   private LocationFactory locationFactory;
   private Map<String, String> properties;
+  private LaunchMode launchMode;
 
   /**
    * This method initializes the dataproc runtime environment.
    *
    * @param sparkCompat spark compat version supported by dataproc cluster
+   * @param launchMode program launch mode
    * @throws Exception any exception while initializing the environment.
    */
-  public void initialize(String sparkCompat) throws Exception {
+  public void initialize(String sparkCompat, String launchMode) throws Exception {
     addConsoleAppender();
     System.setProperty(TWILL_ZK_SERVER_LOCALHOST, "false");
     zkServer = InMemoryZKServer.builder().build();
@@ -78,6 +80,7 @@ public class DataprocRuntimeEnvironment implements RuntimeJobEnvironment {
     yarnTwillRunnerService = new YarnTwillRunnerService(conf, connectionStr, locationFactory);
     yarnTwillRunnerService.start();
     properties = ImmutableMap.of(ZK_QUORUM, connectionStr, APP_SPARK_COMPAT, sparkCompat);
+    this.launchMode = LaunchMode.valueOf(launchMode);
   }
 
   @Override
@@ -93,6 +96,11 @@ public class DataprocRuntimeEnvironment implements RuntimeJobEnvironment {
   @Override
   public Map<String, String> getProperties() {
     return properties;
+  }
+
+  @Override
+  public LaunchMode getLaunchMode() {
+    return launchMode;
   }
 
   /**

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
@@ -604,6 +604,27 @@
           }
         },
         {
+          "widget-type": "radio-group",
+          "label": "Launch Mode",
+          "name": "launchMode",
+          "description": "Whether to launch the program directly in the Dataproc job (client mode) or in a separate container (cluster mode). Client mode will result in faster start up times and fewer cluster resources used, but may run into errors if the launcher requires more memory.",
+          "widget-attributes": {
+            "layout": "inline",
+            "size": "medium",
+            "default": "cluster",
+            "options": [
+              {
+                "id": "client",
+                "label": "Client"
+              },
+              {
+                "id": "cluster",
+                "label": "Cluster"
+              }
+            ]
+          }
+        },
+        {
           "widget-type": "toggle",
           "label": "Prefer External IP",
           "name": "preferExternalIP",

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-existing-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-existing-dataproc.json
@@ -84,6 +84,32 @@
       ]
     },
     {
+      "label": "Advanced",
+      "properties": [
+        {
+          "widget-type": "radio-group",
+          "label": "Launch Mode",
+          "name": "launchMode",
+          "description": "Whether to launch the program directly in the Dataproc job (client mode) or in a separate container (cluster mode). Client mode will result in faster start up times and fewer cluster resources used, but may run into errors if the launcher requires more memory.",
+          "widget-attributes": {
+            "layout": "inline",
+            "size": "medium",
+            "default": "cluster",
+            "options": [
+              {
+                "id": "client",
+                "label": "Client"
+              },
+              {
+                "id": "cluster",
+                "label": "Cluster"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
       "label": "Monitoring",
       "properties": [
         {

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocRuntimeJobManagerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocRuntimeJobManagerTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.SparkCompat;
 import io.cdap.cdap.runtime.spi.runtimejob.DataprocRuntimeJobManager;
+import io.cdap.cdap.runtime.spi.runtimejob.LaunchMode;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobInfo;
 import java.util.Collection;
 import java.util.Collections;
@@ -129,8 +130,9 @@ public class DataprocRuntimeJobManagerTest {
             runtimeJobInfo,
             Collections.emptyList(),
             SparkCompat.SPARK3_2_12.getCompat(),
-            Constants.Files.APPLICATION_JAR);
-    Assert.assertEquals(4, arguments.size());
+            Constants.Files.APPLICATION_JAR,
+            LaunchMode.CLIENT);
+    Assert.assertEquals(5, arguments.size());
     Assert.assertTrue(arguments.contains("--propkey=\"val\""));
     Assert.assertTrue(
         arguments.contains("--runtimeJobClass=" + runtimeJobInfo.getRuntimeJobClassname()));
@@ -138,6 +140,7 @@ public class DataprocRuntimeJobManagerTest {
     Assert.assertTrue(
         arguments.contains(
             "--" + Constants.Files.APPLICATION_JAR + "=" + Constants.Files.APPLICATION_JAR));
+    Assert.assertTrue(arguments.contains("--launchMode=CLIENT"));
   }
 
   @Test

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/LaunchMode.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/LaunchMode.java
@@ -1,0 +1,33 @@
+/*
+ *  Copyright © 2023 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.cdap.runtime.spi.runtimejob;
+
+/**
+ * Program launch mode.
+ */
+public enum LaunchMode {
+  /**
+   * Client mode is used when the RuntimeJob should run the workflow driver, spark client, etc.
+   * in-process instead of as a separate container in the cluster.
+   */
+  CLIENT,
+  /**
+   * Cluster mode is used when the RuntimeJob should run the workflow driver, spark client, etc.
+   * as a separate container in the cluster.
+   */
+  CLUSTER;
+}

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobEnvironment.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobEnvironment.java
@@ -40,4 +40,11 @@ public interface RuntimeJobEnvironment {
    * Returns runtime environment properties to be available to {@link RuntimeJob}.
    */
   Map<String, String> getProperties();
+
+  /**
+   * Returns how the RuntimeJob should launch the program client.
+   */
+  default LaunchMode getLaunchMode() {
+    return LaunchMode.CLUSTER;
+  }
 }

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobInfo.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/RuntimeJobInfo.java
@@ -58,4 +58,18 @@ public interface RuntimeJobInfo {
   default Map<String, String> getArguments() {
     return Collections.emptyMap();
   }
+
+  /**
+   * Returns the number of virtual cores to use for the {@link RuntimeJob}.
+   */
+  default int getVirtualCores() {
+    return 0;
+  }
+
+  /**
+   * Returns the amount of memory to use for the {@link RuntimeJob}.
+   */
+  default int getMemoryMb() {
+    return 0;
+  }
 }

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkPackageUtils.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkPackageUtils.java
@@ -314,7 +314,7 @@ public final class SparkPackageUtils {
   /**
    * Returns the Spark environment setup via the start up script.
    */
-  private static synchronized Map<String, String> getSparkEnv() {
+  public static synchronized Map<String, String> getSparkEnv() {
     if (sparkEnv != null) {
       return sparkEnv;
     }

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRunner.java
@@ -42,6 +42,7 @@ import io.cdap.cdap.app.runtime.spark.submit.MasterEnvironmentSparkSubmitter;
 import io.cdap.cdap.app.runtime.spark.submit.SparkSubmitter;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.AppFabric;
 import io.cdap.cdap.common.http.CommonNettyHttpServiceFactory;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.lang.FilterClassLoader;
@@ -66,6 +67,7 @@ import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.runtime.spi.runtimejob.LaunchMode;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import org.apache.hadoop.conf.Configuration;
@@ -222,10 +224,13 @@ public final class SparkProgramRunner extends AbstractProgramRunnerWithPlugin
         submitter = new MasterEnvironmentSparkSubmitter(cConf, locationFactory, host, runtimeContext,
                                                         masterEnv, options);
       } else {
+        String launchModeStr = options.getArguments().getOption(ProgramOptionConstants.LAUNCH_MODE);
+        LaunchMode launchMode = LaunchMode.valueOf(launchModeStr);
+        String schedulerQueue = options.getArguments().getOption(AppFabric.APP_SCHEDULER_QUEUE);
         submitter = isLocal
           ? new LocalSparkSubmitter()
           : new DistributedSparkSubmitter(hConf, locationFactory, host, runtimeContext,
-                                          options.getArguments().getOption(Constants.AppFabric.APP_SCHEDULER_QUEUE));
+                                          schedulerQueue, launchMode);
       }
 
       String jvmOpts = options.getUserArguments().getOption(SystemArguments.JVM_OPTS);

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
@@ -32,6 +32,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;


### PR DESCRIPTION
Added the concept of a launch mode for runtime jobs. When set to cluster mode, the workflow driver/spark client will be run in a separate container, which is the previous behavior. When set to client mode, the workflow driver/spark client will be run within the runtime job, reducing the overhead required for the job.