### PR TITLE
use jdk17 for sonar report

### DIFF
--- a/.github/workflows/build-sonar.yml
+++ b/.github/workflows/build-sonar.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Sonar report
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
         run: >-
           mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -fae -T 2 -B -V
           -Dmaven.repo.local=$HOME/.m2/repository11


### PR DESCRIPTION
JDK 17 support was added in self hosted github runner in https://github.com/cdapio/gh-runners/pull/11

Tested: https://github.com/cdapio/cdap/actions/runs/7958876682/job/21724648731