### PR TITLE
[CDAP-20654] Add watcher on correct namespace

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -337,7 +337,7 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
             workloadIdentityProvider);
       }
     }
-    addAndStartWatchers(cdapNamespace);
+    addAndStartWatchers(namespace);
   }
 
   @Override


### PR DESCRIPTION
Fixed a bug where we were adding a watcher on the cdap namespace (instead of k8s namespace) on namespace creation.