### PR TITLE
[CDAP-20657] fixes & additional support

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/DelegatingSparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/DelegatingSparkCollection.java
@@ -55,7 +55,7 @@ public abstract class DelegatingSparkCollection<T> implements SparkCollection<T>
   @Override
   public SparkCollection<RecordInfo<Object>> multiOutputTransform(StageSpec stageSpec,
                                                                   StageStatisticsCollector collector) {
-    return getDelegate().transform(stageSpec, collector);
+    return getDelegate().multiOutputTransform(stageSpec, collector);
   }
 
   @Override
@@ -94,8 +94,8 @@ public abstract class DelegatingSparkCollection<T> implements SparkCollection<T>
 
   @Override
   public Runnable createStoreTask(StageSpec stageSpec,
-                                  SparkSink sink) throws Exception {
-    return getDelegate().createStoreTask(stageSpec, sink);
+                                  SparkSink sink) {
+    return () -> getDelegate().createStoreTask(stageSpec, sink).run();
   }
 
   @Override
@@ -135,13 +135,13 @@ public abstract class DelegatingSparkCollection<T> implements SparkCollection<T>
   @Override
   public Runnable createStoreTask(StageSpec stageSpec,
       PairFlatMapFunction<T, Object, Object> sinkFunction) {
-    return getDelegate().createStoreTask(stageSpec, sinkFunction);
+    return () -> getDelegate().createStoreTask(stageSpec, sinkFunction).run();
   }
 
   @Override
   public Runnable createMultiStoreTask(PhaseSpec phaseSpec, Set<String> group, Set<String> sinks,
       Map<String, StageStatisticsCollector> collectors) {
-    return getDelegate().createMultiStoreTask(phaseSpec, group, sinks, collectors);
+    return () -> getDelegate().createMultiStoreTask(phaseSpec, group, sinks, collectors).run();
   }
 
   @Override

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/SparkCollection.java
@@ -24,6 +24,8 @@ import io.cdap.cdap.etl.common.PhaseSpec;
 import io.cdap.cdap.etl.common.RecordInfo;
 import io.cdap.cdap.etl.common.StageStatisticsCollector;
 import io.cdap.cdap.etl.proto.v2.spec.StageSpec;
+import io.cdap.cdap.etl.spark.function.PluginFunctionContext;
+import io.cdap.cdap.etl.spark.function.TransformFunction;
 import io.cdap.cdap.etl.spark.join.JoinExpressionRequest;
 import io.cdap.cdap.etl.spark.join.JoinRequest;
 import org.apache.spark.api.java.function.FlatMapFunction;
@@ -81,7 +83,7 @@ public interface SparkCollection<T> {
   Runnable createMultiStoreTask(PhaseSpec phaseSpec, Set<String> group, Set<String> sinks,
                                 Map<String, StageStatisticsCollector> collectors);
 
-  Runnable createStoreTask(StageSpec stageSpec, SparkSink<T> sink) throws Exception;
+  Runnable createStoreTask(StageSpec stageSpec, SparkSink<T> sink);
 
   void publishAlerts(StageSpec stageSpec, StageStatisticsCollector collector) throws Exception;
 

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/RDDCollection.java
@@ -144,16 +144,16 @@ public class RDDCollection<T> implements BatchCollection<T> {
   @Override
   public SparkCollection<RecordInfo<Object>> transform(StageSpec stageSpec, StageStatisticsCollector collector) {
     PluginFunctionContext pluginFunctionContext = new PluginFunctionContext(stageSpec, sec, collector);
-    return wrap(rdd.flatMap(new TransformFunction<T>(
-      pluginFunctionContext, functionCacheFactory.newCache())));
+    return flatMap(stageSpec, new TransformFunction<T>(
+      pluginFunctionContext, functionCacheFactory.newCache()));
   }
 
   @Override
   public SparkCollection<RecordInfo<Object>> multiOutputTransform(StageSpec stageSpec,
                                                                   StageStatisticsCollector collector) {
     PluginFunctionContext pluginFunctionContext = new PluginFunctionContext(stageSpec, sec, collector);
-    return wrap(rdd.flatMap(new MultiOutputTransformFunction<T>(
-      pluginFunctionContext, functionCacheFactory.newCache())));
+    return flatMap(stageSpec,new MultiOutputTransformFunction<T>(
+      pluginFunctionContext, functionCacheFactory.newCache()));
   }
 
   @Override
@@ -305,7 +305,7 @@ public class RDDCollection<T> implements BatchCollection<T> {
   }
 
   @Override
-  public Runnable createStoreTask(final StageSpec stageSpec, final SparkSink<T> sink) throws Exception {
+  public Runnable createStoreTask(final StageSpec stageSpec, final SparkSink<T> sink) {
     return new Runnable() {
       @Override
       public void run() {

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/SQLEngineCollection.java
@@ -290,7 +290,7 @@ public class SQLEngineCollection<T> implements SQLBackedCollection<T> {
   }
 
   @Override
-  public Runnable createStoreTask(StageSpec stageSpec, SparkSink<T> sink) throws Exception {
+  public Runnable createStoreTask(StageSpec stageSpec, SparkSink<T> sink) {
     return () -> {
       try {
         pull().createStoreTask(stageSpec, sink).run();

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/streaming/DStreamCollection.java
@@ -205,7 +205,7 @@ public class DStreamCollection<T> implements SparkCollection<T> {
   }
 
   @Override
-  public Runnable createStoreTask(StageSpec stageSpec, SparkSink<T> sink) throws Exception {
+  public Runnable createStoreTask(StageSpec stageSpec, SparkSink<T> sink) {
     return new Runnable() {
       @Override
       public void run() {


### PR DESCRIPTION
 * Add Dataset support & fix transform & multiOutputTransform; 
 * Ensure store & multistore RDD conversion is done when store task is executed

In summary, we can now evade conversion of Dataset to RDD for the most widely used plugins, including Wrangler.