### PR TITLE
[CDAP-20909] Cherry-pick 6.10

### DIFF
--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -38,6 +38,12 @@
     </repository>
   </repositories>
 
+  <properties>
+    <!-- Not set at the parent pom level to avoid impacting other child modules. -->
+    <!-- Not set in cdap-hbase-compat-base to avoid protobuf being pulled into cdap-data-fabric. -->
+    <protobuf.version>2.5.0</protobuf.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -160,6 +166,11 @@
       <artifactId>htrace-core</artifactId>
       <version>3.0.4</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
   </dependencies>
 

--- a/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
@@ -38,6 +38,12 @@
     </repository>
   </repositories>
 
+  <properties>
+    <!-- Not set at the parent pom level to avoid impacting other child modules. -->
+    <!-- Not set in cdap-hbase-compat-base to avoid protobuf being pulled into cdap-data-fabric. -->
+    <protobuf.version>2.5.0</protobuf.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -160,6 +166,11 @@
       <artifactId>htrace-core</artifactId>
       <version>3.0.4</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
   </dependencies>
 

--- a/cdap-hbase-compat-1.0/pom.xml
+++ b/cdap-hbase-compat-1.0/pom.xml
@@ -31,6 +31,12 @@
   <name>CDAP HBase 1.0 Compatibility</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <!-- Not set at the parent pom level to avoid impacting other child modules. -->
+    <!-- Not set in cdap-hbase-compat-base to avoid protobuf being pulled into cdap-data-fabric. -->
+    <protobuf.version>2.5.0</protobuf.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -146,6 +152,11 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
   </dependencies>
 

--- a/cdap-hbase-compat-1.1/pom.xml
+++ b/cdap-hbase-compat-1.1/pom.xml
@@ -31,6 +31,12 @@
   <name>CDAP HBase 1.1 Compatibility</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <!-- Not set at the parent pom level to avoid impacting other child modules. -->
+    <!-- Not set in cdap-hbase-compat-base to avoid protobuf being pulled into cdap-data-fabric. -->
+    <protobuf.version>2.5.0</protobuf.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -146,6 +152,11 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
   </dependencies>
 

--- a/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
@@ -35,6 +35,12 @@
     </repository>
   </repositories>
 
+  <properties>
+    <!-- Not set at the parent pom level to avoid impacting other child modules. -->
+    <!-- Not set in cdap-hbase-compat-base to avoid protobuf being pulled into cdap-data-fabric. -->
+    <protobuf.version>2.5.0</protobuf.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -159,6 +165,11 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>${protobuf.version}</version>
     </dependency>
   </dependencies>
 

--- a/cdap-hbase-compat-base/pom.xml
+++ b/cdap-hbase-compat-base/pom.xml
@@ -29,11 +29,6 @@
   <name>CDAP HBase Compactability Base</name>
   <packaging>jar</packaging>
 
-  <properties>
-    <!-- Not set at the parent pom level to avoid impacting other child modules. -->
-    <protobuf.version>2.5.0</protobuf.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
@@ -143,11 +138,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>${protobuf.version}</version>
-    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
[CDAP-20909] Move protobuf to cdap-hbase-compat child modules instead of cdap-hbase-compat-base

Cherry-pick of #15468 15468

[CDAP-20909]: https://cdap.atlassian.net/browse/CDAP-20909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ