### PR TITLE
[CDAP-20628] Auto install: fix pipeline JSON parsing

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/autoinstall/Spec.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/autoinstall/Spec.java
@@ -149,7 +149,7 @@ public class Spec {
     public String getJarName() {
       for (Argument argument : arguments) {
         if (argument.getName().equals("jar")) {
-          return argument.getValue();
+          return argument.getValueAsString();
         }
       }
       return null;
@@ -158,7 +158,7 @@ public class Spec {
     public String getConfigFilename() {
       for (Argument argument : arguments) {
         if (argument.getName().equals("config")) {
-          return argument.getValue();
+          return argument.getValueAsString();
         }
       }
       return null;
@@ -190,10 +190,10 @@ public class Spec {
     public static class Argument {
 
       private final String name;
-      private final String value;
+      private final Object value;
       private final Boolean canModify;
 
-      public Argument(String name, String value, Boolean canModify) {
+      public Argument(String name, Object value, Boolean canModify) {
         this.name = name;
         this.value = value;
         this.canModify = canModify;
@@ -203,9 +203,14 @@ public class Spec {
         return name;
       }
 
-      public String getValue() {
+      public Object getValue() {
         return value;
       }
+
+      public String getValueAsString() {
+        return value.toString();
+      }
+
 
       public Boolean getCanModify() {
         return canModify;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/AutoInstallTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/capability/AutoInstallTest.java
@@ -187,7 +187,7 @@ public class AutoInstallTest {
   }
 
   @Test
-  public void testDeserializeSpecJson() throws Exception {
+  public void testDeserializePluginSpecJson() throws Exception {
     Spec deserializedSpec = readFile("spec.json", Spec.class);
     List<Spec.Action.Argument> arguments = Arrays.asList(
       new Spec.Action.Argument("name", "my-plugin", false),
@@ -202,4 +202,21 @@ public class AutoInstallTest {
                                  Collections.singletonList("hydrator-plugin"), true, actions);
     Assert.assertEquals(expectedSpec, deserializedSpec);
   }
+
+  @Test
+  public void testDeserializePipelineSpecJson() throws Exception {
+    Spec deserializedSpec = readFile("spec2.json", Spec.class);
+    Map<String, String> artifactDetails = ImmutableMap.of("scope", "system", "name", "cdap-data-pipeline",
+        "version", "[6.4.0,7.0.0-SNAPSHOT)");
+    List<Spec.Action.Argument> arguments = Arrays.asList(
+        new Spec.Action.Argument("name", "my-pipeline", false),
+        new Spec.Action.Argument("config", "pipeline.json", false),
+        new Spec.Action.Argument("artifact", artifactDetails, false));
+    List<Spec.Action> actions = Collections.singletonList(
+        new Spec.Action("create_pipeline_draft", "Label", arguments));
+    Spec expectedSpec = new Spec("1.0", "Label", "Description", "Author",
+        "Org", 1603825065, "[6.1.1,7.0.0-SNAPSHOT)",
+        Collections.singletonList("hydrator-plugin"), true, actions);
+    Assert.assertEquals(expectedSpec, deserializedSpec);
+    }
 }

--- a/cdap-app-fabric/src/test/resources/spec2.json
+++ b/cdap-app-fabric/src/test/resources/spec2.json
@@ -1,0 +1,40 @@
+{
+  "specVersion": "1.0",
+  "label": "Label",
+  "description": "Description",
+  "author": "Author",
+  "org": "Org",
+  "created": 1603825065,
+  "categories": [
+    "hydrator-plugin"
+  ],
+  "cdapVersion": "[6.1.1,7.0.0-SNAPSHOT)",
+  "preview": true,
+  "actions": [
+    {
+      "type": "create_pipeline_draft",
+      "label": "Label",
+      "arguments": [
+        {
+          "name": "name",
+          "value": "my-pipeline",
+          "canModify": false
+        },
+        {
+          "name": "config",
+          "value": "pipeline.json",
+          "canModify": false
+        },
+        {
+          "name": "artifact",
+          "value": {
+            "scope": "system",
+            "name": "cdap-data-pipeline",
+            "version": "[6.4.0,7.0.0-SNAPSHOT)"
+          },
+          "canModify": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Argument value can be a JSON object in the case of a pipeline draft. We were assuming that the value is a string (which is the case for plugins). 