### PR TITLE
[CDAP-20795] remove identity from namespace wi request body

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/handler/GcpWorkloadIdentityHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/handler/GcpWorkloadIdentityHttpHandlerInternal.java
@@ -25,7 +25,6 @@ import io.cdap.cdap.proto.BasicThrowable;
 import io.cdap.cdap.proto.codec.BasicThrowableCodec;
 import io.cdap.cdap.proto.credential.CredentialProvisioningException;
 import io.cdap.cdap.proto.credential.NamespaceCredentialProvider;
-import io.cdap.cdap.security.spi.authorization.ContextAccessEnforcer;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpHandler;
 import io.cdap.http.HttpResponder;
@@ -49,13 +48,10 @@ public class GcpWorkloadIdentityHttpHandlerInternal extends AbstractHttpHandler 
       BasicThrowable.class, new BasicThrowableCodec()).create();
 
   private final NamespaceCredentialProvider credentialProvider;
-  private final ContextAccessEnforcer accessEnforcer;
 
   @Inject
-  GcpWorkloadIdentityHttpHandlerInternal(
-      ContextAccessEnforcer accessEnforcer, NamespaceCredentialProvider credentialProvider) {
+  GcpWorkloadIdentityHttpHandlerInternal(NamespaceCredentialProvider credentialProvider) {
     this.credentialProvider = credentialProvider;
-    this.accessEnforcer = accessEnforcer;
   }
 
   /**

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/NamespaceWorkloadIdentity.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/NamespaceWorkloadIdentity.java
@@ -20,24 +20,15 @@ package io.cdap.cdap.proto.credential;
  * Defines an identity for credential provisioning.
  */
 public class NamespaceWorkloadIdentity {
-
-  private final String identity;
   private final String serviceAccount;
 
   /**
    * Constructs a namespace identity.
    *
-   * @param identity         The identity.
    * @param serviceAccount   The serviceAccount to store for the identity.
    */
-  public NamespaceWorkloadIdentity(String identity,
-      String serviceAccount) {
-    this.identity = identity;
+  public NamespaceWorkloadIdentity(String serviceAccount) {
     this.serviceAccount = serviceAccount;
-  }
-
-  public String getIdentity() {
-    return identity;
   }
 
   public String getServiceAccount() {


### PR DESCRIPTION
Since the GcpWorkloadIdentityHttpHandler has access to the namespaceMeta we don't need the namespace identity in the request body.

Updated requests:

Create/Update Identity
```
PUT v3/namespaces/{namespace-id}/credentials/workloadIdentity

body: {"serviceAccount":"<GSA_EMAIL>"}
```
![image](https://github.com/cdapio/cdap/assets/88528384/97e5f60e-cfe5-4093-bcd6-38211f6294d6)

Validate Identity
```
POST v3/namespaces/<namespace>/credentials/workloadIdentity/validate

body: {"serviceAccount":"<GSA_EMAIL>"}
```
![image](https://github.com/cdapio/cdap/assets/88528384/dcd66189-7f66-480e-95c7-0edfadf3aa2a)