### PR TITLE
Switch to root user in cdap-spark-core docker image for sufficient permissions

### DIFF
--- a/cdap-spark-core3_2.12/src/k8s/Dockerfile
+++ b/cdap-spark-core3_2.12/src/k8s/Dockerfile
@@ -51,6 +51,7 @@ RUN tar -zcvf /tmp/cdap-build-sources.tar.gz --exclude='.git*' --exclude='node_m
   mkdir /tmp/LICENSES/commons-lang-2.6 && jar xvf /tmp/connectors/commons-lang-2.6.jar META-INF/LICENSE META-INF/LICENSE.txt && cp ./META-INF/LICENSE* /tmp/LICENSES/commons-lang-2.6 && rm -r ./META-INF
 
 FROM ${base_image} AS build
+USER root
 RUN apt-get update && apt-get upgrade -y
 
 # copy cdap-spark-core and its dependencies


### PR DESCRIPTION
This PR switches the user to root to get enough permissions to apply software updates.