### PR TITLE
Support bundle script: fix help text

### DIFF
--- a/cdap-support-bundle/bin/collect_support_bundle.md
+++ b/cdap-support-bundle/bin/collect_support_bundle.md
@@ -28,7 +28,7 @@ The CDAP Support Bundle Script takes the following command-line arguments:
 
 6. --run-id, -r : The run ID of the pipeline, if you want to collect logs for a failed pipeline run.
 
-7. --runtime-namespace, -t : The runtime namespace, which is the namespace where the pipeline is running. Default is set to "default".
+7. --runtime-namespace, -t : The runtime namespace, which is the kubernetes namespace where the pipeline is running. Default is set to "default".
 
 **Support Bundle Script Execution**
 -----------------------------------

--- a/cdap-support-bundle/bin/collect_support_bundle.py
+++ b/cdap-support-bundle/bin/collect_support_bundle.py
@@ -73,7 +73,7 @@ parser.add_argument(
 parser.add_argument(
     "--runtime-namespace",
     "-t",
-    help="CDAP Runtime namespace. Namespace where pipeline is running",
+    help="Kubernetes namespace where pipeline is running",
     type=str,
     default="default"
 )


### PR DESCRIPTION
Clarify that the runtime namespace refers to the k8s namespace where the pipeline runs, not the associated CDAP namespace.