### PR TITLE
 [CDAP-20913] Fix bug where runs fails when appfabric is restarted

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java
@@ -165,8 +165,8 @@ public final class DistributedProgramRuntimeService extends AbstractProgramRunti
 
     // Goes through all live application and fill the twillProgramInfo table
     for (TwillRunner.LiveInfo liveInfo : twillRunner.lookupLive()) {
-      String appName = liveInfo.getApplicationName();
-      ProgramId programId = TwillAppNames.fromTwillAppName(appName, false);
+      ProgramId programId = TwillAppNames.fromTwillAppName(liveInfo.getApplicationName(),
+          false, liveInfo.getApplicationVersion());
       if (programId == null) {
         continue;
       }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramTwillApplication.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramTwillApplication.java
@@ -140,4 +140,9 @@ public final class ProgramTwillApplication implements ExtendedTwillApplication {
   public String getRunId() {
     return programRunId.getRun();
   }
+
+  @Override
+  public String getApplicationVersion() {
+    return programRunId.getVersion();
+  }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/twill/TwillAppNames.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/twill/TwillAppNames.java
@@ -68,6 +68,22 @@ public final class TwillAppNames {
    */
   @Nullable
   public static ProgramId fromTwillAppName(String twillAppName, boolean mustMatch) {
+    return fromTwillAppName(twillAppName, mustMatch, null);
+  }
+
+  /**
+   * Given a Twill app name and version, returns the id of the program that was used to construct
+   * this Twill app name.
+   *
+   * @return {@code null} if mustMatch is false, and if the specified Twill app name does not match
+   *     the {@link #APP_NAME_PATTERN}. For instance, for the Constants.Service.MASTER_SERVICES
+   *     Twill app, it will return null.
+   * @throws IllegalArgumentException if the given app name does not match the {@link
+   *     #APP_NAME_PATTERN} and mustMatch is true.
+   */
+  @Nullable
+  public static ProgramId fromTwillAppName(String twillAppName, boolean mustMatch,
+      @Nullable String version) {
     Matcher matcher = APP_NAME_PATTERN.matcher(twillAppName);
     if (!matcher.matches()) {
       Preconditions.checkArgument(!mustMatch,
@@ -79,6 +95,8 @@ public final class TwillAppNames {
         "Expected matcher for '%s' to have 4 groups, but it had %s groups.",
         twillAppName, matcher.groupCount());
     ProgramType type = ProgramType.valueOf(matcher.group(1).toUpperCase());
-    return new ProgramId(matcher.group(2), matcher.group(3), type, matcher.group(4));
+    return version != null ?
+        new ProgramId(matcher.group(2), matcher.group(3), version, type, matcher.group(4)) :
+        new ProgramId(matcher.group(2), matcher.group(3), type, matcher.group(4));
   }
 }

--- a/cdap-common/src/test/java/io/cdap/cdap/common/twill/TwillAppNamesTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/twill/TwillAppNamesTest.java
@@ -17,8 +17,10 @@
 package io.cdap.cdap.common.twill;
 
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
+import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -45,5 +47,15 @@ public class TwillAppNamesTest {
       // expected
       Assert.assertTrue(e.getMessage().contains("does not match pattern for programs"));
     }
+  }
+
+  @Test
+  public void testAppWithVersion() {
+    String appVersion = UUID.randomUUID().toString();
+    ProgramId expected = new ProgramId("default", "app", appVersion,
+        ProgramType.SPARK, "DataPipelineWorkflow");
+    ProgramId programId = TwillAppNames.fromTwillAppName("spark.default.app.DataPipelineWorkflow",
+        false, appVersion);
+    Assert.assertEquals(programId, expected);
   }
 }

--- a/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillApplication.java
+++ b/cdap-master-spi/src/main/java/io/cdap/cdap/master/spi/twill/ExtendedTwillApplication.java
@@ -25,4 +25,6 @@ public interface ExtendedTwillApplication extends TwillApplication {
 
   String getRunId();
 
+  String getApplicationVersion();
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
     <tephra.version>0.15.0-incubating</tephra.version>
     <tez.version>0.8.4</tez.version>
     <thrift.version>0.9.3</thrift.version>
-    <twill.version>1.3.1</twill.version>
+    <twill.version>1.4.0-SNAPSHOT</twill.version>
     <unboundid.version>2.3.6</unboundid.version>
     <zookeeper.version>3.4.5</zookeeper.version>
     <embedded-postgres.version>1.3.1</embedded-postgres.version>


### PR DESCRIPTION
Depends on https://github.com/cdapio/twill/pull/46.

### Bug description

If appfabric is restated while a run is in progress, we fail to correctly process the program completion message, because we [can't find a run record with the given ProgramRunId](https://github.com/cdapio/cdap/blob/develop/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java#L1444) in the AppMetadataStore. 
```
2024-01-09 23:53:51,146 - WARN  [program.status.9:i.c.c.i.a.s.AppMetadataStore@1499] - Ignoring unexpected transition of program run program_run:default.DataFusionQuickstart_longnamewithabunchofcharactersthatexceedsmaximumlabelsize.-SNAPSHOT.workflow.DataPipelineWorkflow.81ea8d94-af49-11ee-a955-1ad446756c3b to program state COMPLETED with no existing run record.
```
Eventually the run record corrector transitions the run to failed state, but in this case the program had actually run to completion successfully.
```
2024-01-09 23:57:59,791 - WARN  [run-corrector:i.c.c.i.a.s.RunRecordCorrectorService@145] - Fixed RunRecord for program run program_run:default.DataFusionQuickstart_longnamewithabunchofcharactersthatexceedsmaximumlabelsize.c2e817f0-ab39-11ee-8f74-02f6e77072f9.workflow.DataPipelineWorkflow.81ea8d94-af49-11ee-a955-1ad446756c3b in RUNNING state because it is actually not running
2024-01-09 23:57:59,797 - WARN  [run-corrector:i.c.c.i.a.s.RunRecordCorrectorService@154] - Fixed 1 RunRecords with status in [STARTING, RUNNING, SUSPENDED], but the programs are not actually running
2024-01-09 23:57:59,798 - INFO  [run-corrector:i.c.c.i.a.s.RunRecordCorrectorService@107] - Corrected 1 run records with status in [STARTING, RUNNING, SUSPENDED] that have no actual running program. Such programs likely have crashed or were killed by external signal.
```

### Root cause

After restart we [construct the ProgramId from the app name](https://github.com/cdapio/cdap/blob/develop/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedProgramRuntimeService.java#L169); app version is not available here, [so it's set the default value = `SNAPSHOT`](https://github.com/cdapio/cdap/blob/develop/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ApplicationId.java#L35).
However, the ProgramRunId in the run record does have a non-default version, so we fail to find the run record as the versions don't match.

### Fix

Added application version to the LiveInfo so we have access to it when constructing the ProgramId from the application name.
