### PR TITLE
[CDAP-20924] Use internal router for creating remote clients when configured and using alternate factory method

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClientFactory.java
@@ -117,15 +117,8 @@ public class RemoteClientFactory {
    */
   public RemoteClient createRemoteClient(String discoverableServiceName,
       HttpRequestConfig httpRequestConfig, String basePath) {
-    basePath = basePath.startsWith("/") ? pathPrefix + basePath
-        : pathPrefix + "/" + basePath;
-    if (this.internalRouterEnabled) {
-      return getClientForInternalRouter(discoverableServiceName,
-          httpRequestConfig, basePath);
-    }
-    return new RemoteClient(internalAuthenticator, discoveryClient,
-        discoverableServiceName, httpRequestConfig, basePath,
-        remoteAuthenticator);
+    return createRemoteClient(discoverableServiceName, httpRequestConfig,
+        basePath, internalAuthenticator);
   }
 
   /**
@@ -143,12 +136,18 @@ public class RemoteClientFactory {
       HttpRequestConfig httpRequestConfig, String basePath,
       InternalAuthenticator internalAuthenticator) {
     basePath = basePath.startsWith("/") ? pathPrefix + basePath : pathPrefix + "/" + basePath;
-    return new RemoteClient(internalAuthenticator, discoveryClient, discoverableServiceName,
+    if (this.internalRouterEnabled) {
+      return getClientForInternalRouter(discoverableServiceName,
+          httpRequestConfig, basePath, internalAuthenticator);
+    }
+    return new RemoteClient(internalAuthenticator, discoveryClient,
+        discoverableServiceName,
         httpRequestConfig, basePath, remoteAuthenticator);
   }
 
   private RemoteClient getClientForInternalRouter(String destinationServiceName,
-      HttpRequestConfig httpRequestConfig, String basePath) {
+      HttpRequestConfig httpRequestConfig, String basePath,
+      InternalAuthenticator internalAuthenticator) {
     LOG.trace(
         "Creating client for service '{}' which routes through service '{}'.",
         destinationServiceName, Service.INTERNAL_ROUTER);


### PR DESCRIPTION
## [CDAP-20924](https://cdap.atlassian.net/browse/CDAP-20924)

Verified that the issue is fixed after replacing the docker image in an instance with namespace isolation and internal router enabled.

[CDAP-20924]: https://cdap.atlassian.net/browse/CDAP-20924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ