### PR TITLE
CDAP-20809 Add LongRunningOperation interface

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/OperationHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/OperationHttpHandler.java
@@ -20,7 +20,7 @@ import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
-import io.cdap.cdap.proto.operationrun.OperationRun;
+import io.cdap.cdap.proto.operation.OperationRun;
 import io.cdap.http.HttpHandler;
 import io.cdap.http.HttpResponder;
 import io.netty.handler.codec.http.FullHttpRequest;
@@ -38,12 +38,12 @@ import javax.ws.rs.QueryParam;
  * The {@link HttpHandler} for handling REST calls to namespace endpoints.
  */
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}/operations")
-public class OperationRunHttpHandler extends AbstractAppFabricHttpHandler {
+public class OperationHttpHandler extends AbstractAppFabricHttpHandler {
 
   private static final Gson GSON = new Gson();
 
   @Inject
-  OperationRunHttpHandler() {
+  OperationHttpHandler() {
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/sourcecontrol/PullAppsOperation.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/sourcecontrol/PullAppsOperation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.sourcecontrol;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.cdap.cdap.internal.operation.LongRunningOperation;
+import io.cdap.cdap.internal.operation.LongRunningOperationContext;
+import io.cdap.cdap.proto.operation.OperationError;
+
+/**
+ * Defines operation for doing SCM Pull for connected repositories.
+ * TODO(samik) implement the pull-op
+ **/
+public class PullAppsOperation implements LongRunningOperation {
+
+  private final PullAppsRequest request;
+
+  public PullAppsOperation(PullAppsRequest request) {
+    this.request = request;
+  }
+
+  @Override
+  public ListenableFuture<OperationError> run(LongRunningOperationContext context) {
+    return null;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/sourcecontrol/PullAppsRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/sourcecontrol/PullAppsRequest.java
@@ -14,28 +14,29 @@
  * the License.
  */
 
-package io.cdap.cdap.proto.operationrun;
+package io.cdap.cdap.internal.app.sourcecontrol;
 
-import java.util.Objects;
+import com.google.common.base.Objects;
+import java.util.Set;
 
 /**
- * Error scoped to a single resource of the operation.
+ * Request type for {@link PullAppsOperation}.
  */
-public class OperationResourceScopedError {
-  private final String resourceUri;
-  private final String message;
+public class PullAppsRequest {
 
-  public OperationResourceScopedError(String resourceUri, String message) {
-    this.resourceUri = resourceUri;
-    this.message = message;
+  private final Set<String> apps;
+
+  /**
+   * Default Constructor.
+   *
+   * @param apps Set of apps to pull.
+   */
+  public PullAppsRequest(Set<String> apps) {
+    this.apps = apps;
   }
 
-  public String getResourceUri() {
-    return resourceUri;
-  }
-
-  public String getMessage() {
-    return message;
+  public Set<String> getApps() {
+    return apps;
   }
 
   @Override
@@ -47,14 +48,12 @@ public class OperationResourceScopedError {
       return false;
     }
 
-    OperationResourceScopedError that = (OperationResourceScopedError) o;
-
-    return Objects.equals(this.resourceUri, that.resourceUri)
-        && Objects.equals(this.message, that.message);
+    PullAppsRequest that = (PullAppsRequest) o;
+    return Objects.equal(this.getApps(), that.getApps());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(resourceUri, message);
+    return Objects.hashCode(getApps());
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/AbstractLongRunningOperationContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/AbstractLongRunningOperationContext.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.operation;
+
+import io.cdap.cdap.proto.id.OperationRunId;
+import io.cdap.cdap.proto.operation.OperationType;
+
+/**
+ * Abstract implementation of {@link LongRunningOperationContext} providing shared functionalities.
+ */
+public abstract class AbstractLongRunningOperationContext implements LongRunningOperationContext {
+
+  private final OperationRunId runId;
+  private final OperationType type;
+
+  /**
+   * Default constructor.
+   */
+  protected AbstractLongRunningOperationContext(OperationRunId runid, OperationType operationType) {
+    this.runId = runid;
+    this.type = operationType;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/LongRunningOperation.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/LongRunningOperation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.operation;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import io.cdap.cdap.proto.operation.OperationError;
+
+/**
+ * LongRunningOperation represents a long-running asynchronous operation.
+ */
+public interface LongRunningOperation {
+
+  /**
+   * Run the operation with the given request.
+   *
+   * @param request the operation input
+   * @param updateMetadata func to update the metadata of the operation. This would be passed by
+   *     the runner.
+   * @return {@link ListenableFuture} containing the {@link OperationError} for the run
+   */
+  ListenableFuture<OperationError> run(LongRunningOperationContext context);
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/LongRunningOperationContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/LongRunningOperationContext.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.operation;
+
+import io.cdap.cdap.proto.id.OperationRunId;
+import io.cdap.cdap.proto.operation.OperationResource;
+import io.cdap.cdap.proto.operation.OperationType;
+import java.util.Set;
+
+/**
+ * Provides the context for the current operation run.
+ */
+public interface LongRunningOperationContext {
+
+  /**
+   * Get the {@link OperationRunId} for the current run.
+   *
+   * @return the current runid
+   */
+  OperationRunId getRunId();
+
+  /**
+   * Get the {@link OperationType} to be used by the runner for loading the right operation class.
+   *
+   * @return the type of the current operation
+   */
+  OperationType getType();
+
+  /**
+   * Used by the {@link LongRunningOperation} to update the resources operated on in the
+   * {@link io.cdap.cdap.proto.operation.OperationMeta} for the run. The input is set as we want all
+   * resources to be unique
+   *
+   * @param resources A set of resources to be updated.
+   *
+   */
+  // TODO Add exceptions based on implementations.
+  void updateOperationResources(Set<OperationResource> resources);
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationLifecycleManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationLifecycleManager.java
@@ -14,10 +14,9 @@
  * the License.
  */
 
-package io.cdap.cdap.internal.operations;
+package io.cdap.cdap.internal.operation;
 
 import com.google.inject.Inject;
-import io.cdap.cdap.internal.app.store.OperationRunDetail;
 import io.cdap.cdap.spi.data.StructuredTableContext;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
@@ -46,7 +45,7 @@ public class OperationLifecycleManager {
    *     the caller to identify if there is any further runs left to scan.
    */
   public boolean scanOperations(ScanOperationRunsRequest request, int txBatchSize,
-      Consumer<OperationRunDetail<?>> consumer) throws OperationRunNotFoundException, IOException {
+      Consumer<OperationRunDetail> consumer) throws OperationRunNotFoundException, IOException {
     String lastKey = request.getScanAfter();
     int currentLimit = request.getLimit();
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationRunAlreadyExistsException.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationRunAlreadyExistsException.java
@@ -14,17 +14,17 @@
  * the License.
  */
 
-package io.cdap.cdap.internal.operations;
+package io.cdap.cdap.internal.operation;
 
-import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.AlreadyExistsException;
+import io.cdap.cdap.proto.operation.OperationRunStatus;
 
 /**
- * Exception thrown when an operation run with the specified id not found in the specified
- * namespace.
+ * Thrown when an operation run already exists.
  */
-public class OperationRunNotFoundException extends NotFoundException {
+public class OperationRunAlreadyExistsException extends AlreadyExistsException {
 
-  public OperationRunNotFoundException(String namespace, String runId) {
-    super(String.format("Operation run %s does not exist in namespace %s", runId, namespace));
+  public OperationRunAlreadyExistsException(String operationId, OperationRunStatus status) {
+    super(String.format("Operation %s already exists with status %s", operationId, status));
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationRunFilter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationRunFilter.java
@@ -14,9 +14,9 @@
  * the License.
  */
 
-package io.cdap.cdap.internal.operations;
+package io.cdap.cdap.internal.operation;
 
-import io.cdap.cdap.proto.operationrun.OperationRunStatus;
+import io.cdap.cdap.proto.operation.OperationRunStatus;
 import javax.annotation.Nullable;
 
 /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationRunNotFoundException.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/OperationRunNotFoundException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.operation;
+
+import io.cdap.cdap.common.NotFoundException;
+
+/**
+ * Exception thrown when an operation run with the specified id not found in the specified
+ * namespace.
+ */
+public class OperationRunNotFoundException extends NotFoundException {
+
+  public OperationRunNotFoundException(String namespace, String runId) {
+    super(String.format("Operation run %s does not exist in namespace %s", runId, namespace));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/ScanOperationRunsRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/operation/ScanOperationRunsRequest.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.internal.operations;
+package io.cdap.cdap.internal.operation;
 
 import javax.annotation.Nullable;
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/operation/SqlOperationRunsStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/operation/SqlOperationRunsStoreTest.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.internal.operations;
+package io.cdap.cdap.internal.operation;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationError.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationError.java
@@ -14,22 +14,30 @@
  * the License.
  */
 
-package io.cdap.cdap.proto.operationrun;
+package io.cdap.cdap.proto.operation;
 
+import java.util.Collection;
 import java.util.Objects;
 
 /**
- * Representation of a cdap resource on which an operation is executed.
+ * Error representation for Operation Run.
  */
-public class OperationResource {
-  private final String resourceUri;
+public class OperationError {
 
-  public OperationResource(String resourceUri) {
-    this.resourceUri = resourceUri;
+  private final String message;
+  private final Collection<OperationResourceScopedError> details;
+
+  public OperationError(String message, Collection<OperationResourceScopedError> details) {
+    this.message = message;
+    this.details = details;
   }
 
-  public String getResourceUri() {
-    return resourceUri;
+  public String getMessage() {
+    return message;
+  }
+
+  public Collection<OperationResourceScopedError> getDetails() {
+    return details;
   }
 
   @Override
@@ -41,13 +49,13 @@ public class OperationResource {
       return false;
     }
 
-    OperationResource that = (OperationResource) o;
+    OperationError that = (OperationError) o;
 
-    return Objects.equals(this.resourceUri, that.resourceUri);
+    return this.details.equals(that.details);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(resourceUri);
+    return Objects.hash(details);
   }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationMeta.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationMeta.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.proto.operationrun;
+package io.cdap.cdap.proto.operation;
 
 import java.time.Instant;
 import java.util.Objects;

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationResource.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationResource.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.operation;
+
+import java.util.Objects;
+
+/**
+ * Representation of a cdap resource on which an operation is executed.
+ */
+public class OperationResource {
+  private final String resourceUri;
+
+  public OperationResource(String resourceUri) {
+    this.resourceUri = resourceUri;
+  }
+
+  public String getResourceUri() {
+    return resourceUri;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    OperationResource that = (OperationResource) o;
+
+    return Objects.equals(this.resourceUri, that.resourceUri);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(resourceUri);
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationResourceScopedError.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationResourceScopedError.java
@@ -14,30 +14,28 @@
  * the License.
  */
 
-package io.cdap.cdap.proto.operationrun;
+package io.cdap.cdap.proto.operation;
 
-import java.util.Collection;
 import java.util.Objects;
 
 /**
- * Error representation for Operation Run.
+ * Error scoped to a single resource of the operation.
  */
-public class OperationError {
-
+public class OperationResourceScopedError {
+  private final String resourceUri;
   private final String message;
-  private final Collection<OperationResourceScopedError> details;
 
-  public OperationError(String message, Collection<OperationResourceScopedError> details) {
+  public OperationResourceScopedError(String resourceUri, String message) {
+    this.resourceUri = resourceUri;
     this.message = message;
-    this.details = details;
+  }
+
+  public String getResourceUri() {
+    return resourceUri;
   }
 
   public String getMessage() {
     return message;
-  }
-
-  public Collection<OperationResourceScopedError> getDetails() {
-    return details;
   }
 
   @Override
@@ -49,13 +47,14 @@ public class OperationError {
       return false;
     }
 
-    OperationError that = (OperationError) o;
+    OperationResourceScopedError that = (OperationResourceScopedError) o;
 
-    return this.details.equals(that.details);
+    return Objects.equals(this.resourceUri, that.resourceUri)
+        && Objects.equals(this.message, that.message);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(details);
+    return Objects.hash(resourceUri, message);
   }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationRun.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationRun.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.proto.operationrun;
+package io.cdap.cdap.proto.operation;
 
 import com.google.gson.annotations.SerializedName;
 import java.util.Objects;

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationRunStatus.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationRunStatus.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.cdap.proto.operationrun;
+package io.cdap.cdap.proto.operation;
 
 import java.util.EnumSet;
 import java.util.Set;

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationType.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/operation/OperationType.java
@@ -14,17 +14,12 @@
  * the License.
  */
 
-package io.cdap.cdap.internal.operations;
-
-import io.cdap.cdap.common.AlreadyExistsException;
-import io.cdap.cdap.proto.operationrun.OperationRunStatus;
+package io.cdap.cdap.proto.operation;
 
 /**
- * Thrown when an operation run already exists.
+ * Types of operation supported by CDAP.
  */
-public class OperationRunAlreadyExistsException extends AlreadyExistsException {
-
-  public OperationRunAlreadyExistsException(String operationId, OperationRunStatus status) {
-    super(String.format("Operation %s already exists with status %s", operationId, status));
-  }
+public enum OperationType {
+  PUSH_APPS,
+  PULL_APPS
 }


### PR DESCRIPTION
Added the `LongRunningOperation` interface based on the discussion in https://github.com/cdapio/cdap/pull/15319/files#r1357444537

The `LongRunningOperationRequest` interface contains all possible operation request types. Only one should be not null essentially behaving similar to a protobuff `oneof`.

The store related changes will be done in a separate PR.