### PR TITLE
add the internal updateGitMetadata api

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -390,6 +390,16 @@ public interface Store {
                                                              ApplicationSpecification specification);
 
   /**
+   * Updates source control metadata for one or more applications.
+   * If any of the applications in the given collection are not found, this method ignores them.
+   *
+   * @param updateRequests Map of {@link ApplicationId} to {@link SourceControlMeta}
+   * @throws IOException if scm meta update fails
+   */
+  void updateApplicationSourceControlMeta(Map<ApplicationId, SourceControlMeta> updateRequests)
+      throws IOException;
+
+  /**
    * Returns application specification by id.
    *
    * @param id application id

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -600,6 +600,21 @@ public class DefaultStore implements Store {
     }, ConflictException.class);
   }
 
+  @Override
+  public void updateApplicationSourceControlMeta(Map<ApplicationId, SourceControlMeta> updateRequests)
+      throws IOException {
+    TransactionRunners.run(transactionRunner, context -> {
+      AppMetadataStore mds = getAppMetadataStore(context);
+      for (Map.Entry<ApplicationId, SourceControlMeta> updateRequest : updateRequests.entrySet()) {
+        try {
+          mds.updateAppScmMeta(updateRequest.getKey(), updateRequest.getValue());
+        } catch (ApplicationNotFoundException e) {
+          // ignore this exception and continue updating the other applications
+        }
+      }
+    }, IOException.class);
+  }
+
   // todo: this method should be moved into DeletedProgramHandlerState, bad design otherwise
   @Override
   public List<ProgramSpecification> getDeletedProgramSpecifications(ApplicationReference appRef,

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/app/UpdateMultiSourceControlMetaReqeust.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/app/UpdateMultiSourceControlMetaReqeust.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.app;
+
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * Request class to update source control meta of multiple applications.
+ */
+public class UpdateMultiSourceControlMetaReqeust {
+  private final Collection<UpdateSourceControlMetaRequest> apps;
+
+  public UpdateMultiSourceControlMetaReqeust(Collection<UpdateSourceControlMetaRequest> apps) {
+    this.apps = apps;
+  }
+
+  public Collection<UpdateSourceControlMetaRequest> getApps() {
+    return apps;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof UpdateMultiSourceControlMetaReqeust)) {
+      return false;
+    }
+    UpdateMultiSourceControlMetaReqeust that = (UpdateMultiSourceControlMetaReqeust) o;
+    return Objects.equals(apps, that.apps);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(apps);
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/app/UpdateSourceControlMetaRequest.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/app/UpdateSourceControlMetaRequest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.app;
+
+import java.util.Objects;
+
+/**
+ * Request class to update sourceControlMeta of an application.
+ */
+public class UpdateSourceControlMetaRequest {
+  private final String name;
+  private final String appVersion;
+  private final String gitFileHash;
+
+  public UpdateSourceControlMetaRequest(String name, String appVersion, String gitFileHash) {
+    this.name = name;
+    this.appVersion = appVersion;
+    this.gitFileHash = gitFileHash;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getAppVersion() {
+    return appVersion;
+  }
+
+  public String getGitFileHash() {
+    return gitFileHash;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof UpdateSourceControlMetaRequest)) {
+      return false;
+    }
+    UpdateSourceControlMetaRequest that = (UpdateSourceControlMetaRequest) o;
+    return Objects.equals(name, that.name) && Objects.equals(appVersion,
+        that.appVersion) && Objects.equals(gitFileHash, that.gitFileHash);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, appVersion, gitFileHash);
+  }
+}


### PR DESCRIPTION
This PR adds an internal api `api/v3internal/namespaces/:namespace/apps/updateSourceControlMeta`. This api takes a list of appIds (with versionIds) with gitFileHashes and updates their scm metadata in the database.

JIRA: [CDAP-20856](https://cdap.atlassian.net/browse/CDAP-20856)

[CDAP-20856]: https://cdap.atlassian.net/browse/CDAP-20856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ