### PR TITLE
[CDAP-20845] Deprecate transactional feature in cdap-messaging-spi - Part 4

### DIFF
--- a/cdap-messaging-spi/src/main/java/io/cdap/cdap/messaging/spi/MessagingService.java
+++ b/cdap-messaging-spi/src/main/java/io/cdap/cdap/messaging/spi/MessagingService.java
@@ -119,6 +119,7 @@ public interface MessagingService {
    * @throws IOException if failed to store messages
    * @throws ServiceUnavailableException if the messaging service is not available
    */
+  @Deprecated
   void storePayload(StoreRequest request)
       throws TopicNotFoundException, IOException, UnauthorizedException;
 
@@ -132,6 +133,7 @@ public interface MessagingService {
    * @throws IOException if failed to rollback changes
    * @throws ServiceUnavailableException if the messaging service is not available
    */
+  @Deprecated
   void rollback(TopicId topicId, RollbackDetail rollbackDetail)
       throws TopicNotFoundException, IOException, UnauthorizedException;
 

--- a/cdap-messaging-spi/src/main/java/io/cdap/cdap/messaging/spi/RollbackDetail.java
+++ b/cdap-messaging-spi/src/main/java/io/cdap/cdap/messaging/spi/RollbackDetail.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.messaging.spi;
 /**
  * This interface represents information needed to rollback message published transactionally.
  */
+@Deprecated
 public interface RollbackDetail {
 
   /**

--- a/cdap-messaging-spi/src/main/java/io/cdap/cdap/messaging/spi/StoreRequest.java
+++ b/cdap-messaging-spi/src/main/java/io/cdap/cdap/messaging/spi/StoreRequest.java
@@ -28,14 +28,17 @@ public interface StoreRequest extends Iterable<byte[]> {
   TopicId getTopicId();
 
   /** Returns {@code true} if the message should be published transactionally. */
+  @Deprecated
   boolean isTransactional();
 
   /**
    * Returns the transaction write pointer if the message is going to be published transactionally,
    * that is when {@link #isTransactional()} returns {@code true}.
    */
+  @Deprecated
   long getTransactionWritePointer();
 
   /** Returns {@code true} if there is payload in this request. */
+  @Deprecated
   boolean hasPayload();
 }


### PR DESCRIPTION
Why: Messaging service SPI has been introduced in part 1 [PR](https://github.com/cdapio/cdap/pull/15365)
The transactional feature (along with rollback) is no longer used in messaging service. This PR marks those functionalities deprecated in the SPI. 