### PR TITLE
Use module directory as Extension type for Event Reader

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/events/StartProgramEventReaderExtensionProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/events/StartProgramEventReaderExtensionProvider.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,15 +77,16 @@ public class StartProgramEventReaderExtensionProvider
   }
 
   @Override
-  protected Set<String> getSupportedTypesForProvider(EventReader eventReader) {
-    if (enabledEventReaders == null ||
-            !enabledEventReaders.contains(eventReader.getClass().getName())) {
-      LOG.debug("{} is not present in the allowed list of event readers.",
+  protected Set<String> getSupportedTypesForProvider(EventReader eventReader, String moduleDir) {
+    if (enabledEventReaders == null
+            || !enabledEventReaders.contains(moduleDir)) {
+      LOG.debug("{}/{} is not present in the allowed list of event readers.",
+              moduleDir,
               eventReader.getClass().getName());
       return Collections.emptySet();
     }
 
-    return Collections.singleton(eventReader.getClass().getName());
+    return Collections.singleton(moduleDir);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/events/dummy/DummyEventReaderExtensionProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/events/dummy/DummyEventReaderExtensionProvider.java
@@ -39,7 +39,7 @@ public class DummyEventReaderExtensionProvider<T extends Event> implements Event
   @Override
   public Map<String, EventReader> loadEventReaders() {
     Map<String, EventReader> map = new HashMap<>();
-    map.put(this.eventReader.getClass().getName(), this.eventReader);
+    map.put("moduledir", this.eventReader);
     return Collections.unmodifiableMap(map);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/events/StartProgramEventReaderExtensionProviderTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/events/StartProgramEventReaderExtensionProviderTest.java
@@ -33,19 +33,21 @@ public class StartProgramEventReaderExtensionProviderTest {
   @Test
   public void testEnabledEventReaderFilter() {
     EventReader mockReader = new DummyEventReader();
-    String mockReaderName = mockReader.getClass().getName();
+    String mockModuleDir = "dir";
     CConfiguration cConf = CConfiguration.create();
 
     StartProgramEventReaderExtensionProvider readerExtensionProvider1
             = new StartProgramEventReaderExtensionProvider(cConf);
-    Set<String> test1 = readerExtensionProvider1.getSupportedTypesForProvider(mockReader);
+    Set<String> test1 = readerExtensionProvider1.getSupportedTypesForProvider(mockReader,
+            mockModuleDir);
     Assert.assertTrue(test1.isEmpty());
 
-    //Test with reader class name enabled
-    cConf.setStrings(Constants.Event.START_EVENTS_READER_EXTENSIONS_ENABLED_LIST, mockReaderName);
+    //Test with reader dir enabled
+    cConf.setStrings(Constants.Event.START_EVENTS_READER_EXTENSIONS_ENABLED_LIST, mockModuleDir);
     StartProgramEventReaderExtensionProvider readerExtensionProvider2
             = new StartProgramEventReaderExtensionProvider(cConf);
-    Set<String> test2 = readerExtensionProvider2.getSupportedTypesForProvider(mockReader);
-    Assert.assertTrue(test2.contains(mockReaderName));
+    Set<String> test2 = readerExtensionProvider2.getSupportedTypesForProvider(mockReader,
+            mockModuleDir);
+    Assert.assertTrue(test2.contains(mockModuleDir));
   }
 }


### PR DESCRIPTION
Overload AbstractExtensionLoader to accept a module directory as well as extension for getting supported types. 
Use module directory to provide startprogram event readers.
**Consequences**: 
- abstract status of getSupportedTypes has been removed.  
- edit the signature of multiple methods to accommodate directory name

Based on: https://github.com/cdapio/cdap/pull/15227

