### PR TITLE
[CDAP-20547] Skip authorization enforcement from spark job

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4683,6 +4683,15 @@
   </property>
 
   <property>
+    <name>security.authorization.access.enforcer.allowlist.users</name>
+    <value>yarn</value>
+    <description>
+      comma-separated list of users to be allow-listed from authorization access
+      enforcement.
+    </description>
+  </property>
+
+  <property>
     <name>security.data.keyfile.path</name>
     <value>${local.data.dir}/security/keyfile</value>
     <description>

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AllowlistAccessEnforcer.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AllowlistAccessEnforcer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.authorization;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import io.cdap.cdap.api.security.AccessException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.proto.element.EntityType;
+import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.security.Permission;
+import io.cdap.cdap.proto.security.Principal;
+import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of the RemoteAccessEnforcer. It is used to skip authorization enforcement for
+ * some users.
+ */
+public class AllowlistAccessEnforcer extends AbstractAccessEnforcer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AllowlistAccessEnforcer.class);
+  public static final String ALLOWLIST_DELEGATE_ACCESS_ENFORCER =
+      "allowlist.delegate.access.enforcer";
+  public static final String ACCESS_ENFORCER_ALLOWLIST_USERS =
+      "security.authorization.access.enforcer.allowlist.users";
+  private final AccessEnforcer delegate;
+  private final List<String> allowlistUsers;
+
+  @Inject
+  AllowlistAccessEnforcer(
+      @Named(ALLOWLIST_DELEGATE_ACCESS_ENFORCER) AccessEnforcer accessEnforcer,
+      CConfiguration cConf) {
+    super(cConf);
+    delegate = accessEnforcer;
+    allowlistUsers = Arrays.asList(cConf.get(ACCESS_ENFORCER_ALLOWLIST_USERS).split(","));
+  }
+
+  @Override
+  public void enforce(EntityId entity, Principal principal, Set<? extends Permission> permissions)
+      throws AccessException {
+    if (principal != null && allowlistUsers.contains(principal.getName())) {
+      // skip authorization enforcement when user is yarn.
+      LOG.debug("Skipping authorization enforcement for user '{}'", principal.getName());
+      return;
+    }
+    delegate.enforce(entity, principal, permissions);
+  }
+
+  @Override
+  public void enforceOnParent(EntityType entityType, EntityId parentId, Principal principal,
+      Permission permission) throws AccessException {
+    if (principal != null && allowlistUsers.contains(principal.getName())) {
+      // skip authorization enforcement when user is yarn.
+      LOG.debug("Skipping authorization enforcement for user '{}'", principal.getName());
+      return;
+    }
+    delegate.enforceOnParent(entityType, parentId, principal, permission);
+  }
+
+  @Override
+  public Set<? extends EntityId> isVisible(Set<? extends EntityId> entityIds, Principal principal)
+      throws AccessException {
+    return delegate.isVisible(entityIds, principal);
+  }
+}

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizationEnforcementModule.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AuthorizationEnforcementModule.java
@@ -70,6 +70,25 @@ public class AuthorizationEnforcementModule extends RuntimeModule {
   }
 
   /**
+   * Returns an {@link AbstractModule} containing bindings for authorization enforcement to be used
+   * in case of allow listing some users like 'yarn' since authorization enforcement
+   * is not necessary in the distributed program run itself.
+   */
+  public Module getAllowlistModules() {
+    return new AbstractModule() {
+      @Override
+      protected void configure() {
+        bind(AccessEnforcer.class).annotatedWith(
+            Names.named(AllowlistAccessEnforcer.ALLOWLIST_DELEGATE_ACCESS_ENFORCER)).to(
+                RemoteAccessEnforcer.class).in(Scopes.SINGLETON);
+        bind(AccessEnforcer.class).to(AllowlistAccessEnforcer.class).in(Scopes.SINGLETON);
+        bind(ContextAccessEnforcer.class).to(DefaultContextAccessEnforcer.class)
+            .in(Scopes.SINGLETON);
+      }
+    };
+  }
+
+  /**
    * Used by program containers and system services (viz explore service, stream service) that need
    * to enforce authorization in distributed mode.
    */


### PR DESCRIPTION
Tested:
- submitted dataproc jobs after deploying changes on a k8s cluster.