### PR TITLE
CDAP-20631 fix logback localization in client mode

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/ProgramRunnersTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/ProgramRunnersTest.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright © 2023 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.util.Properties;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link ProgramRunners}.
+ */
+public class ProgramRunnersTest {
+
+  @Test
+  public void testLogbackUrlFromProperties() throws MalformedURLException {
+    File logbackFile = new File("abc.xml");
+    Properties p = new Properties();
+    p.setProperty("logback.configurationFile", logbackFile.getAbsolutePath());
+    Assert.assertEquals(logbackFile.toURI().toURL(), ProgramRunners.getLogbackURL(p));
+  }
+
+}


### PR DESCRIPTION
When locating the logback.xml to localize for Spark, prefer any file set through the logback.configurationFile system property. This ensures that the program logback file gets used instead of the console logback used by the Dataproc job.