### PR TITLE
[CDAP-20543] Upgrading dataproc version to 2.1 in default compute profile

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -356,8 +356,8 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
   String getImageVersion(ProvisionerContext context, DataprocConf conf) {
     String imageVersion = conf.getImageVersion();
     if (imageVersion == null) {
-      // Dataproc 2.0 is the default version from 6.7 and later
-      imageVersion = "2.0";
+      // Dataproc 2.1 is the default version from 6.9.1 and later
+      imageVersion = "2.1";
     }
     return imageVersion;
   }

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -241,20 +241,20 @@ public class DataprocProvisionerTest {
     ));
 
     context.setSparkCompat(SparkCompat.SPARK3_2_12);
-    Assert.assertEquals("2.0", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.1", provisioner.getImageVersion(context, defaultConf));
     Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
 
     context.setAppCDAPVersionInfo(new MockVersionInfo("6.5.0"));
-    Assert.assertEquals("2.0", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.1", provisioner.getImageVersion(context, defaultConf));
     Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
 
     context.setAppCDAPVersionInfo(new MockVersionInfo("6.4.0"));
-    Assert.assertEquals("2.0", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.1", provisioner.getImageVersion(context, defaultConf));
     Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
 
     //Doublecheck we still get 2.0 for Spark 3 even with CDAP 6.4
     context.setSparkCompat(SparkCompat.SPARK3_2_12);
-    Assert.assertEquals("2.0", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.1", provisioner.getImageVersion(context, defaultConf));
 
   }
 
@@ -280,7 +280,7 @@ public class DataprocProvisionerTest {
 
     Mockito.when(dataprocClient.getCluster("cdap-app-runId")).thenReturn(Optional.empty());
     Mockito.when(dataprocClient.createCluster(Mockito.eq("cdap-app-runId"),
-                                              Mockito.eq("2.0"),
+                                              Mockito.eq("2.1"),
                                               addedLabelsCaptor.capture(),
                                               Mockito.eq(false),
                                               Mockito.any()))


### PR DESCRIPTION
[CDAP-20543] Upgrading dataproc version to 2.1 in default compute profile #15059

[CDAP-20543]: https://cdap.atlassian.net/browse/CDAP-20543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ