### PR TITLE
[CDAP-20955] Add retries with exponential back-off for fetching metadata

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClient.java
@@ -345,7 +345,8 @@ abstract class DataprocClient implements AutoCloseable {
     String network = conf.getNetwork();
     String systemNetwork = null;
     try {
-      systemNetwork = DataprocUtils.getSystemNetwork();
+      systemNetwork = DataprocUtils.getSystemNetwork(
+          (url) -> (HttpURLConnection) url.openConnection());
     } catch (IllegalArgumentException e) {
       // expected when not running on GCP, ignore
     }
@@ -354,7 +355,8 @@ abstract class DataprocClient implements AutoCloseable {
     String networkHostProjectId = conf.getNetworkHostProjectId();
     String systemProjectId = null;
     try {
-      systemProjectId = DataprocUtils.getSystemProjectId();
+      systemProjectId = DataprocUtils.getSystemProjectId(
+          (url) -> (HttpURLConnection) url.openConnection());
     } catch (IllegalArgumentException e) {
       // expected when not running on GCP, ignore
     }
@@ -485,8 +487,10 @@ abstract class DataprocClient implements AutoCloseable {
     String systemProjectId = null;
     String systemNetwork = null;
     try {
-      systemProjectId = DataprocUtils.getSystemProjectId();
-      systemNetwork = DataprocUtils.getSystemNetwork();
+      systemProjectId = DataprocUtils.getSystemProjectId(
+          (url) -> (HttpURLConnection) url.openConnection());
+      systemNetwork = DataprocUtils.getSystemNetwork(
+          (url) -> (HttpURLConnection) url.openConnection());
     } catch (IllegalArgumentException e) {
       // expected when not running on GCP, ignore
     }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
+import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -585,7 +586,8 @@ final class DataprocConf {
     }
     String projectId = getString(properties, PROJECT_ID_KEY);
     if (projectId == null || AUTO_DETECT.equals(projectId)) {
-      projectId = DataprocUtils.getSystemProjectId();
+      projectId = DataprocUtils.getSystemProjectId(
+          (url -> (HttpURLConnection) url.openConnection()));
     }
 
     String zone = getString(properties, "zone");
@@ -594,7 +596,8 @@ final class DataprocConf {
       // See if the user specified a zone.
       // If it does, derived region from the provided zone; otherwise, use the system zone.
       if (zone == null || AUTO_DETECT.equals(zone)) {
-        region = DataprocUtils.getRegionFromZone(DataprocUtils.getSystemZone());
+        region = DataprocUtils.getRegionFromZone(DataprocUtils.getSystemZone(
+            (url) -> (HttpURLConnection) url.openConnection()));
       } else {
         region = DataprocUtils.getRegionFromZone(zone);
       }


### PR DESCRIPTION
[JIRA](https://cdap.atlassian.net/browse/CDAP-20955)

- Error 5xx is thrown after the first attempt to connect to metadata server that lives on the **VM** which results in a pipeline failure. 

### Changes
- Add retries with exponential back-off while attempting to connect to metadata server that lives on the **VM**.

orignal PR: https://github.com/cdapio/cdap/pull/15547
