### PR TITLE
[CDAP-20893] Cherry-pick 6.10

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/credential/handler/CredentialProviderHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/credential/handler/CredentialProviderHttpHandlerInternal.java
@@ -18,24 +18,30 @@ package io.cdap.cdap.internal.credential.handler;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import com.google.inject.Singleton;
+import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.proto.BasicThrowable;
 import io.cdap.cdap.proto.codec.BasicThrowableCodec;
 import io.cdap.cdap.proto.credential.CredentialProvider;
+import io.cdap.cdap.proto.credential.CredentialProvisionContext;
 import io.cdap.cdap.proto.credential.CredentialProvisioningException;
 import io.cdap.http.AbstractHttpHandler;
 import io.cdap.http.HttpHandler;
 import io.cdap.http.HttpResponder;
-import io.netty.handler.codec.http.HttpRequest;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import javax.inject.Inject;
-import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 
 /**
  * Internal {@link HttpHandler} for credential providers.
@@ -61,22 +67,37 @@ public class CredentialProviderHttpHandlerInternal extends AbstractHttpHandler {
    * @param responder    The HTTP responder.
    * @param namespace    The namespace of the identity for which to provision a credential.
    * @param identityName The name of the identity for which to provision a credential.
-   * @param scopes       A comma separated list of OAuth scopes requested.
    * @throws CredentialProvisioningException If provisioning fails.
    * @throws IOException                     If transport errors occur.
    * @throws NotFoundException               If the identity or associated profile are not found.
    */
-  @GET
+  @POST
   @Path("/namespaces/{namespace-id}/credentials/identities/{identity-name}/provision")
-  public void provisionCredential(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespace, @PathParam("identity-name") String identityName,
-      @QueryParam("scopes") String scopes)
-      throws CredentialProvisioningException, IOException, NotFoundException {
+  public void provisionCredential(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace, @PathParam("identity-name") String identityName)
+      throws BadRequestException, CredentialProvisioningException, IOException, NotFoundException {
+    CredentialProvisionContext context = deserializeRequestContent(request,
+        CredentialProvisionContext.class);
     try {
       responder.sendJson(HttpResponseStatus.OK,
-          GSON.toJson(credentialProvider.provision(namespace, identityName, scopes)));
+          GSON.toJson(credentialProvider.provision(namespace, identityName, context)));
     } catch (io.cdap.cdap.proto.credential.NotFoundException e) {
       throw new NotFoundException(e.getMessage());
+    }
+  }
+
+  private <T> T deserializeRequestContent(FullHttpRequest request, Class<T> clazz)
+      throws BadRequestException {
+    try (Reader reader = new InputStreamReader(new ByteBufInputStream(request.content()),
+        StandardCharsets.UTF_8)) {
+      T content = GSON.fromJson(reader, clazz);
+      if (content == null) {
+        throw new BadRequestException("No request object provided; expected class "
+            + clazz.getName());
+      }
+      return content;
+    } catch (JsonSyntaxException | IOException e) {
+      throw new BadRequestException("Unable to parse request: " + e.getMessage(), e);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/GcpWorkloadIdentityUtil.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/GcpWorkloadIdentityUtil.java
@@ -16,11 +16,17 @@
 
 package io.cdap.cdap.internal.namespace.credential;
 
+import com.google.common.hash.Hashing;
+import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.credential.NamespaceWorkloadIdentity;
+import io.cdap.cdap.proto.id.NamespaceId;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
- * Utility class for {@link NamespaceWorkloadIdentity} associated with
- * the namespace.
+ * Utility class for {@link NamespaceWorkloadIdentity} associated with the namespace.
  */
 public final class GcpWorkloadIdentityUtil {
 
@@ -28,13 +34,59 @@ public final class GcpWorkloadIdentityUtil {
 
   public static final String SYSTEM_PROFILE_NAME = "ns-gcp-wi";
 
+  private static final String GCP_OAUTH_SCOPES_PROPERTY = "gcp.oauth.scopes";
+  private static final String K8S_NAMESPACE_PROPERTY = "k8s.namespace";
+  private static final String WRAPPED_CDAP_NAMESPACE_PROPERTY = "gcp.wrapped.cdap.namespace";
+
   /**
    * Returns the namespace workload identity name.
    *
-   * @param identityName The name of identity provided.
+   * @param namespaceId The namespace which the identity is attached to.
    * @return namespace workload identity name.
    */
-  public static String getWorkloadIdentityName(String identityName) {
-    return String.format("%s-%s", NAMESPACE_IDENTITY_NAME_PREFIX, identityName);
+  public static String getWorkloadIdentityName(NamespaceId namespaceId) {
+    return String.format("%s-%s", NAMESPACE_IDENTITY_NAME_PREFIX,
+        computeLengthLimitedIdentity(namespaceId));
+  }
+
+  /**
+   * Computes unique namespace identity name by lowercase namespace id truncated to 15 characters
+   * appended with the first 15 hex characters of the namespace's SHA256.
+   *
+   * @param namespaceId the {@link NamespaceId} of the namespace.
+   * @return namespace unique identity name.
+   */
+  private static String computeLengthLimitedIdentity(NamespaceId namespaceId) {
+    if (NamespaceId.DEFAULT.equals(namespaceId)) {
+      return namespaceId.getNamespace();
+    }
+    String namespace = namespaceId.getNamespace();
+    String sha256Hex = Hashing.sha256().hashString(namespace, StandardCharsets.UTF_8).toString();
+    sha256Hex = sha256Hex.length() > 15 ? sha256Hex.substring(0, 15) : sha256Hex;
+    namespace = namespace.length() > 15 ? namespace.substring(0, 15) : namespace;
+    return String.format("%s-%s", namespace, sha256Hex).toLowerCase().replace('_', '-');
+  }
+
+  /**
+   * Constructs the provisioning properties to pass to the credential provider.
+   *
+   * @param scopes The GCP OAuth scopes to request.
+   * @param namespaceMeta The metadata for the namespace.
+   * @return A property map for credential provisioning.
+   */
+  public static Map<String, String> createProvisionPropertiesMap(@Nullable String scopes,
+      NamespaceMeta namespaceMeta) {
+    Map<String, String> properties = new HashMap<>();
+    if (scopes != null) {
+      properties.put(GCP_OAUTH_SCOPES_PROPERTY, scopes);
+    }
+    // Add property for k8s namespace tied to a CDAP namespace. This is used in Hybrid mode.
+    properties
+        .put(K8S_NAMESPACE_PROPERTY, namespaceMeta.getConfig().getConfig(K8S_NAMESPACE_PROPERTY));
+    // Add namespace property indicating which CDAP namespace the parent resource was operated on.
+    // This is necessary because the namespace field will be the SYSTEM namespace in which all
+    // managed workload identity resources are stored.
+    properties.put(WRAPPED_CDAP_NAMESPACE_PROPERTY, namespaceMeta.getNamespaceId().getNamespace());
+    return properties;
   }
 }

--- a/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/ProvisionedCredentialCacheKey.java
+++ b/cdap-credential-ext-gcp-wi/src/main/java/io/cdap/cdap/security/spi/credential/ProvisionedCredentialCacheKey.java
@@ -16,16 +16,15 @@
 
 package io.cdap.cdap.security.spi.credential;
 
-import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.credential.CredentialIdentity;
 import java.util.Objects;
 
 /**
- * Defines the contents of key used for
- * caching {@link io.cdap.cdap.proto.credential.ProvisionedCredential}.
+ * Defines the contents of key used for caching {@link io.cdap.cdap.proto.credential.ProvisionedCredential}.
  */
 public final class ProvisionedCredentialCacheKey {
-  private final NamespaceMeta namespaceMeta;
+
+  private final String k8sNamespace;
   private final CredentialIdentity credentialIdentity;
   private final String scopes;
   private transient Integer hashCode;
@@ -33,19 +32,19 @@ public final class ProvisionedCredentialCacheKey {
   /**
    * Constructs the {@link ProvisionedCredentialCacheKey}.
    *
-   * @param namespaceMeta the {@link NamespaceMeta}
+   * @param k8sNamespace       the namespace.
    * @param credentialIdentity the {@link CredentialIdentity}
-   * @param scopes the comma separated list of OAuth scopes.
+   * @param scopes             the comma separated list of OAuth scopes.
    */
-  public ProvisionedCredentialCacheKey(NamespaceMeta namespaceMeta,
-      CredentialIdentity credentialIdentity, String scopes) {
-    this.namespaceMeta = namespaceMeta;
+  public ProvisionedCredentialCacheKey(String k8sNamespace, CredentialIdentity credentialIdentity,
+      String scopes) {
+    this.k8sNamespace = k8sNamespace;
     this.credentialIdentity = credentialIdentity;
     this.scopes = scopes;
   }
 
-  public NamespaceMeta getNamespaceMeta() {
-    return namespaceMeta;
+  public String getK8sNamespace() {
+    return k8sNamespace;
   }
 
   public CredentialIdentity getCredentialIdentity() {
@@ -59,11 +58,12 @@ public final class ProvisionedCredentialCacheKey {
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof ProvisionedCredentialCacheKey)) {
-      return  false;
+      return false;
     }
     ProvisionedCredentialCacheKey that = (ProvisionedCredentialCacheKey) o;
-    return Objects.equals(namespaceMeta.getNamespaceId().getNamespace(),
-        that.namespaceMeta.getNamespaceId().getNamespace())
+    return Objects.equals(k8sNamespace, that.k8sNamespace)
+        && Objects.equals(credentialIdentity.getIdentity(),
+        that.getCredentialIdentity().getIdentity())
         && Objects.equals(credentialIdentity.getSecureValue(),
         that.getCredentialIdentity().getSecureValue())
         && Objects.equals(scopes, that.scopes);
@@ -73,8 +73,9 @@ public final class ProvisionedCredentialCacheKey {
   public int hashCode() {
     Integer hashCode = this.hashCode;
     if (hashCode == null) {
-      this.hashCode = hashCode = Objects.hash(namespaceMeta.getNamespaceId().getNamespace(),
-          credentialIdentity.getSecureValue(), scopes);
+      this.hashCode = hashCode = Objects
+          .hash(k8sNamespace, credentialIdentity.getIdentity(), credentialIdentity.getSecureValue(),
+              scopes);
     }
     return hashCode;
   }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/CredentialProvider.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/CredentialProvider.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.proto.credential;
 
-import io.cdap.cdap.proto.NamespaceMeta;
 import java.io.IOException;
 
 /**
@@ -27,26 +26,29 @@ public interface CredentialProvider {
   /**
    * Provisions a short-lived credential for the provided identity using the provided identity.
    *
-   * @param namespace The identity namespace.
+   * @param namespace    The identity namespace.
    * @param identityName The identity name.
-   * @param scopes A comma separated list of OAuth scopes requested.
+   * @param context      The context to use for provisioning.
    * @return A short-lived credential.
    * @throws CredentialProvisioningException If provisioning the credential fails.
    * @throws IOException                     If any transport errors occur.
    * @throws NotFoundException               If the profile or identity are not found.
    */
-  ProvisionedCredential provision(String namespace, String identityName, String scopes)
+  ProvisionedCredential provision(String namespace, String identityName,
+      CredentialProvisionContext context)
       throws CredentialProvisioningException, IOException, NotFoundException;
 
   /**
    * Validates the provided identity.
    *
-   * @param namespaceMeta    The identity namespace metadata.
-   * @param identity The identity to validate.
+   * @param namespace The identity namespace.
+   * @param identity  The identity to validate.
+   * @param context   The context to use for provisioning.
    * @throws IdentityValidationException If validation fails.
    * @throws IOException                 If any transport errors occur.
    * @throws NotFoundException           If the profile is not found.
    */
-  void validateIdentity(NamespaceMeta namespaceMeta, CredentialIdentity identity)
+  void validateIdentity(String namespace, CredentialIdentity identity,
+      CredentialProvisionContext context)
       throws IdentityValidationException, IOException, NotFoundException;
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/CredentialProvisionContext.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/CredentialProvisionContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.credential;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Context passed to the Credential Provider during credential provisioning.
+ */
+public class CredentialProvisionContext {
+
+  /**
+   * A set of properties to pass to the CredentialProvider for provisioning.
+   */
+  private final Map<String, String> properties;
+
+  public CredentialProvisionContext() {
+    this.properties = Collections.emptyMap();
+  }
+
+  public CredentialProvisionContext(Map<String, String> properties) {
+    this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/IdentityValidationException.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/IdentityValidationException.java
@@ -38,4 +38,14 @@ public class IdentityValidationException extends Exception {
   public IdentityValidationException(String message) {
     super(message);
   }
+
+  /**
+   * Creates a new identity validation exception.
+   *
+   * @param message The message of identity validation failure.
+   * @param cause   The cause of identity validation failure.
+   */
+  public IdentityValidationException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/NamespaceCredentialProvider.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/NamespaceCredentialProvider.java
@@ -27,7 +27,7 @@ public interface NamespaceCredentialProvider {
    * Provisions a short-lived credential for the provided identity using the provided identity.
    *
    * @param namespace The identity namespace.
-   * @param scopes A comma separated list of OAuth scopes requested.
+   * @param scopes    A comma separated list of OAuth scopes requested.
    * @return A short-lived credential.
    * @throws CredentialProvisioningException If provisioning the credential fails.
    * @throws IOException                     If any transport errors occur.
@@ -35,4 +35,15 @@ public interface NamespaceCredentialProvider {
    */
   ProvisionedCredential provision(String namespace, String scopes)
       throws CredentialProvisioningException, IOException, NotFoundException;
+
+  /**
+   * Validates the provided identity.
+   *
+   * @param namespace      The identity namespace.
+   * @param serviceAccount The service account to validate.
+   * @throws IdentityValidationException If validation fails.
+   * @throws IOException                 If any transport errors occur.
+   */
+  void validateIdentity(String namespace, String serviceAccount)
+      throws IdentityValidationException, IOException;
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/ValidateIdentityRequest.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/credential/ValidateIdentityRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.credential;
+
+/**
+ * Represents a validation request for a {@link CredentialIdentity}.
+ */
+public class ValidateIdentityRequest {
+  private final CredentialIdentity identity;
+  private final CredentialProvisionContext context;
+
+  public ValidateIdentityRequest(CredentialIdentity identity, CredentialProvisionContext context) {
+    this.identity = identity;
+    this.context = context;
+  }
+
+  public CredentialIdentity getIdentity() {
+    return identity;
+  }
+
+  public CredentialProvisionContext getContext() {
+    return context;
+  }
+}

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/credential/CredentialProvider.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/credential/CredentialProvider.java
@@ -16,12 +16,11 @@
 
 package io.cdap.cdap.security.spi.credential;
 
-import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.credential.CredentialIdentity;
 import io.cdap.cdap.proto.credential.CredentialProfile;
+import io.cdap.cdap.proto.credential.CredentialProvisionContext;
 import io.cdap.cdap.proto.credential.CredentialProvisioningException;
 import io.cdap.cdap.proto.credential.ProvisionedCredential;
-import javax.annotation.Nullable;
 
 /**
  * Defines an SPI for provisioning a credential.
@@ -47,15 +46,15 @@ public interface CredentialProvider {
    * Provisions a short-lived credential for the provided identity using the provided credential
    * profile.
    *
-   * @param namespaceMeta The credential identity namespace metadata.
-   * @param profile  The credential profile to use.
-   * @param identity The credential identity to use.
-   * @param scopes A comma separated list of OAuth scopes requested.
+   * @param namespace The credential identity namespace.
+   * @param profile       The credential profile to use.
+   * @param identity      The credential identity to use.
+   * @param context The context to use for provisioning.
    * @return A credential provisioned using the specified profile and identity.
    * @throws CredentialProvisioningException If the credential provisioning fails.
    */
-  ProvisionedCredential provision(NamespaceMeta namespaceMeta, CredentialProfile profile,
-      CredentialIdentity identity, @Nullable String scopes)
+  ProvisionedCredential provision(String namespace, CredentialProfile profile,
+      CredentialIdentity identity, CredentialProvisionContext context)
       throws CredentialProvisioningException;
 
   /**


### PR DESCRIPTION
[CDAP-20893] Move created workload identities to system namespace

[CDAP-20893] Disallow provisioning access token in non-system credential identity namespaces

[CDAP-20893] Use identity validation in NamespaceCredentialProvider

[CDAP-20893] Include identity in ProvisionedCredentialCacheKEy hashcode

Cherry-pick of #15453 

[CDAP-20893]: https://cdap.atlassian.net/browse/CDAP-20893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20893]: https://cdap.atlassian.net/browse/CDAP-20893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20893]: https://cdap.atlassian.net/browse/CDAP-20893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CDAP-20893]: https://cdap.atlassian.net/browse/CDAP-20893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ