### PR TITLE
[CDAP-20785] do not set WI env vars when NSA is enabled

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DistributedPreviewManager.java
@@ -235,6 +235,8 @@ public class DistributedPreviewManager extends DefaultPreviewManager implements 
                     String.format("%s:%s", localhost,
                         cConf.getInt(Constants.ArtifactLocalizer.PORT))
                 ));
+            twillPreparer = ((SecureTwillPreparer) twillPreparer)
+                .withNamespacedWorkloadIdentity(PreviewRunnerTwillRunnable.class.getSimpleName());
           }
 
           String priorityClass = cConf.get(Constants.Preview.CONTAINER_PRIORITY_CLASS_NAME);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceLauncher.java
@@ -213,6 +213,8 @@ public class TaskWorkerServiceLauncher extends AbstractScheduledService {
                     String.format("%s:%s", localhost,
                         cConf.getInt(Constants.ArtifactLocalizer.PORT))
                 ));
+            twillPreparer = ((SecureTwillPreparer) twillPreparer)
+                .withNamespacedWorkloadIdentity(TaskWorkerTwillRunnable.class.getSimpleName());
           }
 
           String priorityClass = cConf.get(Constants.TaskWorker.CONTAINER_PRIORITY_CLASS_NAME);

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/SecureTwillPreparer.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/SecureTwillPreparer.java
@@ -44,4 +44,13 @@ public interface SecureTwillPreparer extends TwillPreparer {
   SecureTwillPreparer withSecurityContext(String runnableName,
       SecurityContext securityContext);
 
+  /**
+   * Runs the given runnable with namespace workload identity,
+   * this feature removes the GOOGLE_APPLICATION_CREDENTIALS environment variable
+   * to enable namespaced service accounts.
+   *
+   * @param runnableName name of the {@link TwillRunnable}
+   * @return this {@link TwillPreparer}
+   */
+  SecureTwillPreparer withNamespacedWorkloadIdentity(String runnableName);
 }


### PR DESCRIPTION
This PR does the following:

- It avoids setting workload identity env vars to task worker and preview runner twill runnables when namespaced service accounts is enabled.