### PR TITLE
fix(CDAP-20642): fix the export/apps API and apply latestOnly filter on ScanApplicationsRequest#builder() usages

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -64,7 +64,6 @@ import org.apache.twill.api.RunId;
 
 /**
  * Responsible for managing {@link Program} and {@link Application} metadata.
- *
  * TODO: set state methods are only called from unit tests. They should be removed in favor of using AppMetadataStore.
  */
 public interface Store {
@@ -176,7 +175,7 @@ public interface Store {
    *
    * @param program id of the program
    * @return An instance of {@link ProgramDescriptor} if found.
-   * @throws IOException
+   * @throws IOException when Store fails to get application
    */
   ProgramDescriptor loadProgram(ProgramId program) throws IOException, NotFoundException;
 
@@ -185,9 +184,24 @@ public interface Store {
    *
    * @param programReference reference of the program
    * @return An instance of {@link ProgramDescriptor} if found.
-   * @throws IOException
+   * @throws IOException when Store fails to get application
    */
   ProgramDescriptor loadProgram(ProgramReference programReference) throws IOException, NotFoundException;
+
+  /**
+   * Fetches all run records for all versions of a program.
+   * Returned ProgramRunRecords are sorted by their startTime.
+   *
+   * @param programReference programReference of the program
+   * @param status           status of the program running/completed/failed or all
+   * @param startTime        fetch run history that has started after the startTime in seconds
+   * @param endTime          fetch run history that has started before the endTime in seconds
+   * @param limit            max number of entries to fetch for this history call
+   * @return                 map of logged runs
+   */
+  Map<ProgramRunId, RunRecordDetail> getAllRuns(ProgramReference programReference, ProgramRunStatus status,
+      long startTime, long endTime, int limit,
+      Predicate<RunRecordDetail> filter);
 
   /**
    * Fetches run records for particular program.
@@ -202,21 +216,6 @@ public interface Store {
    */
   Map<ProgramRunId, RunRecordDetail> getRuns(ProgramId id, ProgramRunStatus status,
                                              long startTime, long endTime, int limit);
-
-  /**
-   * Fetches all run records for all versions of a program.
-   * Returned ProgramRunRecords are sorted by their startTime.
-   *
-   * @param programReference programReference of the program
-   * @param status           status of the program running/completed/failed or all
-   * @param startTime        fetch run history that has started after the startTime in seconds
-   * @param endTime          fetch run history that has started before the endTime in seconds
-   * @param limit            max number of entries to fetch for this history call
-   * @return                 map of logged runs
-   */
-  Map<ProgramRunId, RunRecordDetail> getAllRuns(ProgramReference programReference, ProgramRunStatus status,
-                                                long startTime, long endTime, int limit,
-                                                Predicate<RunRecordDetail> filter);
 
   /**
    * Fetches the run records for the particular status. Same as calling
@@ -237,6 +236,7 @@ public interface Store {
    */
   Map<ProgramRunId, RunRecordDetail> getRuns(ProgramRunStatus status, long startTime,
                                              long endTime, int limit, Predicate<RunRecordDetail> filter);
+
   /**
    * Fetches run records for the particular status.
    *
@@ -251,10 +251,24 @@ public interface Store {
 
   /**
    * Fetches the run records for given ProgramRunIds.
+   *
    * @param programRunIds  list of program RunIds to match against
    * @return        map of logged runs
    */
   Map<ProgramRunId, RunRecordDetail> getRuns(Set<ProgramRunId> programRunIds);
+
+  /**
+   * Fetches run records for multiple programs.
+   *
+   * @param programs  the programs to get run records for
+   * @param status    status of the program running/completed/failed or all
+   * @param startTime fetch run history that has started after the startTime in seconds
+   * @param endTime   fetch run history that has started before the endTime in seconds
+   * @param limitPerProgram     max number of runs to fetch for each program
+   * @return          runs for each program
+   */
+  List<ProgramHistory> getRuns(Collection<ProgramReference> programs, ProgramRunStatus status,
+      long startTime, long endTime, int limitPerProgram);
 
   /**
    * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records across all namespaces.
@@ -275,6 +289,7 @@ public interface Store {
 
   /**
    * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records against a given NamespaceId.
+   *
    * @param namespaceId the namespace id to match against
    * @return map of logged runs
    */
@@ -282,6 +297,7 @@ public interface Store {
 
   /**
    * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records from the given NamespaceId's.
+   *
    * @param namespaces the namespace id's to get active run records from
    * @param filter predicate to be passed to filter the records
    * @return map of logged runs
@@ -290,21 +306,15 @@ public interface Store {
 
   /**
    * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records against a given ApplicationId.
+   *
    * @param applicationId the application id to match against
    * @return map of logged runs
    */
   Map<ProgramRunId, RunRecordDetail> getActiveRuns(ApplicationId applicationId);
 
   /**
-   * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records for the
-   * given application.
-   * @param applicationReference versionless reference of the application
-   * @return map of logged runs. If no active run exists, return an empty map.
-   */
-  Map<ProgramRunId, RunRecordDetail> getAllActiveRuns(ApplicationReference applicationReference);
-
-  /**
    * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records against a given ProgramId.
+   *
    * @param programId the program id to match against
    * @return map of logged runs
    */
@@ -315,9 +325,18 @@ public interface Store {
    *
    * @param programRefs collection of program ids for fetching active run records.
    * @return a {@link Map} from the {@link ProgramId} to the list of run records; there will be no entry for programs
-   * that do not exist.
+   *     that do not exist.
    */
   Map<ProgramId, Collection<RunRecordDetail>> getActiveRuns(Collection<ProgramReference> programRefs);
+
+  /**
+   * Fetches the active (i.e STARTING or RUNNING or SUSPENDED) run records for the
+   * given application.
+   *
+   * @param applicationReference versionless reference of the application
+   * @return map of logged runs. If no active run exists, return an empty map.
+   */
+  Map<ProgramRunId, RunRecordDetail> getAllActiveRuns(ApplicationReference applicationReference);
 
   /**
    * Fetches the run record for particular run of a program.
@@ -340,11 +359,12 @@ public interface Store {
 
   /**
    * Creates new application if it doesn't exist. Updates existing one otherwise.
+   *
    * @param id            application id
    * @param meta          application metadata to store
    * @return              the number of edits to the application. A new application will return 0.
    * @throws ConflictException if the app cannot be deployed when the user provided parent-version doesn't match the
-   * current latest version
+   *     current latest version
    */
   int addApplication(ApplicationId id, ApplicationMeta meta) throws ConflictException;
 
@@ -378,7 +398,7 @@ public interface Store {
   ApplicationMeta getApplicationMetadata(ApplicationId id);
 
   /**
-   * Returns the latest version of an application in a namespace
+   * Returns the latest version of an application in a namespace.
    *
    * @param appRef application reference
    * @return The metadata information of the latest application version.
@@ -396,7 +416,7 @@ public interface Store {
   void scanApplications(int txBatchSize, BiConsumer<ApplicationId, ApplicationMeta> consumer);
 
   /**
-   * Scans for applications according to the parameters passed in request
+   * Scans for applications according to the parameters passed in request.
    *
    * @param request  parameters defining filters and sorting
    * @param txBatchSize maximum number of applications to scan in one transaction to
@@ -417,6 +437,7 @@ public interface Store {
 
   /**
    * Update an applications with provided SourceControlMeta.
+   *
    * @param appId the application ID
    * @param sourceControlMeta the source control metadata of the application synced with linked repository.
    */
@@ -424,13 +445,14 @@ public interface Store {
 
   /**
    * Get source control metadata of provided application.
+   *
    * @param appRef the application reference
    * @return {@link SourceControlMeta}
    */
   SourceControlMeta getAppSourceControlMeta(ApplicationReference appRef);
 
   /**
-   * Returns a map of latest programIds given programReferences
+   * Returns a map of latest programIds given programReferences.
    *
    * @param references the list of programReferences to get the latest programIds
    * @return collection of programIds. For applications that don't exist, there will be no entry in the result.
@@ -438,7 +460,7 @@ public interface Store {
   Map<ProgramReference, ProgramId> getPrograms(Collection<ProgramReference> references);
 
   /**
-   * Returns a list of all versions' ApplicationId's of the application by reference
+   * Returns a list of all versions' ApplicationId's of the application by reference.
    *
    * @param appRef application reference
    * @return collection of versionIds of the application's versions
@@ -455,13 +477,14 @@ public interface Store {
 
   /**
    * Returns the number of instances of a service.
+   *
    * @param id id of the program
    * @return number of instances
    */
   int getServiceInstances(ProgramId id);
 
   /**
-   * Sets the number of instances of a {@link Worker}
+   * Sets the number of instances of a {@link Worker}.
    *
    * @param id id of the program
    * @param instances number of instances
@@ -469,7 +492,7 @@ public interface Store {
   void setWorkerInstances(ProgramId id, int instances);
 
   /**
-   * Gets the number of instances of a {@link Worker}
+   * Gets the number of instances of a {@link Worker}.
    *
    * @param id id of the program
    * @return number of instances
@@ -506,7 +529,8 @@ public interface Store {
   Map<String, String> getRuntimeArguments(ProgramRunId runId);
 
   /**
-   * Deletes data for an application from the WorkflowTable table
+   * Deletes data for an application from the WorkflowTable table.
+   *
    * @param id id of application to be deleted
    */
   void deleteWorkflowStats(ApplicationId id);
@@ -580,6 +604,8 @@ public interface Store {
                                                                     long timeInterval);
 
   /**
+   * Get the running Ids in a time range.
+   *
    * @return programs that were running between given start and end time.
    */
   Set<RunId> getRunningInRange(long startTimeInSecs, long endTimeInSecs);
@@ -603,26 +629,12 @@ public interface Store {
   long getProgramTotalRunCount(ProgramReference programReference) throws NotFoundException;
 
   /**
-   * Get the run count of the given program collection
+   * Get the run count of the given program collection.
    *
    * @param programRefs collection of program ids to get the count
    * @return the run count result of each program in the collection
    */
   List<RunCountResult> getProgramTotalRunCounts(Collection<ProgramReference> programRefs);
-
-  /**
-   * Fetches run records for multiple programs.
-   *
-   * @param programs  the programs to get run records for
-   * @param status    status of the program running/completed/failed or all
-   * @param startTime fetch run history that has started after the startTime in seconds
-   * @param endTime   fetch run history that has started before the endTime in seconds
-   * @param limitPerProgram     max number of runs to fetch for each program
-   * @return          runs for each program
-   */
-  List<ProgramHistory> getRuns(Collection<ProgramReference> programs, ProgramRunStatus status,
-                               long startTime, long endTime, int limitPerProgram);
-
 
   /**
    * Get application state.
@@ -670,8 +682,8 @@ public interface Store {
     }
     if (!Objects.equals(programId.getApplication(), appSpec.getName())
       || !Objects.equals(programId.getVersion(), appSpec.getAppVersion())) {
-      throw new IllegalArgumentException("Program " + programId + " does not belong to application " +
-                                           appSpec.getName() + ":" + appSpec.getAppVersion());
+      throw new IllegalArgumentException("Program " + programId + " does not belong to application "
+          + appSpec.getName() + ":" + appSpec.getAppVersion());
     }
 
     if (!appSpec.getProgramsByType(programId.getType().getApiProgramType()).contains(programId.getProgram())) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -387,7 +387,7 @@ public interface Store {
   ApplicationMeta getLatest(ApplicationReference appRef);
 
   /**
-   * Scans for applications across all namespaces.
+   * Scans for the latest applications across all namespaces.
    *
    * @param txBatchSize maximum number of applications to scan in one transaction to
    *                    prevent holding a single transaction for too long

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandlerInternal.java
@@ -50,7 +50,7 @@ import javax.ws.rs.QueryParam;
 
 
 /**
- * Internal {@link HttpHandler} for Application Lifecycle Management
+ * Internal {@link HttpHandler} for Application Lifecycle Management.
  */
 @Singleton
 @Path(Constants.Gateway.INTERNAL_API_VERSION_3 + "/namespaces/{namespace-id}")
@@ -70,7 +70,7 @@ public class AppLifecycleHttpHandlerInternal extends AbstractAppFabricHttpHandle
   }
 
   /**
-   * Get a list of {@link ApplicationDetail} for all applications in the given namespace
+   * Get a list of {@link ApplicationDetail} for all applications in the given namespace.
    *
    * @param request {@link HttpRequest}
    * @param responder {@link HttpResponse}
@@ -151,7 +151,7 @@ public class AppLifecycleHttpHandlerInternal extends AbstractAppFabricHttpHandle
   }
 
   /**
-   * Get {@link ApplicationDetail} for a given application
+   * Get {@link ApplicationDetail} for a given application.
    *
    * @param request {@link HttpRequest}
    * @param responder {@link HttpResponse}
@@ -175,7 +175,7 @@ public class AppLifecycleHttpHandlerInternal extends AbstractAppFabricHttpHandle
   }
 
   /**
-   * Get {@link ApplicationDetail} for a given application
+   * Get {@link ApplicationDetail} for a given application.
    *
    * @param request {@link HttpRequest}
    * @param responder {@link HttpResponse}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandlerInternal.java
@@ -145,6 +145,8 @@ public class AppLifecycleHttpHandlerInternal extends AbstractAppFabricHttpHandle
           Arrays.asList(EntityId.IDSTRING_PART_SEPARATOR_PATTERN.split(pageToken))
       )));
     }
+    // Scan the latest applications only for internal apps list api.
+    builder.setLatestOnly(true);
     return builder.build();
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -246,7 +246,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
   }
 
   /**
-   * Scans all applications in the specified namespace, filtered to only include application details
+   * Scans all the latest applications in the specified namespace, filtered to only include application details
    * which satisfy the filters
    *
    * @param namespace the namespace to scan apps from
@@ -259,6 +259,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     scanApplications(ScanApplicationsRequest.builder()
         .setNamespaceId(namespace)
         .addFilters(filters)
+        .setLatestOnly(true)
         .build(), consumer);
   }
 
@@ -1071,6 +1072,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
 
     // All Apps are STOPPED, delete them in a streaming fashion
     store.scanApplications(
+        // Scan and delete all app versions across the namespace
         ScanApplicationsRequest.builder().setNamespaceId(namespaceId).build(),
         batchSize,
         (appId, appMeta) -> {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ProgramLifecycleService.java
@@ -1376,7 +1376,8 @@ public class ProgramLifecycleService {
 
     List<ProgramRecord> programRecords = new ArrayList<>();
     store.scanApplications(
-        ScanApplicationsRequest.builder().setNamespaceId(namespaceId).build(),
+        // Only scan the latest versions for the public program list api
+        ScanApplicationsRequest.builder().setNamespaceId(namespaceId).setLatestOnly(true).build(),
         batchSize,
         (appId, appMeta) -> {
           ApplicationSpecification appSpec = appMeta.getSpec();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -400,14 +400,6 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public Map<ProgramRunId, RunRecordDetail> getRuns(ProgramId id, ProgramRunStatus status,
-      long startTime, long endTime, int limit) {
-    return TransactionRunners.run(transactionRunner, context -> {
-      return getAppMetadataStore(context).getRuns(id, status, startTime, endTime, limit, null);
-    });
-  }
-
-  @Override
   public Map<ProgramRunId, RunRecordDetail> getAllRuns(ProgramReference programReference,
       ProgramRunStatus status,
       long startTime, long endTime, int limit,
@@ -416,6 +408,14 @@ public class DefaultStore implements Store {
       return getAppMetadataStore(context).getAllProgramRuns(programReference, status, startTime,
           endTime, limit,
           filter);
+    });
+  }
+
+  @Override
+  public Map<ProgramRunId, RunRecordDetail> getRuns(ProgramId id, ProgramRunStatus status,
+      long startTime, long endTime, int limit) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      return getAppMetadataStore(context).getRuns(id, status, startTime, endTime, limit, null);
     });
   }
 
@@ -451,6 +451,39 @@ public class DefaultStore implements Store {
   }
 
   @Override
+  public List<ProgramHistory> getRuns(Collection<ProgramReference> programs,
+      ProgramRunStatus status,
+      long startTime, long endTime, int limitPerProgram) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      List<ProgramHistory> result = new ArrayList<>(programs.size());
+      AppMetadataStore appMetadataStore = getAppMetadataStore(context);
+
+      Set<ProgramId> existingPrograms = appMetadataStore.filterProgramsExistence(programs);
+      Map<ProgramReference, ProgramId> programRefsMap =
+          existingPrograms.stream()
+              .collect(Collectors.toMap(ProgramId::getProgramReference, p -> p));
+
+      for (ProgramReference programRef : programs) {
+        ProgramId latestProgramId = programRefsMap.get(programRef);
+        if (latestProgramId == null) {
+          ProgramId defaultVersion = programRef.id(ApplicationId.DEFAULT_VERSION);
+          result.add(new ProgramHistory(defaultVersion, Collections.emptyList(),
+              new ProgramNotFoundException(defaultVersion)));
+          continue;
+        }
+
+        List<RunRecord> runs = appMetadataStore.getRuns(latestProgramId, status, startTime, endTime,
+                limitPerProgram, null)
+            .values().stream()
+            .map(record -> RunRecord.builder(record).build()).collect(Collectors.toList());
+        result.add(new ProgramHistory(latestProgramId, runs, null));
+      }
+
+      return result;
+    });
+  }
+
+  @Override
   public int countActiveRuns(@Nullable Integer limit) {
     return TransactionRunners.run(transactionRunner,
         context -> (int) getAppMetadataStore(context).countActiveRuns(limit));
@@ -472,8 +505,15 @@ public class DefaultStore implements Store {
               consumer.accept(runRecordDetail);
             });
       });
-    }
-    while (count.get() > 0);
+    } while (count.get() > 0);
+  }
+
+  @Override
+  public Map<ProgramRunId, RunRecordDetail> getAllActiveRuns(
+      ApplicationReference applicationReference) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      return getAppMetadataStore(context).getActiveRuns(applicationReference);
+    });
   }
 
   @Override
@@ -495,14 +535,6 @@ public class DefaultStore implements Store {
   public Map<ProgramRunId, RunRecordDetail> getActiveRuns(ApplicationId applicationId) {
     return TransactionRunners.run(transactionRunner, context -> {
       return getAppMetadataStore(context).getActiveRuns(applicationId);
-    });
-  }
-
-  @Override
-  public Map<ProgramRunId, RunRecordDetail> getAllActiveRuns(
-      ApplicationReference applicationReference) {
-    return TransactionRunners.run(transactionRunner, context -> {
-      return getAppMetadataStore(context).getActiveRuns(applicationReference);
     });
   }
 
@@ -1070,39 +1102,6 @@ public class DefaultStore implements Store {
           result.add(new RunCountResult(programRef, runCounts.get(programRef), null));
         }
       }
-      return result;
-    });
-  }
-
-  @Override
-  public List<ProgramHistory> getRuns(Collection<ProgramReference> programs,
-      ProgramRunStatus status,
-      long startTime, long endTime, int limitPerProgram) {
-    return TransactionRunners.run(transactionRunner, context -> {
-      List<ProgramHistory> result = new ArrayList<>(programs.size());
-      AppMetadataStore appMetadataStore = getAppMetadataStore(context);
-
-      Set<ProgramId> existingPrograms = appMetadataStore.filterProgramsExistence(programs);
-      Map<ProgramReference, ProgramId> programRefsMap =
-          existingPrograms.stream()
-              .collect(Collectors.toMap(ProgramId::getProgramReference, p -> p));
-
-      for (ProgramReference programRef : programs) {
-        ProgramId latestProgramId = programRefsMap.get(programRef);
-        if (latestProgramId == null) {
-          ProgramId defaultVersion = programRef.id(ApplicationId.DEFAULT_VERSION);
-          result.add(new ProgramHistory(defaultVersion, Collections.emptyList(),
-              new ProgramNotFoundException(defaultVersion)));
-          continue;
-        }
-
-        List<RunRecord> runs = appMetadataStore.getRuns(latestProgramId, status, startTime, endTime,
-                limitPerProgram, null)
-            .values().stream()
-            .map(record -> RunRecord.builder(record).build()).collect(Collectors.toList());
-        result.add(new ProgramHistory(latestProgramId, runs, null));
-      }
-
       return result;
     });
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -732,7 +732,7 @@ public class DefaultStore implements Store {
   @Override
   public void scanApplications(int txBatchSize,
       BiConsumer<ApplicationId, ApplicationMeta> consumer) {
-    scanApplications(ScanApplicationsRequest.builder().build(), txBatchSize, consumer);
+    scanApplications(ScanApplicationsRequest.builder().setLatestOnly(true).build(), txBatchSize, consumer);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcher.java
@@ -25,12 +25,12 @@ import java.io.IOException;
 import java.util.function.Consumer;
 
 /**
- * Interface for fetching {@code ApplicationDetail}
+ * Interface for fetching {@code ApplicationDetail}.
  */
 public interface ApplicationDetailFetcher {
 
   /**
-   * Get the application detail for the given application reference
+   * Get the application detail for the given application reference.
    *
    * @param appRef the versionless ID of the application
    * @return the detail of the given application
@@ -42,7 +42,7 @@ public interface ApplicationDetailFetcher {
       throws IOException, NotFoundException, UnauthorizedException;
 
   /**
-   * Scans all the latest version of application details in the given namespace
+   * Scans all the latest version of application details in the given namespace.
    *
    * @param namespace the namespace to scan application details from
    * @param consumer a {@link Consumer} to consume each ApplicationDetail being scanned

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/ApplicationDetailFetcher.java
@@ -42,7 +42,7 @@ public interface ApplicationDetailFetcher {
       throws IOException, NotFoundException, UnauthorizedException;
 
   /**
-   * Scans all application details in the given namespace
+   * Scans all the latest version of application details in the given namespace
    *
    * @param namespace the namespace to scan application details from
    * @param consumer a {@link Consumer} to consume each ApplicationDetail being scanned

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalApplicationDetailFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalApplicationDetailFetcher.java
@@ -65,7 +65,7 @@ public class LocalApplicationDetailFetcher implements ApplicationDetailFetcher {
   }
 
   /**
-   * Scans all application details in the given namespace
+   * Scans all the latest application details in the given namespace
    */
   @Override
   public void scan(String namespace, Consumer<ApplicationDetail> consumer, Integer batchSize)

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalApplicationDetailFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/LocalApplicationDetailFetcher.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.util.function.Consumer;
 
 /**
- * Fetch {@link ApplicationDetail} from local store via {@link ApplicationLifecycleService}
+ * Fetch {@link ApplicationDetail} from local store via {@link ApplicationLifecycleService}.
  */
 public class LocalApplicationDetailFetcher implements ApplicationDetailFetcher {
 
@@ -46,7 +46,7 @@ public class LocalApplicationDetailFetcher implements ApplicationDetailFetcher {
   }
 
   /**
-   * Get {@link ApplicationDetail} for the given {@link ApplicationId}
+   * Get {@link ApplicationDetail} for the given {@link ApplicationId}.
    *
    * @param appRef the versionless id of the application
    * @return {@link ApplicationDetail} for the given application
@@ -65,7 +65,7 @@ public class LocalApplicationDetailFetcher implements ApplicationDetailFetcher {
   }
 
   /**
-   * Scans all the latest application details in the given namespace
+   * Scans all the latest application details in the given namespace.
    */
   @Override
   public void scan(String namespace, Consumer<ApplicationDetail> consumer, Integer batchSize)

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataSubscriberService.java
@@ -265,7 +265,7 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
   }
 
   /**
-   * Helper method to emit plugin metadata for a given application
+   * Helper method to emit plugin metadata for a given application.
    *
    * @param namespace the namespace that the app is deployed to
    * @param appSpec Application specification for the app

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataSubscriberService.java
@@ -215,6 +215,7 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
       AtomicInteger appCount = new AtomicInteger();
       List<MetadataMutation> updates = TransactionRunners.run(this.transactionRunner, context -> {
         List<MetadataMutation> mutateUpdates = new ArrayList<>();
+        // Scan all versions since it should be metadata update for all versions
         AppMetadataStore.create(context).scanApplications(
             ScanApplicationsRequest.builder().setNamespaceId(new NamespaceId(namespace)).build(),
             entry -> {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
@@ -190,6 +190,7 @@ public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor
         }
         ProfileId namespaceProfile = getResolvedProfileId(namespaceId);
         appMetadataStore.scanApplications(
+            // Scan all versions
             ScanApplicationsRequest.builder().setNamespaceId(namespaceId).build(),
             entry -> {
               ApplicationMeta meta = entry.getValue();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/profile/ProfileMetadataMessageProcessor.java
@@ -75,7 +75,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Class to process the profile metadata request
+ * Class to process the profile metadata request.
  */
 public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor {
 
@@ -98,6 +98,13 @@ public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor
   private final PreferencesTable preferencesTable;
   private final MetricsCollectionService metricsCollectionService;
 
+  /**
+   * The message processor of profile metadata.
+   *
+   * @param metadataStorage {@link MetadataStorage}
+   * @param structuredTableContext {@link StructuredTableContext}
+   * @param metricsCollectionService {@link MetricsCollectionService}
+   */
   public ProfileMetadataMessageProcessor(MetadataStorage metadataStorage,
       StructuredTableContext structuredTableContext,
       MetricsCollectionService metricsCollectionService) {
@@ -363,7 +370,7 @@ public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor
 
   /**
    * Get the profile id for the provided entity id from the resolved preferences from preference
-   * dataset, if no profile is inside, it will return the default profile
+   * dataset, if no profile is inside, it will return the default profile.
    *
    * @param entityId entity id to lookup the profile id
    * @return the profile id which will be used by this entity id, default profile if not find
@@ -395,7 +402,7 @@ public class ProfileMetadataMessageProcessor implements MetadataMessageProcessor
   }
 
   /**
-   * Get the schedule id from the schedule spec
+   * Get the schedule id from the schedule spec.
    */
   private Set<ScheduleId> getSchedulesInApp(ApplicationId appId,
       Map<String, ? extends ScheduleCreationSpec> scheduleSpecs) {

--- a/cdap-operational-stats-core/src/main/java/io/cdap/cdap/operations/cdap/CDAPEntities.java
+++ b/cdap-operational-stats-core/src/main/java/io/cdap/cdap/operations/cdap/CDAPEntities.java
@@ -88,8 +88,9 @@ public class CDAPEntities extends AbstractCDAPStats implements CDAPEntitiesMXBea
     artifacts += artifactRepository.getArtifactSummaries(NamespaceId.SYSTEM, false).size();
 
     for (NamespaceMeta meta : namespaceMetas) {
+      // Scan the latest active versions for stats
       ScanApplicationsRequest scanApplicationsRequest =
-          ScanApplicationsRequest.builder().setNamespaceId(meta.getNamespaceId()).build();
+          ScanApplicationsRequest.builder().setNamespaceId(meta.getNamespaceId()).setLatestOnly(true).build();
 
       appLifecycleService.scanApplications(scanApplicationsRequest,
           d -> {


### PR DESCRIPTION
## What
1. Fix the export/apps API to return only the latest app versions
2. For all the usages of ScanApplicationsRequest#builder(), applied latestOnly where applicable