### PR TITLE
fix(CDAP-20786): should check Spanner schema equality after compatibility conversion

### DIFF
--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/StructuredTableSchema.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/StructuredTableSchema.java
@@ -46,11 +46,16 @@ public class StructuredTableSchema {
     this(spec.getTableId(), spec.getFieldTypes(), spec.getPrimaryKeys(), spec.getIndexes());
   }
 
-  public StructuredTableSchema(StructuredTableId tableId, List<FieldType> fields,
-      List<String> primaryKeys, Collection<String> indexes) {
+  /** Constructor of {@code StructuredTableSchema} with table schema details. */
+  public StructuredTableSchema(
+      StructuredTableId tableId,
+      List<FieldType> fields,
+      List<String> primaryKeys,
+      Collection<String> indexes) {
     this.tableId = tableId;
-    this.fields = Collections.unmodifiableMap(fields.stream().collect(
-        Collectors.toMap(FieldType::getName, FieldType::getType)));
+    this.fields =
+        Collections.unmodifiableMap(
+            fields.stream().collect(Collectors.toMap(FieldType::getName, FieldType::getType)));
     this.primaryKeys = Collections.unmodifiableList(new ArrayList<>(primaryKeys));
     this.indexes = Collections.unmodifiableSet(new HashSet<>(indexes));
   }
@@ -185,7 +190,7 @@ public class StructuredTableSchema {
   public boolean isCompatible(StructuredTableSchema schema) {
     for (String field : getFieldNames()) {
       FieldType.Type type = schema.getType(field);
-      if (type == null || !getType(field).isCompatible(type)) {
+      if (type == null || !type.isCompatible(getType(field))) {
         return false;
       }
     }

--- a/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableAdminTest.java
+++ b/cdap-storage-spi/src/test/java/io/cdap/cdap/spi/data/StructuredTableAdminTest.java
@@ -127,6 +127,24 @@ public abstract class StructuredTableAdminTest {
   }
 
   @Test
+  public void testCreateOrUpdateTwiceShouldSucceed() throws Exception {
+    StructuredTableAdmin admin = getStructuredTableAdmin();
+
+    // Assert SIMPLE_TABLE Empty
+    Assert.assertFalse(admin.exists(SIMPLE_TABLE));
+
+    // Calling to createOrUpdate the same SIMPLE_TABLE spec twice to mimic the scenario of
+    // connecting to an exsting DB
+    admin.createOrUpdate(SIMPLE_TABLE_SPEC);
+    admin.createOrUpdate(SIMPLE_TABLE_SPEC);
+    Assert.assertTrue(admin.exists(SIMPLE_TABLE));
+
+    // Assert SIMPLE_TABLE schema
+    StructuredTableSchema simpleTableSchema = admin.getSchema(SIMPLE_TABLE);
+    Assert.assertEquals(simpleTableSchema, new StructuredTableSchema(SIMPLE_TABLE_SPEC));
+  }
+
+  @Test
   public void testBackwardCompatible() throws Exception {
     StructuredTableAdmin admin = getStructuredTableAdmin();
 


### PR DESCRIPTION
## What
1. Compare Spanner schema equality after compatibility conversion
2. Fixed a bug in StructuredTableSchema#isCompatible 

Passed tests:

<img width="468" alt="image" src="https://github.com/cdapio/cdap/assets/20428112/2a7644d4-2b65-4afc-b236-27594dcdf9b3">
