### PR TITLE
[CDAP-20868] Allow task workers to run concurrent requests when configured

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -504,6 +504,8 @@ public final class Constants {
         "task.worker.container.kill.after.request.count";
     public static final String CONTAINER_KILL_AFTER_DURATION_SECOND =
         "task.worker.container.kill.after.duration.second";
+    public static final String REQUEST_LIMIT = "task.worker.request.limit";
+    public static final String USER_CODE_ISOLATION_ENABLED = "task.worker.request.userCodeIsolation.enabled";
     public static final String CONTAINER_RUN_AS_USER = "task.worker.container.run.as.user";
     public static final String CONTAINER_RUN_AS_GROUP = "task.worker.container.run.as.group";
     public static final String CONTAINER_DISK_READONLY = "task.worker.container.disk.readonly";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5252,6 +5252,23 @@
   </property>
 
   <property>
+    <name>task.worker.request.limit</name>
+    <value>10</value>
+    <description>
+      Number of concurrent requests accepted by task worker pods.
+    </description>
+  </property>
+
+  <property>
+    <name>task.worker.request.userCodeIsolation.enabled</name>
+    <value>true</value>
+    <description>
+      Whether user code isolation is enabled in task worker. When enabled, task workers will ensure
+      multiple requests that run user code are not executed concurrently.
+    </description>
+  </property>
+
+  <property>
     <name>task.worker.bind.address</name>
     <value>0.0.0.0</value>
     <description>


### PR DESCRIPTION
## [CDAP-20868](https://cdap.atlassian.net/browse/CDAP-20868)
Presently task worker can run only 1 request at a time. This is done to ensure user code isolation. However, there are situations in which task workers are used to only isolate services that require access to external resources. In such situations, running multiple tasks in parallel will lead to better resource utilisation and higher concurrency.

This PR introduces a cdap-site property `task.worker.request.userCodeIsolation.enabled` (true by default) that allows turning of user code isolation and allows task worker to run requests concurrently.

[CDAP-20868]: https://cdap.atlassian.net/browse/CDAP-20868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ