### PR TITLE
[CDAP-20641] Use LCM feature flag for runtimeargs overwrite

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/SmartWorkflow.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/SmartWorkflow.java
@@ -776,14 +776,12 @@ public class SmartWorkflow extends AbstractWorkflow {
 
   private ETLBatchConfig getConfigFromRuntimeArgs(ApplicationConfigurer applicationConfigurer,
                                                   ETLBatchConfig originalConfig) {
-    if (applicationConfigurer == null || applicationConfigurer.getRuntimeConfigurer() == null) {
+    if (applicationConfigurer == null || applicationConfigurer.getRuntimeConfigurer() == null
+      || !Feature.LIFECYCLE_MANAGEMENT_EDIT.isEnabled(applicationConfigurer)) {
       return originalConfig;
     }
     RuntimeConfigurer runtimeConfigurer = applicationConfigurer.getRuntimeConfigurer();
     Map<String, String> runtimeArguments = runtimeConfigurer.getRuntimeArguments();
-    if (!runtimeArguments.containsKey(PipelineArguments.PIPELINE_CONFIG_OVERWRITE)) {
-      return originalConfig;
-    }
     boolean processTimingEnabled = PipelineArguments.isProcessTimingEnabled(runtimeArguments,
                                                   originalConfig.isProcessTimingEnabled());
     Map<String, String> properties = PipelineArguments.getEngineProperties(runtimeArguments,


### PR DESCRIPTION
In LCM, we moved pipeline configurations into runtimeargs. However, we require an additional ‘overwriteConfig’ argument to make it work. The UI generates this argument automatically. However, this is inconvenient for users who do not use the UI. We should just use the LCM feature flag

[CDAP-20641](https://cdap.atlassian.net/browse/CDAP-20641)

[CDAP-20641]: https://cdap.atlassian.net/browse/CDAP-20641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ