### PR TITLE
[CDAP-20840] Check for empty LDAP password

### DIFF
--- a/cdap-security/src/main/java/io/cdap/cdap/security/server/JAASLoginService.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/server/JAASLoginService.java
@@ -194,8 +194,11 @@ public class JAASLoginService extends AbstractLifeCycle implements LoginService 
   @Override
   public UserIdentity login(final String username, final Object credentials) {
     try {
-      CallbackHandler callbackHandler = null;
+      if (credentials instanceof String && ((String) credentials).isEmpty()) {
+        throw new LoginException("Empty password");
+      }
 
+      CallbackHandler callbackHandler = null;
       if (callbackHandlerClass == null) {
         callbackHandler = new CallbackHandler() {
           @Override

--- a/cdap-security/src/test/java/io/cdap/cdap/security/server/ExternalLDAPAuthenticationServerTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/server/ExternalLDAPAuthenticationServerTest.java
@@ -20,11 +20,14 @@ import com.unboundid.ldap.listener.InMemoryListenerConfig;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.SConfiguration;
+import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 /**
  * Tests for {@link ExternalAuthenticationServer}.
@@ -72,4 +75,19 @@ public class ExternalLDAPAuthenticationServerTest extends ExternalLDAPAuthentica
   protected String getAuthenticatedUserName() {
    return "admin";
   }
+
+  /**
+   * Test request to server with empty password
+   */
+   @Test
+   public void testEmptyPassword() throws Exception {
+     HttpURLConnection urlConn = openConnection(getURL(GrantAccessToken.Paths.GET_TOKEN));
+     try {
+       // base64 encoding of admin: (username=admin, password=empty string)
+       urlConn.addRequestProperty("Authorization", "Basic YWRtaW46");
+       Assert.assertEquals(401, urlConn.getResponseCode());
+      } finally {
+       urlConn.disconnect();
+      }
+    }
 }


### PR DESCRIPTION
LDAP server may return an [unauthenticated positive response when an empty password is provided](https://stackoverflow.com/questions/12359831/java-ldap-make-it-not-ignore-blank-passwords/12370710#12370710). We workaround this on the client side by failing login if the password is empty.