### PR TITLE
[cherry-pick] [CDAP-20428] Bump default value for program.status.event.topic.num.partitions to 10

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -950,7 +950,7 @@
 
   <property>
     <name>program.status.event.topic.num.partitions</name>
-    <value>1</value>
+    <value>10</value>
     <description>
       Number of topics to use for program run events. All events realted to same
       run should always

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -547,6 +547,7 @@ public class TestBase {
     cConf.set(Constants.Metadata.SERVICE_BIND_ADDRESS, localhost);
     cConf.set(Constants.Preview.ADDRESS, localhost);
     cConf.set(Constants.SupportBundle.SERVICE_BIND_ADDRESS, localhost);
+    cConf.setInt(Constants.AppFabric.PROGRAM_STATUS_EVENT_NUM_PARTITIONS, 1);
 
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, localDataDir.getAbsolutePath());
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);


### PR DESCRIPTION
Cherry picking [PR](https://github.com/cdapio/cdap/pull/15072) into release/6.9