### PR TITLE
CDAP-20624 make entity id hash code deterministic

### DIFF
--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/EntityId.java
@@ -323,7 +323,7 @@ public abstract class EntityId {
 
   @Override
   public int hashCode() {
-    return Objects.hash(entity);
+    return entity.ordinal();
   }
 
   protected static String next(Iterator<String> iterator, String fieldName) {


### PR DESCRIPTION
Make the EntityType hashCode() method deterministic by using the enum ordinal instead of the enum hash code, which will differ across jvms.

This was causing issues when using ApplicationId hashcode to determine the program status topic to write to. With a deterministic one, the same topic will always be chosen across JVMs.