### PR TITLE
Bugfix/cdap 20896 secure key validation and tooltip

### DIFF
--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/id/SecureKeyId.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/id/SecureKeyId.java
@@ -42,7 +42,7 @@ public class SecureKeyId extends NamespacedEntityId implements ParentedId<Namesp
     if (!isValidSecureKey(name)) {
       throw new IllegalArgumentException(
           String.format("Improperly formatted secure key name '%s'."
-              + " The name can contain lower case alphabets,"
+              + " The name can contain lower case english or latin alphabets,"
               + " numbers, _, and -", name));
     }
     this.name = name;


### PR DESCRIPTION
- Added a validation check for passwordName in PatConfig.java
- Changed the error message of SecureKeyId to contain "latin"