### PR TITLE
[CDAP-20760] add hsts default values in cdap-default.xml

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -6083,4 +6083,36 @@
     </description>
   </property>
 
+  <property>
+    <name>hsts.enabled</name>
+    <value>false</value>
+    <description>
+      Whether to enable HSTS settings on UI node server.
+    </description>
+  </property>
+
+  <property>
+    <name>hsts.max.age</name>
+    <value>31536000</value>
+    <description>
+      The number of seconds browsers should remember to prefer HTTPS.
+    </description>
+  </property>
+
+  <property>
+    <name>hsts.include.sub.domains</name>
+    <value>true</value>
+    <description>
+      Whether to include the includeSubDomains directive, which makes this policy extend to subdomains.
+    </description>
+  </property>
+
+  <property>
+    <name>hsts.preload</name>
+    <value>true</value>
+    <description>
+      Adds the preload directive, expressing intent to add your HSTS policy to browsers.
+    </description>
+  </property>
+
 </configuration>


### PR DESCRIPTION
To address customer issues on HDF cannot load UI through https
[CDAP-20760](https://cdap.atlassian.net/browse/CDAP-20760)

[CDAP-20760]: https://cdap.atlassian.net/browse/CDAP-20760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ