### PR TITLE
[CDAP-20911] Fix ClassCastException by adding a workaround for SPARK-46176

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DatasetDataPipelineTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/DatasetDataPipelineTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.datapipeline;
+
+import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.etl.common.Constants;
+import java.util.Map;
+
+/**
+ * This test runs all testcases of DataPipelineTest while enforcing maximum Dataset usage
+ */
+public class DatasetDataPipelineTest extends DataPipelineTest{
+
+  @Override
+  protected Map<String, String> addRuntimeArguments(Map<String, String> arguments) {
+    return ImmutableMap.<String, String>builder().putAll(arguments)
+        .put(Constants.DATASET_FORCE, "true").build();
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/Constants.java
@@ -38,6 +38,12 @@ public final class Constants {
   public static final String CONSOLIDATE_STAGES = "spark.cdap.pipeline.consolidate.stages";
   public static final String CACHE_FUNCTIONS = "spark.cdap.pipeline.functioncache.enable";
   public static final String DATASET_KRYO_ENABLED = "spark.cdap.pipeline.dataset.kryo.enable";
+
+  /**
+   * Force using Datasets instead of RDDs right out of BatchSource. Should mostly
+   * be used for testing
+   */
+  public static final String DATASET_FORCE = "spark.cdap.pipeline.dataset.force";
   public static final String DATASET_AGGREGATE_ENABLED = "spark.cdap.pipeline.aggregate.dataset.enable";
   public static final String DISABLE_ELT_PUSHDOWN = "cdap.pipeline.pushdown.disable";
   public static final String DATASET_AGGREGATE_IGNORE_PARTITIONS =

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/DataframeCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/DataframeCollection.java
@@ -84,6 +84,11 @@ public class DataframeCollection extends DatasetCollection<StructuredRecord>
     super(sec, jsc, sqlContext, datasetContext, sinkFactory, functionCacheFactory);
     this.schema = Objects.requireNonNull(schema);
     this.dataframe = dataframe;
+    if (!Row.class.isAssignableFrom(dataframe.encoder().clsTag().runtimeClass())) {
+      throw new IllegalArgumentException(
+          "Dataframe collection received dataset of " + dataframe.encoder().clsTag()
+              .runtimeClass());
+    }
   }
 
   /**

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/OpaqueDatasetCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/OpaqueDatasetCollection.java
@@ -56,6 +56,11 @@ public class OpaqueDatasetCollection<T> extends DatasetCollection<T> {
       FunctionCache.Factory functionCacheFactory) {
     super(sec, jsc, sqlContext, datasetContext, sinkFactory, functionCacheFactory);
     this.dataset = dataset;
+    if (Row.class.isAssignableFrom(dataset.encoder().clsTag().runtimeClass())) {
+      throw new IllegalArgumentException(
+          "Opaque collection received dataset of Row (" + dataset.encoder().clsTag()
+              .runtimeClass() + "). DataframeCollection should be used.");
+    }
   }
 
   @Override


### PR DESCRIPTION
- To workaround DatasetCollection now wraps values in arrays before the union operation and unwraps right after.
- Also added safeguards to detect early if DataFrame is used where Dataset is expected and visa versa
- If TransformFunction fails, it will now add the stage name it belongs to. This should make further debugging easier for similar issues
- Added a flag to force using DatasetCollection right after the source. By default DatasetCollections are used only as needed, but for testing it's valuable to use it as much as possible
- Added a test to run all tests from DataPipelineTest in "dataset forced" mode. Validated it catches ClassCastException before the fix.