### PR TITLE
[CDAP-20845] Enable the use of Messaging Service extensions - Part 3

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
@@ -64,7 +64,7 @@ import io.cdap.cdap.logging.guice.TMSLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.messaging.client.ClientMessagingService;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.metadata.RemotePreferencesFetcherInternal;
@@ -163,7 +163,7 @@ public class DistributedProgramContainerModule extends AbstractModule {
     modules.add(new IOModule());
     modules.add(new DFSLocationModule());
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
-    modules.add(new MessagingClientModule());
+    modules.add(new MessagingServiceModule(cConf));
     modules.add(new AuditModule());
     modules.add(new AuthorizationEnforcementModule().getDistributedModules());
     modules.add(new SecureStoreClientModule());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -66,7 +66,7 @@ import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.twill.ExtendedTwillContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
@@ -236,7 +236,7 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     }
 
     modules.add(new PreviewRunnerManagerModule().getDistributedModules());
-    modules.add(new MessagingClientModule());
+    modules.add(new MessagingServiceModule(cConf));
     modules.add(new SecureStoreClientModule());
     // Needed for InMemoryProgramRunnerModule. We use local metadata reader/publisher to avoid conflicting with
     // metadata stored in AppFabric.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppTask.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/SystemAppTask.java
@@ -44,7 +44,7 @@ import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.runtime.artifact.Artifacts;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerClient;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
@@ -175,7 +175,7 @@ public class SystemAppTask implements RunnableTask {
     return Guice.createInjector(new IOModule(),
         CoreSecurityRuntimeModule.getDistributedModule(cConf),
         new ConfigModule(cConf), RemoteAuthenticatorModules.getDefaultModule(),
-        new MessagingClientModule(), new LocalLocationModule(),
+        new MessagingServiceModule(cConf), new LocalLocationModule(),
         new SecureStoreClientModule(),
         new AuthenticationContextModules().getMasterModule(),
         new SystemAppModule(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
@@ -44,7 +44,7 @@ import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
 import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
@@ -94,7 +94,7 @@ public class TaskWorkerTwillRunnable extends AbstractTwillRunnable {
     modules.add(new IOModule());
     modules.add(new AuthenticationContextModules().getMasterWorkerModule());
     modules.add(coreSecurityModule);
-    modules.add(new MessagingClientModule());
+    modules.add(new MessagingServiceModule(cConf));
     modules.add(new SystemAppModule());
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerTwillRunnable.java
@@ -45,7 +45,7 @@ import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
 import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.TokenManager;
@@ -103,7 +103,7 @@ public class ArtifactLocalizerTwillRunnable extends AbstractTwillRunnable {
     modules.add(RemoteAuthenticatorModules.getDefaultModule());
     modules.add(new AuthenticationContextModules().getMasterModule());
     modules.add(coreSecurityModule);
-    modules.add(new MessagingClientModule());
+    modules.add(new MessagingServiceModule(cConf));
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
 
     // If MasterEnvironment is not available, assuming it is the old hadoop stack with ZK, Kafka

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerTwillRunnable.java
@@ -78,7 +78,7 @@ import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
 import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.KeyManager;
@@ -151,7 +151,7 @@ public class SystemWorkerTwillRunnable extends AbstractTwillRunnable {
         new DataSetServiceModules().getStandaloneModules(),
         // The Dataset set modules are only needed to satisfy dependency injection
         new DataSetsModules().getStandaloneModules(),
-        new MessagingClientModule(),
+        new MessagingServiceModule(cConf),
         new AuthorizationModule(),
         new AuthorizationEnforcementModule().getMasterModule(),
         Modules.override(new AppFabricServiceRuntimeModule(cConf).getDistributedModules())

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -2024,6 +2024,9 @@ public final class Constants {
     public static final String LOCAL_DATA_CLEANUP_FREQUENCY = "messaging.local.data.cleanup.frequency.secs";
     public static final String LOCAL_DATA_PARTITION_SECONDS = "messaging.local.data.partition.secs";
 
+    public static final String EXTENSIONS_DIR = "messaging.service.extensions.dir";
+
+    public static final String MESSAGING_SERVICE_NAME = "messaging.service.name";
     public static final String CACHE_SIZE_MB = "messaging.cache.size.mb";
 
     public static final String HBASE_MAX_SCAN_THREADS = "messaging.hbase.max.scan.threads";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2397,6 +2397,11 @@
   <!-- Messaging System Configuration -->
 
   <property>
+    <name>messaging.service.extensions.dir</name>
+    <value>/opt/cdap/master/ext/messagingproviders</value>
+  </property>
+
+  <property>
     <name>messaging.cache.size.mb</name>
     <value>30</value>
     <description>

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -55,7 +55,7 @@ import io.cdap.cdap.internal.app.worker.system.SystemWorkerServiceLauncher;
 import io.cdap.cdap.internal.events.EventPublishManager;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.operations.OperationalStatsService;
 import io.cdap.cdap.operations.guice.OperationalStatsModule;
@@ -94,7 +94,7 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
         // The Dataset set modules are only needed to satisfy dependency injection
         new DataSetsModules().getStandaloneModules(),
         new MetricsStoreModule(),
-        new MessagingClientModule(),
+        new MessagingServiceModule(cConf),
         new AuditModule(),
         new AuthorizationModule(),
         new AuthorizationEnforcementModule().getMasterModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/ArtifactCacheServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/ArtifactCacheServiceMain.java
@@ -32,7 +32,7 @@ import io.cdap.cdap.internal.tethering.ArtifactCacheService;
 import io.cdap.cdap.internal.tethering.TetheringAgentService;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import java.util.Arrays;
@@ -55,7 +55,7 @@ public class ArtifactCacheServiceMain extends AbstractServiceMain<EnvironmentOpt
   protected List<Module> getServiceModules(MasterEnvironment masterEnv,
       EnvironmentOptions options, CConfiguration cConf) {
     return Arrays.asList(
-        new MessagingClientModule(),
+        new MessagingServiceModule(cConf),
         RemoteAuthenticatorModules.getDefaultModule(
             TetheringAgentService.REMOTE_TETHERING_AUTHENTICATOR,
             Constants.Tethering.CLIENT_AUTHENTICATOR_NAME),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AuthenticationServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AuthenticationServiceMain.java
@@ -27,7 +27,7 @@ import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
@@ -56,7 +56,7 @@ public class AuthenticationServiceMain extends AbstractServiceMain<EnvironmentOp
     }
 
     List<Module> modules = new ArrayList<>();
-    modules.add(new MessagingClientModule());
+    modules.add(new MessagingServiceModule(cConf));
     modules.add(new ExternalAuthenticationModule());
     return modules;
   }

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/LogsServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/LogsServiceMain.java
@@ -48,7 +48,7 @@ import io.cdap.cdap.logging.read.LogReader;
 import io.cdap.cdap.logging.service.LogQueryService;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
@@ -79,7 +79,7 @@ public class LogsServiceMain extends AbstractServiceMain<EnvironmentOptions> {
       EnvironmentOptions options, CConfiguration cConf) {
     return Arrays.asList(
         new AuthorizationEnforcementModule().getDistributedModules(),
-        new MessagingClientModule(),
+        new MessagingServiceModule(cConf),
         getDataFabricModule(),
         // Always use local table implementations, which use LevelDB.
         // In K8s, there won't be HBase and the cdap-site should be set to use SQL store for StructuredTable.

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetadataServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetadataServiceMain.java
@@ -42,7 +42,7 @@ import io.cdap.cdap.internal.app.store.DefaultStore;
 import io.cdap.cdap.internal.metadata.MetadataConsumerSubscriberService;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.metadata.MetadataService;
 import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.metadata.MetadataSubscriberService;
@@ -77,7 +77,7 @@ public class MetadataServiceMain extends AbstractServiceMain<EnvironmentOptions>
   protected List<Module> getServiceModules(MasterEnvironment masterEnv,
       EnvironmentOptions options, CConfiguration cConf) {
     return Arrays.asList(
-        new MessagingClientModule(),
+        new MessagingServiceModule(cConf),
         new NamespaceQueryAdminModule(),
         getDataFabricModule(),
         // Always use local table implementations, which use LevelDB.

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/MetricsServiceMain.java
@@ -33,7 +33,7 @@ import io.cdap.cdap.common.namespace.guice.NamespaceQueryAdminModule;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.metrics.guice.MetricsHandlerModule;
 import io.cdap.cdap.metrics.guice.MetricsProcessorStatusServiceModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
@@ -71,7 +71,7 @@ public class MetricsServiceMain extends AbstractServiceMain<EnvironmentOptions> 
     return Arrays.asList(
         new NamespaceQueryAdminModule(),
         new AuthorizationEnforcementModule().getDistributedModules(),
-        new MessagingClientModule(),
+        new MessagingServiceModule(cConf),
         new SystemDatasetRuntimeModule().getStandaloneModules(),
         new MetricsStoreModule(),
         new FactoryModuleBuilder().build(MessagingMetricsProcessorServiceFactory.class),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMain.java
@@ -42,7 +42,7 @@ import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data2.audit.AuditModule;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
@@ -101,7 +101,7 @@ public class PreviewServiceMain extends AbstractServiceMain<EnvironmentOptions> 
         new AppFabricServiceRuntimeModule(cConf).getStandaloneModules(),
         new ProgramRunnerRuntimeModule().getStandaloneModules(),
         new MetricsStoreModule(),
-        new MessagingClientModule(),
+        new MessagingServiceModule(cConf),
         new AuditModule(),
         new SecureStoreClientModule(),
         new MetadataReaderWriterModules().getStandaloneModules(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RouterServiceMain.java
@@ -30,7 +30,7 @@ import io.cdap.cdap.gateway.router.NettyRouter;
 import io.cdap.cdap.gateway.router.RouterModules;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.guice.ExternalAuthenticationModule;
 import java.util.ArrayList;
@@ -59,7 +59,7 @@ public class RouterServiceMain extends AbstractServiceMain<EnvironmentOptions> {
       EnvironmentOptions options, CConfiguration cConf) {
     List<Module> modules = new ArrayList<>();
 
-    modules.add(new MessagingClientModule());
+    modules.add(new MessagingServiceModule(cConf));
     modules.add(new RouterModules().getDistributedModules());
     modules.add(new DFSLocationModule());
     modules.add(new ExternalAuthenticationModule());

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/RuntimeServiceMain.java
@@ -35,7 +35,7 @@ import io.cdap.cdap.internal.app.runtime.monitor.RuntimeProgramStatusSubscriberS
 import io.cdap.cdap.internal.app.runtime.monitor.RuntimeServer;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
@@ -62,7 +62,7 @@ public class RuntimeServiceMain extends AbstractServiceMain<EnvironmentOptions> 
       EnvironmentOptions options, CConfiguration cConf) {
     return Arrays.asList(
         new DFSLocationModule(),
-        new MessagingClientModule(),
+        new MessagingServiceModule(cConf),
         new SystemDatasetRuntimeModule().getStandaloneModules(),
         getDataFabricModule(),
         new RuntimeServerModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/SupportBundleServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/SupportBundleServiceMain.java
@@ -31,7 +31,7 @@ import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.support.guice.SupportBundleServiceModule;
@@ -58,7 +58,7 @@ public class SupportBundleServiceMain extends AbstractServiceMain<EnvironmentOpt
   protected List<Module> getServiceModules(MasterEnvironment masterEnv,
       EnvironmentOptions options, CConfiguration cConf) {
     return Arrays.asList(
-        new MessagingClientModule(),
+        new MessagingServiceModule(cConf),
         new NamespaceQueryAdminModule(),
         getDataFabricModule(),
         // Always use local table implementations, which use LevelDB.

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/SystemMetricsExporterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/SystemMetricsExporterServiceMain.java
@@ -27,7 +27,7 @@ import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.metrics.jmx.JmxMetricsCollectorFactory;
 import io.cdap.cdap.proto.id.NamespaceId;
 import java.util.Arrays;
@@ -66,7 +66,7 @@ public class SystemMetricsExporterServiceMain extends AbstractServiceMain<Enviro
       CConfiguration cConf) {
     return Arrays.asList(
         // required by some module added in super class
-        new MessagingClientModule(),
+        new MessagingServiceModule(cConf),
         new SystemMetricsExporterModule()
     );
   }

--- a/cdap-messaging-spi/src/main/java/io/cdap/cdap/messaging/spi/MessagingService.java
+++ b/cdap-messaging-spi/src/main/java/io/cdap/cdap/messaging/spi/MessagingService.java
@@ -36,6 +36,12 @@ import javax.annotation.Nullable;
 public interface MessagingService {
 
   /**
+   * Returns the name of this MessagingService. The name needs to match with the configuration
+   * provided through {@code messaging.service.name}.
+   */
+  String getName();
+
+  /**
    * Creates a topic with the given metadata.
    *
    * @param topicMetadata topic to be created
@@ -134,7 +140,6 @@ public interface MessagingService {
    * system.
    *
    * @param messageFetchRequest the request for fetching messages
-   *
    * @throws TopicNotFoundException if the topic does not exist
    * @throws IOException if it fails to create the iterator
    * @throws ServiceUnavailableException if the messaging service is not available

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/ClientMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/ClientMessagingService.java
@@ -118,6 +118,11 @@ public final class ClientMessagingService implements MessagingService {
   }
 
   @Override
+  public String getName() {
+    return this.getClass().getSimpleName();
+  }
+
+  @Override
   public void createTopic(TopicMetadata topicMetadata)
       throws TopicAlreadyExistsException, IOException, UnauthorizedException {
     TopicId topicId = topicMetadata.getTopicId();

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/DelegatingMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/DelegatingMessagingService.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.client;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.api.messaging.TopicAlreadyExistsException;
+import io.cdap.cdap.api.messaging.TopicNotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants.MessagingSystem;
+import io.cdap.cdap.messaging.spi.MessageFetchRequest;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.messaging.spi.RawMessage;
+import io.cdap.cdap.messaging.spi.RollbackDetail;
+import io.cdap.cdap.messaging.spi.StoreRequest;
+import io.cdap.cdap.messaging.spi.TopicMetadata;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.TopicId;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Delegates {@link io.cdap.cdap.messaging.spi.MessagingService} based on configured extension */
+public class DelegatingMessagingService implements MessagingService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DelegatingMessagingService.class);
+  private MessagingService delegate;
+  private final CConfiguration cConf;
+  private final MessagingServiceExtensionLoader extensionLoader;
+
+  @Inject
+  public DelegatingMessagingService(
+      CConfiguration cConf, MessagingServiceExtensionLoader extensionLoader) {
+    this.cConf = cConf;
+    this.extensionLoader = extensionLoader;
+  }
+
+  @Override
+  public void createTopic(TopicMetadata topicMetadata)
+      throws TopicAlreadyExistsException, IOException, UnauthorizedException {
+    getDelegate().createTopic(topicMetadata);
+  }
+
+  @Override
+  public void updateTopic(TopicMetadata topicMetadata)
+      throws TopicNotFoundException, IOException, UnauthorizedException {
+    getDelegate().updateTopic(topicMetadata);
+  }
+
+  @Override
+  public void deleteTopic(TopicId topicId)
+      throws TopicNotFoundException, IOException, UnauthorizedException {
+    getDelegate().deleteTopic(topicId);
+  }
+
+  @Override
+  public String getName() {
+    return cConf.get(MessagingSystem.MESSAGING_SERVICE_NAME);
+  }
+
+  @Override
+  public Map<String, String> getTopicMetadataProperties(TopicId topicId)
+      throws TopicNotFoundException, IOException, UnauthorizedException {
+    return getDelegate().getTopicMetadataProperties(topicId);
+  }
+
+  @Nullable
+  @Override
+  public RollbackDetail publish(StoreRequest request)
+      throws TopicNotFoundException, IOException, UnauthorizedException {
+    return getDelegate().publish(request);
+  }
+
+  @Override
+  public CloseableIterator<RawMessage> fetch(MessageFetchRequest messageFetchRequest)
+      throws TopicNotFoundException, IOException {
+    return getDelegate().fetch(messageFetchRequest);
+  }
+
+  @Override
+  public List<TopicId> listTopics(NamespaceId namespaceId)
+      throws IOException, UnauthorizedException {
+    return getDelegate().listTopics(namespaceId);
+  }
+
+  @Override
+  public void storePayload(StoreRequest request)
+      throws TopicNotFoundException, IOException, UnauthorizedException {
+    getDelegate().storePayload(request);
+  }
+
+  @Override
+  public void rollback(TopicId topicId, RollbackDetail rollbackDetail)
+      throws TopicNotFoundException, IOException, UnauthorizedException {
+    getDelegate().rollback(topicId, rollbackDetail);
+  }
+
+  private MessagingService getDelegate() {
+    MessagingService messagingService = this.delegate;
+    if (messagingService != null) {
+      return messagingService;
+    }
+    synchronized (this) {
+      messagingService = this.delegate;
+      if (messagingService != null) {
+        return messagingService;
+      }
+      messagingService = extensionLoader.get(getName());
+
+      if (messagingService == null) {
+        throw new IllegalArgumentException(
+            "Unsupported messaging service implementation " + getName());
+      }
+      LOG.info("Messaging service {} is loaded", messagingService.getName());
+
+      this.delegate = messagingService;
+      return messagingService;
+    }
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/MessagingServiceExtensionLoader.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/MessagingServiceExtensionLoader.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.client;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants.MessagingSystem;
+import io.cdap.cdap.common.lang.ClassPathResources;
+import io.cdap.cdap.common.lang.FilterClassLoader;
+import io.cdap.cdap.extension.AbstractExtensionLoader;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+
+/** A extension loader for {@link MessagingService}. */
+final class MessagingServiceExtensionLoader
+    extends AbstractExtensionLoader<String, MessagingService> {
+
+  private static final Set<String> ALLOWED_RESOURCES = createAllowedResources();
+  private static final Set<String> ALLOWED_PACKAGES = createPackageSets(ALLOWED_RESOURCES);
+
+  private static Set<String> createAllowedResources() {
+    // Only allow messaging service SPI classes.
+    try {
+      return ClassPathResources.getResourcesWithDependencies(
+          MessagingService.class.getClassLoader(), MessagingService.class);
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Failed to trace dependencies for messaging service extension. "
+              + "Usage of messaging service might fail.",
+          e);
+    }
+  }
+
+  @Inject
+  MessagingServiceExtensionLoader(CConfiguration cConf) {
+    super(cConf.get(MessagingSystem.EXTENSIONS_DIR));
+  }
+
+  @Override
+  protected Set<String> getSupportedTypesForProvider(MessagingService messagingService) {
+    return Collections.singleton(messagingService.getName());
+  }
+
+  @Override
+  protected FilterClassLoader.Filter getExtensionParentClassLoaderFilter() {
+    return new FilterClassLoader.Filter() {
+      @Override
+      public boolean acceptResource(String resource) {
+        return ALLOWED_RESOURCES.contains(resource);
+      }
+
+      @Override
+      public boolean acceptPackage(String packageName) {
+        return ALLOWED_PACKAGES.contains(packageName);
+      }
+    };
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/distributed/LeaderElectionMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/distributed/LeaderElectionMessagingService.java
@@ -85,6 +85,11 @@ public class LeaderElectionMessagingService extends AbstractIdleService implemen
   }
 
   @Override
+  public String getName() {
+    return this.getClass().getSimpleName();
+  }
+
+  @Override
   protected void startUp() throws Exception {
     delayExecutor = Executors.newSingleThreadScheduledExecutor(
         Threads.createDaemonThreadFactory("fencing-delay"));

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/guice/MessagingServiceModule.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/guice/MessagingServiceModule.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants.MessagingSystem;
+import io.cdap.cdap.messaging.client.DelegatingMessagingService;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.messaging.client.ClientMessagingService;
+
+/**
+ * The Guice module to bind messaging service based on {@link
+ * io.cdap.cdap.common.conf.Constants.MessagingSystem#MESSAGING_SERVICE_NAME} if set in cConf.
+ * Otherwise, binds to {@link ClientMessagingService}.
+ */
+public class MessagingServiceModule extends AbstractModule {
+
+  private static final String DEFAULT_MESSAGING_SERVICE_NAME =
+      ClientMessagingService.class.getSimpleName();
+  private final String messagingService;
+
+  public MessagingServiceModule(CConfiguration cConf) {
+    messagingService =
+        cConf
+            .get(MessagingSystem.MESSAGING_SERVICE_NAME, DEFAULT_MESSAGING_SERVICE_NAME);
+  }
+
+  @Override
+  protected void configure() {
+    if (messagingService.equals(DEFAULT_MESSAGING_SERVICE_NAME)) {
+      bind(MessagingService.class).to(ClientMessagingService.class).in(Scopes.SINGLETON);
+    } else {
+      bind(MessagingService.class).to(DelegatingMessagingService.class).in(Scopes.SINGLETON);
+    }
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/service/CoreMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/service/CoreMessagingService.java
@@ -131,6 +131,11 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
   }
 
   @Override
+  public String getName() {
+    return this.getClass().getSimpleName();
+  }
+
+  @Override
   public void createTopic(TopicMetadata topicMetadata)
       throws TopicAlreadyExistsException, IOException {
     try (MetadataTable metadataTable = createMetadataTable()) {


### PR DESCRIPTION
Why: Messaging service SPI has been introduced in part 1 [PR](https://github.com/cdapio/cdap/pull/15365)

This PR enables messaging service extensions through DelegatingMessagingService
