### PR TITLE
[CDAP-20815] Fix pipeline description on pipeline upgrade

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/DataStreamsConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/DataStreamsConfig.java
@@ -38,7 +38,8 @@ public final class DataStreamsConfig extends ETLConfig {
   // See comments in DataStreamsSparkLauncher for explanation on why we need this.
   private final boolean isUnitTest;
 
-  private DataStreamsConfig(Set<ETLStage> stages,
+  private DataStreamsConfig(String description,
+      Set<ETLStage> stages,
       Set<Connection> connections,
       Resources resources,
       Resources driverResources,
@@ -52,9 +53,8 @@ public final class DataStreamsConfig extends ETLConfig {
       @Nullable Integer numOfRecordsPreview,
       @Nullable Boolean stopGracefully,
       Map<String, String> properties) {
-    super(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled,
-        processTimingEnabled,
-        numOfRecordsPreview, properties);
+    super(description, stages, connections, resources, driverResources, clientResources,
+        stageLoggingEnabled, processTimingEnabled, numOfRecordsPreview, properties);
     this.batchInterval = batchInterval;
     this.isUnitTest = isUnitTest;
     this.extraJavaOpts = "";
@@ -144,10 +144,9 @@ public final class DataStreamsConfig extends ETLConfig {
       updatedStages.add(stage.updateStage(applicationUpdateContext));
     }
 
-    return new DataStreamsConfig(updatedStages, connections, resources, driverResources,
-        clientResources,
-        stageLoggingEnabled, processTimingEnabled, batchInterval, isUnitTest,
-        disableCheckpoints, checkpointDir, numOfRecordsPreview, stopGracefully,
+    return new DataStreamsConfig(description, updatedStages, connections, resources,
+        driverResources, clientResources, stageLoggingEnabled, processTimingEnabled, batchInterval,
+        isUnitTest, disableCheckpoints, checkpointDir, numOfRecordsPreview, stopGracefully,
         properties);
   }
 
@@ -190,10 +189,9 @@ public final class DataStreamsConfig extends ETLConfig {
     }
 
     public DataStreamsConfig build() {
-      return new DataStreamsConfig(stages, connections, resources, driverResources, clientResources,
-          stageLoggingEnabled, processTimingEnabled, batchInterval, isUnitTest,
-          disableCheckpoints, checkpointDir, numOfRecordsPreview, stopGraceFully,
-          properties);
+      return new DataStreamsConfig(description, stages, connections, resources, driverResources,
+          clientResources, stageLoggingEnabled, processTimingEnabled, batchInterval, isUnitTest,
+          disableCheckpoints, checkpointDir, numOfRecordsPreview, stopGraceFully, properties);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLBatchConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLBatchConfig.java
@@ -51,7 +51,8 @@ public final class ETLBatchConfig extends ETLConfig {
   private final Boolean pushdownEnabled;
   private final ETLTransformationPushdown transformationPushdown;
 
-  private ETLBatchConfig(Set<ETLStage> stages,
+  private ETLBatchConfig(String description,
+      Set<ETLStage> stages,
       Set<Connection> connections,
       List<ETLStage> postActions,
       Resources resources,
@@ -69,9 +70,8 @@ public final class ETLBatchConfig extends ETLConfig {
       List<Object> comments,
       @Nullable Boolean pushdownEnabled,
       @Nullable ETLTransformationPushdown transformationPushdown) {
-    super(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled,
-        processTimingEnabled,
-        numOfRecordsPreview, engineProperties, comments);
+    super(description,stages, connections, resources, driverResources, clientResources,
+        stageLoggingEnabled, processTimingEnabled, numOfRecordsPreview, engineProperties, comments);
     this.postActions = ImmutableList.copyOf(postActions);
     this.engine = engine;
     this.schedule = schedule;
@@ -163,11 +163,10 @@ public final class ETLBatchConfig extends ETLConfig {
     for (ETLStage postAction : getPostActions()) {
       upgradedPostActions.add(postAction.updateStage(upgradeContext));
     }
-    return new ETLBatchConfig(upgradedStages, connections, upgradedPostActions, resources,
-        stageLoggingEnabled,
-        processTimingEnabled, engine, schedule, driverResources, clientResources,
-        numOfRecordsPreview, maxConcurrentRuns, properties, service, connectionConfig, comments,
-        pushdownEnabled, transformationPushdown);
+    return new ETLBatchConfig(description, upgradedStages, connections, upgradedPostActions,
+        resources, stageLoggingEnabled, processTimingEnabled, engine, schedule, driverResources,
+        clientResources, numOfRecordsPreview, maxConcurrentRuns, properties, service,
+        connectionConfig, comments, pushdownEnabled, transformationPushdown);
   }
 
   @Override
@@ -259,6 +258,7 @@ public final class ETLBatchConfig extends ETLConfig {
 
     public Builder(ETLBatchConfig config) {
       super();
+      this.description = config.getDescription();
       this.stages = config.getStages();
       this.connections = config.getConnections();
       this.endingActions = config.getPostActions();
@@ -318,10 +318,10 @@ public final class ETLBatchConfig extends ETLConfig {
     }
 
     public ETLBatchConfig build() {
-      return new ETLBatchConfig(stages, connections, endingActions, resources, stageLoggingEnabled,
-          processTimingEnabled, engine, schedule, driverResources, clientResources,
-          numOfRecordsPreview, maxConcurrentRuns, properties, false, null, comments,
-          pushdownEnabled, transformationPushdown);
+      return new ETLBatchConfig(description, stages, connections, endingActions, resources,
+          stageLoggingEnabled, processTimingEnabled, engine, schedule, driverResources,
+          clientResources, numOfRecordsPreview, maxConcurrentRuns, properties, false, null,
+          comments, pushdownEnabled, transformationPushdown);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLConfig.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/ETLConfig.java
@@ -59,11 +59,11 @@ public class ETLConfig extends Config implements UpgradeableConfig {
   // For serialization purpose for upgrade compatibility.
   protected List<Object> comments;
 
-  protected ETLConfig(Set<ETLStage> stages, Set<Connection> connections, Resources resources,
-      Resources driverResources, Resources clientResources,
+  protected ETLConfig(String description, Set<ETLStage> stages, Set<Connection> connections,
+      Resources resources, Resources driverResources, Resources clientResources,
       @Nullable Boolean stageLoggingEnabled, @Nullable Boolean processTimingEnabled,
       @Nullable Integer numOfRecordsPreview, Map<String, String> properties) {
-    this.description = null;
+    this.description = description;
     this.stages = Collections.unmodifiableSet(stages);
     this.connections = Collections.unmodifiableSet(connections);
     this.resources = resources;
@@ -80,14 +80,13 @@ public class ETLConfig extends Config implements UpgradeableConfig {
     this.comments = new ArrayList<>();
   }
 
-  protected ETLConfig(Set<ETLStage> stages, Set<Connection> connections,
+  protected ETLConfig(String descrition, Set<ETLStage> stages, Set<Connection> connections,
       Resources resources, Resources driverResources, Resources clientResources,
       @Nullable Boolean stageLoggingEnabled, @Nullable Boolean processTimingEnabled,
       @Nullable Integer numOfRecordsPreview, Map<String, String> properties,
       List<Object> comments) {
-    this(stages, connections, resources, driverResources, clientResources, stageLoggingEnabled,
-        processTimingEnabled,
-        numOfRecordsPreview, properties);
+    this(descrition, stages, connections, resources, driverResources, clientResources,
+        stageLoggingEnabled, processTimingEnabled, numOfRecordsPreview, properties);
     this.comments = comments;
     this.sinks = null;
     this.transforms = null;
@@ -257,6 +256,7 @@ public class ETLConfig extends Config implements UpgradeableConfig {
   @SuppressWarnings("unchecked")
   public abstract static class Builder<T extends Builder> {
 
+    protected String description;
     protected List<Object> comments;
     public static final Resources DEFAULT_TEST_RESOURCES = new Resources(2048, 1);
     protected Set<ETLStage> stages;
@@ -348,6 +348,11 @@ public class ETLConfig extends Config implements UpgradeableConfig {
 
     public T setComments(List<Object> comments) {
       this.comments = comments;
+      return (T) this;
+    }
+
+    public T setDescription(String description) {
+      this.description = description;
       return (T) this;
     }
   }


### PR DESCRIPTION
### Issue

[CDAP-20815](https://cdap.atlassian.net/browse/CDAP-20815) Pipeline’s description is replaced with “Data Pipeline Application” when invoking /upgrade REST API

### Repro Steps

To reproduce the issue:
* Deploy a pipeline in an instance with some description. 
* Either follow the [pipeline upgrade process](https://cloud.google.com/data-fusion/docs/how-to/upgrading#upgrade-batch-pipelines) or call the [POST /upgrade](https://cdap.atlassian.net/wiki/spaces/DOCS/pages/477560983/Lifecycle+Microservices#Upgrade-an-Application) method for the pipeline.
* Once upgrade finishes, check pipeline description. It’s been set to “Data Pipeline Application”

This can be reproed in 6.6.0 - 6.9.x. May also be reproduced in versions < 6.6.0.

### Root Cause

On pipeline upgrade the description of the pipeline is preserved and set to `null`. The null description is defaulted to `Data Pipeline Application` ([code](https://github.com/cdapio/cdap/blob/01eb200fdac6661d73466451a4639fe6eeba8776/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/DataPipelineApp.java#L49))

### Solution

Preserve the pipeline description during upgrades for both Batch and Stream pipelines.

### Verification

* Verified using sandbox instance.
* Created a pipeline with some description.
* Upgraded the pipeline.
* Verified that the description is the same and not changed to the default one.

[CDAP-20815]: https://cdap.atlassian.net/browse/CDAP-20815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ