### PR TITLE
[CDAP-20790] Localize cConf as a configmap and support use of the internal router in workers 

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceLauncher.java
@@ -52,6 +52,9 @@ import org.apache.twill.common.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Launches a pool of system workers.
+ */
 public class SystemWorkerServiceLauncher extends AbstractScheduledService {
 
   private static final Logger LOG = LoggerFactory.getLogger(SystemWorkerServiceLauncher.class);
@@ -64,6 +67,9 @@ public class SystemWorkerServiceLauncher extends AbstractScheduledService {
 
   private ScheduledExecutorService executor;
 
+   /**
+   * Default Constructor with injected configuration and {@link TwillRunner}.
+   */
   @Inject
   public SystemWorkerServiceLauncher(CConfiguration cConf, Configuration hConf,
       SConfiguration sConf,
@@ -113,6 +119,9 @@ public class SystemWorkerServiceLauncher extends AbstractScheduledService {
     return executor;
   }
 
+  /**
+   * Inner run method for the service.
+   */
   public void run() {
     TwillController activeController = null;
     for (TwillController controller : twillRunner.lookup(SystemWorkerTwillApplication.NAME)) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceLauncher.java
@@ -20,10 +20,13 @@ import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.inject.Inject;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.InternalRouter;
+import io.cdap.cdap.common.conf.Constants.SystemWorker;
 import io.cdap.cdap.common.conf.Constants.Twill.Security;
 import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
+import io.cdap.cdap.master.spi.twill.ExtendedTwillPreparer;
 import io.cdap.cdap.master.spi.twill.SecretDisk;
 import io.cdap.cdap.master.spi.twill.SecureTwillPreparer;
 import io.cdap.cdap.master.spi.twill.SecurityContext;
@@ -130,6 +133,11 @@ public class SystemWorkerServiceLauncher extends AbstractScheduledService {
         Path runDir = Files.createTempDirectory(tmpDir, "system.worker.launcher");
         try {
           CConfiguration cConfCopy = CConfiguration.copy(cConf);
+          // Enable the use of internal router in the system worker pods if
+          // required.
+          cConfCopy.setBoolean(InternalRouter.CLIENT_ENABLED,
+              cConf.getBoolean(SystemWorker.INTERNAL_ROUTER_ENABLED));
+
           Path cConfPath = runDir.resolve("cConf.xml");
           try (Writer writer = Files.newBufferedWriter(cConfPath, StandardCharsets.UTF_8)) {
             cConfCopy.writeXml(writer);
@@ -157,6 +165,14 @@ public class SystemWorkerServiceLauncher extends AbstractScheduledService {
               new SystemWorkerTwillApplication(cConfPath.toUri(), hConfPath.toUri(),
                   sConfPath.toUri(),
                   systemResourceSpec));
+          // If internal router is enabled, we need to localize the cdap-site copy
+          // as a configmap so that the init container also uses the internal
+          // router.
+          if (twillPreparer instanceof ExtendedTwillPreparer) {
+            twillPreparer = ((ExtendedTwillPreparer) twillPreparer)
+                .setShouldLocalizeConfigurationAsConfigmap(
+                    cConf.getBoolean(SystemWorker.INTERNAL_ROUTER_ENABLED));
+          }
 
           Map<String, String> configMap = new HashMap<>();
           configMap.put(ProgramOptionConstants.RUNTIME_NAMESPACE,

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -460,6 +460,7 @@ public final class Constants {
     public static final String CONTAINER_PRIORITY_CLASS_NAME = "preview.runner.container.priority.class.name";
     public static final String CONTAINER_JVM_OPTS = "preview.runner.container.jvm.opts";
     public static final String GCE_METADATA_HOST_ENV_VAR = "GCE_METADATA_HOST";
+    public static final String INTERNAL_ROUTER_ENABLED = "preview.runner.internal.router.enabled";
   }
 
   /**
@@ -520,6 +521,7 @@ public final class Constants {
         "task.worker.systemapp.http.client.read.timeout.ms";
     public static final String SYSTEMAPP_HTTP_CLIENT_CONNECTION_TIMEOUT_MS =
         "task.worker.systemapp.http.client.connection.timeout.ms";
+    public static final String INTERNAL_ROUTER_ENABLED = "task.worker.internal.router.enabled";
 
     /**
      * Task worker http handler configuration.
@@ -551,6 +553,7 @@ public final class Constants {
     public static final String HTTP_CLIENT_CONNECTION_TIMEOUT_MS = "system.worker.http.client.connection.timeout.ms";
     public static final String TWILL_CONTROLLER_START_SECONDS = "system.worker.program.twill.controller.start.seconds";
     public static final String ARTIFACT_LOCALIZER_ENABLED = "system.worker.artifact.localizer.enabled";
+    public static final String INTERNAL_ROUTER_ENABLED = "system.worker.internal.router.enabled";
 
     /**
      * System worker http handler configuration.

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3744,6 +3744,15 @@
   </property>
 
   <property>
+    <name>preview.runner.internal.router.enabled</name>
+    <value>false</value>
+    <description>
+     Whether to route requests from preview runners through the internal router service. This
+      is only applicable for k8s environment presently. By default, it is disabled.
+    </description>
+  </property>
+
+  <property>
     <name>service.retry.policy.base.delay.ms</name>
     <value>100</value>
     <description>
@@ -5278,6 +5287,15 @@
   </property>
 
   <property>
+    <name>task.worker.internal.router.enabled</name>
+    <value>false</value>
+    <description>
+     Whether to route requests from task workers through the internal router service. This
+      is only applicable for k8s environment presently. By default, it is disabled.
+    </description>
+  </property>
+
+  <property>
     <name>task.worker.container.jvm.opts</name>
     <value>-XX:+UseG1GC -XX:+ExitOnOutOfMemoryError</value>
     <description>
@@ -5456,6 +5474,15 @@
     <value>workflow</value>
     <description>
       comma separated list of ProgramTypes
+    </description>
+  </property>
+
+  <property>
+    <name>system.worker.internal.router.enabled</name>
+    <value>false</value>
+    <description>
+     Whether to route requests from system workers through the internal router service. This
+      is only applicable for k8s environment presently. By default, it is disabled.
     </description>
   </property>
 

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
@@ -24,17 +24,25 @@ import io.kubernetes.client.openapi.models.V1Job;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1OwnerReference;
 import io.kubernetes.client.openapi.models.V1PodSecurityContext;
+import io.kubernetes.client.openapi.models.V1PodSpec;
 import io.kubernetes.client.openapi.models.V1ResourceRequirements;
+import io.kubernetes.client.openapi.models.V1Volume;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.twill.api.AbstractTwillRunnable;
+import org.apache.twill.api.Configs;
 import org.apache.twill.api.ResourceSpecification;
+import org.apache.twill.api.RunId;
+import org.apache.twill.api.RuntimeSpecification;
 import org.apache.twill.api.TwillSpecification;
+import org.apache.twill.filesystem.LocalLocationFactory;
 import org.apache.twill.filesystem.LocationFactory;
 import org.apache.twill.internal.DefaultResourceSpecification;
+import org.apache.twill.internal.DefaultRuntimeSpecification;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,7 +54,7 @@ public class KubeTwillPreparerTest {
 
   private MasterEnvironmentContext createMasterEnvironmentContext() {
     return new MasterEnvironmentContext() {
-      private final Map<String, String> configurations = new HashMap<>();
+      private final Map<String, String> configurations = getTwillConfigs();
 
       @Override
       public LocationFactory getLocationFactory() {
@@ -133,7 +141,7 @@ public class KubeTwillPreparerTest {
       Assert.assertThat(ex.toString(), CoreMatchers.containsString(SidecarRunnable2.class.getSimpleName()));
     }
 
-    // test catching missing runnable in twill specfication
+    // test catching missing runnable in twill specification
     try {
       preparer.dependentRunnableNames(MainRunnable.class.getSimpleName(),
                                       SidecarRunnable.class.getSimpleName(),
@@ -276,20 +284,117 @@ public class KubeTwillPreparerTest {
   @Test(expected = IllegalArgumentException.class)
   public void testCreateUserResourceSpecificationInvalidProgramMemoryMultiplier() throws Exception {
     MasterEnvironmentContext masterEnvironmentContext = createMasterEnvironmentContext();
-    masterEnvironmentContext.getConfigurations().put(KubeTwillPreparer.PROGRAM_MEMORY_MULTIPLIER, "2");
-    KubeTwillPreparer preparer = new KubeTwillPreparer(masterEnvironmentContext, null, "default",
-                                                       createPodInfo(), createTwillSpecification(), null, null,
-                                                       null, null, null);
+    masterEnvironmentContext.getConfigurations()
+        .put(KubeTwillPreparer.PROGRAM_MEMORY_MULTIPLIER, "2");
+    KubeTwillPreparer preparer = new KubeTwillPreparer(masterEnvironmentContext,
+        null, "default",
+        createPodInfo(), createTwillSpecification(), null, null,
+        null, null, null);
     Map<String, String> config = new HashMap<>();
     config.put(MasterOptionConstants.RUNTIME_NAMESPACE, "non-system-namespace");
     preparer.withConfiguration(config);
 
-    ResourceSpecification resourceSpecification = new DefaultResourceSpecification(1, 100, 1, 1, 1);
+    ResourceSpecification resourceSpecification = new DefaultResourceSpecification(
+        1, 100, 1, 1, 1);
     preparer.createResourceRequirements(resourceSpecification);
   }
 
+  @Test
+  public void testCreatePodSpecUserNameSpace() throws Exception {
+    MasterEnvironmentContext masterEnvironmentContext = createMasterEnvironmentContext();
+    KubeTwillPreparer preparer = new KubeTwillPreparer(masterEnvironmentContext,
+        null, "default",
+        createPodInfo(), createTwillSpecification(), createRunId("abc-123"),
+        null,
+        null, null, null);
+    preparer.withConfiguration(
+        Collections.singletonMap(MasterOptionConstants.RUNTIME_NAMESPACE,
+            "non-system"));
+    RuntimeSpecification runtimeSpec = new DefaultRuntimeSpecification(
+        MainRunnable.class.getSimpleName(), null, createResourceSpecification(),
+        Collections.emptyList());
+
+    V1PodSpec podSpec = preparer.createPodSpec(new LocalLocationFactory().create("yes"),
+        Collections.singletonMap(MainRunnable.class.getSimpleName(),
+            runtimeSpec));
+    Set<String> configmapsNames = podSpec.getVolumes().stream()
+        .map(V1Volume::getName)
+        .collect(Collectors.toSet());
+
+    Assert.assertTrue(configmapsNames.contains("cdap-config-abc-123"));
+    Assert.assertTrue(podSpec.getContainers().get(0).getVolumeMounts().stream()
+        .anyMatch(v -> v.getName().equals("cdap-config-abc-123") && v.getMountPath().equals("/config")));
+  }
+
+  @Test
+  public void testCreatePodSpecSystemNameSpace() throws Exception {
+    MasterEnvironmentContext masterEnvironmentContext = createMasterEnvironmentContext();
+    KubeTwillPreparer preparer = new KubeTwillPreparer(masterEnvironmentContext,
+        null, "default",
+        createPodInfo(), createTwillSpecification(), createRunId("abc-123"),
+        null,
+        null, null, null);
+    preparer.withConfiguration(
+        Collections.singletonMap(MasterOptionConstants.RUNTIME_NAMESPACE,
+            "system"));
+    RuntimeSpecification runtimeSpec = new DefaultRuntimeSpecification(
+        MainRunnable.class.getSimpleName(), null, createResourceSpecification(),
+        Collections.emptyList());
+
+    V1PodSpec podSpec = preparer.createPodSpec(new LocalLocationFactory().create("yes"),
+        Collections.singletonMap(MainRunnable.class.getSimpleName(),
+            runtimeSpec));
+    Set<String> configmapsNames = podSpec.getVolumes().stream()
+        .map(V1Volume::getName)
+        .collect(Collectors.toSet());
+
+    Assert.assertFalse(configmapsNames.contains("cdap-config-abc-123"));
+    Assert.assertFalse(podSpec.getContainers().get(0).getVolumeMounts().stream()
+        .anyMatch(v -> v.getName().equals("cdap-config-abc-123") && v.getMountPath().equals("/config")));
+  }
+
+  @Test
+  public void testCreatePodSpecSystemNamespaceWithConfigmapOption()
+      throws Exception {
+    MasterEnvironmentContext masterEnvironmentContext = createMasterEnvironmentContext();
+    KubeTwillPreparer preparer = new KubeTwillPreparer(masterEnvironmentContext,
+        null, "default",
+        createPodInfo(), createTwillSpecification(), createRunId("abc-123"),
+        null,
+        null, null, null);
+    preparer.withConfiguration(
+        Collections.singletonMap(MasterOptionConstants.RUNTIME_NAMESPACE,
+            "system"));
+    preparer.setShouldLocalizeConfigurationAsConfigmap(true);
+    RuntimeSpecification runtimeSpec = new DefaultRuntimeSpecification(
+        MainRunnable.class.getSimpleName(), null, createResourceSpecification(),
+        Collections.emptyList());
+
+    V1PodSpec podSpec = preparer.createPodSpec(new LocalLocationFactory().create("yes"),
+        Collections.singletonMap(MainRunnable.class.getSimpleName(),
+            runtimeSpec));
+    Set<String> configmapsNames = podSpec.getVolumes().stream()
+        .map(V1Volume::getName)
+        .collect(Collectors.toSet());
+
+    Assert.assertTrue(configmapsNames.contains("cdap-config-abc-123"));
+    Assert.assertTrue(podSpec.getContainers().get(0).getVolumeMounts().stream()
+        .anyMatch(v -> v.getName().equals("cdap-config-abc-123") && v.getMountPath().equals("/config")));
+  }
+
+  private static Map<String, String> getTwillConfigs() {
+    HashMap<String, String> cConf = new HashMap<>();
+    cConf.put(Configs.Keys.JAVA_RESERVED_MEMORY_MB, "1024");
+    cConf.put(Configs.Keys.HEAP_RESERVED_MIN_RATIO, "0.5");
+    return cConf;
+  }
+
+  private RunId createRunId(String id) {
+    return () -> id;
+  }
 
   public static class MainRunnable extends AbstractTwillRunnable {
+
     @Override
     public void run() {
 
@@ -297,6 +402,7 @@ public class KubeTwillPreparerTest {
   }
 
   public static class SidecarRunnable extends AbstractTwillRunnable {
+
     @Override
     public void run() {
 

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
@@ -267,7 +267,7 @@ public class KubeTwillPreparerTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testCreateUserResourceSpecificationInvalidProgramCPUMultiplier() throws Exception {
+  public void testCreateUserResourceSpecificationInvalidProgramCpuMultiplier() throws Exception {
     MasterEnvironmentContext masterEnvironmentContext = createMasterEnvironmentContext();
     masterEnvironmentContext.getConfigurations().put(KubeTwillPreparer.PROGRAM_CPU_MULTIPLIER, "2");
     KubeTwillPreparer preparer = new KubeTwillPreparer(masterEnvironmentContext, null, "default",

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillPreparer.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillPreparer.java
@@ -25,9 +25,23 @@ import org.apache.twill.api.TwillPreparer;
 public interface ExtendedTwillPreparer extends TwillPreparer {
 
   /**
-   * Set size limit for workdir volume in kube twill application which is an emptydir.
+   * Set size limit for workdir volume in kube twill application which is an
+   * emptydir.
    *
    * @param sizeLimitInMB volume size limit in MB
    */
   ExtendedTwillPreparer setWorkdirSizeLimit(int sizeLimitInMB);
+
+  /**
+   * Sets whether config files such as cdap-site.xml should be localized using
+   * kubernetes configmaps instead of having the init container fetch them. This
+   * ensures that the init container runs with the same configuration as the
+   * twill runables. Configmaps have a size limit of 1MiB, so they can't be used
+   * to localize larger files.
+   *
+   * @param shouldLocalizeConfigurationAsConfigmap whether to localize config
+   *                                               files using configmaps
+   */
+  ExtendedTwillPreparer setShouldLocalizeConfigurationAsConfigmap(
+      boolean shouldLocalizeConfigurationAsConfigmap);
 }

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillPreparer.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillPreparer.java
@@ -28,9 +28,9 @@ public interface ExtendedTwillPreparer extends TwillPreparer {
    * Set size limit for workdir volume in kube twill application which is an
    * emptydir.
    *
-   * @param sizeLimitInMB volume size limit in MB
+   * @param sizeLimitInMiB volume size limit in Mega Bytes
    */
-  ExtendedTwillPreparer setWorkdirSizeLimit(int sizeLimitInMB);
+  ExtendedTwillPreparer setWorkdirSizeLimit(int sizeLimitInMiB);
 
   /**
    * Sets whether config files such as cdap-site.xml should be localized using


### PR DESCRIPTION
## [CDAP-20790](https://cdap.atlassian.net/browse/CDAP-20790)
This change allows enabling the use of the internal router service system workers, task worker and preview runner pods.

This change also localizes cdap-site.xml as a k8s configmap instead of having the file localizer init container fetch it from GCS through appfabric. This allows the init container to use the copy cdap-site which has the property to use the internal router enabled. This is a requirement when the worker pods can't directly communicate with Appfabric. If the init container uses the original cdap-site, it will try to reach out to appfabric directly and fail with connection timeouts.


### Tested
Deployed the changes to a k8s cluster and verified that the the init container and the regular containers are using the internal router when the cdap-site property is enabled.

[CDAP-20790]: https://cdap.atlassian.net/browse/CDAP-20790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ