### PR TITLE
CDAP-20667 Deprecate table based datasets and custom datasets

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/DatasetDefinition.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/DatasetDefinition.java
@@ -43,8 +43,9 @@ import java.util.Map;
  *
  * @param <D> defines data operations that can be performed on this dataset instance
  * @param <A> defines administrative operations that can be performed on this dataset instance
+ * @deprecated custom datasets will be removed in a future version
  */
-@Beta
+@Deprecated
 public interface DatasetDefinition<D extends Dataset, A extends DatasetAdmin> {
 
   /**

--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/CounterTimeseriesTable.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/CounterTimeseriesTable.java
@@ -33,7 +33,9 @@ import java.util.NoSuchElementException;
  * usage, please see the {@link TimeseriesTable} class description.</p>
  *
  * @see TimeseriesTable
+ * @deprecated table based datasets will be removed in a future version
  */
+@Deprecated
 public class CounterTimeseriesTable extends TimeseriesDataset {
 
   /**

--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/IndexedObjectStore.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/IndexedObjectStore.java
@@ -37,7 +37,9 @@ import java.util.stream.Collectors;
  * the index.
  *
  * @param <T> the type of objects in the store
+ * @deprecated table based datasets will be removed in a future version
  */
+@Deprecated
 public class IndexedObjectStore<T> extends AbstractDataset {
 
   /**

--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/IndexedTable.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/IndexedTable.java
@@ -95,7 +95,9 @@ import org.slf4j.LoggerFactory;
  * </p>
  *
  * @see #INDEX_COLUMNS_CONF_KEY
+ * @deprecated table based datasets will be removed in a future version
  */
+@Deprecated
 public class IndexedTable extends AbstractDataset implements Table {
 
   /**

--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/KeyValueTable.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/KeyValueTable.java
@@ -45,7 +45,10 @@ import javax.annotation.Nullable;
 /**
  * A key/value map implementation on top of {@link Table} supporting read, write and delete
  * operations.
+ *
+ * @deprecated table based datasets will be removed in a future version
  */
+@Deprecated
 public class KeyValueTable extends AbstractDataset implements
     BatchReadable<byte[], byte[]>, BatchWritable<byte[], byte[]>,
     RecordScannable<KeyValue<byte[], byte[]>>, RecordWritable<KeyValue<byte[], byte[]>> {

--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/ObjectMappedTable.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/ObjectMappedTable.java
@@ -42,8 +42,9 @@ import javax.annotation.Nullable;
  * {@link ObjectMappedTableProperties} for more information on properties for this Dataset.
  *
  * @param <T> the type of objects in the table
+ * @deprecated table based datasets will be removed in a future version
  */
-@Beta
+@Deprecated
 public interface ObjectMappedTable<T> extends Dataset, BatchReadable<byte[], T>,
     BatchWritable<byte[], T>, RecordScannable<StructuredRecord>, RecordWritable<StructuredRecord> {
 

--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/ObjectStore.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/ObjectStore.java
@@ -40,8 +40,9 @@ import java.util.List;
  * columns.
  *
  * @param <T> the type of objects in the store
+ * @deprecated table based datasets will be removed in a future version
  */
-@Beta
+@Deprecated
 public interface ObjectStore<T> extends Dataset, BatchReadable<byte[], T>,
     BatchWritable<byte[], T> {
 

--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/PartitionedFileSet.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/PartitionedFileSet.java
@@ -33,8 +33,10 @@ import javax.annotation.Nullable;
  * attached as meta data. Note that the partitioning of the dataset is fixed, that is, all
  * operations that accept a partition key as a parameter require that that key has exactly the same
  * schema as the partitioning.
+ *
+ * @deprecated table based datasets will be removed in a future version
  */
-@Beta
+@Deprecated
 public interface PartitionedFileSet extends Dataset, InputFormatProvider, OutputFormatProvider {
 
   /**

--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/TimePartitionedFileSet.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/TimePartitionedFileSet.java
@@ -34,8 +34,11 @@ import javax.annotation.Nullable;
  * retrieving partitions via time or time range using {@link #getPartitionByTime}, {@link
  * #getPartitionsByTime}, or when writing a partition using {@link #getPartitionOutput}, the seconds
  * and milliseconds on the time or time range are ignored.
+ *
+ * @deprecated table based datasets will be removed in a future version
  */
 @Beta
+@Deprecated
 public interface TimePartitionedFileSet extends PartitionedFileSet {
 
   /**

--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/TimeseriesTable.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/TimeseriesTable.java
@@ -110,7 +110,9 @@ import java.util.Objects;
  * </p>
  *
  * @see CounterTimeseriesTable
+ * @deprecated table based datasets will be removed in a future version
  */
+@Deprecated
 public class TimeseriesTable extends TimeseriesDataset
     implements BatchReadable<byte[], TimeseriesTable.Entry>,
     BatchWritable<byte[], TimeseriesTable.Entry> {

--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/cube/Cube.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/lib/cube/Cube.java
@@ -26,8 +26,10 @@ import java.util.List;
  * Cube data set.
  * <p/>
  * Basic operations include adding {@link CubeFact}s and querying data.
+ *
+ * @deprecated table based datasets will be removed in a future version
  */
-@Beta
+@Deprecated
 public interface Cube extends Dataset, BatchWritable<Object, CubeFact> {
 
   /**

--- a/cdap-api/src/main/java/io/cdap/cdap/api/dataset/table/Table.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/dataset/table/Table.java
@@ -31,7 +31,10 @@ import javax.annotation.Nullable;
 
 /**
  * An ordered, optionally explorable, named table.
+ *
+ * @deprecated table based datasets will be removed in a future version
  */
+@Deprecated
 public interface Table extends BatchReadable<byte[], Row>, BatchWritable<byte[], Put>,
     Dataset, RecordScannable<StructuredRecord>, RecordWritable<StructuredRecord> {
 


### PR DESCRIPTION
Deprecating any dataset that uses the Table dataset and custom datasets. These datasets are unused except in very old Hadoop installations and are not supported with provisioners. Due to this, support will be removed in a future version.