### PR TITLE
[CDAP-20792] Fix CDAP-20792 failure on shutdown

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerService.java
@@ -64,7 +64,9 @@ import java.net.HttpURLConnection;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -1030,7 +1032,8 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
   /**
    * Create and start watchers for the given Kubernetes namespace
    */
-  private synchronized void addAndStartWatchers(String namespace) {
+  @VisibleForTesting
+  synchronized void addAndStartWatchers(String namespace) {
     if (resourceWatchers.containsKey(namespace)) {
       return;
     }
@@ -1068,8 +1071,10 @@ public class KubeTwillRunnerService implements TwillRunnerService, NamespaceList
   /**
    * Stop and remove watchers for all Kubernetes namespaces
    */
-  private synchronized void stopAndRemoveWatchers() {
-    resourceWatchers.keySet().forEach(this::stopAndRemoveWatchers);
+  @VisibleForTesting
+  synchronized void stopAndRemoveWatchers() {
+    resourceWatchers.values().forEach(e -> e.values().forEach(AbstractWatcherThread::close));
+    resourceWatchers.clear();
   }
 
   /**

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerServiceTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillRunnerServiceTest.java
@@ -332,6 +332,12 @@ public class KubeTwillRunnerServiceTest {
 
   }
 
+  @Test
+  public void testDeleteWatchers() {
+    twillRunnerService.addAndStartWatchers(KUBE_NAMESPACE);
+    twillRunnerService.stopAndRemoveWatchers();
+  }
+
   private void enableWorkloadIdentity() {
     String workloadIdentityPool = "test-workload-pool";
     String workloadIdentityProvider =


### PR DESCRIPTION
Fixes this failure:
```
Caused by: java.util.ConcurrentModificationException: null
        at java.util.HashMap$KeySet.forEach(HashMap.java:937)
        at io.cdap.cdap.k8s.runtime.KubeTwillRunnerService.stopAndRemoveWatchers(KubeTwillRunnerService.java:1072)
        at io.cdap.cdap.k8s.runtime.KubeTwillRunnerService.stop(KubeTwillRunnerService.java:656)
        at io.cdap.cdap.master.environment.k8s.TwillRunnerServiceWrapper.shutDown(TwillRunnerServiceWrapper.java:42)
        at com.google.common.util.concurrent.AbstractIdleService$1$2.run(AbstractIdleService.java:57)
```