### PR TITLE
Fix netty max direct memory setting

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -79,8 +79,7 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
   @Override
   public void initialize() throws Exception {
     SparkClientContext context = getContext();
-    String arguments =
-        Joiner.on(", ").withKeyValueSeparator("=").join(context.getRuntimeArguments());
+    String arguments = Joiner.on(", ").withKeyValueSeparator("=").join(context.getRuntimeArguments());
     WRAPPERLOGGER.info("Pipeline '{}' is started by user '{}' with arguments {}",
                        context.getApplicationSpecification().getName(),
                        UserGroupInformation.getCurrentUser().getShortUserName(),
@@ -127,25 +126,16 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
       }
     }
     sparkConf.set("spark.streaming.backpressure.enabled", "true");
-    sparkConf.set(
-        "spark.spark.streaming.blockInterval", String.valueOf(spec.getBatchIntervalMillis() / 5));
-    String maxFetchSize = String.valueOf(Integer.MAX_VALUE - 512);
-    sparkConf.set("spark.network.maxRemoteBlockSizeFetchToMem", maxFetchSize);
+    sparkConf.set("spark.spark.streaming.blockInterval", String.valueOf(spec.getBatchIntervalMillis() / 5));
+    sparkConf.set("spark.network.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
 
     // spark... makes you set this to at least the number of receivers (streaming sources)
     // because it holds one thread per receiver, or one core in distributed mode.
     // so... we have to set this hacky master variable based on the isUnitTest setting in the config
     String extraOpts = spec.getExtraJavaOpts();
-    // In Spark v3.2.0 and later, max netty direct memory must be
-    // >= spark.network.maxRemoteBlockSizeFetchToMem for executors.
-    // So we set max netty direct memory = spark.network.maxRemoteBlockSizeFetchToMem
-    // See CDAP-20758 for details.
-    String nettyMaxDirectMemory = String.format("-Dio.netty.maxDirectMemory=%s", maxFetchSize);
     if (extraOpts != null && !extraOpts.isEmpty()) {
       sparkConf.set("spark.driver.extraJavaOptions", extraOpts);
-      sparkConf.set("spark.executor.extraJavaOptions", nettyMaxDirectMemory + " " + extraOpts);
-    } else {
-      sparkConf.set("spark.executor.extraJavaOptions", nettyMaxDirectMemory);
+      sparkConf.set("spark.executor.extraJavaOptions", extraOpts);
     }
     // without this, stopping will hang on machines with few cores.
     sparkConf.set("spark.rpc.netty.dispatcher.numThreads", String.valueOf(numSources + 2));
@@ -165,11 +155,8 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
         try {
           int numExecutors = Integer.parseInt(property.getValue());
           if (numExecutors < minExecutors) {
-            LOG.warn(
-                "Number of executors {} is less than the minimum number required to run the"
-                    + " pipeline. Automatically increasing it to {}",
-                numExecutors,
-                minExecutors);
+            LOG.warn("Number of executors {} is less than the minimum number required to run the pipeline. "
+                       + "Automatically increasing it to {}", numExecutors, minExecutors);
             numExecutors = minExecutors;
           }
           sparkConf.set(property.getKey(), String.valueOf(numExecutors));
@@ -199,10 +186,9 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
   public void destroy() {
     super.destroy();
     ProgramStatus status = getContext().getState().getStatus();
-    WRAPPERLOGGER.info(
-        "Pipeline '{}' {}",
-        getContext().getApplicationSpecification().getName(),
-        status == ProgramStatus.COMPLETED ? "succeeded" : status.name().toLowerCase());
+    WRAPPERLOGGER.info("Pipeline '{}' {}", getContext().getApplicationSpecification().getName(),
+                       status == ProgramStatus.COMPLETED ? "succeeded" : status.name().toLowerCase());
+
   }
 
   private void emitMetrics(DataStreamsPipelineSpec spec) {

--- a/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-streams-base/src/main/java/io/cdap/cdap/datastreams/DataStreamsSparkLauncher.java
@@ -127,6 +127,8 @@ public class DataStreamsSparkLauncher extends AbstractSpark {
     }
     sparkConf.set("spark.streaming.backpressure.enabled", "true");
     sparkConf.set("spark.spark.streaming.blockInterval", String.valueOf(spec.getBatchIntervalMillis() / 5));
+    // NOTE: If you change this value, also update io.netty.maxDirectMemory in
+    // KubeMasterEnvironment
     sparkConf.set("spark.network.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
 
     // spark... makes you set this to at least the number of receivers (streaming sources)

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
@@ -102,6 +102,8 @@ public class ETLSpark extends AbstractSpark {
     // turn off auto-broadcast by default until we better understand the implications and can set this to a
     // value that we are confident is safe.
     sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1");
+    // NOTE: If you change this value, also update io.netty.maxDirectMemory in
+    // KubeMasterEnvironment
     sparkConf.set("spark.network.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
     sparkConf.set("spark.network.timeout", "600s");
     // Disable yarn app retries since spark already performs retries at a task level.

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/ETLSpark.java
@@ -102,14 +102,7 @@ public class ETLSpark extends AbstractSpark {
     // turn off auto-broadcast by default until we better understand the implications and can set this to a
     // value that we are confident is safe.
     sparkConf.set("spark.sql.autoBroadcastJoinThreshold", "-1");
-    String maxFetchSize = String.valueOf(Integer.MAX_VALUE - 512);
-    sparkConf.set("spark.network.maxRemoteBlockSizeFetchToMem", maxFetchSize);
-    // In Spark v3.2.0 and later, max netty direct memory must be
-    // >= spark.network.maxRemoteBlockSizeFetchToMem for executors.
-    // So we set max netty direct memory = spark.network.maxRemoteBlockSizeFetchToMem
-    // See CDAP-20758 for details.
-    String nettyMaxDirectMemory = String.format("-Dio.netty.maxDirectMemory=%s", maxFetchSize);
-    sparkConf.set("spark.executor.extraJavaOptions", nettyMaxDirectMemory);
+    sparkConf.set("spark.network.maxRemoteBlockSizeFetchToMem", String.valueOf(Integer.MAX_VALUE - 512));
     sparkConf.set("spark.network.timeout", "600s");
     // Disable yarn app retries since spark already performs retries at a task level.
     sparkConf.set("spark.yarn.maxAppAttempts", "1");

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -211,6 +211,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String SPARK_DRIVER_LABEL_VALUE = "driver";
   private static final String CDAP_CONTAINER_LABEL = "cdap.container";
   private static final String TWILL_RUNNER_SERVICE_MONITOR_DISABLE = "twill.runner.service.monitor.disable";
+  private static final String SPARK_EXECUTOR_JAVA_OPTS = "spark.executor.extraJavaOptions";
 
   private static final String CONNECT_TIMEOUT = "master.environment.k8s.connect.timeout.sec";
   static final String CONNECT_TIMEOUT_DEFAULT = "120";
@@ -494,6 +495,16 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     sparkConfMap.put(SPARK_DRIVER_POD_CPU_LIMIT, String.format("%dm", driverCpuLimit));
     sparkConfMap.put(SPARK_EXECUTOR_POD_CPU_REQUEST, String.format("%dm", executorCpuRequested));
     sparkConfMap.put(SPARK_EXECUTOR_POD_CPU_LIMIT, String.format("%dm", executorCpuLimit));
+
+    // In Spark v3.2.0 and later, max netty direct memory must be
+    // >= spark.network.maxRemoteBlockSizeFetchToMem for executors.
+    // So we set max netty direct memory = spark.network.maxRemoteBlockSizeFetchToMem
+    // See CDAP-20758 for details.
+    // NOTE: If spark.network.maxRemoteBlockSizeFetchToMem is changed in ETLSpark.java,
+    // DataStreamsSparkLaunch.java, then io.netty.maxDirectMemory will need also need to changed
+    // here.
+    String nettyMaxDirectMemory = String.format("-Dio.netty.maxDirectMemory=%d", Integer.MAX_VALUE - 512);
+    sparkConfMap.put(SPARK_EXECUTOR_JAVA_OPTS, nettyMaxDirectMemory);
 
     // Add spark pod labels. This will be same as job labels
     populateLabels(sparkConfMap);


### PR DESCRIPTION
Reverts #15280. Set `io.netty.maxDirectMemory` in KubeMasterEnvironment as setting it in the app doesn't work for some reason (created [CDAP-20777](https://cdap.atlassian.net/browse/CDAP-20777) to investige this).

[CDAP-20777]: https://cdap.atlassian.net/browse/CDAP-20777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ