### PR TITLE
[CDAP-20763] Allow disabling the internal router service

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -2417,6 +2417,7 @@ public final class Constants {
     public static final String BIND_ADDRESS = "internal.router.service.bind.address";
     public static final String BIND_PORT = "internal.router.service.bind.port";
     public static final String SSL_ENABLED = "internal.router.service.ssl.enabled";
-    public static final String INTERNAL_ROUTER_ENABLED = "internal.router.enabled";
+    public static final String CLIENT_ENABLED = "internal.router.client.enabled";
+    public static final String SERVER_ENABLED = "internal.router.server.enabled";
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
@@ -57,7 +57,14 @@ public class RemoteClientFactory {
       InternalAuthenticator internalAuthenticator,
       RemoteAuthenticator remoteAuthenticator, CConfiguration cConf) {
     this(discoveryClient, internalAuthenticator, remoteAuthenticator, "",
-        cConf.getBoolean(InternalRouter.INTERNAL_ROUTER_ENABLED));
+        cConf.getBoolean(InternalRouter.CLIENT_ENABLED));
+    if (cConf.getBoolean(InternalRouter.CLIENT_ENABLED) && !cConf.getBoolean(
+        InternalRouter.SERVER_ENABLED)) {
+      throw new IllegalStateException(
+          "Using internal router clients is enabled but the internal router server is not."
+          + "Enable internal router server by setting property "
+          + InternalRouter.SERVER_ENABLED);
+    }
   }
 
   public RemoteClientFactory(DiscoveryServiceClient discoveryClient,

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -6016,11 +6016,20 @@
   </property>
 
   <property>
-    <name>internal.router.enabled</name>
+    <name>internal.router.client.enabled</name>
     <value>false</value>
     <description>
       Whether to route traffic for CDAP APIs through the internal router service. By default, it is
       disabled.
+    </description>
+  </property>
+
+  <property>
+    <name>internal.router.server.enabled</name>
+    <value>false</value>
+    <description>
+      Whether the internal router service is enabled. It can be disabled to save service IP space
+      when the internal router is not being used.
     </description>
   </property>
 

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
@@ -25,6 +25,7 @@ import com.google.inject.Module;
 import io.cdap.cdap.app.guice.RuntimeServerModule;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.InternalRouter;
 import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
@@ -84,7 +85,8 @@ public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> 
     services.add(new AbstractIdleService() {
       @Override
       protected void startUp() throws Exception {
-        StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
+        StoreDefinition.createAllTables(
+            injector.getInstance(StructuredTableAdmin.class));
       }
 
       @Override
@@ -94,7 +96,10 @@ public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> 
     });
     services.add(injector.getInstance(RuntimeProgramStatusSubscriberService.class));
     services.add(injector.getInstance(RuntimeServer.class));
-    services.add(injector.getInstance(InternalRouterService.class));
+    if (injector.getInstance(CConfiguration.class)
+        .getBoolean(InternalRouter.SERVER_ENABLED)) {
+      services.add(injector.getInstance(InternalRouterService.class));
+    }
     Binding<ZKClientService> zkBinding = injector.getExistingBinding(
         Key.get(ZKClientService.class));
     if (zkBinding != null) {


### PR DESCRIPTION
## [CDAP-20763](https://cdap.atlassian.net/browse/CDAP-20763)

Allow disabling the Internal Router service . This is required since k8s deployments with shortage of Service IPs may hit the limit when a new k8s service is published. The service is enabled by default.

[CDAP-20763]: https://cdap.atlassian.net/browse/CDAP-20763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ