### PR TITLE
[CDAP-20990] Added new database schemas, API schema and Store methods

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -69,6 +69,7 @@ import io.cdap.cdap.proto.id.EntityId;
 import io.cdap.cdap.proto.id.KerberosPrincipalId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.proto.sourcecontrol.SortBy;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
@@ -658,6 +659,34 @@ public class AppLifecycleHttpHandler extends AbstractAppLifecycleHttpHandler {
       }
     }
     responder.sendJson(HttpResponseStatus.OK, GSON.toJson(result));
+  }
+
+  /**
+   * Returns the source control metadata and sync status of all applications
+   * filter query format - "name=&lt;name-filter&gt; AND syncStatus=&lt;SYNCED/UNSYNCED&gt;".
+   */
+  @GET
+  @Path("/sourcecontrol/apps")
+  public void getAllNamespaceSourceControlMetadata(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace,
+      @QueryParam("pageToken") String pageToken,
+      @QueryParam("pageSize") Integer pageSize,
+      @QueryParam("orderBy") SortOrder orderBy,
+      @QueryParam("orderByOption") SortBy orderByOption,
+      @QueryParam("filter") String filter
+     ) throws Exception {
+    // TODO(CDAP-20989): Implement the API handler
+  }
+
+  /**
+   * Returns the source control metadata and sync status of a specific application.
+   */
+  @GET
+  @Path("/apps/{app-id}/sourcecontrol")
+  public void getNamespaceSourceControlMetadata(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") final String namespaceId,
+      @PathParam("app-id") final String appName) throws Exception {
+    // TODO(CDAP-20989): Implement the API handler
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.lang.FunctionWithException;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
@@ -101,23 +102,28 @@ import org.slf4j.LoggerFactory;
 /**
  * Store for application metadata.
  *
- * This class is mostly responsible for reading and storing run records. Each program run will have
+ * <p>This class is mostly responsible for reading and storing run records. Each program run will
+ * have
  * several run records corresponding to state changes that occur during the program run. The rowkeys
- * are of the form:
+ * are of the form:</p>
  *
- * runRecordActive|namespace|app|version|programtype|program|inverted start time|runid
- * runRecordCompleted|namespace|app|version|programtype|program|inverted start time|runid
+ * <ul>
+ *   <li>runRecordActive|namespace|app|version|programtype|program|inverted start time|runid</li>
+ *   <li>runRecordCompleted|namespace|app|version|programtype|program|inverted start time|runid</li>
+ *   <li>runRecordCount|namespace|app|version|programtype|program</li>
+ * </ul>
  *
- * The run count will have the row key of format: runRecordCount|namespace|app|version|programtype|program
+ * <p>These rows get deleted whenever state changes, with a new record written on top. In addition,
+ * workflow node state is stored as:</p>
  *
- * These rows get deleted whenever state changes, with a new record written on top. In addition,
- * workflow node state is stored as:
+ * <ul>
+ *   <li>wns|namespace|app|version|programtype|program|runid|nodeid</li>
+ * </ul>
  *
- * wns|namespace|app|version|programtype|program|runid|nodeid
- *
- * Workflow node state is updated whenever program state is updated and we notice that the program
- * belongs to a workflow.
+ * <p>Workflow node state is updated whenever program state is updated and we notice that the
+ * program belongs to a workflow.</p>
  */
+
 public class AppMetadataStore {
 
   public static final String WORKFLOW_RUNID = "workflowrunid";
@@ -381,6 +387,13 @@ public class AppMetadataStore {
     return table.scan(range, Integer.MAX_VALUE, sortOrder);
   }
 
+  /**
+   * Retrieves the total number of applications, excluding system applications, stored in the
+   * ApplicationSpecification table.
+   *
+   * @return The total number of applications, excluding system applications.
+   * @throws IOException If an error occurs while accessing the application metadata store.
+   */
   public long getApplicationCount() throws IOException {
     // Get number of applications where namespace != SYSTEM (exclude system applications)
     Collection<Field<?>> fields = ImmutableList.of(
@@ -394,6 +407,19 @@ public class AppMetadataStore {
     return getApplicationSpecificationTable().count(ranges);
   }
 
+  /**
+   * Retrieves the latest version of the specified application.
+   *
+   * <p>This method retrieves the most recently created application version for the specified
+   * application reference. If no latest version is found, it falls back to treating the -SNAPSHOT
+   * version as the latest. If still not found, it sorts the versions by version ID, with the larger
+   * version ID string considered as the latest.</p>
+   *
+   * @param appReference The reference to the application.
+   * @return The latest version of the specified application, or {@code null} if the application
+   *         does not exist.
+   * @throws IOException If an error occurs while accessing the application metadata store.
+   */
   @Nullable
   public ApplicationMeta getLatest(ApplicationReference appReference) throws IOException {
     Range range = getLatestApplicationRange(appReference);
@@ -431,6 +457,15 @@ public class AppMetadataStore {
     return null;
   }
 
+  /**
+   * Retrieves a list of all application IDs corresponding to the specified application reference,
+   * including all versions of the application.
+   *
+   * @param appRef The reference to the application.
+   * @return A list of all application IDs corresponding to the specified application reference,
+   *         including all versions of the application.
+   * @throws IOException If an error occurs while accessing the application metadata store.
+   */
   public List<ApplicationId> getAllAppVersionsAppIds(ApplicationReference appRef)
       throws IOException {
     List<ApplicationId> appIds = new ArrayList<>();
@@ -455,16 +490,28 @@ public class AppMetadataStore {
    * @throws IOException if failed to read metadata
    */
   public Map<ApplicationId, ApplicationMeta> getApplicationsForAppIds(
-      Collection<ApplicationId> appIds)
+      Collection<ApplicationId> appIds,
+      FunctionWithException<ApplicationId, SourceControlMeta, IOException> getSourceControlMeta)
       throws IOException {
     List<List<Field<?>>> multiKeys = appIds.stream()
         .map(this::getApplicationPrimaryKeys)
         .collect(Collectors.toList());
-    return getApplicationSpecificationTable().multiRead(multiKeys)
-        .stream()
-        .collect(Collectors.toMap(
-            AppMetadataStore::getApplicationIdFromRow,
-            this::decodeRow));
+    Map<ApplicationId, ApplicationMeta> map = new HashMap<>();
+    Collection<StructuredRow> rows = getApplicationSpecificationTable().multiRead(multiKeys);
+    for (StructuredRow row : rows) {
+      map.put(AppMetadataStore.getApplicationIdFromRow(row),
+          getSourceControlMetaAndDecodeRow(row, getSourceControlMeta));
+    }
+    return map;
+  }
+
+  private ApplicationMeta getSourceControlMetaAndDecodeRow(StructuredRow row,
+      FunctionWithException<ApplicationId, SourceControlMeta, IOException> getSourceControlMeta)
+      throws IOException {
+    ApplicationId appId = AppMetadataStore.getApplicationIdFromRow(row);
+    ApplicationMeta meta = decodeRow(row);
+    SourceControlMeta sourceControlMeta = getSourceControlMeta.apply(appId);
+    return new ApplicationMeta(meta.getId(), meta.getSpec(), meta.getChange(), sourceControlMeta);
   }
 
   /**
@@ -655,7 +702,8 @@ public class AppMetadataStore {
    * @throws ConflictException if parent-version provided in the request doesn't match the
    *     latest version, do not allow app to be created
    */
-  public int createApplicationVersion(ApplicationId id, ApplicationMeta appMeta, boolean markAsLatest)
+  public int createApplicationVersion(ApplicationId id,
+      ApplicationMeta appMeta, boolean markAsLatest)
       throws IOException, ConflictException {
     String parentVersion = Optional.ofNullable(appMeta.getChange())
         .map(ChangeDetail::getParentVersion).orElse(null);
@@ -712,7 +760,7 @@ public class AppMetadataStore {
     writeApplicationSerialized(namespaceId, appId, versionId,
         GSON.toJson(
             new ApplicationMeta(appId, spec, null, null)),
-        change, sourceControlMeta, markAsLatest);
+        change, markAsLatest);
     updateApplicationEdit(namespaceId, appId);
   }
 
@@ -774,6 +822,15 @@ public class AppMetadataStore {
     getApplicationSpecificationTable().deleteAll(getNamespaceRange(namespaceId));
   }
 
+  /**
+   * Updates the application specification for the specified application ID in the application
+   * metadata store.
+   *
+   * @param appId The ID of the application to update.
+   * @param spec  The updated application specification.
+   * @throws IOException If failed to upsert
+   * @throws IllegalArgumentException If the application ID does not exist.
+   */
   public void updateAppSpec(ApplicationId appId, ApplicationSpecification spec) throws IOException {
     if (LOG.isTraceEnabled()) {
       LOG.trace("App spec to be updated: id: {}: spec: {}", appId, GSON.toJson(spec));
@@ -1168,6 +1225,18 @@ public class AppMetadataStore {
     return meta;
   }
 
+  /**
+   * Records the rejected state for the specified program run in the run records.
+   *
+   * @param programRunId The ID of the program run to record the rejected state for.
+   * @param runtimeArgs  The runtime arguments passed to the program run.
+   * @param systemArgs   The system arguments passed to the program run.
+   * @param sourceId     The source ID associated with the program run.
+   * @param artifactId   The artifact ID associated with the program run, if any.
+   * @return The details of the recorded run record for the rejected program run, or {@code null} if
+   *         the rejected state could not be recorded.
+   * @throws IOException If an error occurs while accessing the run records.
+   */
   @Nullable
   public RunRecordDetail recordProgramRejected(ProgramRunId programRunId,
       Map<String, String> runtimeArgs, Map<String, String> systemArgs,
@@ -1821,6 +1890,24 @@ public class AppMetadataStore {
     }
   }
 
+  /**
+   * Retrieves a filtered collection of {@link RunRecordDetail} objects associated with a program.
+   * The result set is limited in size and can include runs with different statuses, depending on
+   * the provided parameters.
+   *
+   * @param programReference The {@link ProgramReference} object identifying the program.
+   * @param status           The {@link ProgramRunStatus} to filter the runs by. If
+   *                         {@code ProgramRunStatus.ALL} is provided, both active and completed
+   *                         runs might be included in the result.
+   * @param startTime        The start timestamp (inclusive) to filter runs.
+   * @param endTime          The end timestamp (inclusive) to filter runs.
+   * @param limit            The maximum number of desired runs in the result set.
+   * @param filter           An optional {@link Predicate} to apply additional filtering on the
+   *                         {@link RunRecordDetail} objects.
+   * @return A {@link Map} where keys are {@link ProgramRunId} and values are the corresponding
+   * {@link RunRecordDetail} objects.
+   * @throws IOException If an error occurs during data retrieval.
+   */
   public Map<ProgramRunId, RunRecordDetail> getAllProgramRuns(ProgramReference programReference,
       ProgramRunStatus status, long startTime,
       long endTime, int limit,
@@ -1886,6 +1973,14 @@ public class AppMetadataStore {
   // TODO: getRun is duplicated in cdap-watchdog AppMetadataStore class.
   // Any changes made here will have to be made over there too.
   // JIRA https://issues.cask.co/browse/CDAP-2172
+
+  /**
+   * Retrieves details of the program run identified by the specified program run ID.
+   *
+   * @param programRun The ID of the program run to retrieve details for.
+   * @return The details of the program run, or {@code null} if the program run does not exist.
+   * @throws IOException If an error occurs while accessing the run records.
+   */
   @Nullable
   public RunRecordDetail getRun(ProgramRunId programRun) throws IOException {
     // Query active run record first
@@ -1908,6 +2003,15 @@ public class AppMetadataStore {
 
   // Fetching run record ignoring versions
   // We do this for places like LogHandler APIs that does not pass in a version
+
+  /**
+   * Retrieves details of the program run identified by the specified program reference and run ID.
+   *
+   * @param programRef The reference to the program.
+   * @param runId      The ID of the program run to retrieve details for.
+   * @return The details of the program run, or {@code null} if the program run does not exist.
+   * @throws IOException If an error occurs while accessing the run records.
+   */
   @Nullable
   public RunRecordDetail getRun(ProgramReference programRef, String runId) throws IOException {
     // Query active run record first
@@ -2215,6 +2319,14 @@ public class AppMetadataStore {
     return invertedTsKey < Long.MAX_VALUE ? invertedTsKey + 1 : invertedTsKey;
   }
 
+  /**
+   * Deletes the historical run records and counts associated with a specific application.
+   *
+   * @param namespaceId The namespace ID of the application.
+   * @param appId       The application ID.
+   * @param versionId   The version ID of the application.
+   * @throws IOException If an error occurs while deleting the historical data.
+   */
   public void deleteProgramHistory(String namespaceId, String appId, String versionId)
       throws IOException {
     ApplicationId applicationId = new ApplicationId(namespaceId, appId, versionId);
@@ -2230,6 +2342,12 @@ public class AppMetadataStore {
         Range.singleton(getCountApplicationPrefix(TYPE_RUN_RECORD_UPGRADE_COUNT, applicationId)));
   }
 
+  /**
+   * Deletes the historical run records and counts associated with a specific application.
+   *
+   * @param applicationReference The reference to the application.
+   * @throws IOException If an error occurs while deleting the historical data.
+   */
   public void deleteProgramHistory(ApplicationReference applicationReference)
     throws IOException {
     getRunRecordsTable()
@@ -2244,6 +2362,13 @@ public class AppMetadataStore {
       Range.singleton(getCountApplicationRefPrefix(TYPE_RUN_RECORD_UPGRADE_COUNT, applicationReference)));
   }
 
+  /**
+   * Deletes the historical run records and counts associated with all applications within the
+   * specified namespace.
+   *
+   * @param namespaceId The ID of the namespace containing the applications.
+   * @throws IOException If an error occurs while deleting the historical data.
+   */
   public void deleteProgramHistory(NamespaceId namespaceId) throws IOException {
     getRunRecordsTable().deleteAll(
         Range.singleton(getRunRecordNamespacePrefix(TYPE_RUN_RECORD_ACTIVE, namespaceId)));
@@ -2274,6 +2399,15 @@ public class AppMetadataStore {
     getWorkflowsTable().upsert(keys);
   }
 
+  /**
+   * Retrieves the workflow token associated with the specified workflow run.
+   *
+   * @param workflowId    The {@link ProgramId} representing the workflow.
+   * @param workflowRunId The unique ID of the workflow run.
+   * @return The workflow token associated with the specified workflow run.
+   * @throws IOException              If an error occurs while retrieving the workflow token.
+   * @throws IllegalArgumentException If the program ID does not represent a workflow.
+   */
   public WorkflowToken getWorkflowToken(ProgramId workflowId, String workflowRunId)
       throws IOException {
     Preconditions.checkArgument(ProgramType.WORKFLOW == workflowId.getType());
@@ -2292,7 +2426,14 @@ public class AppMetadataStore {
   }
 
   /**
-   * @return programs that were running between given start and end time and are completed
+   * Retrieves the set of program runs that were running between the specified start and end times
+   * and have completed.
+   *
+   * @param startTimeInSecs The start time (in seconds since the epoch) of the time range.
+   * @param endTimeInSecs   The end time (in seconds since the epoch) of the time range.
+   * @return A {@link Set} of {@link RunId} objects representing the completed program runs within
+   *         the specified time range.
+   * @throws IOException If an error occurs while retrieving the program runs.
    */
   public Set<RunId> getRunningInRangeCompleted(long startTimeInSecs, long endTimeInSecs)
       throws IOException {
@@ -2304,7 +2445,14 @@ public class AppMetadataStore {
   }
 
   /**
-   * @return programs that were running between given start and end time and are active
+   * Retrieves the set of program runs that were running between the specified start and end times
+   * and are active.
+   *
+   * @param startTimeInSecs The start time (in seconds since the epoch) of the time range.
+   * @param endTimeInSecs   The end time (in seconds since the epoch) of the time range.
+   * @return A {@link Set} of {@link RunId} objects representing the active program runs within the
+   *         specified time range.
+   * @throws IOException If an error occurs while retrieving the program runs.
    */
   public Set<RunId> getRunningInRangeActive(long startTimeInSecs, long endTimeInSecs)
       throws IOException {
@@ -2393,7 +2541,7 @@ public class AppMetadataStore {
   }
 
   /**
-   * Gets the id of the last fetched message that was set for a subscriber of the given TMS topic
+   * Gets the id of the last fetched message that was set for a subscriber of the given TMS topic.
    *
    * @param topic the topic to lookup the last message id
    * @param subscriber the subscriber name
@@ -2451,6 +2599,12 @@ public class AppMetadataStore {
     return runIds;
   }
 
+  /**
+   * Deletes all metadata tables in the App Metadata Store. This method is intended for use only in
+   * testing environments and will delete all metadata store information.
+   *
+   * @throws IOException If an error occurs while deleting the metadata tables.
+   */
   @VisibleForTesting
   // USE ONLY IN TESTS: WILL DELETE ALL METADATA STORE INFO
   public void deleteAllAppMetadataTables() throws IOException {
@@ -2545,15 +2699,13 @@ public class AppMetadataStore {
   }
 
   private void writeApplicationSerialized(String namespaceId, String appId, String versionId,
-      String serialized, @Nullable ChangeDetail change,
-      @Nullable SourceControlMeta sourceControlMeta)
+      String serialized, @Nullable ChangeDetail change)
       throws IOException {
-    writeApplicationSerialized(namespaceId, appId, versionId, serialized, change, sourceControlMeta, true);
+    writeApplicationSerialized(namespaceId, appId, versionId, serialized, change, true);
   }
 
   private void writeApplicationSerialized(String namespaceId, String appId, String versionId,
-      String serialized, @Nullable ChangeDetail change,
-      @Nullable SourceControlMeta sourceControlMeta, boolean markAsLatest)
+      String serialized, @Nullable ChangeDetail change, boolean markAsLatest)
       throws IOException {
     List<Field<?>> fields = getApplicationPrimaryKeys(namespaceId, appId, versionId);
     fields.add(
@@ -2567,11 +2719,6 @@ public class AppMetadataStore {
           change.getDescription()));
     }
     fields.add(Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, markAsLatest));
-
-    if (sourceControlMeta != null) {
-      fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.SOURCE_CONTROL_META,
-          GSON.toJson(sourceControlMeta)));
-    }
     getApplicationSpecificationTable().upsert(fields);
   }
 
@@ -2649,10 +2796,6 @@ public class AppMetadataStore {
     ApplicationMeta meta = GSON.fromJson(
         row.getString(StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD),
         ApplicationMeta.class);
-    SourceControlMeta sourceControl = GSON.fromJson(
-        row.getString(StoreDefinition.AppMetadataStore.SOURCE_CONTROL_META),
-        SourceControlMeta.class);
-
     ApplicationSpecification spec = meta.getSpec();
     String id = meta.getId();
     ChangeDetail changeDetail;
@@ -2662,7 +2805,7 @@ public class AppMetadataStore {
       changeDetail = new ChangeDetail(changeSummary, null, author, creationTimeMillis, latest);
     }
 
-    return new ApplicationMeta(id, spec, changeDetail, sourceControl);
+    return new ApplicationMeta(id, spec, changeDetail);
   }
 
   private void writeToStructuredTableWithPrimaryKeys(
@@ -2898,9 +3041,7 @@ public class AppMetadataStore {
         this.changeDetail = new ChangeDetail(changeSummary, null, author, creationTimeMillis,
             latest);
       }
-      this.sourceControlMeta = GSON.fromJson(
-          row.getString(StoreDefinition.AppMetadataStore.SOURCE_CONTROL_META),
-          SourceControlMeta.class);
+      this.sourceControlMeta = null;
     }
 
     @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/SourceControlMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/SourceControlMetadataStore.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
+import io.cdap.cdap.spi.data.StructuredRow;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.StructuredTableContext;
+import io.cdap.cdap.spi.data.TableNotFoundException;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.store.StoreDefinition;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/**
+ * Store for namespace and repository source control metadata.
+ */
+public class SourceControlMetadataStore {
+
+  private StructuredTable namespaceSourceControlMetadataTable;
+  private final StructuredTableContext context;
+
+  public static SourceControlMetadataStore create(StructuredTableContext context) {
+    return new SourceControlMetadataStore(context);
+  }
+
+  private SourceControlMetadataStore(StructuredTableContext context) {
+    this.context = context;
+  }
+
+  private StructuredTable getNamespaceSourceControlMetadataTable() {
+    try {
+      if (namespaceSourceControlMetadataTable == null) {
+        namespaceSourceControlMetadataTable = context.getTable(
+            StoreDefinition.NamespaceSourceControlMetadataStore.NAMESPACE_SOURCE_CONTROL_METADATA);
+      }
+    } catch (TableNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+    return namespaceSourceControlMetadataTable;
+  }
+
+  /**
+   * Retrieves the source control metadata for the specified application ID in the namespace from
+   * {@code NamespaceSourceControlMetadata} table.
+   *
+   * @param appId {@link ApplicationId} for which the source control metadata is being retrieved.
+   * @return The {@link SourceControlMeta} associated with the application ID, or {@code null} if no
+   *         metadata is found.
+   * @throws IOException If it fails to read the metadata.
+   */
+  @Nullable
+  public SourceControlMeta get(ApplicationId appId) throws IOException {
+    List<Field<?>> primaryKey = getPrimaryKey(appId);
+    StructuredTable table = getNamespaceSourceControlMetadataTable();
+    Optional<StructuredRow> row = table.read(primaryKey);
+
+    return row.map(nonNullRow -> {
+      String specificationHash = nonNullRow.getString(
+          StoreDefinition.NamespaceSourceControlMetadataStore.SPECIFICATION_HASH_FIELD);
+      String commitId = nonNullRow.getString(
+          StoreDefinition.NamespaceSourceControlMetadataStore.COMMIT_ID_FIELD);
+      Long lastSynced = nonNullRow.getLong(
+          StoreDefinition.NamespaceSourceControlMetadataStore.LAST_MODIFIED_FIELD);
+      if (specificationHash == null && commitId == null && lastSynced == 0L) {
+        return null;
+      }
+      return new SourceControlMeta(specificationHash, commitId, Instant.ofEpochMilli(lastSynced));
+    }).orElse(null);
+  }
+
+
+  /**
+   * Sets the source control metadata for the specified application ID in the namespace.  Source
+   * control metadata will be null when the application is deployed in the namespace. It will be
+   * non-null when the application is pulled from the remote repository and deployed in the
+   * namespace.
+   *
+   * @param appId             {@link ApplicationId} for which the source control metadata is being
+   *                          set.
+   * @param sourceControlMeta The {@link SourceControlMeta} to be set. Can be {@code null} if
+   *                          application is just deployed.
+   * @throws IOException If failed to write the data.
+   */
+  public void write(ApplicationId appId,
+      @Nullable SourceControlMeta sourceControlMeta)
+      throws IOException {
+    // In the Namespace Pipelines page, the sync status (SYNCED or UNSYNCED)
+    // and last modified of all the applications deployed in the namespace needs to be shown.
+    // If source control information is not added when the app is deployed, the data will
+    // split into two tables.
+    // JOIN operation is not currently supported yet. The filtering (eg,
+    // filter on UNSYNCED sync status) , sorting, searching , pagination becomes difficult.
+    // Instead of doing filtering, searching, sorting in memory, it will happen at
+    // database level.
+    StructuredTable scmTable = getNamespaceSourceControlMetadataTable();
+    scmTable.upsert(getNamespaceSourceControlMetaFields(appId, sourceControlMeta));
+  }
+
+  /**
+   * Deletes the source control metadata associated with the specified application ID from the
+   * namespace.
+   *
+   * @param appId {@link ApplicationId} whose source control metadata is to be deleted.
+   * @throws IOException if it failed to read or delete the metadata
+   */
+  public void delete(ApplicationId appId) throws IOException {
+    getNamespaceSourceControlMetadataTable().delete(getPrimaryKey(appId));
+  }
+
+  /**
+   * Deletes all rows of source control metadata within the specified namespace.
+   *
+   * @param namespace The namespace for which all source control metadata rows are to be deleted.
+   * @throws IOException if it failed to read or delete the metadata.
+   */
+  public void deleteAll(String namespace) throws IOException {
+    getNamespaceSourceControlMetadataTable().deleteAll(getNamespaceRange(namespace));
+  }
+
+  private Collection<Field<?>> getNamespaceSourceControlMetaFields(ApplicationId appId,
+      SourceControlMeta scmMeta) throws IOException {
+    List<Field<?>> fields = getPrimaryKey(appId);
+    fields.add(Fields.stringField(
+        StoreDefinition.NamespaceSourceControlMetadataStore.SPECIFICATION_HASH_FIELD,
+        scmMeta == null ? "" : scmMeta.getFileHash()));
+    fields.add(
+        Fields.stringField(StoreDefinition.NamespaceSourceControlMetadataStore.COMMIT_ID_FIELD,
+            scmMeta == null ? "" : scmMeta.getCommitId()));
+    // Whenever an app is deployed, the expected behavior is that the last modified field will be
+    // retained and not reset.
+    Long lastModified = 0L;
+    if (scmMeta != null) {
+      lastModified = scmMeta.getLastSyncedAt().toEpochMilli();
+    } else {
+      SourceControlMeta sourceControlMeta = get(appId);
+      if (sourceControlMeta != null) {
+        lastModified = sourceControlMeta.getLastSyncedAt().toEpochMilli();
+      }
+    }
+    fields.add(
+        Fields.longField(StoreDefinition.NamespaceSourceControlMetadataStore.LAST_MODIFIED_FIELD,
+            lastModified));
+    fields.add(
+        Fields.booleanField(StoreDefinition.NamespaceSourceControlMetadataStore.IS_SYNCED_FIELD,
+            scmMeta == null ? false : true));
+    return fields;
+  }
+
+  private List<Field<?>> getPrimaryKey(ApplicationId appId) {
+    List<Field<?>> primaryKey = new ArrayList<>();
+    primaryKey.add(
+        Fields.stringField(StoreDefinition.NamespaceSourceControlMetadataStore.NAMESPACE_FIELD,
+            appId.getNamespace()));
+    primaryKey.add(
+        Fields.stringField(StoreDefinition.NamespaceSourceControlMetadataStore.TYPE_FIELD,
+            appId.getEntityType().toString()));
+    primaryKey.add(
+        Fields.stringField(StoreDefinition.NamespaceSourceControlMetadataStore.NAME_FIELD,
+            appId.getEntityName()));
+    return primaryKey;
+  }
+
+  private Range getNamespaceRange(String namespaceId) {
+    return Range.singleton(
+        ImmutableList.of(
+            Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD, namespaceId)));
+  }
+
+  /**
+   * Deletes all rows from the namespace source control metadata table. Only to be used in testing.
+   *
+   * @throws IOException If an I/O error occurs while deleting the metadata.
+   */
+  @VisibleForTesting
+  void deleteNamespaceSourceControlMetadataTable() throws IOException {
+    getNamespaceSourceControlMetadataTable().deleteAll(
+        Range.from(ImmutableList.of(
+                Fields.stringField(
+                    StoreDefinition.NamespaceSourceControlMetadataStore.NAMESPACE_FIELD, "")),
+            Range.Bound.INCLUSIVE));
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
@@ -710,7 +710,12 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     // deploy an app, then update its scm meta
     deploy(AllProgramsApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
     ApplicationDetail applicationDetail = getAppDetails(TEST_NAMESPACE1, AllProgramsApp.NAME);
-    Assert.assertNull(applicationDetail.getSourceControlMeta());
+    // Changed the assertions because source control metadata was updated with a non-null value in
+    // test testUpdateSourceControlMetaWithDuplicateAppIds for a specific appId. In this test,
+    // we have deployed this appId, which makes file hash and commitId null but last synced value is retained
+    Assert.assertNull(applicationDetail.getSourceControlMeta().getFileHash());
+    Assert.assertNull(applicationDetail.getSourceControlMeta().getCommitId());
+    Assert.assertNotNull(applicationDetail.getSourceControlMeta().getLastSyncedAt());
 
     applicationLifecycleService.updateSourceControlMeta(
         new NamespaceId(TEST_NAMESPACE1),
@@ -733,7 +738,6 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     // deploy an app, then update its scm meta
     deploy(AllProgramsApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
     ApplicationDetail applicationDetail = getAppDetails(TEST_NAMESPACE1, AllProgramsApp.NAME);
-    Assert.assertNull(applicationDetail.getSourceControlMeta());
 
     applicationLifecycleService.updateSourceControlMeta(
         new NamespaceId(TEST_NAMESPACE1),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.artifact.ArtifactId;
 import io.cdap.cdap.app.store.ScanApplicationsRequest;
 import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.common.lang.FunctionWithException;
 import io.cdap.cdap.common.utils.ProjectInfo;
 import io.cdap.cdap.internal.AppFabricTestHelper;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
@@ -42,6 +43,7 @@ import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
 import io.cdap.cdap.spi.data.SortOrder;
 import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.table.field.Field;
@@ -963,9 +965,11 @@ public abstract class AppMetadataStoreTest {
     for (int i = 0; i < 30; i++) {
       appIds.add(NamespaceId.DEFAULT.app("test" + i));
     }
+    FunctionWithException<ApplicationId, SourceControlMeta, IOException> sourceControlRetriever
+        = appId -> new SourceControlMeta("fileHash", "commitId", Instant.now());
     Map<ApplicationId, ApplicationMeta> result = TransactionRunners.run(transactionRunner, context -> {
       AppMetadataStore store = AppMetadataStore.create(context);
-      return store.getApplicationsForAppIds(appIds);
+      return store.getApplicationsForAppIds(appIds, sourceControlRetriever);
     });
 
     Assert.assertEquals(20, result.size());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/NoSqlSourceControlMetadataTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/NoSqlSourceControlMetadataTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store;
+
+import com.google.inject.Injector;
+import io.cdap.cdap.internal.AppFabricTestHelper;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+public class NoSqlSourceControlMetadataTest extends SourceControlMetadataStoreTest {
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Injector injector = AppFabricTestHelper.getInjector();
+    AppFabricTestHelper.ensureNamespaceExists(NamespaceId.DEFAULT);
+    transactionRunner = injector.getInstance(TransactionRunner.class);
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    AppFabricTestHelper.shutdown();
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/SourceControlMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/SourceControlMetadataStoreTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store;
+
+import static org.junit.Assert.assertEquals;
+
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import java.time.Instant;
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class SourceControlMetadataStoreTest {
+
+  private static final String NAMESPACE = "testNamespace";
+  private static final String COMMIT_ID = "testCommitId";
+  private static final String SPEC_HASH = "testSpecHash";
+  private static final Instant LAST_MODIFIED = Instant.now();
+  private static final String NAME = "testName";
+  private static final ApplicationId APP_ID = new ApplicationId(NAMESPACE, NAME);
+  private static final SourceControlMeta SOURCE_CONTROL_META = new SourceControlMeta(SPEC_HASH,
+      COMMIT_ID, LAST_MODIFIED);
+
+  protected static TransactionRunner transactionRunner;
+
+  @Before
+  public void before() {
+    TransactionRunners.run(transactionRunner, context -> {
+      SourceControlMetadataStore store = SourceControlMetadataStore.create(context);
+      store.deleteNamespaceSourceControlMetadataTable();
+    });
+
+    TransactionRunners.run(transactionRunner, context -> {
+      SourceControlMetadataStore store = SourceControlMetadataStore.create(context);
+      store.write(APP_ID, SOURCE_CONTROL_META);
+    });
+  }
+
+  @Test
+  public void testSetNamespaceSourceControlMeta() throws Exception {
+    TransactionRunners.run(transactionRunner, context -> {
+      SourceControlMetadataStore store = SourceControlMetadataStore.create(context);
+      ApplicationId appId = new ApplicationId(NAMESPACE, "test2");
+      store.write(appId, SOURCE_CONTROL_META);
+      SourceControlMeta sourceControlMeta = store.get(appId);
+      assertEquals(SOURCE_CONTROL_META, sourceControlMeta);
+    });
+  }
+
+  @Test
+  public void testGetNamespaceSourceControlMeta() throws Exception {
+    TransactionRunners.run(transactionRunner, context -> {
+      SourceControlMetadataStore store = SourceControlMetadataStore.create(context);
+      SourceControlMeta scmMeta = store.get(APP_ID);
+      assertEquals(SOURCE_CONTROL_META, scmMeta);
+    });
+  }
+
+  @Test
+  public void testUpdateNamespaceSourceControlMeta() throws Exception {
+    SourceControlMeta newSourceControlMeta = new SourceControlMeta("newFileHash", "newCommitId",
+        Instant.now());
+    TransactionRunners.run(transactionRunner, context -> {
+      SourceControlMetadataStore store = SourceControlMetadataStore.create(context);
+      store.write(APP_ID, newSourceControlMeta);
+      SourceControlMeta scmMeta = store.get(APP_ID);
+      assertEquals(newSourceControlMeta, scmMeta);
+    });
+  }
+
+  @Test
+  public void testDeleteNamespaceSourceControlMetadata() throws Exception {
+    TransactionRunners.run(transactionRunner, context -> {
+      SourceControlMetadataStore store = SourceControlMetadataStore.create(context);
+      store.delete(APP_ID);
+      SourceControlMeta scmMeta = store.get(APP_ID);
+      assertEquals(null, scmMeta);
+    });
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/SqlSourceControlMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/SqlSourceControlMetadataStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 Cask Data, Inc.
+ * Copyright © 2024 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -39,10 +39,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.rules.TemporaryFolder;
 
-/**
- * Tests {@link AppMetadataStore} using SQL.
- */
-public class SqlAppMetadataStoreTest extends AppMetadataStoreTest {
+public class SqlSourceControlMetadataStoreTest extends SourceControlMetadataStoreTest {
 
   @ClassRule
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
@@ -54,21 +51,22 @@ public class SqlAppMetadataStoreTest extends AppMetadataStoreTest {
     CConfiguration cConf = CConfiguration.create();
     pg = PostgresInstantiator.createAndStart(cConf, TEMP_FOLDER.newFolder());
     Injector injector = Guice.createInjector(
-      new ConfigModule(cConf),
-      new LocalLocationModule(),
-      new SystemDatasetRuntimeModule().getInMemoryModules(),
-      new StorageModule(),
-      new AbstractModule() {
-        @Override
-        protected void configure() {
-          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class)
-              .in(Scopes.SINGLETON);
+        new ConfigModule(cConf),
+        new LocalLocationModule(),
+        new SystemDatasetRuntimeModule().getInMemoryModules(),
+        new StorageModule(),
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class)
+                .in(Scopes.SINGLETON);
+          }
         }
-      }
     );
 
     transactionRunner = injector.getInstance(TransactionRunner.class);
-    StoreDefinition.AppMetadataStore.create(injector.getInstance(StructuredTableAdmin.class));
+    StoreDefinition.NamespaceSourceControlMetadataStore.create(
+        injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/store/StoreDefinition.java
@@ -72,6 +72,8 @@ public final class StoreDefinition {
     AppStateStore.create(tableAdmin);
     CredentialProviderStore.create(tableAdmin);
     OperationRunsStore.create(tableAdmin);
+    NamespaceSourceControlMetadataStore.create(tableAdmin);
+    RepositorySourceControlMetadataStore.create(tableAdmin);
   }
 
   /**
@@ -176,6 +178,74 @@ public final class StoreDefinition {
 
     public static void create(StructuredTableAdmin tableAdmin) throws IOException {
       createIfNotExists(tableAdmin, PREFERENCES_TABLE_SPEC);
+    }
+  }
+
+  /**
+   * Schema for NamespaceSourceControlMetadata table. This table stores the source control metadata,
+   * i.e its file hash, commitID, last modified and sync status, of an entity within a namespace
+   */
+  public static final class NamespaceSourceControlMetadataStore {
+
+    public static final StructuredTableId NAMESPACE_SOURCE_CONTROL_METADATA =
+        new StructuredTableId("namespace_source_control_metadata");
+
+    public static final String NAMESPACE_FIELD = "namespace";
+    public static final String TYPE_FIELD = "type";
+    public static final String NAME_FIELD = "name";
+    public static final String SPECIFICATION_HASH_FIELD = "specification_hash";
+    public static final String COMMIT_ID_FIELD = "commit_id";
+    public static final String LAST_MODIFIED_FIELD = "last_modified";
+    public static final String IS_SYNCED_FIELD = "is_synced";
+
+    public static final StructuredTableSpecification NAMESPACE_SOURCE_CONTROL_METADATA_TABLE_SPEC =
+        new StructuredTableSpecification.Builder()
+        .withId(NAMESPACE_SOURCE_CONTROL_METADATA)
+        .withFields(Fields.stringType(NAMESPACE_FIELD),
+            Fields.stringType(TYPE_FIELD),
+            Fields.stringType(NAME_FIELD),
+            Fields.stringType(SPECIFICATION_HASH_FIELD),
+            Fields.stringType(COMMIT_ID_FIELD),
+            Fields.longType(LAST_MODIFIED_FIELD),
+            Fields.booleanType(IS_SYNCED_FIELD))
+        .withPrimaryKeys(NAMESPACE_FIELD, TYPE_FIELD, NAME_FIELD)
+        .withIndexes(IS_SYNCED_FIELD, LAST_MODIFIED_FIELD)
+        .build();
+
+    public static void create(StructuredTableAdmin tableAdmin) throws IOException {
+      createIfNotExists(tableAdmin, NAMESPACE_SOURCE_CONTROL_METADATA_TABLE_SPEC);
+    }
+  }
+
+  /**
+   * Schema for RespositorySourceControlMetadata table. This table stores the source control metadata,
+   * i.e its last modified and sync status, of an entity within the provided repository
+   */
+  public static final class RepositorySourceControlMetadataStore {
+
+    public static final StructuredTableId REPOSITORY_SOURCE_CONTROL_METADATA =
+        new StructuredTableId("repository_source_control_metadata");
+
+    public static final String NAMESPACE_FIELD = "namespace";
+    public static final String TYPE_FIELD = "type";
+    public static final String NAME_FIELD = "name";
+    public static final String LAST_MODIFIED_FIELD = "last_modified";
+    public static final String IS_SYNCED_FIELD = "is_synced";
+
+    public static final StructuredTableSpecification REPOSITORY_SOURCE_CONTROL_METADATA_TABLE_SPEC =
+        new StructuredTableSpecification.Builder()
+        .withId(REPOSITORY_SOURCE_CONTROL_METADATA)
+        .withFields(Fields.stringType(NAMESPACE_FIELD),
+            Fields.stringType(TYPE_FIELD),
+            Fields.stringType(NAME_FIELD),
+            Fields.longType(LAST_MODIFIED_FIELD),
+            Fields.booleanType(IS_SYNCED_FIELD))
+        .withPrimaryKeys(NAMESPACE_FIELD, TYPE_FIELD, NAME_FIELD)
+        .withIndexes(IS_SYNCED_FIELD, LAST_MODIFIED_FIELD)
+        .build();
+
+    public static void create(StructuredTableAdmin tableAdmin) throws IOException {
+      createIfNotExists(tableAdmin, REPOSITORY_SOURCE_CONTROL_METADATA_TABLE_SPEC);
     }
   }
 
@@ -1351,7 +1421,7 @@ public final class StoreDefinition {
                 Fields.longType(START_TIME_FIELD),
                 Fields.longType(UPDATE_TIME_FIELD),
                 Fields.stringType(DETAILS_FIELD)
-                )
+            )
             .withPrimaryKeys(NAMESPACE_FIELD, ID_FIELD)
             .withIndexes(TYPE_FIELD, STATUS_FIELD, START_TIME_FIELD)
             .build();

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/SortBy.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/SortBy.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto.sourcecontrol;
+
+/**
+ * Sort order options for namespace and repository pipelines.
+ */
+public enum SortBy {
+  PIPELINE_NAME, LAST_SYNCED_DATE
+}


### PR DESCRIPTION
- Added schema for SourceControlMetadata table. SourceControlMetadata won't be stored in AppSpec table anymore.  
- Added Schema for Repository Metadata table required for pagination of repository pipelines
- Added methods in SourceControlMetadataStore
- Modified AppMetadataStore to get/set sourceControlMetadata from/to the new table
- Added API schema for status API for namespace pipelines