### PR TITLE
[CDAP-20910] Close class loaders to prevent memory leaks

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactClassLoaderFactory.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/artifact/ArtifactClassLoaderFactory.java
@@ -101,9 +101,13 @@ final class ArtifactClassLoaderFactory {
     }
 
     final ClassLoader finalProgramClassLoader = programClassLoader;
+    final ClassLoader finalSparkClassLoader = sparkClassLoader;
     return new CloseableClassLoader(programClassLoader, () -> {
       if (finalProgramClassLoader instanceof Closeable) {
         Closeables.closeQuietly((Closeable) finalProgramClassLoader);
+      }
+      if (finalSparkClassLoader instanceof Closeable) {
+        Closeables.closeQuietly((Closeable) finalSparkClassLoader);
       }
     });
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginClassLoader.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/PluginClassLoader.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.internal.app.runtime.plugin;
 
 import com.google.common.base.Preconditions;
 import io.cdap.cdap.api.artifact.ArtifactId;
+import io.cdap.cdap.api.artifact.CloseableClassLoader;
 import io.cdap.cdap.app.program.ManifestFields;
 import io.cdap.cdap.common.lang.CombineClassLoader;
 import io.cdap.cdap.common.lang.DirectoryClassLoader;
@@ -58,23 +59,31 @@ public class PluginClassLoader extends DirectoryClassLoader {
   static ClassLoader createParent(ClassLoader templateClassLoader) {
     // Find the ProgramClassLoader from the template ClassLoader
     ClassLoader programClassLoader = templateClassLoader;
-    while (programClassLoader != null && !(programClassLoader instanceof ProgramClassLoader)) {
+    while (programClassLoader != null
+           && !(programClassLoader instanceof ProgramClassLoader)) {
       programClassLoader = programClassLoader.getParent();
     }
     // This shouldn't happen
-    Preconditions.checkArgument(programClassLoader != null, "Cannot find ProgramClassLoader");
+    Preconditions.checkArgument(programClassLoader != null,
+        "Cannot find ProgramClassLoader");
 
     // Package filtered classloader of the template classloader, which only classes in "Export-Packages" are loadable.
     Manifest manifest = ((ProgramClassLoader) programClassLoader).getManifest();
     Set<String> exportPackages = ManifestFields.getExportPackages(manifest);
-    ClassLoader filteredTemplateClassLoader = new PackageFilterClassLoader(templateClassLoader,
-        exportPackages::contains);
+    PackageFilterClassLoader filteredTemplateClassLoader =
+        new PackageFilterClassLoader(templateClassLoader,
+            exportPackages::contains);
 
     // The lib Classloader needs to be able to see all cdap api classes as well.
-    // In this way, parent ClassLoader of the plugin ClassLoader will load class from the parent of the
-    // template program class loader (which is a filtered CDAP classloader),
-    // followed by template export-packages, then by a plugin lib jars.
-    return new CombineClassLoader(programClassLoader.getParent(), filteredTemplateClassLoader);
+    // In this way, parent ClassLoader of the plugin ClassLoader will load class
+    // from the parent of the template program class loader (which is a filtered
+    // CDAP classloader), followed by template export-packages, then by a plugin
+    // lib jars.
+    CombineClassLoader classLoader = new CombineClassLoader(
+        programClassLoader.getParent(), filteredTemplateClassLoader);
+    // Creating a CloseableClassLoader ensures that the caller can close the
+    // PackageFilterClassLoader that is held by the CombineClassLoader.
+    return new CloseableClassLoader(classLoader, filteredTemplateClassLoader);
   }
 
   PluginClassLoader(ArtifactId artifactId, File directory, String topLevelJar, ClassLoader parent) {

--- a/cdap-common/src/main/java/io/cdap/cdap/common/lang/PackageFilterClassLoader.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/lang/PackageFilterClassLoader.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.common.lang;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -30,10 +31,10 @@ import javax.annotation.Nullable;
  * A {@link ClassLoader} that filter class based on package name. Classes in the bootstrap
  * ClassLoader is always loadable from this ClassLoader.
  */
-public class PackageFilterClassLoader extends ClassLoader {
+public class PackageFilterClassLoader extends ClassLoader implements Closeable {
 
   private final Predicate<String> predicate;
-  private final ClassLoader bootstrapClassLoader;
+  private final URLClassLoader bootstrapClassLoader;
 
   /**
    * Constructs a new instance that only allow class's package name passes the given {@link
@@ -128,5 +129,10 @@ public class PackageFilterClassLoader extends ClassLoader {
       return packageName.substring(1);
     }
     return packageName;
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.bootstrapClassLoader.close();
   }
 }


### PR DESCRIPTION
## [CDAP-20910](https://cdap.atlassian.net/browse/CDAP-20910)

* Wrap class loaders in CloseableClassLoader class so that the callers of their constructors can close them to free resources. 
* Close the class loaders when their work is complete.

## Testing
* Deployed 50 batch pipelines and verified that the memory usage of appfabric and task workers is stable.
* Verified using logs that the class loaders are being closed.

[CDAP-20910]: https://cdap.atlassian.net/browse/CDAP-20910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ