### PR TITLE
[CDAP-20742] Create k8s SA on namespace creation

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/NamespaceHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/NamespaceHttpHandler.java
@@ -58,16 +58,31 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     this.namespaceAdmin = namespaceAdmin;
   }
 
+  /**
+   * Returns the list of namespaces.
+   *
+   * @param request The {@link HttpRequest}.
+   * @param responder The {@link HttpResponder}.
+   * @throws Exception Any {@link Exception} encountered.
+   */
   @GET
   @Path("/namespaces")
   public void getAllNamespaces(HttpRequest request, HttpResponder responder) throws Exception {
     // return keytab URI without version
     responder.sendJson(HttpResponseStatus.OK,
         GSON.toJson(namespaceAdmin.list().stream()
-            .map(meta -> new NamespaceMeta.Builder(meta).buildWithoutKeytabURIVersion())
+            .map(meta -> new NamespaceMeta.Builder(meta).buildWithoutKeytabUriVersion())
             .collect(Collectors.toList())));
   }
 
+  /**
+   * Returns the metadata of requested namespace.
+   *
+   * @param request The {@link HttpRequest}.
+   * @param responder The {@link HttpResponder}.
+   * @param namespaceId Namespace id string.
+   * @throws Exception Any {@link Exception} encountered.
+   */
   @GET
   @Path("/namespaces/{namespace-id}")
   public void getNamespace(HttpRequest request, HttpResponder responder,
@@ -75,10 +90,18 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     // return keytab URI without version
     NamespaceMeta ns =
         new NamespaceMeta.Builder(
-            namespaceAdmin.get(new NamespaceId(namespaceId))).buildWithoutKeytabURIVersion();
+            namespaceAdmin.get(new NamespaceId(namespaceId))).buildWithoutKeytabUriVersion();
     responder.sendJson(HttpResponseStatus.OK, GSON.toJson(ns));
   }
 
+  /**
+   * Updates the properties of requested namespace.
+   *
+   * @param request The {@link HttpRequest}.
+   * @param responder The {@link HttpResponder}.
+   * @param namespaceId Namespace id string.
+   * @throws Exception Any {@link Exception} encountered.
+   */
   @PUT
   @Path("/namespaces/{namespace-id}/properties")
   @AuditPolicy(AuditDetail.REQUEST_BODY)
@@ -90,6 +113,14 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
         String.format("Updated properties for namespace '%s'.", namespaceId));
   }
 
+  /**
+   * Creates the requested namespace.
+   *
+   * @param request The {@link HttpRequest}.
+   * @param responder The {@link HttpResponder}.
+   * @param namespaceId Namespace id string.
+   * @throws Exception Any {@link Exception} encountered.
+   */
   @PUT
   @Path("/namespaces/{namespace-id}")
   @AuditPolicy(AuditDetail.REQUEST_BODY)
@@ -115,6 +146,7 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
         new NamespaceMeta.Builder(metadata);
     builder.setName(namespace);
     builder.setGeneration(System.currentTimeMillis());
+    builder.setIdentity(namespaceAdmin.getIdentity(namespace));
 
     NamespaceMeta finalMetadata = builder.build();
 
@@ -128,6 +160,14 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     }
   }
 
+  /**
+   * Deletes the requested namespace.
+   *
+   * @param request The {@link HttpRequest}.
+   * @param responder The {@link HttpResponder}.
+   * @param namespace Namespace id string.
+   * @throws Exception Any {@link Exception} encountered.
+   */
   @DELETE
   @Path("/unrecoverable/namespaces/{namespace-id}")
   public void delete(HttpRequest request, HttpResponder responder,
@@ -146,6 +186,14 @@ public class NamespaceHttpHandler extends AbstractAppFabricHttpHandler {
     responder.sendStatus(HttpResponseStatus.OK);
   }
 
+  /**
+   * Deletes all datasets from the requested namespace.
+   *
+   * @param request The {@link HttpRequest}.
+   * @param responder The {@link HttpResponder}.
+   * @param namespace Namespace id string.
+   * @throws Exception Any {@link Exception} encountered.
+   */
   @DELETE
   @Path("/unrecoverable/namespaces/{namespace-id}/datasets")
   public void deleteDatasets(HttpRequest request, HttpResponder responder,

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/namespace/DefaultNamespaceAdminTest.java
@@ -204,7 +204,7 @@ public class DefaultNamespaceAdminTest extends AppFabricTestBase {
     }
 
     // now check with just key tab uri
-    namespaceMeta = new NamespaceMeta.Builder().setName("test_ns").setKeytabURI("/some/path").build();
+    namespaceMeta = new NamespaceMeta.Builder().setName("test_ns").setKeytabUri("/some/path").build();
     try {
       namespaceAdmin.create(namespaceMeta);
       Assert.fail();
@@ -212,7 +212,7 @@ public class DefaultNamespaceAdminTest extends AppFabricTestBase {
       // expected
     }
 
-    namespaceMeta = new NamespaceMeta.Builder().setName("test_ns").setKeytabURI("/some/path")
+    namespaceMeta = new NamespaceMeta.Builder().setName("test_ns").setKeytabUri("/some/path")
       .build();
     try {
       namespaceAdmin.create(namespaceMeta);
@@ -293,7 +293,7 @@ public class DefaultNamespaceAdminTest extends AppFabricTestBase {
     // updating the keytabURI for an existing namespace with no existing principal should fail
     try {
       namespaceAdmin.updateProperties(nsMeta.getNamespaceId(),
-                                      new NamespaceMeta.Builder(nsMeta).setKeytabURI("/new/keytab/uri").build());
+                                      new NamespaceMeta.Builder(nsMeta).setKeytabUri("/new/keytab/uri").build());
       Assert.fail();
     } catch (BadRequestException e) {
       // expected
@@ -318,21 +318,21 @@ public class DefaultNamespaceAdminTest extends AppFabricTestBase {
     String namespace = "updateNamespace";
     NamespaceId namespaceId = new NamespaceId(namespace);
     NamespaceMeta nsMeta = new NamespaceMeta.Builder().setName(namespaceId)
-      .setPrincipal("alice").setKeytabURI("/alice/keytab").build();
+      .setPrincipal("alice").setKeytabUri("/alice/keytab").build();
     namespaceAdmin.create(nsMeta);
     Assert.assertTrue(namespaceAdmin.exists(namespaceId));
     // update the keytab URI
     String newKeytab = "/alice/new_keytab";
-    NamespaceMeta newKeytabMeta = new NamespaceMeta.Builder(nsMeta).setKeytabURI(newKeytab).build();
+    NamespaceMeta newKeytabMeta = new NamespaceMeta.Builder(nsMeta).setKeytabUri(newKeytab).build();
     namespaceAdmin.updateProperties(nsMeta.getNamespaceId(), newKeytabMeta);
     // assert the keytab URI is updated and the version remains 0
-    Assert.assertEquals(newKeytab, namespaceAdmin.get(namespaceId).getConfig().getKeytabURIWithoutVersion());
-    Assert.assertEquals(0, namespaceAdmin.get(namespaceId).getConfig().getKeytabURIVersion());
+    Assert.assertEquals(newKeytab, namespaceAdmin.get(namespaceId).getConfig().getKeytabUriWithoutVersion());
+    Assert.assertEquals(0, namespaceAdmin.get(namespaceId).getConfig().getKeytabUriVersion());
     // update the namespace with the same keytab URI
     namespaceAdmin.updateProperties(nsMeta.getNamespaceId(), newKeytabMeta);
     // assert the keytab URI without version remains the same and the version is incremented to 1
-    Assert.assertEquals(newKeytab, namespaceAdmin.get(namespaceId).getConfig().getKeytabURIWithoutVersion());
-    Assert.assertEquals(1, namespaceAdmin.get(namespaceId).getConfig().getKeytabURIVersion());
+    Assert.assertEquals(newKeytab, namespaceAdmin.get(namespaceId).getConfig().getKeytabUriWithoutVersion());
+    Assert.assertEquals(1, namespaceAdmin.get(namespaceId).getConfig().getKeytabUriVersion());
     //clean up
     namespaceAdmin.delete(namespaceId);
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
@@ -274,7 +274,7 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     String nsPrincipal = "nsCreator/somehost.net@somekdc.net";
     String nsKeytabURI = "some/path";
     NamespaceMeta impNsMeta =
-      new NamespaceMeta.Builder().setName("impNs").setPrincipal(nsPrincipal).setKeytabURI(nsKeytabURI).build();
+      new NamespaceMeta.Builder().setName("impNs").setPrincipal(nsPrincipal).setKeytabUri(nsKeytabURI).build();
     createNamespace(GSON.toJson(impNsMeta), impNsMeta.getName());
 
     // deploy an app without owner

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/NamespaceHttpHandlerTest.java
@@ -95,8 +95,8 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     HttpResponse response = listAllNamespaces();
     assertResponseCode(200, response);
     List<JsonObject> namespaces = readListResponse(response);
-    int initialSize = namespaces.size();
     // create and verify
+    final int initialSize = namespaces.size();
     response = createNamespace(METADATA_VALID, NAME);
     assertResponseCode(200, response);
     response = listAllNamespaces();
@@ -106,7 +106,7 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     Assert.assertEquals(DESCRIPTION, namespaces.get(0).get(DESCRIPTION_FIELD).getAsString());
     // verify that keytab URI cannot be updated since the namespace was created with no principal
     NamespaceMeta meta =
-      new NamespaceMeta.Builder().setName(NAME).setKeytabURI("new.keytab").build();
+      new NamespaceMeta.Builder().setName(NAME).setKeytabUri("new.keytab").build();
     response = setProperties(NAME, meta);
     assertResponseCode(400, response);
     // cleanup
@@ -256,6 +256,7 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
   @Test
   public void testDeleteAll() throws Exception {
     CConfiguration cConf = getInjector().getInstance(CConfiguration.class);
+    cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
     // test deleting non-existent namespace
     assertResponseCode(404, deleteNamespace("doesnotexist"));
     assertResponseCode(200, createNamespace(NAME));
@@ -267,23 +268,20 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     Location nsLocation = namespacePathLocator.get(new NamespaceId(NAME));
     Assert.assertTrue(nsLocation.exists());
 
-    DatasetFramework dsFramework = getInjector().getInstance(DatasetFramework.class);
-
     deploy(AppWithServices.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, NAME);
     deploy(AppWithDataset.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, NAME);
     deploy(AppForUnrecoverableResetTest.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, OTHER_NAME);
 
     DatasetId myDataset = new DatasetId(NAME, "myds");
-
+    DatasetFramework dsFramework = getInjector().getInstance(DatasetFramework.class);
     Assert.assertTrue(dsFramework.hasInstance(myDataset));
     Id.Program program = Id.Program.from(NAME_ID, "AppWithServices", ProgramType.SERVICE, "NoOpService");
     startProgram(program);
     waitState(program, ProgramStatus.RUNNING.name());
-    boolean resetEnabled = cConf.getBoolean(Constants.Dangerous.UNRECOVERABLE_RESET);
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, false);
     // because unrecoverable reset is disabled
     assertResponseCode(403, deleteNamespace(NAME));
-    cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, resetEnabled);
+    cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
     // because service is running
     assertResponseCode(409, deleteNamespace(NAME));
     Assert.assertTrue(nsLocation.exists());
@@ -304,7 +302,6 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
 
   @Test
   public void testDeleteDatasetsOnly() throws Exception {
-    CConfiguration cConf = getInjector().getInstance(CConfiguration.class);
     // test deleting non-existent namespace
     assertResponseCode(200, createNamespace(NAME));
     assertResponseCode(200, getNamespace(NAME));
@@ -324,12 +321,12 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     Id.Program program = Id.Program.from(NAME_ID, "AppWithServices", ProgramType.SERVICE, "NoOpService");
     startProgram(program);
     waitState(program, ProgramStatus.RUNNING.name());
-    boolean resetEnabled = cConf.getBoolean(Constants.Dangerous.UNRECOVERABLE_RESET);
+    CConfiguration cConf = getInjector().getInstance(CConfiguration.class);
     cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, false);
     // because reset is not enabled
     assertResponseCode(403, deleteNamespaceData(NAME));
     Assert.assertTrue(nsLocation.exists());
-    cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, resetEnabled);
+    cConf.setBoolean(Constants.Dangerous.UNRECOVERABLE_RESET, true);
     // because service is running
     assertResponseCode(409, deleteNamespaceData(NAME));
     Assert.assertTrue(nsLocation.exists());
@@ -406,9 +403,9 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
   public void testProperties() throws Exception {
     // create a namespace with principal
     String nsPrincipal = "nsCreator/somehost.net@somekdc.net";
-    String nsKeytabURI = "some/path";
+    String nsKeytabUri = "some/path";
     NamespaceMeta impNsMeta =
-      new NamespaceMeta.Builder().setName(NAME).setPrincipal(nsPrincipal).setKeytabURI(nsKeytabURI).build();
+      new NamespaceMeta.Builder().setName(NAME).setPrincipal(nsPrincipal).setKeytabUri(nsKeytabUri).build();
     HttpResponse response = createNamespace(GSON.toJson(impNsMeta), impNsMeta.getName());
     assertResponseCode(200, response);
     // verify
@@ -453,7 +450,7 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     Assert.assertEquals("prod", config.getSchedulerQueueName());
 
     // verify updating keytab URI with version initialized
-    setProperties(NAME, new NamespaceMeta.Builder(impNsMeta).setKeytabURI("new/url").build());
+    setProperties(NAME, new NamespaceMeta.Builder(impNsMeta).setKeytabUri("new/url").build());
     response = getNamespace(NAME);
     namespace = readGetResponse(response);
     Assert.assertNotNull(namespace);
@@ -463,5 +460,61 @@ public class NamespaceHttpHandlerTest extends AppFabricTestBase {
     // cleanup
     response = deleteNamespace(NAME);
     Assert.assertEquals(200, response.getResponseCode());
+  }
+
+  @Test
+  public void testNamespaceIdentity() throws Exception {
+    NamespaceId fooNamespace = new NamespaceId("Foo_Namespace");
+
+    //get non-existent namespace
+    HttpResponse response = getNamespace(fooNamespace.getNamespace());
+    Assert.assertEquals(404, response.getResponseCode());
+
+    // create Namespace
+    response = createNamespace(METADATA_VALID, fooNamespace.getNamespace());
+    Assert.assertEquals(200, response.getResponseCode());
+    NamespaceId longNamespace = new NamespaceId("Test_Long_Namespace");
+    response = createNamespace(METADATA_VALID, longNamespace.getNamespace());
+    Assert.assertEquals(200, response.getResponseCode());
+
+    //get identity
+    String expectedIdentity = "foo-namespace-396fb5b48c8bbdb";
+    response = getNamespace(fooNamespace.getNamespace());
+    Assert.assertEquals(200, response.getResponseCode());
+    NamespaceMeta ns = GSON.fromJson(response.getResponseBodyAsString(), NamespaceMeta.class);
+    Assert.assertEquals(expectedIdentity, ns.getIdentity());
+
+    expectedIdentity = "test-long-names-e190a7e512d7030";
+    response = getNamespace(longNamespace.getNamespace());
+    Assert.assertEquals(200, response.getResponseCode());
+    ns = GSON.fromJson(response.getResponseBodyAsString(), NamespaceMeta.class);
+    Assert.assertEquals(expectedIdentity, ns.getIdentity());
+
+    //deleteNamespace
+    response = deleteNamespace(fooNamespace.getNamespace());
+    Assert.assertEquals(200, response.getResponseCode());
+    response = deleteNamespace(longNamespace.getNamespace());
+    Assert.assertEquals(200, response.getResponseCode());
+
+    //reserved namespace
+    expectedIdentity = NamespaceId.DEFAULT.getNamespace();
+    response = getNamespace(NamespaceId.DEFAULT.getNamespace());
+    Assert.assertEquals(200, response.getResponseCode());
+    ns = GSON.fromJson(response.getResponseBodyAsString(), NamespaceMeta.class);
+    Assert.assertEquals(expectedIdentity, ns.getIdentity());
+
+    // namespace creation hook enabled
+    CConfiguration cConf = getInjector().getInstance(CConfiguration.class);
+    cConf.setBoolean(Constants.Namespace.NAMESPACE_CREATION_HOOK_ENABLED, true);
+    response = createNamespace(METADATA_VALID, fooNamespace.getNamespace());
+    Assert.assertEquals(200, response.getResponseCode());
+    expectedIdentity = "default";
+    response = getNamespace(fooNamespace.getNamespace());
+    Assert.assertEquals(200, response.getResponseCode());
+    ns = GSON.fromJson(response.getResponseBodyAsString(), NamespaceMeta.class);
+    Assert.assertEquals(expectedIdentity, ns.getIdentity());
+    response = deleteNamespace(fooNamespace.getNamespace());
+    Assert.assertEquals(200, response.getResponseCode());
+    cConf.setBoolean(Constants.Namespace.NAMESPACE_CREATION_HOOK_ENABLED, false);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/security/impersonation/DefaultUGIProviderTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/security/impersonation/DefaultUGIProviderTest.java
@@ -146,7 +146,7 @@ public class DefaultUGIProviderTest extends AppFabricTestBase {
     // create a namespace with a principal and keytab so that later we can verify that if a required entity owner does
     // not exists then the provider gives the UGI for namespace owner
     namespaceClient.create(new NamespaceMeta.Builder().setName(namespaceId).setPrincipal(
-      eveKerberosPrincipalId.getPrincipal()).setKeytabURI(eveKeytabFile.getAbsolutePath()).build());
+      eveKerberosPrincipalId.getPrincipal()).setKeytabUri(eveKeytabFile.getAbsolutePath()).build());
 
     // add an owner for some entity
     ownerAdmin.add(aliceEntity, aliceKerberosPrincipalId);

--- a/cdap-cli-tests/src/test/java/io/cdap/cdap/cli/CLITestBase.java
+++ b/cdap-cli-tests/src/test/java/io/cdap/cdap/cli/CLITestBase.java
@@ -619,7 +619,7 @@ public abstract class CLITestBase {
 
     NamespaceMeta expected = new NamespaceMeta.Builder()
         .setName(name).setDescription(description).setPrincipal(principal).setGroupName(group)
-        .setKeytabURI(keytab)
+        .setKeytabUri(keytab)
         .setHBaseNamespace(hbaseNamespace).setSchedulerQueueName(schedulerQueueName)
         .setHiveDatabase(hiveDatabase).setRootDirectory(rootDirectory).build();
     expectedNamespaces = Lists.newArrayList(defaultNs, expected);

--- a/cdap-cli/src/main/java/io/cdap/cdap/cli/command/CreateNamespaceCommand.java
+++ b/cdap-cli/src/main/java/io/cdap/cdap/cli/command/CreateNamespaceCommand.java
@@ -61,7 +61,7 @@ public class CreateNamespaceCommand extends AbstractCommand {
     NamespaceMeta.Builder builder = new NamespaceMeta.Builder();
     builder.setName(name).setDescription(description).setPrincipal(principal)
         .setGroupName(groupName)
-        .setKeytabURI(keytabPath).setRootDirectory(rootDir).setHBaseNamespace(hbaseNamespace)
+        .setKeytabUri(keytabPath).setRootDirectory(rootDir).setHBaseNamespace(hbaseNamespace)
         .setHiveDatabase(hiveDatabase).setSchedulerQueueName(schedulerQueueName);
     namespaceClient.create(builder.build());
     output.printf(SUCCESS_MSG, name);

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
@@ -147,8 +147,8 @@ public class KubeMasterEnvironmentTest {
             + "memberships/test-cluster";
     kubeMasterEnvironment.setWorkloadIdentityEnabled();
     kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
-    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTTLSeconds(172800L);
-    kubeMasterEnvironment.setCDAPInstallNamespace(KUBE_INSTALL_NAMESPACE);
+    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTtlSeconds(172800L);
+    kubeMasterEnvironment.setCdapInstallNamespace(KUBE_INSTALL_NAMESPACE);
 
     Map<String, String> conf = new HashMap<>();
     conf.put(KubeTwillRunnerService.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY,
@@ -179,8 +179,8 @@ public class KubeMasterEnvironmentTest {
             + "memberships/test-cluster";
     kubeMasterEnvironment.setWorkloadIdentityEnabled();
     kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
-    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTTLSeconds(172800L);
-    kubeMasterEnvironment.setCDAPInstallNamespace(KUBE_INSTALL_NAMESPACE);
+    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTtlSeconds(172800L);
+    kubeMasterEnvironment.setCdapInstallNamespace(KUBE_INSTALL_NAMESPACE);
 
     Map<String, String> conf = new HashMap<>();
     conf.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_INSTALL_NAMESPACE);
@@ -208,8 +208,8 @@ public class KubeMasterEnvironmentTest {
         "https://gkehub.googleapis.com/projects/test-project-id/locations/global/"
             + "memberships/test-cluster";
     kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
-    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTTLSeconds(172800L);
-    kubeMasterEnvironment.setCDAPInstallNamespace(KUBE_INSTALL_NAMESPACE);
+    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTtlSeconds(172800L);
+    kubeMasterEnvironment.setCdapInstallNamespace(KUBE_INSTALL_NAMESPACE);
 
     Map<String, String> conf = new HashMap<>();
     conf.put(KubeTwillRunnerService.WORKLOAD_IDENTITY_GCP_SERVICE_ACCOUNT_EMAIL_PROPERTY,
@@ -240,8 +240,8 @@ public class KubeMasterEnvironmentTest {
             + "memberships/test-cluster";
     kubeMasterEnvironment.setWorkloadIdentityEnabled();
     kubeMasterEnvironment.setWorkloadIdentityPool(workloadIdentityPool);
-    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTTLSeconds(172800L);
-    kubeMasterEnvironment.setCDAPInstallNamespace(KUBE_INSTALL_NAMESPACE);
+    kubeMasterEnvironment.setWorkloadIdentityServiceAccountTokenTtlSeconds(172800L);
+    kubeMasterEnvironment.setCdapInstallNamespace(KUBE_INSTALL_NAMESPACE);
 
     Map<String, String> conf = new HashMap<>();
     conf.put(KubeMasterEnvironment.NAMESPACE_PROPERTY, KUBE_NAMESPACE);
@@ -317,19 +317,19 @@ public class KubeMasterEnvironmentTest {
                                                   V1Pod executorPod) {
     // NOTE: Several of these values are hard-coded to ensure that it is not changed by accident as it can cause other
     // pieces to fail. If one of the values changed, the other constants must be validated!
-    V1ServiceAccountTokenProjection workloadIdentityKSATokenProjection = new V1ServiceAccountTokenProjection()
+    V1ServiceAccountTokenProjection workloadIdentityKsaTokenProjection = new V1ServiceAccountTokenProjection()
       .path("token")
       .expirationSeconds(172800L)
       .audience(workloadIdentityPool);
-    V1ConfigMapProjection workloadIdentityGSAConfigMapProjection = new V1ConfigMapProjection()
+    V1ConfigMapProjection workloadIdentityGsaConfigMapProjection = new V1ConfigMapProjection()
       .name("workload-identity-config")
       .optional(false)
       .addItemsItem(new V1KeyToPath().key("config").path("google-application-credentials.json"));
     V1Volume expectedWorkloadIdentityProjectedVolume = new V1Volume().name("gcp-ksa")
       .projected(new V1ProjectedVolumeSource()
                    .defaultMode(420)
-                   .addSourcesItem(new V1VolumeProjection().serviceAccountToken(workloadIdentityKSATokenProjection))
-                   .addSourcesItem(new V1VolumeProjection().configMap(workloadIdentityGSAConfigMapProjection)));
+                   .addSourcesItem(new V1VolumeProjection().serviceAccountToken(workloadIdentityKsaTokenProjection))
+                   .addSourcesItem(new V1VolumeProjection().configMap(workloadIdentityGsaConfigMapProjection)));
     V1VolumeMount expectedWorkloadIdentityProjectedVolumeMount = new V1VolumeMount().name("gcp-ksa")
       .mountPath("/var/run/secrets/tokens/gcp-ksa").readOnly(true);
     V1EnvVar expectedGoogleApplicationCredentialsEnvVar = new V1EnvVar().name("GOOGLE_APPLICATION_CREDENTIALS")

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/MasterEnvironment.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/MasterEnvironment.java
@@ -117,6 +117,13 @@ public interface MasterEnvironment {
   }
 
   /**
+   * Used to create a credential identity associated with a namespace.
+   */
+  default void createIdentity(String namespace, String identity) throws Exception {
+    // no-op by default
+  }
+
+  /**
    * Called during namespace deletion. Namespace deletion is rolled back if this method throws an
    * exception.
    *

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/NamespaceConfig.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/NamespaceConfig.java
@@ -130,7 +130,7 @@ public class NamespaceConfig {
    * @return the keytab URI without the fragment containing version.
    */
   @Nullable
-  public String getKeytabURIWithoutVersion() {
+  public String getKeytabUriWithoutVersion() {
     // try to get the keytab URI version if the keytab URI is not null
     String keytabURI = getKeytabURI();
     if (keytabURI != null) {
@@ -144,7 +144,7 @@ public class NamespaceConfig {
   /**
    * @return the version of the keytab URI or 0 if no version is present in the keytab URI.
    */
-  public int getKeytabURIVersion() {
+  public int getKeytabUriVersion() {
     // try to get the keytab URI version if the keytab URI is not null
     String keytabURI = getKeytabURI();
     if (keytabURI != null) {

--- a/cdap-security/src/test/java/io/cdap/cdap/security/authorization/AuthorizationUtilTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/authorization/AuthorizationUtilTest.java
@@ -60,7 +60,7 @@ public class AuthorizationUtilTest {
     // test with complete principal (alice/somehost.net@somerealm.net)
     String principal = username + "/" + InetAddress.getLocalHost().getHostName() + "@REALM.net";
     NamespaceMeta nsMeta = new NamespaceMeta.Builder().setName(namespaceId).setPrincipal(principal)
-      .setKeytabURI("doesnotmatter").build();
+      .setKeytabUri("doesnotmatter").build();
     namespaceClient.create(nsMeta);
     Assert.assertEquals(username, AuthorizationUtil.getAppAuthorizingUser(ownerAdmin, authenticationContext,
                                                                           applicationId, null));
@@ -69,7 +69,7 @@ public class AuthorizationUtilTest {
     namespaceClient.delete(namespaceId);
     principal = username;
     nsMeta = new NamespaceMeta.Builder().setName(namespaceId).setPrincipal(principal)
-      .setKeytabURI("doesnotmatter").build();
+      .setKeytabUri("doesnotmatter").build();
     namespaceClient.create(nsMeta);
     Assert.assertEquals(username, AuthorizationUtil.getAppAuthorizingUser(ownerAdmin, authenticationContext,
                                                                           applicationId, null));
@@ -78,7 +78,7 @@ public class AuthorizationUtilTest {
     namespaceClient.delete(namespaceId);
     principal = username + "@REALM.net";
     nsMeta = new NamespaceMeta.Builder().setName(namespaceId).setPrincipal(principal)
-      .setKeytabURI("doesnotmatter").build();
+      .setKeytabUri("doesnotmatter").build();
     namespaceClient.create(nsMeta);
     Assert.assertEquals(username, AuthorizationUtil.getAppAuthorizingUser(ownerAdmin, authenticationContext,
                                                                           applicationId, null));

--- a/cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java
+++ b/cdap-unit-test/src/test/java/io/cdap/cdap/security/AuthorizationTest.java
@@ -1262,7 +1262,7 @@ public class AuthorizationTest extends TestBase {
     // We will create a namespace as owner bob, the keytab url is provided to pass the check for DefaultNamespaceAdmin
     // in unit test, it is useless, since impersonation will never happen
     NamespaceMeta ownerNSMeta = new NamespaceMeta.Builder().setName(namespaceId.getNamespace())
-      .setPrincipal(BOB.getName()).setKeytabURI("/tmp/").build();
+      .setPrincipal(BOB.getName()).setKeytabUri("/tmp/").build();
     KerberosPrincipalId bobPrincipalId = new KerberosPrincipalId(BOB.getName());
 
     // grant alice admin to the namespace, but creation should still fail since alice needs to have privilege on


### PR DESCRIPTION
JIRA: [CDAP-20742](https://cdap.atlassian.net/browse/CDAP-20742)

This PR does the following:

- Adds a field named `identity` in `NamespaceMeta`
- Adds a method `CreateIdentity` in `MasterEnvironment` and implements it in `KubeMasterEnvironment` to create a service account on namespace creation.
- Adds a method `getIdentity` in `NamespaceAdmin` which generates the identity for particular namespace.
- Adds unit test.

[CDAP-20742]: https://cdap.atlassian.net/browse/CDAP-20742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ