### PR TITLE
[CDAP-20928] Disable SSL verification for internal clients in system services

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/services/AbstractServiceDiscoverer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/services/AbstractServiceDiscoverer.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.service.ServiceDiscoverable;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramId;
-import io.cdap.common.http.HttpRequestConfig;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -85,6 +84,8 @@ public abstract class AbstractServiceDiscoverer implements ServiceDiscoverer {
   }
 
   /**
+   * Gets a factory for creating clients for CDAP services.
+   *
    * @return the {@link RemoteClientFactory}
    */
   protected abstract RemoteClientFactory getRemoteClientFactory();
@@ -103,7 +104,7 @@ public abstract class AbstractServiceDiscoverer implements ServiceDiscoverer {
         ProgramType.SERVICE, serviceId);
     String basePath = String.format("%s/namespaces/%s/apps/%s/services/%s/methods/",
         Constants.Gateway.API_VERSION_3_TOKEN, namespaceId, applicationId, serviceId);
-    return getRemoteClientFactory().createRemoteClient(discoveryName, HttpRequestConfig.DEFAULT,
-        basePath);
+    return getRemoteClientFactory().createRemoteClient(discoveryName,
+        RemoteClientFactory.NO_VERIFY_HTTP_REQUEST_CONFIG, basePath);
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/InternalRouterService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/InternalRouterService.java
@@ -66,7 +66,7 @@ public class InternalRouterService extends AbstractIdleService {
         .setHost(cConf.get(Constants.InternalRouter.BIND_ADDRESS))
         .setPort(cConf.getInt(Constants.InternalRouter.BIND_PORT));
 
-    if (cConf.getBoolean(Constants.InternalRouter.SSL_ENABLED)) {
+    if (cConf.getBoolean(Constants.Security.SSL.INTERNAL_ENABLED)) {
       new HttpsEnabler().configureKeyStore(cConf, sConf).enable(builder);
     }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -2495,7 +2495,6 @@ public final class Constants {
 
     public static final String BIND_ADDRESS = "internal.router.service.bind.address";
     public static final String BIND_PORT = "internal.router.service.bind.port";
-    public static final String SSL_ENABLED = "internal.router.service.ssl.enabled";
     public static final String CLIENT_ENABLED = "internal.router.client.enabled";
     public static final String SERVER_ENABLED = "internal.router.server.enabled";
   }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -6064,15 +6064,6 @@
   </property>
 
   <property>
-    <name>internal.router.service.ssl.enabled</name>
-    <value>${ssl.internal.enabled}</value>
-    <description>
-      Enable usage of SSL for the internal router service. By default, it is
-      disabled.
-    </description>
-  </property>
-
-  <property>
     <name>internal.router.client.enabled</name>
     <value>false</value>
     <description>


### PR DESCRIPTION
## [CDAP-20928](https://cdap.atlassian.net/browse/CDAP-20928)

Internal services may be using ssl certs signed by a private certificate authority. As a result server ssl cert verification will fail unless the certs are added to the trust store of all the clients. 

This PR also removes the cdap-site configuration for controlling whether the internal router server uses https. Instead it relies on the pre-existing `ssl.internal.enabled` configuration to enable https.

[CDAP-20928]: https://cdap.atlassian.net/browse/CDAP-20928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ