### PR TITLE
[CDAP-20550] Fix bug where driver, executor cpu requests are not honored

### DIFF
--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitter.java
@@ -163,9 +163,31 @@ public class MasterEnvironmentSparkSubmitter extends AbstractSparkSubmitter {
   private SparkConfig generateOrGetSparkConfig() throws Exception {
     if (sparkConfig == null) {
       SparkSpecification spec = runtimeContext.getSparkSpecification();
+      int driverCores = spec.getDriverResources().getVirtualCores();
+      String driverCoresKey = "task.driver." + SystemArguments.CORES_KEY;
+      String value = runtimeContext.getRuntimeArguments().get(driverCoresKey);
+      if (value != null) {
+        try {
+         driverCores = Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+          LOG.warn("Invalid {} value: {}",
+              driverCoresKey, value);
+        }
+      }
+      int executorCores = spec.getExecutorResources().getVirtualCores();
+      String executorCoresKey = "task.executor." + SystemArguments.CORES_KEY;
+      value = runtimeContext.getRuntimeArguments().get(executorCoresKey);
+      if (value != null) {
+        try {
+          executorCores = Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+          LOG.warn("Invalid {} value: {}",
+              executorCoresKey, value);
+        }
+      }
       SparkSubmitContext context = new SparkSubmitContext(getLocalizeResources(resources), namespaceConfig,
-                                                          spec.getDriverResources().getVirtualCores(),
-                                                          spec.getExecutorResources().getVirtualCores());
+                                                          driverCores,
+                                                          executorCores);
       sparkConfig = masterEnv.generateSparkSubmitConfig(context);
     }
     return sparkConfig;


### PR DESCRIPTION
`task.driver.system.resources.cores`, `task.executor.system.resources.cores` set in runtime args or pipeline resource configuration should take precedence over the values present in the appspec.