### PR TITLE
[CDAP-20795] Create NamespaceWorkloadIdentity and GcpWorkloadIdentityHandler

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/namespace/DefaultNamespaceAdmin.java
@@ -415,6 +415,10 @@ public final class DefaultNamespaceAdmin implements NamespaceAdmin {
       builder.setDescription(namespaceMeta.getDescription());
     }
 
+    if (Strings.isNullOrEmpty(existingMeta.getIdentity())) {
+      builder.setIdentity(getIdentity(namespaceId));
+    }
+
     NamespaceConfig config = namespaceMeta.getConfig();
     if (config != null && !Strings.isNullOrEmpty(config.getSchedulerQueueName())) {
       builder.setSchedulerQueueName(config.getSchedulerQueueName());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/credential/DefaultCredentialProviderService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/credential/DefaultCredentialProviderService.java
@@ -18,7 +18,7 @@ package io.cdap.cdap.internal.credential;
 
 import com.google.common.util.concurrent.AbstractIdleService;
 import io.cdap.cdap.common.conf.CConfiguration;
-import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.credential.CredentialIdentity;
 import io.cdap.cdap.proto.credential.CredentialProfile;
@@ -51,7 +51,7 @@ public class DefaultCredentialProviderService extends AbstractIdleService
   private final Map<String, CredentialProvider> credentialProviders;
   private final CredentialIdentityManager credentialIdentityManager;
   private final CredentialProfileManager credentialProfileManager;
-  private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final NamespaceAdmin namespaceAdmin;
 
   @Inject
   DefaultCredentialProviderService(CConfiguration cConf,
@@ -59,17 +59,18 @@ public class DefaultCredentialProviderService extends AbstractIdleService
       CredentialProviderLoader credentialProviderLoader,
       CredentialIdentityManager credentialIdentityManager,
       CredentialProfileManager credentialProfileManager,
-      NamespaceQueryAdmin namespaceQueryAdmin) {
+      NamespaceAdmin namespaceAdmin) {
     this.cConf = cConf;
     this.contextAccessEnforcer = contextAccessEnforcer;
     this.credentialProviders = credentialProviderLoader.loadCredentialProviders();
     this.credentialIdentityManager = credentialIdentityManager;
     this.credentialProfileManager = credentialProfileManager;
-    this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.namespaceAdmin = namespaceAdmin;
   }
 
   @Override
   protected void startUp() throws Exception {
+
     for (CredentialProvider provider : credentialProviders.values()) {
       provider.initialize(new DefaultCredentialProviderContext(cConf, provider.getName()));
     }
@@ -100,7 +101,7 @@ public class DefaultCredentialProviderService extends AbstractIdleService
     contextAccessEnforcer.enforce(identityId, StandardPermission.USE);
     NamespaceMeta namespaceMeta;
     try {
-      namespaceMeta = namespaceQueryAdmin.get(new NamespaceId(namespace));
+      namespaceMeta = namespaceAdmin.get(new NamespaceId(namespace));
     } catch (Exception e) {
       throw new IOException(String.format("Failed to get namespace '%s' metadata",
           namespace), e);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/credential/guice/MasterCredentialProviderModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/credential/guice/MasterCredentialProviderModule.java
@@ -22,7 +22,10 @@ import io.cdap.cdap.internal.credential.CredentialProviderExtensionLoader;
 import io.cdap.cdap.internal.credential.CredentialProviderLoader;
 import io.cdap.cdap.internal.credential.CredentialProviderService;
 import io.cdap.cdap.internal.credential.DefaultCredentialProviderService;
+import io.cdap.cdap.internal.namespace.credential.DefaultNamespaceCredentialProviderService;
+import io.cdap.cdap.internal.namespace.credential.NamespaceCredentialProviderService;
 import io.cdap.cdap.proto.credential.CredentialProvider;
+import io.cdap.cdap.proto.credential.NamespaceCredentialProvider;
 
 /**
  * Credential provider module for AppFabric.
@@ -35,5 +38,9 @@ public class MasterCredentialProviderModule extends AbstractModule {
     bind(CredentialProviderService.class).to(DefaultCredentialProviderService.class)
         .in(Scopes.SINGLETON);
     bind(CredentialProviderLoader.class).to(CredentialProviderExtensionLoader.class);
+    bind(NamespaceCredentialProvider.class).to(NamespaceCredentialProviderService.class)
+        .in(Scopes.SINGLETON);
+    bind(NamespaceCredentialProviderService.class)
+        .to(DefaultNamespaceCredentialProviderService.class).in(Scopes.SINGLETON);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/DefaultNamespaceCredentialProviderService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/DefaultNamespaceCredentialProviderService.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.namespace.credential;
+
+import com.google.common.base.Strings;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.AlreadyExistsException;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.namespace.NamespaceAdmin;
+import io.cdap.cdap.internal.credential.CredentialProfileManager;
+import io.cdap.cdap.master.environment.MasterEnvironments;
+import io.cdap.cdap.master.spi.environment.MasterEnvironment;
+import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.credential.CredentialProfile;
+import io.cdap.cdap.proto.credential.CredentialProvider;
+import io.cdap.cdap.proto.credential.CredentialProvisioningException;
+import io.cdap.cdap.proto.credential.NotFoundException;
+import io.cdap.cdap.proto.credential.ProvisionedCredential;
+import io.cdap.cdap.proto.id.CredentialProfileId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.security.NamespacePermission;
+import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
+import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Default implementation for {@link NamespaceCredentialProviderService} used in AppFabric.
+ */
+public class DefaultNamespaceCredentialProviderService extends AbstractIdleService
+    implements NamespaceCredentialProviderService {
+
+  private static final String CREDENTIAL_PROVIDER_NAME = "gcp-wi-credential-provider";
+  private final CredentialProvider credentialProvider;
+  private final NamespaceAdmin namespaceAdmin;
+  private final ContextAccessEnforcer contextAccessEnforcer;
+  private final CredentialProfileManager credentialProfileManager;
+  private final CConfiguration cConf;
+
+
+  @Inject
+  DefaultNamespaceCredentialProviderService(CConfiguration cConf,
+      CredentialProvider credentialProvider, ContextAccessEnforcer contextAccessEnforcer,
+      NamespaceAdmin namespaceAdmin, CredentialProfileManager credentialProfileManager) {
+    this.cConf = cConf;
+    this.credentialProvider = credentialProvider;
+    this.contextAccessEnforcer = contextAccessEnforcer;
+    this.namespaceAdmin = namespaceAdmin;
+    this.credentialProfileManager = credentialProfileManager;
+  }
+
+  /**
+   * Provisions a short-lived credential for the provided identity using the provided identity.
+   *
+   * @param namespace The identity namespace.
+   * @param scopes A comma separated list of OAuth scopes requested.
+   * @return A short-lived credential.
+   * @throws CredentialProvisioningException If provisioning the credential fails.
+   * @throws IOException If any transport errors occur.
+   * @throws NotFoundException If the profile or identity are not found.
+   */
+  @Override
+  public ProvisionedCredential provision(String namespace, String scopes)
+      throws CredentialProvisioningException, IOException, NotFoundException {
+    contextAccessEnforcer.enforce(new NamespaceId(namespace),
+        NamespacePermission.PROVISION_CREDENTIAL);
+    NamespaceMeta namespaceMeta;
+    try {
+      namespaceMeta = namespaceAdmin.get(new NamespaceId(namespace));
+    } catch (Exception e) {
+      throw new IOException(String.format("Failed to get namespace '%s' metadata",
+          namespace), e);
+    }
+    String identityName =
+        GcpWorkloadIdentityUtil.getWorkloadIdentityName(namespaceMeta.getIdentity());
+    switchToInternalUser();
+    return credentialProvider.provision(namespace, identityName, scopes);
+  }
+
+  private void switchToInternalUser() {
+    SecurityRequestContext.reset();
+  }
+
+  /**
+   * Start the service.
+   */
+  @Override
+  protected void startUp() throws Exception {
+    // Updates the namespaces and creates the identities if not exist.
+    List<NamespaceMeta> namespaceMetaList = namespaceAdmin.list();
+    for (NamespaceMeta namespaceMeta : namespaceMetaList) {
+      if (Strings.isNullOrEmpty(namespaceMeta.getIdentity())) {
+        String identityName = namespaceAdmin.getIdentity(namespaceMeta.getNamespaceId());
+        MasterEnvironment masterEnv = MasterEnvironments.getMasterEnvironment();
+        if (masterEnv != null
+            && !cConf.getBoolean(Constants.Namespace.NAMESPACE_CREATION_HOOK_ENABLED)) {
+          masterEnv.createIdentity(NamespaceId.DEFAULT.getNamespace(), identityName);
+        }
+        NamespaceMeta newNamespaceMeta =
+            new NamespaceMeta.Builder(namespaceMeta)
+                .setIdentity(identityName)
+                .build();
+        namespaceAdmin.updateProperties(newNamespaceMeta.getNamespaceId(), newNamespaceMeta);
+      }
+    }
+    // create the system profile if not exists.
+    createSystemProfileIfNotExists();
+  }
+
+  private void createSystemProfileIfNotExists() throws BadRequestException, IOException {
+    CredentialProfileId profileId = new CredentialProfileId(NamespaceId.SYSTEM.getNamespace(),
+        GcpWorkloadIdentityUtil.SYSTEM_PROFILE_NAME);
+    CredentialProfile profile = new CredentialProfile(
+        CREDENTIAL_PROVIDER_NAME,
+        "System Credential Profile for GCP Workload Identity Credential Provider",
+        Collections.emptyMap());
+    try {
+      credentialProfileManager.create(profileId, profile);
+    } catch (AlreadyExistsException e) {
+      // ignore if the profile already exists.
+    }
+  }
+
+  /**
+   * Stop the service.
+   */
+  @Override
+  protected void shutDown() throws Exception {
+
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/GcpWorkloadIdentityUtil.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/GcpWorkloadIdentityUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.namespace.credential;
+
+import io.cdap.cdap.proto.credential.NamespaceWorkloadIdentity;
+
+/**
+ * Utility class for {@link NamespaceWorkloadIdentity} associated with
+ * the namespace.
+ */
+public final class GcpWorkloadIdentityUtil {
+
+  private static final String NAMESPACE_IDENTITY_NAME_PREFIX = "ns-gcp-wi";
+
+  public static final String SYSTEM_PROFILE_NAME = "ns-gcp-wi";
+
+  /**
+   * Returns the namespace workload identity name.
+   *
+   * @param identityName The name of identity provided.
+   * @return namespace workload identity name.
+   */
+  public static String getWorkloadIdentityName(String identityName) {
+    return String.format("%s-%s", NAMESPACE_IDENTITY_NAME_PREFIX, identityName);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/NamespaceCredentialProviderService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/NamespaceCredentialProviderService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.namespace.credential;
+
+import com.google.common.util.concurrent.Service;
+import io.cdap.cdap.proto.credential.NamespaceCredentialProvider;
+
+/**
+ * A service which provides credentials based on identity and profile associated with the namespace.
+ */
+public interface NamespaceCredentialProviderService extends NamespaceCredentialProvider, Service {
+
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/RemoteNamespaceCredentialProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/RemoteNamespaceCredentialProvider.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.namespace.credential;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.retry.Idempotency;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.InternalAuthenticator;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.internal.credential.RemoteCredentialProvider;
+import io.cdap.cdap.proto.BasicThrowable;
+import io.cdap.cdap.proto.codec.BasicThrowableCodec;
+import io.cdap.cdap.proto.credential.CredentialProvisioningException;
+import io.cdap.cdap.proto.credential.NamespaceCredentialProvider;
+import io.cdap.cdap.proto.credential.NotFoundException;
+import io.cdap.cdap.proto.credential.ProvisionedCredential;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.io.IOException;
+import joptsimple.internal.Strings;
+
+/**
+ * Remote implementation for {@link NamespaceCredentialProvider} used in
+ * {@link io.cdap.cdap.common.conf.Constants.ArtifactLocalizer}.
+ */
+public class RemoteNamespaceCredentialProvider implements NamespaceCredentialProvider {
+  private static final Gson GSON = new GsonBuilder().registerTypeAdapter(BasicThrowable.class,
+      new BasicThrowableCodec()).create();
+  private final RemoteClient remoteClient;
+
+  /**
+   * Construct the {@link RemoteCredentialProvider}.
+   *
+   * @param remoteClientFactory A factory to create {@link RemoteClient}.
+   * @param internalAuthenticator An authenticator to propagate internal identity headers.
+   */
+  public RemoteNamespaceCredentialProvider(RemoteClientFactory remoteClientFactory,
+      InternalAuthenticator internalAuthenticator) {
+
+    this.remoteClient = remoteClientFactory.createRemoteClient(Constants.Service.APP_FABRIC_HTTP,
+        RemoteClientFactory.NO_VERIFY_HTTP_REQUEST_CONFIG, Constants.Gateway.INTERNAL_API_VERSION_3,
+        internalAuthenticator);
+  }
+
+  /**
+   * Provisions a short-lived credential for the provided identity using the provided identity.
+   *
+   * @param namespace The identity namespace.
+   * @param scopes A comma separated list of OAuth scopes requested.
+   * @return A short-lived credential.
+   * @throws CredentialProvisioningException If provisioning the credential fails.
+   * @throws IOException If any transport errors occur.
+   * @throws NotFoundException If the profile or identity are not found.
+   */
+  @Override
+  public ProvisionedCredential provision(String namespace, String scopes)
+      throws CredentialProvisioningException, IOException, NotFoundException {
+    String url = String.format("namespaces/%s/credentials/workloadIdentity/provision",
+        namespace);
+    if (!Strings.isNullOrEmpty(scopes)) {
+      url = String.format("%s?scopes=%s", url, scopes);
+    }
+    io.cdap.common.http.HttpRequest tokenRequest =
+        remoteClient.requestBuilder(HttpMethod.GET, url).build();
+    HttpResponse response = remoteClient.execute(tokenRequest, Idempotency.NONE);
+
+    if (response.getResponseCode() == HttpResponseStatus.NOT_FOUND.code()) {
+      throw new NotFoundException(
+          String.format("Credential Identity not found for namespace '%s'.", namespace));
+    }
+
+    if (response.getResponseCode() != HttpResponseStatus.OK.code()) {
+      throw new CredentialProvisioningException(String.format(
+          "Failed to provision credential with response code: %s and error: %s",
+          response.getResponseCode(),
+          response.getResponseBodyAsString()));
+    }
+
+    return GSON.fromJson(response.getResponseBodyAsString(), ProvisionedCredential.class);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/handler/GcpWorkloadIdentityHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/handler/GcpWorkloadIdentityHttpHandler.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.namespace.credential.handler;
+
+import com.google.common.base.Strings;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.cdap.cdap.common.AlreadyExistsException;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.NamespaceNotFoundException;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.conf.Constants.Gateway;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.internal.credential.CredentialIdentityManager;
+import io.cdap.cdap.internal.credential.CredentialProfileManager;
+import io.cdap.cdap.internal.namespace.credential.GcpWorkloadIdentityUtil;
+import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.credential.CredentialIdentity;
+import io.cdap.cdap.proto.credential.CredentialProvider;
+import io.cdap.cdap.proto.credential.IdentityValidationException;
+import io.cdap.cdap.proto.credential.NamespaceWorkloadIdentity;
+import io.cdap.cdap.proto.id.CredentialIdentityId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.security.NamespacePermission;
+import io.cdap.cdap.security.spi.authentication.SecurityRequestContext;
+import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * {@link HttpHandler} for namespace identity providers.
+ */
+@Singleton
+@Path(Gateway.API_VERSION_3)
+public class GcpWorkloadIdentityHttpHandler extends AbstractHttpHandler {
+  private static final Gson GSON = new Gson();
+
+  private final ContextAccessEnforcer accessEnforcer;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final CredentialIdentityManager credentialIdentityManager;
+  private final CredentialProfileManager credentialProfileManager;
+  private final CredentialProvider credentialProvider;
+
+  @Inject
+  GcpWorkloadIdentityHttpHandler(ContextAccessEnforcer accessEnforcer,
+      NamespaceQueryAdmin namespaceQueryAdmin,
+      CredentialIdentityManager credentialIdentityManager,
+      CredentialProfileManager credentialProfileManager,
+      CredentialProvider credentialProvider) {
+    this.accessEnforcer = accessEnforcer;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.credentialIdentityManager = credentialIdentityManager;
+    this.credentialProfileManager = credentialProfileManager;
+    this.credentialProvider = credentialProvider;
+  }
+
+  /**
+   * Validates a credential identity.
+   *
+   * @param request   The HTTP request.
+   * @param responder The HTTP responder.
+   * @throws BadRequestException If identity validation fails.
+   * @throws NotFoundException   If the associated profile is not found.
+   * @throws IOException         If transport errors occur.
+   */
+  @POST
+  @Path("/namespaces/{namespace-id}/credentials/workloadIdentity/validate")
+  public void validateIdentity(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace) throws Exception {
+    accessEnforcer.enforce(new NamespaceId(namespace), NamespacePermission.PROVISION_CREDENTIAL);
+    NamespaceWorkloadIdentity namespaceWorkloadIdentity =
+        deserializeRequestContent(request, NamespaceWorkloadIdentity.class);
+    if (Strings.isNullOrEmpty(namespaceWorkloadIdentity.getIdentity())) {
+      throw new BadRequestException("Identity cannot be null or empty.");
+    }
+    NamespaceMeta namespaceMeta = getNamespaceMeta(namespace);
+    validateNamespaceIdentity(namespaceMeta, namespaceWorkloadIdentity);
+    CredentialIdentity credentialIdentity = new CredentialIdentity(
+        NamespaceId.SYSTEM.getNamespace(), GcpWorkloadIdentityUtil.SYSTEM_PROFILE_NAME,
+        namespaceWorkloadIdentity.getIdentity(),
+        namespaceWorkloadIdentity.getServiceAccount());
+    switchToInternalUser();
+    try {
+      credentialProvider.validateIdentity(namespaceMeta, credentialIdentity);
+    } catch (IdentityValidationException e) {
+      throw new BadRequestException(String.format("Identity validation failed with error: %s",
+          e.getMessage()), e);
+    } catch (io.cdap.cdap.proto.credential.NotFoundException e) {
+      throw new NotFoundException(e.getMessage());
+    }
+    responder.sendJson(HttpResponseStatus.OK, "Namespace identity validated successfully");
+  }
+
+  /**
+   * Fetches a credential identity.
+   *
+   * @param request      The HTTP request.
+   * @param responder    The HTTP responder.
+   * @param namespace    The identity namespace.
+   * @throws BadRequestException If the identity name is invalid.
+   * @throws IOException         If transport errors occur.
+   * @throws NotFoundException   If the namespace or identity are not found.
+   */
+  @GET
+  @Path("/namespaces/{namespace-id}/credentials/workloadIdentity")
+  public void getIdentity(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace) throws Exception {
+    NamespaceMeta namespaceMeta = getNamespaceMeta(namespace);
+    CredentialIdentityId credentialIdentityId = createIdentityIdOrPropagate(namespace,
+        GcpWorkloadIdentityUtil.getWorkloadIdentityName(namespaceMeta.getIdentity()));
+    switchToInternalUser();
+    Optional<CredentialIdentity> identity = credentialIdentityManager.get(credentialIdentityId);
+    if (!identity.isPresent()) {
+      throw new NotFoundException("Namespace identity not found.");
+    }
+    NamespaceWorkloadIdentity workloadIdentity = new NamespaceWorkloadIdentity(
+        identity.get().getIdentity(), identity.get().getSecureValue());
+    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(workloadIdentity));
+  }
+
+  /**
+   * Creates a new identity.
+   *
+   * @param request   The HTTP request.
+   * @param responder The HTTP responder.
+   * @param namespace The identity namespace.
+   * @throws AlreadyExistsException If the identity exists.
+   * @throws BadRequestException    If the identity name or identity are invalid.
+   * @throws IOException            If transport errors occur.
+   * @throws NotFoundException      If the namespace is not found.
+   */
+  @PUT
+  @Path("/namespaces/{namespace-id}/credentials/workloadIdentity")
+  public void createIdentity(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace) throws Exception {
+    accessEnforcer.enforce(new NamespaceId(namespace), NamespacePermission.SET_SERVICE_ACCOUNT);
+    NamespaceWorkloadIdentity namespaceWorkloadIdentity =
+        deserializeRequestContent(request, NamespaceWorkloadIdentity.class);
+    if (Strings.isNullOrEmpty(namespaceWorkloadIdentity.getIdentity())) {
+      throw new BadRequestException("Identity cannot be null or empty.");
+    }
+    NamespaceMeta namespaceMeta = getNamespaceMeta(namespace);
+    validateNamespaceIdentity(namespaceMeta, namespaceWorkloadIdentity);
+    CredentialIdentityId credentialIdentityId = createIdentityIdOrPropagate(namespace,
+        GcpWorkloadIdentityUtil.getWorkloadIdentityName(namespaceMeta.getIdentity()));
+    switchToInternalUser();
+    Optional<CredentialIdentity> identity = credentialIdentityManager.get(credentialIdentityId);
+    CredentialIdentity credentialIdentity = new CredentialIdentity(
+        NamespaceId.SYSTEM.getNamespace(), GcpWorkloadIdentityUtil.SYSTEM_PROFILE_NAME,
+        namespaceMeta.getIdentity(), namespaceWorkloadIdentity.getServiceAccount());
+    if (identity.isPresent()) {
+      credentialIdentityManager.update(credentialIdentityId, credentialIdentity);
+    } else {
+      credentialIdentityManager.create(credentialIdentityId, credentialIdentity);
+    }
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  /**
+   * Deletes an identity.
+   *
+   * @param request      The HTTP request.
+   * @param responder    The HTTP responder.
+   * @param namespace    The identity namespace.
+   * @throws BadRequestException If the identity name is invalid.
+   * @throws IOException         If transport errors occur.
+   * @throws NotFoundException   If the namespace or identity are not found.
+   */
+  @DELETE
+  @Path("/namespaces/{namespace-id}/credentials/workloadIdentity")
+  public void deleteIdentity(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace) throws Exception {
+    accessEnforcer.enforce(new NamespaceId(namespace), NamespacePermission.UNSET_SERVICE_ACCOUNT);
+    NamespaceMeta namespaceMeta = getNamespaceMeta(namespace);
+    CredentialIdentityId credentialIdentityId = createIdentityIdOrPropagate(namespace,
+        GcpWorkloadIdentityUtil.getWorkloadIdentityName(namespaceMeta.getIdentity()));
+    switchToInternalUser();
+    credentialIdentityManager.delete(credentialIdentityId);
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  private NamespaceMeta getNamespaceMeta(String namespace) throws Exception {
+    if (NamespaceId.SYSTEM.getNamespace().equals(namespace)) {
+      return NamespaceMeta.SYSTEM;
+    }
+    try {
+      return namespaceQueryAdmin.get(new NamespaceId(namespace));
+    } catch (Exception e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof NamespaceNotFoundException || cause instanceof UnauthorizedException) {
+        throw (Exception) cause;
+      }
+      throw new IOException(String.format("Failed to get namespace '%s' metadata",
+          namespace), e);
+    }
+  }
+
+  private void switchToInternalUser() {
+    SecurityRequestContext.reset();
+  }
+
+  private void validateNamespaceIdentity(NamespaceMeta namespaceMeta, NamespaceWorkloadIdentity identity)
+      throws BadRequestException {
+    if (!namespaceMeta.getIdentity().equals(identity.getIdentity())) {
+      throw new BadRequestException("Incorrect value provided for namespace identity.");
+    }
+  }
+
+  private CredentialIdentityId createIdentityIdOrPropagate(String namespace, String name)
+      throws BadRequestException {
+    try {
+      return new CredentialIdentityId(namespace, name);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e.getMessage(), e);
+    }
+  }
+
+  private <T> T deserializeRequestContent(FullHttpRequest request, Class<T> clazz)
+      throws BadRequestException {
+    try (Reader reader = new InputStreamReader(new ByteBufInputStream(request.content()),
+        StandardCharsets.UTF_8)) {
+      T content = GSON.fromJson(reader, clazz);
+      if (content == null) {
+        throw new BadRequestException("No request object provided; expected class "
+            + clazz.getName());
+      }
+      return content;
+    } catch (JsonSyntaxException | IOException e) {
+      throw new BadRequestException("Unable to parse request: " + e.getMessage(), e);
+    }
+  }
+}
+

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/handler/GcpWorkloadIdentityHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/handler/GcpWorkloadIdentityHttpHandlerInternal.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.namespace.credential.handler;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.inject.Singleton;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.proto.BasicThrowable;
+import io.cdap.cdap.proto.codec.BasicThrowableCodec;
+import io.cdap.cdap.proto.credential.CredentialProvisioningException;
+import io.cdap.cdap.proto.credential.NamespaceCredentialProvider;
+import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
+import io.cdap.http.AbstractHttpHandler;
+import io.cdap.http.HttpHandler;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.io.IOException;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * Internal {@link HttpHandler} for credential providers.
+ */
+@Singleton
+@Path(Constants.Gateway.INTERNAL_API_VERSION_3)
+public class GcpWorkloadIdentityHttpHandlerInternal extends AbstractHttpHandler {
+
+  private static final Gson GSON = new GsonBuilder().registerTypeAdapter(
+      BasicThrowable.class, new BasicThrowableCodec()).create();
+
+  private final NamespaceCredentialProvider credentialProvider;
+  private final ContextAccessEnforcer accessEnforcer;
+
+  @Inject
+  GcpWorkloadIdentityHttpHandlerInternal(
+      ContextAccessEnforcer accessEnforcer, NamespaceCredentialProvider credentialProvider) {
+    this.credentialProvider = credentialProvider;
+    this.accessEnforcer = accessEnforcer;
+  }
+
+  /**
+   * Provisions a credential for a given identity.
+   *
+   * @param request      The HTTP request.
+   * @param responder    The HTTP responder.
+   * @param namespace    The namespace of the identity for which to provision a credential.
+   * @param scopes       A comma separated list of OAuth scopes requested.
+   * @throws CredentialProvisioningException If provisioning fails.
+   * @throws IOException                     If transport errors occur.
+   * @throws NotFoundException               If the identity or associated profile are not found.
+   */
+  @GET
+  @Path("/namespaces/{namespace-id}/credentials/workloadIdentity/provision")
+  public void provisionCredential(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace, @QueryParam("scopes") String scopes)
+      throws CredentialProvisioningException, IOException, NotFoundException {
+    try {
+      responder.sendJson(HttpResponseStatus.OK,
+          GSON.toJson(credentialProvider.provision(namespace, scopes)));
+    } catch (io.cdap.cdap.proto.credential.NotFoundException e) {
+      throw new NotFoundException(e.getMessage());
+    }
+  }
+}

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -564,6 +564,10 @@ public class KubeMasterEnvironment implements MasterEnvironment {
       coreV1Api.createNamespacedServiceAccount(k8sNamespace, serviceAccount,
           null, null, null, null);
     } catch (ApiException e) {
+      if (e.getCode() == 409) {
+        // ignore, the SA already exists.
+        return;
+      }
       LOG.error(
           String.format("Unable to create the service account %s with status %s and body: %s",
               serviceAccount.getMetadata().getName(), e.getCode(), e.getResponseBody()), e);

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -52,7 +52,6 @@ import io.cdap.cdap.internal.app.namespace.StorageProviderNamespaceAdmin;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.internal.app.worker.TaskWorkerServiceLauncher;
 import io.cdap.cdap.internal.app.worker.system.SystemWorkerServiceLauncher;
-import io.cdap.cdap.internal.credential.CredentialProviderService;
 import io.cdap.cdap.internal.events.EventPublishManager;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
@@ -169,8 +168,6 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
 
     // Event publisher could rely on task workers for token generated for security enabled deployments
     services.add(injector.getInstance(EventPublishManager.class));
-
-    services.add(injector.getInstance(CredentialProviderService.class));
 
     // Adds the master environment tasks
     masterEnv.getTasks()

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/NamespaceCredentialProvider.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/NamespaceCredentialProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.credential;
+
+import java.io.IOException;
+
+/**
+ * Provides a credential based on a profile and identity associated with the namespace.
+ */
+public interface NamespaceCredentialProvider {
+
+  /**
+   * Provisions a short-lived credential for the provided identity using the provided identity.
+   *
+   * @param namespace The identity namespace.
+   * @param scopes A comma separated list of OAuth scopes requested.
+   * @return A short-lived credential.
+   * @throws CredentialProvisioningException If provisioning the credential fails.
+   * @throws IOException                     If any transport errors occur.
+   * @throws NotFoundException               If the profile or identity are not found.
+   */
+  ProvisionedCredential provision(String namespace, String scopes)
+      throws CredentialProvisioningException, IOException, NotFoundException;
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/NamespaceWorkloadIdentity.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/NamespaceWorkloadIdentity.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.credential;
+
+/**
+ * Defines an identity for credential provisioning.
+ */
+public class NamespaceWorkloadIdentity {
+
+  private final String identity;
+  private final String serviceAccount;
+
+  /**
+   * Constructs a namespace identity.
+   *
+   * @param identity         The identity.
+   * @param serviceAccount   The serviceAccount to store for the identity.
+   */
+  public NamespaceWorkloadIdentity(String identity,
+      String serviceAccount) {
+    this.identity = identity;
+    this.serviceAccount = serviceAccount;
+  }
+
+  public String getIdentity() {
+    return identity;
+  }
+
+  public String getServiceAccount() {
+    return serviceAccount;
+  }
+
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/security/NamespacePermission.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/security/NamespacePermission.java
@@ -32,6 +32,18 @@ public enum NamespacePermission implements Permission {
    * Permission to update metadata of the SCM repository of a namespace.
    */
   UPDATE_REPOSITORY_METADATA,
+  /**
+   * Permission to set the service account associated with the namespace.
+   */
+  SET_SERVICE_ACCOUNT,
+  /**
+   * Permission to unset the service account associated with the namespace.
+   */
+  UNSET_SERVICE_ACCOUNT,
+  /**
+   * Permission to provision the credential using the service account associated with the namespace.
+   */
+  PROVISION_CREDENTIAL
   ;
 
   @Override


### PR DESCRIPTION
This PR does the following:

- Creates namespace identities if not exist when the `DefaultNamespaceCredentialProviderService` starts.
- Introduces `NamespaceWorkloadIdentity`.
- Introduces `NamespaceCredentialProvider` for `NamespaceGcpWorkloadIdentities`.
- Implements `GcpWorkloadIdentityHttpHandler` and `GcpWorkloadIdentityHttpHandlerInternal`.