### PR TITLE
Add onBatchStarted and onBatchRetry methods for streaming batch.

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingEventHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api-spark/src/main/java/io/cdap/cdap/etl/api/streaming/StreamingEventHandler.java
@@ -17,7 +17,7 @@
 package io.cdap.cdap.etl.api.streaming;
 
 /**
- * Interface for handling Streaming batch events
+ * Interface for handling Streaming batch events.
  */
 public interface StreamingEventHandler {
 
@@ -27,4 +27,22 @@ public interface StreamingEventHandler {
    * @param streamingContext @link{StreamingContext} Context object for this stage
    */
   void onBatchCompleted(StreamingContext streamingContext);
+
+  /**
+   * Call before starting each batch.
+   *
+   * @param streamingContext @link{StreamingContext} Context object for this stage
+   */
+  default void onBatchStarted(StreamingContext streamingContext) {
+    // default implementation for backward compatibility
+  }
+
+  /**
+   * Call before batch retry.
+   *
+   * @param streamingContext @link{StreamingContext} Context object for this stage
+   */
+  default void onBatchRetry(StreamingContext streamingContext) {
+    // default implementation for backward compatibility
+  }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SinkRunnableProvider.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SinkRunnableProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark;
+
+import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.common.PhaseSpec;
+import io.cdap.cdap.etl.common.RecordInfo;
+import io.cdap.cdap.etl.common.StageStatisticsCollector;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.function.FunctionCache;
+import io.cdap.cdap.etl.spark.function.PluginFunctionContext;
+import java.util.Map;
+import java.util.Set;
+
+public interface SinkRunnableProvider {
+
+  /**
+   * Returns runnable for batch sink.
+   *
+   * @param stageSpec {@link StageSpec}
+   * @param stageData {@link SparkCollection} with stageData.
+   * @param functionCacheFactory {@link FunctionCache.Factory}
+   * @param pluginFunctionContext {@link PluginFunctionContext}
+   * @return {@link Runnable} for the sink.
+   */
+  Runnable getBatchSinkRunnable(StageSpec stageSpec, SparkCollection<Object> stageData,
+      FunctionCache.Factory functionCacheFactory, PluginFunctionContext pluginFunctionContext);
+
+  /**
+   * Returns runnable for Spark sink.
+   *
+   * @param stageSpec {@link StageSpec}
+   * @param stageData {@link SparkCollection} with stageData.
+   * @param sparkSink {@link SparkSink} reference.
+   * @return {@link Runnable} for the sink.
+   * @throws Exception Exception thrown by the sink.
+   */
+  Runnable getSparkSinkRunnable(StageSpec stageSpec, SparkCollection<Object> stageData,
+      SparkSink<Object> sparkSink) throws Exception;
+
+  /**
+   * Returns runnable for group sink.
+   *
+   * @param phaseSpec {@link PhaseSpec}
+   * @param stageData {@link SparkCollection} with stageData.
+   * @param groupStages {@link Set} of stages in the group.
+   * @param collectors {@link Map} of stage to {@link StageStatisticsCollector}.
+   * @param groupSinks {@link Set} of sinks in the group.
+   * @return {@link Runnable} for the sink.
+   */
+  Runnable getGroupSinkRunnable(PhaseSpec phaseSpec, SparkCollection<RecordInfo<Object>> stageData,
+      Set<String> groupStages, Map<String, StageStatisticsCollector> collectors,
+      Set<String> groupSinks);
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSinkRunnableProvider.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/BatchSinkRunnableProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.batch;
+
+import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.common.PhaseSpec;
+import io.cdap.cdap.etl.common.RecordInfo;
+import io.cdap.cdap.etl.common.StageStatisticsCollector;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.SinkRunnableProvider;
+import io.cdap.cdap.etl.spark.SparkCollection;
+import io.cdap.cdap.etl.spark.function.BatchSinkFunction;
+import io.cdap.cdap.etl.spark.function.FunctionCache;
+import io.cdap.cdap.etl.spark.function.PluginFunctionContext;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Runnable provider for sinks in batch pipelines.
+ */
+public class BatchSinkRunnableProvider implements SinkRunnableProvider {
+
+  @Override
+  public Runnable getBatchSinkRunnable(StageSpec stageSpec, SparkCollection<Object> stageData,
+      FunctionCache.Factory functionCacheFactory, PluginFunctionContext pluginFunctionContext) {
+    return stageData.createStoreTask(stageSpec, new BatchSinkFunction(
+        pluginFunctionContext, functionCacheFactory.newCache()));
+  }
+
+  @Override
+  public Runnable getSparkSinkRunnable(StageSpec stageSpec, SparkCollection<Object> stageData,
+      SparkSink<Object> sparkSink) throws Exception {
+    return stageData.createStoreTask(stageSpec, sparkSink);
+  }
+
+  @Override
+  public Runnable getGroupSinkRunnable(PhaseSpec phaseSpec,
+      SparkCollection<RecordInfo<Object>> stageData, Set<String> groupStages,
+      Map<String, StageStatisticsCollector> collectors, Set<String> groupSinks) {
+    return stageData.createMultiStoreTask(phaseSpec, groupStages, groupSinks, collectors);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/StreamingSinkRunnableProvider.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/StreamingSinkRunnableProvider.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.streaming;
+
+import io.cdap.cdap.api.spark.JavaSparkExecutionContext;
+import io.cdap.cdap.etl.api.batch.SparkSink;
+import io.cdap.cdap.etl.common.PhaseSpec;
+import io.cdap.cdap.etl.common.RecordInfo;
+import io.cdap.cdap.etl.common.StageStatisticsCollector;
+import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.SparkCollection;
+import io.cdap.cdap.etl.spark.batch.BatchSinkRunnableProvider;
+import io.cdap.cdap.etl.spark.function.FunctionCache;
+import io.cdap.cdap.etl.spark.function.PluginFunctionContext;
+import io.cdap.cdap.etl.spark.streaming.function.SerializableCallable;
+import io.cdap.cdap.etl.spark.streaming.function.StreamingBatchSinkFunction;
+import io.cdap.cdap.etl.spark.streaming.function.StreamingMultiSinkFunction;
+import io.cdap.cdap.etl.spark.streaming.function.StreamingSparkSinkFunction;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import org.apache.spark.streaming.Time;
+
+/**
+ * Runnable provider for sinks in streaming pipelines.
+ */
+public class StreamingSinkRunnableProvider extends BatchSinkRunnableProvider {
+
+  private final boolean stateStoreEnabled;
+  private final SerializableCallable batchRetryFunction;
+  private final long batchTime;
+  private final JavaSparkExecutionContext sec;
+  private final StreamingRetrySettings streamingRetrySettings;
+
+  public StreamingSinkRunnableProvider(JavaSparkExecutionContext sec, boolean stateStoreEnabled,
+      StreamingRetrySettings streamingRetrySettings, SerializableCallable batchRetryFunction,
+      long batchTime) {
+
+    this.stateStoreEnabled = stateStoreEnabled;
+    this.batchRetryFunction = batchRetryFunction;
+    this.batchTime = batchTime;
+    this.sec = sec;
+    this.streamingRetrySettings = streamingRetrySettings;
+  }
+
+  @Override
+  public Runnable getBatchSinkRunnable(StageSpec stageSpec, SparkCollection<Object> stageData,
+      FunctionCache.Factory functionCacheFactory, PluginFunctionContext pluginFunctionContext) {
+    if (!stateStoreEnabled) {
+      return super.getBatchSinkRunnable(stageSpec, stageData, functionCacheFactory,
+          pluginFunctionContext);
+    }
+
+    return () -> {
+      try {
+        new StreamingBatchSinkFunction<>(sec, stageSpec, functionCacheFactory.newCache(),
+            streamingRetrySettings, batchRetryFunction)
+            .call(stageData.getUnderlying(), Time.apply(batchTime));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+
+  @Override
+  public Runnable getSparkSinkRunnable(StageSpec stageSpec, SparkCollection<Object> stageData,
+      SparkSink<Object> sparkSink) throws Exception {
+    if (!stateStoreEnabled) {
+      return super.getSparkSinkRunnable(stageSpec, stageData, sparkSink);
+    }
+
+    return () -> {
+      try {
+        new StreamingSparkSinkFunction<>(sec, stageSpec, streamingRetrySettings, batchRetryFunction)
+            .call(stageData.getUnderlying(), Time.apply(batchTime));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+
+  @Override
+  public Runnable getGroupSinkRunnable(PhaseSpec phaseSpec,
+      SparkCollection<RecordInfo<Object>> stageData, Set<String> groupStages,
+      Map<String, StageStatisticsCollector> collectors, Set<String> groupSinks) {
+    if (!stateStoreEnabled) {
+      return super.getGroupSinkRunnable(phaseSpec, stageData, groupStages, collectors, groupSinks);
+    }
+
+    return () -> {
+      try {
+        new StreamingMultiSinkFunction(sec, phaseSpec, groupStages, groupSinks, collectors,
+            streamingRetrySettings, batchRetryFunction)
+            .call(stageData.getUnderlying(), Time.apply(batchTime));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/SerializableCallable.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/SerializableCallable.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.spark.streaming.function;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+
+/**
+ * A serializable callable.
+ */
+public interface SerializableCallable extends Callable<Void>, Serializable {
+
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingBatchSinkFunction.java
@@ -57,9 +57,16 @@ public class StreamingBatchSinkFunction<T> extends AbstractStreamingSinkFunction
   private final StageSpec stageSpec;
   private final FunctionCache functionCache;
 
-  public StreamingBatchSinkFunction(JavaSparkExecutionContext sec, StageSpec stageSpec, FunctionCache functionCache,
-                                    StreamingRetrySettings retrySettings) {
-    super(retrySettings);
+  public StreamingBatchSinkFunction(JavaSparkExecutionContext sec, StageSpec stageSpec,
+      FunctionCache functionCache, StreamingRetrySettings retrySettings) {
+    this(sec, stageSpec, functionCache, retrySettings, () -> null);
+
+  }
+
+  public StreamingBatchSinkFunction(JavaSparkExecutionContext sec, StageSpec stageSpec,
+      FunctionCache functionCache, StreamingRetrySettings retrySettings,
+      SerializableCallable batchRetryFunction) {
+    super(retrySettings, batchRetryFunction);
     this.sec = sec;
     this.stageSpec = stageSpec;
     this.functionCache = functionCache;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingMultiSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingMultiSinkFunction.java
@@ -66,10 +66,15 @@ public class StreamingMultiSinkFunction extends AbstractStreamingSinkFunction<Ja
   private final Map<String, StageStatisticsCollector> collectors;
 
   public StreamingMultiSinkFunction(JavaSparkExecutionContext sec, PhaseSpec phaseSpec,
-                                    Set<String> group, Set<String> sinkNames,
-                                    Map<String, StageStatisticsCollector> collectors,
-                                    StreamingRetrySettings retrySettings) {
-    super(retrySettings);
+      Set<String> group, Set<String> sinkNames, Map<String, StageStatisticsCollector> collectors,
+      StreamingRetrySettings retrySettings) {
+    this(sec, phaseSpec, group, sinkNames, collectors, retrySettings, () -> null);
+  }
+
+  public StreamingMultiSinkFunction(JavaSparkExecutionContext sec, PhaseSpec phaseSpec,
+      Set<String> group, Set<String> sinkNames, Map<String, StageStatisticsCollector> collectors,
+      StreamingRetrySettings retrySettings, SerializableCallable batchRetryFunction) {
+    super(retrySettings, batchRetryFunction);
     this.sec = sec;
     this.phaseSpec = phaseSpec;
     this.group = group;

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingSparkSinkFunction.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/function/StreamingSparkSinkFunction.java
@@ -54,8 +54,13 @@ public class StreamingSparkSinkFunction<T> extends AbstractStreamingSinkFunction
   private final StageSpec stageSpec;
 
   public StreamingSparkSinkFunction(JavaSparkExecutionContext sec, StageSpec stageSpec,
-                                    StreamingRetrySettings retrySettings) {
-    super(retrySettings);
+      StreamingRetrySettings retrySettings) {
+    this(sec, stageSpec, retrySettings, () -> null);
+  }
+
+  public StreamingSparkSinkFunction(JavaSparkExecutionContext sec, StageSpec stageSpec,
+      StreamingRetrySettings retrySettings, SerializableCallable batchRetryFunction) {
+    super(retrySettings, batchRetryFunction);
     this.sec = sec;
     this.stageSpec = stageSpec;
   }


### PR DESCRIPTION
Add onBatchStarted and onBatchRetry methods for streaming batch.

- When state store is enabled, some streaming sources need to do special actions when a batch is started and when it is retried. Add additional functions to enable this and call these during the processing.
- Refactored code to get the Runnables for different types of sinks as a separate interface. This makes the code cleaner when a retry function is passed. 
