### PR TITLE
[CDAP-20957] Add scopes support to Remote Authenticator

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ProvisionedCredentialCacheKey.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ProvisionedCredentialCacheKey.java
@@ -48,6 +48,15 @@ public final class ProvisionedCredentialCacheKey {
       return  false;
     }
     ProvisionedCredentialCacheKey that = (ProvisionedCredentialCacheKey) o;
+
+    if (gcpMetadataTaskContext == null && that.gcpMetadataTaskContext == null) {
+      return Objects.equals(scopes, that.scopes);
+    }
+
+    if (gcpMetadataTaskContext == null || that.gcpMetadataTaskContext == null) {
+      return false;
+    }
+
     return Objects.equals(gcpMetadataTaskContext.getNamespace(),
         that.gcpMetadataTaskContext.getNamespace())
         && Objects.equals(gcpMetadataTaskContext.getUserCredential().toString(),
@@ -63,9 +72,14 @@ public final class ProvisionedCredentialCacheKey {
   public int hashCode() {
     Integer hashCode = this.hashCode;
     if (hashCode == null) {
-      this.hashCode = hashCode = Objects.hash(gcpMetadataTaskContext.getNamespace(),
-          gcpMetadataTaskContext.getUserCredential().toString(),
-          gcpMetadataTaskContext.getUserId(), gcpMetadataTaskContext.getUserIp(), scopes);
+
+      if (gcpMetadataTaskContext == null) {
+        this.hashCode = hashCode = Objects.hash(scopes);
+      } else {
+        this.hashCode = hashCode = Objects.hash(gcpMetadataTaskContext.getNamespace(),
+            gcpMetadataTaskContext.getUserCredential().toString(),
+            gcpMetadataTaskContext.getUserId(), gcpMetadataTaskContext.getUserIp(), scopes);
+      }
     }
     return hashCode;
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingTest.java
@@ -62,6 +62,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.EnumSet;
+import javax.annotation.Nullable;
 import org.apache.twill.common.Cancellable;
 import org.apache.twill.discovery.DiscoveryService;
 import org.junit.After;
@@ -267,6 +268,15 @@ public class RuntimeServiceRoutingTest {
       String credentialValue = Base64.getEncoder().encodeToString(Hashing.md5().hashString(programRunId.toString())
                                                                     .asBytes());
       return new Credential(credentialValue, Credential.CredentialType.EXTERNAL_BEARER);
+    }
+
+    /**
+     * Returns the credentials for the authentication with scopes.
+     */
+    @Nullable
+    @Override
+    public Credential getCredentials(String scopes) throws IOException {
+      return getCredentials();
     }
   }
 

--- a/cdap-authenticator-ext-gcp/src/main/java/io/cdap/cdap/authenticator/gcp/GCPRemoteAuthenticator.java
+++ b/cdap-authenticator-ext-gcp/src/main/java/io/cdap/cdap/authenticator/gcp/GCPRemoteAuthenticator.java
@@ -19,6 +19,7 @@ package io.cdap.cdap.authenticator.gcp;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import io.cdap.cdap.proto.security.Credential;
 import io.cdap.cdap.security.spi.authenticator.RemoteAuthenticator;
 import java.io.IOException;
@@ -64,6 +65,21 @@ public class GCPRemoteAuthenticator implements RemoteAuthenticator {
     if (accessToken == null || accessToken.getExpirationTime().before(Date.from(clock.instant()))) {
       accessToken = googleCredentials.refreshAccessToken();
     }
+    return new Credential(accessToken.getTokenValue(), Credential.CredentialType.EXTERNAL_BEARER,
+        accessToken.getExpirationTime().getTime() / 1000L);
+  }
+
+  /**
+   * Returns the credentials for the authentication with scopes.
+   */
+  @Nullable
+  @Override
+  public Credential getCredentials(@Nullable String scopes) throws IOException {
+    if (Strings.isNullOrEmpty(scopes)) {
+      return getCredentials();
+    }
+    AccessToken accessToken =
+        GoogleCredentials.getApplicationDefault().createScoped(scopes).refreshAccessToken();
     return new Credential(accessToken.getTokenValue(), Credential.CredentialType.EXTERNAL_BEARER,
         accessToken.getExpirationTime().getTime() / 1000L);
   }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/NoOpRemoteAuthenticator.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/NoOpRemoteAuthenticator.java
@@ -38,4 +38,13 @@ public class NoOpRemoteAuthenticator implements RemoteAuthenticator {
   public Credential getCredentials() throws IOException {
     return null;
   }
+
+  /**
+   * Returns the credentials for the authentication with scopes.
+   */
+  @Nullable
+  @Override
+  public Credential getCredentials(String scopes) throws IOException {
+    return null;
+  }
 }

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authenticator/RemoteAuthenticator.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authenticator/RemoteAuthenticator.java
@@ -39,4 +39,10 @@ public interface RemoteAuthenticator {
    */
   @Nullable
   Credential getCredentials() throws IOException;
+
+  /**
+   * Returns the credentials for the authentication with scopes.
+   */
+  @Nullable
+  Credential getCredentials(String scopes) throws IOException;
 }


### PR DESCRIPTION
JIRA: [CDAP-20957](https://cdap.atlassian.net/browse/CDAP-20957)

context: We implemented fake metadata server in `CDAP 6.10.0` which falls back to actual metadata server when namespace service account is not configured. In that case, we do not accept scopes which is an important property when fetching token for APIs which are not included in cloud platform scope like `drive.googleapis.com`, etc.

Before Fix:
![image](https://github.com/cdapio/cdap/assets/88528384/5d7d5101-4ed1-4d69-afec-2645bf8942fc)

After Fix:
![image](https://github.com/cdapio/cdap/assets/88528384/2b466a7b-60c5-446c-97f5-4ec9e65959ee)

[CDAP-20957]: https://cdap.atlassian.net/browse/CDAP-20957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ