### PR TITLE
CDAP-20455 add flag to allow source macros in streaming

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/macro/MacroFunction.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/macro/MacroFunction.java
@@ -16,14 +16,15 @@
 
 package io.cdap.cdap.api.macro;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 
 /**
  * Class representing a macro function.
  */
-public class MacroFunction {
-
+public class MacroFunction implements Serializable {
+  private static final long serialVersionUID = 5883638727963250169L;
   private final String functionName;
   private final List<String> arguments;
 

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
@@ -51,6 +51,9 @@ public final class Constants {
   public static final String CDAP_STREAMING_BASE_RETRY_DELAY_IN_SECONDS = "cdap.streaming.baseRetryDelayInSeconds";
   // Can be used as a runtime argument for streaming pipeline to set max retry delay in seconds
   public static final String CDAP_STREAMING_MAX_RETRY_DELAY_IN_SECONDS = "cdap.streaming.maxRetryDelayInSeconds";
+  // Can be used as a runtime argument for streaming pipelines to allow macros in the source,
+  // even when using spark checkpointing.
+  public static final String CDAP_STREAMING_ALLOW_SOURCE_MACROS = "cdap.streaming.allow.source.macros";
 
   private Constants() {
     throw new AssertionError("Suppress default constructor for noninstantiability");

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/spark/streaming/MockSource.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/spark/streaming/MockSource.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.etl.mock.spark.streaming;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
+import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.annotation.Plugin;
 import io.cdap.cdap.api.data.format.StructuredRecord;
@@ -149,6 +150,7 @@ public class MockSource extends StreamingSource<StructuredRecord> {
     private String records;
     @Nullable
     private Long intervalMillis;
+    @Macro
     @Nullable
     private String referenceName;
 
@@ -194,7 +196,7 @@ public class MockSource extends StreamingSource<StructuredRecord> {
     properties.put("intervalMillis",
         new PluginPropertyField("intervalMillis", "", "long", false, false));
     properties.put("referenceName",
-        new PluginPropertyField("referenceName", "", "string", false, false));
+        new PluginPropertyField("referenceName", "", "string", false, true));
     return PluginClass.builder().setName("Mock").setType(StreamingSource.PLUGIN_TYPE)
         .setDescription("").setClassName(MockSource.class.getName()).setProperties(properties)
         .setConfigFieldName("conf").build();


### PR DESCRIPTION
Added a flag to allow using source macros in streaming pipelines, even if Spark checkpointing is used. When set, there will be a warning log indicating that the macro will never be re-evaluated, even in subsequent runs.