### PR TITLE
[CDAP-20860] Cache provisioned credentials in memory for task workers and preview runners.

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteConfigurator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/RemoteConfigurator.java
@@ -74,6 +74,7 @@ public class RemoteConfigurator implements Configurator {
     try {
       RunnableTaskRequest request = RunnableTaskRequest.getBuilder(ConfiguratorTask.class.getName())
           .withParam(GSON.toJson(deploymentInfo))
+          .withNamespace(deploymentInfo.getNamespaceId().getNamespace())
           .build();
 
       byte[] result = remoteTaskExecutor.runTask(request);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternal.java
@@ -16,11 +16,13 @@
 
 package io.cdap.cdap.internal.app.worker.sidecar;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Singleton;
-import io.cdap.cdap.api.common.HttpErrorStatusProvider;
 import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.ForbiddenException;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -32,7 +34,6 @@ import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import io.cdap.cdap.internal.namespace.credential.RemoteNamespaceCredentialProvider;
 import io.cdap.cdap.proto.BasicThrowable;
 import io.cdap.cdap.proto.codec.BasicThrowableCodec;
-import io.cdap.cdap.proto.credential.CredentialProvisioningException;
 import io.cdap.cdap.proto.credential.NamespaceCredentialProvider;
 import io.cdap.cdap.proto.credential.NotFoundException;
 import io.cdap.cdap.proto.credential.ProvisionedCredential;
@@ -49,6 +50,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
@@ -74,6 +77,8 @@ public class GcpMetadataHttpHandlerInternal extends AbstractAppFabricHttpHandler
   private final NamespaceCredentialProvider credentialProvider;
   private final GcpWorkloadIdentityInternalAuthenticator gcpWorkloadIdentityInternalAuthenticator;
   private GcpMetadataTaskContext gcpMetadataTaskContext;
+  private final LoadingCache<ProvisionedCredentialCacheKey,
+        ProvisionedCredential> credentialLoadingCache;
 
   /**
    * Constructs the {@link GcpMetadataHttpHandlerInternal}.
@@ -89,6 +94,18 @@ public class GcpMetadataHttpHandlerInternal extends AbstractAppFabricHttpHandler
         new GcpWorkloadIdentityInternalAuthenticator(gcpMetadataTaskContext);
     this.credentialProvider = new RemoteNamespaceCredentialProvider(remoteClientFactory,
         this.gcpWorkloadIdentityInternalAuthenticator);
+    this.credentialLoadingCache = CacheBuilder.newBuilder()
+        // Provisioned credential expire after 60mins, assuming 20% buffer in cache exp (0.8*60).
+        .expireAfterWrite(48, TimeUnit.MINUTES)
+        .build(new CacheLoader<ProvisionedCredentialCacheKey, ProvisionedCredential>() {
+          @Override
+          public ProvisionedCredential load(ProvisionedCredentialCacheKey
+              provisionedCredentialCacheKey) throws Exception {
+            return fetchTokenFromCredentialProvider(
+                provisionedCredentialCacheKey.getGcpMetadataTaskContext(),
+                provisionedCredentialCacheKey.getScopes());
+          }
+        });
   }
 
   /**
@@ -146,24 +163,21 @@ public class GcpMetadataHttpHandlerInternal extends AbstractAppFabricHttpHandler
 
     try {
       // fetch token from credential provider
-      GcpTokenResponse gcpTokenResponse =
-          Retries.callWithRetries(() -> fetchTokenFromCredentialProvider(scopes),
-              RetryStrategies.fromConfiguration(cConf, Constants.Service.TASK_WORKER + "."));
+      ProvisionedCredential provisionedCredential =
+          credentialLoadingCache.get(
+              new ProvisionedCredentialCacheKey(this.gcpMetadataTaskContext, scopes));
+      GcpTokenResponse gcpTokenResponse = new GcpTokenResponse("Bearer",
+          provisionedCredential.get(),
+          Duration.between(Instant.now(), provisionedCredential.getExpiration()).getSeconds());
       responder.sendJson(HttpResponseStatus.OK, GSON.toJson(gcpTokenResponse));
       return;
-    } catch (NotFoundException e) {
+    } catch (ExecutionException e) {
+      if (!(e.getCause() instanceof NotFoundException)) {
+        LOG.error("Failed to fetch token from credential provider", e.getCause());
+        throw e;
+      }
       // if credential identity not found,
       // fallback to gcp metadata server for backward compatibility.
-    } catch (Exception ex) {
-      if (ex instanceof HttpErrorStatusProvider) {
-        HttpResponseStatus status = HttpResponseStatus.valueOf(
-            ((HttpErrorStatusProvider) ex).getStatusCode());
-        responder.sendJson(status, exceptionToJson(ex));
-      } else {
-        LOG.warn("Failed to fetch token from credential provider", ex);
-        responder.sendJson(HttpResponseStatus.INTERNAL_SERVER_ERROR, exceptionToJson(ex));
-      }
-      return;
     }
 
     if (metadataServiceTokenEndpoint == null) {
@@ -177,17 +191,16 @@ public class GcpMetadataHttpHandlerInternal extends AbstractAppFabricHttpHandler
       responder.sendJson(HttpResponseStatus.OK,
           fetchTokenFromMetadataServer(scopes).getResponseBodyAsString());
     } catch (Exception ex) {
-      LOG.warn("Failed to fetch token from metadata service", ex);
+      LOG.error("Failed to fetch token from metadata server", ex);
       responder.sendJson(HttpResponseStatus.INTERNAL_SERVER_ERROR, exceptionToJson(ex));
     }
   }
 
-  private GcpTokenResponse fetchTokenFromCredentialProvider(String scopes) throws NotFoundException,
-      IOException, CredentialProvisioningException {
-    ProvisionedCredential provisionedCredential =
-        this.credentialProvider.provision(gcpMetadataTaskContext.getNamespace(), scopes);
-    return new GcpTokenResponse("Bearer", provisionedCredential.get(),
-        Duration.between(Instant.now(), provisionedCredential.getExpiration()).getSeconds());
+  private ProvisionedCredential fetchTokenFromCredentialProvider(
+      GcpMetadataTaskContext gcpMetadataTaskContext, String scopes) throws Exception {
+    return Retries.callWithRetries(() ->
+            this.credentialProvider.provision(gcpMetadataTaskContext.getNamespace(), scopes),
+        RetryStrategies.fromConfiguration(cConf, Constants.Service.TASK_WORKER + "."));
   }
 
   private HttpResponse fetchTokenFromMetadataServer(String scopes) throws IOException {
@@ -229,6 +242,7 @@ public class GcpMetadataHttpHandlerInternal extends AbstractAppFabricHttpHandler
   public void clearContext(HttpRequest request, HttpResponder responder) {
     this.gcpMetadataTaskContext = null;
     this.gcpWorkloadIdentityInternalAuthenticator.setGcpMetadataTaskContext(gcpMetadataTaskContext);
+    this.credentialLoadingCache.invalidateAll();
     LOG.trace("Context cleared.");
     responder.sendStatus(HttpResponseStatus.OK);
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternal.java
@@ -156,6 +156,7 @@ public class GcpMetadataHttpHandlerInternal extends AbstractAppFabricHttpHandler
       // needed when initializing
       // io.cdap.cdap.common.guice.DFSLocationModule$LocationFactoryProvider#get
       // in io.cdap.cdap.internal.app.worker.TaskWorkerTwillRunnable.
+      LOG.warn("The GCP Metadata Task Context has been identified as null.");
       GcpTokenResponse gcpTokenResponse = new GcpTokenResponse("Bearer", "invalidToken", 3599);
       responder.sendJson(HttpResponseStatus.OK, GSON.toJson(gcpTokenResponse));
       return;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ProvisionedCredentialCacheKey.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ProvisionedCredentialCacheKey.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.worker.sidecar;
+
+import io.cdap.cdap.proto.security.GcpMetadataTaskContext;
+import java.util.Objects;
+
+/**
+ * Defines the contents of key used for
+ * caching {@link io.cdap.cdap.proto.credential.ProvisionedCredential}.
+ */
+public final class ProvisionedCredentialCacheKey {
+  private final GcpMetadataTaskContext gcpMetadataTaskContext;
+  private final String scopes;
+  private transient Integer hashCode;
+
+  public ProvisionedCredentialCacheKey(GcpMetadataTaskContext gcpMetadataTaskContext,
+      String scopes) {
+    this.gcpMetadataTaskContext = gcpMetadataTaskContext;
+    this.scopes = scopes;
+  }
+
+  public GcpMetadataTaskContext getGcpMetadataTaskContext() {
+    return gcpMetadataTaskContext;
+  }
+
+  public String getScopes() {
+    return scopes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof ProvisionedCredentialCacheKey)) {
+      return  false;
+    }
+    ProvisionedCredentialCacheKey that = (ProvisionedCredentialCacheKey) o;
+    return Objects.equals(gcpMetadataTaskContext.getNamespace(),
+        that.gcpMetadataTaskContext.getNamespace())
+        && Objects.equals(gcpMetadataTaskContext.getUserCredential().toString(),
+        that.gcpMetadataTaskContext.getUserCredential().toString())
+        && Objects.equals(gcpMetadataTaskContext.getUserId(),
+        that.gcpMetadataTaskContext.getUserId())
+        && Objects.equals(gcpMetadataTaskContext.getUserIp(),
+        that.gcpMetadataTaskContext.getUserIp())
+        && Objects.equals(scopes, that.scopes);
+  }
+
+  @Override
+  public int hashCode() {
+    Integer hashCode = this.hashCode;
+    if (hashCode == null) {
+      this.hashCode = hashCode = Objects.hash(gcpMetadataTaskContext.getNamespace(),
+          gcpMetadataTaskContext.getUserCredential().toString(),
+          gcpMetadataTaskContext.getUserId(), gcpMetadataTaskContext.getUserIp(), scopes);
+    }
+    return hashCode;
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerMetricsTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerMetricsTest.java
@@ -105,8 +105,7 @@ public class TaskWorkerMetricsTest {
   public void testSimpleRequest() throws IOException {
     String taskClassName = TaskWorkerServiceTest.TestRunnableClass.class.getName();
     RunnableTaskRequest req = RunnableTaskRequest.getBuilder(taskClassName)
-      .withParam("100")
-      .build();
+      .withParam("100").withNamespace("testNamespace").build();
     String reqBody = GSON.toJson(req);
     HttpResponse response = HttpRequests.execute(
       HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceTest.java
@@ -145,8 +145,8 @@ public class TaskWorkerServiceTest {
 
     // Post valid request
     String want = "5000";
-    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName()).withParam(want)
-      .build();
+    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName())
+        .withParam(want).withNamespace("testNamespace").build();
     String reqBody = GSON.toJson(req);
     HttpResponse response = HttpRequests.execute(
       HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
@@ -224,8 +224,8 @@ public class TaskWorkerServiceTest {
 
     // Post valid request
     String want = "100";
-    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName()).withParam(want)
-      .build();
+    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName())
+        .withParam(want).withNamespace("testNamespace").build();
     String reqBody = GSON.toJson(req);
     HttpResponse response = HttpRequests.execute(
       HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
@@ -248,8 +248,8 @@ public class TaskWorkerServiceTest {
 
     // Post valid request
     String want = "100";
-    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName()).withParam(want)
-      .build();
+    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName())
+        .withParam(want).withNamespace("testNamespace").build();
     String reqBody = GSON.toJson(req);
     HttpResponse response = HttpRequests.execute(
       HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
@@ -267,7 +267,8 @@ public class TaskWorkerServiceTest {
     URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
 
     // Post invalid request
-    RunnableTaskRequest noClassReq = RunnableTaskRequest.getBuilder("NoClass").build();
+    RunnableTaskRequest noClassReq = RunnableTaskRequest.getBuilder("NoClass")
+        .withNamespace("testNamespace").withParam("100").build();
     String reqBody = GSON.toJson(noClassReq);
     HttpResponse response = HttpRequests.execute(
       HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
@@ -287,8 +288,8 @@ public class TaskWorkerServiceTest {
     InetSocketAddress addr = taskWorkerService.getBindAddress();
     URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
 
-    RunnableTaskRequest request = RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName()).
-      withParam("1000").build();
+    RunnableTaskRequest request = RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName())
+            .withParam("1000").withNamespace("testNamespace").build();
 
     String reqBody = GSON.toJson(request);
     List<Callable<HttpResponse>> calls = new ArrayList<>();

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
@@ -207,13 +207,16 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
       RunnableTaskContext runnableTaskContext = new RunnableTaskContext(
           runnableTaskRequest);
       try {
-        if (runnableTaskRequest.getParam().getEmbeddedTaskRequest() != null
-            && runnableTaskRequest.getParam().getEmbeddedTaskRequest().getNamespace() != null) {
-          // set the GcpMetadataTaskContext before running the task.
-          NamespaceId namespaceId = new NamespaceId(
+        NamespaceId namespaceId;
+        if (runnableTaskRequest.getParam().getEmbeddedTaskRequest() != null) {
+          // For system app tasks
+          namespaceId = new NamespaceId(
               runnableTaskRequest.getParam().getEmbeddedTaskRequest().getNamespace());
-          GcpMetadataTaskContextUtil.setGcpMetadataTaskContext(namespaceId, cConf);
+        } else {
+          namespaceId = new NamespaceId(runnableTaskRequest.getNamespace());
         }
+        // set the GcpMetadataTaskContext before running the task.
+        GcpMetadataTaskContextUtil.setGcpMetadataTaskContext(namespaceId, cConf);
         runnableTaskLauncher.launchRunnableTask(runnableTaskContext);
         TaskDetails taskDetails = new TaskDetails(metricsCollectionService,
             startTime,

--- a/cdap-common/src/test/java/io/cdap/cdap/common/internal/remote/RemoteTaskExecutorTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/internal/remote/RemoteTaskExecutorTest.java
@@ -179,7 +179,7 @@ public class RemoteTaskExecutorTest {
     RemoteTaskExecutor remoteTaskExecutor = new RemoteTaskExecutor(cConf, mockMetricsCollector, remoteClientFactory,
                                                                    RemoteTaskExecutor.Type.TASK_WORKER);
     RunnableTaskRequest runnableTaskRequest = RunnableTaskRequest.getBuilder(InValidRunnableClass.class.getName()).
-      withParam("param").build();
+      withParam("param").withNamespace("testNamespace").build();
     try {
       remoteTaskExecutor.runTask(runnableTaskRequest);
     } catch (RemoteExecutionException e) {
@@ -203,7 +203,7 @@ public class RemoteTaskExecutorTest {
     RemoteTaskExecutor remoteTaskExecutor = new RemoteTaskExecutor(cConf, mockMetricsCollector, remoteClientFactory,
         RemoteTaskExecutor.Type.TASK_WORKER);
     RunnableTaskRequest runnableTaskRequest = RunnableTaskRequest.getBuilder(ValidRunnableClass.class.getName()).
-      withParam("param").build();
+      withParam("param").withNamespace("testNamespace").build();
     remoteTaskExecutor.runTask(runnableTaskRequest);
     mockMetricsCollector.stopAndWait();
     Assert.assertSame(1, metricCollectors.size());
@@ -224,7 +224,7 @@ public class RemoteTaskExecutorTest {
     RemoteTaskExecutor remoteTaskExecutor = new RemoteTaskExecutor(cConf, mockMetricsCollector, remoteClientFactory,
         RemoteTaskExecutor.Type.TASK_WORKER);
     RunnableTaskRequest runnableTaskRequest = RunnableTaskRequest.getBuilder(ValidRunnableClass.class.getName()).
-      withParam("param").build();
+      withParam("param").withNamespace("testNamespace").build();
     try {
       remoteTaskExecutor.runTask(runnableTaskRequest);
     } catch (Exception e) {

--- a/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/GcpWorkloadIdentityCredentialProvider.java
+++ b/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/GcpWorkloadIdentityCredentialProvider.java
@@ -283,6 +283,7 @@ public class GcpWorkloadIdentityCredentialProvider implements CredentialProvider
       throws IOException {
 
     // replace comma with space, see:
+    // https://cloud.google.com/functions/docs/securing/function-identity#access_tokens
     // https://cloud.google.com/iam/docs/reference/sts/rest/v1/TopLevel/token#request-body
     scopes = Arrays.stream(scopes.split(",")).map(String::trim)
         .filter(s -> !s.isEmpty()).distinct().collect(Collectors.joining(" "));

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunner.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunner.java
@@ -78,7 +78,9 @@ public class RemoteSourceControlOperationRunner extends
     AuthenticationConfigException {
     try {
       RunnableTaskRequest request = RunnableTaskRequest.getBuilder(PushAppTask.class.getName())
-        .withParam(GSON.toJson(pushAppOperationRequest)).build();
+          .withParam(GSON.toJson(pushAppOperationRequest))
+          .withNamespace(pushAppOperationRequest.getNamespaceId().getNamespace())
+          .build();
 
       LOG.trace("Pushing application {} to linked repository", pushAppOperationRequest.getApp());
       byte[] result = remoteTaskExecutor.runTask(request);
@@ -95,7 +97,9 @@ public class RemoteSourceControlOperationRunner extends
     AuthenticationConfigException {
     try {
       RunnableTaskRequest request = RunnableTaskRequest.getBuilder(PullAppTask.class.getName())
-        .withParam(GSON.toJson(pulAppOperationRequest)).build();
+          .withParam(GSON.toJson(pulAppOperationRequest))
+          .withNamespace(pulAppOperationRequest.getApp().getNamespace())
+          .build();
 
       LOG.trace("Pulling application {} from linked repository", pulAppOperationRequest.getApp());
       byte[] result = remoteTaskExecutor.runTask(request);
@@ -112,7 +116,9 @@ public class RemoteSourceControlOperationRunner extends
     throws AuthenticationConfigException, NotFoundException {
     try {
       RunnableTaskRequest request = RunnableTaskRequest.getBuilder(ListAppsTask.class.getName())
-        .withParam(GSON.toJson(nameSpaceRepository)).build();
+          .withParam(GSON.toJson(nameSpaceRepository))
+          .withNamespace(nameSpaceRepository.getNamespaceId().getNamespace())
+          .build();
       LOG.trace("Listing applications for namespace {} in linked repository", nameSpaceRepository.getNamespaceId());
       byte[] result = remoteTaskExecutor.runTask(request);
       return GSON.fromJson(new String(result, StandardCharsets.UTF_8), RepositoryAppsResponse.class);


### PR DESCRIPTION
This PR does the following:
- Sets the `namespace` in all task runnable requests which are meant to run in task worker.
- Caches provisioned credentials in memory for task workers and preview runners.
- Do not create KSA if already exists.
