### PR TITLE
[CDAP-20785] Use GCP remote authenticator to fetch token

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerService.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.CommonNettyHttpServiceFactory;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.security.spi.authenticator.RemoteAuthenticator;
 import io.cdap.http.NettyHttpService;
 import java.net.InetAddress;
 import java.nio.file.Paths;
@@ -52,7 +53,7 @@ public class ArtifactLocalizerService extends AbstractIdleService {
   ArtifactLocalizerService(CConfiguration cConf,
       ArtifactLocalizer artifactLocalizer,
       CommonNettyHttpServiceFactory commonNettyHttpServiceFactory,
-      RemoteClientFactory remoteClientFactory) {
+      RemoteClientFactory remoteClientFactory, RemoteAuthenticator remoteAuthenticator) {
     this.cConf = cConf;
     this.artifactLocalizer = artifactLocalizer;
     this.httpService = commonNettyHttpServiceFactory.builder(Constants.Service.TASK_WORKER)
@@ -61,7 +62,7 @@ public class ArtifactLocalizerService extends AbstractIdleService {
         .setBossThreadPoolSize(cConf.getInt(Constants.ArtifactLocalizer.BOSS_THREADS))
         .setWorkerThreadPoolSize(cConf.getInt(Constants.ArtifactLocalizer.WORKER_THREADS))
         .setHttpHandlers(new ArtifactLocalizerHttpHandlerInternal(artifactLocalizer),
-            new GcpMetadataHttpHandlerInternal(cConf, remoteClientFactory))
+            new GcpMetadataHttpHandlerInternal(cConf, remoteClientFactory, remoteAuthenticator))
         .build();
 
     this.cacheCleanupInterval = cConf.getInt(

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.common.discovery.URIScheme;
 import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
+import io.cdap.cdap.common.internal.remote.NoOpRemoteAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.internal.remote.TaskWorkerHttpHandlerInternal;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
@@ -126,7 +127,8 @@ public class RemoteConfiguratorTest {
               new ArtifactLocalizer(cConf, remoteClientFactory,
                   ((namespaceId, retryStrategy) -> new NoOpArtifactManager()))
           ),
-          new GcpMetadataHttpHandlerInternal(cConf, remoteClientFactory)
+          new GcpMetadataHttpHandlerInternal(cConf, remoteClientFactory,
+              new NoOpRemoteAuthenticator())
       )
       .setChannelPipelineModifier(new ChannelPipelineModifier() {
         @Override

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.common.http.CommonNettyHttpServiceFactory;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.NoOpInternalAuthenticator;
+import io.cdap.cdap.common.internal.remote.NoOpRemoteAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
@@ -85,7 +86,7 @@ public class ArtifactLocalizerServiceTest extends AppFabricTestBase {
       cConf, new ArtifactLocalizer(cConf, remoteClientFactory, (namespaceId, retryStrategy) -> {
       return new NoOpArtifactManager();
     }), new CommonNettyHttpServiceFactory(cConf, new NoOpMetricsCollectionService()),
-        remoteClientFactory);
+        remoteClientFactory, new NoOpRemoteAuthenticator());
     // start the service
     artifactLocalizerService.startAndWait();
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternalTest.java
@@ -21,6 +21,7 @@ import com.google.gson.GsonBuilder;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.http.CommonNettyHttpServiceBuilder;
+import io.cdap.cdap.common.internal.remote.NoOpRemoteAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.common.namespace.InMemoryNamespaceAdmin;
@@ -69,7 +70,8 @@ public class GcpMetadataHttpHandlerInternalTest {
     httpService = new CommonNettyHttpServiceBuilder(cConf, "test",
         new NoOpMetricsCollectionService())
         .setHttpHandlers(
-            new GcpMetadataHttpHandlerInternal(cConf, remoteClientFactory)
+            new GcpMetadataHttpHandlerInternal(cConf, remoteClientFactory,
+                new NoOpRemoteAuthenticator())
         )
         .setChannelPipelineModifier(new ChannelPipelineModifier() {
           @Override

--- a/cdap-authenticator-ext-gcp/src/main/java/io/cdap/cdap/authenticator/gcp/GCPRemoteAuthenticator.java
+++ b/cdap-authenticator-ext-gcp/src/main/java/io/cdap/cdap/authenticator/gcp/GCPRemoteAuthenticator.java
@@ -64,6 +64,7 @@ public class GCPRemoteAuthenticator implements RemoteAuthenticator {
     if (accessToken == null || accessToken.getExpirationTime().before(Date.from(clock.instant()))) {
       accessToken = googleCredentials.refreshAccessToken();
     }
-    return new Credential(accessToken.getTokenValue(), Credential.CredentialType.EXTERNAL_BEARER);
+    return new Credential(accessToken.getTokenValue(), Credential.CredentialType.EXTERNAL_BEARER,
+        accessToken.getExpirationTime().getTime() / 1000L);
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -594,6 +594,8 @@ public final class Constants {
     public static final String WORKER_THREADS = "artifact.localizer.worker.threads";
     public static final String PRELOAD_LIST = "artifact.localizer.preload.list";
     public static final String PRELOAD_VERSION_LIMIT = "artifact.localizer.preload.version.limit";
+    public static final String REMOTE_AUTHENTICATOR_NAME =
+        "artifact.localizer.remote.authenticator.name";
   }
 
   /**

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Credential.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/security/Credential.java
@@ -84,10 +84,31 @@ public class Credential {
 
   private final String value;
   private final CredentialType type;
+  private final Long expirationTimeSecs;
 
+  /**
+   * Constructs the Credential.
+   *
+   * @param value credential value
+   * @param type credential type
+   */
   public Credential(String value, CredentialType type) {
     this.value = value;
     this.type = type;
+    this.expirationTimeSecs = null;
+  }
+
+  /**
+   * Constructs the Credential.
+   *
+   * @param value credential value
+   * @param type credential type
+   * @param expirationTimeSecs the time in seconds after which credential will expire
+   */
+  public Credential(String value, CredentialType type, Long expirationTimeSecs) {
+    this.value = value;
+    this.type = type;
+    this.expirationTimeSecs = expirationTimeSecs;
   }
 
   public String getValue() {
@@ -98,10 +119,15 @@ public class Credential {
     return type;
   }
 
+  public Long getExpirationTimeSecs() {
+    return expirationTimeSecs;
+  }
+
   @Override
   public String toString() {
     return "Credential{"
         + "type=" + type
+        + ", expires_in=" + expirationTimeSecs
         + ", length=" + value.length()
         + "}";
   }


### PR DESCRIPTION
This PR does the following:
- Uses GCP Remote Authenticator to fetch credentials when namespace service account is not set instead of directly polling gcp metadata server which might not be present in some cases.
- `artifact.localizer.remote.authenticator.name` will be populated from CConf.

Tested after deploying CDAP in k8s.