### PR TITLE
[CDAP-20920] Use spark partitions autotuning for predefined autoscaling policy

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -227,8 +227,7 @@ abstract class DataprocClient implements AutoCloseable {
           .setDiskConfig(workerDiskConfig);
 
       //Set default concurrency settings for fixed cluster
-      if (Strings.isNullOrEmpty(conf.getAutoScalingPolicy())
-          && !conf.isPredefinedAutoScaleEnabled()) {
+      if (Strings.isNullOrEmpty(conf.getAutoScalingPolicy())) {
         //Set spark.default.parallelism according to cluster size.
         //Spark defaults it to number of current executors, but when we configure the job
         //executors may not have started yet, so this value gets artificially low.


### PR DESCRIPTION
Notes:
 * DataprocConf#getTotalWorkerCpus already calculates proper value for display
 * Customers can get back old behaviour by setting `spark.default.parallelism` and `spark.sql.adaptive.coalescePartitions.initialPartitionNum` explicitly