### PR TITLE
[CDAP-20871][Cherrypick] System worker capacity leak

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerHttpHandlerInternal.java
@@ -100,6 +100,7 @@ public class SystemWorkerHttpHandlerInternal extends AbstractHttpHandler {
 
     if (requestProcessedCount.incrementAndGet() > requestLimit) {
       responder.sendStatus(HttpResponseStatus.TOO_MANY_REQUESTS);
+      requestProcessedCount.decrementAndGet();
       return;
     }
 


### PR DESCRIPTION
## [CDAP-20871](https://cdap.atlassian.net/browse/CDAP-20871)
Original PR: https://github.com/cdapio/cdap/pull/15390

When system worker is at full capacity, system worker would increment the request count, but not decrement it before returning a 429 response. As a result, the capacity of the system worker would reduce by 1 till it is restarted. This PR fixes this bug by decrementing the request count before returning.

[CDAP-20871]: https://cdap.atlassian.net/browse/CDAP-20871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ