### PR TITLE
CDAP-20867 switch to cheaper secure store call in oauth handler

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisionerMacroEvaluator.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisionerMacroEvaluator.java
@@ -54,7 +54,7 @@ public class ProvisionerMacroEvaluator implements MacroEvaluator {
       throw new InvalidMacroException("Secure store macro function only supports 1 argument.");
     }
     try {
-      return Bytes.toString(secureStore.get(namespace, arguments[0]).get());
+      return Bytes.toString(secureStore.getData(namespace, arguments[0]));
     } catch (Exception e) {
       throw new InvalidMacroException(
           "Failed to resolve macro '" + macroFunction + "(" + arguments[0] + ")'", e);

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthStore.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthStore.java
@@ -113,7 +113,7 @@ public class OAuthStore {
     OAuthClientCredentials clientCreds;
     try {
       String clientCredsJson = new String(
-          secureStore.get(NamespaceId.SYSTEM.getNamespace(), getClientCredsKey(name)).get(),
+          secureStore.getData(NamespaceId.SYSTEM.getNamespace(), getClientCredsKey(name)),
           StandardCharsets.UTF_8);
       clientCreds = GSON.fromJson(clientCredsJson, OAuthClientCredentials.class);
     } catch (IOException e) {
@@ -171,7 +171,7 @@ public class OAuthStore {
       throws OAuthStoreException {
     try {
       String tokenJson = new String(
-          secureStore.get(NamespaceId.SYSTEM.getNamespace(), getRefreshTokenKey(oauthProvider, credentialId)).get(),
+          secureStore.getData(NamespaceId.SYSTEM.getNamespace(), getRefreshTokenKey(oauthProvider, credentialId)),
           StandardCharsets.UTF_8);
       return Optional.of(GSON.fromJson(tokenJson, OAuthRefreshToken.class));
     } catch (IOException e) {


### PR DESCRIPTION
cherry-pick #15399
Switch to use cheaper SecureStore.getData() call instead of SecureStore.get() when the secure key metadata is not needed