### PR TITLE
[CDAP-20943] Use a separate consumer id for MetadataConsumerSubscriberService

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/metadata/MetadataConsumerSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/metadata/MetadataConsumerSubscriberService.java
@@ -38,8 +38,8 @@ import io.cdap.cdap.data2.metadata.writer.MetadataMessage;
 import io.cdap.cdap.data2.metadata.writer.MetadataOperation;
 import io.cdap.cdap.data2.metadata.writer.MetadataOperationTypeAdapter;
 import io.cdap.cdap.internal.app.store.AppMetadataStore;
-import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
+import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.messaging.subscriber.AbstractMessagingSubscriberService;
 import io.cdap.cdap.metadata.MetadataMessageProcessor;
 import io.cdap.cdap.proto.ProgramRunStatus;
@@ -112,7 +112,7 @@ public class MetadataConsumerSubscriberService extends AbstractMessagingSubscrib
         Constants.Metrics.Tag.INSTANCE_ID, "0",
         Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace(),
         Constants.Metrics.Tag.TOPIC, cConf.get(Constants.Metadata.MESSAGING_TOPIC),
-        Constants.Metrics.Tag.CONSUMER, Constants.Metadata.METADATA_WRITER_SUBSCRIBER
+        Constants.Metrics.Tag.CONSUMER, Constants.Metadata.METADATA_CONSUMER_WRITER_SUBSCRIBER
       )));
     this.messagingContext = new MultiThreadMessagingContext(messagingService);
     this.transactionRunner = transactionRunner;
@@ -141,8 +141,14 @@ public class MetadataConsumerSubscriberService extends AbstractMessagingSubscrib
   @Override
   protected String loadMessageId(StructuredTableContext context) throws IOException, TableNotFoundException {
     AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
-    return appMetadataStore.retrieveSubscriberState(getTopicId().getTopic(),
-                                                    Constants.Metadata.METADATA_WRITER_SUBSCRIBER);
+    String messageId = appMetadataStore.retrieveSubscriberState(getTopicId().getTopic(),
+        Constants.Metadata.METADATA_CONSUMER_WRITER_SUBSCRIBER);
+    if (messageId == null) {
+      // for backward compatibility in case of upgrade
+      messageId = appMetadataStore.retrieveSubscriberState(getTopicId().getTopic(),
+          Constants.Metadata.METADATA_WRITER_SUBSCRIBER);
+    }
+    return messageId;
   }
 
   @Override
@@ -150,7 +156,7 @@ public class MetadataConsumerSubscriberService extends AbstractMessagingSubscrib
     throws IOException, TableNotFoundException {
     AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
     appMetadataStore.persistSubscriberState(getTopicId().getTopic(),
-                                            Constants.Metadata.METADATA_WRITER_SUBSCRIBER, messageId);
+                                            Constants.Metadata.METADATA_CONSUMER_WRITER_SUBSCRIBER, messageId);
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/MetadataSubscriberService.java
@@ -47,8 +47,8 @@ import io.cdap.cdap.data2.registry.DatasetUsage;
 import io.cdap.cdap.data2.registry.UsageTable;
 import io.cdap.cdap.internal.app.runtime.workflow.BasicWorkflowToken;
 import io.cdap.cdap.internal.app.store.AppMetadataStore;
-import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
+import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.messaging.subscriber.AbstractMessagingSubscriberService;
 import io.cdap.cdap.metadata.profile.ProfileMetadataMessageProcessor;
 import io.cdap.cdap.proto.NamespaceMeta;
@@ -138,7 +138,7 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
             Constants.Metrics.Tag.INSTANCE_ID, "0",
             Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace(),
             Constants.Metrics.Tag.TOPIC, cConf.get(Constants.Metadata.MESSAGING_TOPIC),
-            Constants.Metrics.Tag.CONSUMER, "metadata.writer"
+            Constants.Metrics.Tag.CONSUMER, Constants.Metadata.METADATA_WRITER_SUBSCRIBER
         )));
 
     this.cConf = cConf;
@@ -169,14 +169,16 @@ public class MetadataSubscriberService extends AbstractMessagingSubscriberServic
   protected String loadMessageId(StructuredTableContext context)
       throws IOException, TableNotFoundException {
     AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
-    return appMetadataStore.retrieveSubscriberState(getTopicId().getTopic(), "metadata.writer");
+    return appMetadataStore.retrieveSubscriberState(getTopicId().getTopic(),
+        Constants.Metadata.METADATA_WRITER_SUBSCRIBER);
   }
 
   @Override
   protected void storeMessageId(StructuredTableContext context, String messageId)
       throws IOException, TableNotFoundException {
     AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
-    appMetadataStore.persistSubscriberState(getTopicId().getTopic(), "metadata.writer", messageId);
+    appMetadataStore.persistSubscriberState(getTopicId().getTopic(),
+        Constants.Metadata.METADATA_WRITER_SUBSCRIBER, messageId);
   }
 
   @Override

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -2070,6 +2070,7 @@ public final class Constants {
     public static final String STORAGE_PROVIDER_ELASTICSEARCH = "elastic";
 
     public static final String METADATA_WRITER_SUBSCRIBER = "metadata.writer";
+    public static final String METADATA_CONSUMER_WRITER_SUBSCRIBER = "metadata.consumer.writer";
   }
 
   /**


### PR DESCRIPTION
JIRA: [CDAP-20943](https://cdap.atlassian.net/browse/CDAP-20943)

Tested:

```
cdap=> select namespace,application,version,program_type,program,run from workflows where run in ('10a248d2-b9ee-11ee-b5d4-e6adf015ef44', '0cbdef44-b9d9-11ee-a8a2-6e00dd568637');
 namespace |     application      |               version                | program_type |       program        |                 run                  
-----------+----------------------+--------------------------------------+--------------+----------------------+--------------------------------------
 default   | DataFusionQuickstart | fe668473-b9d8-11ee-9046-6e00dd568637 | WORKFLOW     | DataPipelineWorkflow | 0cbdef44-b9d9-11ee-a8a2-6e00dd568637
 default   | DataFusionQuickstart | fe668473-b9d8-11ee-9046-6e00dd568637 | WORKFLOW     | DataPipelineWorkflow | 10a248d2-b9ee-11ee-b5d4-e6adf015ef44
(2 rows)
```

[CDAP-20943]: https://cdap.atlassian.net/browse/CDAP-20943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ