### PR TITLE
[CDAP-20604] Java11 fix for stream pipelines

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/lang/ClassLoaders.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/lang/ClassLoaders.java
@@ -268,7 +268,7 @@ public final class ClassLoaders {
    */
   public static URL getClassPathURL(String className, URL classUrl) {
     try {
-      if ("file".equals(classUrl.getProtocol())) {
+      if ("file".equals(classUrl.getProtocol()) || "jrt".equals(classUrl.getProtocol())) {
         String path = classUrl.getFile();
         // Compute the directory container the class.
         int endIdx = path.length() - className.length() - ".class".length();
@@ -276,7 +276,7 @@ public final class ClassLoaders {
           // If it is not the root directory, return the end index to remove the trailing '/'.
           endIdx--;
         }
-        return new URL("file", "", -1, path.substring(0, endIdx));
+        return new URL(classUrl.getProtocol(), "", -1, path.substring(0, endIdx));
       }
       if ("jar".equals(classUrl.getProtocol())) {
         String path = classUrl.getFile();

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
@@ -433,6 +433,11 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
       }
       // resource = jar:file:/path/to/cdap/lib/org.scala-lang.scala-library-2.10.4.jar!/library.properties
       // baseClasspath = /path/to/cdap/lib/org.scala-lang.scala-library-2.10.4.jar
+
+      // ignoring jrt scheme for java11 support
+      if (resource.getProtocol().equals("jrt")) {
+        return null;
+      }
       String baseClasspath = ClassLoaders.getClassPathURL(name, resource).getPath();
       String jarName = baseClasspath.substring(baseClasspath.lastIndexOf('/') + 1, baseClasspath.length());
       return jarName.startsWith("org.scala-lang") ? null : resource;


### PR DESCRIPTION
Added the fix for below issue:

Bug bash of streaming pipeline resulted in this error, 

2023-05-02 20:46:25,809 - DEBUG [ STARTING:i.c.c.c.l.c.UncaughtExceptionHandler@40] - Uncaught exception in thread Thread[ STARTING,5,main]
java.lang.IllegalStateException: Unsupported class URL: jrt:/java.security.sasl/javax/security/sasl/SaslClient.class
	at io.cdap.cdap.common.lang.ClassLoaders.getClassPathURL(ClassLoaders.java:288)
	at io.cdap.cdap.app.runtime.spark.SparkProgramRuntimeProvider$ScalaFilterClassLoader.getResource(SparkProgramRuntimeProvider.java:436)
	at java.lang.ClassLoader.getResource(ClassLoader.java:1396)
	at java.lang.ClassLoader.getResource(ClassLoader.java:1396)
	at org.apache.twill.internal.utils.Dependencies.getClassURL(Dependencies.java:106)
	at org.apache.twill.internal.utils.Dependencies.findClassDependencies(Dependencies.java:74)
	at org.apache.twill.internal.ApplicationBundler.findDependencies(ApplicationBundler.java:236)
	at org.apache.twill.internal.ApplicationBundler.createBundle(ApplicationBundler.java:201)
	at org.apache.twill.internal.ApplicationBundler.createBundle(ApplicationBundler.java:171)
	at org.apache.twill.yarn.YarnTwillPreparer$2.load(YarnTwillPreparer.java:567)
	at org.apache.twill.internal.io.NoCachingLocationCache.get(NoCachingLocationCache.java:42)
	at org.apache.twill.yarn.YarnTwillPreparer.createTwillJar(YarnTwillPreparer.java:556)
	at org.apache.twill.yarn.YarnTwillPreparer.access$300(YarnTwillPreparer.java:126)
	at org.apache.twill.yarn.YarnTwillPreparer$1.call(YarnTwillPreparer.java:399)
	at org.apache.twill.yarn.YarnTwillPreparer$1.call(YarnTwillPreparer.java:392)
	at org.apache.twill.yarn.YarnTwillController.doStartUp(YarnTwillController.java:116)
	at org.apache.twill.internal.AbstractZKServiceController.startUp(AbstractZKServiceController.java:76)
	at org.apache.twill.internal.AbstractExecutionServiceController$ServiceDelegate.startUp(AbstractExecutionServiceController.java:207)
	at com.google.common.util.concurrent.AbstractIdleService$1$1.run(AbstractIdleService.java:43)