### PR TITLE
Implement SCM Pull LRO

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/OperationHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/OperationHttpHandler.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.gateway.handlers;
 
 import com.google.gson.Gson;
-import com.google.inject.Inject;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import io.cdap.cdap.proto.operation.OperationRun;
@@ -35,14 +34,13 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 
 /**
- * The {@link HttpHandler} for handling REST calls to namespace endpoints.
+ * The {@link HttpHandler} for handling REST calls to operation endpoints.
  */
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}/operations")
 public class OperationHttpHandler extends AbstractAppFabricHttpHandler {
 
   private static final Gson GSON = new Gson();
-
-  @Inject
+  
   OperationHttpHandler() {
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
@@ -49,7 +49,7 @@ import io.cdap.cdap.sourcecontrol.RepositoryManager;
 import io.cdap.cdap.sourcecontrol.SourceControlConfig;
 import io.cdap.cdap.sourcecontrol.SourceControlException;
 import io.cdap.cdap.sourcecontrol.operationrunner.NamespaceRepository;
-import io.cdap.cdap.sourcecontrol.operationrunner.PulAppOperationRequest;
+import io.cdap.cdap.sourcecontrol.operationrunner.PullAppOperationRequest;
 import io.cdap.cdap.sourcecontrol.operationrunner.PullAppResponse;
 import io.cdap.cdap.sourcecontrol.operationrunner.PushAppOperationRequest;
 import io.cdap.cdap.sourcecontrol.operationrunner.PushAppResponse;
@@ -293,7 +293,8 @@ public class SourceControlManagementService {
     throws NoChangesToPullException, NotFoundException, AuthenticationConfigException {
     RepositoryConfig repoConfig = getRepositoryMeta(appRef.getParent()).getConfig();
     SourceControlMeta latestMeta = store.getAppSourceControlMeta(appRef);
-    PullAppResponse<?> pullResponse = sourceControlOperationRunner.pull(new PulAppOperationRequest(appRef, repoConfig));
+    PullAppResponse<?> pullResponse = sourceControlOperationRunner.pull(
+        new PullAppOperationRequest(appRef, repoConfig));
 
     if (latestMeta != null
         && latestMeta.getFileHash().equals(pullResponse.getApplicationFileHash())) {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/sourcecontrol/ApplicationManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/sourcecontrol/ApplicationManager.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.sourcecontrol;
+
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.sourcecontrol.SourceControlException;
+import io.cdap.cdap.sourcecontrol.operationrunner.PullAppResponse;
+import java.util.Collection;
+
+/**
+ * Provides various helper methods for source control operations to operate on applications.
+ * Would be implemented for both running in app-fabric and running in workers.
+ */
+public interface ApplicationManager {
+
+  /**
+   * Deploys a given app with the given pull app details.
+   *
+   * @param appRef the {@link ApplicationReference} for the app to be deployed
+   * @param pullDetails {@link PullAppResponse} which includes the app spec and the git hash.
+   * @return The {@link ApplicationId} for the deployed version
+   * @throws SourceControlException for any failure. We wrap all failures to
+   *     {@link SourceControlException}
+   */
+  ApplicationId deployApp(ApplicationReference appRef, PullAppResponse<?> pullDetails)
+      throws SourceControlException;
+
+  /**
+   * Mark the given list of app-versions as the latest. Only the latest version for any app is
+   * runnable.
+   *
+   * @param appIds List of {@link ApplicationId} to be marked latest
+   * @throws SourceControlException for any failure. We wrap all failures to
+   *     {@link SourceControlException}
+   */
+  void markAppVersionsLatest(Collection<ApplicationId> appIds) throws SourceControlException;
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/sourcecontrol/PullAppsOperationFactory.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/sourcecontrol/PullAppsOperationFactory.java
@@ -14,23 +14,21 @@
  * the License.
  */
 
-package io.cdap.cdap.sourcecontrol;
+package io.cdap.cdap.internal.app.sourcecontrol;
+
 
 /**
- * Exception thrown when an error is encountered while setting up authentication credentials for the
- * remote Git repo.
+ * Factory interface for creating {@link PullAppsOperation}.
+ * This interface is for Guice assisted binding, hence there will be no concrete implementation of it.
  */
-public class AuthenticationConfigException extends SourceControlException {
+public interface PullAppsOperationFactory {
 
-  public AuthenticationConfigException(String message, Exception cause) {
-    super(message, cause);
-  }
-
-  public AuthenticationConfigException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
-  public AuthenticationConfigException(String message) {
-    super(message);
-  }
+  /**
+   * Returns an implementation of {@link PullAppsOperation} that operates on the given {@link
+   * PullAppsRequest}.
+   *
+   * @param request contains list of apps to pull
+   * @return a new instance of {@link PullAppsOperation}.
+   */
+  PullAppsOperation create(PullAppsRequest request);
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/sourcecontrol/PullAppsRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/sourcecontrol/PullAppsRequest.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.internal.app.sourcecontrol;
 
 import com.google.common.base.Objects;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import java.util.Set;
 
 /**
@@ -25,18 +26,24 @@ import java.util.Set;
 public class PullAppsRequest {
 
   private final Set<String> apps;
+  private final RepositoryConfig config;
 
   /**
    * Default Constructor.
    *
    * @param apps Set of apps to pull.
    */
-  public PullAppsRequest(Set<String> apps) {
+  public PullAppsRequest(Set<String> apps, RepositoryConfig config) {
     this.apps = apps;
+    this.config = config;
   }
 
   public Set<String> getApps() {
     return apps;
+  }
+
+  public RepositoryConfig getConfig() {
+    return config;
   }
 
   @Override
@@ -49,11 +56,12 @@ public class PullAppsRequest {
     }
 
     PullAppsRequest that = (PullAppsRequest) o;
-    return Objects.equal(this.getApps(), that.getApps());
+    return Objects.equal(this.getApps(), that.getApps())
+        && Objects.equal(this.getConfig(), that.getConfig());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(getApps());
+    return Objects.hashCode(getApps(), getConfig());
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/LongRunningOperation.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/LongRunningOperation.java
@@ -17,7 +17,8 @@
 package io.cdap.cdap.internal.operation;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import io.cdap.cdap.proto.operation.OperationError;
+import io.cdap.cdap.proto.operation.OperationResource;
+import java.util.Set;
 
 /**
  * LongRunningOperation represents a long-running asynchronous operation.
@@ -27,10 +28,11 @@ public interface LongRunningOperation {
   /**
    * Run the operation with the given request.
    *
-   * @param request the operation input
-   * @param updateMetadata func to update the metadata of the operation. This would be passed by
-   *     the runner.
-   * @return {@link ListenableFuture} containing the {@link OperationError} for the run
+   * @param context the operation context. Contains func to update the resources of the
+   *     operation. This would be passed by the runner.
+   * @return {@link ListenableFuture} containing the {@link OperationResource}s operation on by the
+   *     run
    */
-  ListenableFuture<OperationError> run(LongRunningOperationContext context);
+  ListenableFuture<Set<OperationResource>> run(LongRunningOperationContext context)
+      throws OperationException;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationException.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationException.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.operation;
+
+import io.cdap.cdap.proto.operation.OperationError;
+import io.cdap.cdap.proto.operation.OperationResourceScopedError;
+import java.util.Collection;
+
+/**
+ * Wrapper Exception class for operations. Provides capability to store per resource failure.
+ */
+public class OperationException extends Exception {
+
+  private final Collection<OperationResourceScopedError> errors;
+
+  public OperationException(String message, Collection<OperationResourceScopedError> errors) {
+    super(message);
+    this.errors = errors;
+  }
+
+  public OperationError toOperationError() {
+    return new OperationError(getMessage(), errors);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationRunFilter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationRunFilter.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.internal.operation;
 
 import io.cdap.cdap.proto.operation.OperationRunStatus;
+import io.cdap.cdap.proto.operation.OperationType;
 import javax.annotation.Nullable;
 
 /**
@@ -25,18 +26,18 @@ import javax.annotation.Nullable;
 public class OperationRunFilter {
 
   @Nullable
-  private final String operationType;
+  private final OperationType operationType;
   @Nullable
   private final OperationRunStatus status;
   // TODO(samik) status and type filters as list
 
-  public OperationRunFilter(@Nullable String operationType, @Nullable OperationRunStatus status) {
+  public OperationRunFilter(@Nullable OperationType operationType, @Nullable OperationRunStatus status) {
     this.operationType = operationType;
     this.status = status;
   }
 
   @Nullable
-  public String getOperationType() {
+  public OperationType getOperationType() {
     return operationType;
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationRunStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationRunStore.java
@@ -210,12 +210,12 @@ public class OperationRunStore {
     );
     if (request.getFilter().getOperationType() != null) {
       startFields.add(Fields.stringField(StoreDefinition.OperationRunsStore.TYPE_FIELD,
-          request.getFilter().getOperationType())
+          request.getFilter().getOperationType().name())
       );
     }
     if (request.getFilter().getStatus() != null) {
       startFields.add(Fields.stringField(StoreDefinition.OperationRunsStore.STATUS_FIELD,
-          request.getFilter().getStatus().toString()));
+          request.getFilter().getStatus().name()));
     }
 
     Collection<Field<?>> endFields = startFields;
@@ -311,9 +311,9 @@ public class OperationRunStore {
         Fields.stringField(StoreDefinition.OperationRunsStore.NAMESPACE_FIELD,
             runId.getNamespace()),
         Fields.stringField(StoreDefinition.OperationRunsStore.STATUS_FIELD,
-            detail.getRun().getStatus().toString()),
+            detail.getRun().getStatus().name()),
         Fields.stringField(StoreDefinition.OperationRunsStore.TYPE_FIELD,
-            detail.getRun().getType()),
+            detail.getRun().getType().name()),
         Fields.longField(StoreDefinition.OperationRunsStore.START_TIME_FIELD,
             detail.getRun().getMetadata().getCreateTime().toEpochMilli()),
         Fields.longField(StoreDefinition.OperationRunsStore.UPDATE_TIME_FIELD,

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/sourcecontrol/PullAppsOperationTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/sourcecontrol/PullAppsOperationTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.sourcecontrol;
+
+
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import com.google.inject.AbstractModule;
+import com.google.inject.Injector;
+import io.cdap.cdap.api.artifact.ArtifactSummary;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.internal.AppFabricTestHelper;
+import io.cdap.cdap.internal.operation.LongRunningOperationContext;
+import io.cdap.cdap.internal.operation.OperationException;
+import io.cdap.cdap.proto.artifact.AppRequest;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.proto.id.OperationRunId;
+import io.cdap.cdap.proto.operation.OperationResource;
+import io.cdap.cdap.sourcecontrol.RepositoryManager;
+import io.cdap.cdap.sourcecontrol.RepositoryManagerFactory;
+import io.cdap.cdap.sourcecontrol.SourceControlException;
+import io.cdap.cdap.sourcecontrol.operationrunner.InMemorySourceControlOperationRunner;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+public class PullAppsOperationTest {
+
+  private static final AppRequest<?> TEST_APP_REQUEST = new AppRequest<>(
+      new ArtifactSummary("name", "version"));
+
+  private static final Gson GSON = new Gson();
+
+  private final PullAppsRequest req = new PullAppsRequest(ImmutableSet.of("1", "2", "3", "4"),
+      null);
+
+  private InMemorySourceControlOperationRunner opRunner;
+  private LongRunningOperationContext context;
+  private Set<OperationResource> gotResources;
+
+  @ClassRule
+  public static TemporaryFolder repositoryBase = new TemporaryFolder();
+
+  @Before
+  public void setUp() throws Exception {
+    RepositoryManagerFactory mockRepositoryManagerFactory = Mockito.mock(
+        RepositoryManagerFactory.class);
+    RepositoryManager mockRepositoryManager = Mockito.mock(RepositoryManager.class);
+    Mockito.doReturn(mockRepositoryManager).when(mockRepositoryManagerFactory)
+        .create(Mockito.any(), Mockito.any());
+    Mockito.doReturn(Paths.get("")).when(mockRepositoryManager).getRepositoryRoot();
+    Mockito.doReturn(repositoryBase.getRoot().toPath()).when(mockRepositoryManager)
+        .getRepositoryRoot();
+    Mockito.doReturn(repositoryBase.getRoot().toPath()).when(mockRepositoryManager).getBasePath();
+    Mockito.doReturn("testHash")
+        .when(mockRepositoryManager)
+        .getFileHash(Mockito.any(), Mockito.any());
+    Path tempFile = repositoryBase.newFile().toPath();
+    Files.write(tempFile, GSON.toJson(TEST_APP_REQUEST).getBytes(StandardCharsets.UTF_8));
+    Mockito.doNothing().when(mockRepositoryManager).close();
+    Mockito.doReturn(tempFile.getFileName()).when(mockRepositoryManager)
+        .getFileRelativePath(Mockito.any());
+
+    this.context = Mockito.mock(LongRunningOperationContext.class);
+    Mockito.doReturn(new OperationRunId("default", "id")).when(this.context).getRunId();
+    gotResources = new HashSet<>();
+    Mockito.doAnswer(i -> {
+      gotResources.addAll(
+          (Collection<? extends OperationResource>) i.getArguments()[0]);
+      return null;
+    }).when(context).updateOperationResources(Mockito.any());
+
+    Injector injector = AppFabricTestHelper.getInjector(CConfiguration.create(),
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(RepositoryManagerFactory.class).toInstance(mockRepositoryManagerFactory);
+          }
+        });
+
+    this.opRunner = injector.getInstance(InMemorySourceControlOperationRunner.class);
+  }
+
+  @Test
+  public void testRunSuccess() throws Exception {
+    ApplicationManager mockManager = Mockito.mock(ApplicationManager.class);
+    PullAppsOperation operation = new PullAppsOperation(this.req, opRunner, mockManager);
+
+    Mockito.doAnswer(i -> {
+          ApplicationReference appref = (ApplicationReference) i.getArguments()[0];
+          return appref.app(appref.getApplication());
+        }
+    ).when(mockManager).deployApp(Mockito.any(), Mockito.any());
+
+    gotResources = operation.run(context).get();
+
+    verifyCreatedResources(ImmutableSet.of("1", "2", "3", "4"));
+  }
+
+  @Test(expected = OperationException.class)
+  public void testRunFailedAtFirstApp() throws Exception {
+    ApplicationManager mockManager = Mockito.mock(ApplicationManager.class);
+    LongRunningOperationContext mockContext = Mockito.mock(LongRunningOperationContext.class);
+    PullAppsOperation operation = new PullAppsOperation(this.req, opRunner, mockManager);
+
+    Mockito.doThrow(new SourceControlException("")).when(mockManager)
+        .deployApp(Mockito.any(), Mockito.any());
+
+    operation.run(context).get();
+  }
+
+  @Test
+  public void testRunFailedAtSecondApp() throws Exception {
+    ApplicationManager mockManager = Mockito.mock(ApplicationManager.class);
+    PullAppsOperation operation = new PullAppsOperation(this.req, opRunner, mockManager);
+
+    Mockito.doAnswer(
+            i -> {
+              ApplicationReference appref = (ApplicationReference) i.getArguments()[0];
+              return appref.app(appref.getApplication());
+            }
+        ).doThrow(new SourceControlException("")).when(mockManager)
+        .deployApp(Mockito.any(), Mockito.any());
+
+    try {
+      operation.run(context).get();
+    } catch (Exception e) {
+      // expected
+    }
+
+    verifyCreatedResources(ImmutableSet.of("1"));
+  }
+
+  @Test
+  public void testRunFailedWhenMarkingLatest() throws Exception {
+    ApplicationManager mockManager = Mockito.mock(ApplicationManager.class);
+    PullAppsOperation operation = new PullAppsOperation(this.req, opRunner, mockManager);
+
+    Mockito.doAnswer(
+        i -> {
+          ApplicationReference appref = (ApplicationReference) i.getArguments()[0];
+          return appref.app(appref.getApplication());
+        }
+    ).when(mockManager).deployApp(Mockito.any(), Mockito.any());
+
+    Mockito.doThrow(new SourceControlException("")).when(mockManager)
+        .markAppVersionsLatest(Mockito.any());
+
+    try {
+      operation.run(context).get();
+    } catch (Exception e) {
+      // expected
+    }
+
+    verifyCreatedResources(ImmutableSet.of("1", "2", "3", "4"));
+  }
+
+  private void verifyCreatedResources(Set<String> expectedApps) {
+    Set<ApplicationId> createdAppIds = gotResources.stream()
+        .map(r -> ApplicationId.fromString(r.getResourceUri())).collect(Collectors.toSet());
+    Set<ApplicationId> expectedAppIds = expectedApps.stream()
+        .map(a -> new ApplicationId("default", a, a)).collect(Collectors.toSet());
+    Assert.assertEquals(expectedAppIds, createdAppIds);
+  }
+
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationRun.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationRun.java
@@ -29,7 +29,7 @@ public class OperationRun {
   private final String id;
 
   @SerializedName("type")
-  private final String type;
+  private final OperationType type;
 
   // derived from the operation status
   @SerializedName("done")
@@ -49,7 +49,7 @@ public class OperationRun {
   /**
    * Constructor for OperationRun.
    */
-  protected OperationRun(String id, String type, OperationRunStatus status, OperationMeta metadata,
+  protected OperationRun(String id, OperationType type, OperationRunStatus status, OperationMeta metadata,
       @Nullable OperationError error) {
     this.id = id;
     this.type = type;
@@ -116,7 +116,7 @@ public class OperationRun {
     return error;
   }
 
-  public String getType() {
+  public OperationType getType() {
     return type;
   }
 
@@ -129,7 +129,7 @@ public class OperationRun {
   public static class Builder<T extends Builder> {
 
     protected String runId;
-    protected String type;
+    protected OperationType type;
     protected OperationRunStatus status;
     protected OperationMeta metadata;
     protected OperationError error;
@@ -165,7 +165,7 @@ public class OperationRun {
       return (T) this;
     }
 
-    public T setType(String type) {
+    public T setType(OperationType type) {
       this.type = type;
       return (T) this;
     }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/InvalidApplicationConfigException.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/InvalidApplicationConfigException.java
@@ -16,21 +16,22 @@
 
 package io.cdap.cdap.sourcecontrol;
 
+import java.nio.file.Path;
+
 /**
- * Exception thrown when an error is encountered while setting up authentication credentials for the
- * remote Git repo.
+ * Thrown when the application json could not be de-serialized.
  */
-public class AuthenticationConfigException extends SourceControlException {
+public class InvalidApplicationConfigException extends SourceControlException {
 
-  public AuthenticationConfigException(String message, Exception cause) {
-    super(message, cause);
-  }
-
-  public AuthenticationConfigException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
-  public AuthenticationConfigException(String message) {
-    super(message);
+  /**
+   * Default constructor.
+   *
+   * @param appRelativePath the relative path of config file in repository.
+   * @param cause the causing exception.
+   */
+  public InvalidApplicationConfigException(Path appRelativePath, Throwable cause) {
+    super(String.format(
+        "Failed to de-serialize application json at path %s. Ensure application json is valid.",
+        appRelativePath), cause);
   }
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/SourceControlAppConfigNotFoundException.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/SourceControlAppConfigNotFoundException.java
@@ -16,21 +16,20 @@
 
 package io.cdap.cdap.sourcecontrol;
 
+import io.cdap.cdap.common.NotFoundException;
+import java.nio.file.Path;
+
 /**
- * Exception thrown when an error is encountered while setting up authentication credentials for the
- * remote Git repo.
+ * Thrown when the application config file is not present in the repository.
  */
-public class AuthenticationConfigException extends SourceControlException {
+public class SourceControlAppConfigNotFoundException extends NotFoundException {
 
-  public AuthenticationConfigException(String message, Exception cause) {
-    super(message, cause);
+  public SourceControlAppConfigNotFoundException(String applicationName, Path appRelativePath) {
+    super(String.format("App with name %s not found at path %s in git repository",
+        applicationName, appRelativePath));
   }
 
-  public AuthenticationConfigException(String message, Throwable cause) {
+  public SourceControlAppConfigNotFoundException(String message, Throwable cause) {
     super(message, cause);
-  }
-
-  public AuthenticationConfigException(String message) {
-    super(message);
   }
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/MultiPullAppOperationRequest.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/MultiPullAppOperationRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.sourcecontrol.operationrunner;
+
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
+import java.util.Set;
+
+/**
+ * Information required by {@link SourceControlOperationRunner} to execute the task of pulling
+ * multiple application from linked repository.
+ */
+public class MultiPullAppOperationRequest {
+
+  private final RepositoryConfig repoConfig;
+
+  private final NamespaceId namespace;
+
+  private final Set<String> apps;
+
+  /**
+   * Default constructor.
+   */
+  public MultiPullAppOperationRequest(RepositoryConfig repoConfig, NamespaceId namespace,
+      Set<String> apps) {
+    this.repoConfig = repoConfig;
+    this.namespace = namespace;
+    this.apps = apps;
+  }
+
+  public NamespaceId getNamespace() {
+    return namespace;
+  }
+
+  public RepositoryConfig getRepositoryConfig() {
+    return repoConfig;
+  }
+
+  public Set<String> getApps() {
+    return apps;
+  }
+
+}

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/PullAppOperationRequest.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/PullAppOperationRequest.java
@@ -23,12 +23,12 @@ import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
  * Information required by {@link SourceControlOperationRunner} to execute the task of
  * pulling an application from linked repository.
  */
-public class PulAppOperationRequest {
+public class PullAppOperationRequest {
   private final RepositoryConfig repoConfig;
 
   private final ApplicationReference app;
 
-  public PulAppOperationRequest(ApplicationReference app, RepositoryConfig repoConfig) {
+  public PullAppOperationRequest(ApplicationReference app, RepositoryConfig repoConfig) {
     this.repoConfig = repoConfig;
     this.app = app;
   }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/SourceControlOperationRunner.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/SourceControlOperationRunner.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
 import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
 import io.cdap.cdap.sourcecontrol.SourceControlException;
+import java.util.function.Consumer;
 
 /**
  * An interface encapsulating all operations needed for source control management.
@@ -29,20 +30,20 @@ public interface SourceControlOperationRunner extends Service {
   /**
    * Push an application config to remote git repository.
    *
-   * @param pushAppOperationRequest {@link PushAppOperationRequest} of the application to be pushed
+   * @param pushRequest {@link PushAppOperationRequest} of the application to be pushed
    * @return file-paths and file-hashes for the updated configs.
    * @throws NoChangesToPushException      if there is no effective changes on the config file to commit
    * @throws AuthenticationConfigException when there is an error while creating the authentication credentials to
    *                                       call remote Git.
    * @throws SourceControlException when the push operation fails for any other reason.
    */
-  PushAppResponse push(PushAppOperationRequest pushAppOperationRequest) throws NoChangesToPushException,
+  PushAppResponse push(PushAppOperationRequest pushRequest) throws NoChangesToPushException,
     AuthenticationConfigException;
 
   /**
    * Gets an application spec from a Git repository.
    *
-   * @param pulAppOperationRequest The {@link PulAppOperationRequest} of the application to pull from
+   * @param pullRequest The {@link PullAppOperationRequest} of the application to pull from
    * @return the details of the pulled application.
    * @throws NotFoundException             when the requested application is not found in the Git repository.
    * @throws AuthenticationConfigException when there is an error while creating the authentication credentials to
@@ -50,8 +51,23 @@ public interface SourceControlOperationRunner extends Service {
    * @throws IllegalArgumentException      when the fetched application json or file path is invalid.
    * @throws SourceControlException when the operation fails for any other reason.
    */
-  PullAppResponse<?> pull(PulAppOperationRequest pulAppOperationRequest) throws NotFoundException,
+  PullAppResponse<?> pull(PullAppOperationRequest pullRequest) throws NotFoundException,
     AuthenticationConfigException;
+
+  /**
+   * Pulls multiple application specs from repository. Rather than returning the specs it calls the
+   * given {@link Consumer} for each spec.
+   *
+   * @param pullRequest The {@link MultiPullAppOperationRequest} of the applications to pull
+   * @param consumer {@link Consumer} that would be applied on each spec
+   * @throws NotFoundException             when the requested application is not found in the Git repository.
+   * @throws AuthenticationConfigException when there is an error while creating the authentication credentials to
+   *                                       call remote Git.
+   * @throws IllegalArgumentException      when the fetched application json or file path is invalid.
+   * @throws SourceControlException when the operation fails for any other reason.
+   */
+  void pull(MultiPullAppOperationRequest pullRequest, Consumer<PullAppResponse<?>> consumer)
+    throws NotFoundException, AuthenticationConfigException;
 
   /**
    * Lists application configs found in repository.

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/worker/PullAppTask.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/worker/PullAppTask.java
@@ -23,7 +23,7 @@ import io.cdap.cdap.api.service.worker.RunnableTaskContext;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.sourcecontrol.AuthenticationConfigException;
-import io.cdap.cdap.sourcecontrol.operationrunner.PulAppOperationRequest;
+import io.cdap.cdap.sourcecontrol.operationrunner.PullAppOperationRequest;
 import io.cdap.cdap.sourcecontrol.operationrunner.PullAppResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -52,10 +52,10 @@ public class PullAppTask extends SourceControlTask {
   @Override
   public void doRun(RunnableTaskContext context)
     throws AuthenticationConfigException, IOException, NotFoundException {
-    PulAppOperationRequest pulAppOperationRequest = GSON.fromJson(context.getParam(), PulAppOperationRequest.class);
+    PullAppOperationRequest pullAppOperationRequest = GSON.fromJson(context.getParam(), PullAppOperationRequest.class);
 
-    LOG.info("Pulling application {} in worker.", pulAppOperationRequest.getApp().getApplication());
-    PullAppResponse<?> result = inMemoryOperationRunner.pull(pulAppOperationRequest);
+    LOG.info("Pulling application {} in worker.", pullAppOperationRequest.getApp().getApplication());
+    PullAppResponse<?> result = inMemoryOperationRunner.pull(pullAppOperationRequest);
     context.writeResult(GSON.toJson(result).getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/SourceControlTestBase.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/SourceControlTestBase.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.sourcecontrol.AuthConfig;
 import io.cdap.cdap.proto.sourcecontrol.AuthType;
 import io.cdap.cdap.proto.sourcecontrol.PatConfig;
+import io.cdap.cdap.sourcecontrol.operationrunner.PullAppResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -53,6 +54,7 @@ public abstract class SourceControlTestBase {
   protected static final AuthConfig AUTH_CONFIG = new AuthConfig(AuthType.PAT, PAT_CONFIG);
   protected static final String PATH_PREFIX = "pathPrefix";
   protected static final String TEST_APP_NAME = "app1";
+  protected static final String TEST_APP2_NAME = "app2";
   protected static final String TEST_APP_SPEC = "{\n"
       + "  \"artifact\": {\n"
       + "     \"name\": \"cdap-notifiable-workflow\",\n"
@@ -76,6 +78,8 @@ public abstract class SourceControlTestBase {
       + "    },\n"
       + "  \"principal\" : \"test2\"\n"
       + "}";
+
+  protected static final String TEST_FILE_HASH = "a163ca52d8b8180456f8233656ebefe5fe7a4851";
 
   @ClassRule
   public static TemporaryFolder baseTempFolder = new TemporaryFolder();
@@ -150,7 +154,10 @@ public abstract class SourceControlTestBase {
   }
 
 
-  public void validateTestAppRequest(AppRequest<?> appRequest) {
+  public void validatePullResponse(PullAppResponse<?> response, String appName) {
+    Assert.assertEquals(response.getApplicationFileHash(), TEST_FILE_HASH);
+    Assert.assertEquals(response.getApplicationName(), appName);
+    AppRequest<?> appRequest = response.getAppRequest();
     Assert.assertNotNull(appRequest.getArtifact());
     Assert.assertEquals("cdap-notifiable-workflow",
         appRequest.getArtifact().getName());

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunnerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunnerTest.java
@@ -34,7 +34,6 @@ import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.common.namespace.InMemoryNamespaceAdmin;
 import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.NamespaceMeta;
-import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.sourcecontrol.AuthConfig;
@@ -51,6 +50,7 @@ import io.cdap.cdap.sourcecontrol.CommitMeta;
 import io.cdap.cdap.sourcecontrol.LocalGitServer;
 import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
 import io.cdap.cdap.sourcecontrol.SecureSystemReader;
+import io.cdap.cdap.sourcecontrol.SourceControlAppConfigNotFoundException;
 import io.cdap.cdap.sourcecontrol.SourceControlException;
 import io.cdap.cdap.sourcecontrol.SourceControlTestBase;
 import io.cdap.http.ChannelPipelineModifier;
@@ -251,7 +251,7 @@ public class RemoteSourceControlOperationRunnerTest extends SourceControlTestBas
     String serverUrl = gitServer.getServerUrl();
     RepositoryConfig repoConfig =
       new RepositoryConfig.Builder(mockRepoConfig).setLink(serverUrl + "ignored").build();
-    PulAppOperationRequest mockPullRequest = new PulAppOperationRequest(mockAppRef, repoConfig);
+    PullAppOperationRequest mockPullRequest = new PullAppOperationRequest(mockAppRef, repoConfig);
 
     RemoteSourceControlOperationRunner operationRunner =
       new RemoteSourceControlOperationRunner(cConf, metricsCollectionService, remoteClientFactory);
@@ -264,17 +264,16 @@ public class RemoteSourceControlOperationRunnerTest extends SourceControlTestBas
     Assert.assertTrue(SystemReader.getInstance() instanceof SecureSystemReader);
 
     // validate pull response
-    AppRequest<?> appRequest = response.getAppRequest();
-    validateTestAppRequest(appRequest);
+    validatePullResponse(response, TEST_APP_NAME);
     Assert.assertEquals(response.getApplicationName(), mockAppDetails.getName());
   }
 
-  @Test(expected = NotFoundException.class)
+  @Test(expected = SourceControlAppConfigNotFoundException.class)
   public void testPullAppConfigNotFoundException() throws Exception {
     String serverUrl = gitServer.getServerUrl();
     RepositoryConfig repoConfig =
       new RepositoryConfig.Builder(mockRepoConfig).setLink(serverUrl + "ignored").build();
-    PulAppOperationRequest mockPullRequest = new PulAppOperationRequest(mockAppRef, repoConfig);
+    PullAppOperationRequest mockPullRequest = new PullAppOperationRequest(mockAppRef, repoConfig);
 
     RemoteSourceControlOperationRunner operationRunner =
       new RemoteSourceControlOperationRunner(cConf, metricsCollectionService, remoteClientFactory);
@@ -286,7 +285,7 @@ public class RemoteSourceControlOperationRunnerTest extends SourceControlTestBas
     String serverUrl = gitServer.getServerUrl();
     RepositoryConfig repoConfig =
       new RepositoryConfig.Builder(mockRepoConfig).setLink(serverUrl + "ignored").build();
-    PulAppOperationRequest mockPullRequest = new PulAppOperationRequest(mockAppRef, repoConfig);
+    PullAppOperationRequest mockPullRequest = new PullAppOperationRequest(mockAppRef, repoConfig);
 
     RemoteSourceControlOperationRunner operationRunner =
       new RemoteSourceControlOperationRunner(cConf, metricsCollectionService, remoteClientFactory);
@@ -306,8 +305,8 @@ public class RemoteSourceControlOperationRunnerTest extends SourceControlTestBas
         .setLink(serverUrl + "ignored")
         .setAuth(NON_EXISTS_AUTH_CONFIG)
         .build();
-    PulAppOperationRequest mockPullRequest =
-      new PulAppOperationRequest(mockAppRef, repoConfig);
+    PullAppOperationRequest mockPullRequest =
+      new PullAppOperationRequest(mockAppRef, repoConfig);
 
     RemoteSourceControlOperationRunner operationRunner =
       new RemoteSourceControlOperationRunner(cConf, metricsCollectionService, remoteClientFactory);


### PR DESCRIPTION
Long running operation implementation for SCM pull. It reuses most of the existing git operation logic in `InMemorySourceControlOperationRunner` which will be refactored when we remove the previous task based implementation.

The actual deploy and mark latest operations are exposed via a new helper interface which will be implemented when the following will be merged
https://github.com/cdapio/cdap/pull/15336
https://github.com/cdapio/cdap/pull/15340 