### PR TITLE
[CDAP-20579] Replace BlockingDeque with ConcurrentQueue in MessagingMetricsProcessor

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -836,7 +836,8 @@ public final class Constants {
     public static final String SERVICE_DESCRIPTION = "Service to handle metrics requests.";
     public static final String PROCESSOR_MAX_DELAY_MS = "metrics.processor.max.delay.ms";
     public static final String QUEUE_SIZE = "metrics.processor.queue.size";
-    public static final String OFFER_TIMEOUT_MS = "metrics.processor.offer.timeout.ms";
+    public static final String PROCESSOR_FETCH_BACKOFF_DELAY_MS =
+        "metrics.processor.fetch.backoff.delay.ms";
 
     public static final String ENTITY_TABLE_NAME = "metrics.data.entity.tableName";
     public static final String METRICS_TABLE_WRITE_PARRALELISM = "metrics.data.table.write.parallelism";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3076,6 +3076,15 @@
   </property>
 
   <property>
+    <name>metrics.processor.fetch.backoff.delay.ms</name>
+    <value>50</value>
+    <description>
+      Delay in milliseconds for a metrics processor topic thread to wait when metrics queue
+      is filled.
+    </description>
+  </property>
+
+  <property>
     <name>app.program.metrics.enabled</name>
     <value>true</value>
     <description>
@@ -5927,5 +5936,4 @@
       Path where git repositories will be cloned for source control operations.
     </description>
   </property>
-
 </configuration>


### PR DESCRIPTION
[CDAP-20579](https://cdap.atlassian.net/browse/CDAP-20579)

## Tested
Ran a test to publish a large number of metrics repeatedly to check queue size never exceeds `queueSize + nTopics`. Ensured that there are no deadlocks and performance is better than BlockingQueue implementation.

[CDAP-20579]: https://cdap.atlassian.net/browse/CDAP-20579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ