### PR TITLE
[CDAP-20932] Decode principal name in git committer

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -1458,6 +1458,10 @@ public class ApplicationLifecycleService extends AbstractIdleService {
    * @return the User Id
    */
   public String decodeUserId(AuthenticationContext authenticationContext) {
+    // If internal auth is not enabled the principal name is not base64 encoded
+    if (!SecurityUtil.isInternalAuthEnabled(cConf)) {
+      return authenticationContext.getPrincipal().getName();
+    }
     String decodedUserId = "emptyUserId";
     try {
       byte[] decodedBytes = Base64.getDecoder()

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
@@ -262,7 +262,7 @@ public class SourceControlManagementService {
     // AppLifecycleService already enforces ApplicationDetail Access
     ApplicationDetail appDetail = appLifecycleService.getLatestAppDetail(appRef, false);
 
-    String committer = authenticationContext.getPrincipal().getName();
+    String committer = appLifecycleService.decodeUserId(authenticationContext);
     // TODO CDAP-20371 revisit and put correct Author and Committer, for now they are the same
     CommitMeta commitMeta = new CommitMeta(committer, committer, System.currentTimeMillis(),
         commitMessage);
@@ -409,7 +409,7 @@ public class SourceControlManagementService {
     accessEnforcer.enforce(namespace, authenticationContext.getPrincipal(),
         NamespacePermission.WRITE_REPOSITORY);
     RepositoryConfig repoConfig = getRepositoryMeta(namespace).getConfig();
-    String principal = authenticationContext.getPrincipal().getName();
+    String principal = appLifecycleService.decodeUserId(authenticationContext);
     CommitMeta commitMeta = new CommitMeta(principal, principal, System.currentTimeMillis(),
         request.getCommitMessage());
     PushAppsRequest pushOpRequest = new PushAppsRequest(new HashSet<>(request.getApps()),

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/PatAuthenticationStrategy.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/PatAuthenticationStrategy.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.proto.sourcecontrol.PatConfig;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import joptsimple.internal.Strings;
 import org.eclipse.jgit.errors.UnsupportedCredentialItem;
 import org.eclipse.jgit.transport.CredentialItem;
 import org.eclipse.jgit.transport.URIish;
@@ -31,6 +32,8 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
  * An {@link AuthenticationStrategy} to use with GitHub/GitLab and Personal Access Tokens.
  */
 public class PatAuthenticationStrategy implements AuthenticationStrategy {
+
+  private static final String DEFAULT_USER_NAME = "x-token-auth";
 
   private final SecureStorePasswordProvider credentialsProvider;
 
@@ -44,8 +47,10 @@ public class PatAuthenticationStrategy implements AuthenticationStrategy {
   public PatAuthenticationStrategy(SecureStore secureStore, RepositoryConfig config,
       String namespaceId) {
     PatConfig patConfig = config.getAuth().getPatConfig();
+    String username =
+        Strings.isNullOrEmpty(patConfig.getUsername()) ? DEFAULT_USER_NAME : patConfig.getUsername();
     this.credentialsProvider =
-        new SecureStorePasswordProvider(secureStore, patConfig.getUsername(),
+        new SecureStorePasswordProvider(secureStore, username,
             patConfig.getPasswordName(), namespaceId);
   }
 


### PR DESCRIPTION
We were setting the principal name as git committer but that is base64 encoded for RBAC instances hence we need to decode the username. 
For non-rbac instances the principal is always set as cdap hence we need to skip decoding.

Also fixed a regression introduced by #15563 

- [x] Manual testing

RBAC 
<img width="1594" alt="Screenshot 2024-04-04 at 1 48 51 PM" src="https://github.com/cdapio/cdap/assets/25403205/d2d8d308-b014-4161-be76-59bb8564bd80">
NON RBAC
<img width="1472" alt="Screenshot 2024-04-04 at 12 54 38 PM" src="https://github.com/cdapio/cdap/assets/25403205/580f852c-e5e2-4ffe-8202-46289f72ab4f">

