### PR TITLE
CDAP-20685: Exclude failed pods from instance assignments

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillContext.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillContext.java
@@ -508,7 +508,8 @@ public class KubeTwillContext implements ExtendedTwillContext, Closeable {
           .map(e -> e.getKey() + "=" + e.getValue())
           .collect(Collectors.joining(","));
 
-      V1PodList podList = coreApi.listNamespacedPod(podInfo.getNamespace(), null, null, null, null,
+      V1PodList podList = coreApi.listNamespacedPod(podInfo.getNamespace(), null, null, null,
+          "status.phase!=Failed",
           labelSelector, null, null, null, null, null);
       Set<String> activePods = podList.getItems().stream()
           .map(V1Pod::getMetadata)


### PR DESCRIPTION
This helps to ignore evicted pods otherwise a new pod can't come up until evicted pod is manually deleted.