### PR TITLE
CDAP-20827 fix extra java opts executor clobbering in k8s mode

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -211,7 +211,6 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String SPARK_DRIVER_LABEL_VALUE = "driver";
   private static final String CDAP_CONTAINER_LABEL = "cdap.container";
   private static final String TWILL_RUNNER_SERVICE_MONITOR_DISABLE = "twill.runner.service.monitor.disable";
-  private static final String SPARK_EXECUTOR_JAVA_OPTS = "spark.executor.extraJavaOptions";
 
   private static final String CONNECT_TIMEOUT = "master.environment.k8s.connect.timeout.sec";
   static final String CONNECT_TIMEOUT_DEFAULT = "120";
@@ -496,16 +495,6 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     sparkConfMap.put(SPARK_EXECUTOR_POD_CPU_REQUEST, String.format("%dm", executorCpuRequested));
     sparkConfMap.put(SPARK_EXECUTOR_POD_CPU_LIMIT, String.format("%dm", executorCpuLimit));
 
-    // In Spark v3.2.0 and later, max netty direct memory must be
-    // >= spark.network.maxRemoteBlockSizeFetchToMem for executors.
-    // So we set max netty direct memory = spark.network.maxRemoteBlockSizeFetchToMem
-    // See CDAP-20758 for details.
-    // NOTE: If spark.network.maxRemoteBlockSizeFetchToMem is changed in ETLSpark.java,
-    // DataStreamsSparkLaunch.java, then io.netty.maxDirectMemory will need also need to changed
-    // here.
-    String nettyMaxDirectMemory = String.format("-Dio.netty.maxDirectMemory=%d", Integer.MAX_VALUE - 512);
-    sparkConfMap.put(SPARK_EXECUTOR_JAVA_OPTS, nettyMaxDirectMemory);
-
     // Add spark pod labels. This will be same as job labels
     populateLabels(sparkConfMap);
 
@@ -513,7 +502,15 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     // https://github.com/cdapio/cdap/blob/develop/cdap-spark-core3_2.12/src/k8s/Dockerfile#L46
     return new SparkConfig("k8s://" + master,
         URI.create("local:/opt/cdap/cdap-spark-core/cdap-spark-core.jar"),
-        sparkConfMap, getPodWatcherThread());
+        sparkConfMap, getPodWatcherThread(),
+        // In Spark v3.2.0 and later, max netty direct memory must be
+        // >= spark.network.maxRemoteBlockSizeFetchToMem for executors.
+        // So we set max netty direct memory = spark.network.maxRemoteBlockSizeFetchToMem
+        // See CDAP-20758 for details.
+        // NOTE: If spark.network.maxRemoteBlockSizeFetchToMem is changed in ETLSpark.java,
+        // DataStreamsSparkLaunch.java, then io.netty.maxDirectMemory will need also need to changed
+        // here.
+        String.format("-Dio.netty.maxDirectMemory=%d", Integer.MAX_VALUE - 512));
   }
 
   @Override

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/spark/SparkConfig.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/environment/spark/SparkConfig.java
@@ -32,13 +32,24 @@ public class SparkConfig {
   private final URI sparkJobFile;
   private final Map<String, String> configs;
   private final SparkDriverWatcher sparkDriverWatcher;
+  private final String extraJavaOpts;
 
+  /**
+   * Create spark configurations for a specific environment
+   *
+   * @param master the spark master
+   * @param sparkJobFile location of the job file
+   * @param configs SparkConf properties that should be added to the spark job
+   * @param sparkDriverWatcher watcher for the Spark driver
+   * @param extraJavaOpts extra java options that should be added to the driver and executor
+   */
   public SparkConfig(String master, URI sparkJobFile, Map<String, String> configs,
-      SparkDriverWatcher sparkDriverWatcher) {
+      SparkDriverWatcher sparkDriverWatcher, @Nullable String extraJavaOpts) {
     this.master = master;
     this.sparkJobFile = sparkJobFile;
     this.configs = Collections.unmodifiableMap(new HashMap<>(configs));
     this.sparkDriverWatcher = sparkDriverWatcher;
+    this.extraJavaOpts = extraJavaOpts;
   }
 
   /**
@@ -60,16 +71,27 @@ public class SparkConfig {
 
   /**
    * Returns additional environment specific spark submit configurations. These will be added to
-   * --conf of spark submit.
+   * --conf of spark submit. These will *override* any value specified by the application. Note
+   * that extra java options should be specified separately rather than returned
+   * as a spark configuration here.
    */
   public Map<String, String> getConfigs() {
     return configs;
   }
 
   /**
-   * Returns driver watcher thread
+   * Returns driver watcher thread.
    */
   public SparkDriverWatcher getSparkDriverWatcher() {
     return sparkDriverWatcher;
+  }
+
+  /**
+   * Returns extra java options to set for the driver and executor. This will be prepended to any
+   * extra java options set for the application.
+   */
+  @Nullable
+  public String getExtraJavaOpts() {
+    return extraJavaOpts;
   }
 }

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/AbstractSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/AbstractSparkSubmitter.java
@@ -146,9 +146,11 @@ public abstract class AbstractSparkSubmitter implements SparkSubmitter {
 
   /**
    * Returns configs that are specific to the submission context.
+   *
+   * @param appConf Spark configs specified by the application
    * @throws Exception if there is error while generating submit conf.
    */
-  protected Map<String, String> generateSubmitConf() throws Exception {
+  protected Map<String, String> generateSubmitConf(Map<String, String> appConf) throws Exception {
     return Collections.emptyMap();
   }
 
@@ -225,7 +227,7 @@ public abstract class AbstractSparkSubmitter implements SparkSubmitter {
     addMaster(configs, builder);
     builder.add("--conf").add("spark.app.name=" + spec.getName());
 
-    configs.putAll(generateSubmitConf());
+    configs.putAll(generateSubmitConf(configs));
     BiConsumer<String, String> confAdder = (k, v) -> builder.add("--conf").add(k + "=" + v);
     configs.forEach(confAdder);
 

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/DistributedSparkSubmitter.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/submit/DistributedSparkSubmitter.java
@@ -68,7 +68,7 @@ public class DistributedSparkSubmitter extends AbstractSparkSubmitter {
   }
 
   @Override
-  protected Map<String, String> generateSubmitConf() {
+  protected Map<String, String> generateSubmitConf(Map<String, String> appConf) {
     Map<String, String> config = new HashMap<>();
     if (schedulerQueueName != null && !schedulerQueueName.isEmpty()) {
       config.put("spark.yarn.queue", schedulerQueueName);

--- a/cdap-spark-core-base/src/test/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitterTest.java
+++ b/cdap-spark-core-base/src/test/java/io/cdap/cdap/app/runtime/spark/submit/MasterEnvironmentSparkSubmitterTest.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright © 2023 Cask Data, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+package io.cdap.cdap.app.runtime.spark.submit;
+
+import io.cdap.cdap.master.spi.environment.spark.SparkConfig;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for MasterEnvironment Spark submission.
+ */
+public class MasterEnvironmentSparkSubmitterTest {
+
+  @Test
+  public void testExtraJavaOptionsAppended() {
+    String envOption = "-Dextra.java.opt=0";
+    SparkConfig sparkConfig = new SparkConfig("master", URI.create("local://0"),
+        Collections.emptyMap(), null, envOption);
+
+    Map<String, String> appConf = new HashMap<>();
+    String driverOption = "-Dapp.opt=driver";
+    String executorOption = "-Dapp.opt=executor";
+    appConf.put("spark.driver.extraJavaOptions", "-Dapp.opt=driver");
+    appConf.put("spark.executor.extraJavaOptions", "-Dapp.opt=executor");
+    Map<String, String> expected = new HashMap<>();
+    expected.put("spark.driver.extraJavaOptions", envOption + " " + driverOption);
+    expected.put("spark.executor.extraJavaOptions", envOption + " " + executorOption);
+
+    Map<String, String> merged =
+        MasterEnvironmentSparkSubmitter.mergeSparkConfs(appConf, sparkConfig);
+    Assert.assertEquals(expected, merged);
+  }
+}


### PR DESCRIPTION
Make sure extra java options specified by the environment and by the app get appeneded to each other rather than one overriding the other. This fixes issues where the executor fails to run due to missing java options, like when proxy settings are being set through the java options.