### PR TITLE
[CDAP-20790] Enable routing requests through InternalRouterService

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java
@@ -144,7 +144,8 @@ public class MasterEnvironmentMain {
 
         RemoteClientFactory remoteClientFactory = new RemoteClientFactory(
             masterEnv.getDiscoveryServiceClientSupplier().get(),
-            getInternalAuthenticator(cConf), getRemoteAuthenticator(cConf));
+            getInternalAuthenticator(cConf), getRemoteAuthenticator(cConf),
+            cConf);
 
         MasterEnvironmentRunnableContext runnableContext =
             new DefaultMasterEnvironmentRunnableContext(context.getLocationFactory(),

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -2414,8 +2414,9 @@ public final class Constants {
    */
   public static final class InternalRouter {
 
-    public static final String BIND_ADDRESS = "app.program.internal.router.service.bind.address";
-    public static final String BIND_PORT = "app.program.internal.router.service.bind.port";
-    public static final String SSL_ENABLED = "app.program.internal.router.service.ssl.enabled";
+    public static final String BIND_ADDRESS = "internal.router.service.bind.address";
+    public static final String BIND_PORT = "internal.router.service.bind.port";
+    public static final String SSL_ENABLED = "internal.router.service.ssl.enabled";
+    public static final String INTERNAL_ROUTER_ENABLED = "internal.router.enabled";
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
@@ -17,51 +17,120 @@
 package io.cdap.cdap.common.internal.remote;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.InternalRouter;
+import io.cdap.cdap.common.conf.Constants.Service;
 import io.cdap.cdap.security.spi.authenticator.RemoteAuthenticator;
 import io.cdap.common.http.HttpRequestConfig;
-import javax.inject.Inject;
 import org.apache.twill.discovery.DiscoveryServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A factory to create {@link RemoteClient}.
  */
 public class RemoteClientFactory {
 
-  public static final HttpRequestConfig NO_VERIFY_HTTP_REQUEST_CONFIG = new HttpRequestConfig(15000,
+  public static final HttpRequestConfig NO_VERIFY_HTTP_REQUEST_CONFIG = new HttpRequestConfig(
+      15000,
       15000,
       false);
+  private static final Logger LOG = LoggerFactory.getLogger(
+      RemoteClientFactory.class);
   private final DiscoveryServiceClient discoveryClient;
   private final InternalAuthenticator internalAuthenticator;
   private final RemoteAuthenticator remoteAuthenticator;
   private final String pathPrefix;
+  private final boolean internalRouterEnabled;
 
   @VisibleForTesting
   public RemoteClientFactory(DiscoveryServiceClient discoveryClient,
       InternalAuthenticator internalAuthenticator) {
-    this(discoveryClient, internalAuthenticator, new NoOpRemoteAuthenticator(), "");
+    this(discoveryClient, internalAuthenticator, new NoOpRemoteAuthenticator(),
+        "", false);
   }
 
   @Inject
   public RemoteClientFactory(DiscoveryServiceClient discoveryClient,
       InternalAuthenticator internalAuthenticator,
-      RemoteAuthenticator remoteAuthenticator) {
-    this(discoveryClient, internalAuthenticator, remoteAuthenticator, "");
+      RemoteAuthenticator remoteAuthenticator, CConfiguration cConf) {
+    this(discoveryClient, internalAuthenticator, remoteAuthenticator, "",
+        cConf.getBoolean(InternalRouter.INTERNAL_ROUTER_ENABLED));
   }
 
   public RemoteClientFactory(DiscoveryServiceClient discoveryClient,
       InternalAuthenticator internalAuthenticator,
+      RemoteAuthenticator remoteAuthenticator) {
+    this(discoveryClient, internalAuthenticator, remoteAuthenticator, "",
+        false);
+  }
+
+
+  public RemoteClientFactory(DiscoveryServiceClient discoveryClient,
+      InternalAuthenticator internalAuthenticator,
       RemoteAuthenticator remoteAuthenticator, String pathPrefix) {
+    this(discoveryClient, internalAuthenticator, remoteAuthenticator,
+        pathPrefix, false);
+  }
+
+  /**
+   * Constructs a {@link RemoteClientFactory} for creating {@link RemoteClient}s
+   * for CDAP services.
+   *
+   * @param discoveryClient       Discovery client for getting discoverables.
+   * @param pathPrefix            URL prefix to be added to the base path of
+   *                              each client.
+   * @param internalRouterEnabled Boolean indicating whether the
+   *                              {@link InternalRouter} service for routing. If
+   *                              true, clients to the Internal Router service
+   *                              will be created and requests will be routed to
+   *                              destination services via the router.
+   */
+  public RemoteClientFactory(DiscoveryServiceClient discoveryClient,
+      InternalAuthenticator internalAuthenticator,
+      RemoteAuthenticator remoteAuthenticator, String pathPrefix,
+      boolean internalRouterEnabled) {
     this.discoveryClient = discoveryClient;
     this.internalAuthenticator = internalAuthenticator;
     this.remoteAuthenticator = remoteAuthenticator;
     this.pathPrefix = pathPrefix;
+    this.internalRouterEnabled = internalRouterEnabled;
   }
 
+  /**
+   * Creates a {@link RemoteClient}.
+   *
+   * @param discoverableServiceName Name of the CDAP service for which a client
+   *                                is requested.
+   * @param basePath                Common path prefix for all the requests that
+   *                                will be sent using the returned client.
+   * @return A {@link RemoteClient} for the requested service.
+   */
   public RemoteClient createRemoteClient(String discoverableServiceName,
-      HttpRequestConfig httpRequestConfig,
-      String basePath) {
-    basePath = basePath.startsWith("/") ? pathPrefix + basePath : pathPrefix + "/" + basePath;
-    return new RemoteClient(internalAuthenticator, discoveryClient, discoverableServiceName,
-        httpRequestConfig, basePath, remoteAuthenticator);
+      HttpRequestConfig httpRequestConfig, String basePath) {
+    basePath = basePath.startsWith("/") ? pathPrefix + basePath
+        : pathPrefix + "/" + basePath;
+    if (this.internalRouterEnabled) {
+      return getClientForInternalRouter(discoverableServiceName,
+          httpRequestConfig, basePath);
+    }
+    return new RemoteClient(internalAuthenticator, discoveryClient,
+        discoverableServiceName, httpRequestConfig, basePath,
+        remoteAuthenticator);
+  }
+
+  private RemoteClient getClientForInternalRouter(String destinationServiceName,
+      HttpRequestConfig httpRequestConfig, String basePath) {
+    LOG.trace(
+        "Creating client for service '{}' which routes through service '{}'.",
+        destinationServiceName, Service.INTERNAL_ROUTER);
+    String internalRouterPath = String.format("/%s/router/services/%s%s",
+        Constants.Gateway.INTERNAL_API_VERSION_3, destinationServiceName,
+        basePath);
+    return new RemoteClient(internalAuthenticator, discoveryClient,
+        Service.INTERNAL_ROUTER, httpRequestConfig, internalRouterPath,
+        remoteAuthenticator);
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5991,7 +5991,7 @@
 
   <!--Configuration for the Internal Router service -->
   <property>
-    <name>app.program.internal.router.service.bind.address</name>
+    <name>internal.router.service.bind.address</name>
     <value>0.0.0.0</value>
     <description>
       The address for the internal router service to bind to.
@@ -5999,7 +5999,7 @@
   </property>
 
   <property>
-    <name>app.program.internal.router.service.bind.port</name>
+    <name>internal.router.service.bind.port</name>
     <value>0</value>
     <description>
       The port for the internal router service to bind to.
@@ -6007,10 +6007,19 @@
   </property>
 
   <property>
-    <name>app.program.internal.router.service.ssl.enabled</name>
+    <name>internal.router.service.ssl.enabled</name>
     <value>${ssl.internal.enabled}</value>
     <description>
-      Enable usage of SSL for the internal router service. By default it is
+      Enable usage of SSL for the internal router service. By default, it is
+      disabled.
+    </description>
+  </property>
+
+  <property>
+    <name>internal.router.enabled</name>
+    <value>false</value>
+    <description>
+      Whether to route traffic for CDAP APIs through the internal router service. By default, it is
       disabled.
     </description>
   </property>

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/k8s/SparkContainerDriverLauncher.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/k8s/SparkContainerDriverLauncher.java
@@ -293,7 +293,7 @@ public class SparkContainerDriverLauncher {
                             @Nullable RemoteAuthenticator remoteAuthenticator) {
 
       RemoteClientFactory remoteClientFactory =
-        new RemoteClientFactory(discoveryServiceClient, internalAuthenticator, remoteAuthenticator);
+        new RemoteClientFactory(discoveryServiceClient, internalAuthenticator, remoteAuthenticator, cConf);
       this.artifactLocalizer = new ArtifactLocalizer(cConf, remoteClientFactory, artifactManagerFactory);
     }
 


### PR DESCRIPTION
## [CDAP-20790](https://cdap.atlassian.net/browse/CDAP-20790)

In https://github.com/cdapio/cdap/pull/15276 an InternalRouterService was introduced. This PR enables the usage of the new service if a property `app.program.internal.router.use` is set to `true`. In a future PR the property will be enabled for workers (preview runners, task workers, system workers) in the cdap-site copy that is localised during their deployment.

[CDAP-20790]: https://cdap.atlassian.net/browse/CDAP-20790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ