### PR TITLE
Enable feature flag for Wrangler filter pushdown by default

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5861,7 +5861,7 @@
 
   <property>
     <name>feature.wrangler.precondition.sql.enabled</name>
-    <value>false</value>
+    <value>true</value>
     <description>
       Enables the Precondition Language selector in Wrangler, allowing to select
       between JEXL and SQL preconditions.


### PR DESCRIPTION
This PR enables the Wrangler filter pushdown feature by default by setting `feature.wrangler.precondition.sql.enabled` to true, which causes the JEXL/SQL language selector to show up in Wrangler. A SQL expression in Wrangler will automatically become a candidate for pushdown.

This is required for Filter Pushdown GA.