### PR TITLE
Bump twill version to 1.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <tez.version>0.8.4</tez.version>
     <tink.version>1.6.0</tink.version>
     <thrift.version>0.9.3</thrift.version>
-    <twill.version>1.3.1</twill.version>
+    <twill.version>1.3.2</twill.version>
     <unboundid.version>2.3.6</unboundid.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <embedded-postgres.version>1.3.1</embedded-postgres.version>


### PR DESCRIPTION
Bumping twill version to 1.3.2 because of https://github.com/cdapio/twill/pull/38