### PR TITLE
[CDAP-18394] 6.9 Cherry-Pick

### DIFF
--- a/cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java
@@ -1398,8 +1398,9 @@ public class AuthorizationTest extends TestBase {
 
   private void createAuthNamespace() throws Exception {
     AccessController accessController = getAccessController();
-    grantAndAssertSuccess(AUTH_NAMESPACE, ALICE, ImmutableSet.of(StandardPermission.GET, StandardPermission.CREATE));
+    grantAndAssertSuccess(AUTH_NAMESPACE, ALICE, ImmutableSet.of(StandardPermission.CREATE));
     getNamespaceAdmin().create(AUTH_NAMESPACE_META);
+    grantAndAssertSuccess(AUTH_NAMESPACE, ALICE, ImmutableSet.of(StandardPermission.GET));
     Assert.assertEquals(ImmutableSet.of(new GrantedPermission(AUTH_NAMESPACE, StandardPermission.GET),
                                         new GrantedPermission(AUTH_NAMESPACE, StandardPermission.CREATE)),
                         accessController.listGrants(ALICE));


### PR DESCRIPTION
[CDAP-18394] Only check namespace create permission on namespace creation, and remove namespace get permission check

[CDAP-18394] Remove GET permissions from grant in unit test during namespace creation

Cherry-pick of #15112 

[CDAP-18394]: https://cdap.atlassian.net/browse/CDAP-18394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-18394]: https://cdap.atlassian.net/browse/CDAP-18394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ