### PR TITLE
[CDAP-20757] Ignore empty Common Labels property set by UI

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -284,7 +284,12 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
     // specified in cdap-site. This is to ensure consistent delimiters for
     // provisioner properties.
     String provisionerLabelsStr = provisionerContext.getProperties().get(LABELS_PROPERTY);
-    labels.putAll(DataprocUtils.parseKeyValueConfig(provisionerLabelsStr, ";", "\\|"));
+    // the UI never sends nulls, it only sends empty strings. We need to ignore
+    // both null and empty strings.
+    if (!Strings.isNullOrEmpty(provisionerLabelsStr)) {
+      labels.putAll(
+          DataprocUtils.parseLabels(provisionerLabelsStr, ";", "|"));
+    }
 
     // Add system labels.
     ProvisionerSystemContext systemContext = getSystemContext();
@@ -295,7 +300,9 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
 
     // labels are expected to be in format:
     // name1=val1,name2=val2
-    labels.putAll(DataprocUtils.parseKeyValueConfig(extraLabelsStr, ",", "="));
+    if (extraLabelsStr != null) {
+      labels.putAll(DataprocUtils.parseLabels(extraLabelsStr, ",", "="));
+    }
     return Collections.unmodifiableMap(labels);
   }
 

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/common/DataprocUtilsTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/common/DataprocUtilsTest.java
@@ -30,7 +30,7 @@ public class DataprocUtilsTest {
   public void testParseSingleLabel() {
     Map<String, String> expected = new HashMap<>();
     expected.put("key", "val");
-    Assert.assertEquals(expected, DataprocUtils.parseKeyValueConfig("key=val", ",", "="));
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("key=val", ",", "="));
   }
 
   @Test
@@ -38,7 +38,8 @@ public class DataprocUtilsTest {
     Map<String, String> expected = new HashMap<>();
     expected.put("k1", "v1");
     expected.put("k2", "v2");
-    Assert.assertEquals(expected, DataprocUtils.parseKeyValueConfig("k1=v1,k2=v2", ",", "="));
+    Assert.assertEquals(expected,
+        DataprocUtils.parseLabels("k1=v1,k2=v2", ",", "="));
   }
 
   @Test
@@ -46,7 +47,8 @@ public class DataprocUtilsTest {
     Map<String, String> expected = new HashMap<>();
     expected.put("k1", "v1");
     expected.put("k2", "v2");
-    Assert.assertEquals(expected, DataprocUtils.parseKeyValueConfig(" k1  =\tv1  ,\nk2 = v2  ", ",", "="));
+    Assert.assertEquals(expected,
+        DataprocUtils.parseLabels(" k1  =\tv1  ,\nk2 = v2  ", ",", "="));
   }
 
   @Test
@@ -54,6 +56,32 @@ public class DataprocUtilsTest {
     Map<String, String> expected = new HashMap<>();
     expected.put("k1", "");
     expected.put("k2", "");
-    Assert.assertEquals(expected, DataprocUtils.parseKeyValueConfig("k1,k2=", ",", "="));
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("k1,k2=", ",", "="));
+  }
+
+  @Test
+  public void testParseLabelsIgnoresInvalidKey() {
+    Map<String, String> expected = new HashMap<>();
+    Assert.assertEquals(expected, DataprocUtils.parseLabels(("A"), ",", "="));
+    Assert.assertEquals(expected, DataprocUtils.parseLabels(("0"), ",", "="));
+    Assert.assertEquals(expected, DataprocUtils.parseLabels(("a.b"), ",", "="));
+    Assert.assertEquals(expected, DataprocUtils.parseLabels(("a^b"), ",", "="));
+    StringBuilder longStr = new StringBuilder();
+    for (int i = 0; i < 64; i++) {
+      longStr.append('a');
+    }
+    Assert.assertEquals(expected, DataprocUtils.parseLabels(longStr.toString(), ",", "="));
+  }
+
+  @Test
+  public void testParseLabelsIgnoresInvalidVal() {
+    Map<String, String> expected = new HashMap<>();
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("a=A", ",", "="));
+    Assert.assertEquals(expected, DataprocUtils.parseLabels("a=ab.c", ",", "="));
+    StringBuilder longStr = new StringBuilder();
+    for (int i = 0; i < 64; i++) {
+      longStr.append('a');
+    }
+    Assert.assertEquals(expected, DataprocUtils.parseLabels(String.format("a=%s", longStr.toString()), ",", "="));
   }
 }

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -486,12 +486,19 @@ public class DataprocProvisionerTest {
     context.addProperty("labels", "user|cdap;program|data-pipeline");
     Map<String, String> labels = provisioner.getCommonDataprocLabels(context);
     // Check that the value from system context has overwritten the provisioner context.
-    Assert.assertEquals(labels.get("user"), "system");
+    Assert.assertEquals("system", labels.get("user"));
     // Check that the CDAP version is set by system context.
-    Assert.assertEquals(labels.get("cdap-version"), "6_4");
+    Assert.assertEquals("6_4", labels.get("cdap-version"));
     // Check that the non-overwritten value from user context is present.
-    Assert.assertEquals(labels.get("program"), "data-pipeline");
+    Assert.assertEquals("data-pipeline", labels.get("program"));
     // Check that the unique value from system context is present.
-    Assert.assertEquals(labels.get("system-prop"), "value");
+    Assert.assertEquals("value", labels.get("system-prop"));
+  }
+
+  @Test
+  public void testCommonDataprocLabelsInvalidLabel() {
+    context.addProperty("labels", "email|user@cdapio");
+    Map<String, String> labels = provisioner.getCommonDataprocLabels(context);
+    Assert.assertNull(labels.get("email"));
   }
 }


### PR DESCRIPTION
## [CDAP-20757](https://cdap.atlassian.net/browse/CDAP-20757)

The new `Common Labels` field was added in https://github.com/cdapio/cdap/pull/15237. When no `Common Labels` are specified in the UI, the value of the field is an empty string. An empty string was parsed to a single key value pair `"": ""`, i.e. both the key and the value were empty. This change ignores empty strings passed as `Common Labels`.

This change also reverts changes made https://github.com/cdapio/cdap/pull/15237 to the parsing logic of the `Common Labels` set through `cdap-site` and UI to restore behaviour changes.

[CDAP-20757]: https://cdap.atlassian.net/browse/CDAP-20757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ