### PR TITLE
[CDAP-20750] Implement GcpWorkloadIdentity Credential Provider

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternal.java
@@ -109,7 +109,11 @@ public class GcpMetadataHttpHandlerInternal extends AbstractAppFabricHttpHandler
   public void token(HttpRequest request, HttpResponder responder,
       @QueryParam("scopes") String scopes) throws Exception {
 
-    LOG.debug("Token requested for namespace: {}", gcpMetadataTaskContext.getNamespace());
+    if (gcpMetadataTaskContext != null && gcpMetadataTaskContext.getNamespace() != null) {
+      LOG.trace("Token requested for namespace: {}", gcpMetadataTaskContext.getNamespace());
+    } else {
+      LOG.trace("Token requested but namespace not set");
+    }
     // check that metadata header is present in the request.
     if (!request.headers().contains(METADATA_FLAVOR_HEADER_KEY,
         METADATA_FLAVOR_HEADER_VALUE, true)) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/credential/DefaultCredentialProviderContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/credential/DefaultCredentialProviderContext.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.credential;
 
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants.CredentialProvider;
+import io.cdap.cdap.common.conf.Constants.Namespace;
 import io.cdap.cdap.security.spi.credential.CredentialProviderContext;
 import java.util.Collections;
 import java.util.Map;
@@ -28,6 +29,7 @@ import java.util.Map;
 public class DefaultCredentialProviderContext implements CredentialProviderContext {
 
   private final Map<String, String> properties;
+  private final boolean isNamespaceCreationHookEnabled;
 
   /**
    * Creates a new context.
@@ -39,6 +41,8 @@ public class DefaultCredentialProviderContext implements CredentialProviderConte
     String prefix = String.format("%s%s.", CredentialProvider.SYSTEM_PROPERTY_PREFIX,
         providerName);
     this.properties = Collections.unmodifiableMap(cConf.getPropsWithPrefix(prefix));
+    this.isNamespaceCreationHookEnabled = cConf.getBoolean(
+        Namespace.NAMESPACE_CREATION_HOOK_ENABLED, false);
   }
 
   /**
@@ -49,5 +53,15 @@ public class DefaultCredentialProviderContext implements CredentialProviderConte
   @Override
   public Map<String, String> getProperties() {
     return properties;
+  }
+
+  /**
+   * Returns a boolean if namespace creation hook is enabled.
+   *
+   * @return true if namespace creation hook is enabled, otherwise false.
+   */
+  @Override
+  public boolean isNamespaceCreationHookEnabled() {
+    return isNamespaceCreationHookEnabled;
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/credential/CredentialProviderTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/credential/CredentialProviderTestBase.java
@@ -101,14 +101,14 @@ public class CredentialProviderTestBase {
         .getInstance(StructuredTableAdmin.class));
     // Setup mock credential providers.
     CredentialProvider mockCredentialProvider = mock(CredentialProvider.class);
-    when(mockCredentialProvider.provision(any(), any())).thenReturn(RETURNED_TOKEN);
+    when(mockCredentialProvider.provision(any(), any(), any())).thenReturn(RETURNED_TOKEN);
     CredentialProvider validationFailureMockCredentialProvider = mock(CredentialProvider.class);
-    when(validationFailureMockCredentialProvider.provision(any(), any()))
+    when(validationFailureMockCredentialProvider.provision(any(), any(), any()))
         .thenReturn(RETURNED_TOKEN);
     doThrow(new ProfileValidationException("profile validation always fails with this provider"))
         .when(validationFailureMockCredentialProvider).validateProfile(any());
     CredentialProvider provisionFailureMockCredentialProvider = mock(CredentialProvider.class);
-    when(provisionFailureMockCredentialProvider.provision(any(), any()))
+    when(provisionFailureMockCredentialProvider.provision(any(), any(), any()))
         .thenThrow(new CredentialProvisioningException("provisioning always fails with this "
             + "provider"));
     credentialProviders.put(CREDENTIAL_PROVIDER_TYPE_SUCCESS, mockCredentialProvider);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/credential/DefaultCredentialProviderServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/credential/DefaultCredentialProviderServiceTest.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.internal.credential;
 
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.credential.CredentialIdentity;
 import io.cdap.cdap.proto.credential.CredentialProvisioningException;
 import io.cdap.cdap.proto.credential.IdentityValidationException;
@@ -45,6 +46,12 @@ public class DefaultCredentialProviderServiceTest extends CredentialProviderTest
   public void testProvisionSuccess() throws Exception {
     // Create a new profile.
     String namespace = "testProvisionSuccess";
+    String identityName = "test";
+    NamespaceMeta namespaceMeta = new
+        NamespaceMeta.Builder()
+        .setName(namespace)
+        .setIdentity(identityName)
+        .buildWithoutKeytabUriVersion();
     CredentialProfileId profileId = createDummyProfile(CREDENTIAL_PROVIDER_TYPE_SUCCESS, namespace,
         "test-profile");
 
@@ -54,13 +61,20 @@ public class DefaultCredentialProviderServiceTest extends CredentialProviderTest
         profileId.getName(), "some-identity", "some-secure-value");
     credentialIdentityManager.create(id, identity);
 
-    Assert.assertEquals(RETURNED_TOKEN, credentialProviderService.provision(namespace, "test"));
+    Assert.assertEquals(RETURNED_TOKEN,
+        credentialProviderService.provision(namespaceMeta, identityName));
   }
 
   @Test(expected = NotFoundException.class)
   public void testProvisionWithNotFoundIdentityThrowsException() throws Exception {
     String namespace = "testProvisionWithNotFoundIdentityThrowsException";
-    credentialProviderService.provision(namespace, "does-not-exist");
+    String identityName = "does-not-exist";
+    NamespaceMeta namespaceMeta = new
+        NamespaceMeta.Builder()
+        .setName(namespace)
+        .setIdentity(identityName)
+        .buildWithoutKeytabUriVersion();
+    credentialProviderService.provision(namespaceMeta, identityName);
   }
 
   @Test(expected = CredentialProvisioningException.class)
@@ -71,43 +85,68 @@ public class DefaultCredentialProviderServiceTest extends CredentialProviderTest
         namespace, "test-profile");
 
     // Create a new identity.
-    CredentialIdentityId id = new CredentialIdentityId(namespace, "test");
+    String identityName = "test";
+    CredentialIdentityId id = new CredentialIdentityId(namespace, identityName);
     CredentialIdentity identity = new CredentialIdentity(profileId.getNamespace(),
         profileId.getName(), "some-identity", "some-secure-value");
     credentialIdentityManager.create(id, identity);
 
-    Assert.assertEquals(RETURNED_TOKEN, credentialProviderService.provision(namespace, "test"));
+    NamespaceMeta namespaceMeta = new
+        NamespaceMeta.Builder()
+        .setName(namespace)
+        .setIdentity(identityName)
+        .buildWithoutKeytabUriVersion();
+    Assert.assertEquals(RETURNED_TOKEN, credentialProviderService.provision(namespaceMeta,
+        identityName));
   }
 
   @Test
   public void testIdentityValidationSuccess() throws Exception {
     // Create a new profile.
+    String identityName = "some-identity";
     String namespace = "testIdentityValidationSuccess";
+    NamespaceMeta namespaceMeta = new
+        NamespaceMeta.Builder()
+        .setName(namespace)
+        .setIdentity(identityName)
+        .buildWithoutKeytabUriVersion();
     CredentialProfileId profileId = createDummyProfile(CREDENTIAL_PROVIDER_TYPE_SUCCESS,
         namespace, "test-profile");
 
     CredentialIdentity identity = new CredentialIdentity(profileId.getNamespace(),
-        profileId.getName(), "some-identity", "some-secure-value");
-    credentialProviderService.validateIdentity(identity);
+        profileId.getName(), identityName, "some-secure-value");
+    credentialProviderService.validateIdentity(namespaceMeta, identity);
   }
 
   @Test(expected = IdentityValidationException.class)
   public void testIdentityValidationOnProvisionFailureThrowsException() throws Exception {
     // Create a new profile.
     String namespace = "testIdentityValidationFailureThrowsException";
+    String identityName = "some-identity";
+    NamespaceMeta namespaceMeta = new
+        NamespaceMeta.Builder()
+        .setName(namespace)
+        .setIdentity(identityName)
+        .buildWithoutKeytabUriVersion();
     CredentialProfileId profileId = createDummyProfile(CREDENTIAL_PROVIDER_TYPE_PROVISION_FAILURE,
         namespace, "test-profile");
 
     CredentialIdentity identity = new CredentialIdentity(profileId.getNamespace(),
-        profileId.getName(), "some-identity", "some-secure-value");
-    credentialProviderService.validateIdentity(identity);
+        profileId.getName(), identityName, "some-secure-value");
+    credentialProviderService.validateIdentity(namespaceMeta, identity);
   }
 
   @Test(expected = NotFoundException.class)
   public void testIdentityValidationWithNotFoundProfileThrowsException() throws Exception {
     String namespace = "testIdentityValidationWithNotFoundProfileThrowsException";
+    String identityName = "some-identity";
+    NamespaceMeta namespaceMeta = new
+        NamespaceMeta.Builder()
+        .setName(namespace)
+        .setIdentity(identityName)
+        .buildWithoutKeytabUriVersion();
     CredentialIdentity identity = new CredentialIdentity(namespace, "does-not-exist",
-        "some-identity", "some-secure-value");
-    credentialProviderService.validateIdentity(identity);
+        identityName, "some-secure-value");
+    credentialProviderService.validateIdentity(namespaceMeta, identity);
   }
 }

--- a/cdap-credential-ext-gcp-wi/pom.xml
+++ b/cdap-credential-ext-gcp-wi/pom.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2023 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>cdap</artifactId>
+    <groupId>io.cdap.cdap</groupId>
+    <version>6.10.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>cdap-credential-ext-gcp-wi</artifactId>
+  <name>CDAP Google Cloud Platform Credential Provider Extension</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <guava.version>31.1-jre</guava.version>
+    <k8s.version>16.0.2</k8s.version>
+    <!-- Needs to bump the okhttp version for fixing https://github.com/square/okhttp/issues/4029 that hangs on exit -->
+    <okhttp.version>4.9.1</okhttp.version>
+    <!-- Needs to define the gson and guava versions to override the one from dependency management in cdap pom.xml -->
+    <gson.version>2.8.6</gson.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-security-spi</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.kubernetes</groupId>
+      <artifactId>client-java</artifactId>
+      <version>${k8s.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${okhttp.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>logging-interceptor</artifactId>
+      <version>${okhttp.version}</version>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>dist</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>copy-dependencies</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <outputDirectory>${project.build.directory}/libexec</outputDirectory>
+                  <overWriteReleases>false</overWriteReleases>
+                  <overWriteSnapshots>false</overWriteSnapshots>
+                  <overWriteIfNewer>true</overWriteIfNewer>
+                  <prependGroupId>true</prependGroupId>
+                  <silent>true</silent>
+                  <includeScope>runtime</includeScope>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.4</version>
+            <executions>
+              <execution>
+                <id>jar</id>
+                <phase>prepare-package</phase>
+                <configuration combine.self="override">
+                  <outputDirectory>${project.build.directory}/libexec</outputDirectory>
+                  <finalName>${project.groupId}.${project.build.finalName}</finalName>
+                </configuration>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/GcpWorkloadIdentityCredentialProvider.java
+++ b/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/GcpWorkloadIdentityCredentialProvider.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.spi.credential;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.retry.RetryableException;
+import io.cdap.cdap.proto.BasicThrowable;
+import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.codec.BasicThrowableCodec;
+import io.cdap.cdap.proto.credential.CredentialIdentity;
+import io.cdap.cdap.proto.credential.CredentialProfile;
+import io.cdap.cdap.proto.credential.CredentialProvisioningException;
+import io.cdap.cdap.proto.credential.ProvisionedCredential;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.spi.credential.SecurityTokenServiceRequest.GrantType;
+import io.cdap.cdap.security.spi.credential.SecurityTokenServiceRequest.TokenType;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.AuthenticationV1TokenRequest;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1TokenRequestSpec;
+import io.kubernetes.client.util.Config;
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.HttpHeaders;
+import okhttp3.OkHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link CredentialProvider} Credential Provider which returns application default credentials.
+ * For more details, see
+ * medium.com/google-cloud/gcp-workload-identity-federation-with-federated-tokens-d03b8bad0228
+ */
+public class GcpWorkloadIdentityCredentialProvider implements CredentialProvider {
+
+  public static final String NAME = "gcp-wi-credential-provider";
+  private static final Gson GSON = new GsonBuilder().registerTypeAdapter(BasicThrowable.class,
+      new BasicThrowableCodec()).create();
+  private static final String TOKEN_EXCHANGE_AUDIENCE_FORMAT = "identitynamespace:%s:%s";
+  private static final Logger LOG =
+      LoggerFactory.getLogger(GcpWorkloadIdentityCredentialProvider.class);
+  private CredentialProviderContext credentialProviderContext;
+  private ApiClient client;
+  static final String CONNECT_TIMEOUT_SECS = "k8s.api.client.connect.timeout.secs";
+  static final String CONNECT_TIMEOUT_SECS_DEFAULT = "120";
+  static final String READ_TIMEOUT_SECS = "k8s.api.client.read.timeout.secs";
+  static final String READ_TIMEOUT_SECS_DEFAULT = "120";
+  static final String WORKLOAD_IDENTITY_POOL = "k8s.workload.identity.pool";
+  static final String WORKLOAD_IDENTITY_PROVIDER = "k8s.workload.identity.provider";
+  static final String RETRY_MAX_DELAY_MILLIS = "retry.policy.max.delay.ms";
+  static final String RETRY_MAX_DELAY_MILLIS_DEFAULT = "10000";
+  static final String RETRY_BASE_DELAY_MILLIS = "retry.policy.base.delay.ms";
+  static final String RETRY_BASE_DELAY_MILLIS_DEFAULT = "200";
+  static final String RETRY_TIMEOUT_SECS = "retry.policy.max.time.secs";
+  static final String RETRY_TIMEOUT_SECS_DEFAULT = "300";
+  private static final double RETRY_DELAY_MULTIPLIER = 1.2d;
+  private static final double RETRY_RANDOMIZE_FACTOR = 0.1d;
+  private static final String CLOUD_PLATFORM_SCOPE =
+      "https://www.googleapis.com/auth/cloud-platform";
+  private static final String PROVISIONING_FAILURE_ERROR_MESSAGE_FORMAT =
+      "Failed to provision credential with identity '%s'";
+  static final String NAMESPACE_CREATION_HOOK_ENABLED = "namespaces.creation.hook.enabled";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public void initialize(CredentialProviderContext credentialProviderContext) {
+    this.credentialProviderContext = credentialProviderContext;
+    LOG.info("Initialized Gcp Workload Identity Credential Provider.");
+  }
+
+  /**
+   * Returns the k8s Api Client.
+   *
+   * @return an ApiClient
+   * @throws IOException if there was a problem creating the ApiClient
+   */
+  @VisibleForTesting
+  public ApiClient getApiClient() throws IOException {
+    if (this.client != null) {
+      return this.client;
+    }
+
+    this.client = Config.defaultClient();
+    int connectTimeoutSec = Integer.parseInt(
+        credentialProviderContext.getProperties().getOrDefault(CONNECT_TIMEOUT_SECS,
+            CONNECT_TIMEOUT_SECS_DEFAULT));
+    int readTimeoutSec = Integer.parseInt(
+        credentialProviderContext.getProperties().getOrDefault(READ_TIMEOUT_SECS,
+            READ_TIMEOUT_SECS_DEFAULT));
+    OkHttpClient httpClient = this.client.getHttpClient().newBuilder()
+        .connectTimeout(connectTimeoutSec, TimeUnit.SECONDS)
+        .readTimeout(readTimeoutSec, TimeUnit.SECONDS)
+        .build();
+    this.client.setHttpClient(httpClient);
+
+    return this.client;
+  }
+
+  @Override
+  public ProvisionedCredential provision(NamespaceMeta namespaceMeta,
+      CredentialProfile profile, CredentialIdentity identity)
+      throws CredentialProvisioningException {
+
+    // Provision the credential with exponential delay on retryable failure.
+    long delay = Long.parseLong(
+        credentialProviderContext.getProperties().getOrDefault(RETRY_BASE_DELAY_MILLIS,
+            RETRY_BASE_DELAY_MILLIS_DEFAULT));
+    long maxDelay = Long.parseLong(
+        credentialProviderContext.getProperties().getOrDefault(RETRY_MAX_DELAY_MILLIS,
+            RETRY_MAX_DELAY_MILLIS_DEFAULT));
+    long timeout = Long.parseLong(
+        credentialProviderContext.getProperties().getOrDefault(RETRY_TIMEOUT_SECS,
+            RETRY_TIMEOUT_SECS_DEFAULT));
+    double minMultiplier = RETRY_DELAY_MULTIPLIER - RETRY_DELAY_MULTIPLIER * RETRY_RANDOMIZE_FACTOR;
+    double maxMultiplier = RETRY_DELAY_MULTIPLIER + RETRY_DELAY_MULTIPLIER * RETRY_RANDOMIZE_FACTOR;
+    Stopwatch stopWatch = Stopwatch.createStarted();
+    try {
+      while (stopWatch.elapsed(TimeUnit.SECONDS) < timeout) {
+        try {
+          return getProvisionedCredential(namespaceMeta, identity);
+        } catch (RetryableException e) {
+          TimeUnit.MILLISECONDS.sleep(delay);
+          delay = (long) (delay * (minMultiplier + Math.random() * (maxMultiplier - minMultiplier
+              + 1)));
+          delay = Math.min(delay, maxDelay);
+        } catch (Exception e) {
+
+          LOG.error(
+              String.format(PROVISIONING_FAILURE_ERROR_MESSAGE_FORMAT, identity.getIdentity()), e);
+
+          throw new CredentialProvisioningException(
+              String.format(PROVISIONING_FAILURE_ERROR_MESSAGE_FORMAT, identity.getIdentity()), e);
+        }
+      }
+    } catch (InterruptedException e) {
+      throw new CredentialProvisioningException(
+          String.format(PROVISIONING_FAILURE_ERROR_MESSAGE_FORMAT, identity.getIdentity()), e);
+    }
+
+    // timed out while provisioning the credential.
+    throw new CredentialProvisioningException(
+        new TimeoutException(
+            String.format("Timed out while provisioning the credential for identity '%s'",
+                identity.getIdentity())
+        ));
+  }
+
+  private ProvisionedCredential getProvisionedCredential(NamespaceMeta namespaceMeta,
+      CredentialIdentity identity) throws IOException, ApiException {
+
+    // get k8s namespace from namespace metadata if namespace creation hook is enabled.
+    String k8sNamespace = NamespaceId.DEFAULT.getNamespace();
+    if (credentialProviderContext.isNamespaceCreationHookEnabled()) {
+      k8sNamespace = namespaceMeta.getConfig().getConfigs().get("k8s.namespace");
+    }
+
+    try {
+      String workloadIdentityPool =
+          credentialProviderContext.getProperties().get(WORKLOAD_IDENTITY_POOL);
+
+      // generate k8s SA token for pod
+      String k8sSaToken = getK8sServiceAccountToken(k8sNamespace, identity.getIdentity(),
+          workloadIdentityPool);
+      LOG.trace("Successfully generated K8SA token.");
+
+      String workloadIdentityProvider =
+          credentialProviderContext.getProperties().get(WORKLOAD_IDENTITY_PROVIDER);
+
+      // exchange JWT token via STS for Federating Token
+      String tokenExchangeAudience = String.format(TOKEN_EXCHANGE_AUDIENCE_FORMAT,
+          workloadIdentityPool, workloadIdentityProvider);
+
+      LOG.trace("Exchanging JWT token for Federating Token via STS with audience {}",
+          tokenExchangeAudience);
+      SecurityTokenServiceResponse securityTokenServiceResponse = GSON.fromJson(
+          exchangeTokenViaSts(k8sSaToken, CLOUD_PLATFORM_SCOPE, tokenExchangeAudience),
+          SecurityTokenServiceResponse.class
+      );
+      LOG.trace("Successfully exchanged JWT token for Federating Token via STS.");
+
+      // get GSA token using Federating Token as credential
+      IamCredentialGenerateAccessTokenResponse iamCredentialGenerateAccessTokenResponse =
+          GSON.fromJson(fetchIamServiceAccountToken(securityTokenServiceResponse.getAccessToken(),
+          CLOUD_PLATFORM_SCOPE, identity.getSecureValue()),
+              IamCredentialGenerateAccessTokenResponse.class);
+      LOG.trace("Successfully generated GSA token using Federating Token as credential.");
+
+      return new ProvisionedCredential(iamCredentialGenerateAccessTokenResponse.getAccessToken(),
+          Instant.parse(iamCredentialGenerateAccessTokenResponse.getExpireTime()));
+
+    } catch (ApiException e) {
+      if ((e.getCode() / 100) != 4) {
+        // if there was an API exception that was not a 4xx, we can just retry
+        throw new RetryableException(e);
+      }
+      LOG.error("Failed to create KSA token with response code: {} and message: {}",
+          e.getCode(), e.getMessage());
+      throw e;
+    } catch (SocketTimeoutException | ConnectException e) {
+      // if there was a socket timeout or connect exception, we can just retry
+      throw new RetryableException(e);
+    }
+  }
+
+  @Override
+  public void validateProfile(CredentialProfile profile) throws ProfileValidationException {
+    if (!profile.getCredentialProviderType().equals(NAME)) {
+      throw new ProfileValidationException(
+          String.format("Profile is not supported by %s credential provider", NAME));
+    }
+  }
+
+  private String getK8sServiceAccountToken(String namespace,
+      String serviceAccountName, String audience) throws ApiException, IOException {
+
+    // Create the TokenRequestSpec with the specified audience.
+    V1TokenRequestSpec v1TokenRequestSpec = new V1TokenRequestSpec()
+        .audiences(Collections.singletonList(audience))
+        .expirationSeconds(3600L);
+
+    AuthenticationV1TokenRequest authenticationV1TokenRequest = new AuthenticationV1TokenRequest()
+        .apiVersion("authentication.k8s.io/v1").kind("TokenRequest").spec(v1TokenRequestSpec);
+
+    V1ObjectMeta serviceAccountMetadata = new V1ObjectMeta()
+        .name(serviceAccountName).namespace(namespace);
+    authenticationV1TokenRequest.setMetadata(serviceAccountMetadata);
+
+    CoreV1Api coreV1Api = new CoreV1Api(getApiClient());
+    authenticationV1TokenRequest = coreV1Api.createNamespacedServiceAccountToken(serviceAccountName,
+        namespace, authenticationV1TokenRequest, null, null,
+        null, null);
+
+    return authenticationV1TokenRequest.getStatus().getToken();
+  }
+
+  private String exchangeTokenViaSts(String token, String scopes, String audience)
+      throws IOException {
+
+    SecurityTokenServiceRequest securityTokenServiceRequest =
+        new SecurityTokenServiceRequest(GrantType.TOKEN_EXCHANCE, audience, scopes,
+            TokenType.ACCESS_TOKEN, TokenType.JWT, token);
+    String securityTokenServiceRequestJson = GSON.toJson(securityTokenServiceRequest);
+    URL url = new URL(SecurityTokenServiceRequest.STS_ENDPOINT);
+
+    Map<String, String> headers = new HashMap<>();
+    headers.put(HttpHeaders.CONTENT_TYPE, "application/json");
+    return executeHttpPostRequest(url, securityTokenServiceRequestJson, headers);
+  }
+
+  /**
+   * Executes a http post request with the specified parameters.
+   */
+  @VisibleForTesting
+  String executeHttpPostRequest(URL url, String body, Map<String, String> headers)
+      throws IOException {
+
+    HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+    connection.setRequestMethod(HttpMethod.POST);
+    connection.setUseCaches(false);
+    for (Map.Entry<String, String> entry : headers.entrySet()) {
+      connection.setRequestProperty(entry.getKey(), entry.getValue());
+    }
+    connection.setDoOutput(true);
+
+    // Write the request body to the output stream
+    try (DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream())) {
+      outputStream.writeBytes(body);
+      outputStream.flush();
+    }
+
+    StringBuilder response = new StringBuilder();
+    try (BufferedReader in = new BufferedReader(
+        new InputStreamReader(connection.getInputStream()))) {
+      String inputLine;
+      while ((inputLine = in.readLine()) != null) {
+        response.append(inputLine);
+      }
+    }
+    return response.toString();
+  }
+
+  private String fetchIamServiceAccountToken(String token, String scopes,
+      String serviceAccountEmail) throws IOException {
+
+    URL url = new URL(String.format(
+        IamCredentialsGenerateAccessTokenRequest.IAM_CREDENTIALS_GENERATE_SA_TOKEN_URL_FORMAT,
+        serviceAccountEmail));
+    IamCredentialsGenerateAccessTokenRequest credentialsGenerateAccessTokenRequest = new
+        IamCredentialsGenerateAccessTokenRequest(scopes);
+
+    Map<String, String> headers = new HashMap<>();
+    headers.put(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", token));
+    headers.put(HttpHeaders.CONTENT_TYPE, "application/json");
+    String generateAccessTokenRequestJson = GSON.toJson(credentialsGenerateAccessTokenRequest);
+    return executeHttpPostRequest(url, generateAccessTokenRequestJson, headers);
+  }
+}

--- a/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/IamCredentialGenerateAccessTokenResponse.java
+++ b/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/IamCredentialGenerateAccessTokenResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.spi.credential;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents a IAM Credentials General Access Token request. For more details,
+ * <a href="
+ * https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts">
+ * see
+ * </a>
+ */
+public class IamCredentialGenerateAccessTokenResponse {
+
+  @SerializedName("accessToken")
+  private final String accessToken;
+
+  @SerializedName("expireTime")
+  private final String expireTime;
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  public String getExpireTime() {
+    return expireTime;
+  }
+
+  /**
+   * Constructs a {@link IamCredentialGenerateAccessTokenResponse}.
+   */
+  public IamCredentialGenerateAccessTokenResponse(String accessToken, String expireTime) {
+    this.accessToken = accessToken;
+    this.expireTime = expireTime;
+  }
+}

--- a/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/IamCredentialsGenerateAccessTokenRequest.java
+++ b/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/IamCredentialsGenerateAccessTokenRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.spi.credential;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents a IAM Credentials General Access Token request. For more details,
+ * <a href=
+ * "https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts">
+ * see</a>
+ */
+public class IamCredentialsGenerateAccessTokenRequest {
+
+  public static final String IAM_CREDENTIALS_GENERATE_SA_TOKEN_URL_FORMAT =
+      "https://iamcredentials.googleapis.com/"
+          + "v1/projects/-/serviceAccounts/%s:generateAccessToken";
+
+  @SerializedName("scope")
+  private final String scope;
+
+  /**
+   * Constructs a {@link IamCredentialsGenerateAccessTokenRequest}.
+   */
+  public IamCredentialsGenerateAccessTokenRequest(String scope) {
+    this.scope = scope;
+  }
+}

--- a/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/SecurityTokenServiceRequest.java
+++ b/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/SecurityTokenServiceRequest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.spi.credential;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Represents a Security Token Service Token Exchange request. For more details,
+ * <a href="https://cloud.google.com/iam/docs/reference/sts/rest/v1/TopLevel/token">see</a>
+ */
+public class SecurityTokenServiceRequest {
+
+  public static String STS_ENDPOINT = "https://sts.googleapis.com/v1/token";
+
+  /**
+   * Represents the type of token.
+   */
+  public enum TokenType {
+    @SerializedName("urn:ietf:params:oauth:token-type:jwt")
+    JWT,
+    @SerializedName("urn:ietf:params:oauth:token-type:access_token")
+    ACCESS_TOKEN
+  }
+
+  /**
+   * Represents the type of grant.
+   */
+  public enum GrantType {
+    @SerializedName("urn:ietf:params:oauth:grant-type:token-exchange")
+    TOKEN_EXCHANCE
+  }
+
+  @SerializedName("grantType")
+  private final GrantType grantType;
+
+  @SerializedName("audience")
+  private final String audience;
+
+  @SerializedName("scope")
+  private final String scope;
+
+  @SerializedName("subjectTokenType")
+  private final TokenType subjectTokenType;
+
+  @SerializedName("requestedTokenType")
+  private final TokenType requestedTokenType;
+
+  @SerializedName("subjectToken")
+  private final String subjectToken;
+
+  /**
+   * Constructs a {@link SecurityTokenServiceRequest}.
+   */
+  public SecurityTokenServiceRequest(GrantType grantType, String audience, String scope,
+      TokenType requestedTokenType, TokenType subjectTokenType, String subjectToken) {
+    this.grantType = grantType;
+    this.requestedTokenType = requestedTokenType;
+    this.subjectTokenType = subjectTokenType;
+    this.audience = audience;
+    this.scope = scope;
+    this.subjectToken = subjectToken;
+  }
+}

--- a/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/SecurityTokenServiceResponse.java
+++ b/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/SecurityTokenServiceResponse.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.spi.credential;
+
+import com.google.gson.annotations.SerializedName;
+import io.cdap.cdap.security.spi.credential.SecurityTokenServiceRequest.TokenType;
+
+/**
+ * Represents a Security Token Service Token Exchange response. For more details,
+ * <a href="https://cloud.google.com/iam/docs/reference/sts/rest/v1/TopLevel/token#response-body">
+ *   see
+ * </a>
+ */
+public class SecurityTokenServiceResponse {
+
+  @SerializedName("access_token")
+  private final String accessToken;
+
+  @SerializedName("issued_token_type")
+  private final TokenType issuedTokenType;
+
+  @SerializedName("token_type")
+  private final String tokenType;
+
+  @SerializedName("expires_in")
+  private final int expiresIn;
+
+  public String getAccessToken() {
+    return accessToken;
+  }
+
+  /**
+   * Constructs a {@link SecurityTokenServiceResponse}.
+   */
+  public SecurityTokenServiceResponse(String accessToken, TokenType issuedTokenType,
+      String tokenType, int expiresIn) {
+    this.accessToken = accessToken;
+    this.issuedTokenType = issuedTokenType;
+    this.tokenType = tokenType;
+    this.expiresIn = expiresIn;
+  }
+}

--- a/cdap-credential-ext-gcp-wi/src/main/resources/META-INF/services/io.cdap.cdap.security.spi.credential.CredentialProvider
+++ b/cdap-credential-ext-gcp-wi/src/main/resources/META-INF/services/io.cdap.cdap.security.spi.credential.CredentialProvider
@@ -1,0 +1,17 @@
+#
+# Copyright © 2023 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+io.cdap.cdap.security.spi.credential.GcpWorkloadIdentityCredentialProvider

--- a/cdap-credential-ext-gcp-wi/src/test/java/io/cdap/cdap/security/spi/credential/GcpWorkloadIdentityCredentialProviderTest.java
+++ b/cdap-credential-ext-gcp-wi/src/test/java/io/cdap/cdap/security/spi/credential/GcpWorkloadIdentityCredentialProviderTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.spi.credential;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.proto.BasicThrowable;
+import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.codec.BasicThrowableCodec;
+import io.cdap.cdap.proto.credential.CredentialIdentity;
+import io.cdap.cdap.proto.credential.CredentialProfile;
+import io.cdap.cdap.proto.credential.ProvisionedCredential;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.spi.credential.SecurityTokenServiceRequest.TokenType;
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.ApiResponse;
+import io.kubernetes.client.openapi.models.AuthenticationV1TokenRequest;
+import io.kubernetes.client.openapi.models.V1TokenRequestStatus;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit Tests for {@link GcpWorkloadIdentityCredentialProvider}.
+ */
+public class GcpWorkloadIdentityCredentialProviderTest {
+  private static final Gson GSON = new GsonBuilder().registerTypeAdapter(BasicThrowable.class,
+      new BasicThrowableCodec()).create();
+  private static final String IAM_TOKEN = "iam-token";
+  private static final String EXPIRES_IN = LocalDateTime.now().format(
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'"));
+
+  @Test
+  public void testProvisioningCredentialWithRetries() throws Exception {
+
+    GcpWorkloadIdentityCredentialProvider gcpWorkloadIdentityCredentialProvider =
+        new GcpWorkloadIdentityCredentialProvider();
+
+    CredentialProviderContext credentialProviderContext = getCredentialProviderContext();
+    gcpWorkloadIdentityCredentialProvider.initialize(credentialProviderContext);
+
+    GcpWorkloadIdentityCredentialProvider mockedCredentialProvider =
+        Mockito.spy(gcpWorkloadIdentityCredentialProvider);
+
+    Mockito
+        .doThrow(new SocketTimeoutException())
+        .doThrow(new ConnectException())
+        .doReturn(getSecurityTokenServiceResponse())
+        .doReturn(getIamCredentialGenerateAccessTokenResponse())
+        .when(mockedCredentialProvider).executeHttpPostRequest(Mockito.any(), Mockito.anyString(),
+            Mockito.any());
+
+    Mockito.doReturn(getMockApiClient()).when(mockedCredentialProvider).getApiClient();
+
+    CredentialProfile credentialProfile = new CredentialProfile(
+        GcpWorkloadIdentityCredentialProvider.NAME, "profile", Collections.emptyMap());
+    CredentialIdentity credentialIdentity = new CredentialIdentity(
+        NamespaceId.DEFAULT.getNamespace(), "default",
+        NamespaceMeta.DEFAULT.getIdentity(), "secureVal");
+
+    // validate profile
+    mockedCredentialProvider.validateProfile(credentialProfile);
+    // provision credential
+    ProvisionedCredential credential =
+        mockedCredentialProvider.provision(NamespaceMeta.DEFAULT, credentialProfile,
+            credentialIdentity);
+
+    Assert.assertEquals(credential.get(), IAM_TOKEN);
+    Assert.assertEquals(credential.getExpiration().toString(), EXPIRES_IN);
+    // twice per invocation of
+    // {@link GcpWorkloadIdentityCredentialProvider#getProvisionedCredential}
+    Mockito.verify(mockedCredentialProvider.getApiClient(), Mockito.times(8));
+  }
+
+  private String getSecurityTokenServiceResponse() {
+    SecurityTokenServiceResponse securityTokenServiceResponse =
+        new SecurityTokenServiceResponse("token", TokenType.ACCESS_TOKEN,
+            "Bearer", 3600);
+    return GSON.toJson(securityTokenServiceResponse);
+  }
+
+  private String getIamCredentialGenerateAccessTokenResponse() {
+    IamCredentialGenerateAccessTokenResponse iamCredentialGenerateAccessTokenResponse =
+        new IamCredentialGenerateAccessTokenResponse(IAM_TOKEN, EXPIRES_IN);
+    return GSON.toJson(iamCredentialGenerateAccessTokenResponse);
+  }
+
+  private ApiClient getMockApiClient() throws ApiException {
+    ApiClient mockApiClient = Mockito.mock(ApiClient.class);
+    Mockito.when(mockApiClient.escapeString(Mockito.anyString())).thenCallRealMethod();
+    ApiResponse<Object> apiResponse = getAuthenticationTokenRequestResponse();
+    Mockito
+        .doThrow(new ApiException(500, "Service is unavailable"))
+        .doReturn(apiResponse)
+        .when(mockApiClient).execute(Mockito.any(), Mockito.any());
+    return mockApiClient;
+  }
+
+  private V1TokenRequestStatus getV1TokenRequestStatus() {
+    V1TokenRequestStatus v1TokenRequestStatus = new V1TokenRequestStatus();
+    v1TokenRequestStatus.setToken("auth-token");
+    v1TokenRequestStatus.setExpirationTimestamp(OffsetDateTime.now().plusHours(1L));
+    return v1TokenRequestStatus;
+  }
+
+  private ApiResponse<Object> getAuthenticationTokenRequestResponse() {
+    AuthenticationV1TokenRequest authenticationV1TokenRequest =
+        Mockito.mock(AuthenticationV1TokenRequest.class);
+    Mockito.doReturn(getV1TokenRequestStatus()).when(authenticationV1TokenRequest).getStatus();
+    return new
+        ApiResponse<Object>(200, Collections.emptyMap(), authenticationV1TokenRequest);
+  }
+
+  private CredentialProviderContext getCredentialProviderContext() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put(GcpWorkloadIdentityCredentialProvider.WORKLOAD_IDENTITY_PROVIDER, "provider");
+    properties.put(GcpWorkloadIdentityCredentialProvider.WORKLOAD_IDENTITY_POOL, "pool");
+    properties.put(GcpWorkloadIdentityCredentialProvider.RETRY_BASE_DELAY_MILLIS, "0");
+    properties.put(GcpWorkloadIdentityCredentialProvider.RETRY_MAX_DELAY_MILLIS, "1");
+    properties.put(GcpWorkloadIdentityCredentialProvider.RETRY_TIMEOUT_SECS, "10");
+    return new CredentialProviderContext() {
+      @Override
+      public Map<String, String> getProperties() {
+        return properties;
+      }
+      @Override
+      public boolean isNamespaceCreationHookEnabled() {
+        return false;
+      }
+    };
+  }
+
+  @Test(expected = ProfileValidationException.class)
+  public void testInvalidProfile() throws ProfileValidationException {
+    GcpWorkloadIdentityCredentialProvider gcpWorkloadIdentityCredentialProvider =
+        new GcpWorkloadIdentityCredentialProvider();
+    CredentialProfile invalidCredentialProfile = new CredentialProfile(
+        "unknown-provider", "profile", Collections.emptyMap());
+    gcpWorkloadIdentityCredentialProvider.validateProfile(invalidCredentialProfile);
+  }
+}

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -274,6 +274,7 @@
         <stage.securestores.ext.dir>${stage.opt.dir}/ext/securestores</stage.securestores.ext.dir>
         <stage.storage.ext.dir>${stage.opt.dir}/ext/storageproviders</stage.storage.ext.dir>
         <stage.authenticators.ext.dir>${stage.opt.dir}/ext/authenticators</stage.authenticators.ext.dir>
+        <stage.credential.provider.extensions.dir>${stage.opt.dir}/ext/credentialproviders</stage.credential.provider.extensions.dir>
         <stage.metricswriters.ext.dir>${stage.opt.dir}/ext/metricswriters/google_cloud_monitoring_writer
         </stage.metricswriters.ext.dir>
         <stage.eventwriters.ext.dir>${stage.opt.dir}/ext/eventwriters/google_cloud_pubsub_writer
@@ -743,6 +744,27 @@
                 </configuration>
               </execution>
 
+              <!-- Copy credential provider extensions -->
+              <execution>
+                <id>copy-credential-ext-gcp-wi</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <outputDirectory>${stage.credential.provider.extensions.dir}/gcp-wi-credential-provider</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>
+                        ${project.parent.basedir}/cdap-credential-ext-gcp-wi/target/libexec/
+                      </directory>
+                      <includes>
+                        <include>*.jar</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
           <plugin>

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/CredentialProvider.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/CredentialProvider.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.proto.credential;
 
+import io.cdap.cdap.proto.NamespaceMeta;
 import java.io.IOException;
 
 /**
@@ -26,24 +27,25 @@ public interface CredentialProvider {
   /**
    * Provisions a short-lived credential for the provided identity using the provided identity.
    *
-   * @param namespace    The identity namespace.
+   * @param namespaceMeta    The identity namespace metadata.
    * @param identityName The identity name.
    * @return A short-lived credential.
    * @throws CredentialProvisioningException If provisioning the credential fails.
    * @throws IOException                     If any transport errors occur.
    * @throws NotFoundException               If the profile or identity are not found.
    */
-  ProvisionedCredential provision(String namespace, String identityName)
+  ProvisionedCredential provision(NamespaceMeta namespaceMeta, String identityName)
       throws CredentialProvisioningException, IOException, NotFoundException;
 
   /**
    * Validates the provided identity.
    *
+   * @param namespaceMeta    The identity namespace metadata.
    * @param identity The identity to validate.
    * @throws IdentityValidationException If validation fails.
    * @throws IOException                 If any transport errors occur.
    * @throws NotFoundException           If the profile is not found.
    */
-  void validateIdentity(CredentialIdentity identity) throws IdentityValidationException,
-      IOException, NotFoundException;
+  void validateIdentity(NamespaceMeta namespaceMeta, CredentialIdentity identity)
+      throws IdentityValidationException, IOException, NotFoundException;
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/CredentialProvisioningException.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/CredentialProvisioningException.java
@@ -29,4 +29,23 @@ public class CredentialProvisioningException extends Exception {
   public CredentialProvisioningException(String message) {
     super(message);
   }
+
+  /**
+   * Creates a new credential provisioning exception.
+   *
+   * @param cause cause of the provisioning failure.
+   */
+  public CredentialProvisioningException(Throwable cause) {
+    super(cause);
+  }
+
+  /**
+   * Creates a new credential provisioning exception.
+   *
+   * @param message The message for the provisioning failure.
+   * @param cause cause of the failure.
+   */
+  public CredentialProvisioningException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/EntityId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/EntityId.java
@@ -199,7 +199,7 @@ public abstract class EntityId {
   public static void ensureValidCredentialId(String name) {
     if (!isValidCredentialId(name)) {
       throw new IllegalArgumentException(
-          String.format("Invalid credential ID: %s. Should only contain alphanumeric "
+          String.format("Invalid credential ID: %s. Should only contain lowercase alphanumeric "
               + "characters and _ or -.", name));
     }
   }

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/credential/CredentialProvider.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/credential/CredentialProvider.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.security.spi.credential;
 
+import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.credential.CredentialIdentity;
 import io.cdap.cdap.proto.credential.CredentialProfile;
 import io.cdap.cdap.proto.credential.CredentialProvisioningException;
@@ -45,12 +46,14 @@ public interface CredentialProvider {
    * Provisions a short-lived credential for the provided identity using the provided credential
    * profile.
    *
+   * @param namespaceMeta The credential identity namespace metadata.
    * @param profile  The credential profile to use.
    * @param identity The credential identity to use.
    * @return A credential provisioned using the specified profile and identity.
    * @throws CredentialProvisioningException If the credential provisioning fails.
    */
-  ProvisionedCredential provision(CredentialProfile profile, CredentialIdentity identity)
+  ProvisionedCredential provision(NamespaceMeta namespaceMeta, CredentialProfile profile,
+      CredentialIdentity identity)
       throws CredentialProvisioningException;
 
   /**

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/credential/CredentialProviderContext.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/credential/CredentialProviderContext.java
@@ -34,4 +34,11 @@ public interface CredentialProviderContext {
    * @return Unmodifiable system properties for the provider.
    */
   Map<String, String> getProperties();
+
+  /**
+   * Derives namespace creation hook is enabled or not from CDAP configuration.
+   *
+   * @return true if namespace creation hook is enabled, otherwise false.
+   */
+  boolean isNamespaceCreationHookEnabled();
 }

--- a/pom.xml
+++ b/pom.xml
@@ -2750,6 +2750,7 @@
         <module>cdap-master-spi</module>
         <module>cdap-master</module>
         <module>cdap-proto</module>
+        <module>cdap-credential-ext-gcp-wi</module>
         <module>cdap-runtime-ext-dataproc</module>
         <module>cdap-runtime-ext-emr</module>
         <module>cdap-runtime-ext-remote-hadoop</module>


### PR DESCRIPTION
JIRA: [CDAP-20750](https://cdap.atlassian.net/browse/CDAP-20750)

This PR does the following:

- Implements `GcpWorkloadIdentityCredentialProvider` extension.
- Modifies the `CredentialProvider` interface to accept `NamespaceMeta` which is used by `GcpWorkloadIdentityCredentialProvider` to identify `k8sNamespace`.
- Restricts `CredentialProviderHttpHandler` from creating a credential identity in a namespace that is associated with a profile in a different namespace.

[CDAP-20750]: https://cdap.atlassian.net/browse/CDAP-20750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ