### PR TITLE
[CDAP-20933] Fix k8s resource name cleaning logic

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java
@@ -104,6 +104,7 @@ import java.util.jar.JarOutputStream;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.twill.api.ClassAcceptor;
 import org.apache.twill.api.Configs;
 import org.apache.twill.api.LocalFile;
@@ -780,11 +781,17 @@ class KubeTwillPreparer implements DependentTwillPreparer, StatefulTwillPreparer
 
   /**
    * Kubernetes names must be lowercase alphanumeric, or '-'. Some are less restrictive, but those
-   * characters should always be ok.
+   * characters should always be ok. They should also start and end with an alphanumeric.
    */
-  private String cleanse(String val, int maxLength) {
+  @VisibleForTesting
+  static String cleanse(String val, int maxLength) {
+    // Replace characters that are not alphanumeric or '=' with '-'
     String cleansed = val.replaceAll("[^A-Za-z0-9\\-]", "-").toLowerCase();
-    return cleansed.length() > maxLength ? cleansed.substring(0, maxLength) : cleansed;
+    // Truncate to maxLength if needed
+    cleansed = cleansed.length() > maxLength ? cleansed.substring(0, maxLength) : cleansed;
+    // Remove leading and trailing '-'
+    cleansed = StringUtils.stripEnd(cleansed, "-");
+    return StringUtils.stripStart(cleansed, "-");
   }
 
   /**

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparerTest.java
@@ -382,6 +382,19 @@ public class KubeTwillPreparerTest {
         .anyMatch(v -> v.getName().equals("cdap-config-abc-123") && v.getMountPath().equals("/config")));
   }
 
+  @Test
+  public void testResourceNameCleanse() {
+    // Trailing '-' is stripped
+    Assert.assertEquals("name", KubeTwillPreparer.cleanse("name-1",
+        5));
+    // Leading '-' removed
+    Assert.assertEquals("name", KubeTwillPreparer.cleanse("--name",
+        6));
+    // '_' is replaced with '-'
+    Assert.assertEquals("name-1", KubeTwillPreparer.cleanse("name_1",
+        6));
+  }
+
   private static Map<String, String> getTwillConfigs() {
     HashMap<String, String> cConf = new HashMap<>();
     cConf.put(Configs.Keys.JAVA_RESERVED_MEMORY_MB, "1024");


### PR DESCRIPTION
CDAP [truncates](https://github.com/cdapio/cdap/blob/v6.9.2/cdap-kubernetes/src/main/java/io/cdap/cdap/k8s/runtime/KubeTwillPreparer.java#L761) label values to conform to k8s requirement that label values [must be <= 63 chars](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). 

However, there is an additional requirement that that the label should start and end with alphanumeric character - this check is missing in the cleaning/truncation logic, is added in this PR.