### PR TITLE
[CDAP-20653] fix upgrade node 12 to 16 warnings

### DIFF
--- a/.github/workflows/build-sonar.yml
+++ b/.github/workflows/build-sonar.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       # Pinned 1.0.0 version
-      - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94
+      - uses: marocchino/action-workflow_run-status@54b6e87d6cb552fc5f36dbe9a722a6048725917a
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       # Pinned 1.0.0 version
-      - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94
+      - uses: marocchino/action-workflow_run-status@54b6e87d6cb552fc5f36dbe9a722a6048725917a
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
addressed this issue https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/