### PR TITLE
CDAP-20593 partition state messages by app id instead of run id

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/program/MessagingProgramStatePublisherTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/program/MessagingProgramStatePublisherTest.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.messaging.MessagingService;
 import io.cdap.cdap.messaging.StoreRequest;
 import io.cdap.cdap.proto.Notification;
 import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import java.io.IOException;
 import java.util.Map;
@@ -76,7 +77,8 @@ public class MessagingProgramStatePublisherTest {
     Map<String, String> properties = ImmutableMap.of(
       ProgramOptionConstants.PROGRAM_RUN_ID, GSON.toJson(runId));
     publisher.publish(Notification.Type.PROGRAM_STATUS, properties);
-    int topicNum = Math.abs(RUN_ID.hashCode() % NUM_PARTITIONS);
+    ApplicationId applicationId = runId.getParent().getParent();
+    int topicNum = Math.abs(applicationId.hashCode()) % NUM_PARTITIONS;
     Mockito.verify(messagingService).publish(storeRequestCaptor.capture());
     StoreRequest storeRequest = storeRequestCaptor.getValue();
     Assert.assertEquals("programstatusevent" + topicNum, storeRequest.getTopicId().getTopic());


### PR DESCRIPTION
Changed the partitioning strategy to use app id instead of run id to avoid potential issues where messages from different topics end up modifying the same rows. This can cause there to be more skew than using the run id, but should be good enough for most situations.