### PR TITLE
[Cherry-pic into 6.10][CDAP-20915] Use exprEnc() instead of encoder() as latter is only available in Spark 3

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/DataframeCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/DataframeCollection.java
@@ -84,9 +84,9 @@ public class DataframeCollection extends DatasetCollection<StructuredRecord>
     super(sec, jsc, sqlContext, datasetContext, sinkFactory, functionCacheFactory);
     this.schema = Objects.requireNonNull(schema);
     this.dataframe = dataframe;
-    if (!Row.class.isAssignableFrom(dataframe.encoder().clsTag().runtimeClass())) {
+    if (!Row.class.isAssignableFrom(dataframe.exprEnc().clsTag().runtimeClass())) {
       throw new IllegalArgumentException(
-          "Dataframe collection received dataset of " + dataframe.encoder().clsTag()
+          "Dataframe collection received dataset of " + dataframe.exprEnc().clsTag()
               .runtimeClass());
     }
   }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/OpaqueDatasetCollection.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/batch/OpaqueDatasetCollection.java
@@ -56,9 +56,9 @@ public class OpaqueDatasetCollection<T> extends DatasetCollection<T> {
       FunctionCache.Factory functionCacheFactory) {
     super(sec, jsc, sqlContext, datasetContext, sinkFactory, functionCacheFactory);
     this.dataset = dataset;
-    if (Row.class.isAssignableFrom(dataset.encoder().clsTag().runtimeClass())) {
+    if (Row.class.isAssignableFrom(dataset.exprEnc().clsTag().runtimeClass())) {
       throw new IllegalArgumentException(
-          "Opaque collection received dataset of Row (" + dataset.encoder().clsTag()
+          "Opaque collection received dataset of Row (" + dataset.exprEnc().clsTag()
               .runtimeClass() + "). DataframeCollection should be used.");
     }
   }


### PR DESCRIPTION
Cherry-pick of https://github.com/cdapio/cdap/pull/15484