### PR TITLE
[CDAP-20826] Add label for CDAP install namespace in Kube Twill Preparer

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.master.environment.k8s;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.k8s.common.AbstractWatcherThread;
 import io.cdap.cdap.k8s.common.DefaultLocalFileProvider;
@@ -198,6 +199,8 @@ public class KubeMasterEnvironment implements MasterEnvironment {
 
   public static final String DEFAULT_NAMESPACE = "default";
   private static final String DEFAULT_INSTANCE_LABEL = "cdap.instance";
+  private static final String CDAP_INSTALL_NAMESPACE_LABEL = "cdap.k8s.namespace";
+
   private static final String DEFAULT_CONTAINER_LABEL = "cdap.container";
   private static final String DEFAULT_POD_INFO_DIR = "/etc/podinfo";
   private static final String DEFAULT_POD_NAME_FILE = "pod.name";
@@ -394,7 +397,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     String resourcePrefix = "cdap-" + instanceName + "-";
     twillRunner = new KubeTwillRunnerService(context, apiClientFactory, namespace, discoveryService,
         podInfo, resourcePrefix,
-        Collections.singletonMap(instanceLabel, instanceName),
+        ImmutableMap.of(instanceLabel, instanceName, CDAP_INSTALL_NAMESPACE_LABEL, cdapInstallNamespace),
         enableMonitor,
         workloadIdentityEnabled,
         workloadLauncherRoleNameForNamespace,


### PR DESCRIPTION
## [CDAP-20826](https://cdap.atlassian.net/browse/CDAP-20826)

This change adds a new label to to pods launched by Kube Twill which identifies the namespace in which CDAPMaster is deployed. When CDAP deploys pods in different namespaces, there is no way to look at the pod resource to find the namespace in which CDAPMaster is present. This is required by the CDAP operator change https://github.com/cdapio/cdap-operator/pull/106 to determine the appropriate  k8s namespace to search for CDAPMaster while mutating pods.

[CDAP-20826]: https://cdap.atlassian.net/browse/CDAP-20826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ