### PR TITLE
CDAP-20791 fix master service startup on Hadoop

### DIFF
--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
@@ -936,7 +936,12 @@ public class MasterServiceMain extends DaemonMain {
         try {
           MasterTwillApplication masterTwillApp = new MasterTwillApplication(cConf,
               getServiceInstances(serviceStore, cConf));
+          List<String> extraClassPath = masterTwillApp.prepareLocalizeResource(runDir, hConf);
           TwillPreparer preparer = twillRunner.prepare(masterTwillApp);
+          // Setup extra classpath. Currently twill doesn't support different classpath per runnable,
+          // hence we just set it for all containers. The actual jars are localized via the MasterTwillApplication,
+          // and having missing jars as specified in the classpath is ok.
+          preparer = preparer.withClassPaths(extraClassPath);
 
           Map<String, String> twillConfigs = new HashMap<>();
           if (!cConf.getBoolean(Constants.COLLECT_CONTAINER_LOGS)) {
@@ -978,12 +983,6 @@ public class MasterServiceMain extends DaemonMain {
 
           preparer.withApplicationClassPaths(yarnAppClassPath)
               .withBundlerClassAcceptor(new HadoopClassExcluder());
-
-          // Setup extra classpath. Currently twill doesn't support different classpath per runnable,
-          // hence we just set it for all containers. The actual jars are localized via the MasterTwillApplication,
-          // and having missing jars as specified in the classpath is ok.
-          List<String> extraClassPath = masterTwillApp.prepareLocalizeResource(runDir, hConf);
-          preparer = preparer.withClassPaths(extraClassPath);
 
           // Set the container to use MasterServiceMainClassLoader for class rewriting
           preparer.setClassLoader(MasterServiceMainClassLoader.class.getName());


### PR DESCRIPTION
Move hconf and cconf localization earlier so they are properly applied before creating the TwillPreparer.