### PR TITLE
[CDAP-20758] Set max netty direct memory

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
@@ -102,7 +102,14 @@ public class ETLSpark extends AbstractSpark {
     // turn off auto-broadcast by default until we better understand the implications and can set this to a
     // value that we are confident is safe.
     sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1");
-    sparkConf.set("spark.network.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
+    String maxFetchSize = String.valueOf(Integer.MAX_VALUE - 512);
+    sparkConf.set("spark.network.maxRemoteBlockSizeFetchToMem", maxFetchSize);
+    // In Spark v3.2.0 and later, max netty direct memory must be
+    // >= spark.network.maxRemoteBlockSizeFetchToMem for executors.
+    // So we set max netty direct memory = spark.network.maxRemoteBlockSizeFetchToMem
+    // See CDAP-20758 for details.
+    String nettyMaxDirectMemory = String.format("-Dio.netty.maxDirectMemory=%s", maxFetchSize);
+    sparkConf.set("spark.executor.extraJavaOptions", nettyMaxDirectMemory);
     sparkConf.set("spark.network.timeout", "600s");
     // Disable yarn app retries since spark already performs retries at a task level.
     sparkConf.set("spark.yarn.maxAppAttempts", "1");


### PR DESCRIPTION
In Spark v3.2.0 and later, max netty direct memory must be >= max Spark remote block fetch size ([ref](https://github.com/apache/spark/commit/00b63c8dc2170cfbc3f3ea7882dfd417d7fde744#diff-3dab33a017224cf1ca0bf994a40f8068204e3344eeba9a810c4c8eda72c89c1fR96)).

So we set netty's max direct memory = remote block fetch size. 
Spark remote block fetch size was set to a large value to address some issues with joins as part of [CDAP-16461](https://cdap.atlassian.net/browse/CDAP-16461).


[CDAP-16461]: https://cdap.atlassian.net/browse/CDAP-16461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This fixes the following executor pod failure:
```
2023-08-03 16:19:37,019 - ERROR [dispatcher-Executor:o.a.s.i.Logging@98] - Executor self-exiting due to : Unable to create executor due to Netty direct memory should at least be bigger than 'spark.network.maxRemoteBlockSizeFetchToMem', but got 2075918336 bytes < 2147483135
org.apache.spark.SparkException: Netty direct memory should at least be bigger than 'spark.network.maxRemoteBlockSizeFetchToMem', but got 2075918336 bytes < 2147483135
	at org.apache.spark.executor.CoarseGrainedExecutorBackend.onStart(CoarseGrainedExecutorBackend.scala:96)
```