### PR TITLE
[CDAP-20807][🍒 for 6.9] Fix NoSuchMethodError in GeneratedMessageV3 for static clusters with managed instance groups due to library incompatibility.

### DIFF
--- a/cdap-runtime-ext-dataproc/pom.xml
+++ b/cdap-runtime-ext-dataproc/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <google.api.client.version>1.34.0</google.api.client.version>
-    <google.cloud.libraries.bom.version>25.1.0</google.cloud.libraries.bom.version>
+    <google.cloud.libraries.bom.version>26.22.0</google.cloud.libraries.bom.version>
   </properties>
 
 
@@ -50,18 +50,15 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-dataproc</artifactId>
-      <version>4.5.0</version>
     </dependency>
-    <!-- for some reason, seeing old proto versions getting pulled in instead of the correct ones -->
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-dataproc-v1</artifactId>
-      <version>4.5.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-compute</artifactId>
-      <version>v1-rev214-1.25.0</version>
+      <version>v1-rev20230829-2.0.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>
@@ -98,7 +95,6 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>${google.api.client.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/15318