### PR TITLE
[CDAP-20955] Add retries with exponential back-off for fetching metadata

### DIFF
--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/common/DataprocUtilsTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/common/DataprocUtilsTest.java
@@ -16,12 +16,31 @@
 
 package io.cdap.cdap.runtime.spi.common;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
+import java.net.URL;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-/**
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({DataprocUtils.class})
+/*
  * Unit tests for {@link DataprocUtils}.
  */
 public class DataprocUtilsTest {
@@ -30,7 +49,7 @@ public class DataprocUtilsTest {
   public void testParseSingleLabel() {
     Map<String, String> expected = new HashMap<>();
     expected.put("key", "val");
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("key=val", ",", "="));
+    assertEquals(expected, DataprocUtils.parseLabels("key=val", ",", "="));
   }
 
   @Test
@@ -38,8 +57,8 @@ public class DataprocUtilsTest {
     Map<String, String> expected = new HashMap<>();
     expected.put("k1", "v1");
     expected.put("k2", "v2");
-    Assert.assertEquals(expected,
-        DataprocUtils.parseLabels("k1=v1,k2=v2", ",", "="));
+    assertEquals(expected,
+                 DataprocUtils.parseLabels("k1=v1,k2=v2", ",", "="));
   }
 
   @Test
@@ -47,8 +66,8 @@ public class DataprocUtilsTest {
     Map<String, String> expected = new HashMap<>();
     expected.put("k1", "v1");
     expected.put("k2", "v2");
-    Assert.assertEquals(expected,
-        DataprocUtils.parseLabels(" k1  =\tv1  ,\nk2 = v2  ", ",", "="));
+    assertEquals(expected,
+                 DataprocUtils.parseLabels(" k1  =\tv1  ,\nk2 = v2  ", ",", "="));
   }
 
   @Test
@@ -56,32 +75,121 @@ public class DataprocUtilsTest {
     Map<String, String> expected = new HashMap<>();
     expected.put("k1", "");
     expected.put("k2", "");
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("k1,k2=", ",", "="));
+    assertEquals(expected, DataprocUtils.parseLabels("k1,k2=", ",", "="));
   }
 
   @Test
   public void testParseLabelsIgnoresInvalidKey() {
     Map<String, String> expected = new HashMap<>();
-    Assert.assertEquals(expected, DataprocUtils.parseLabels(("A"), ",", "="));
-    Assert.assertEquals(expected, DataprocUtils.parseLabels(("0"), ",", "="));
-    Assert.assertEquals(expected, DataprocUtils.parseLabels(("a.b"), ",", "="));
-    Assert.assertEquals(expected, DataprocUtils.parseLabels(("a^b"), ",", "="));
+    assertEquals(expected, DataprocUtils.parseLabels(("A"), ",", "="));
+    assertEquals(expected, DataprocUtils.parseLabels(("0"), ",", "="));
+    assertEquals(expected, DataprocUtils.parseLabels(("a.b"), ",", "="));
+    assertEquals(expected, DataprocUtils.parseLabels(("a^b"), ",", "="));
     StringBuilder longStr = new StringBuilder();
     for (int i = 0; i < 64; i++) {
       longStr.append('a');
     }
-    Assert.assertEquals(expected, DataprocUtils.parseLabels(longStr.toString(), ",", "="));
+    assertEquals(expected, DataprocUtils.parseLabels(longStr.toString(), ",", "="));
   }
 
   @Test
   public void testParseLabelsIgnoresInvalidVal() {
     Map<String, String> expected = new HashMap<>();
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("a=A", ",", "="));
-    Assert.assertEquals(expected, DataprocUtils.parseLabels("a=ab.c", ",", "="));
+    assertEquals(expected, DataprocUtils.parseLabels("a=A", ",", "="));
+    assertEquals(expected, DataprocUtils.parseLabels("a=ab.c", ",", "="));
     StringBuilder longStr = new StringBuilder();
     for (int i = 0; i < 64; i++) {
       longStr.append('a');
     }
-    Assert.assertEquals(expected, DataprocUtils.parseLabels(String.format("a=%s", longStr.toString()), ",", "="));
+    assertEquals(expected, DataprocUtils.parseLabels(String.format("a=%s", longStr.toString()), ",", "="));
+  }
+
+  @Test
+  public void testGetMetadataSuccessOnFirstAttempt() throws Exception {
+    // Arrange
+    String expectedMetadata = "Sample metadata";
+    HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+    when(mockConnection.getInputStream()).thenReturn(new ByteArrayInputStream(expectedMetadata.getBytes()));
+
+    URL mockUrl = PowerMockito.mock(URL.class);
+    PowerMockito.whenNew(URL.class).withAnyArguments().thenReturn(mockUrl);
+    when(mockUrl.openConnection()).thenReturn(mockConnection);
+
+    String zone = DataprocUtils.getSystemZone();
+    assertEquals(expectedMetadata, zone);
+
+    verify(mockConnection).setRequestProperty("Metadata-Flavor", "Google");
+    verify(mockConnection).connect();
+    verify(mockConnection).disconnect();
+  }
+
+  @Test
+  public void testGetMetadataFailureOnFirstAttempt() throws Exception {
+    HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+    when(mockConnection.getResponseCode()).thenReturn(403);
+    when(mockConnection.getInputStream()).thenThrow(new IOException("Test Exception"));
+
+    URL mockUrl = PowerMockito.mock(URL.class);
+    PowerMockito.whenNew(URL.class).withAnyArguments().thenReturn(mockUrl);
+    when(mockUrl.openConnection()).thenReturn(mockConnection);
+
+    // Act
+    Exception exception = null;
+    try {
+      DataprocUtils.getSystemZone();
+    } catch (Exception e) {
+      exception = e;
+    }
+
+    // Assert
+    verify(mockConnection, times(1)).setRequestProperty("Metadata-Flavor", "Google");
+    verify(mockConnection, times(1)).connect();
+    verify(mockConnection, times(1)).disconnect();
+    Assert.assertTrue(exception instanceof RuntimeException);
+  }
+
+  @Test
+  public void testGetMetadataSuccessAfterRetries() throws Exception {
+    String expectedMetadata = "Sample metadata";
+    HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+    when(mockConnection.getResponseCode()).thenReturn(500).thenReturn(500).thenReturn(200);
+    when(mockConnection.getInputStream()).thenThrow(new IOException("Test Exception")).thenThrow(new IOException("Test Exception")).thenReturn(new ByteArrayInputStream(expectedMetadata.getBytes()));
+
+    URL mockUrl = PowerMockito.mock(URL.class);
+    PowerMockito.whenNew(URL.class).withAnyArguments().thenReturn(mockUrl);
+    when(mockUrl.openConnection()).thenReturn(mockConnection);
+
+    String zone = DataprocUtils.getSystemZone();
+    assertEquals(expectedMetadata, zone);
+
+    verify(mockConnection, times(3)).setRequestProperty("Metadata-Flavor", "Google");
+    verify(mockConnection, times(3)).connect();
+    verify(mockConnection, times(3)).disconnect();
+  }
+
+  @Test
+  public void testGetMetadataMaxRetriesExceeded() throws Exception {
+    // Arrange
+    HttpURLConnection mockConnection = mock(HttpURLConnection.class);
+    when(mockConnection.getResponseCode()).thenReturn(500);
+    when(mockConnection.getInputStream()).thenThrow(new IOException("Test Exception"));
+
+    URL mockUrl = PowerMockito.mock(URL.class);
+    PowerMockito.whenNew(URL.class).withAnyArguments().thenReturn(mockUrl);
+    when(mockUrl.openConnection()).thenReturn(mockConnection);
+
+    // Act
+    Exception exception = null;
+    try {
+      DataprocUtils.getSystemZone();
+    } catch (Exception e) {
+      exception = e;
+    }
+
+    // Assert
+    verify(mockConnection, times(5)).setRequestProperty("Metadata-Flavor", "Google");
+    verify(mockConnection, times(5)).connect();
+    verify(mockConnection, times(5)).disconnect();
+    Assert.assertTrue(exception instanceof RuntimeException);
   }
 }


### PR DESCRIPTION
[JIRA](https://cdap.atlassian.net/browse/CDAP-20955)

- Error 5xx is thrown after the first attempt to connect to metadata server that lives on the **VM** which results in a pipeline failure. 

### Changes
- Add retries with exponential back-off while attempting to connect to metadata server that lives on the **VM**.
