### PR TITLE
[CDAP-20597] skip normal macro evaluation during app spec regeneration

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java
@@ -65,6 +65,7 @@ import io.cdap.cdap.internal.app.runtime.BasicArguments;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.internal.app.runtime.ProgramRunners;
 import io.cdap.cdap.internal.app.runtime.SimpleProgramOptions;
+import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDescriptor;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactDetail;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
@@ -350,6 +351,9 @@ public class InMemoryProgramRunDispatcher implements ProgramRunDispatcher {
           String.format("No application class found in artifact '%s' in namespace '%s'.",
               artifactDetail.getDescriptor().getArtifactId(), programId.getNamespace()));
     }
+    Map <String, String> runtimeArguments =
+        SystemArguments.skipNormalMacroEvaluation(options.getUserArguments().asMap()) ?
+            Collections.emptyMap() : options.getUserArguments().asMap();
 
     AppDeploymentInfo deploymentInfo = AppDeploymentInfo.builder()
         .setArtifactId(artifactId)
@@ -361,7 +365,7 @@ public class InMemoryProgramRunDispatcher implements ProgramRunDispatcher {
         .setConfigString(existingAppSpec.getConfiguration())
         .setUpdateSchedules(false)
         .setRuntimeInfo(new AppDeploymentRuntimeInfo(existingAppSpec,
-            options.getUserArguments().asMap(), options.getArguments().asMap()))
+            runtimeArguments, options.getArguments().asMap()))
         .setDeployedApplicationSpec(existingAppSpec)
         .build();
     Configurator configurator = new InMemoryConfigurator(cConf, pluginFinder, impersonator,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/SystemArguments.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/SystemArguments.java
@@ -106,6 +106,8 @@ public final class SystemArguments {
   public static final String RUNTIME_CLEANUP_DISABLED = "system.runtime.cleanup.disabled";
 
   public static final String JVM_OPTS = "system.program.jvm.opts";
+  // Runtime argument to skip the normal macro evaluation during app spec regeneration.
+  public static final String SKIP_NORMAL_MACRO_EVALUATION = "system.skip.normal.macro.evaluation";
 
   /**
    * Extracts log level settings from the given arguments. It extracts arguments prefixed with key
@@ -541,6 +543,16 @@ public final class SystemArguments {
       }
     }
     return properties;
+  }
+
+  /**
+   * @param args runtime arguments
+   * @return boolean which helps to determine whether to skip normal macro evaluation during
+   * app spec regeneration
+   */
+  public static boolean skipNormalMacroEvaluation(Map<String, String> args) {
+    return Boolean.parseBoolean(args.getOrDefault(
+        SystemArguments.SKIP_NORMAL_MACRO_EVALUATION, "false"));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
@@ -126,6 +126,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -398,6 +399,9 @@ public class DefaultRuntimeJob implements RuntimeJob {
     String appClassName = systemArguments.get(ProgramOptionConstants.APPLICATION_CLASS);
     Location programJarLocation = Locations.toLocation(
         new File(systemArguments.get(ProgramOptionConstants.PROGRAM_JAR)));
+
+    userArguments = SystemArguments.skipNormalMacroEvaluation(userArguments) ?
+        Collections.emptyMap() : userArguments;
 
     AppDeploymentInfo deploymentInfo = AppDeploymentInfo.builder()
         .setArtifactId(programDescriptor.getArtifactId())


### PR DESCRIPTION
The following scenarios were tested with/without connection:
- BigQuery and database plugins using connections, with some macros in the fields(not the jdbc field) and secure macros for the credentials field(service account json, password, etc).
- Macros for some fields, and provide the macros using both runtime arguments(wrong value) and actions(correct value). The pipeline picks up the value from actions.
