### PR TITLE
[CDAP-20956] retry 5xx errors for requests which run on system worker and task workers.

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/service/ServiceUnavailableException.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/service/ServiceUnavailableException.java
@@ -26,33 +26,50 @@ import java.net.HttpURLConnection;
 public class ServiceUnavailableException extends RetryableException implements
     HttpErrorStatusProvider {
 
+  private static final String MESSAGE_FORMAT =
+      "Service %s is not available. Please wait until it is up and running.";
   private final String serviceName;
 
+  /**
+   * Constructs the {@link ServiceUnavailableException} with the provided service name.
+   */
   public ServiceUnavailableException(String serviceName) {
-    this(serviceName,
-        "Service '" + serviceName + "' is not available. Please wait until it is up and running.");
+    this(serviceName, String.format(MESSAGE_FORMAT, serviceName));
   }
 
+  /**
+   * Constructs the {@link ServiceUnavailableException} with the provided service name and message.
+   */
   public ServiceUnavailableException(String serviceName, String message) {
     super(message);
     this.serviceName = serviceName;
   }
 
+  /**
+   * Constructs the {@link ServiceUnavailableException} with the provided params.
+   */
   public ServiceUnavailableException(String serviceName, Throwable cause) {
-    this(serviceName,
-        "Service '" + serviceName + "' is not available. Please wait until it is up and running.",
-        cause);
+    this(serviceName, String.format(MESSAGE_FORMAT, serviceName), cause);
   }
 
+  /**
+   * Constructs the {@link ServiceUnavailableException} with the provided params.
+   */
   public ServiceUnavailableException(String serviceName, String message, Throwable cause) {
     super(message, cause);
     this.serviceName = serviceName;
   }
 
+  /**
+   * Returns the service name.
+   */
   public String getServiceName() {
     return serviceName;
   }
 
+  /**
+   * Returns the http status code.
+   */
   @Override
   public int getStatusCode() {
     return HttpURLConnection.HTTP_UNAVAILABLE;

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClient.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteClient.java
@@ -22,8 +22,8 @@ import com.google.common.collect.Multimap;
 import com.google.common.net.HttpHeaders;
 import io.cdap.cdap.api.retry.Idempotency;
 import io.cdap.cdap.api.retry.RetryableException;
-import io.cdap.cdap.common.ServiceException;
 import io.cdap.cdap.api.service.ServiceUnavailableException;
+import io.cdap.cdap.common.ServiceException;
 import io.cdap.cdap.common.discovery.EndpointStrategy;
 import io.cdap.cdap.common.discovery.RandomEndpointStrategy;
 import io.cdap.cdap.common.discovery.URIScheme;
@@ -174,12 +174,12 @@ public class RemoteClient {
         String message;
         String jsonDetails = null;
         if ("application/json".equals(contentType)) {
-          message = String.format("Service %s is not available (%d)", discoverableServiceName,
-              responseCode);
+          message = String.format("Service %s is not available with response code (%d)",
+              discoverableServiceName, responseCode);
           jsonDetails = response.getResponseBodyAsString();
         } else {
-          message = String.format("Service %s is not available: %s", discoverableServiceName,
-              response.getResponseBodyAsString());
+          message = String.format("Service %s is not available with response code (%d): %s",
+              discoverableServiceName, responseCode, response.getResponseBodyAsString());
         }
         throw new ServiceException(message, null,
             jsonDetails, HttpResponseStatus.valueOf(responseCode));


### PR DESCRIPTION
JIRA: [CDAP-20956](https://cdap.atlassian.net/browse/CDAP-20956)

context: During fault injection when system worker service was down temporarily, the pipeline was failed instead of retrying the request.

[CDAP-20956]: https://cdap.atlassian.net/browse/CDAP-20956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ