### PR TITLE
[CDAP-20819] Throw an exception in DefaultRuntimeJob when program fails

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/ProgramRunCompletionDetails.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/ProgramRunCompletionDetails.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import io.cdap.cdap.proto.ProgramRunStatus;
+import java.util.Objects;
+
+/**
+ * Information about the completion of a
+ * {@link io.cdap.cdap.app.program.Program} run managed by a
+ * {@link io.cdap.cdap.runtime.spi.runtimejob.RuntimeJob}.
+ */
+public class ProgramRunCompletionDetails {
+
+  private final long endTimestamp;
+  private final ProgramRunStatus endStatus;
+
+  public ProgramRunCompletionDetails(long endTimestamp, ProgramRunStatus endStatus) {
+    this.endTimestamp = endTimestamp;
+    this.endStatus = endStatus;
+  }
+
+  public long getEndTimestamp() {
+    return endTimestamp;
+  }
+
+  public ProgramRunStatus getEndStatus() {
+    return endStatus;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ProgramRunCompletionDetails)) {
+      return false;
+    }
+    ProgramRunCompletionDetails that = (ProgramRunCompletionDetails) o;
+    return endTimestamp == that.endTimestamp && endStatus == that.endStatus;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(endTimestamp, endStatus);
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
@@ -56,9 +56,9 @@ import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
 import io.cdap.cdap.internal.io.DatumReaderFactory;
 import io.cdap.cdap.internal.io.DatumWriterFactory;
 import io.cdap.cdap.internal.io.SchemaGenerator;
-import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
 import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
+import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.proto.Notification;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.id.NamespaceId;
@@ -440,7 +440,8 @@ public class RuntimeClientServiceTest {
     // Send a terminate program state first, wait for the service sees the state change,
     // then publish messages to other topics.
     programStateWriter.completed(PROGRAM_RUN_ID);
-    Tasks.waitFor(true, () -> runtimeClientService.getProgramFinishTime() >= 0,
+    Tasks.waitFor(true, () ->
+            runtimeClientService.getProgramCompletionDetails() != null,
         2, TimeUnit.SECONDS);
 
     for (String topic : nonStatusTopicNames) {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocJobMain.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocJobMain.java
@@ -55,7 +55,7 @@ public class DataprocJobMain {
   private static final Logger LOG = LoggerFactory.getLogger(DataprocJobMain.class);
 
   /**
-   * Main method to setup classpath and call the RuntimeJob.run() method.
+   * Main method to set up classpath and call the RuntimeJob.run() method.
    *
    * @param args the name of implementation of RuntimeJob class
    * @throws Exception any exception while running the job
@@ -111,14 +111,14 @@ public class DataprocJobMain {
     // Don't close the classloader since this is the main classloader,
     // which can be used for shutdown hook execution.
     // Closing it too early can result in NoClassDefFoundError in shutdown hook execution.
-    ClassLoader newCL = createContainerClassLoader(urls);
+    ClassLoader newCl = createContainerClassLoader(urls);
     CompletableFuture<?> completion = new CompletableFuture<>();
     try {
-      Thread.currentThread().setContextClassLoader(newCL);
+      Thread.currentThread().setContextClassLoader(newCl);
 
       // load environment class and create instance of it
       String dataprocEnvClassName = DataprocRuntimeEnvironment.class.getName();
-      Class<?> dataprocEnvClass = newCL.loadClass(dataprocEnvClassName);
+      Class<?> dataprocEnvClass = newCl.loadClass(dataprocEnvClassName);
       Object newDataprocEnvInstance = dataprocEnvClass.newInstance();
 
       try {
@@ -130,15 +130,14 @@ public class DataprocJobMain {
         initializeMethod.invoke(newDataprocEnvInstance, sparkCompat, launchMode);
 
         // call run() method on runtimeJobClass
-        Class<?> runEnvCls = newCL.loadClass(RuntimeJobEnvironment.class.getName());
-        Class<?> runnerCls = newCL.loadClass(runtimeJobClassName);
+        Class<?> runEnvCls = newCl.loadClass(RuntimeJobEnvironment.class.getName());
+        Class<?> runnerCls = newCl.loadClass(runtimeJobClassName);
         Method runMethod = runnerCls.getMethod("run", runEnvCls);
         Method stopMethod = runnerCls.getMethod("requestStop");
-
         Object runner = runnerCls.newInstance();
 
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-          // Request the runtime job to stop if it it hasn't been completed
+          // Request the runtime job to stop if it hasn't been completed.
           if (completion.isDone()) {
             return;
           }
@@ -171,7 +170,6 @@ public class DataprocJobMain {
   /**
    * This method will generate class path by adding following to urls to front of default
    * classpath:
-   *
    * expanded.resource.jar expanded.application.jar expanded.application.jar/lib/*.jar
    * expanded.application.jar/classes expanded.twill.jar expanded.twill.jar/lib/*.jar
    * expanded.twill.jar/classes
@@ -185,7 +183,7 @@ public class DataprocJobMain {
       if (file.equals(Constants.Files.RESOURCES_JAR)) {
         continue;
       }
-      urls.addAll(createClassPathURLs(jarDir));
+      urls.addAll(createClassPathUrls(jarDir));
     }
 
     // Add the system class path to the URL list
@@ -200,16 +198,16 @@ public class DataprocJobMain {
     return urls.toArray(new URL[0]);
   }
 
-  private static List<URL> createClassPathURLs(File dir) throws MalformedURLException {
+  private static List<URL> createClassPathUrls(File dir) throws MalformedURLException {
     List<URL> urls = new ArrayList<>();
     // add jar urls from lib under dir
-    addJarURLs(new File(dir, "lib"), urls);
+    addJarUrls(new File(dir, "lib"), urls);
     // add classes under dir
     urls.add(new File(dir, "classes").toURI().toURL());
     return urls;
   }
 
-  private static void addJarURLs(File dir, List<URL> result) throws MalformedURLException {
+  private static void addJarUrls(File dir, List<URL> result) throws MalformedURLException {
     File[] files = dir.listFiles(f -> f.getName().endsWith(".jar"));
     if (files == null) {
       return;
@@ -285,7 +283,7 @@ public class DataprocJobMain {
   }
 
   /**
-   * Creates a {@link ClassLoader} for the the job execution.
+   * Creates a {@link ClassLoader} for the job execution.
    */
   private static ClassLoader createContainerClassLoader(URL[] classpath) {
     String containerClassLoaderName = System.getProperty(Constants.TWILL_CONTAINER_CLASSLOADER);

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/ProgramRunFailureException.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/ProgramRunFailureException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.runtime.spi.runtimejob;
+
+/**
+ * An exception thrown to indicate that a Program launched by the
+ * {@link io.cdap.cdap.runtime.spi.runtimejob.RuntimeJob} completed gracefully,
+ * but finished with an unsuccessful status.
+ */
+public class ProgramRunFailureException extends RuntimeException {
+
+  public ProgramRunFailureException(String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
## [CDAP-20819](https://cdap.atlassian.net/browse/CDAP-20819)
When the program launched by the DefaultRuntimeJob completes with an unsuccessful status, throw an exception at the end. This informs the Main class that that the RuntimeJob has completed with a failure and the main class can propagate the exception and fail itself.

## Tested
Ran the changes with the ephemeral Dataproc provisioner, while setting very low memory sizes for executors and driver. Verified that the Dataproc job fails when the DataPipelineWorkflow fails.
![image](https://github.com/cdapio/cdap/assets/46515553/da0a1f44-b8f4-4d23-bb86-184b7e4fd9e4)

Also verified that the Dataproc job succeeds when the DataPipelineWorkflow completes successfully.

[CDAP-20819]: https://cdap.atlassian.net/browse/CDAP-20819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ