### PR TITLE
[CDAP-20922] Reuse the Spark ClassLoader in app-fabric

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/ProgramClassLoaderProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/ProgramClassLoaderProvider.java
@@ -19,7 +19,7 @@ package io.cdap.cdap.app.runtime;
 import io.cdap.cdap.internal.app.runtime.ProgramClassLoader;
 
 /**
- * A provider for for program classloading creation.
+ * A provider for program classloading creation.
  */
 public interface ProgramClassLoaderProvider {
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/ProgramRuntimeProvider.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/ProgramRuntimeProvider.java
@@ -24,29 +24,22 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Provider for runtime system of programs.
- */
+/** Provider for runtime system of programs. */
 public interface ProgramRuntimeProvider {
 
-  /**
-   * Annotation for implementation to specify what are the supported {@link ProgramType}.
-   */
+  /** Annotation for implementation to specify what are the supported {@link ProgramType}. */
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.TYPE)
   @interface SupportedProgramType {
 
-    /**
-     * Returns the list of supported {@link ProgramType}.
-     */
+    /** Returns the list of supported {@link ProgramType}. */
     ProgramType[] value();
   }
 
-  /**
-   * The execution mode of the program runtime system.
-   */
+  /** The execution mode of the program runtime system. */
   enum Mode {
-    LOCAL, DISTRIBUTED
+    LOCAL,
+    DISTRIBUTED
   }
 
   /**
@@ -70,12 +63,15 @@ public interface ProgramRuntimeProvider {
   boolean isSupported(ProgramType programType, CConfiguration cConf);
 
   /**
-   * Creates a ClassLoader for the given program type. This is useful if you need the program class
-   * loader but do not need to run a program.
+   * Returns a ClassLoader for the given program type. This is useful if you only need the runtime
+   * classloader for the given program type, but not for program execution.
    *
-   * @param cConf The configuration to use
    * @param programType The type of program
+   * @param cConf The configuration to use
    * @return a {@link ClassLoader} for the given program runner
+   * @throws UnsupportedOperationException if the given program type is not supported by this
+   *     provider. Caller can use the {@link #isSupported(ProgramType, CConfiguration)} method to
+   *     check.
    */
-  ClassLoader createProgramClassLoader(CConfiguration cConf, ProgramType programType);
+  ClassLoader getRuntimeClassLoader(ProgramType programType, CConfiguration cConf);
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/DefaultMasterEnvironmentRunnableContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/DefaultMasterEnvironmentRunnableContext.java
@@ -34,9 +34,7 @@ import org.apache.twill.api.TwillRunnable;
 import org.apache.twill.filesystem.LocationFactory;
 import org.apache.twill.internal.utils.Instances;
 
-/**
- * Default implementation of {@link MasterEnvironmentRunnableContext}.
- */
+/** Default implementation of {@link MasterEnvironmentRunnableContext}. */
 public class DefaultMasterEnvironmentRunnableContext implements MasterEnvironmentRunnableContext {
 
   private final LocationFactory locationFactory;
@@ -46,13 +44,14 @@ public class DefaultMasterEnvironmentRunnableContext implements MasterEnvironmen
 
   private ClassLoader extensionCombinedClassLoader;
 
-  public DefaultMasterEnvironmentRunnableContext(LocationFactory locationFactory,
+  public DefaultMasterEnvironmentRunnableContext(
+      LocationFactory locationFactory,
       RemoteClientFactory remoteClientFactory,
       CConfiguration cConf) {
     this.locationFactory = locationFactory;
-    this.remoteClient = remoteClientFactory.createRemoteClient(
-        Constants.Service.APP_FABRIC_HTTP,
-        new DefaultHttpRequestConfig(false), "");
+    this.remoteClient =
+        remoteClientFactory.createRemoteClient(
+            Constants.Service.APP_FABRIC_HTTP, new DefaultHttpRequestConfig(false), "");
     this.cConf = cConf;
     this.programRuntimeProviderLoader = new ProgramRuntimeProviderLoader(cConf);
     this.extensionCombinedClassLoader = null;
@@ -63,9 +62,7 @@ public class DefaultMasterEnvironmentRunnableContext implements MasterEnvironmen
     return locationFactory;
   }
 
-  /**
-   * Opens a {@link HttpURLConnection} for the given resource path.
-   */
+  /** Opens a {@link HttpURLConnection} for the given resource path. */
   @Override
   public HttpURLConnection openHttpURLConnection(String resource) throws IOException {
     return remoteClient.openConnection(resource);
@@ -79,20 +76,22 @@ public class DefaultMasterEnvironmentRunnableContext implements MasterEnvironmen
     } catch (ClassNotFoundException e) {
       // Try loading the class from the runtime extensions.
       if (extensionCombinedClassLoader == null) {
-        Map<ProgramType, ProgramRuntimeProvider> classLoaderProviderMap = programRuntimeProviderLoader.getAll();
-        extensionCombinedClassLoader = new CombineClassLoader(getClass().getClassLoader(),
-            classLoaderProviderMap.entrySet().stream()
-                .map(entry -> entry.getValue()
-                    .createProgramClassLoader(cConf, entry.getKey()))
-                .collect(Collectors.toList())
-                .toArray(new ClassLoader[0]));
+        Map<ProgramType, ProgramRuntimeProvider> classLoaderProviderMap =
+            programRuntimeProviderLoader.getAll();
+        extensionCombinedClassLoader =
+            new CombineClassLoader(
+                getClass().getClassLoader(),
+                classLoaderProviderMap.entrySet().stream()
+                    .map(entry -> entry.getValue().getRuntimeClassLoader(entry.getKey(), cConf))
+                    .collect(Collectors.toList()));
       }
       try {
         runnableClass = extensionCombinedClassLoader.loadClass(className);
       } catch (ClassNotFoundException cnfe) {
         throw new RuntimeException(
-            String.format("Failed to load twill runnable class from runtime extension '%s'",
-                className), cnfe);
+            String.format(
+                "Failed to load twill runnable class from runtime extension '%s'", className),
+            cnfe);
       }
     }
     if (!TwillRunnable.class.isAssignableFrom(runnableClass)) {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactInspectorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/artifact/DefaultArtifactInspectorTest.java
@@ -56,14 +56,10 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-/**
- *
- */
+/** */
 public class DefaultArtifactInspectorTest {
-  @ClassRule
-  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+  @ClassRule public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
 
-  private static ArtifactClassLoaderFactory classLoaderFactory;
   private static DefaultArtifactInspector artifactInspector;
 
   @BeforeClass
@@ -71,9 +67,9 @@ public class DefaultArtifactInspectorTest {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TMP_FOLDER.newFolder().getAbsolutePath());
 
-    classLoaderFactory = new ArtifactClassLoaderFactory(cConf);
-    artifactInspector = new DefaultArtifactInspector(cConf, classLoaderFactory,
-                                                     new DefaultImpersonator(cConf, null));
+    artifactInspector =
+        new DefaultArtifactInspector(
+            cConf, new ArtifactClassLoaderFactory(cConf), new DefaultImpersonator(cConf, null));
   }
 
   @Test(expected = InvalidArtifactException.class)
@@ -82,53 +78,74 @@ public class DefaultArtifactInspectorTest {
   public void testInvalidConfigApp() throws Exception {
     Manifest manifest = new Manifest();
     File appFile =
-      createJar(InvalidConfigApp.class, new File(TMP_FOLDER.newFolder(), "InvalidConfigApp-1.0.0.jar"), manifest);
+        createJar(
+            InvalidConfigApp.class,
+            new File(TMP_FOLDER.newFolder(), "InvalidConfigApp-1.0.0.jar"),
+            manifest);
 
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "InvalidConfigApp", "1.0.0");
     Location artifactLocation = Locations.toLocation(appFile);
     List<ArtifactDescriptor> parentDescriptor = new ArrayList<>();
-    parentDescriptor.add(new ArtifactDescriptor(artifactId.getNamespace().getId(),
-                                                artifactId.toArtifactId(), artifactLocation));
-    artifactInspector.inspectArtifact(artifactId, appFile, parentDescriptor, Collections.emptySet());
+    parentDescriptor.add(
+        new ArtifactDescriptor(
+            artifactId.getNamespace().getId(), artifactId.toArtifactId(), artifactLocation));
+    artifactInspector.inspectArtifact(
+        artifactId, appFile, parentDescriptor, Collections.emptySet());
   }
 
   @Test
   public void testGetPluginRequirements() {
     // check that if a plugin does not specify requirement annotation then it has empty requirements
-    Assert.assertTrue(artifactInspector.getArtifactRequirements(InspectionApp.AppPlugin.class).isEmpty());
+    Assert.assertTrue(
+        artifactInspector.getArtifactRequirements(InspectionApp.AppPlugin.class).isEmpty());
 
     // check that if a plugin specify a requirement it is captured
-    Assert.assertEquals(new Requirements(ImmutableSet.of(Table.TYPE)),
-                        artifactInspector.getArtifactRequirements(InspectionApp.SingleRequirementPlugin.class));
+    Assert.assertEquals(
+        new Requirements(ImmutableSet.of(Table.TYPE)),
+        artifactInspector.getArtifactRequirements(InspectionApp.SingleRequirementPlugin.class));
 
-    // check if a plugin specify a requirement annotation but it is empty the requirement captured is no requirement
-    Assert
-      .assertTrue(artifactInspector.getArtifactRequirements(InspectionApp.EmptyRequirementPlugin.class).isEmpty());
+    // check if a plugin specify a requirement annotation but it is empty the requirement captured
+    // is no requirement
+    Assert.assertTrue(
+        artifactInspector
+            .getArtifactRequirements(InspectionApp.EmptyRequirementPlugin.class)
+            .isEmpty());
 
     // check if a plugin specify multiple requirement all of them are captured
-    Assert.assertEquals(new Requirements(ImmutableSet.of(Table.TYPE, KeyValueTable.TYPE)),
-                        artifactInspector.getArtifactRequirements(InspectionApp.MultipleRequirementsPlugin.class));
+    Assert.assertEquals(
+        new Requirements(ImmutableSet.of(Table.TYPE, KeyValueTable.TYPE)),
+        artifactInspector.getArtifactRequirements(InspectionApp.MultipleRequirementsPlugin.class));
 
     // check if a plugin has specified empty string as requirement is captured as no requirements
-    Assert.assertTrue(artifactInspector
-                        .getArtifactRequirements(InspectionApp.SingleEmptyRequirementPlugin.class).isEmpty());
+    Assert.assertTrue(
+        artifactInspector
+            .getArtifactRequirements(InspectionApp.SingleEmptyRequirementPlugin.class)
+            .isEmpty());
 
-    // check if a plugin has specified empty string with a valid requirement only the valid requirement is captured
-    Assert.assertEquals(new Requirements(ImmutableSet.of(Table.TYPE)),
-                        artifactInspector
-                          .getArtifactRequirements(InspectionApp.ValidAndEmptyRequirementsPlugin.class));
+    // check if a plugin has specified empty string with a valid requirement only the valid
+    // requirement is captured
+    Assert.assertEquals(
+        new Requirements(ImmutableSet.of(Table.TYPE)),
+        artifactInspector.getArtifactRequirements(
+            InspectionApp.ValidAndEmptyRequirementsPlugin.class));
 
-    // test that duplicate requirements are only stored once and the beginning and ending white spaces are trimmed
-    Assert.assertEquals(new Requirements(ImmutableSet.of(Table.TYPE, "duplicate")),
-                        artifactInspector.getArtifactRequirements(InspectionApp.DuplicateRequirementsPlugin.class));
+    // test that duplicate requirements are only stored once and the beginning and ending white
+    // spaces are trimmed
+    Assert.assertEquals(
+        new Requirements(ImmutableSet.of(Table.TYPE, "duplicate")),
+        artifactInspector.getArtifactRequirements(InspectionApp.DuplicateRequirementsPlugin.class));
 
-    //Test that capabilities in the Requirements annotation is being captured
-    Assert.assertEquals(new Requirements(ImmutableSet.of(), ImmutableSet.of("cdc")),
-                        artifactInspector.getArtifactRequirements(InspectionApp.CapabilityPlugin.class));
-    Assert.assertEquals(new Requirements(ImmutableSet.of(), ImmutableSet.of("cdc", "healthcare")),
-                        artifactInspector.getArtifactRequirements(InspectionApp.MultipleCapabilityPlugin.class));
-    Assert.assertEquals(new Requirements(ImmutableSet.of(Table.TYPE, "sometype"), ImmutableSet.of("cdc", "healthcare")),
-                        artifactInspector.getArtifactRequirements(InspectionApp.DatasetAndCapabilityPlugin.class));
+    // Test that capabilities in the Requirements annotation is being captured
+    Assert.assertEquals(
+        new Requirements(ImmutableSet.of(), ImmutableSet.of("cdc")),
+        artifactInspector.getArtifactRequirements(InspectionApp.CapabilityPlugin.class));
+    Assert.assertEquals(
+        new Requirements(ImmutableSet.of(), ImmutableSet.of("cdc", "healthcare")),
+        artifactInspector.getArtifactRequirements(InspectionApp.MultipleCapabilityPlugin.class));
+    Assert.assertEquals(
+        new Requirements(
+            ImmutableSet.of(Table.TYPE, "sometype"), ImmutableSet.of("cdc", "healthcare")),
+        artifactInspector.getArtifactRequirements(InspectionApp.DatasetAndCapabilityPlugin.class));
   }
 
   @Test
@@ -137,124 +154,181 @@ public class DefaultArtifactInspectorTest {
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "InspectionApp", "1.0.0");
     Location artifactLocation = Locations.toLocation(appFile);
     List<ArtifactDescriptor> parentDescriptor = new ArrayList<>();
-    parentDescriptor.add(new ArtifactDescriptor(artifactId.getNamespace().getId(),
-                                                artifactId.toArtifactId(), artifactLocation));
-    ArtifactClasses classes = artifactInspector.inspectArtifact(artifactId, appFile, parentDescriptor,
-                                                                Collections.emptySet()).getArtifactClasses();
+    parentDescriptor.add(
+        new ArtifactDescriptor(
+            artifactId.getNamespace().getId(), artifactId.toArtifactId(), artifactLocation));
+    ArtifactClasses classes =
+        artifactInspector
+            .inspectArtifact(artifactId, appFile, parentDescriptor, Collections.emptySet())
+            .getArtifactClasses();
 
     // check app classes
-    Set<ApplicationClass> expectedApps = ImmutableSet.of(new ApplicationClass(
-      InspectionApp.class.getName(), "", new ReflectionSchemaGenerator(false).generate(InspectionApp.AConfig.class),
-      new Requirements(Collections.emptySet(), Collections.singleton("cdc"))));
+    Set<ApplicationClass> expectedApps =
+        ImmutableSet.of(
+            new ApplicationClass(
+                InspectionApp.class.getName(),
+                "",
+                new ReflectionSchemaGenerator(false).generate(InspectionApp.AConfig.class),
+                new Requirements(Collections.emptySet(), Collections.singleton("cdc"))));
     Assert.assertEquals(expectedApps, classes.getApps());
 
     // check plugin classes
     PluginClass expectedPlugin =
-      PluginClass.builder().setName(InspectionApp.PLUGIN_NAME).setType(InspectionApp.PLUGIN_TYPE)
-        .setDescription(InspectionApp.PLUGIN_DESCRIPTION).setClassName(InspectionApp.AppPlugin.class.getName())
-        .setConfigFieldName("pluginConf").setProperties(ImmutableMap.of(
-        "y", new PluginPropertyField("y", "", "double", true, true),
-        "isSomething", new PluginPropertyField("isSomething", "", "boolean", true, false))).build();
+        PluginClass.builder()
+            .setName(InspectionApp.PLUGIN_NAME)
+            .setType(InspectionApp.PLUGIN_TYPE)
+            .setDescription(InspectionApp.PLUGIN_DESCRIPTION)
+            .setClassName(InspectionApp.AppPlugin.class.getName())
+            .setConfigFieldName("pluginConf")
+            .setProperties(
+                ImmutableMap.of(
+                    "y", new PluginPropertyField("y", "", "double", true, true),
+                    "isSomething",
+                        new PluginPropertyField("isSomething", "", "boolean", true, false)))
+            .build();
 
-    PluginClass multipleRequirementPlugin = PluginClass.builder()
-      .setName(InspectionApp.MULTIPLE_REQUIREMENTS_PLUGIN)
-      .setType(InspectionApp.PLUGIN_TYPE)
-      .setCategory(InspectionApp.PLUGIN_CATEGORY)
-      .setClassName(InspectionApp.MultipleRequirementsPlugin.class.getName())
-      .setConfigFieldName("pluginConf")
-      .setProperties(ImmutableMap.of(
-        "y", new PluginPropertyField("y", "", "double", true, true),
-        "isSomething", new PluginPropertyField("isSomething", "", "boolean", true, false)))
-      .setRequirements(new Requirements(ImmutableSet.of(Table.TYPE, KeyValueTable.TYPE)))
-      .setDescription(InspectionApp.PLUGIN_DESCRIPTION)
-      .build();
-    Assert.assertTrue(classes.getPlugins().containsAll(ImmutableSet.of(expectedPlugin, multipleRequirementPlugin)));
+    PluginClass multipleRequirementPlugin =
+        PluginClass.builder()
+            .setName(InspectionApp.MULTIPLE_REQUIREMENTS_PLUGIN)
+            .setType(InspectionApp.PLUGIN_TYPE)
+            .setCategory(InspectionApp.PLUGIN_CATEGORY)
+            .setClassName(InspectionApp.MultipleRequirementsPlugin.class.getName())
+            .setConfigFieldName("pluginConf")
+            .setProperties(
+                ImmutableMap.of(
+                    "y", new PluginPropertyField("y", "", "double", true, true),
+                    "isSomething",
+                        new PluginPropertyField("isSomething", "", "boolean", true, false)))
+            .setRequirements(new Requirements(ImmutableSet.of(Table.TYPE, KeyValueTable.TYPE)))
+            .setDescription(InspectionApp.PLUGIN_DESCRIPTION)
+            .build();
+    Assert.assertTrue(
+        classes
+            .getPlugins()
+            .containsAll(ImmutableSet.of(expectedPlugin, multipleRequirementPlugin)));
   }
 
   @Test
   public void testInspectNestedConfigPlugin() throws Exception {
     Manifest manifest = new Manifest();
-    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, NestedConfigPlugin.class.getPackage().getName());
-    File artifactFile = createJar(NestedConfigPlugin.class, new File(TMP_FOLDER.newFolder(), "NestedPlugin-1.0.0.jar"),
-                                  manifest);
+    manifest
+        .getMainAttributes()
+        .put(ManifestFields.EXPORT_PACKAGE, NestedConfigPlugin.class.getPackage().getName());
+    File artifactFile =
+        createJar(
+            NestedConfigPlugin.class,
+            new File(TMP_FOLDER.newFolder(), "NestedPlugin-1.0.0.jar"),
+            manifest);
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "NestedPlugin", "1.0.0");
     Location artifactLocation = Locations.toLocation(artifactFile);
     List<ArtifactDescriptor> parentDescriptor = new ArrayList<>();
-    parentDescriptor.add(new ArtifactDescriptor(artifactId.getNamespace().getId(),
-                                                artifactId.toArtifactId(), artifactLocation));
-    ArtifactClasses classes = artifactInspector.inspectArtifact(artifactId, artifactFile, parentDescriptor,
-                                                                Collections.emptySet()).getArtifactClasses();
+    parentDescriptor.add(
+        new ArtifactDescriptor(
+            artifactId.getNamespace().getId(), artifactId.toArtifactId(), artifactLocation));
+    ArtifactClasses classes =
+        artifactInspector
+            .inspectArtifact(artifactId, artifactFile, parentDescriptor, Collections.emptySet())
+            .getArtifactClasses();
     Set<PluginClass> plugins = classes.getPlugins();
 
-    Map<String, PluginPropertyField> expectedFields = ImmutableMap.of(
-      "X", new PluginPropertyField("X", "", "int", true, false),
-      "Nested", new PluginPropertyField("Nested", "", "nestedconfig", true, true, false,
-                                        ImmutableSet.of("Nested1", "Nested2")),
-      "Nested1", new PluginPropertyField("Nested1", "", "string", true, true),
-      "Nested2", new PluginPropertyField("Nested2", "", "string", true, true)
-    );
+    Map<String, PluginPropertyField> expectedFields =
+        ImmutableMap.of(
+            "X", new PluginPropertyField("X", "", "int", true, false),
+            "Nested",
+                new PluginPropertyField(
+                    "Nested",
+                    "",
+                    "nestedconfig",
+                    true,
+                    true,
+                    false,
+                    ImmutableSet.of("Nested1", "Nested2")),
+            "Nested1", new PluginPropertyField("Nested1", "", "string", true, true),
+            "Nested2", new PluginPropertyField("Nested2", "", "string", true, true));
 
-    PluginClass expected = PluginClass.builder()
-      .setName("nested").setType("dummy").setDescription("Nested config")
-      .setClassName(NestedConfigPlugin.class.getName()).setConfigFieldName("config")
-      .setProperties(expectedFields).build();
+    PluginClass expected =
+        PluginClass.builder()
+            .setName("nested")
+            .setType("dummy")
+            .setDescription("Nested config")
+            .setClassName(NestedConfigPlugin.class.getName())
+            .setConfigFieldName("config")
+            .setProperties(expectedFields)
+            .build();
 
     Assert.assertEquals(Collections.singleton(expected), plugins);
   }
 
   @Test(expected = InvalidArtifactException.class)
   public void inspectAdditionaPluginClasses() throws Exception {
-    File artifactFile = createJar(InspectionApp.class, new File(TMP_FOLDER.newFolder(), "InspectionApp-1.0.0.jar"),
-                                  new Manifest());
+    File artifactFile =
+        createJar(
+            InspectionApp.class,
+            new File(TMP_FOLDER.newFolder(), "InspectionApp-1.0.0.jar"),
+            new Manifest());
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "InspectionApp", "1.0.0");
     Location artifactLocation = Locations.toLocation(artifactFile);
     List<ArtifactDescriptor> parentDescriptor = new ArrayList<>();
-    parentDescriptor.add(new ArtifactDescriptor(artifactId.getNamespace().getId(),
-                                                artifactId.toArtifactId(), artifactLocation));
-      // PluginClass contains a non existing classname that is not present in the artifact jar being used
-      PluginClass pluginClass =
-        PluginClass.builder().setName("plugin_name").setType("plugin_type")
-          .setDescription("").setClassName("non-existing-class")
-          .setConfigFieldName("pluginConf").setProperties(ImmutableMap.of()).build();
-      // Inspects the jar and ensures that additional plugin classes can be loaded from the artifact jar
-      artifactInspector.inspectArtifact(artifactId, artifactFile, parentDescriptor,
-                                        ImmutableSet.of(pluginClass));
+    parentDescriptor.add(
+        new ArtifactDescriptor(
+            artifactId.getNamespace().getId(), artifactId.toArtifactId(), artifactLocation));
+    // PluginClass contains a non existing classname that is not present in the artifact jar being
+    // used
+    PluginClass pluginClass =
+        PluginClass.builder()
+            .setName("plugin_name")
+            .setType("plugin_type")
+            .setDescription("")
+            .setClassName("non-existing-class")
+            .setConfigFieldName("pluginConf")
+            .setProperties(ImmutableMap.of())
+            .build();
+    // Inspects the jar and ensures that additional plugin classes can be loaded from the artifact
+    // jar
+    artifactInspector.inspectArtifact(
+        artifactId, artifactFile, parentDescriptor, ImmutableSet.of(pluginClass));
   }
 
   @Test
   public void testGetClassNameCheckPredicate() {
-    Assert.assertTrue(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
-      "my.package"
-    )).test("my/package/my.class"));
-    Assert.assertTrue(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
-      "blah", "my.package", "blah2"
-    )).test("my/package/my.class"));
-    Assert.assertTrue(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
-      "my.package", "my.package.subpackage"
-    )).test("my/package/subpackage/my.class"));
-    Assert.assertFalse(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
-      "my.package"
-    )).test("my/package/subpackage/my.class"));
-    Assert.assertFalse(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
-      "my.package"
-    )).test("prefix/my/package/my.class"));
-    Assert.assertFalse(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
-      "my.package"
-    )).test("prefix/my/package/my.notclass"));
-    Assert.assertFalse(DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of(
-      "my.package"
-    )).test("prefix/my/package/my.class/some.class"));
+    Assert.assertTrue(
+        DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of("my.package"))
+            .test("my/package/my.class"));
+    Assert.assertTrue(
+        DefaultArtifactInspector.getClassNameCheckPredicate(
+                ImmutableList.of("blah", "my.package", "blah2"))
+            .test("my/package/my.class"));
+    Assert.assertTrue(
+        DefaultArtifactInspector.getClassNameCheckPredicate(
+                ImmutableList.of("my.package", "my.package.subpackage"))
+            .test("my/package/subpackage/my.class"));
+    Assert.assertFalse(
+        DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of("my.package"))
+            .test("my/package/subpackage/my.class"));
+    Assert.assertFalse(
+        DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of("my.package"))
+            .test("prefix/my/package/my.class"));
+    Assert.assertFalse(
+        DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of("my.package"))
+            .test("prefix/my/package/my.notclass"));
+    Assert.assertFalse(
+        DefaultArtifactInspector.getClassNameCheckPredicate(ImmutableList.of("my.package"))
+            .test("prefix/my/package/my.class/some.class"));
   }
 
   private File getAppFile() throws IOException {
     Manifest manifest = new Manifest();
-    manifest.getMainAttributes().put(ManifestFields.EXPORT_PACKAGE, InspectionApp.class.getPackage().getName());
-    return createJar(InspectionApp.class, new File(TMP_FOLDER.newFolder(), "InspectionApp-1.0.0.jar"), manifest);
+    manifest
+        .getMainAttributes()
+        .put(ManifestFields.EXPORT_PACKAGE, InspectionApp.class.getPackage().getName());
+    return createJar(
+        InspectionApp.class, new File(TMP_FOLDER.newFolder(), "InspectionApp-1.0.0.jar"), manifest);
   }
 
   private static File createJar(Class<?> cls, File destFile, Manifest manifest) throws IOException {
-    Location deploymentJar = AppJarHelper.createDeploymentJar(new LocalLocationFactory(TMP_FOLDER.newFolder()),
-                                                              cls, manifest);
+    Location deploymentJar =
+        AppJarHelper.createDeploymentJar(
+            new LocalLocationFactory(TMP_FOLDER.newFolder()), cls, manifest);
     DirUtils.mkdirs(destFile.getParentFile());
     Locations.linkOrCopyOverwrite(deploymentJar, destFile);
     return destFile;

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/SparkProgramRuntimeProvider.java
@@ -16,6 +16,9 @@
 
 package io.cdap.cdap.app.runtime.spark;
 
+import static io.cdap.cdap.app.runtime.spark.SparkPackageUtils.SPARK_YARN_MODE;
+import static io.cdap.cdap.app.runtime.spark.SparkRuntimeUtils.SPARK_STREAMING_CHECKPOINT_REWRITE_ENABLED;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.io.Closeables;
@@ -40,9 +43,6 @@ import io.cdap.cdap.common.lang.FilterClassLoader;
 import io.cdap.cdap.internal.app.spark.SparkCompatReader;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.runtime.spi.SparkCompat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -55,10 +55,12 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * A {@link ProgramRuntimeProvider} that provides runtime system support for {@link ProgramType#SPARK} program.
- * This class shouldn't have dependency on Spark classes.
+ * A {@link ProgramRuntimeProvider} that provides runtime system support for {@link
+ * ProgramType#SPARK} program. This class shouldn't have dependency on Spark classes.
  */
 public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvider {
 
@@ -66,8 +68,10 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
 
   static {
     try {
-      // Load the shutdown manager to have the ShutdownHookManager static initialization block execute
-      // This is to avoid having the shutdown hook thread holding reference to SparkRunnerClassLoader
+      // Load the shutdown manager to have the ShutdownHookManager static initialization block
+      // execute
+      // This is to avoid having the shutdown hook thread holding reference to
+      // SparkRunnerClassLoader
       // when it is being used by Spark.
       Class.forName("org.apache.hadoop.util.ShutdownHookManager");
     } catch (ClassNotFoundException e) {
@@ -77,35 +81,34 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
 
   private final SparkCompat providerSparkCompat;
   private final boolean filterScalaClasses;
-  private ClassLoader distributedRunnerClassLoader;
+  private volatile ClassLoader distributedRunnerClassLoader;
   private URL[] classLoaderUrls;
 
   protected SparkProgramRuntimeProvider(SparkCompat providerSparkCompat) {
     this.providerSparkCompat = providerSparkCompat;
-    this.filterScalaClasses = Boolean.parseBoolean(System.getenv(SparkPackageUtils.SPARK_YARN_MODE));
+    this.filterScalaClasses = Boolean.parseBoolean(System.getenv(SPARK_YARN_MODE));
   }
 
   @Override
-  public ClassLoader createProgramClassLoader(CConfiguration cConf, ProgramType type) {
-    Preconditions.checkArgument(type == ProgramType.SPARK, "Unsupported program type %s. Only %s is supported",
-                                type, ProgramType.SPARK);
-    boolean rewriteCheckpointTempFileName =
-      cConf.getBoolean(SparkRuntimeUtils.SPARK_STREAMING_CHECKPOINT_REWRITE_ENABLED);
-    boolean rewriteYarnClient = cConf.getBoolean(Constants.AppFabric.SPARK_YARN_CLIENT_REWRITE);
+  public ClassLoader getRuntimeClassLoader(ProgramType type, CConfiguration cConf) {
+    Preconditions.checkArgument(
+        isSupported(type, cConf),
+        "Unsupported program type %s. Only %s with version %s is supported",
+        type,
+        ProgramType.SPARK,
+        providerSparkCompat.getCompat());
 
+    ClassLoader sparkRunnerClassLoader = getDistributedRunnerClassLoader();
+
+    // SparkResourceFilter must be instantiated using the above classloader as it has the
+    // org.apache.spark.streaming.StreamingContext class, otherwise it will cause
+    // NoClassDefFoundError at runtime
+    // because the parent classloader does not have Spark resources loaded.
     try {
-      ClassLoader sparkRunnerClassLoader = sparkRunnerClassLoader = createClassLoader(filterScalaClasses,
-                                                                                      rewriteYarnClient,
-                                                                                      rewriteCheckpointTempFileName);
-
-      // SparkResourceFilter must be instantiated using the above classloader as it has the
-      // org.apache.spark.streaming.StreamingContext class, otherwise it will cause NoClassDefFoundError at runtime
-      // because the parent classloader does not have Spark resources loaded.
-      FilterClassLoader.Filter sparkClassLoaderFilter = (FilterClassLoader.Filter) sparkRunnerClassLoader
-        .loadClass(SparkResourceFilter.class.getName()).newInstance();
+      FilterClassLoader.Filter sparkClassLoaderFilter =
+          (FilterClassLoader.Filter)
+              sparkRunnerClassLoader.loadClass(SparkResourceFilter.class.getName()).newInstance();
       return new FilterClassLoader(sparkRunnerClassLoader, sparkClassLoaderFilter);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
     } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
       throw new RuntimeException("Failed to create SparkResourceFilter class", e);
     }
@@ -113,30 +116,40 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
 
   @Override
   public ProgramRunner createProgramRunner(ProgramType type, Mode mode, Injector injector) {
-    Preconditions.checkArgument(type == ProgramType.SPARK, "Unsupported program type %s. Only %s is supported",
-                                type, ProgramType.SPARK);
+    Preconditions.checkArgument(
+        type == ProgramType.SPARK,
+        "Unsupported program type %s. Only %s is supported",
+        type,
+        ProgramType.SPARK);
 
     CConfiguration conf = injector.getInstance(CConfiguration.class);
 
-    boolean rewriteCheckpointTempFileName =
-      conf.getBoolean(SparkRuntimeUtils.SPARK_STREAMING_CHECKPOINT_REWRITE_ENABLED);
-
     switch (mode) {
       case LOCAL:
-        // Rewrite YarnClient based on config. The LOCAL runner is used in both SDK and distributed mode
-        // The actual mode that Spark is running is determined by the cdap.spark.cluster.mode attribute
+        // Rewrite YarnClient based on config. The LOCAL runner is used in both SDK and distributed
+        // mode
+        // The actual mode that Spark is running is determined by the cdap.spark.cluster.mode
+        // attribute
         // in the hConf
         boolean rewriteYarnClient = conf.getBoolean(Constants.AppFabric.SPARK_YARN_CLIENT_REWRITE);
         try {
-          SparkRunnerClassLoader classLoader = createClassLoader(filterScalaClasses, rewriteYarnClient,
-                                                                 rewriteCheckpointTempFileName);
+          SparkRunnerClassLoader classLoader =
+              createClassLoader(
+                  filterScalaClasses,
+                  rewriteYarnClient,
+                  conf.getBoolean(SPARK_STREAMING_CHECKPOINT_REWRITE_ENABLED));
           try {
-            // Closing of the SparkRunnerClassLoader is done by the SparkProgramRunner when the program execution
+            // Closing of the SparkRunnerClassLoader is done by the SparkProgramRunner when the
+            // program execution
             // finished.
-            // The current CDAP call run right after it get a ProgramRunner and never reuse a ProgramRunner.
-            // TODO: CDAP-5506 to refactor the program runtime architecture to remove the need of this assumption
-            return createSparkProgramRunner(createRunnerInjector(injector, classLoader),
-                                            SparkProgramRunner.class.getName(), classLoader);
+            // The current CDAP call run right after it get a ProgramRunner and never reuse a
+            // ProgramRunner.
+            // TODO: CDAP-5506 to refactor the program runtime architecture to remove the need of
+            // this assumption
+            return createSparkProgramRunner(
+                createRunnerInjector(injector, classLoader),
+                SparkProgramRunner.class.getName(),
+                classLoader);
           } catch (Throwable t) {
             // If there is any exception, close the classloader
             Closeables.closeQuietly(classLoader);
@@ -146,16 +159,11 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
           throw Throwables.propagate(e);
         }
       case DISTRIBUTED:
-        // The distributed program runner is only used by the CDAP master to launch the twill container
-        // hence it doesn't need to do any class rewrite.
-        // We only create the SparkRunnerClassLoader once and keep reusing it since in the CDAP master, there is
-        // no SparkContext being created, hence no need to provide runtime isolation.
-        // This also limits the amount of permgen usage to be constant in the CDAP master regardless of how
-        // many Spark programs are running. We never need to close the SparkRunnerClassLoader until process shutdown.
-        ClassLoader classLoader = getDistributedRunnerClassLoader(rewriteCheckpointTempFileName);
-        return createSparkProgramRunner(createRunnerInjector(injector, classLoader),
-                                        DistributedSparkProgramRunner.class.getName(),
-                                        classLoader);
+        ClassLoader classLoader = getDistributedRunnerClassLoader();
+        return createSparkProgramRunner(
+            createRunnerInjector(injector, classLoader),
+            DistributedSparkProgramRunner.class.getName(),
+            classLoader);
       default:
         throw new IllegalArgumentException("Unsupported Spark execution mode " + mode);
     }
@@ -163,10 +171,14 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
 
   @Override
   public boolean isSupported(ProgramType programType, CConfiguration cConf) {
+    if (!ProgramType.SPARK.equals(programType)) {
+      return false;
+    }
+
     // TODO: Need to check if it actually has the corresponding spark version available
     SparkCompat runtimeSparkCompat = SparkCompatReader.get(cConf);
     if (runtimeSparkCompat == providerSparkCompat) {
-      LOG.debug("using sparkCompat {}", providerSparkCompat);
+      LOG.trace("Using sparkCompat {}", providerSparkCompat);
       return true;
     }
     return false;
@@ -180,49 +192,68 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
    * @return a new injector for injection for program runner.
    */
   private Injector createRunnerInjector(Injector injector, final ClassLoader runnerClassLoader) {
-    return injector.createChildInjector(new AbstractModule() {
-      @Override
-      protected void configure() {
-        // Add a binding for SparkCompat enum
-        // The binding needs to be on the enum class loaded by the runner classloader
-        try {
-          Class<? extends Enum> type = (Class<? extends Enum>) runnerClassLoader.loadClass(SparkCompat.class.getName());
-          bindEnum(binder(), type, providerSparkCompat.name());
-        } catch (ClassNotFoundException e) {
-          // This shouldn't happen
-          throw Throwables.propagate(e);
-        }
-      }
+    return injector.createChildInjector(
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            // Add a binding for SparkCompat enum
+            // The binding needs to be on the enum class loaded by the runner classloader
+            try {
+              Class<? extends Enum> type =
+                  (Class<? extends Enum>) runnerClassLoader.loadClass(SparkCompat.class.getName());
+              bindEnum(binder(), type, providerSparkCompat.name());
+            } catch (ClassNotFoundException e) {
+              // This shouldn't happen
+              throw Throwables.propagate(e);
+            }
+          }
 
-      private <T extends Enum<T>> void bindEnum(Binder binder, Class<T> enumType, String name) {
-        // This workaround the enum generic
-        binder.bind(enumType).toInstance(Enum.valueOf(enumType, name));
-      }
-    });
-  }
-
-  private synchronized ClassLoader getDistributedRunnerClassLoader(boolean rewriteCheckpointTempFileName) {
-    try {
-      if (distributedRunnerClassLoader == null) {
-        // Never needs to rewrite yarn client in CDAP master, which is the only place using distributed program runner
-        distributedRunnerClassLoader = createClassLoader(true, false, rewriteCheckpointTempFileName);
-      }
-      return distributedRunnerClassLoader;
-    } catch (IOException e) {
-      throw Throwables.propagate(e);
-    }
+          private <T extends Enum<T>> void bindEnum(Binder binder, Class<T> enumType, String name) {
+            // This workaround the enum generic
+            binder.bind(enumType).toInstance(Enum.valueOf(enumType, name));
+          }
+        });
   }
 
   /**
-   * Creates a {@link ProgramRunner} that execute Spark program from the given {@link Injector}.
+   * Returns the singleton {@link ClassLoader} for distributed program execution. The distributed
+   * program runner is used by the CDAP master to launch program that execute remotely, hence it
+   * doesn't need to do any class rewrite. We only create the SparkRunnerClassLoader once and keep
+   * reusing it since in the CDAP master, there is no SparkContext being created, hence no need to
+   * provide runtime isolation. This also limits the amount of permgen usage to be constant in the
+   * CDAP master regardless of how many Spark programs are running. We never need to close the
+   * SparkRunnerClassLoader until process shutdown.
    */
-  private ProgramRunner createSparkProgramRunner(Injector injector,
-                                                 String programRunnerClassName,
-                                                 ClassLoader classLoader) {
+  private ClassLoader getDistributedRunnerClassLoader() {
+    ClassLoader classLoader = distributedRunnerClassLoader;
+    if (classLoader != null) {
+      return classLoader;
+    }
+
+    synchronized (this) {
+      classLoader = distributedRunnerClassLoader;
+      if (classLoader != null) {
+        return classLoader;
+      }
+      try {
+        // Never needs to rewrite yarn client in CDAP master, which is the only place using
+        // distributed program runner. Also wrap the classloader so that it can't be closed.
+        distributedRunnerClassLoader = new ClassLoader(createClassLoader(true, false, false)) {};
+        return distributedRunnerClassLoader;
+      } catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+    }
+  }
+
+  /** Creates a {@link ProgramRunner} that execute Spark program from the given {@link Injector}. */
+  private ProgramRunner createSparkProgramRunner(
+      Injector injector, String programRunnerClassName, ClassLoader classLoader) {
     try {
       ClassLoader oldClassLoader = ClassLoaders.setContextClassLoader(classLoader);
       try {
-        return createInstance(injector, Key.get(classLoader.loadClass(programRunnerClassName)), classLoader);
+        return createInstance(
+            injector, Key.get(classLoader.loadClass(programRunnerClassName)), classLoader);
       } finally {
         ClassLoaders.setContextClassLoader(oldClassLoader);
       }
@@ -232,16 +263,18 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
   }
 
   /**
-   * Create a new instance of the given {@link Type} from the given {@link Injector}. This method
-   * is doing Guice injection manually through the @Inject constructor to avoid ClassLoader leakage
-   * due to the just-in-time binding map inside the Guice Injector that holds a strong reference to the type,
-   * hence the ClassLoader of that type
+   * Create a new instance of the given {@link Type} from the given {@link Injector}. This method is
+   * doing Guice injection manually through the @Inject constructor to avoid ClassLoader leakage due
+   * to the just-in-time binding map inside the Guice Injector that holds a strong reference to the
+   * type, hence the ClassLoader of that type
    *
    * @param injector The Guice Injector for acquiring CDAP system instances
-   * @param key the guice binding {@link Key} for acquiring an instance that binded to the given key.
+   * @param key the guice binding {@link Key} for acquiring an instance that binded to the given
+   *     key.
    * @return a new instance of the given {@link Type}
    */
-  private <T> T createInstance(Injector injector, Key<?> key, ClassLoader sparkClassLoader) throws Exception {
+  private <T> T createInstance(Injector injector, Key<?> key, ClassLoader sparkClassLoader)
+      throws Exception {
     // If there is an explicit instance binding, return the binded instance directly
     Binding<?> binding = injector.getExistingBinding(key);
     if (binding != null && binding instanceof InstanceBinding) {
@@ -266,12 +299,14 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
       // If there is one, and it can only have one according to Guice,
       // use it to construct the binding key for the parmater.
       // Otherwise, just use the parameter type.
-      Optional<Annotation> bindingAnnotation = Arrays.stream(paramAnnotations[i])
-        .filter(paramAnnotation ->
-                  Arrays.stream(paramAnnotation.annotationType().getAnnotations())
-                    .map(Annotation::annotationType)
-                    .anyMatch(BindingAnnotation.class::equals))
-        .findFirst();
+      Optional<Annotation> bindingAnnotation =
+          Arrays.stream(paramAnnotations[i])
+              .filter(
+                  paramAnnotation ->
+                      Arrays.stream(paramAnnotation.annotationType().getAnnotations())
+                          .map(Annotation::annotationType)
+                          .anyMatch(BindingAnnotation.class::equals))
+              .findFirst();
 
       Key<?> paramTypeKey;
       if (bindingAnnotation.isPresent()) {
@@ -281,17 +316,23 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
       }
 
       try {
-        // If the classloader of the parameter is the same as the Spark ClassLoader, we need to create the
-        // instance manually instead of getting through the Guice Injector to avoid ClassLoader leakage
+        // If the classloader of the parameter is the same as the Spark ClassLoader, we need to
+        // create the
+        // instance manually instead of getting through the Guice Injector to avoid ClassLoader
+        // leakage
         if (paramTypeKey.getTypeLiteral().getRawType().getClassLoader() == sparkClassLoader) {
           args[i] = createInstance(injector, paramTypeKey, sparkClassLoader);
         } else {
           args[i] = injector.getInstance(paramTypeKey);
         }
       } catch (ConfigurationException e) {
-        // Wrap the Guice ConfigurationException with information on what class is getting bound to allow for debugging.
-        throw new RuntimeException(String.format("Failed to bind paramTypeKey '%s' for paramType '%s' in key '%s'",
-                                                 paramTypeKey, paramType, key), e);
+        // Wrap the Guice ConfigurationException with information on what class is getting bound to
+        // allow for debugging.
+        throw new RuntimeException(
+            String.format(
+                "Failed to bind paramTypeKey '%s' for paramType '%s' in key '%s'",
+                paramTypeKey, paramType, key),
+            e);
       }
     }
 
@@ -299,9 +340,9 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
   }
 
   /**
-   * Finds the constructor of the given type that is suitable for Guice injection. If the given type has
-   * a constructor annotated with {@link Inject}, then it will be returned. Otherwise, the default constructor
-   * will be returned.
+   * Finds the constructor of the given type that is suitable for Guice injection. If the given type
+   * has a constructor annotated with {@link Inject}, then it will be returned. Otherwise, the
+   * default constructor will be returned.
    *
    * @throws ProvisionException if failed to locate a constructor for the injection
    */
@@ -319,50 +360,54 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
       return type.getDeclaredConstructor();
     } catch (NoSuchMethodException e) {
       throw new ProvisionException(
-        "No constructor is annotated with @Inject and there is no default constructor for class " + type.getName(), e);
+          "No constructor is annotated with @Inject and there is no default constructor for class "
+              + type.getName(),
+          e);
     }
   }
 
-  /**
-   * Returns an array of {@link URL} being used by the {@link ClassLoader} of this {@link Class}.
-   */
-  private synchronized SparkRunnerClassLoader createClassLoader(boolean filterScalaClasses,
-                                                                boolean rewriteYarnClient,
-                                                                boolean rewriteCheckpointTempName) throws IOException {
+  /** Returns a {@link SparkRunnerClassLoader} for program execution. */
+  private synchronized SparkRunnerClassLoader createClassLoader(
+      boolean filterScalaClasses, boolean rewriteYarnClient, boolean rewriteCheckpointTempName)
+      throws IOException {
     // Determine if needs to filter Scala classes or not.
-    FilterClassLoader filteredBaseParent = new FilterClassLoader(getClass().getClassLoader(), createClassFilter());
-    ClassLoader runnerParentClassLoader = filterScalaClasses
-      ? new ScalaFilterClassLoader(filteredBaseParent) : filteredBaseParent;
+    FilterClassLoader filteredBaseParent =
+        new FilterClassLoader(getClass().getClassLoader(), createClassFilter());
+    ClassLoader runnerParentClassLoader =
+        filterScalaClasses ? new ScalaFilterClassLoader(filteredBaseParent) : filteredBaseParent;
 
     if (classLoaderUrls == null) {
       classLoaderUrls = getSparkClassloaderURLs(getClass().getClassLoader());
     }
 
-    return new SparkRunnerClassLoader(classLoaderUrls,
-                                      runnerParentClassLoader,
-                                      rewriteYarnClient,
-                                      rewriteCheckpointTempName);
+    return new SparkRunnerClassLoader(
+        classLoaderUrls, runnerParentClassLoader, rewriteYarnClient, rewriteCheckpointTempName);
   }
 
   /**
-   * Returns an array of URLs to be used for creation of classloader for Spark, based on the urls used by the
-   * given {@link ClassLoader}.
+   * Returns an array of URLs to be used for creation of classloader for Spark, based on the urls
+   * used by the given {@link ClassLoader}.
    */
   private URL[] getSparkClassloaderURLs(ClassLoader classLoader) throws IOException {
     List<URL> urls = ClassLoaders.getClassLoaderURLs(classLoader, new LinkedList<URL>());
 
-    // If Spark classes are not available in the given ClassLoader, try to locate the Spark framework
-    // This class cannot have dependency on Spark directly, hence using the class resource to discover if SparkContext
+    // If Spark classes are not available in the given ClassLoader, try to locate the Spark
+    // framework
+    // This class cannot have dependency on Spark directly, hence using the class resource to
+    // discover if SparkContext
     // is there
     if (classLoader.getResource("org/apache/spark/SparkContext.class") == null) {
       // The scala from the Spark library should replace the one from the parent classloader
-      // CDH also packages spark-yarn-shuffle.jar linked to spark-<version>-yarn-shuffle.jar in yarn's lib dir
+      // CDH also packages spark-yarn-shuffle.jar linked to spark-<version>-yarn-shuffle.jar in
+      // yarn's lib dir
       // Also filter out all jackson libraries that comes from the parent
       Iterator<URL> itor = urls.iterator();
       while (itor.hasNext()) {
         URL url = itor.next();
         String filename = Paths.get(url.getPath()).getFileName().toString();
-        if (filename.startsWith("org.scala-lang") || filename.startsWith("spark-") || filename.contains("jackson-")) {
+        if (filename.startsWith("org.scala-lang")
+            || filename.startsWith("spark-")
+            || filename.contains("jackson-")) {
           itor.remove();
         }
       }
@@ -376,16 +421,16 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
   }
 
   /**
-   * Returns {@code true} if the given string is equals to the equals string, or if the given string is
-   * starts with the given equal string concatenated with the given suffix.
+   * Returns {@code true} if the given string is equals to the equals string, or if the given string
+   * is starts with the given equal string concatenated with the given suffix.
    */
   private static boolean equalsOrStartWith(String str, String equalStr, char startWithSuffix) {
     return str.equals(equalStr) || str.startsWith(equalStr + startWithSuffix);
   }
 
   /**
-   * Creates a {@link FilterClassLoader.Filter} for shielding out unwanted classes that comes from the CDAP
-   * main classloader. It includes classes that are known to cause conflicts with Spark.
+   * Creates a {@link FilterClassLoader.Filter} for shielding out unwanted classes that comes from
+   * the CDAP main classloader. It includes classes that are known to cause conflicts with Spark.
    */
   private FilterClassLoader.Filter createClassFilter() {
     return new FilterClassLoader.Filter() {
@@ -401,28 +446,29 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
     };
   }
 
-  /**
-   * A ClassLoader that filter out scala class.
-   */
+  /** A ClassLoader that filter out scala class. */
   private static final class ScalaFilterClassLoader extends ClassLoader {
 
     ScalaFilterClassLoader(ClassLoader parent) {
-      super(new FilterClassLoader(parent, new FilterClassLoader.Filter() {
-        @Override
-        public boolean acceptResource(String resource) {
-          return !equalsOrStartWith(resource, "org/apache/spark", '/')
-            && !equalsOrStartWith(resource, "org/spark-project", '/')
-            && !equalsOrStartWith(resource, "scala", '/')
-            && !"scala/class".equals(resource);
-        }
+      super(
+          new FilterClassLoader(
+              parent,
+              new FilterClassLoader.Filter() {
+                @Override
+                public boolean acceptResource(String resource) {
+                  return !equalsOrStartWith(resource, "org/apache/spark", '/')
+                      && !equalsOrStartWith(resource, "org/spark-project", '/')
+                      && !equalsOrStartWith(resource, "scala", '/')
+                      && !"scala/class".equals(resource);
+                }
 
-        @Override
-        public boolean acceptPackage(String packageName) {
-          return !equalsOrStartWith(packageName, "org.apache.spark", '.')
-            && !equalsOrStartWith(packageName, "org.spark-project", '.')
-            && !equalsOrStartWith(packageName, "scala", '.');
-        }
-      }));
+                @Override
+                public boolean acceptPackage(String packageName) {
+                  return !equalsOrStartWith(packageName, "org.apache.spark", '.')
+                      && !equalsOrStartWith(packageName, "org.spark-project", '.')
+                      && !equalsOrStartWith(packageName, "scala", '.');
+                }
+              }));
     }
 
     @Override
@@ -431,7 +477,8 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
       if (resource == null) {
         return null;
       }
-      // resource = jar:file:/path/to/cdap/lib/org.scala-lang.scala-library-2.10.4.jar!/library.properties
+      // resource =
+      // jar:file:/path/to/cdap/lib/org.scala-lang.scala-library-2.10.4.jar!/library.properties
       // baseClasspath = /path/to/cdap/lib/org.scala-lang.scala-library-2.10.4.jar
 
       // ignoring jrt scheme for java11 support
@@ -439,7 +486,8 @@ public abstract class SparkProgramRuntimeProvider implements ProgramRuntimeProvi
         return null;
       }
       String baseClasspath = ClassLoaders.getClassPathURL(name, resource).getPath();
-      String jarName = baseClasspath.substring(baseClasspath.lastIndexOf('/') + 1, baseClasspath.length());
+      String jarName =
+          baseClasspath.substring(baseClasspath.lastIndexOf('/') + 1, baseClasspath.length());
       return jarName.startsWith("org.scala-lang") ? null : resource;
     }
   }

--- a/cdap-spark-core-base/src/test/java/io/cdap/cdap/app/runtime/spark/SparkProgramRuntimeProviderTest.java
+++ b/cdap-spark-core-base/src/test/java/io/cdap/cdap/app/runtime/spark/SparkProgramRuntimeProviderTest.java
@@ -52,7 +52,7 @@ public class SparkProgramRuntimeProviderTest {
     ServiceLoader<ProgramRuntimeProvider> serviceLoader = ServiceLoader.load(ProgramRuntimeProvider.class,
                                                                              noSparkClassLoader);
     SparkProgramRuntimeProvider runtimeProvider = (SparkProgramRuntimeProvider) serviceLoader.iterator().next();
-    ClassLoader sparkClassLoader = runtimeProvider.createProgramClassLoader(cConf, ProgramType.SPARK);
+    ClassLoader sparkClassLoader = runtimeProvider.getRuntimeClassLoader(ProgramType.SPARK, cConf);
     // Load any spark streaming class.
     sparkClassLoader.loadClass("org.apache.spark.streaming.StreamingContext");
     MasterEnvironments.setMasterEnvironment(tmpMasterEnv);


### PR DESCRIPTION
- For non local spark program execution purposes, we don’t need to isolate the Spark classloader, since there is no creation of the SparkContext object.