### PR TITLE
[CDAP-20831] Forces task worker to restart if ongoing request is stuck

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
@@ -165,17 +165,25 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
           (new Random()).nextInt(upperBound - lowerBound) + lowerBound;
       Executors.newSingleThreadScheduledExecutor(
               Threads.createDaemonThreadFactory("task-worker-restart"))
-          .schedule(
+          .scheduleWithFixedDelay(
               () -> {
+                if (mustRestart.get()) {
+                  // We force pod restart as the ongoing request has not finished since last
+                  // periodic restart check.
+                  stopper.accept("");
+                  return;
+                }
+                // we restart once ongoing request (which has set hasInflightRequest to true)
+                // finishes.
+                mustRestart.set(true);
                 if (hasInflightRequest.compareAndSet(false, true)) {
                   // there is no ongoing request. pod gets restarted.
                   stopper.accept("");
                 }
-                // we restart once a request finishes.
-                // TODO: this might delay the pod restart to after executing a new request if the
-                // ongoing request is already in the stopper.
-                mustRestart.set(true);
-              }, waitTime, TimeUnit.SECONDS);
+              },
+              waitTime,
+              waitTime,
+              TimeUnit.SECONDS);
     }
   }
 


### PR DESCRIPTION
Why: currently if an ongoing request is stuck for whatever reason (e.g., due to https://cdap.atlassian.net/browse/CDAP-20832) , task worker pod will hang such that it can neither restart nor accept a new request. 
