### PR TITLE
[CDAP-20698] Allow adding dataproc labels using provisioner properties

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/ArtifactCacheManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/ArtifactCacheManager.java
@@ -132,7 +132,7 @@ public class ArtifactCacheManager {
         .forEach(artifact -> {
           String cachedArtifactFilePath = getPath(cachedArtifactsPath, artifact);
           try {
-            DataprocUtils.removeTemporaryHoldOnGCSObject(client, bucket,
+            DataprocUtils.removeTemporaryHoldOnGcsObject(client, bucket,
                 BlobId.of(bucket, cachedArtifactFilePath),
                 cachedArtifactFilePath);
           } catch (InterruptedException e) {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -204,7 +204,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
 
       // Reload system context properties and get system labels
       Map<String, String> labels = new HashMap<>();
-      labels.putAll(getSystemLabels());
+      labels.putAll(getCommonDataprocLabels(context));
       labels.putAll(getReuseLabels(context, conf));
       labels.putAll(conf.getClusterLabels());
       LOG.info(

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/ExistingDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/ExistingDataprocProvisioner.java
@@ -95,7 +95,7 @@ public class ExistingDataprocProvisioner extends AbstractDataprocProvisioner {
     String clusterName = contextProperties.get(CLUSTER_NAME);
     try (DataprocClient client = CLIENT_FACTORY.create(conf)) {
       try {
-        client.updateClusterLabels(clusterName, getSystemLabels());
+        client.updateClusterLabels(clusterName, getCommonDataprocLabels(context));
       } catch (DataprocRuntimeException e) {
         // It's ok not able to update the labels
         // Only log the stacktrace if trace log level is enabled

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/SshDataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/SshDataprocClient.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
 class SshDataprocClient extends DataprocClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(SshDataprocClient.class);
-  private static final List<IPRange> PRIVATE_IP_RANGES = DataprocUtils.parseIPRanges(
+  private static final List<IPRange> PRIVATE_IP_RANGES = DataprocUtils.parseIpRanges(
       Arrays.asList("10.0.0.0/8",
           "172.16.0.0/12",
           "192.168.0.0/16"));
@@ -168,7 +168,7 @@ class SshDataprocClient extends DataprocClient {
         // private IP blocks in order to be able to communicate with Dataproc.
         try {
           List<IPRange> sourceRanges = Optional.ofNullable(firewall.getSourceRanges())
-              .map(DataprocUtils::parseIPRanges)
+              .map(DataprocUtils::parseIpRanges)
               .orElse(Collections.emptyList());
 
           if (!sourceRanges.isEmpty()) {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -357,7 +357,7 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
       String errorMessage = String.format("Error while launching job %s on cluster %s.",
           getJobId(runInfo), clusterName);
       // delete all uploaded gcs files in case of exception
-      DataprocUtils.deleteGCSPath(getStorageClient(), bucket, runRootPath);
+      DataprocUtils.deleteGcsPath(getStorageClient(), bucket, runRootPath);
       DataprocUtils.emitMetric(provisionerContext, region,
           "provisioner.submitJob.response.count", e);
       // ResourceExhaustedException indicates Dataproc agent running on master node isn't emitting heartbeat.

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-dataproc.json
@@ -527,7 +527,20 @@
         },
         {
           "widget-type": "keyvalue",
-          "label": "Labels",
+          "label": "Common Labels",
+          "name": "labels",
+          "description": "Specifies labels for Dataproc clusters and jobs.",
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "delimiter": ";",
+            "kv-delimiter": "|",
+            "key-placeholder": "Key",
+            "value-placeholder": "Value"
+          }
+        },
+        {
+          "widget-type": "keyvalue",
+          "label": "Cluster Labels",
           "name": "clusterLabels",
           "description": "Specifies labels for the Dataproc cluster being created.",
           "widget-attributes": {

--- a/cdap-runtime-ext-dataproc/src/main/resources/gcp-existing-dataproc.json
+++ b/cdap-runtime-ext-dataproc/src/main/resources/gcp-existing-dataproc.json
@@ -106,6 +106,19 @@
               }
             ]
           }
+        },
+        {
+          "widget-type": "keyvalue",
+          "label": "Common Labels",
+          "name": "labels",
+          "description": "Specifies labels for Dataproc jobs.",
+          "widget-attributes": {
+            "showDelimiter": "false",
+            "delimiter": ";",
+            "kv-delimiter": "|",
+            "key-placeholder": "Key",
+            "value-placeholder": "Value"
+          }
         }
       ]
     },

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/common/DataprocUtilsTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/common/DataprocUtilsTest.java
@@ -30,7 +30,7 @@ public class DataprocUtilsTest {
   public void testParseSingleLabel() {
     Map<String, String> expected = new HashMap<>();
     expected.put("key", "val");
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("key=val"));
+    Assert.assertEquals(expected, DataprocUtils.parseKeyValueConfig("key=val", ",", "="));
   }
 
   @Test
@@ -38,7 +38,7 @@ public class DataprocUtilsTest {
     Map<String, String> expected = new HashMap<>();
     expected.put("k1", "v1");
     expected.put("k2", "v2");
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("k1=v1,k2=v2"));
+    Assert.assertEquals(expected, DataprocUtils.parseKeyValueConfig("k1=v1,k2=v2", ",", "="));
   }
 
   @Test
@@ -46,7 +46,7 @@ public class DataprocUtilsTest {
     Map<String, String> expected = new HashMap<>();
     expected.put("k1", "v1");
     expected.put("k2", "v2");
-    Assert.assertEquals(expected, DataprocUtils.parseLabels(" k1  =\tv1  ,\nk2 = v2  "));
+    Assert.assertEquals(expected, DataprocUtils.parseKeyValueConfig(" k1  =\tv1  ,\nk2 = v2  ", ",", "="));
   }
 
   @Test
@@ -54,32 +54,6 @@ public class DataprocUtilsTest {
     Map<String, String> expected = new HashMap<>();
     expected.put("k1", "");
     expected.put("k2", "");
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("k1,k2="));
-  }
-
-  @Test
-  public void testParseLabelsIgnoresInvalidKey() {
-    Map<String, String> expected = new HashMap<>();
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("A"));
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("0"));
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("a.b"));
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("a^b"));
-    StringBuilder longStr = new StringBuilder();
-    for (int i = 0; i < 64; i++) {
-      longStr.append('a');
-    }
-    Assert.assertEquals(expected, DataprocUtils.parseLabels(longStr.toString()));
-  }
-
-  @Test
-  public void testParseLabelsIgnoresInvalidVal() {
-    Map<String, String> expected = new HashMap<>();
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("a=A"));
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("a=ab.c"));
-    StringBuilder longStr = new StringBuilder();
-    for (int i = 0; i < 64; i++) {
-      longStr.append('a');
-    }
-    Assert.assertEquals(expected, DataprocUtils.parseLabels(String.format("a=%s", longStr.toString())));
+    Assert.assertEquals(expected, DataprocUtils.parseKeyValueConfig("k1,k2=", ",", "="));
   }
 }

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -50,7 +50,8 @@ public class DataprocProvisionerTest {
   private static final String RESOURCE_MAX_PERCENT_KEY =
     "capacity-scheduler:yarn.scheduler.capacity.maximum-am-resource-percent";
   private static final String RESOURCE_MAX_PERCENT_VAL = "0.5";
-  private static final String CLUSTER_META_DATA = "metadata-key1|metadata-val1;metadata-key2|metadata-val2";
+  private static final String CLUSTER_META_DATA =
+      "metadata-key1|metadata-val1;metadata-key2|metadata-val2";
   private static final String SERVICE_ACCOUNT = "service-account-1";
   private static final String tokTOKEN_ENDPOINTnEndpoint = "end-point1";
 
@@ -72,7 +73,7 @@ public class DataprocProvisionerTest {
     provisioner = new DataprocProvisioner((conf, requireSsh) -> dataprocClient);
     MockProvisionerSystemContext provisionerSystemContext = new MockProvisionerSystemContext();
 
-    //default system properties defined by DataprocProvisioner
+    // default system properties defined by DataprocProvisioner
     provisionerSystemContext.addProperty(DataprocConf.NETWORK, "old-network");
     provisionerSystemContext.addProperty(DataprocConf.STACKDRIVER_LOGGING_ENABLED, "true");
     provisionerSystemContext
@@ -80,11 +81,14 @@ public class DataprocProvisionerTest {
     provisionerSystemContext.addProperty(DataprocConf.SERVICE_ACCOUNT, SERVICE_ACCOUNT);
     provisionerSystemContext.addProperty(DataprocConf.TOKEN_ENDPOINT_KEY, tokTOKEN_ENDPOINTnEndpoint);
 
-    //default system properties defined by AbstractDataprocProvisioner
-    provisionerSystemContext.addProperty(RESOURCE_MAX_PERCENT_KEY, RESOURCE_MAX_PERCENT_VAL);
-    provisionerSystemContext.addProperty(DataprocConf.RUNTIME_JOB_MANAGER, "job_manager");
-
-    //non-default system properties
+    // default system properties defined by AbstractDataprocProvisioner
+    provisionerSystemContext
+        .addProperty(RESOURCE_MAX_PERCENT_KEY, RESOURCE_MAX_PERCENT_VAL);
+    provisionerSystemContext
+        .addProperty(DataprocConf.RUNTIME_JOB_MANAGER, "job_manager");
+    provisionerSystemContext
+        .addProperty("labels", "system-prop=value,user=system");
+    // non-default system properties
     provisionerSystemContext.addProperty("non-system-default-key", "any-value");
     provisionerSystemContext.setCDAPVersion("6.4");
 
@@ -103,7 +107,8 @@ public class DataprocProvisionerTest {
       .setRun(UUID.randomUUID().toString())
       .build();
     Assert.assertEquals("cdap-app-" + programRunInfo.getRun(),
-                        new DataprocProvisioner().getRunKey(new MockProvisionerContext(programRunInfo)));
+        new DataprocProvisioner().getRunKey(
+            new MockProvisionerContext(programRunInfo)));
 
     // test lowercasing, stripping of invalid characters, and truncation
     programRunInfo = new ProgramRunInfo.Builder()
@@ -115,7 +120,8 @@ public class DataprocProvisionerTest {
       .setRun(UUID.randomUUID().toString())
       .build();
     Assert.assertEquals("cdap-myapplcat-" + programRunInfo.getRun(),
-                        new DataprocProvisioner().getRunKey(new MockProvisionerContext(programRunInfo)));
+        new DataprocProvisioner().getRunKey(
+            new MockProvisionerContext(programRunInfo)));
   }
 
   @Test
@@ -132,7 +138,8 @@ public class DataprocProvisionerTest {
     props.put("spark:spark.reducer.maxSizeInFlight", "100");
     props.put("hadoop-env:MAPREDUCE_CLASSPATH", "xyz");
     props.put("dataproc:am.primary_only", "true");
-    props.put("clusterMetaData", "metadata-key1|metadata-val1;metadata-key2|metadata-val2");
+    props.put("clusterMetaData",
+        "metadata-key1|metadata-val1;metadata-key2|metadata-val2");
     props.put("clusterLabels", "label-key1|label-val1;label-key2|label-val2");
     props.put("token.endpoint", "point1");
     props.put("secureBootEnabled", "false");
@@ -161,8 +168,10 @@ public class DataprocProvisionerTest {
     Map<String, String> dataprocProps = conf.getClusterProperties();
     Assert.assertEquals(3, dataprocProps.size());
 
-    Assert.assertEquals("100", dataprocProps.get("spark:spark.reducer.maxSizeInFlight"));
-    Assert.assertEquals("xyz", dataprocProps.get("hadoop-env:MAPREDUCE_CLASSPATH"));
+    Assert.assertEquals("100",
+        dataprocProps.get("spark:spark.reducer.maxSizeInFlight"));
+    Assert.assertEquals("xyz",
+        dataprocProps.get("hadoop-env:MAPREDUCE_CLASSPATH"));
     Assert.assertEquals("true", dataprocProps.get("dataproc:am.primary_only"));
 
     Assert.assertFalse(conf.isSecureBootEnabled());
@@ -214,15 +223,22 @@ public class DataprocProvisionerTest {
     final String network = "test-network";
     context.addProperty(DataprocConf.NETWORK, network);
 
-    Map<String, String> properties = provisioner.createContextProperties(context);
+    Map<String, String> properties = provisioner.createContextProperties(
+        context);
 
     Assert.assertEquals(network, properties.get(DataprocConf.NETWORK));
-    Assert.assertEquals("true", properties.get(DataprocConf.STACKDRIVER_LOGGING_ENABLED));
-    Assert.assertEquals(RESOURCE_MAX_PERCENT_VAL, properties.get(RESOURCE_MAX_PERCENT_KEY));
-    Assert.assertEquals(CLUSTER_META_DATA, properties.get(DataprocConf.CLUSTER_META_DATA));
-    Assert.assertEquals(SERVICE_ACCOUNT, properties.get(DataprocConf.SERVICE_ACCOUNT));
-    Assert.assertEquals(tokTOKEN_ENDPOINTnEndpoint, properties.get(DataprocConf.TOKEN_ENDPOINT_KEY));
-    Assert.assertEquals("job_manager", properties.get(DataprocConf.RUNTIME_JOB_MANAGER));
+    Assert.assertEquals("true",
+        properties.get(DataprocConf.STACKDRIVER_LOGGING_ENABLED));
+    Assert.assertEquals(RESOURCE_MAX_PERCENT_VAL,
+        properties.get(RESOURCE_MAX_PERCENT_KEY));
+    Assert.assertEquals(CLUSTER_META_DATA,
+        properties.get(DataprocConf.CLUSTER_META_DATA));
+    Assert.assertEquals(SERVICE_ACCOUNT,
+        properties.get(DataprocConf.SERVICE_ACCOUNT));
+    Assert.assertEquals(tokTOKEN_ENDPOINTnEndpoint,
+        properties.get(DataprocConf.TOKEN_ENDPOINT_KEY));
+    Assert.assertEquals("job_manager",
+        properties.get(DataprocConf.RUNTIME_JOB_MANAGER));
     Assert.assertNull(properties.get("non-system-default-key"));
   }
 
@@ -254,20 +270,27 @@ public class DataprocProvisionerTest {
     ));
 
     context.setSparkCompat(SparkCompat.SPARK3_2_12);
-    Assert.assertEquals("2.0", provisioner.getImageVersion(context, defaultConf));
-    Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
+    Assert.assertEquals("2.0",
+        provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("explicit",
+        provisioner.getImageVersion(context, explicitVersionConf));
 
     context.setAppCDAPVersionInfo(new MockVersionInfo("6.5.0"));
-    Assert.assertEquals("2.0", provisioner.getImageVersion(context, defaultConf));
-    Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
+    Assert.assertEquals("2.0",
+        provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("explicit",
+        provisioner.getImageVersion(context, explicitVersionConf));
 
     context.setAppCDAPVersionInfo(new MockVersionInfo("6.4.0"));
-    Assert.assertEquals("2.0", provisioner.getImageVersion(context, defaultConf));
-    Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
+    Assert.assertEquals("2.0",
+        provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("explicit",
+        provisioner.getImageVersion(context, explicitVersionConf));
 
     //Doublecheck we still get 2.0 for Spark 3 even with CDAP 6.4
     context.setSparkCompat(SparkCompat.SPARK3_2_12);
-    Assert.assertEquals("2.0", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.0",
+        provisioner.getImageVersion(context, defaultConf));
 
   }
 
@@ -291,18 +314,22 @@ public class DataprocProvisionerTest {
     context.setSparkCompat(SparkCompat.SPARK3_2_12);
     context.addProperty(DataprocConf.CLUSTER_REUSE_ENABLED, "false");
 
-    Mockito.when(dataprocClient.getCluster("cdap-app-runId")).thenReturn(Optional.empty());
+    Mockito.when(dataprocClient.getCluster("cdap-app-runId"))
+        .thenReturn(Optional.empty());
     Mockito.when(dataprocClient.createCluster(Mockito.eq("cdap-app-runId"),
-                                              Mockito.eq("2.0"),
-                                              addedLabelsCaptor.capture(),
-                                              Mockito.eq(false),
-                                              Mockito.any()))
-      .thenReturn(ClusterOperationMetadata.getDefaultInstance());
-    Cluster expectedCluster = new Cluster(
-      "cdap-app-runId", ClusterStatus.CREATING, Collections.emptyList(), Collections.emptyMap());
+            Mockito.eq("2.0"), addedLabelsCaptor.capture(), Mockito.eq(false),
+            Mockito.any()))
+        .thenReturn(ClusterOperationMetadata.getDefaultInstance());
+    Cluster expectedCluster = new Cluster("cdap-app-runId",
+        ClusterStatus.CREATING, Collections.emptyList(),
+        Collections.emptyMap());
     Assert.assertEquals(expectedCluster, provisioner.createCluster(context));
-    Assert.assertEquals(Collections.singletonMap("cdap-version", "6_4"),
-                        addedLabelsCaptor.getValue());
+    HashMap<String, String> expectedLables = new HashMap<>();
+    expectedLables.put("cdap-version", "6_4");
+    expectedLables.put("system-prop", "value");
+    expectedLables.put("user", "system");
+    Assert.assertEquals(expectedLables,
+        addedLabelsCaptor.getValue());
   }
 
   @Test
@@ -326,36 +353,39 @@ public class DataprocProvisionerTest {
 
     //A. Check with existing client, probably after a retry
     Mockito.when(dataprocClient.getClusters(
-      Collections.singletonMap(AbstractDataprocProvisioner.LABEL_RUN_KEY, "cdap-app-runId")))
-      .thenAnswer(i -> Stream.of(cluster));
-    Mockito.when(cluster.getStatus()).thenReturn(ClusterStatus.RUNNING);
+            Collections.singletonMap(AbstractDataprocProvisioner.LABEL_RUN_KEY,
+                "cdap-app-runId")))
+        .thenAnswer(i -> Stream.of(cluster));
+    Mockito.when(cluster.getStatus())
+        .thenReturn(ClusterStatus.RUNNING);
     Assert.assertEquals(cluster, provisioner.createCluster(context));
 
     //B. With preallocated cluster in "bad" state new allocation should happen.
-    Mockito.when(cluster.getStatus()).thenReturn(ClusterStatus.FAILED);
-    Mockito.when(cluster2.getName()).thenReturn("cluster2");
-    DataprocConf conf = DataprocConf.create(provisioner.createContextProperties(context));
+    Mockito.when(cluster.getStatus())
+        .thenReturn(ClusterStatus.FAILED);
+    Mockito.when(cluster2.getName())
+        .thenReturn("cluster2");
+    DataprocConf conf = DataprocConf.create(
+        provisioner.createContextProperties(context));
     ImmutableMap<String, String> reuseClusterFilter = ImmutableMap.of(
         AbstractDataprocProvisioner.LABEL_VERSON, "6_4",
         AbstractDataprocProvisioner.LABEL_REUSE_KEY, conf.getClusterReuseKey(),
-        AbstractDataprocProvisioner.LABEL_PROFILE, "testProfile"
-    );
+        AbstractDataprocProvisioner.LABEL_PROFILE, "testProfile");
 
-    Mockito.when(dataprocClient.getClusters(Mockito.eq(reuseClusterFilter), Mockito.any()))
+    Mockito.when(dataprocClient.getClusters(Mockito.eq(reuseClusterFilter),
+            Mockito.any()))
         //B.1. When there is no good cluster found, a retry should happen
         .thenAnswer(i -> {
           //Ensure we call the predicate
           Predicate clusterPredicate = i.getArgumentAt(1, Predicate.class);
-          com.google.cloud.dataproc.v1.Cluster updatingCluster =
-              com.google.cloud.dataproc.v1.Cluster.newBuilder()
-                  .setStatus(com.google.cloud.dataproc.v1.ClusterStatus
-                      .newBuilder().setState(State.UPDATING))
-                  .build();
-          com.google.cloud.dataproc.v1.Cluster deletingCluster =
-              com.google.cloud.dataproc.v1.Cluster.newBuilder()
-                  .setStatus(com.google.cloud.dataproc.v1.ClusterStatus
-                      .newBuilder().setState(State.DELETING))
-                  .build();
+          com.google.cloud.dataproc.v1.Cluster updatingCluster = com.google.cloud.dataproc.v1.Cluster.newBuilder()
+              .setStatus(com.google.cloud.dataproc.v1.ClusterStatus.newBuilder()
+                  .setState(State.UPDATING))
+              .build();
+          com.google.cloud.dataproc.v1.Cluster deletingCluster = com.google.cloud.dataproc.v1.Cluster.newBuilder()
+              .setStatus(com.google.cloud.dataproc.v1.ClusterStatus.newBuilder()
+                  .setState(State.DELETING))
+              .build();
           Assert.assertFalse(clusterPredicate.test(updatingCluster));
           Assert.assertFalse(clusterPredicate.test(deletingCluster));
           return Stream.empty();
@@ -365,10 +395,11 @@ public class DataprocProvisionerTest {
 
     Assert.assertEquals(cluster2, provisioner.createCluster(context));
 
-    Mockito.verify(dataprocClient).updateClusterLabels(
-      "cluster2",
-      Collections.singletonMap(AbstractDataprocProvisioner.LABEL_RUN_KEY, "cdap-app-runId"),
-      Collections.singleton(AbstractDataprocProvisioner.LABEL_REUSE_UNTIL));
+    Mockito.verify(dataprocClient)
+        .updateClusterLabels("cluster2",
+            Collections.singletonMap(AbstractDataprocProvisioner.LABEL_RUN_KEY,
+                "cdap-app-runId"), Collections.singleton(
+                AbstractDataprocProvisioner.LABEL_REUSE_UNTIL));
   }
 
   @Test
@@ -378,16 +409,20 @@ public class DataprocProvisionerTest {
     context.addProperty("region", "testRegion");
     context.addProperty("idleTTL", "5");
     context.addProperty(DataprocConf.SKIP_DELETE, "true");
-    DataprocConf conf = DataprocConf.create(provisioner.createContextProperties(context));
-    Mockito.when(cluster.getName()).thenReturn("testClusterName");
+    DataprocConf conf = DataprocConf.create(
+        provisioner.createContextProperties(context));
+    Mockito.when(cluster.getName())
+        .thenReturn("testClusterName");
     provisioner.doDeleteCluster(context, cluster, conf);
 
-    Mockito.verify(dataprocClient).updateClusterLabels(
-      Mockito.eq("testClusterName"),
-      addedLabelsCaptor.capture(),
-      Mockito.eq(Collections.singleton(AbstractDataprocProvisioner.LABEL_RUN_KEY)));
-    Assert.assertEquals(Collections.singleton(AbstractDataprocProvisioner.LABEL_REUSE_UNTIL),
-                        addedLabelsCaptor.getValue().keySet());
+    Mockito.verify(dataprocClient)
+        .updateClusterLabels(Mockito.eq("testClusterName"),
+            addedLabelsCaptor.capture(), Mockito.eq(Collections.singleton(
+                AbstractDataprocProvisioner.LABEL_RUN_KEY)));
+    Assert.assertEquals(
+        Collections.singleton(AbstractDataprocProvisioner.LABEL_REUSE_UNTIL),
+        addedLabelsCaptor.getValue()
+            .keySet());
   }
 
   @Test
@@ -400,7 +435,8 @@ public class DataprocProvisionerTest {
     DataprocImageVersion v1dot5 = new DataprocImageVersion("1.5");
     DataprocImageVersion v1dot5debian = new DataprocImageVersion("1.5-debian");
     DataprocImageVersion v1dot5dot0 = new DataprocImageVersion("1.5.0");
-    DataprocImageVersion v1dot5dot0debian = new DataprocImageVersion("1.5.0-debian");
+    DataprocImageVersion v1dot5dot0debian = new DataprocImageVersion(
+        "1.5.0-debian");
     DataprocImageVersion v1dot5dot0dot0 = new DataprocImageVersion("1.5.0.0");
     DataprocImageVersion v1dot5dot1 = new DataprocImageVersion("1.5.1");
     DataprocImageVersion v1dot6 = new DataprocImageVersion("1.6");
@@ -445,4 +481,17 @@ public class DataprocProvisionerTest {
     DataprocImageVersion emptyVersion = new DataprocImageVersion("abcd");
   }
 
+  @Test
+  public void testCommonDataprocLabels() {
+    context.addProperty("labels", "user|cdap;program|data-pipeline");
+    Map<String, String> labels = provisioner.getCommonDataprocLabels(context);
+    // Check that the value from system context has overwritten the provisioner context.
+    Assert.assertEquals(labels.get("user"), "system");
+    // Check that the CDAP version is set by system context.
+    Assert.assertEquals(labels.get("cdap-version"), "6_4");
+    // Check that the non-overwritten value from user context is present.
+    Assert.assertEquals(labels.get("program"), "data-pipeline");
+    // Check that the unique value from system context is present.
+    Assert.assertEquals(labels.get("system-prop"), "value");
+  }
 }


### PR DESCRIPTION
## [CDAP-20698](https://cdap.atlassian.net/browse/CDAP-20698)
* Merge provisioner property `labels` provided in cdap-site with the values provided in provisioner configuration. Give priority to cdap-site config when keys collide.
* Provide UI widget to specify `labels` property that adds labels to all dataproc entities (eg: Cluster, job).

### Tested
* Manually verified that `labels` specified in compute profiles are applied to the Dataproc Job.
* Verified that the UI widgets show the `labels` input for static and ephemeral compute profiles.

Static Dataproc Compute profile creation
![image](https://github.com/cdapio/cdap/assets/46515553/415b7a28-0a45-4819-bedf-0ef64860aa4a)

Ephemeral Dataproc Compute profile creation
![image](https://github.com/cdapio/cdap/assets/46515553/844db8d2-fdd6-42d0-a055-8c9449984f37)


[CDAP-20698]: https://cdap.atlassian.net/browse/CDAP-20698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ