### PR TITLE
Add operational stats e2e test

### DIFF
--- a/cdap-operational-stats-core/pom.xml
+++ b/cdap-operational-stats-core/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright © 2016 Cask Data, Inc.
-  
+
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
   the License at
-  
+
   http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
   WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
@@ -24,6 +24,9 @@
     <version>6.10.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
+  <properties>
+    <slf4j.version>1.7.5</slf4j.version>
+  </properties>
 
   <artifactId>cdap-operational-stats-core</artifactId>
   <name>CDAP Operational Stats Core</name>
@@ -52,6 +55,12 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -100,6 +109,103 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>e2e-tests</id>
+      <properties>
+        <testSourceLocation>src/e2e-test/java</testSourceLocation>
+        <TEST_RUNNER>TestRunner.java</TEST_RUNNER>
+      </properties>
+      <build>
+        <testResources>
+          <testResource>
+            <directory>src/e2e-test/resources</directory>
+          </testResource>
+        </testResources>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.18.1</version>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>3.0.0-M5</version>
+            <configuration>
+              <includes>
+                <include>${TEST_RUNNER}</include>
+              </includes>
+              <!--Start configuration to run TestRunners in parallel-->
+              <parallel>classes</parallel> <!--Running TestRunner classes in parallel-->
+              <threadCount>2</threadCount> <!--Number of classes to run in parallel-->
+              <forkCount>2</forkCount> <!--Number of JVM processes -->
+              <reuseForks>true</reuseForks>
+              <!--End configuration to run TestRunners in parallel-->
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>net.masterthought</groupId>
+            <artifactId>maven-cucumber-reporting</artifactId>
+            <version>5.5.0</version>
+
+            <executions>
+              <execution>
+                <id>execution</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+                <configuration>
+                  <projectName>Cucumber Reports</projectName> <!-- Replace with project name -->
+                  <outputDirectory>target/cucumber-reports/advanced-reports</outputDirectory>
+                  <buildNumber>1</buildNumber>
+                  <skip>false</skip>
+                  <inputDirectory>${project.build.directory}/cucumber-reports</inputDirectory>
+                  <jsonFiles> <!-- supports wildcard or name pattern -->
+                    <param>**/*.json</param>
+                  </jsonFiles> <!-- optional, defaults to outputDirectory if not specified -->
+                  <classificationDirectory>${project.build.directory}/cucumber-reports</classificationDirectory>
+                  <checkBuildResult>true</checkBuildResult>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+
+      <dependencies>
+        <dependency>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+          <version>31.1-jre</version>
+        </dependency>
+        <dependency>
+          <groupId>io.cdap.tests.e2e</groupId>
+          <artifactId>cdap-e2e-framework</artifactId>
+          <version>0.3.0-SNAPSHOT</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+          <version>1.2.8</version>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+
     </profile>
   </profiles>
 

--- a/cdap-operational-stats-core/src/e2e-test/features/OperationalStats.feature
+++ b/cdap-operational-stats-core/src/e2e-test/features/OperationalStats.feature
@@ -1,0 +1,40 @@
+#
+# Copyright © 2023 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+@Integration_Tests
+Feature: Test operational stats
+
+  @OPERATIONAL_STATS_TEST
+  Scenario: Correct operational stats should be shown in UI
+    When Open administration page
+    Then Check system uptime is positive
+    And Check in table "generic-details-entities" value "Namespaces" is greater than or equal to 1
+    And Check in table "generic-details-entities" value "Artifacts" is greater than or equal to 0
+    And Check in table "generic-details-entities" value "Applications" is greater than or equal to 0
+    And Check in table "generic-details-entities" value "Programs" is greater than or equal to 0
+    And Check in table "generic-details-entities" value "Datasets" is greater than or equal to 0
+
+    And Check in table "generic-details-lasthourload" value "TotalRequests" is greater than or equal to 0
+    And Check in table "generic-details-lasthourload" value "Successful" is greater than or equal to 0
+    And Check in table "generic-details-lasthourload" value "ServerErrors" is greater than or equal to 0
+    And Check in table "generic-details-lasthourload" value "ClientErrors" is greater than or equal to 0
+    And Check in table "generic-details-lasthourload" value "WarnLogs" is greater than or equal to 0
+    And Check in table "generic-details-lasthourload" value "ErrorLogs" is greater than or equal to 0
+
+    And Check in table "generic-details-transactions" value "NumCommittingChangeSets" is greater than or equal to 0
+    And Check in table "generic-details-transactions" value "NumCommittedChangeSets" is greater than or equal to 0
+    And Check in table "generic-details-transactions" value "NumInProgressTransactions" is greater than or equal to 0
+    And Check in table "generic-details-transactions" value "NumInvalidTransactions" is greater than or equal to 0

--- a/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/runners/TestRunner.java
+++ b/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/runners/TestRunner.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.operations.cdap.runners;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+/**
+ * Test Runner to execute operational stats related test cases.
+ */
+@RunWith(Cucumber.class)
+@CucumberOptions(
+    features = {"src/e2e-test/features"},
+    glue = {"io.cdap.cdap.operations.cdap.stepsdesign", "stepsdesign"},
+    tags = {"not @ignore"},
+    plugin = {"pretty", "html:target/cucumber-html-report/tethering",
+        "json:target/cucumber-reports/cucumber-tethering.json",
+        "junit:target/cucumber-reports/cucumber-tethering.xml"}
+)
+public class TestRunner {
+}

--- a/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/runners/package-info.java
+++ b/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/runners/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the test runner class(es) for e2e tests.
+ */
+
+package io.cdap.cdap.operations.cdap.runners;

--- a/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/stepdesign/OperationalStatsSteps.java
+++ b/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/stepdesign/OperationalStatsSteps.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.operations.cdap.stepdesign;
+
+import io.cdap.e2e.utils.CdfHelper;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.cdap.cdap.operations.cdap.utils.OperationalStatsActions;
+
+/**
+ *Operational Stats plugin related StepsDesign.
+ */
+
+public class OperationalStatsSteps implements CdfHelper {
+
+  @When("Open administration page")
+  public void openAdminPage() {
+    OperationalStatsActions.openAdminPage();
+  }
+
+  @Then("Check system uptime is positive")
+  public void checkUptime() {
+    OperationalStatsActions.checkUptimeValue();
+  }
+
+  @Then("Check in table {string} value {string} is greater than or equal to {int}")
+  public void checkInTableValueIsGTE(String tableTestId, String key, int lowerLimit) {
+    OperationalStatsActions.checkValueInTableGTE(tableTestId, key, lowerLimit);
+  }
+
+}

--- a/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/stepdesign/package-info.java
+++ b/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/stepdesign/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the stepdesign class(es) for e2e tests.
+ */
+
+package io.cdap.cdap.operations.cdap.stepdesign;

--- a/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/utils/Constants.java
+++ b/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/utils/Constants.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.operations.cdap.utils;
+
+public class Constants {
+  public static final String BASE_URL = "http://localhost:11011";
+
+  public static final String ADMIN_PAGE_URL = BASE_URL + "/cdap/administration";
+
+}

--- a/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/utils/OperationalStatsActions.java
+++ b/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/utils/OperationalStatsActions.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.operations.cdap.utils;
+
+import io.cdap.e2e.utils.SeleniumDriver;
+import io.cdap.e2e.utils.WaitHelper;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import org.junit.Assert;
+import io.cdap.cdap.operations.cdap.utils.Constants;
+
+/**
+ * Operational Stats plugin related Actions.
+ */
+
+public class OperationalStatsActions {
+
+  public static void openAdminPage() {
+    SeleniumDriver.openPage(Constants.ADMIN_PAGE_URL);
+    WaitHelper.waitForPageToLoad();
+  }
+
+  public static void checkUptimeValue() {
+    String xpath = "//span[@data-testid='system-uptime-container']";
+    WebElement el = SeleniumDriver.getDriver().findElement(By.xpath(xpath));
+    double uptime = Double.parseDouble(el.getAttribute("data-uptime"));
+    Assert.assertTrue(uptime > 0);
+  }
+
+  public static void checkValueInTableGTE(String tableTestId, String key, int lowerLimit) {
+    Assert.assertTrue(findValueInGenericTable(tableTestId, key) >= lowerLimit);
+  }
+
+  public static double findValueInGenericTable(String tableTestId, String key) {
+    String xpath = "//div[@data-testid='" + tableTestId + "']//td[@data-testid='" + key + "']";
+    WebElement el = SeleniumDriver.getDriver().findElement(By.xpath(xpath));
+    return Double.parseDouble(el.getText().replaceAll(",", ""));
+  }
+
+}

--- a/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/utils/package-info.java
+++ b/cdap-operational-stats-core/src/e2e-test/java/io/cdap/cdap/operations/cdap/utils/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package contains the utility class(es) for e2e tests.
+ */
+
+package io.cdap.cdap.operations.cdap.utils;


### PR DESCRIPTION
Converts the integration test [OperationalStatsTest.java](https://github.com/cdapio/cdap-integration-tests/blob/develop/integration-test-remote/src/test/java/io/cdap/cdap/operations/OperationalStatsTest.java) to e2e test with the following exceptions:

+ The value `readPointer` is not displayed in the UI, therefore it's not tested.
+ The value `writePointer` is not displayed in the UI, therefore it's not tested.