### PR TITLE
[CDAP-20872] Cherry-pick 6.10

### DIFF
--- a/cdap-encryption-ext-tink/src/main/java/io/cdap/cdap/encryption/tink/GcpEnvelopeTinkCipherCryptor.java
+++ b/cdap-encryption-ext-tink/src/main/java/io/cdap/cdap/encryption/tink/GcpEnvelopeTinkCipherCryptor.java
@@ -101,10 +101,6 @@ public class GcpEnvelopeTinkCipherCryptor extends AbstractTinkAeadCipherCryptor 
   private void validateProperties(AeadCipherContext context) throws CipherInitializationException {
     Map<String, String> properties = context.getProperties();
     List<String> invalidProperties = new ArrayList<>();
-    String projectId = properties.get(TINK_GCP_KMS_PROJECT_ID);
-    if (projectId == null || projectId.isEmpty()) {
-      invalidProperties.add(TINK_GCP_KMS_PROJECT_ID);
-    }
     String location = properties.get(TINK_GCP_KMS_LOCATION);
     if (location == null || location.isEmpty()) {
       invalidProperties.add(TINK_GCP_KMS_LOCATION);


### PR DESCRIPTION
[CDAP-20872] Remove validation check for default project in GcpEnvelopeTinkCipherCryptor since CloudKmsClient is capable of detecting the local project automatically

Cherry-pick of #15469 

[CDAP-20872]: https://cdap.atlassian.net/browse/CDAP-20872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ