### PR TITLE
[CDAP-20763] Create a new InternalRouter service to route worker requests

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/AbstractServiceRoutingHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/AbstractServiceRoutingHandler.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.io.Closeables;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.ServiceException;
+import io.cdap.cdap.common.ServiceUnavailableException;
+import io.cdap.cdap.common.discovery.EndpointStrategy;
+import io.cdap.cdap.common.discovery.RandomEndpointStrategy;
+import io.cdap.cdap.common.discovery.URIScheme;
+import io.cdap.cdap.common.security.HttpsEnabler;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.BodyConsumer;
+import io.cdap.http.BodyProducer;
+import io.cdap.http.HttpResponder;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URI;
+import java.net.URL;
+import java.net.UnknownServiceException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import javax.net.ssl.HttpsURLConnection;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link AbstractServiceRoutingHandler} forwards  requests to CDAP services and
+ * relays the response. It doesn't carry out any auth checks. Auth checks can be
+ * performed by child classes or by the downstream CDAP service.
+ */
+public abstract class AbstractServiceRoutingHandler extends AbstractHttpHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      AbstractServiceRoutingHandler.class);
+
+  private final LoadingCache<String, EndpointStrategy> endpointStrategyLoadingCache;
+
+  /**
+   * Handles requests for CDAP services by forwarding them to the correct
+   * destinations and relaying the response.
+   *
+   * @param discoveryServiceClient Discovery client for getting CDAP service
+   *                               addresses.
+   */
+  protected AbstractServiceRoutingHandler(
+      DiscoveryServiceClient discoveryServiceClient) {
+    this.endpointStrategyLoadingCache = CacheBuilder.newBuilder()
+        .expireAfterAccess(1, TimeUnit.HOURS)
+        .build(new CacheLoader<String, EndpointStrategy>() {
+          @Override
+          public EndpointStrategy load(String key) {
+            return new RandomEndpointStrategy(
+                () -> discoveryServiceClient.discover(key));
+          }
+        });
+  }
+
+  /**
+   * Handles calls without request body to access CDAP services. It forwards the
+   * call to internal CDAP service.
+   *
+   * @param request the incoming request.
+   * @param service the CDAP service to which the call is to be forwarded.
+   * @param path    the url path for the service to forward the call to.
+   */
+  public void routeService(HttpRequest request, HttpResponder responder,
+      String service, String path) throws Exception {
+    LOG.trace("Got request to route to service '{}'", service);
+    HttpURLConnection urlConn = openConnection(request, service, path);
+    ResponseInfo responseInfo = new ResponseInfo(service, urlConn);
+    responder.sendContent(
+        HttpResponseStatus.valueOf(responseInfo.getResponseCode()),
+        new RelayBodyProducer(urlConn.getURL(), responseInfo),
+        responseInfo.getHeaders());
+  }
+
+  /**
+   * Handles http calls with a request body to access CDAP services. It forwards
+   * the call to internal CDAP services.
+   *
+   * @param request the incoming request.
+   * @param service the CDAP service to which the call is to be forwarded.
+   * @param path    the url path for the service to forward the call to.
+   */
+  public BodyConsumer routeServiceWithBody(HttpRequest request,
+      HttpResponder responder, String service, String path) throws Exception {
+    LOG.trace("Got request to route to service '{}'", service);
+    HttpURLConnection urlConn = openConnection(request, service, path);
+    urlConn.setDoOutput(true);
+    OutputStream output;
+    try {
+      output = urlConn.getOutputStream();
+    } catch (UnknownServiceException e) {
+      throw new BadRequestException(e.getMessage(), e);
+    } catch (IOException e) {
+      // If fails to get output stream, treat it as service unavailable so that the client can retry
+      throw new ServiceUnavailableException(service, e);
+    }
+
+    return new BodyConsumer() {
+
+      @Override
+      public void chunk(ByteBuf byteBuf, HttpResponder httpResponder) {
+        try {
+          byteBuf.readBytes(output, byteBuf.readableBytes());
+        } catch (IOException e) {
+          throw new ServiceUnavailableException(service, e);
+        }
+      }
+
+      @Override
+      public void finished(HttpResponder httpResponder) {
+        try {
+          output.close();
+        } catch (IOException e) {
+          throw new ServiceUnavailableException(service, e);
+        }
+        LOG.trace("Finished sending data to {}", urlConn.getURL());
+        try {
+          ResponseInfo responseInfo = new ResponseInfo(service, urlConn);
+          responder.sendContent(
+              HttpResponseStatus.valueOf(responseInfo.getResponseCode()),
+              new RelayBodyProducer(urlConn.getURL(), responseInfo),
+              responseInfo.getHeaders());
+        } catch (BadRequestException e) {
+          throw new ServiceException(e, HttpResponseStatus.BAD_REQUEST);
+        }
+      }
+
+      @Override
+      public void handleError(Throwable throwable) {
+        LOG.warn("Exception raised for call to {}", urlConn.getURL(),
+            throwable);
+      }
+    };
+  }
+
+  /**
+   * Opens a {@link HttpURLConnection} to the given service for the given
+   * program run.
+   *
+   * @throws BadRequestException if the request for service routing is not
+   *                             valid
+   */
+  private HttpURLConnection openConnection(HttpRequest request, String service,
+      String path) throws BadRequestException {
+    Discoverable discoverable = endpointStrategyLoadingCache.getUnchecked(
+        service).pick(2, TimeUnit.SECONDS);
+    if (discoverable == null) {
+      throw new ServiceUnavailableException(service);
+    }
+
+    URI uri = URIScheme.createURI(discoverable, path);
+    LOG.trace("Routing request for service '{}' to uri '{}'.", service, uri);
+    try {
+      URL url = uri.toURL();
+      HttpURLConnection urlConn;
+      try {
+        urlConn = (HttpURLConnection) url.openConnection();
+      } catch (IOException e) {
+        // If fail to open the connection, treat it as service unavailable so that the client can retry
+        throw new ServiceUnavailableException(service);
+      }
+
+      if (urlConn instanceof HttpsURLConnection) {
+        new HttpsEnabler().setTrustAll(true)
+            .enable((HttpsURLConnection) urlConn);
+      }
+      for (Map.Entry<String, String> header : request.headers().entries()) {
+        urlConn.setRequestProperty(header.getKey(), header.getValue());
+      }
+      urlConn.setRequestMethod(request.method().name());
+      urlConn.setDoInput(true);
+
+      return urlConn;
+
+    } catch (MalformedURLException | ProtocolException e) {
+      // This can only happen if the incoming request is bad
+      throw new BadRequestException("Invalid request due to " + e.getMessage(),
+          e);
+    }
+  }
+
+  /**
+   * A holder object for holding information related to the response from remote
+   * service to which the request is routed.
+   */
+  private static final class ResponseInfo implements Closeable {
+
+    private final HttpURLConnection urlConn;
+    private final int responseCode;
+    private final HttpHeaders headers;
+    private final InputStream input;
+
+    ResponseInfo(String serviceName, HttpURLConnection urlConn)
+        throws BadRequestException, ServiceUnavailableException {
+      InputStream is = null;
+      try {
+        this.responseCode = urlConn.getResponseCode();
+      } catch (IOException e) {
+        throw new ServiceUnavailableException(serviceName, e);
+      }
+      try {
+        is = urlConn.getInputStream();
+        if (this.responseCode >= 400) {
+          Closeables.closeQuietly(is);
+          is = null;
+        }
+      } catch (UnknownServiceException e) {
+        throw new BadRequestException(e.getMessage(), e);
+      } catch (IOException e) {
+        // Intentionally empty catch. This happens when server return 404.
+        // We handle all errors uniformly below.
+      }
+      this.input = is == null ? urlConn.getErrorStream() : is;
+
+      // Copy all headers
+      DefaultHttpHeaders headers = new DefaultHttpHeaders();
+      for (Map.Entry<String, List<String>> entry : urlConn.getHeaderFields()
+          .entrySet()) {
+        if (entry.getKey() != null && entry.getValue() != null) {
+          headers.add(entry.getKey(), entry.getValue());
+        }
+      }
+
+      this.headers = headers;
+      this.urlConn = urlConn;
+    }
+
+    int getResponseCode() {
+      return responseCode;
+    }
+
+    HttpHeaders getHeaders() {
+      return headers;
+    }
+
+    @Nullable
+    InputStream getInput() {
+      return input;
+    }
+
+    @Override
+    public void close() {
+      Closeables.closeQuietly(input);
+      urlConn.disconnect();
+    }
+  }
+
+  /**
+   * A {@link BodyProducer} to relay response from a http call.
+   */
+  private static final class RelayBodyProducer extends BodyProducer {
+
+    private final URL url;
+    private final ResponseInfo responseInfo;
+
+    private RelayBodyProducer(URL url, ResponseInfo responseInfo) {
+      this.url = url;
+      this.responseInfo = responseInfo;
+    }
+
+    @Override
+    public ByteBuf nextChunk() throws Exception {
+      if (responseInfo.getInput() == null) {
+        return Unpooled.EMPTY_BUFFER;
+      }
+      ByteBuf buffer = Unpooled.buffer(8192);
+      buffer.writeBytes(responseInfo.getInput(), buffer.writableBytes());
+      return buffer;
+    }
+
+    @Override
+    public void finished() {
+      Closeables.closeQuietly(responseInfo);
+    }
+
+    @Override
+    public void handleError(@Nullable Throwable cause) {
+      LOG.warn("Exception raised when handling request to {}", url, cause);
+      Closeables.closeQuietly(responseInfo);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/InternalRouterService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/InternalRouterService.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.Service;
+import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.common.discovery.ResolvingDiscoverable;
+import io.cdap.cdap.common.discovery.URIScheme;
+import io.cdap.cdap.common.http.CommonNettyHttpServiceFactory;
+import io.cdap.cdap.common.security.HttpsEnabler;
+import io.cdap.http.ChannelPipelineModifier;
+import io.cdap.http.NettyHttpService;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.http.HttpContentDecompressor;
+import java.util.Collections;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.discovery.Discoverable;
+import org.apache.twill.discovery.DiscoveryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The internal router service for routing CDAP API calls from workers.
+ */
+public class InternalRouterService extends AbstractIdleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      InternalRouterService.class);
+
+  private final NettyHttpService httpService;
+  private final DiscoveryService discoveryService;
+  private Cancellable cancelDiscovery;
+
+  @Inject
+  InternalRouterService(CConfiguration cConf, SConfiguration sConf,
+      DiscoveryService discoveryService,
+      InternalServiceRoutingHandler handler,
+      CommonNettyHttpServiceFactory commonNettyHttpServiceFactory) {
+    NettyHttpService.Builder builder = commonNettyHttpServiceFactory.builder(
+            Service.INTERNAL_ROUTER)
+        .setHttpHandlers(Collections.singleton(handler))
+        .setChannelPipelineModifier(new ChannelPipelineModifier() {
+          @Override
+          public void modify(ChannelPipeline pipeline) {
+            pipeline.addAfter("compressor", "decompressor", new HttpContentDecompressor());
+          }
+        })
+        .setHost(cConf.get(Constants.InternalRouter.BIND_ADDRESS))
+        .setPort(cConf.getInt(Constants.InternalRouter.BIND_PORT));
+
+    if (cConf.getBoolean(Constants.InternalRouter.SSL_ENABLED)) {
+      new HttpsEnabler().configureKeyStore(cConf, sConf).enable(builder);
+    }
+
+    this.httpService = builder.build();
+    this.discoveryService = discoveryService;
+  }
+
+
+  @Override
+  protected void startUp() throws Exception {
+    httpService.start();
+    Discoverable discoverable = ResolvingDiscoverable.of(
+        URIScheme.createDiscoverable(Service.INTERNAL_ROUTER,
+            httpService));
+    cancelDiscovery = discoveryService.register(discoverable);
+    LOG.debug("Internal router server with service name '{}' started on {}:{}", discoverable.getName(),
+        discoverable.getSocketAddress().getHostName(), discoverable.getSocketAddress().getPort());
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    cancelDiscovery.cancel();
+    httpService.stop();
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/InternalServiceRoutingHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/InternalServiceRoutingHandler.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.http.BodyConsumer;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.HttpRequest;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+/**
+ * The http handler for routing CDAP service requests from workers running in
+ * the same cluster. This service delegates all auth checks to downstream
+ * services.
+ */
+@Path(Constants.Gateway.INTERNAL_API_VERSION_3 + "/router")
+public class InternalServiceRoutingHandler extends
+    AbstractServiceRoutingHandler {
+
+  @Inject
+  InternalServiceRoutingHandler(DiscoveryServiceClient discoveryServiceClient) {
+    super(discoveryServiceClient);
+  }
+
+  /**
+   * Handles http calls without a request body. It forwards calls from program
+   * runtime to access CDAP services.
+   */
+  @Path("/services/{service}/**")
+  @GET
+  @DELETE
+  public void routeService(HttpRequest request, HttpResponder responder,
+      @PathParam("service") String service) throws Exception {
+    routeService(request, responder, service, getServicePath(request, service));
+  }
+
+  /**
+   * Handles http calls with request body. It streams the body to the internal
+   * service and forwards the response.
+   */
+  @Path("/services/{service}/**")
+  @PUT
+  @POST
+  public BodyConsumer routeServiceWithBody(HttpRequest request,
+      HttpResponder responder,
+      @PathParam("service") String service) throws Exception {
+    return routeServiceWithBody(request, responder, service,
+        getServicePath(request, service));
+  }
+
+  private String getServicePath(HttpRequest request, String service) {
+    String prefix = String.format(
+        "%s/router/services/%s",
+        Constants.Gateway.INTERNAL_API_VERSION_3, service);
+    return request.uri().substring(prefix.length());
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Cask Data, Inc.
+ * Copyright © 2020-2023 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -16,320 +16,107 @@
 
 package io.cdap.cdap.internal.app.runtime.monitor;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.io.Closeables;
 import com.google.inject.Inject;
 import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.GoneException;
-import io.cdap.cdap.common.ServiceException;
-import io.cdap.cdap.common.ServiceUnavailableException;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.common.discovery.EndpointStrategy;
-import io.cdap.cdap.common.discovery.RandomEndpointStrategy;
-import io.cdap.cdap.common.discovery.URIScheme;
-import io.cdap.cdap.common.security.HttpsEnabler;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramRunId;
-import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.BodyConsumer;
-import io.cdap.http.BodyProducer;
 import io.cdap.http.HttpResponder;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.http.DefaultHttpHeaders;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponseStatus;
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.ProtocolException;
-import java.net.URI;
-import java.net.URL;
-import java.net.UnknownServiceException;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
-import javax.net.ssl.HttpsURLConnection;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import org.apache.twill.discovery.Discoverable;
 import org.apache.twill.discovery.DiscoveryServiceClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The http handler for routing CDAP service requests from program runtime.
  */
 @Path(Constants.Gateway.INTERNAL_API_VERSION_3
-    + "/runtime/namespaces/{namespace}/apps/{app}/versions/{version}/{program-type}/{program}/runs/{run}")
-public class RuntimeServiceRoutingHandler extends AbstractHttpHandler {
-
-  private static final Logger LOG = LoggerFactory.getLogger(RuntimeServiceRoutingHandler.class);
+      + "/runtime/namespaces/{namespace}/apps/{app}/versions/{version}/{program-type}/{program}/runs/{run}")
+public class RuntimeServiceRoutingHandler extends
+    AbstractServiceRoutingHandler {
 
   private final RuntimeRequestValidator requestValidator;
-  private final LoadingCache<String, EndpointStrategy> endpointStrategyLoadingCache;
 
   @Inject
   RuntimeServiceRoutingHandler(DiscoveryServiceClient discoveryServiceClient,
       RuntimeRequestValidator requestValidator) {
+    super(discoveryServiceClient);
     this.requestValidator = requestValidator;
-    this.endpointStrategyLoadingCache = CacheBuilder.newBuilder()
-        .expireAfterAccess(1, TimeUnit.HOURS)
-        .build(new CacheLoader<String, EndpointStrategy>() {
-          @Override
-          public EndpointStrategy load(String key) {
-            return new RandomEndpointStrategy(() -> discoveryServiceClient.discover(key));
-          }
-        });
   }
 
   /**
-   * Handles GET and DELETE calls from program runtime to access CDAP services. It simply verifies
-   * the request and forward the call to internal CDAP service.
+   * Handles GET and DELETE calls from program runtime to access CDAP services.
+   * It simply verifies the request and forward the call to internal CDAP
+   * service.
    */
   @Path("/services/{service}/**")
   @GET
   @DELETE
   public void routeService(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace") String namespace,
-      @PathParam("app") String app,
+      @PathParam("namespace") String namespace, @PathParam("app") String app,
       @PathParam("version") String version,
       @PathParam("program-type") String programType,
-      @PathParam("program") String program,
-      @PathParam("run") String run,
+      @PathParam("program") String program, @PathParam("run") String run,
       @PathParam("service") String service) throws Exception {
-    HttpURLConnection urlConn = openConnection(request, namespace, app, version, programType,
-        program, run, service);
-    ResponseInfo responseInfo = new ResponseInfo(service, urlConn);
-    responder.sendContent(HttpResponseStatus.valueOf(responseInfo.getResponseCode()),
-        new RelayBodyProducer(urlConn.getURL(), responseInfo),
-        responseInfo.getHeaders());
+    validateRequest(request, namespace, app, version, programType, program, run
+    );
+    String servicePath = getServicePath(request, namespace, app, version,
+        programType, program, run, service);
+    routeService(request, responder, service, servicePath);
   }
 
   /**
-   * Handles PUT and POST calls from program runtime to access CDAP services. It simply verify the
-   * request and forward the call to internal CDAP services.
+   * Handles PUT and POST calls from program runtime to access CDAP services. It
+   * simply verifies the request and forwards the call to internal CDAP
+   * services.
    */
   @Path("/services/{service}/**")
   @PUT
   @POST
-  public BodyConsumer routeServiceWithBody(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace") String namespace,
-      @PathParam("app") String app,
-      @PathParam("version") String version,
+  public BodyConsumer routeServiceWithBody(HttpRequest request,
+      HttpResponder responder, @PathParam("namespace") String namespace,
+      @PathParam("app") String app, @PathParam("version") String version,
       @PathParam("program-type") String programType,
-      @PathParam("program") String program,
-      @PathParam("run") String run,
+      @PathParam("program") String program, @PathParam("run") String run,
       @PathParam("service") String service) throws Exception {
-    HttpURLConnection urlConn = openConnection(request, namespace, app, version, programType,
-        program, run, service);
-    urlConn.setDoOutput(true);
-    OutputStream output;
-    try {
-      output = urlConn.getOutputStream();
-    } catch (UnknownServiceException e) {
-      throw new BadRequestException(e.getMessage(), e);
-    } catch (IOException e) {
-      // If fails to get output stream, treat it as service unavailable so that the client can retry
-      throw new ServiceUnavailableException(service, e);
-    }
-
-    return new BodyConsumer() {
-
-      @Override
-      public void chunk(ByteBuf byteBuf, HttpResponder httpResponder) {
-        try {
-          byteBuf.readBytes(output, byteBuf.readableBytes());
-        } catch (IOException e) {
-          throw new ServiceUnavailableException(service, e);
-        }
-      }
-
-      @Override
-      public void finished(HttpResponder httpResponder) {
-        try {
-          output.close();
-        } catch (IOException e) {
-          throw new ServiceUnavailableException(service, e);
-        }
-        try {
-          ResponseInfo responseInfo = new ResponseInfo(service, urlConn);
-          responder.sendContent(HttpResponseStatus.valueOf(responseInfo.getResponseCode()),
-              new RelayBodyProducer(urlConn.getURL(), responseInfo),
-              responseInfo.getHeaders());
-        } catch (BadRequestException e) {
-          throw new ServiceException(e, HttpResponseStatus.BAD_REQUEST);
-        }
-      }
-
-      @Override
-      public void handleError(Throwable throwable) {
-        LOG.warn("Exception raised for call to {}", urlConn.getURL(), throwable);
-      }
-    };
+    validateRequest(request, namespace, app, version, programType, program,
+        run);
+    String servicePath = getServicePath(request, namespace, app, version,
+        programType, program, run, service);
+    return routeServiceWithBody(request, responder, service,
+        servicePath);
   }
 
   /**
-   * Opens a {@link HttpURLConnection} to the given service for the given program run.
+   * Validates the request.
    *
-   * @throws BadRequestException if the request for service routing is not valid
    * @throws GoneException if the run already finished
    */
-  private HttpURLConnection openConnection(HttpRequest request, String namespace, String app,
-      String version, String programType, String program, String run,
-      String service) throws BadRequestException, GoneException {
+  private void validateRequest(HttpRequest request, String namespace,
+      String app, String version, String programType, String program,
+      String run) throws BadRequestException, GoneException {
     ApplicationId appId = new NamespaceId(namespace).app(app, version);
     ProgramRunId programRunId = new ProgramRunId(appId,
         ProgramType.valueOfCategoryName(programType, BadRequestException::new),
         program, run);
     requestValidator.getProgramRunStatus(programRunId, request);
-    Discoverable discoverable = endpointStrategyLoadingCache.getUnchecked(service)
-        .pick(2, TimeUnit.SECONDS);
-    if (discoverable == null) {
-      throw new ServiceUnavailableException(service);
-    }
+  }
 
+  private String getServicePath(HttpRequest request, String namespace,
+      String app, String version, String programType, String program,
+      String run, String service) {
     String prefix = String.format(
         "%s/runtime/namespaces/%s/apps/%s/versions/%s/%s/%s/runs/%s/services/%s",
-        Constants.Gateway.INTERNAL_API_VERSION_3,
-        namespace, app, version, programType, program, run, service);
-    URI uri = URIScheme.createURI(discoverable, request.uri().substring(prefix.length()));
-    try {
-      URL url = uri.toURL();
-      HttpURLConnection urlConn;
-      try {
-        urlConn = (HttpURLConnection) url.openConnection();
-      } catch (IOException e) {
-        // If fail to open the connection, treat it as service unavailable so that the client can retry
-        throw new ServiceUnavailableException(service);
-      }
-
-      if (urlConn instanceof HttpsURLConnection) {
-        new HttpsEnabler().setTrustAll(true).enable((HttpsURLConnection) urlConn);
-      }
-      for (Map.Entry<String, String> header : request.headers().entries()) {
-        urlConn.setRequestProperty(header.getKey(), header.getValue());
-      }
-      urlConn.setRequestMethod(request.method().name());
-      urlConn.setDoInput(true);
-
-      return urlConn;
-
-    } catch (MalformedURLException | ProtocolException e) {
-      // This can only happen if the incoming request is bad
-      throw new BadRequestException("Invalid request due to " + e.getMessage(), e);
-    }
-  }
-
-  /**
-   * A holder object for holding information related to the
-   */
-  private static final class ResponseInfo implements Closeable {
-
-    private final HttpURLConnection urlConn;
-    private final int responseCode;
-    private final HttpHeaders headers;
-    private final InputStream input;
-
-    ResponseInfo(String serviceName,
-        HttpURLConnection urlConn) throws BadRequestException, ServiceUnavailableException {
-      InputStream is = null;
-      try {
-        this.responseCode = urlConn.getResponseCode();
-      } catch (IOException e) {
-        throw new ServiceUnavailableException(serviceName, e);
-      }
-      try {
-        is = urlConn.getInputStream();
-        if (this.responseCode >= 400) {
-          Closeables.closeQuietly(is);
-          is = null;
-        }
-      } catch (UnknownServiceException e) {
-        throw new BadRequestException(e.getMessage(), e);
-      } catch (IOException e) {
-        // Intentionally empty catch. This happen when server return 404.
-        // We handle all errors uniformly below.
-      }
-      this.input = is == null ? urlConn.getErrorStream() : is;
-
-      // Copy all headers
-      DefaultHttpHeaders headers = new DefaultHttpHeaders();
-      for (Map.Entry<String, List<String>> entry : urlConn.getHeaderFields().entrySet()) {
-        if (entry.getKey() != null && entry.getValue() != null) {
-          headers.add(entry.getKey(), entry.getValue());
-        }
-      }
-
-      this.headers = headers;
-      this.urlConn = urlConn;
-    }
-
-    int getResponseCode() {
-      return responseCode;
-    }
-
-    HttpHeaders getHeaders() {
-      return headers;
-    }
-
-    @Nullable
-    InputStream getInput() {
-      return input;
-    }
-
-    @Override
-    public void close() {
-      Closeables.closeQuietly(input);
-      urlConn.disconnect();
-    }
-  }
-
-  /**
-   * A {@link BodyProducer} to relay response from a http call.
-   */
-  private static final class RelayBodyProducer extends BodyProducer {
-
-    private final URL url;
-    private final ResponseInfo responseInfo;
-
-    private RelayBodyProducer(URL url, ResponseInfo responseInfo) {
-      this.url = url;
-      this.responseInfo = responseInfo;
-    }
-
-    @Override
-    public ByteBuf nextChunk() throws Exception {
-      if (responseInfo.getInput() == null) {
-        return Unpooled.EMPTY_BUFFER;
-      }
-      ByteBuf buffer = Unpooled.buffer(8192);
-      buffer.writeBytes(responseInfo.getInput(), buffer.writableBytes());
-      return buffer;
-    }
-
-    @Override
-    public void finished() {
-      Closeables.closeQuietly(responseInfo);
-    }
-
-    @Override
-    public void handleError(@Nullable Throwable cause) {
-      LOG.warn("Exception raised when handling request to {}", url, cause);
-      Closeables.closeQuietly(responseInfo);
-    }
+        Constants.Gateway.INTERNAL_API_VERSION_3, namespace, app, version,
+        programType, program, run, service);
+    return request.uri().substring(prefix.length());
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/InternalServiceRoutingHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/InternalServiceRoutingHandlerTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.common.base.Strings;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.Service;
+import io.cdap.cdap.common.discovery.URIScheme;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.internal.remote.InternalAuthenticator;
+import io.cdap.cdap.common.internal.remote.NoOpInternalAuthenticator;
+import io.cdap.cdap.common.internal.remote.NoOpRemoteAuthenticator;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.gateway.handlers.PingHandler;
+import io.cdap.cdap.security.spi.authenticator.RemoteAuthenticator;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpResponse;
+import io.cdap.http.NettyHttpService;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.EnumSet;
+import org.apache.twill.common.Cancellable;
+import org.apache.twill.discovery.DiscoveryService;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Unit tests for the {@link InternalServiceRoutingHandler}.
+ */
+public class InternalServiceRoutingHandlerTest {
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  private static final String MOCK_SERVICE = "mock";
+
+  private Injector injector;
+  private InternalRouterService internalRouterService;
+  private NettyHttpService mockService;
+  private Cancellable mockServiceCancellable;
+
+  @Before
+  public void beforeTest() throws Exception {
+    CConfiguration cConf = CConfiguration.create();
+    cConf.set(Constants.CFG_LOCAL_DATA_DIR,
+        TEMP_FOLDER.newFolder().getAbsolutePath());
+
+    injector = Guice.createInjector(
+        new ConfigModule(cConf),
+        new LocalLocationModule(),
+        new InMemoryDiscoveryModule(),
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(MetricsCollectionService.class).to(
+                NoOpMetricsCollectionService.class);
+            bind(InternalAuthenticator.class).to(
+                NoOpInternalAuthenticator.class);
+            bind(RemoteAuthenticator.class).to(NoOpRemoteAuthenticator.class);
+          }
+        }
+    );
+
+    internalRouterService = injector.getInstance(InternalRouterService.class);
+    internalRouterService.startAndWait();
+
+    mockService = NettyHttpService.builder(MOCK_SERVICE)
+        .setHost(InetAddress.getLocalHost().getCanonicalHostName())
+        .setHttpHandlers(new PingHandler(), new MockServiceHandler())
+        .build();
+
+    mockService.start();
+    mockServiceCancellable = injector.getInstance(DiscoveryService.class)
+        .register(URIScheme.createDiscoverable(MOCK_SERVICE, mockService));
+  }
+
+  @After
+  public void afterTest() throws Exception {
+    mockServiceCancellable.cancel();
+    mockService.stop();
+    internalRouterService.stopAndWait();
+  }
+
+  @Test
+  public void testGetAndDelete() throws IOException, UnauthorizedException {
+    RemoteClient remoteClient = injector.getInstance(RemoteClientFactory.class)
+        .createRemoteClient(
+            Constants.Service.INTERNAL_ROUTER,
+            DefaultHttpRequestConfig.DEFAULT,
+            Constants.Gateway.INTERNAL_API_VERSION_3 + "/router");
+
+    for (HttpMethod method : EnumSet.of(HttpMethod.GET, HttpMethod.DELETE)) {
+      for (int status : Arrays.asList(200, 400, 404, 501)) {
+        HttpRequest request = remoteClient.requestBuilder(method,
+                String.format("services/%s/mock/%s/%d",
+                    MOCK_SERVICE, method.name().toLowerCase(), status))
+            .build();
+
+        HttpResponse response = remoteClient.execute(request);
+        Assert.assertEquals(status, response.getResponseCode());
+      }
+    }
+  }
+
+  @Test
+  public void testPutAndPost() throws IOException, UnauthorizedException {
+    RemoteClient remoteClient = injector.getInstance(RemoteClientFactory.class)
+        .createRemoteClient(
+            Service.INTERNAL_ROUTER,
+            DefaultHttpRequestConfig.DEFAULT,
+            Constants.Gateway.INTERNAL_API_VERSION_3 + "/router");
+    String largeContent = Strings.repeat("Testing", 32768);
+
+    for (String content : Arrays.asList("", "Small content", largeContent)) {
+      for (HttpMethod method : EnumSet.of(HttpMethod.PUT, HttpMethod.POST)) {
+        for (int status : Arrays.asList(200, 400, 404, 501)) {
+          io.cdap.common.http.HttpRequest request =
+              remoteClient.requestBuilder(method,
+                      String.format("services/%s/mock/%s/%d",
+                          MOCK_SERVICE, method.name().toLowerCase(), status))
+                  .withBody(content)
+                  .build();
+
+          HttpResponse response = remoteClient.execute(request);
+          Assert.assertEquals(status, response.getResponseCode());
+          Assert.assertEquals(content, response.getResponseBodyAsString(
+              StandardCharsets.UTF_8));
+        }
+      }
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/MockServiceHandler.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/MockServiceHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.nio.charset.StandardCharsets;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * A mock handler for testing service routing. It provides service endpoints for
+ * testing.
+ */
+@Path("/mock")
+public final class MockServiceHandler extends AbstractHttpHandler {
+
+  @Path("/get/{status}")
+  @GET
+  public void get(HttpRequest request, HttpResponder responder,
+      @PathParam("status") int statusCode) {
+    responder.sendString(HttpResponseStatus.valueOf(statusCode),
+        "Status is " + statusCode);
+  }
+
+  @Path("/delete/{status}")
+  @DELETE
+  public void delete(HttpRequest request, HttpResponder responder,
+      @PathParam("status") int statusCode) {
+    responder.sendString(HttpResponseStatus.valueOf(statusCode),
+        "Status is " + statusCode);
+  }
+
+  @Path("/put/{status}")
+  @PUT
+  public void put(FullHttpRequest request, HttpResponder responder,
+      @PathParam("status") int statusCode) {
+    responder.sendString(HttpResponseStatus.valueOf(statusCode),
+        request.content().toString(
+            StandardCharsets.UTF_8));
+  }
+
+  @Path("/post/{status}")
+  @POST
+  public void post(FullHttpRequest request, HttpResponder responder,
+      @PathParam("status") int statusCode) {
+    responder.sendString(HttpResponseStatus.valueOf(statusCode),
+        request.content().toString(StandardCharsets.UTF_8));
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2022 Cask Data, Inc.
+ * Copyright © 2020-2023 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -53,13 +53,8 @@ import io.cdap.cdap.security.spi.authenticator.RemoteAuthenticator;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.common.http.HttpMethod;
 import io.cdap.common.http.HttpResponse;
-import io.cdap.http.AbstractHttpHandler;
-import io.cdap.http.HttpResponder;
 import io.cdap.http.NettyHttpService;
-import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
-import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.InetAddress;
@@ -67,12 +62,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.EnumSet;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import org.apache.twill.common.Cancellable;
 import org.apache.twill.discovery.DiscoveryService;
 import org.junit.After;
@@ -255,37 +244,6 @@ public class RuntimeServiceRoutingTest {
 
     HttpResponse response = remoteClient.execute(request);
     Assert.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, response.getResponseCode());
-  }
-
-  /**
-   * A mock handler for testing service routing. It provides service endpoints for testing.
-   */
-  @Path("/mock")
-  public static final class MockServiceHandler extends AbstractHttpHandler {
-
-    @Path("/get/{status}")
-    @GET
-    public void get(HttpRequest request, HttpResponder responder, @PathParam("status") int statusCode) {
-      responder.sendString(HttpResponseStatus.valueOf(statusCode), "Status is " + statusCode);
-    }
-
-    @Path("/delete/{status}")
-    @DELETE
-    public void delete(HttpRequest request, HttpResponder responder, @PathParam("status") int statusCode) {
-      responder.sendString(HttpResponseStatus.valueOf(statusCode), "Status is " + statusCode);
-    }
-
-    @Path("/put/{status}")
-    @PUT
-    public void put(FullHttpRequest request, HttpResponder responder, @PathParam("status") int statusCode) {
-      responder.sendString(HttpResponseStatus.valueOf(statusCode), request.content().toString(StandardCharsets.UTF_8));
-    }
-
-    @Path("/post/{status}")
-    @POST
-    public void post(FullHttpRequest request, HttpResponder responder, @PathParam("status") int statusCode) {
-      responder.sendString(HttpResponseStatus.valueOf(statusCode), request.content().toString(StandardCharsets.UTF_8));
-    }
   }
 
   /**

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -130,6 +130,7 @@ public final class Constants {
     public static final String EXTERNAL_AUTHENTICATION = "external.authentication";
     public static final String MESSAGING_SERVICE = "messaging.service";
     public static final String RUNTIME = "runtime";
+    public static final String INTERNAL_ROUTER = "internal.router";
     public static final String AUTHENTICATION = "authentication";
     public static final String TASK_WORKER = "task.worker";
     public static final String SYSTEM_WORKER = "system.worker";
@@ -2403,5 +2404,15 @@ public final class Constants {
 
     public static final String EXTENSIONS_DIR = "credential.provider.extensions.dir";
     public static final String SYSTEM_PROPERTY_PREFIX = "credential.provider.system.properties.";
+  }
+
+  /**
+   * Constants for Internal Router Service.
+   */
+  public static final class InternalRouter {
+
+    public static final String BIND_ADDRESS = "app.program.internal.router.service.bind.address";
+    public static final String BIND_PORT = "app.program.internal.router.service.bind.port";
+    public static final String SSL_ENABLED = "app.program.internal.router.service.ssl.enabled";
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5972,6 +5972,32 @@
     </description>
   </property>
 
+  <!--Configuration for the Internal Router service -->
+  <property>
+    <name>app.program.internal.router.service.bind.address</name>
+    <value>0.0.0.0</value>
+    <description>
+      The address for the internal router service to bind to.
+    </description>
+  </property>
+
+  <property>
+    <name>app.program.internal.router.service.bind.port</name>
+    <value>0</value>
+    <description>
+      The port for the internal router service to bind to.
+    </description>
+  </property>
+
+  <property>
+    <name>app.program.internal.router.service.ssl.enabled</name>
+    <value>${ssl.internal.enabled}</value>
+    <description>
+      Enable usage of SSL for the internal router service. By default it is
+      disabled.
+    </description>
+  </property>
+
   <!-- Configurations for Credential Providers -->
   <property>
     <name>credential.provider.extensions.dir</name>

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
@@ -29,6 +29,7 @@ import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
+import io.cdap.cdap.internal.app.runtime.monitor.InternalRouterService;
 import io.cdap.cdap.internal.app.runtime.monitor.RuntimeProgramStatusSubscriberService;
 import io.cdap.cdap.internal.app.runtime.monitor.RuntimeServer;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
@@ -49,7 +50,7 @@ import org.apache.twill.zookeeper.ZKClientService;
 public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> {
 
   /**
-   * Main entry point
+   * Main entry point.
    */
   public static void main(String[] args) throws Exception {
     main(RuntimeServiceMain.class, args);
@@ -93,6 +94,7 @@ public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> 
     });
     services.add(injector.getInstance(RuntimeProgramStatusSubscriberService.class));
     services.add(injector.getInstance(RuntimeServer.class));
+    services.add(injector.getInstance(InternalRouterService.class));
     Binding<ZKClientService> zkBinding = injector.getExistingBinding(
         Key.get(ZKClientService.class));
     if (zkBinding != null) {


### PR DESCRIPTION
## [CDAP-20763](https://cdap.atlassian.net/browse/CDAP-20763)

Create a service to route CDAP API requests from worker pods in the same GKE cluster which may not be able to communicate with CDAP services directly. This is similar to the RuntimeService minus the path parameters for program run and the auth checks for the program.

[CDAP-20763]: https://cdap.atlassian.net/browse/CDAP-20763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ