### PR TITLE
retry maven deployment failures due to network issues

### DIFF
--- a/cdap-cli/pom.xml
+++ b/cdap-cli/pom.xml
@@ -312,6 +312,7 @@
                   <classifier>1</classifier>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -352,6 +353,7 @@
                   <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -392,6 +394,7 @@
                   <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-distributions/pom.xml
+++ b/cdap-distributions/pom.xml
@@ -151,6 +151,7 @@
                   <classifier>1</classifier>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -230,6 +231,7 @@
                   <file>${project.build.directory}/cdap_${package.version}-1_all.deb</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-gateway/pom.xml
+++ b/cdap-gateway/pom.xml
@@ -223,6 +223,7 @@
                   <classifier>1</classifier>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -263,6 +264,7 @@
                   <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -303,6 +305,7 @@
                   <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-hbase-compat-1.0-cdh/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh/pom.xml
@@ -372,6 +372,7 @@
                   <classifier>1</classifier>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -412,6 +413,7 @@
                   <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -452,6 +454,7 @@
                   <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
+++ b/cdap-hbase-compat-1.0-cdh5.5.0/pom.xml
@@ -372,6 +372,7 @@
                   <classifier>1</classifier>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -412,6 +413,7 @@
                   <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -452,6 +454,7 @@
                   <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-hbase-compat-1.0/pom.xml
+++ b/cdap-hbase-compat-1.0/pom.xml
@@ -358,6 +358,7 @@
                   <classifier>1</classifier>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -398,6 +399,7 @@
                   <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -438,6 +440,7 @@
                   <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-hbase-compat-1.1/pom.xml
+++ b/cdap-hbase-compat-1.1/pom.xml
@@ -358,6 +358,7 @@
                   <classifier>1</classifier>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -398,6 +399,7 @@
                   <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -438,6 +440,7 @@
                   <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
+++ b/cdap-hbase-compat-1.2-cdh5.7.0/pom.xml
@@ -371,6 +371,7 @@
                   <classifier>1</classifier>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -411,6 +412,7 @@
                   <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -451,6 +453,7 @@
                   <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-kafka/pom.xml
+++ b/cdap-kafka/pom.xml
@@ -142,6 +142,7 @@
                   <classifier>1</classifier>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -182,6 +183,7 @@
                   <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -222,6 +224,7 @@
                   <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -1093,6 +1093,7 @@
                   <classifier>1</classifier>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -1133,6 +1134,7 @@
                   <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -1173,6 +1175,7 @@
                   <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-security/pom.xml
+++ b/cdap-security/pom.xml
@@ -281,6 +281,7 @@
                   <classifier>1</classifier>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -321,6 +322,7 @@
                   <file>${project.build.directory}/${project.artifactId}_${package.version}-1_all.deb</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>
@@ -361,6 +363,7 @@
                   <file>${project.build.directory}/${project.artifactId}-${package.version}.tar.gz</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-standalone/pom.xml
+++ b/cdap-standalone/pom.xml
@@ -879,6 +879,7 @@
                   <file>${project.build.directory}/cdap-sandbox-${project.version}.zip</file>
                   <repositoryId>continuuity</repositoryId>
                   <url>${deploy.url}</url>
+                  <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                 </configuration>
               </execution>
             </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1858,6 +1858,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>2.8</version>
+        <configuration>
+        <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
ref: https://maven.apache.org/plugins/maven-deploy-plugin/examples/deploy-network-issues.html

context: `cdap-build` often fails on maven deploy step due to network failures.

example:

```
Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.2:deploy (injected-nexus-deploy) on project cdap-hbase-compat-1.1: Failed to retrieve remote metadata io.cdap.cdap:cdap-hbase-compat-1.1:6.9.5-SNAPSHOT/maven-metadata.xml: Could not transfer metadata io.cdap.cdap:cdap-hbase-compat-1.1:6.9.5-SNAPSHOT/maven-metadata.xml from/to sonatype.snapshots (https://oss.sonatype.org/content/repositories/snapshots): Transfer failed for https://oss.sonatype.org/content/repositories/snapshots/io/cdap/cdap/cdap-hbase-compat-1.1/6.9.5-SNAPSHOT/maven-metadata.xml 502 Bad Gateway -> [Help 1]
```