### PR TITLE
CDAP-20969: Add support for gitlab as provider

### DIFF
--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/AuthType.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/AuthType.java
@@ -20,5 +20,5 @@ package io.cdap.cdap.proto.sourcecontrol;
  * Auth Type Enums.
  */
 public enum AuthType {
-  PAT;
+  PAT
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/Provider.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/Provider.java
@@ -20,5 +20,6 @@ package io.cdap.cdap.proto.sourcecontrol;
  * The Provider Enum.
  */
 public enum Provider {
-  GITHUB;
+  GITHUB,
+  GITLAB,
 }

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/AuthenticationStrategyProvider.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/AuthenticationStrategyProvider.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.sourcecontrol;
 
 import io.cdap.cdap.api.security.store.SecureStore;
 import io.cdap.cdap.proto.sourcecontrol.AuthType;
-import io.cdap.cdap.proto.sourcecontrol.Provider;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 
 /**
@@ -38,15 +37,13 @@ public class AuthenticationStrategyProvider {
    * Returns an {@link AuthenticationStrategy} for the given Git repository provider and auth type.
    *
    * @return an instance of {@link  AuthenticationStrategy}.
-   * @throws AuthenticationStrategyNotFoundException when the corresponding {@link
-   *     AuthenticationStrategy} is not found.
+   * @throws AuthenticationStrategyNotFoundException when the corresponding
+   *     {@link AuthenticationStrategy} is not found.
    */
   AuthenticationStrategy get(RepositoryConfig repoConfig) throws
       AuthenticationStrategyNotFoundException {
-    if (repoConfig.getProvider() == Provider.GITHUB) {
-      if (repoConfig.getAuth().getType() == AuthType.PAT) {
-        return new GitPatAuthenticationStrategy(secureStore, repoConfig, namespaceId);
-      }
+    if (repoConfig.getAuth().getType() == AuthType.PAT) {
+      return new PatAuthenticationStrategy(secureStore, repoConfig, namespaceId);
     }
     throw new AuthenticationStrategyNotFoundException(
         String.format("No strategy found for provider %s and type %s.",

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/PatAuthenticationStrategy.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/PatAuthenticationStrategy.java
@@ -18,6 +18,7 @@ package io.cdap.cdap.sourcecontrol;
 
 import com.google.common.base.Throwables;
 import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.proto.sourcecontrol.PatConfig;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -27,25 +28,25 @@ import org.eclipse.jgit.transport.URIish;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 
 /**
- * An {@link AuthenticationStrategy} to use with GitHub and Personal Access Tokens.
+ * An {@link AuthenticationStrategy} to use with GitHub/GitLab and Personal Access Tokens.
  */
-public class GitPatAuthenticationStrategy implements AuthenticationStrategy {
+public class PatAuthenticationStrategy implements AuthenticationStrategy {
 
-  private static final String GITHUB_PAT_USERNAME = "oauth2";
   private final SecureStorePasswordProvider credentialsProvider;
 
   /**
    * Construct a Git PAT auth strategy.
-
+   *
    * @param secureStore {@link SecureStore} to fetch the secrets with.
    * @param config {@link RepositoryConfig}
    * @param namespaceId the namespaceId
    */
-  public GitPatAuthenticationStrategy(SecureStore secureStore, RepositoryConfig config,
+  public PatAuthenticationStrategy(SecureStore secureStore, RepositoryConfig config,
       String namespaceId) {
+    PatConfig patConfig = config.getAuth().getPatConfig();
     this.credentialsProvider =
-        new SecureStorePasswordProvider(secureStore, GITHUB_PAT_USERNAME,
-            config.getAuth().getPatConfig().getPasswordName(), namespaceId);
+        new SecureStorePasswordProvider(secureStore, patConfig.getUsername(),
+            patConfig.getPasswordName(), namespaceId);
   }
 
   @Override

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/RepositoryManagerTest.java
@@ -110,7 +110,7 @@ public class RepositoryManagerTest extends SourceControlTestBase {
             .setLink(serverUrl + "ignored")
             .setDefaultBranch("develop")
             .setAuth(new AuthConfig(AuthType.PAT,
-                new PatConfig(PASSWORD_NAME + "invalid", null)))
+                new PatConfig(PASSWORD_NAME + "invalid", GIT_SERVER_USERNAME)))
             .build();
     SourceControlConfig sourceControlConfig = new SourceControlConfig(
         new NamespaceId(NAMESPACE),

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/SourceControlTestBase.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/SourceControlTestBase.java
@@ -50,7 +50,7 @@ public abstract class SourceControlTestBase {
   protected static final String MOCK_TOKEN = UUID.randomUUID().toString();
   protected static final String NAMESPACE = "namespace1";
   protected static final String PASSWORD_NAME = "github-pat";
-  protected static final PatConfig PAT_CONFIG = new PatConfig(PASSWORD_NAME, null);
+  protected static final PatConfig PAT_CONFIG = new PatConfig(PASSWORD_NAME, GIT_SERVER_USERNAME);
   protected static final AuthConfig AUTH_CONFIG = new AuthConfig(AuthType.PAT, PAT_CONFIG);
   protected static final String PATH_PREFIX = "pathPrefix";
   protected static final String TEST_APP_NAME = "app1";

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunnerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunnerTest.java
@@ -84,7 +84,8 @@ public class RemoteSourceControlOperationRunnerTest extends SourceControlTestBas
     new ArrayList<>(), new ArrayList<>(), null, null);
   private static final CommitMeta mockCommit = new CommitMeta("author", "commiter", System.currentTimeMillis(),
                                                               "commit");
-  private static final AuthConfig AUTH_CONFIG = new AuthConfig(AuthType.PAT, new PatConfig(PASSWORD_NAME, null));
+  private static final AuthConfig AUTH_CONFIG = new AuthConfig(AuthType.PAT,
+      new PatConfig(PASSWORD_NAME, GIT_SERVER_USERNAME));
   private static final AuthConfig NON_EXISTS_AUTH_CONFIG = new AuthConfig(
       AuthType.PAT, new PatConfig(PASSWORD_NAME + "not_exist", null));
   @ClassRule


### PR DESCRIPTION
JIRA: [CDAP-20969](https://cdap.atlassian.net/browse/CDAP-20969)

**Changes**
1. Added *gitlab* as provider
2. Removed the hardcoded username. Username can be anything in the git API calls (for both *gitlab* and *github*) and it makes sense to send the actual username customer provides so that in case of issues there might be logs in github/gitlab side to correlate.

**Testing**
- [x] Unit test updated
- [x] Verified connection manually for gitlab and github


[CDAP-20969]: https://cdap.atlassian.net/browse/CDAP-20969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ