### PR TITLE
[CDAP-20608] Set program version in stop message

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/TetheringAgentService.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.internal.tethering;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -51,6 +52,7 @@ import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
 import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.Notification;
 import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
@@ -210,22 +212,9 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
     String lastMessageId = null;
     for (TetheringControlMessageWithId messageWithId : response.getControlMessages()) {
       TetheringControlMessage controlMessage = messageWithId.getControlMessage();
+      lastMessageId = messageWithId.getMessageId();
       try {
-        LOG.trace("Got message type {} from {}", controlMessage.getType(), peerInfo.getName());
-        switch (controlMessage.getType()) {
-          case KEEPALIVE:
-            break;
-          case START_PROGRAM:
-            publishStartProgram(Bytes.toString(controlMessage.getPayload()), peerInfo);
-            break;
-          case STOP_PROGRAM:
-            publishStopProgram(Bytes.toString(controlMessage.getPayload()));
-            break;
-          case KILL_PROGRAM:
-            publishKillProgram(Bytes.toString(controlMessage.getPayload()));
-            break;
-        }
-        lastMessageId = messageWithId.getMessageId();
+        processControlMessage(controlMessage, peerInfo);
       } catch (IOException e) {
         LOG.warn("Failed to process control message of type {} from peer {}",
             controlMessage.getType(), peerInfo.getName(), e);
@@ -233,6 +222,25 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
       }
     }
     return lastMessageId;
+  }
+
+  @VisibleForTesting
+  void processControlMessage(TetheringControlMessage controlMessage, PeerInfo peerInfo)
+      throws IOException {
+    LOG.trace("Got message type {} from {}", controlMessage.getType(), peerInfo.getName());
+    switch (controlMessage.getType()) {
+      case KEEPALIVE:
+        break;
+      case START_PROGRAM:
+        publishStartProgram(Bytes.toString(controlMessage.getPayload()), peerInfo);
+        break;
+      case STOP_PROGRAM:
+        publishStopProgram(Bytes.toString(controlMessage.getPayload()));
+        break;
+      case KILL_PROGRAM:
+        publishKillProgram(Bytes.toString(controlMessage.getPayload()));
+        break;
+    }
   }
 
   /**
@@ -332,11 +340,7 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
   }
 
   private void publishStopProgram(String stopPayload) {
-    ProgramRunInfo programRunInfo = GSON.fromJson(stopPayload, ProgramRunInfo.class);
-    ProgramRunId programRunId = new ProgramRunId(programRunInfo.getNamespace(),
-        programRunInfo.getApplication(),
-        ProgramType.valueOf(programRunInfo.getProgramType()),
-        programRunInfo.getProgram(), programRunInfo.getRun());
+    ProgramRunId programRunId = new ProgramRunId(GSON.fromJson(stopPayload, ProgramRunInfo.class));
     // Do a graceful stop without a timeout. ProgramStopSubscriberService on the tethered peer will send a kill if the
     // graceful shutdown time is exceeded.
     programStateWriter.stop(programRunId, Integer.MAX_VALUE);
@@ -344,11 +348,7 @@ public class TetheringAgentService extends AbstractRetryableScheduledService {
   }
 
   private void publishKillProgram(String stopPayload) {
-    ProgramRunInfo programRunInfo = GSON.fromJson(stopPayload, ProgramRunInfo.class);
-    ProgramRunId programRunId = new ProgramRunId(programRunInfo.getNamespace(),
-        programRunInfo.getApplication(),
-        ProgramType.valueOf(programRunInfo.getProgramType()),
-        programRunInfo.getProgram(), programRunInfo.getRun());
+    ProgramRunId programRunId = new ProgramRunId(GSON.fromJson(stopPayload, ProgramRunInfo.class));
     // Kill the program
     programStateWriter.stop(programRunId, 0);
     LOG.debug("Published program kill message for program run {}", programRunId);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManager.java
@@ -265,7 +265,8 @@ public class TetheringRuntimeJobManager implements RuntimeJobManager {
   /**
    * Create control message payload to stop or kill a program.
    */
-  private TetheringControlMessage createProgramTerminatePayload(ProgramRunInfo programRunInfo,
+  @VisibleForTesting
+  public static TetheringControlMessage createProgramTerminatePayload(ProgramRunInfo programRunInfo,
       TetheringControlMessage.Type messageType) {
     byte[] payload = Bytes.toBytes(GSON.toJson(programRunInfo));
     return new TetheringControlMessage(messageType, payload);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringAgentServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringAgentServiceTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.tethering;
+
+import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.app.runtime.ProgramStateWriter;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.internal.provision.ProvisionerNotifier;
+import io.cdap.cdap.internal.tethering.runtime.spi.runtimejob.TetheringRuntimeJobManager;
+import io.cdap.cdap.messaging.MessagingService;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
+import io.cdap.cdap.security.spi.authenticator.RemoteAuthenticator;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.twill.filesystem.LocationFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+public class TetheringAgentServiceTest {
+
+  private TetheringAgentService tetheringAgentService;
+  private ProgramStateWriter programStateWriter;
+  private ProgramRunInfo programRunInfo;
+  private PeerInfo peerInfo;
+  @Before
+  public void setup() {
+    CConfiguration cConf = CConfiguration.create();
+    programStateWriter = Mockito.mock(ProgramStateWriter.class);
+    tetheringAgentService = new TetheringAgentService(cConf,
+        Mockito.mock(TetheringStore.class),
+        programStateWriter,
+        Mockito.mock(MessagingService.class),
+        Mockito.mock(RemoteAuthenticator.class),
+        Mockito.mock(LocationFactory.class),
+        Mockito.mock(ProvisionerNotifier.class),
+        Mockito.mock(NamespaceQueryAdmin.class));
+
+    programRunInfo =
+        new ProgramRunInfo.Builder()
+            .setNamespace("ns")
+            .setApplication("app")
+            .setVersion("1.0")
+            .setProgramType("WORKFLOW")
+            .setProgram("program")
+            .setRun("runId")
+            .build();
+
+    Map<String, String> metadata = ImmutableMap.of("project", "proj",
+        "location", "us-west1");
+    List<NamespaceAllocation> namespaces = Collections.singletonList(new NamespaceAllocation("default",
+        null, null));
+    PeerMetadata peerMetadata = new PeerMetadata(namespaces, metadata, "");
+    peerInfo = new PeerInfo("my-inst", "http://my.com/api",
+        TetheringStatus.ACCEPTED, peerMetadata, System.currentTimeMillis());
+  }
+
+  @Test
+  public void testStopProgram() throws IOException {
+    TetheringControlMessage controlMessage = TetheringRuntimeJobManager
+        .createProgramTerminatePayload(programRunInfo, TetheringControlMessage.Type.STOP_PROGRAM);
+    tetheringAgentService.processControlMessage(controlMessage, peerInfo);
+    ProgramRunId programRunId = new ProgramRunId(programRunInfo);
+    Mockito.verify(programStateWriter, Mockito.times(1)).stop(programRunId, Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void testStopProgramKill() throws IOException {
+    TetheringControlMessage controlMessage = TetheringRuntimeJobManager
+        .createProgramTerminatePayload(programRunInfo, TetheringControlMessage.Type.KILL_PROGRAM);
+    tetheringAgentService.processControlMessage(controlMessage, peerInfo);
+    ProgramRunId programRunId = new ProgramRunId(programRunInfo);
+    Mockito.verify(programStateWriter, Mockito.times(1)).stop(programRunId, 0);
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ProgramRunId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ProgramRunId.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.proto.id;
 import io.cdap.cdap.api.metadata.MetadataEntity;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.element.EntityType;
+import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -56,6 +57,14 @@ public class ProgramRunId extends NamespacedEntityId implements ParentedId<Progr
     this.type = type;
     this.program = program;
     this.run = run;
+  }
+
+  public ProgramRunId(ProgramRunInfo programRunInfo) {
+    this(new ApplicationId(programRunInfo.getNamespace(), programRunInfo.getApplication(),
+            programRunInfo.getVersion()),
+        ProgramType.valueOf(programRunInfo.getProgramType()),
+        programRunInfo.getProgram(),
+        programRunInfo.getRun());
   }
 
   public String getApplication() {


### PR DESCRIPTION
Failure to set correct program version in stop message results in the the message getting ignored in appfabric because the corresponding run record cannot be found.