### PR TITLE
add the internal marklatest api

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -369,6 +369,16 @@ public interface Store {
   int addApplication(ApplicationId id, ApplicationMeta meta) throws ConflictException;
 
   /**
+   * Marks existing applications as latest.
+   *
+   * @param applicationIds List of application ids
+   * @throws IOException if the apps cannot be marked latest because of any IO failure
+   * @throws ApplicationNotFoundException when any of the applications is not found
+   */
+  void markApplicationsLatest(Collection<ApplicationId> applicationIds)
+      throws IOException, ApplicationNotFoundException;
+
+  /**
    * Return a list of program specifications that are deleted comparing the specification in the store with the
    * spec that is passed.
    *

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AbstractAppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AbstractAppLifecycleHttpHandler.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers;
+
+import com.google.common.base.Throwables;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.api.dataset.DatasetManagementException;
+import io.cdap.cdap.api.security.AccessException;
+import io.cdap.cdap.app.runtime.ProgramController;
+import io.cdap.cdap.app.runtime.ProgramRuntimeService;
+import io.cdap.cdap.common.ArtifactNotFoundException;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.ConflictException;
+import io.cdap.cdap.common.InvalidArtifactException;
+import io.cdap.cdap.common.NamespaceNotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.http.AbstractBodyConsumer;
+import io.cdap.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import io.cdap.cdap.internal.app.deploy.ProgramTerminator;
+import io.cdap.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
+import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
+import io.cdap.cdap.proto.ApplicationRecord;
+import io.cdap.cdap.proto.artifact.AppRequest;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.id.KerberosPrincipalId;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import io.cdap.http.BodyConsumer;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The abstract base class for the {@link AppLifecycleHttpHandler} and {@link AppLifecycleHttpHandlerInternal}
+ * It contains the common methods used in both handlers mentioned above.
+ */
+public abstract class AbstractAppLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
+  protected static final Gson GSON = new Gson();
+  protected static final Gson DECODE_GSON = new GsonBuilder()
+      .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
+      .create();
+  protected static final Logger LOG = LoggerFactory.getLogger(AbstractAppLifecycleHttpHandler.class);
+
+  protected final CConfiguration configuration;
+  protected final NamespaceQueryAdmin namespaceQueryAdmin;
+  protected final ProgramRuntimeService runtimeService;
+  protected final ApplicationLifecycleService applicationLifecycleService;
+  protected final File tmpDir;
+
+  /**
+   * Constructor for the abstract class.
+   *
+   * @param configuration CConfiguration, passed from the derived class where it's injected
+   * @param namespaceQueryAdmin passed from the derived class where it's injected
+   * @param runtimeService passed from the derived class where it's injected
+   */
+  public AbstractAppLifecycleHttpHandler(CConfiguration configuration,
+      NamespaceQueryAdmin namespaceQueryAdmin,
+      ProgramRuntimeService runtimeService,
+      ApplicationLifecycleService applicationLifecycleService) {
+    this.configuration = configuration;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.runtimeService = runtimeService;
+    this.applicationLifecycleService = applicationLifecycleService;
+    this.tmpDir = new File(new File(configuration.get(Constants.CFG_LOCAL_DATA_DIR)),
+        configuration.get(Constants.AppFabric.TEMP_DIR)).getAbsoluteFile();
+  }
+
+  protected ApplicationId validateApplicationVersionId(NamespaceId namespaceId, String appId,
+      String versionId) throws BadRequestException {
+    if (appId == null) {
+      throw new BadRequestException("Path parameter app-id cannot be empty");
+    }
+    if (!EntityId.isValidId(appId)) {
+      throw new BadRequestException(String.format("Invalid app name '%s'", appId));
+    }
+    if (versionId == null) {
+      throw new BadRequestException("Path parameter version-id cannot be empty");
+    }
+    if (EntityId.isValidVersionId(versionId)) {
+      return namespaceId.app(appId, versionId);
+    }
+    throw new BadRequestException(String.format("Invalid version '%s'", versionId));
+  }
+
+  protected NamespaceId validateNamespace(@Nullable String namespace)
+      throws BadRequestException, NamespaceNotFoundException, AccessException {
+
+    if (namespace == null) {
+      throw new BadRequestException("Path parameter namespace-id cannot be empty");
+    }
+
+    NamespaceId namespaceId;
+    try {
+      namespaceId = new NamespaceId(namespace);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(String.format("Invalid namespace '%s'", namespace), e);
+    }
+
+    try {
+      if (!namespaceId.equals(NamespaceId.SYSTEM)) {
+        namespaceQueryAdmin.get(namespaceId);
+      }
+    } catch (NamespaceNotFoundException | AccessException e) {
+      throw e;
+    } catch (Exception e) {
+      // This can only happen when NamespaceAdmin uses HTTP calls to interact with namespaces.
+      // In AppFabricServer, NamespaceAdmin is bound to DefaultNamespaceAdmin, which interacts directly with the MDS.
+      // Hence, this exception will never be thrown
+      throw Throwables.propagate(e);
+    }
+    return namespaceId;
+  }
+
+  protected ProgramTerminator createProgramTerminator() {
+    return programId -> {
+      switch (programId.getType()) {
+        case SERVICE:
+        case WORKER:
+          killProgramIfRunning(programId);
+          break;
+        default:
+          break;
+      }
+    };
+  }
+
+  protected void killProgramIfRunning(ProgramId programId) {
+    ProgramRuntimeService.RuntimeInfo programRunInfo = findRuntimeInfo(programId, runtimeService);
+    if (programRunInfo != null) {
+      ProgramController controller = programRunInfo.getController();
+      controller.kill();
+    }
+  }
+
+  protected ApplicationRecord getApplicationRecord(ApplicationWithPrograms deployedApp) {
+    return new ApplicationRecord(
+        ArtifactSummary.from(deployedApp.getArtifactId().toApiArtifactId()),
+        deployedApp.getApplicationId().getApplication(),
+        deployedApp.getApplicationId().getVersion(),
+        deployedApp.getSpecification().getDescription(),
+        Optional.ofNullable(deployedApp.getOwnerPrincipal()).map(KerberosPrincipalId::getPrincipal)
+            .orElse(null),
+        deployedApp.getChangeDetail(), null);
+  }
+
+  protected BodyConsumer deployAppFromArtifact(
+      final ApplicationId appId,
+      final boolean skipMarkingLatest)
+      throws IOException {
+    return new AbstractBodyConsumer(
+        File.createTempFile("apprequest-" + appId, ".json", tmpDir)) {
+      @Override
+      protected void onFinish(HttpResponder responder, File uploadedFile) {
+        try (FileReader fileReader = new FileReader(uploadedFile)) {
+          AppRequest<?> appRequest = DECODE_GSON.fromJson(fileReader, AppRequest.class);
+
+          try {
+            ApplicationWithPrograms app = applicationLifecycleService.deployApp(appId, appRequest,
+                null, createProgramTerminator(), skipMarkingLatest);
+            responder.sendJson(HttpResponseStatus.OK, GSON.toJson(getApplicationRecord(app)));
+          } catch (DatasetManagementException e) {
+            if (e.getCause() instanceof UnauthorizedException) {
+              throw (UnauthorizedException) e.getCause();
+            } else {
+              throw e;
+            }
+          }
+        } catch (ArtifactNotFoundException e) {
+          responder.sendString(HttpResponseStatus.NOT_FOUND, e.getMessage());
+        } catch (ConflictException e) {
+          responder.sendString(HttpResponseStatus.CONFLICT, e.getMessage());
+        } catch (UnauthorizedException e) {
+          responder.sendString(HttpResponseStatus.FORBIDDEN, e.getMessage());
+        } catch (InvalidArtifactException e) {
+          responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
+        } catch (IOException e) {
+          LOG.error("Error reading request body for creating app {}.", appId, e);
+          responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, String.format(
+              "Error while reading json request body for app %s.", appId));
+        } catch (Exception e) {
+          LOG.error("Deploy failure", e);
+          responder.sendString(HttpResponseStatus.BAD_REQUEST, e.getMessage());
+        }
+      }
+    };
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/AppDeploymentInfo.java
@@ -59,6 +59,7 @@ public class AppDeploymentInfo {
   @Nullable
   private final ApplicationSpecification deployedApplicationSpec;
   private final boolean isUpgrade;
+  private final boolean skipMarkingLatest;
 
   /**
    * Creates a new {@link Builder}.
@@ -86,6 +87,7 @@ public class AppDeploymentInfo {
         .setChangeDetail(other.changeDetail)
         .setSourceControlMeta(other.sourceControlMeta)
         .setIsUpgrade(other.isUpgrade)
+        .setSkipMarkingLatest(other.skipMarkingLatest)
         .setDeployedApplicationSpec(other.deployedApplicationSpec);
   }
 
@@ -95,7 +97,7 @@ public class AppDeploymentInfo {
       @Nullable String configString, @Nullable KerberosPrincipalId ownerPrincipal,
       boolean updateSchedules, @Nullable AppDeploymentRuntimeInfo runtimeInfo,
       @Nullable ChangeDetail changeDetail, @Nullable SourceControlMeta sourceControlMeta,
-      boolean isUpgrade, @Nullable ApplicationSpecification deployedApplicationSpec) {
+      boolean isUpgrade, @Nullable ApplicationSpecification deployedApplicationSpec, boolean skipMarkingLatest) {
     this.artifactId = artifactId;
     this.artifactLocation = artifactLocation;
     this.namespaceId = namespaceId;
@@ -109,6 +111,7 @@ public class AppDeploymentInfo {
     this.changeDetail = changeDetail;
     this.sourceControlMeta = sourceControlMeta;
     this.isUpgrade = isUpgrade;
+    this.skipMarkingLatest = skipMarkingLatest;
     this.deployedApplicationSpec = deployedApplicationSpec;
   }
 
@@ -212,6 +215,10 @@ public class AppDeploymentInfo {
     return isUpgrade;
   }
 
+  public boolean isSkipMarkingLatest() {
+    return skipMarkingLatest;
+  }
+
   /**
    * Returns the previously deployed Application Specification. Will be null for the 1st deployment
    */
@@ -243,6 +250,7 @@ public class AppDeploymentInfo {
     @Nullable
     private ApplicationSpecification deployedApplicationSpec;
     private boolean isUpgrade;
+    private boolean skipMarkingLatest;
 
     private Builder() {
       // Only for the builder() method to use
@@ -320,6 +328,11 @@ public class AppDeploymentInfo {
       return this;
     }
 
+    public Builder setSkipMarkingLatest(boolean skipMarkingLatest) {
+      this.skipMarkingLatest = skipMarkingLatest;
+      return this;
+    }
+
     public Builder setDeployedApplicationSpec(
         @Nullable ApplicationSpecification deployedApplicationSpec) {
       this.deployedApplicationSpec = deployedApplicationSpec;
@@ -341,7 +354,7 @@ public class AppDeploymentInfo {
       }
       return new AppDeploymentInfo(artifactId, artifactLocation, namespaceId, applicationClass,
           appName, appVersion, configString, ownerPrincipal, updateSchedules, runtimeInfo,
-          changeDetail, sourceControlMeta, isUpgrade, deployedApplicationSpec);
+          changeDetail, sourceControlMeta, isUpgrade, deployedApplicationSpec, skipMarkingLatest);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationDeployable.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
+import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 import java.util.Collection;
 import java.util.Collections;
@@ -56,6 +57,7 @@ public class ApplicationDeployable {
   @Nullable
   private final SourceControlMeta sourceControlMeta;
   private final boolean isUpgrade;
+  private final boolean skipMarkingLatest;
 
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
       ApplicationId applicationId, ApplicationSpecification specification,
@@ -65,7 +67,7 @@ public class ApplicationDeployable {
     this(artifactId, artifactLocation, applicationId, specification, existingAppSpec,
         applicationDeployScope,
         applicationClass, null, true, Collections.emptyList(), Collections.emptyMap(),
-        null, null, false);
+        null, null, false, false);
   }
 
   public ApplicationDeployable(ArtifactId artifactId, Location artifactLocation,
@@ -77,7 +79,7 @@ public class ApplicationDeployable {
       boolean updateSchedules,
       Collection<StructuredTableSpecification> systemTables,
       Map<MetadataScope, Metadata> metadata, @Nullable ChangeDetail changeDetail,
-      @Nullable SourceControlMeta sourceControlMeta, boolean isUpgrade) {
+      @Nullable SourceControlMeta sourceControlMeta, boolean isUpgrade, boolean skipMarkingLatest) {
     this.artifactId = artifactId;
     this.artifactLocation = artifactLocation;
     this.applicationId = applicationId;
@@ -92,6 +94,7 @@ public class ApplicationDeployable {
     this.changeDetail = changeDetail;
     this.sourceControlMeta = sourceControlMeta;
     this.isUpgrade = isUpgrade;
+    this.skipMarkingLatest = skipMarkingLatest;
   }
 
   /**
@@ -184,6 +187,13 @@ public class ApplicationDeployable {
    */
   public boolean isUpgrade() {
     return isUpgrade;
+  }
+
+  /**
+   * Returns true if the application is not to be marked as latest.
+   */
+  public boolean isSkipMarkingLatest() {
+    return skipMarkingLatest;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationRegistrationStage.java
@@ -67,11 +67,15 @@ public class ApplicationRegistrationStage extends AbstractStage<ApplicationWithP
     boolean ownerAdded = addOwnerIfRequired(input, allAppVersionsAppIds);
     ApplicationMeta appMeta = new ApplicationMeta(applicationSpecification.getName(),
         input.getSpecification(),
-        input.getChangeDetail(), input.getSourceControlMeta());
+        input.getChangeDetail(), input.getSourceControlMeta(), !input.isSkipMarkingLatest());
     try {
       int editCount = store.addApplication(input.getApplicationId(), appMeta);
-      // increment metric : app.deploy.event.count.upgrade
-      if (input.isUpgrade()) {
+
+      if (input.isSkipMarkingLatest()) {
+        // TODO [CDAP-20848]
+        // do not emit any metrics. the application may be cleaned up or marked latest later
+      } else if (input.isUpgrade()) {
+        // increment metric : app.deploy.event.count.upgrade
         emitMetrics(applicationId.getNamespace(), applicationId.getApplication(),
             Constants.Metrics.AppMetadataStore.DEPLOY_UPGRADE_COUNT);
       } else if (editCount == 1) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/ApplicationWithPrograms.java
@@ -37,7 +37,8 @@ public class ApplicationWithPrograms extends ApplicationDeployable {
         applicationDeployable.getApplicationClass(), applicationDeployable.getOwnerPrincipal(),
         applicationDeployable.canUpdateSchedules(), applicationDeployable.getSystemTables(),
         applicationDeployable.getMetadata(), applicationDeployable.getChangeDetail(),
-        applicationDeployable.getSourceControlMeta(), applicationDeployable.isUpgrade());
+        applicationDeployable.getSourceControlMeta(), applicationDeployable.isUpgrade(),
+        applicationDeployable.isSkipMarkingLatest());
     this.programDescriptors = ImmutableList.copyOf(programDescriptors);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/LocalArtifactLoaderStage.java
@@ -126,6 +126,7 @@ public class LocalArtifactLoaderStage extends AbstractStage<AppDeploymentInfo> {
         ApplicationDeployScope.USER, deploymentInfo.getApplicationClass(),
         deploymentInfo.getOwnerPrincipal(), deploymentInfo.canUpdateSchedules(),
         appSpecInfo.getSystemTables(), metadatas, deploymentInfo.getChangeDetail(),
-        deploymentInfo.getSourceControlMeta(), deploymentInfo.isUpgrade()));
+        deploymentInfo.getSourceControlMeta(), deploymentInfo.isUpgrade(),
+        deploymentInfo.isSkipMarkingLatest()));
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
@@ -193,7 +193,7 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
           preview.getVersion(),
           artifactSummary, config, request.getChange(), null,
           NOOP_PROGRAM_TERMINATOR, null, request.canUpdateSchedules(),
-          true, userProps);
+          true, false, userProps);
     } catch (Exception e) {
       PreviewStatus previewStatus = new PreviewStatus(PreviewStatus.Status.DEPLOY_FAILED,
           submitTimeMillis,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
@@ -263,7 +263,7 @@ public class SourceControlManagementService {
         appLifecycleService.decodeUserId(authenticationContext));
 
     ApplicationWithPrograms app = appLifecycleService.deployApp(appId, appRequest,
-                                                                sourceControlMeta, x -> { });
+                                                                sourceControlMeta, x -> { }, false);
 
     LOG.info("Successfully deployed app {} in namespace {} from artifact {} with configuration {} and "
             + "principal {}", app.getApplicationId().getApplication(), app.getApplicationId().getNamespace(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/ApplicationMeta.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/ApplicationMeta.java
@@ -36,13 +36,23 @@ public class ApplicationMeta {
   private final ChangeDetail change;
   @Nullable
   private final SourceControlMeta sourceControlMeta;
+  // the isLatest field does not need to be serialized in the ApplicationMetadata object
+  // as it's stored as a separate column in the app spec table.
+  private final transient boolean isLatest;
 
   public ApplicationMeta(String id, ApplicationSpecification spec,
-      @Nullable ChangeDetail change, @Nullable SourceControlMeta sourceControlMeta) {
+      @Nullable ChangeDetail change, @Nullable SourceControlMeta sourceControlMeta,
+      boolean isLatest) {
     this.id = id;
     this.spec = spec;
     this.change = change;
     this.sourceControlMeta = sourceControlMeta;
+    this.isLatest = isLatest;
+  }
+
+  public ApplicationMeta(String id, ApplicationSpecification spec,
+      @Nullable ChangeDetail change, @Nullable SourceControlMeta sourceControlMeta) {
+    this(id, spec, change, sourceControlMeta, true);
   }
 
   public ApplicationMeta(String id, ApplicationSpecification spec, @Nullable ChangeDetail change) {
@@ -67,6 +77,10 @@ public class ApplicationMeta {
     return sourceControlMeta;
   }
 
+  public boolean getIsLatest() {
+    return isLatest;
+  }
+
   @Override
   public String toString() {
     return Objects.toStringHelper(this)
@@ -74,6 +88,7 @@ public class ApplicationMeta {
         .add("spec", ADAPTER.toJson(spec))
         .add("change", change)
         .add("sourceControlMeta", sourceControlMeta)
+        .add("isLatest", isLatest)
         .toString();
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -583,6 +583,17 @@ public class DefaultStore implements Store {
   }
 
   @Override
+  public void markApplicationsLatest(Collection<ApplicationId> appIds)
+      throws IOException, ApplicationNotFoundException {
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore mds = getAppMetadataStore(context);
+      for (ApplicationId appId : appIds) {
+        mds.markAsLatest(appId);
+      }
+    }, IOException.class, ApplicationNotFoundException.class);
+  }
+
+  @Override
   public int addApplication(ApplicationId id, ApplicationMeta meta) throws ConflictException {
     return TransactionRunners.run(transactionRunner, context -> {
       return getAppMetadataStore(context).createApplicationVersion(id, meta);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/executor/AppCreator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/executor/AppCreator.java
@@ -69,7 +69,7 @@ public class AppCreator extends BaseStepExecutor<AppCreator.Arguments> {
           ApplicationId.DEFAULT_VERSION,
           artifactSummary, configString, arguments.getChange(), null, x -> {
           },
-          ownerPrincipalId, arguments.canUpdateSchedules(), false,
+          ownerPrincipalId, arguments.canUpdateSchedules(), false, false,
           Collections.emptyMap());
     } catch (NotFoundException | UnauthorizedException | InvalidArtifactException e) {
       // these exceptions are for sure not retry-able. It's hard to tell if the others are, so we just try retrying

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityApplier.java
@@ -330,7 +330,7 @@ class CapabilityApplier {
         .deployApp(applicationReference.getParent(), applicationReference.getApplication(),
             ApplicationId.DEFAULT_VERSION,
             application.getArtifact(), configString, null, null, NOOP_PROGRAM_TERMINATOR,
-            null, null, false, Collections.emptyMap());
+            null, null, false, false, Collections.emptyMap());
   }
 
   @VisibleForTesting

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/sysapp/SystemAppEnableExecutor.java
@@ -120,7 +120,7 @@ public class SystemAppEnableExecutor {
           appId.getVersion(),
           artifactSummary, configString, null, null, x -> {
           },
-          ownerPrincipalId, arguments.canUpdateSchedules(), false,
+          ownerPrincipalId, arguments.canUpdateSchedules(), false, false,
           Collections.emptyMap());
 
     } catch (UnauthorizedException | InvalidArtifactException e) {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/Specifications.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/Specifications.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.app.DefaultAppConfigurer;
 import io.cdap.cdap.app.DefaultApplicationContext;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.internal.DefaultId;
+import javax.annotation.Nullable;
 
 /**
  * Util for building app spec for tests.
@@ -30,10 +31,15 @@ public final class Specifications {
   private Specifications() {}
 
   public static ApplicationSpecification from(Application app) {
+    return from(app, null, null);
+  }
+
+  public static ApplicationSpecification from(
+      Application app, @Nullable String applicationName, @Nullable String applicationVersion) {
     DefaultAppConfigurer appConfigurer = new DefaultAppConfigurer(Id.Namespace.fromEntityId(DefaultId.NAMESPACE),
-                                                                  Id.Artifact.fromEntityId(DefaultId.ARTIFACT),
-                                                                  app);
+        Id.Artifact.fromEntityId(DefaultId.ARTIFACT),
+        app);
     app.configure(appConfigurer, new DefaultApplicationContext());
-    return appConfigurer.createSpecification(null);
+    return appConfigurer.createSpecification(applicationName, applicationVersion);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
@@ -22,26 +22,33 @@ import com.google.common.io.Files;
 import io.cdap.cdap.AllProgramsApp;
 import io.cdap.cdap.AppWithProgramsUsingGuava;
 import io.cdap.cdap.CapabilityAppWithWorkflow;
+import io.cdap.cdap.ConfigTestApp;
 import io.cdap.cdap.MetadataEmitApp;
 import io.cdap.cdap.MissingMapReduceWorkflowApp;
 import io.cdap.cdap.api.annotation.Requirements;
 import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.metadata.MetadataEntity;
 import io.cdap.cdap.api.metadata.MetadataScope;
+import io.cdap.cdap.common.ApplicationNotFoundException;
 import io.cdap.cdap.common.ArtifactNotFoundException;
+import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.id.Id.Namespace;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.lang.ProgramResources;
 import io.cdap.cdap.common.lang.jar.BundleJarUtil;
 import io.cdap.cdap.common.test.AppJarHelper;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.data2.metadata.system.AppSystemMetadataWriter;
+import io.cdap.cdap.features.Feature;
 import io.cdap.cdap.internal.AppFabricTestHelper;
 import io.cdap.cdap.internal.app.deploy.ProgramTerminator;
 import io.cdap.cdap.internal.app.deploy.Specifications;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
 import io.cdap.cdap.internal.capability.CapabilityConfig;
 import io.cdap.cdap.internal.capability.CapabilityNotAvailableException;
 import io.cdap.cdap.internal.capability.CapabilityStatus;
@@ -51,6 +58,9 @@ import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.ProgramRecord;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.app.AppVersion;
+import io.cdap.cdap.proto.app.MarkLatestAppsRequest;
+import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -59,6 +69,7 @@ import io.cdap.cdap.spi.metadata.Metadata;
 import io.cdap.cdap.spi.metadata.MetadataKind;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
 import io.cdap.cdap.spi.metadata.Read;
+import io.cdap.common.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -67,6 +78,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +93,7 @@ import org.apache.twill.filesystem.LocationFactory;
 import org.jboss.resteasy.util.HttpResponseCodes;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -88,7 +101,7 @@ import org.junit.Test;
  *
  */
 public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
-
+  private static final String FEATURE_FLAG_PREFIX = "feature.";
   private static ApplicationLifecycleService applicationLifecycleService;
   private static LocationFactory locationFactory;
   private static ArtifactRepository artifactRepository;
@@ -107,6 +120,16 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
   @AfterClass
   public static void stop() {
     AppFabricTestHelper.shutdown();
+  }
+
+  private void setLcmEditFlag(boolean lcmFlag) {
+    cConf.setBoolean(
+        FEATURE_FLAG_PREFIX + Feature.LIFECYCLE_MANAGEMENT_EDIT.getFeatureFlagString(), lcmFlag);
+  }
+
+  @Before
+  public void setDefaultFeatureFlags() {
+    setLcmEditFlag(true);
   }
 
   // test that the call to deploy an artifact and application in a single step will delete the artifact
@@ -450,6 +473,236 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     deleteNamespace("ns1");
     deleteNamespace("ns2");
     deleteNamespace("ns3");
+  }
+
+  /**
+   * Testcase to deploy an application without marking it as latest. (using the
+   * internal API to deploy, with the skipMarkingLatest flag set to true).
+   * The appliaction should be deployed successfully.
+   * There should be only one version of the application deployed, and that should not be marked latest.
+   * Therefore, trying to get the latest version of the application should throw ApplicationNotFoundException.
+   *
+   * @throws Exception it's expected to throw {@link ApplicationNotFoundException}
+   */
+  @Test(expected = ApplicationNotFoundException.class)
+  public void testDeployWithoutMarkingAppAsLatest() throws Exception {
+    String appName = "application_not_marked_latest";
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, appName);
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "appWithConfig", "1.0.0-SNAPSHOT");
+    addAppArtifact(artifactId, ConfigTestApp.class);
+    HttpResponse resp = deployWithoutMarkingLatest(
+        appId, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId())));
+    // the application deployment should succeed
+    Assert.assertEquals(200, resp.getResponseCode());
+    List<String> deployedAppVersions = applicationLifecycleService.getAppVersions(
+        appId.toEntityId().getAppReference()
+    ).stream().collect(Collectors.toList());
+
+    // there should be only one version of this application deployed
+    Assert.assertEquals(1, deployedAppVersions.size());
+    String deployedVersion = deployedAppVersions.get(0);
+    // the deployed version should be accessible in the applicationLifecycleService by ApplicationId
+    ApplicationDetail appDetail = applicationLifecycleService.getAppDetail(new ApplicationId(
+        Namespace.DEFAULT.getId(), appName, deployedVersion
+    ));
+    Assert.assertEquals(appName, appDetail.getName());
+    Assert.assertEquals(deployedVersion, appDetail.getAppVersion());
+
+    // But as the only deployed version is not marked as latest, trying to get the
+    // latest application by ApplicationReference should throw ApplicationNotFoundException (expected).
+    applicationLifecycleService.getLatestAppDetail(appId.toEntityId().getAppReference());
+  }
+
+  /**
+   * Testcase to deploy an application without marking it as latest (using the
+   * internal API to deploy, with the skipMarkingLatest flag set to true).
+   * And then mark the deployed application as latest using the markAppsAsLatest method.
+   *
+   * @throws Exception when the test crashes (not expected)
+   */
+  @Test
+  public void testMarkAppsAsLatest() throws Exception {
+    String appName = "application_to_be_marked_latest";
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, appName);
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "appWithConfig", "1.0.0-SNAPSHOT");
+    addAppArtifact(artifactId, ConfigTestApp.class);
+    HttpResponse resp = deployWithoutMarkingLatest(
+        appId, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId())));
+
+    // the application deployment should succeed
+    Assert.assertEquals(200, resp.getResponseCode());
+    List<String> deployedAppVersions = applicationLifecycleService.getAppVersions(
+        appId.toEntityId().getAppReference()
+    ).stream().collect(Collectors.toList());
+    // there should be only one version of this application deployed
+    Assert.assertEquals(1, deployedAppVersions.size());
+    String deployedVersion = deployedAppVersions.get(0);
+
+    applicationLifecycleService.markAppsAsLatest(
+        Namespace.DEFAULT.toEntityId(),
+        new MarkLatestAppsRequest(
+            Collections.singletonList(new AppVersion(appName, deployedVersion))));
+
+    // now that the deployed application has been marked latest, trying to get the
+    // latest version of the application by ApplicationReference should succeed. And
+    // it should return the version of the application that we marked latest in the previous step.
+    ApplicationDetail appDetail = applicationLifecycleService.getLatestAppDetail(appId.toEntityId().getAppReference());
+    Assert.assertEquals(appName, appDetail.getName());
+    Assert.assertEquals(deployedVersion, appDetail.getAppVersion());
+  }
+
+  /**
+   * Testcase to verify that the markAppsAsLatest method throws BadRequestException when
+   * we try to mark multiple versions of the same application as latest.
+   *
+   * @throws Exception this test is expected to throw {@link BadRequestException}
+   */
+  @Test(expected = BadRequestException.class)
+  public void testMarkAppsAsLatestWithDuplicateAppIds() throws Exception {
+    applicationLifecycleService.markAppsAsLatest(
+        Namespace.DEFAULT.toEntityId(),
+        new MarkLatestAppsRequest(
+            Arrays.asList(new AppVersion("app1", "v1"),
+                new AppVersion("app1", "v2"))
+        ));
+  }
+
+  /**
+   * Testcase to verify that the markAppsAsLatest method throws BadRequestException when
+   * we provide any Invalid application id.
+   *
+   * @throws Exception this test is expected to throw {@link BadRequestException}
+   */
+  @Test(expected = BadRequestException.class)
+  public void testMarkAppsAsLatestWithInvalidAppId() throws Exception {
+    applicationLifecycleService.markAppsAsLatest(
+        Namespace.DEFAULT.toEntityId(),
+        new MarkLatestAppsRequest(
+            Collections.singletonList(new AppVersion("invalid app id", "v1"))
+        ));
+  }
+
+  /**
+   * Testcase to verify that the markAppsAsLatest method throws BadRequestException when
+   * any of the given application id is null.
+   *
+   * @throws Exception this test is expected to throw {@link BadRequestException}
+   */
+  @Test(expected = BadRequestException.class)
+  public void testMarkAppsAsLatestWithNullAppId() throws Exception {
+    applicationLifecycleService.markAppsAsLatest(
+        Namespace.DEFAULT.toEntityId(),
+        new MarkLatestAppsRequest(
+            Collections.singletonList(new AppVersion(null, "v1"))
+        ));
+  }
+
+  /**
+   * Testcase to verify that the markAppsAsLatest method throws BadRequestException when
+   * any of the given application version is null.
+   *
+   * @throws Exception this test is expected to throw {@link BadRequestException}
+   */
+  @Test(expected = BadRequestException.class)
+  public void testMarkAppsAsLatestWithNullAppVersion() throws Exception {
+    applicationLifecycleService.markAppsAsLatest(
+        Namespace.DEFAULT.toEntityId(),
+        new MarkLatestAppsRequest(
+            Collections.singletonList(new AppVersion("app", null))
+        ));
+  }
+
+  /**
+   * Testcase to verify that the markAppsAsLatest method throws ApplicationNotFoundException when
+   * any of the given application does not exist (or not found).
+   * In this test, we deploy an application without marking it as latest.
+   * Then we try to mark 2 applications as latest, one of them being the one that we deployed,
+   * and the other being an application id that does not exist. In this case, as one of the
+   * applications was not found, the markAppsAsLatest method should fail with the proper exception.
+   *
+   * @throws Exception this test is expected to throw {@link ApplicationNotFoundException}
+   */
+  @Test(expected = ApplicationNotFoundException.class)
+  public void testMarkAppsAsLatestWithNonExistingAppVersion() throws Exception {
+    String appName = "existing_app";
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, appName);
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "appWithConfig", "1.0.0-SNAPSHOT");
+    addAppArtifact(artifactId, ConfigTestApp.class);
+    HttpResponse resp = deployWithoutMarkingLatest(
+        appId, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId())));
+    Assert.assertEquals(200, resp.getResponseCode());
+    String deployedVersion = applicationLifecycleService.getAppVersions(
+        appId.toEntityId().getAppReference()
+    ).stream().collect(Collectors.toList()).get(0);
+
+
+    applicationLifecycleService.markAppsAsLatest(
+        Namespace.DEFAULT.toEntityId(),
+        new MarkLatestAppsRequest(
+            Arrays.asList(new AppVersion("non_existing_app", "v1"),
+                new AppVersion(appName, deployedVersion))
+        ));
+  }
+
+  /**
+   * Testcase to verify the intended behaviour of the markAppsAsLatest method.
+   * In this case, we deploy two versions of the same application one after another.
+   * The first version will be deployed using the public deploy API (without the skipMarkingLatest flag).
+   * Therefore the first verison should be marked as latest initially.
+   * Then the second version will be deployed using the internal deploy API (with skipMarkingLatest=true).
+   * At this point,  we should get the first version should be returned when we try to get the latest version.
+   * Then, using the markAppsAsLatest method, we will mark the second version as latest.
+   * At this point, we should get the second version should be returned when we try to get the latest version.
+   *
+   * @throws Exception if the test crashes (not expected)
+   */
+  @Test
+  public void testMarkLatestAppsWithTwoVersionsOfSameApp() throws Exception {
+    String appName = "testApplicationWithTwoVersions";
+    Id.Application appId = Id.Application.from(Id.Namespace.DEFAULT, appName);
+    Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "appWithConfig", "1.0.0-SNAPSHOT");
+    addAppArtifact(artifactId, ConfigTestApp.class);
+    // deploy the first version using the public deploy API (without the skipMarkingLatest flag)
+    HttpResponse resp1 = deploy(
+        appId, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId())));
+    Assert.assertEquals(200, resp1.getResponseCode());
+    String firstVersion = applicationLifecycleService.getAppVersions(
+        appId.toEntityId().getAppReference()
+    ).stream().collect(Collectors.toList()).get(0);
+
+    // deploy the second version using the internal deploy API (with skipMarkingLatest set to true)
+    HttpResponse resp2 = deployWithoutMarkingLatest(
+        appId, new AppRequest<>(ArtifactSummary.from(artifactId.toArtifactId())));
+    Assert.assertEquals(200, resp2.getResponseCode());
+    String secondVersion = applicationLifecycleService.getAppVersions(
+        appId.toEntityId().getAppReference()
+    ).stream().filter(version -> !version.equals(firstVersion)).collect(Collectors.toList()).get(0);
+
+    // verify that the first version was deployed before the second version
+    ApplicationDetail v1Detail = applicationLifecycleService.getAppDetail(
+        new ApplicationId(Id.Namespace.DEFAULT.getId(), appName, firstVersion));
+    ApplicationDetail v2Detail = applicationLifecycleService.getAppDetail(
+        new ApplicationId(Id.Namespace.DEFAULT.getId(), appName, secondVersion));
+    Assert.assertTrue(
+        v1Detail.getChange().getCreationTimeMillis() < v2Detail.getChange().getCreationTimeMillis());
+
+    // get the latest version of the app. It should be the first version at this point.
+    ApplicationDetail latest = applicationLifecycleService.getLatestAppDetail(
+        appId.toEntityId().getAppReference());
+    Assert.assertEquals(appName, latest.getName());
+    Assert.assertEquals(firstVersion, latest.getAppVersion());
+
+    // now mark the second version as latest
+    applicationLifecycleService.markAppsAsLatest(
+        Namespace.DEFAULT.toEntityId(),
+        new MarkLatestAppsRequest(
+            Collections.singletonList(new AppVersion(appName, secondVersion))
+        ));
+
+    // get the latest version of the app. It should be the second version at this point.
+    latest = applicationLifecycleService.getLatestAppDetail(appId.toEntityId().getAppReference());
+    Assert.assertEquals(appName, latest.getName());
+    Assert.assertEquals(secondVersion, latest.getAppVersion());
   }
 
   private void waitForRuns(int expected, final ProgramId programId, final ProgramRunStatus status) throws Exception {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SystemProgramManagementServiceTest.java
@@ -123,6 +123,6 @@ public class SystemProgramManagementServiceTest extends AppFabricTestBase {
     applicationLifecycleService.deployApp(NamespaceId.SYSTEM, APP_NAME, VERSION, summary, null, null, null,
                                           programId -> {
                                             // no-op
-                                          }, null, false, false, Collections.emptyMap());
+                                          }, null, false, false, false, Collections.emptyMap());
   }
 }

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/ExpectedNumberOfAuditPolicyPaths.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/ExpectedNumberOfAuditPolicyPaths.java
@@ -22,5 +22,5 @@ package io.cdap.cdap.gateway.router;
  */
 public final class ExpectedNumberOfAuditPolicyPaths {
 
-  public static final int EXPECTED_PATH_NUMBER = 46;
+  public static final int EXPECTED_PATH_NUMBER = 47;
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/app/AppVersion.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/app/AppVersion.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.app;
+
+import java.util.Objects;
+
+/**
+ * Contains an app name and version.
+ */
+public class AppVersion {
+  private final String name;
+  private final String appVersion;
+
+  public AppVersion(String name, String appVersion) {
+    this.name = name;
+    this.appVersion = appVersion;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getAppVersion() {
+    return appVersion;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof AppVersion)) {
+      return false;
+    }
+    AppVersion that = (AppVersion) o;
+    return Objects.equals(name, that.name) && Objects.equals(appVersion,
+        that.appVersion);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, appVersion);
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/app/MarkLatestAppsRequest.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/app/MarkLatestAppsRequest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.app;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Request class for the markLatest api.
+ */
+public class MarkLatestAppsRequest {
+  private final List<AppVersion> apps;
+
+  public MarkLatestAppsRequest(List<AppVersion> apps) {
+    this.apps = apps;
+  }
+
+  /**
+   * Get the list of apps the are to be marked latest.
+   *
+   * @return List of {@link AppVersion} or an empty list. Should not return null.
+   */
+  public List<AppVersion> getApps() {
+    if (null == apps) {
+      return new ArrayList<>();
+    }
+    return apps;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MarkLatestAppsRequest)) {
+      return false;
+    }
+    MarkLatestAppsRequest that = (MarkLatestAppsRequest) o;
+    return Objects.equals(apps, that.apps);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(apps);
+  }
+}


### PR DESCRIPTION
This PR adds:
1. Support for a query param `skipMakingLatest` in the `PUT api/v3internal/namespaces/:namespace/apps/:appId` . When this param is `true`, the application is deployed, but it's not marked as latest.
2. Adds an internal api `api/v3internal/namespaces/:namespace/apps/markLatest`. This api takes a list of appIds (with versionIds) and marks the specified versions of the apps as latest.


JIRA: [CDAP-20857](https://cdap.atlassian.net/browse/CDAP-20857)

[CDAP-20857]: https://cdap.atlassian.net/browse/CDAP-20857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ