### PR TITLE
Added support for Java 11 in program runtime (not for CDAP system its…

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/lang/ClassPathResources.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/lang/ClassPathResources.java
@@ -19,7 +19,6 @@ package io.cdap.cdap.common.lang;
 import io.cdap.cdap.common.internal.guava.ClassPath;
 import io.cdap.cdap.common.internal.guava.ClassPath.ClassInfo;
 import io.cdap.cdap.common.internal.guava.ClassPath.ResourceInfo;
-import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;

--- a/cdap-hbase-compat-base/src/main/java/io/cdap/cdap/data2/util/hbase/CoprocessorManager.java
+++ b/cdap-hbase-compat-base/src/main/java/io/cdap/cdap/data2/util/hbase/CoprocessorManager.java
@@ -36,15 +36,17 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
+
 import javax.annotation.Nullable;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.twill.api.ClassAcceptor;
 import org.apache.twill.filesystem.Location;
 import org.apache.twill.filesystem.LocationFactory;
-import org.apache.twill.internal.utils.Dependencies;
+import org.apache.twill.internal.ApplicationBundler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -346,7 +346,7 @@
           <version>${project.version}</version>
           <scope>provided</scope>
         </dependency>
-	<dependency>
+        <dependency>
           <groupId>io.cdap.cdap</groupId>
           <artifactId>cdap-securestore-ext-gcp-secretstore</artifactId>
           <version>${project.version}</version>
@@ -899,6 +899,15 @@
           <artifactId>cdap-kubernetes</artifactId>
           <version>${project.version}</version>
           <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>log4j-over-slf4j</artifactId>
+          <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
         </dependency>
       </dependencies>
 

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocJobMain.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocJobMain.java
@@ -190,11 +190,7 @@ public class DataprocJobMain {
 
     // Add the system class path to the URL list
     for (String path : System.getProperty("java.class.path").split(File.pathSeparator)) {
-      try {
-        urls.add(Paths.get(path).toRealPath().toUri().toURL());
-      } catch (NoSuchFileException e) {
-        // ignore anything that doesn't exist
-      }
+      urls.add(Paths.get(path).toRealPath().toUri().toURL());
     }
 
     return urls.toArray(new URL[0]);

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/SparkContainerLauncher.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.common.lang.FilterClassLoader;
 import io.cdap.cdap.common.logging.StandardOutErrorRedirector;
 import io.cdap.cdap.common.logging.common.UncaughtExceptionHandler;
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -103,7 +104,10 @@ public final class SparkContainerLauncher {
     Thread.setDefaultUncaughtExceptionHandler(new UncaughtExceptionHandler());
 
     Set<URL> urls = new LinkedHashSet<>();
-    urls.addAll(ClassPathResources.getClasspathUrls());
+
+    for (String path : System.getProperty("java.class.path").split(File.pathSeparator)) {
+      urls.add(Paths.get(path).toRealPath().toUri().toURL());
+    }
 
     ClassLoader systemClassLoader = ClassLoader.getSystemClassLoader();
 

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
     <jetty8.version>8.1.15.v20140411</jetty8.version>
     <jline.version>2.12</jline.version>
     <junit.version>4.11</junit.version>
+    <log4j2.slf4j.version>2.20.0</log4j2.slf4j.version>
     <pragmatists.version>1.0.5</pragmatists.version>
     <kafka.version>0.10.2.2</kafka.version>
     <leveldb.version>0.12</leveldb.version>
@@ -208,6 +209,11 @@
         <groupId>org.slf4j</groupId>
         <artifactId>log4j-over-slf4j</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-to-slf4j</artifactId>
+        <version>${log4j2.slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
…elf)

  - Added support for configuration activation based on JVM version
  - Make class loading compatible with Java 11
    - Remove the usage of `sun.boot.class.path`
    - Replace getURLs call on the system class loader with java.class.path
  - Make it compatible with Spark3 in GCP Dataproc environment out of the box - Added dependency log4j-to-slf4j for log4j2 with version compatible with Spark 3
  - Fix HBase coprocessor jar building to include all classes and resources correctly (for unit-test)