### PR TITLE
Add schema support to SparkSQLRelation

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/batch/relation/SparkSQLRelationTest.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/batch/relation/SparkSQLRelationTest.java
@@ -47,7 +47,8 @@ public class SparkSQLRelationTest {
 
     SparkSQLRelation expectedRelation = new SparkSQLRelation("testDataset",
                                                      Arrays.asList("a", "b", "c"),
-                                                     "SELECT a AS a , b AS b , a+b AS c FROM testDataset");
+                                                     "SELECT a AS a , b AS b , a+b AS c FROM testDataset",
+                                                     null);
 
     Assert.assertTrue(expectedRelation.equals(actualRelation));
   }
@@ -57,7 +58,8 @@ public class SparkSQLRelationTest {
     SparkSQLRelation actualRelation = (SparkSQLRelation) baseSQLRelation.dropColumn("b");
     SparkSQLRelation expectedRelation = new SparkSQLRelation("testDataset",
                                                              Arrays.asList("a"),
-                                                             "SELECT a AS a FROM testDataset");
+                                                             "SELECT a AS a FROM testDataset",
+                                                             null);
     Assert.assertTrue(expectedRelation.equals(actualRelation));
   }
 
@@ -71,7 +73,8 @@ public class SparkSQLRelationTest {
     SparkSQLRelation expectedRelation = new SparkSQLRelation("testDataset",
                                                              Arrays.asList("new_a", "new_b"),
                                                              "SELECT a AS new_a , b AS new_b FROM " +
-                                                               "testDataset");
+                                                               "testDataset",
+                                                             null);
     Assert.assertTrue(expectedRelation.equals(actualRelation));
   }
 
@@ -81,7 +84,8 @@ public class SparkSQLRelationTest {
     SparkSQLRelation expectedRelation = new SparkSQLRelation("testDataset",
                                                              Arrays.asList("a", "b"),
                                                              "SELECT a AS a , b AS b FROM testDataset " +
-                                                               "WHERE a > 2");
+                                                               "WHERE a > 2",
+                                                             null);
     Assert.assertEquals(expectedRelation.getSqlStatement(), actualRelation.getSqlStatement());
   }
 }


### PR DESCRIPTION
This PR adds a `schema` field to `SparkSQLRelation` similar to the one added in BigQueryRelation ([PR](https://github.com/data-integrations/google-cloud/pull/1215)).