### PR TITLE
[cherry-pick] [CDAP-20597] skip normal macro evaluation during app spec regeneration

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/SystemArguments.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/SystemArguments.java
@@ -57,7 +57,8 @@ public final class SystemArguments {
   // Keys for container resources
   public static final String MEMORY_KEY = "system.resources.memory";
   public static final String CORES_KEY = "system.resources.cores";
-  public static final String RESERVED_MEMORY_KEY_OVERRIDE = "system.resources.reserved.memory.override";
+  public static final String RESERVED_MEMORY_KEY_OVERRIDE =
+      "system.resources.reserved.memory.override";
 
   // Keys for log levels
   private static final String LOG_LEVEL = "system.log.level";
@@ -105,6 +106,8 @@ public final class SystemArguments {
   public static final String RUNTIME_CLEANUP_DISABLED = "system.runtime.cleanup.disabled";
 
   public static final String JVM_OPTS = "system.program.jvm.opts";
+  // Runtime argument to skip the normal macro evaluation during app spec regeneration.
+  public static final String SKIP_NORMAL_MACRO_EVALUATION = "system.skip.normal.macro.evaluation";
 
   /**
    * Extracts log level settings from the given arguments. It extracts arguments prefixed with key
@@ -518,6 +521,16 @@ public final class SystemArguments {
       }
     }
     return properties;
+  }
+
+  /**
+   * return boolean whether to skip normal macro evaluation during app spec regeneration
+   * @param args runtime arguments
+   * @return true if flag is set otherwise false
+   */
+  public static boolean skipNormalMacroEvaluation(Map<String, String> args) {
+    return Boolean.parseBoolean(args.getOrDefault(
+        SystemArguments.SKIP_NORMAL_MACRO_EVALUATION, "false"));
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJob.java
@@ -140,6 +140,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -350,7 +351,10 @@ public class DefaultRuntimeJob implements RuntimeJob {
     String appClassName = systemArguments.get(ProgramOptionConstants.APPLICATION_CLASS);
     Location programJarLocation = Locations.toLocation(
       new File(systemArguments.get(ProgramOptionConstants.PROGRAM_JAR)));
-    
+
+    userArguments = SystemArguments.skipNormalMacroEvaluation(userArguments)
+        ? Collections.emptyMap() : userArguments;
+
     AppDeploymentInfo deploymentInfo = AppDeploymentInfo.builder()
       .setArtifactId(programDescriptor.getArtifactId())
       .setArtifactLocation(programJarLocation)

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineConnectionTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DataPipelineConnectionTest.java
@@ -41,6 +41,7 @@ import io.cdap.cdap.etl.api.connector.BrowseRequest;
 import io.cdap.cdap.etl.api.connector.Connector;
 import io.cdap.cdap.etl.api.connector.SampleRequest;
 import io.cdap.cdap.etl.common.Constants;
+import io.cdap.cdap.etl.mock.action.MockAction;
 import io.cdap.cdap.etl.mock.batch.MockSink;
 import io.cdap.cdap.etl.mock.batch.MockSource;
 import io.cdap.cdap.etl.mock.connector.FileConnector;
@@ -682,6 +683,86 @@ public class DataPipelineConnectionTest extends HydratorTestBase {
     deleteConnection(sourceConnName);
     deleteConnection(sinkConnName);
     deleteConnection(transformConnName);
+
+    deleteDatasetInstance(NamespaceId.DEFAULT.dataset(srcTableName));
+    deleteDatasetInstance(NamespaceId.DEFAULT.dataset(sinkTableName));
+  }
+
+  @Test
+  public void testConnectionsWithArgumentSetterAction() throws Exception {
+    testConnectionsWithArgumentSetterAction(Engine.MAPREDUCE);
+    testConnectionsWithArgumentSetterAction(Engine.SPARK);
+  }
+
+  private void testConnectionsWithArgumentSetterAction(Engine engine) throws Exception {
+    String sourceConnName = "sourceConn" + engine;
+    String sinkConnName = "sinkConn" + engine;
+    String srcTableName = "src" + engine;
+    String sinkTableName = "sink" + engine;
+    String actionTableName = "action" + engine;
+
+    Schema schema = Schema.recordOf("x", Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
+
+    // add secure macro to verify json value of secure data does not fail the macro evaluation in connections
+    String schemaJson = schema.toString();
+    getSecureStoreManager().put(NamespaceId.DEFAULT.getNamespace(), "json", schemaJson, "", Collections.emptyMap());
+
+    // 'row1column1' is the macro key for src table name which should be set by the action plugin
+    addConnection(
+        sourceConnName, new ConnectionCreationRequest(
+            "", new PluginInfo("test", "dummy", null, ImmutableMap.of("tableName", "${row1column1}",
+            "schema", "${secure(json)}"),
+            new ArtifactSelectorConfig())));
+
+    addConnection(
+        sinkConnName, new ConnectionCreationRequest(
+            "", new PluginInfo("test", "dummy", null, Collections.singletonMap("tableName",
+            sinkTableName), new ArtifactSelectorConfig())));
+
+    ETLBatchConfig config = ETLBatchConfig.builder()
+        // 'row1column1' is configured in runtime arg to 'dummy'
+        // but action will set an argument that will make it 'srcTableName'
+        .addStage(new ETLStage("action1", MockAction.getPlugin(actionTableName, "row1", "column1",
+            String.format("%s", srcTableName))))
+        .addStage(new ETLStage("source", MockSource.getPluginUsingConnection(sourceConnName)))
+        .addStage(new ETLStage("sink", MockSink.getPluginUsingConnection(sinkConnName)))
+        .addConnection("action1", "source")
+        .addConnection("source", "sink")
+        .build();
+    // runtime arguments
+    Map<String, String> runtimeArguments = ImmutableMap.<String, String>builder()
+        .put("row1column1", "dummy")
+        .build();
+
+    StructuredRecord samuel = StructuredRecord.builder(schema).set("name", "samuel").build();
+    StructuredRecord dwayne = StructuredRecord.builder(schema).set("name", "dwayne").build();
+
+    addDatasetInstance(NamespaceId.DEFAULT.dataset(srcTableName), Table.class.getName());
+    DataSetManager<Table> sourceTable = getDataset(srcTableName);
+    MockSource.writeInput(sourceTable, ImmutableList.of(samuel, dwayne));
+
+    AppRequest<ETLBatchConfig> appRequest = new AppRequest<>(APP_ARTIFACT, config);
+    ApplicationId appId = NamespaceId.DEFAULT.app("testConnectionsWithArgumentSetterAction" + engine);
+    ApplicationManager appManager = deployApplication(appId, appRequest);
+
+    // start the actual pipeline run
+    WorkflowManager manager = appManager.getWorkflowManager(SmartWorkflow.NAME);
+    manager.startAndWaitForRun(runtimeArguments, ProgramRunStatus.FAILED, 3,
+        TimeUnit.MINUTES);
+
+    runtimeArguments = ImmutableMap.<String, String>builder()
+        .put("row1column1", "dummy")
+        .put("system.skip.normal.macro.evaluation", "true")
+        .build();
+    manager.startAndWaitForRun(runtimeArguments, ProgramRunStatus.COMPLETED, 3,
+        TimeUnit.MINUTES);
+
+    DataSetManager<Table> sinkTable = getDataset(sinkTableName);
+    List<StructuredRecord> outputRecords = MockSink.readOutput(sinkTable);
+    Assert.assertEquals(ImmutableSet.of(dwayne, samuel), new HashSet<>(outputRecords));
+
+    deleteConnection(sourceConnName);
+    deleteConnection(sinkConnName);
 
     deleteDatasetInstance(NamespaceId.DEFAULT.dataset(srcTableName));
     deleteDatasetInstance(NamespaceId.DEFAULT.dataset(sinkTableName));


### PR DESCRIPTION
cherry-pick #15155, #15161