### PR TITLE
[CDAP-20956] increase system worker request retry timeout

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteTaskExecutor.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteTaskExecutor.java
@@ -90,13 +90,15 @@ public class RemoteTaskExecutor {
     this.remoteClient = remoteClientFactory.createRemoteClient(serviceName,
         httpRequestConfig,
         Constants.Gateway.INTERNAL_API_VERSION_3);
-    this.retryStrategy = RetryStrategies.fromConfiguration(cConf,
-        Constants.Service.TASK_WORKER + ".");
     this.metricsCollectionService = metricsCollectionService;
     if (workerType == Type.TASK_WORKER) {
       this.workerUrl = TASK_WORKER_URL;
+      this.retryStrategy = RetryStrategies.fromConfiguration(cConf,
+          Constants.Service.TASK_WORKER + ".");
     } else {
       this.workerUrl = SYSTEM_WORKER_URL;
+      this.retryStrategy = RetryStrategies.fromConfiguration(cConf,
+          Constants.Service.SYSTEM_WORKER + ".");
     }
   }
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4251,6 +4251,51 @@
     </description>
   </property>
 
+  <!-- Retry configuration for system worker -->
+  <!-- Use an exponential delay that cap at 2 seconds interval -->
+  <property>
+    <name>system.worker.retry.policy.base.delay.ms</name>
+    <value>100</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>system.worker.retry.policy.max.delay.ms</name>
+    <value>2000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <!-- Set to Integer max value, so the retry attempts end based on task.worker.retry.policy.max.time.secs -->
+  <property>
+    <name>system.worker.retry.policy.max.retries</name>
+    <value>2147483647</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <!-- Set to 300s to match the default http request timeout -->
+  <property>
+    <name>system.worker.retry.policy.max.time.secs</name>
+    <value>300</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>system.worker.retry.policy.type</name>
+    <value>exponential.backoff</value>
+    <description>
+      The type of retry policy for programs. Allowed options:
+      "none", "fixed.delay", or "exponential.backoff".
+    </description>
+  </property>
+
   <!-- Retry configuration for artifact cache -->
   <!-- Use an exponential delay that cap at 2 seconds interval -->
   <property>


### PR DESCRIPTION
context: When system services is restarted when pipeline is still in starting state, it may take more than 3-4 min for system workers to come up since they start after Appfabric which also takes couple of mins.