### PR TITLE
[CDAP-20846] Fetch artifacts from cache for tethered runs with pushdo…

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteIsolatedPluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemoteIsolatedPluginFinder.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.common.ArtifactNotFoundException;
 import io.cdap.cdap.common.ServiceUnavailableException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.HttpCodes;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizer;
@@ -58,6 +59,12 @@ public class RemoteIsolatedPluginFinder extends RemotePluginFinder {
       RemoteClientFactory remoteClientFactory,
       @Named(ISOLATED_PLUGIN_DIR) String pluginDir) {
     super(locationFactory, remoteClientFactory);
+    this.pluginDir = new File(pluginDir);
+  }
+
+  public RemoteIsolatedPluginFinder(LocationFactory locationFactory, RemoteClient remoteClient,
+      RemoteClient remoteClientInternal, @Named(ISOLATED_PLUGIN_DIR) String pluginDir) {
+    super(locationFactory, remoteClient, remoteClientInternal);
     this.pluginDir = new File(pluginDir);
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/RemotePluginFinder.java
@@ -74,14 +74,21 @@ public class RemotePluginFinder implements PluginFinder {
   @Inject
   public RemotePluginFinder(LocationFactory locationFactory,
       RemoteClientFactory remoteClientFactory) {
-    this.remoteClient = remoteClientFactory.createRemoteClient(
-        Constants.Service.APP_FABRIC_HTTP,
-        new DefaultHttpRequestConfig(false),
-        String.format("%s", Constants.Gateway.API_VERSION_3));
-    this.remoteClientInternal = remoteClientFactory.createRemoteClient(
-        Constants.Service.APP_FABRIC_HTTP,
-        new DefaultHttpRequestConfig(false),
-        String.format("%s", Constants.Gateway.INTERNAL_API_VERSION_3));
+    this(locationFactory,
+         remoteClientFactory.createRemoteClient(
+           Constants.Service.APP_FABRIC_HTTP,
+           new DefaultHttpRequestConfig(false),
+           String.format("%s", Constants.Gateway.API_VERSION_3)),
+           remoteClientFactory.createRemoteClient(
+             Constants.Service.APP_FABRIC_HTTP,
+             new DefaultHttpRequestConfig(false),
+             String.format("%s", Constants.Gateway.INTERNAL_API_VERSION_3)));
+  }
+
+  public RemotePluginFinder(LocationFactory locationFactory, RemoteClient remoteClient,
+                            RemoteClient remoteClientInternal) {
+    this.remoteClient = remoteClient;
+    this.remoteClientInternal = remoteClientInternal;
     this.locationFactory = locationFactory;
     this.retryStrategy = RetryStrategies.limit(30, RetryStrategies.fixDelay(2, TimeUnit.SECONDS));
   }


### PR DESCRIPTION
…wn enabled

The `PluginFinder` created in `InMemoryProgramRunDispatcher` downloads artifacts from the remote appfabric ([ref](https://github.com/cdapio/cdap/blob/e1d660cf5a6514f92186bb107fc3f7701e8970c0/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/InMemoryProgramRunDispatcher.java#L282)). This results in the sqlengine artifact (which is the same as the google-cloud jar) getting downloaded from remote appfabric instead of the artifact cache.