### PR TITLE
[Cherry-pick into 6.8][CDAP-20807] Update Guava version to match google libraries needs and ensure Errors (e.g. method not found) are properly propagated.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/task/DeprovisionTask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/task/DeprovisionTask.java
@@ -117,7 +117,7 @@ public class DeprovisionTask extends ProvisioningTask {
   }
 
   @Override
-  protected void handleSubtaskFailure(ProvisioningTaskInfo taskInfo, Exception e) {
+  protected void handleSubtaskFailure(ProvisioningTaskInfo taskInfo, Throwable e) {
     provisionerNotifier.orphaned(programRunId);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/task/ProvisionTask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/task/ProvisionTask.java
@@ -105,7 +105,7 @@ public class ProvisionTask extends ProvisioningTask {
   }
 
   @Override
-  protected void handleSubtaskFailure(ProvisioningTaskInfo taskInfo, Exception e) {
+  protected void handleSubtaskFailure(ProvisioningTaskInfo taskInfo, Throwable e) {
     notifyFailed(e);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/task/ProvisioningTask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/task/ProvisioningTask.java
@@ -152,7 +152,7 @@ public abstract class ProvisioningTask implements RepeatedTask {
       return 0;
     } catch (InterruptedException e) {
       throw e;
-    } catch (Exception e) {
+    } catch (Throwable e) {
       LOG.error("{} task failed in {} state for program run {} due to {}.",
                 currentTaskInfo.getProvisioningOp().getType(), state, programRunId,
                 Exceptions.condenseThrowableMessage(e), e);
@@ -220,7 +220,7 @@ public abstract class ProvisioningTask implements RepeatedTask {
    * @param taskInfo task info for the failure
    * @param e the non-retryable exception
    */
-  protected abstract void handleSubtaskFailure(ProvisioningTaskInfo taskInfo, Exception e);
+  protected abstract void handleSubtaskFailure(ProvisioningTaskInfo taskInfo, Throwable e);
 
   /**
    * Logic to run when task info could not be saved to the ProvisionerStore.

--- a/cdap-runtime-ext-dataproc/pom.xml
+++ b/cdap-runtime-ext-dataproc/pom.xml
@@ -73,9 +73,10 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <!-- required by com.google.auth:google-auth-library-oauth2-http,
-           but set to 0.13.0 by google-cloud-dataproc for some reason -->
-      <version>20.0</version>
+      <!-- newer version required by google libs,
+           but set to 0.13.0 by parent pom, so put explicit version
+           needed by google libs -->
+      <version>32.1.2-jre</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/15327