### PR TITLE
fix scm multi feature flag issue in sandbox

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -6010,6 +6010,14 @@
     </description>
   </property>
   <property>
+    <name>feature.source.control.management.multi.app.enabled</name>
+    <value>true</value>
+    <description>
+      If true, source control management bulk sync operations for multiple
+      pipelines will be enabled.
+    </description>
+  </property>
+  <property>
     <name>source.control.git.command.timeout.seconds</name>
     <value>30</value>
     <description>


### PR DESCRIPTION
Add the default value for `feature.source.control.management.multi.app.enabled` in `cdap-default.xml`