### PR TITLE
Add feature flag for Wrangler precondition selector

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5848,6 +5848,15 @@
   </property>
 
   <property>
+    <name>feature.wrangler.precondition.sql.enabled</name>
+    <value>false</value>
+    <description>
+      Enables the Precondition Language selector in Wrangler, allowing to select
+      between JEXL and SQL preconditions.
+    </description>
+  </property>
+
+  <property>
     <name>artifact.cache.bind.address</name>
     <value>0.0.0.0</value>
     <description>

--- a/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
+++ b/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
@@ -36,7 +36,8 @@ public enum Feature {
   WRANGLER_FAIL_PIPELINE_FOR_ERROR("6.8.0"),
   STREAMING_PIPELINE_NATIVE_STATE_TRACKING("6.8.0", false),
   PUSHDOWN_TRANSFORMATION_WINDOWAGGREGATION("6.9.0"),
-  SOURCE_CONTROL_MANAGEMENT_GIT("6.9.0");
+  SOURCE_CONTROL_MANAGEMENT_GIT("6.9.0"),
+  WRANGLER_PRECONDITION_SQL("6.9.1");
 
   private final PlatformInfo.Version versionIntroduced;
   private final boolean defaultAfterIntroduction;


### PR DESCRIPTION
This PR adds the feature flag `feature.wrangler.precondition.sql.enabled`. This flag can be enabled to allow changing Precondition language in Wrangler to SQL.