### PR TITLE
[CDAP-20832] Enable periodic restart when task workers are running concurrent requests

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceTest.java
@@ -36,6 +36,7 @@ import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.io.IOException;
+import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -44,6 +45,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -60,6 +62,7 @@ import org.junit.rules.TemporaryFolder;
  * Unit test for {@link TaskWorkerService}.
  */
 public class TaskWorkerServiceTest {
+
   @ClassRule
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
 
@@ -91,9 +94,11 @@ public class TaskWorkerServiceTest {
 
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     TaskWorkerService taskWorkerService = new TaskWorkerService(
-      cConf, sConf, discoveryService, discoveryService, metricsCollectionService,
-      new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
-    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);
+        cConf, sConf, discoveryService, discoveryService,
+        metricsCollectionService,
+        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
+        taskWorkerService);
     // start the service
     taskWorkerService.startAndWait();
     this.taskWorkerService = taskWorkerService;
@@ -116,9 +121,11 @@ public class TaskWorkerServiceTest {
 
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     TaskWorkerService taskWorkerService = new TaskWorkerService(
-      cConf, sConf, discoveryService, discoveryService, metricsCollectionService,
-      new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
-    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);
+        cConf, sConf, discoveryService, discoveryService,
+        metricsCollectionService,
+        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
+        taskWorkerService);
     // start the service
     taskWorkerService.startAndWait();
 
@@ -135,24 +142,28 @@ public class TaskWorkerServiceTest {
 
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     TaskWorkerService taskWorkerService = new TaskWorkerService(
-      cConf, sConf, discoveryService, discoveryService, metricsCollectionService,
-      new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
-    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);
+        cConf, sConf, discoveryService, discoveryService,
+        metricsCollectionService,
+        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
+        taskWorkerService);
     // start the service
     taskWorkerService.startAndWait();
 
     InetSocketAddress addr = taskWorkerService.getBindAddress();
-    URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
+    URI uri = URI.create(
+        String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
 
     // Post valid request
     String want = "5000";
-    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName())
+    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(
+            TestRunnableClass.class.getName())
         .withParam(want).withNamespace("testNamespace").build();
     String reqBody = GSON.toJson(req);
     HttpResponse response = HttpRequests.execute(
-      HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-        .withBody(reqBody).build(),
-      new DefaultHttpRequestConfig(false));
+        HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
+            .withBody(reqBody).build(),
+        new DefaultHttpRequestConfig(false));
 
     Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
     Assert.assertEquals(want, response.getResponseBodyAsString());
@@ -161,11 +172,12 @@ public class TaskWorkerServiceTest {
   }
 
   @Test
-  public void testPeriodicRestartWithNeverEndingInflightRequest() throws IOException {
+  public void testPeriodicRestartWithNeverEndingInflightRequest() {
     CConfiguration cConf = createCConf();
     SConfiguration sConf = createSConf();
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 10);
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 2);
+    cConf.setInt(TaskWorker.TASK_EXECUTION_DEADLINE_SECOND, -1);
 
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     TaskWorkerService taskWorkerService =
@@ -176,18 +188,21 @@ public class TaskWorkerServiceTest {
             discoveryService,
             metricsCollectionService,
             new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
-    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);
+    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
+        taskWorkerService);
     // start the service
     taskWorkerService.startAndWait();
 
     new Thread(
         () -> {
           InetSocketAddress addr = taskWorkerService.getBindAddress();
-          URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
+          URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(),
+              addr.getPort()));
           // Post valid request
           RunnableTaskRequest req =
               RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName())
                   .withParam("200000")
+                  .withNamespace("testNamespace")
                   .build();
           String reqBody = GSON.toJson(req);
           try {
@@ -205,6 +220,7 @@ public class TaskWorkerServiceTest {
     TaskWorkerTestUtil.waitForServiceCompletion(serviceCompletionFuture);
     Assert.assertEquals(Service.State.TERMINATED, taskWorkerService.state());
   }
+
   @Test
   public void testRestartAfterMultipleExecutions() throws IOException {
     CConfiguration cConf = createCConf();
@@ -214,29 +230,33 @@ public class TaskWorkerServiceTest {
 
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     TaskWorkerService taskWorkerService = new TaskWorkerService(
-      cConf, sConf, discoveryService, discoveryService, metricsCollectionService,
-      new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
-    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);
+        cConf, sConf, discoveryService, discoveryService,
+        metricsCollectionService,
+        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
+        taskWorkerService);
     // start the service
     taskWorkerService.startAndWait();
 
     InetSocketAddress addr = taskWorkerService.getBindAddress();
-    URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
+    URI uri = URI.create(
+        String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
 
     // Post valid request
     String want = "100";
-    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName())
+    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(
+            TestRunnableClass.class.getName())
         .withParam(want).withNamespace("testNamespace").build();
     String reqBody = GSON.toJson(req);
-    HttpResponse response = HttpRequests.execute(
-      HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-        .withBody(reqBody).build(),
-      new DefaultHttpRequestConfig(false));
+    HttpRequests.execute(
+        HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
+            .withBody(reqBody).build(),
+        new DefaultHttpRequestConfig(false));
 
-    response = HttpRequests.execute(
-      HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-        .withBody(reqBody).build(),
-      new DefaultHttpRequestConfig(false));
+    HttpRequests.execute(
+        HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
+            .withBody(reqBody).build(),
+        new DefaultHttpRequestConfig(false));
 
     TaskWorkerTestUtil.waitForServiceCompletion(serviceCompletionFuture);
     Assert.assertEquals(Service.State.TERMINATED, taskWorkerService.state());
@@ -245,17 +265,19 @@ public class TaskWorkerServiceTest {
   @Test
   public void testStartAndStopWithValidRequest() throws IOException {
     InetSocketAddress addr = taskWorkerService.getBindAddress();
-    URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
+    URI uri = URI.create(
+        String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
 
     // Post valid request
     String want = "100";
-    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName())
+    RunnableTaskRequest req = RunnableTaskRequest.getBuilder(
+            TestRunnableClass.class.getName())
         .withParam(want).withNamespace("testNamespace").build();
     String reqBody = GSON.toJson(req);
     HttpResponse response = HttpRequests.execute(
-      HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-        .withBody(reqBody).build(),
-      new DefaultHttpRequestConfig(false));
+        HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
+            .withBody(reqBody).build(),
+        new DefaultHttpRequestConfig(false));
     TaskWorkerTestUtil.waitForServiceCompletion(serviceCompletionFuture);
     Assert.assertEquals(HttpURLConnection.HTTP_OK, response.getResponseCode());
     Assert.assertEquals(want, response.getResponseBodyAsString());
@@ -265,20 +287,24 @@ public class TaskWorkerServiceTest {
   @Test
   public void testStartAndStopWithInvalidRequest() throws Exception {
     InetSocketAddress addr = taskWorkerService.getBindAddress();
-    URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
+    URI uri = URI.create(
+        String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
 
     // Post invalid request
     RunnableTaskRequest noClassReq = RunnableTaskRequest.getBuilder("NoClass")
         .withNamespace("testNamespace").withParam("100").build();
     String reqBody = GSON.toJson(noClassReq);
     HttpResponse response = HttpRequests.execute(
-      HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-        .withBody(reqBody).build(),
-      new DefaultHttpRequestConfig(false));
-    Assert.assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, response.getResponseCode());
+        HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
+            .withBody(reqBody).build(),
+        new DefaultHttpRequestConfig(false));
+    Assert.assertEquals(HttpURLConnection.HTTP_BAD_REQUEST,
+        response.getResponseCode());
     BasicThrowable basicThrowable;
-    basicThrowable = GSON.fromJson(response.getResponseBodyAsString(), BasicThrowable.class);
-    Assert.assertTrue(basicThrowable.getClassName().contains("java.lang.ClassNotFoundException"));
+    basicThrowable = GSON.fromJson(response.getResponseBodyAsString(),
+        BasicThrowable.class);
+    Assert.assertTrue(basicThrowable.getClassName()
+        .contains("java.lang.ClassNotFoundException"));
     Assert.assertNotNull(basicThrowable.getMessage());
     Assert.assertTrue(basicThrowable.getMessage().contains("NoClass"));
     Assert.assertNotEquals(basicThrowable.getStackTraces().length, 0);
@@ -300,18 +326,20 @@ public class TaskWorkerServiceTest {
 
     for (int i = 0; i < concurrentRequests; i++) {
       calls.add(
-        () -> HttpRequests.execute(
-          HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-            .withBody(reqBody).build(),
-          new DefaultHttpRequestConfig(false))
+          () -> HttpRequests.execute(
+              HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
+                  .withBody(reqBody).build(),
+              new DefaultHttpRequestConfig(false))
       );
     }
 
-    List<Future<HttpResponse>> responses = Executors.newFixedThreadPool(concurrentRequests).invokeAll(calls);
+    List<Future<HttpResponse>> responses = Executors.newFixedThreadPool(
+        concurrentRequests).invokeAll(calls);
     int okResponse = 0;
     int conflictResponse = 0;
     for (int i = 0; i < concurrentRequests; i++) {
-      if (responses.get(i).get().getResponseCode() == HttpResponseStatus.OK.code()) {
+      if (responses.get(i).get().getResponseCode()
+          == HttpResponseStatus.OK.code()) {
         okResponse++;
       } else if (responses.get(i).get().getResponseCode()
                  == HttpResponseStatus.TOO_MANY_REQUESTS.code()) {
@@ -371,7 +399,7 @@ public class TaskWorkerServiceTest {
     }
     // Verify that the task worker service doesn't stop automatically.
     try {
-      Tasks.waitFor(false, () -> taskWorkerService.isRunning(), 1,
+      Tasks.waitFor(false, taskWorkerService::isRunning, 1,
           TimeUnit.SECONDS);
       Assert.fail();
     } catch (TimeoutException e) {
@@ -380,6 +408,81 @@ public class TaskWorkerServiceTest {
     taskWorkerService.stopAndWait();
     Assert.assertEquals(2, okResponse);
     Assert.assertEquals(concurrentRequests, okResponse + conflictResponse);
+    Assert.assertEquals(Service.State.TERMINATED, taskWorkerService.state());
+  }
+
+  @Test
+  public void testRestartWithConcurrentRequests() throws Exception {
+    CConfiguration cConf = createCConf();
+    cConf.setInt(TaskWorker.REQUEST_LIMIT, 3);
+    cConf.setBoolean(TaskWorker.USER_CODE_ISOLATION_ENABLED, false);
+    cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 2);
+    cConf.setInt(Constants.TaskWorker.TASK_EXECUTION_DEADLINE_SECOND, 1);
+    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
+    TaskWorkerService taskWorkerService = new TaskWorkerService(cConf,
+        createSConf(), discoveryService, discoveryService,
+        metricsCollectionService,
+        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
+        taskWorkerService);
+    taskWorkerService.startAndWait();
+    InetSocketAddress addr = taskWorkerService.getBindAddress();
+    URI uri = URI.create(
+        String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
+
+    List<Callable<HttpResponse>> calls = new ArrayList<>();
+    int concurrentRequests = 2;
+
+    for (int i = 0; i < concurrentRequests; i++) {
+      RunnableTaskRequest request = RunnableTaskRequest.getBuilder(
+              TestRunnableClass.class.getName())
+          .withParam("100").withNamespace("testNamespace").build();
+      calls.add(
+          () -> HttpRequests.execute(
+              HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
+                  .withBody(GSON.toJson(request)).build(),
+              new DefaultHttpRequestConfig(false))
+      );
+    }
+
+    // Send a request that never ends.
+    RunnableTaskRequest slowRequest = RunnableTaskRequest.getBuilder(
+            TestRunnableClass.class.getName())
+        .withParam("1000000").withNamespace("testNamespace").build();
+
+    calls.add(
+        () -> HttpRequests.execute(
+            HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
+                .withBody(GSON.toJson(slowRequest)).build(),
+            new DefaultHttpRequestConfig(false))
+    );
+
+    List<Future<HttpResponse>> responses = Executors.newFixedThreadPool(
+        concurrentRequests).invokeAll(calls);
+
+    int okResponse = 0;
+    int connectionRefusedCount = 0;
+    for (Future<HttpResponse> response : responses) {
+      try {
+        final int responseCode = response.get().getResponseCode();
+        if (responseCode == HttpResponseStatus.OK.code()) {
+          okResponse++;
+        }
+      } catch (ExecutionException ex) {
+        if (ex.getCause() instanceof ConnectException) {
+          connectionRefusedCount++;
+        } else {
+          throw ex;
+        }
+      }
+    }
+
+    // Verify that the task worker service has stopped automatically.
+    Assert.assertEquals(2, okResponse);
+    // The slow request will receive a "connection refused" response once the task
+    // worker service stops.
+    Assert.assertEquals(connectionRefusedCount, 1);
+    TaskWorkerTestUtil.waitForServiceCompletion(serviceCompletionFuture);
     Assert.assertEquals(Service.State.TERMINATED, taskWorkerService.state());
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceTest.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.internal.app.worker;
 
-import com.google.common.base.Strings;
 import com.google.common.util.concurrent.Service;
 import com.google.gson.Gson;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
@@ -37,7 +36,6 @@ import io.cdap.common.http.HttpRequests;
 import io.cdap.common.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.io.IOException;
-import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -46,8 +44,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -55,6 +51,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.twill.discovery.InMemoryDiscoveryService;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -72,7 +69,7 @@ public class TaskWorkerServiceTest {
   private TaskWorkerService taskWorkerService;
   private CompletableFuture<Service.State> serviceCompletionFuture;
 
-  private CConfiguration createCconf() {
+  private CConfiguration createCConf() {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(Constants.TaskWorker.ADDRESS, "localhost");
     cConf.setInt(Constants.TaskWorker.PORT, 0);
@@ -83,20 +80,20 @@ public class TaskWorkerServiceTest {
     return cConf;
   }
 
-  private SConfiguration createSconf() {
+  private SConfiguration createSConf() {
     return SConfiguration.create();
   }
 
-  private void startServiceForTest() {
-    CConfiguration cConf = createCconf();
-    SConfiguration sConf = createSconf();
+  @Before
+  public void beforeTest() {
+    CConfiguration cConf = createCConf();
+    SConfiguration sConf = createSConf();
 
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
-    TaskWorkerService taskWorkerService = new TaskWorkerService(cConf, sConf,
-        discoveryService, discoveryService, metricsCollectionService,
-        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
-    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
-        taskWorkerService);
+    TaskWorkerService taskWorkerService = new TaskWorkerService(
+      cConf, sConf, discoveryService, discoveryService, metricsCollectionService,
+      new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+    serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);
     // start the service
     taskWorkerService.startAndWait();
     this.taskWorkerService = taskWorkerService;
@@ -112,8 +109,8 @@ public class TaskWorkerServiceTest {
 
   @Test
   public void testPeriodicRestart() {
-    CConfiguration cConf = createCconf();
-    SConfiguration sConf = createSconf();
+    CConfiguration cConf = createCConf();
+    SConfiguration sConf = createSConf();
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 1);
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 5);
 
@@ -131,8 +128,8 @@ public class TaskWorkerServiceTest {
 
   @Test
   public void testPeriodicRestartWithInflightRequest() throws IOException {
-    CConfiguration cConf = createCconf();
-    SConfiguration sConf = createSconf();
+    CConfiguration cConf = createCConf();
+    SConfiguration sConf = createSConf();
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 10);
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 4);
 
@@ -165,8 +162,8 @@ public class TaskWorkerServiceTest {
 
   @Test
   public void testPeriodicRestartWithNeverEndingInflightRequest() throws IOException {
-    CConfiguration cConf = createCconf();
-    SConfiguration sConf = createSconf();
+    CConfiguration cConf = createCConf();
+    SConfiguration sConf = createSConf();
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 10);
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 2);
 
@@ -208,11 +205,10 @@ public class TaskWorkerServiceTest {
     TaskWorkerTestUtil.waitForServiceCompletion(serviceCompletionFuture);
     Assert.assertEquals(Service.State.TERMINATED, taskWorkerService.state());
   }
-
   @Test
   public void testRestartAfterMultipleExecutions() throws IOException {
-    CConfiguration cConf = createCconf();
-    SConfiguration sConf = createSconf();
+    CConfiguration cConf = createCConf();
+    SConfiguration sConf = createSConf();
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_REQUEST_COUNT, 2);
     cConf.setInt(Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 0);
 
@@ -232,12 +228,12 @@ public class TaskWorkerServiceTest {
     RunnableTaskRequest req = RunnableTaskRequest.getBuilder(TestRunnableClass.class.getName())
         .withParam(want).withNamespace("testNamespace").build();
     String reqBody = GSON.toJson(req);
-    HttpRequests.execute(
+    HttpResponse response = HttpRequests.execute(
       HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
         .withBody(reqBody).build(),
       new DefaultHttpRequestConfig(false));
 
-    HttpRequests.execute(
+    response = HttpRequests.execute(
       HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
         .withBody(reqBody).build(),
       new DefaultHttpRequestConfig(false));
@@ -248,7 +244,6 @@ public class TaskWorkerServiceTest {
 
   @Test
   public void testStartAndStopWithValidRequest() throws IOException {
-    startServiceForTest();
     InetSocketAddress addr = taskWorkerService.getBindAddress();
     URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
 
@@ -269,7 +264,6 @@ public class TaskWorkerServiceTest {
 
   @Test
   public void testStartAndStopWithInvalidRequest() throws Exception {
-    startServiceForTest();
     InetSocketAddress addr = taskWorkerService.getBindAddress();
     URI uri = URI.create(String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
 
@@ -292,7 +286,6 @@ public class TaskWorkerServiceTest {
 
   @Test
   public void testConcurrentRequestsWithIsolationEnabled() throws Exception {
-    startServiceForTest();
     InetSocketAddress addr = taskWorkerService.getBindAddress();
     URI uri = URI.create(
         String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
@@ -333,12 +326,12 @@ public class TaskWorkerServiceTest {
 
   @Test
   public void testConcurrentRequestsWithIsolationDisabled() throws Exception {
-    CConfiguration cConf = createCconf();
+    CConfiguration cConf = createCConf();
     cConf.setInt(TaskWorker.REQUEST_LIMIT, 2);
     cConf.setBoolean(TaskWorker.USER_CODE_ISOLATION_ENABLED, false);
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     TaskWorkerService taskWorkerService = new TaskWorkerService(cConf,
-        createSconf(), discoveryService, discoveryService,
+        createSConf(), discoveryService, discoveryService,
         metricsCollectionService,
         new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
     taskWorkerService.startAndWait();
@@ -378,7 +371,7 @@ public class TaskWorkerServiceTest {
     }
     // Verify that the task worker service doesn't stop automatically.
     try {
-      Tasks.waitFor(false, taskWorkerService::isRunning, 1,
+      Tasks.waitFor(false, () -> taskWorkerService.isRunning(), 1,
           TimeUnit.SECONDS);
       Assert.fail();
     } catch (TimeoutException e) {
@@ -390,196 +383,11 @@ public class TaskWorkerServiceTest {
     Assert.assertEquals(Service.State.TERMINATED, taskWorkerService.state());
   }
 
-  @Test
-  public void testTaskExceededDeadlineAndStopped() throws Exception {
-    CConfiguration cConf = createCconf();
-    cConf.setInt(TaskWorker.REQUEST_LIMIT, 2);
-    cConf.setBoolean(TaskWorker.USER_CODE_ISOLATION_ENABLED, false);
-    cConf.setInt(TaskWorker.TASK_EXECUTION_DEADLINE_SECOND, 1);
-
-    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
-    TaskWorkerService taskWorkerService = new TaskWorkerService(cConf,
-        createSconf(), discoveryService, discoveryService,
-        metricsCollectionService,
-        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
-    taskWorkerService.startAndWait();
-    InetSocketAddress addr = taskWorkerService.getBindAddress();
-    URI uri = URI.create(
-        String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
-
-    RunnableTaskRequest request1 = RunnableTaskRequest.getBuilder(
-            TestRunnableClass.class.getName()).withParam("500")
-        .withNamespace("testNamespace").build();
-
-    RunnableTaskRequest request2 = RunnableTaskRequest.getBuilder(
-            TestRunnableClass.class.getName()).withParam("30000")
-        .withNamespace("testNamespace").build();
-
-    List<Callable<HttpResponse>> calls = new ArrayList<>();
-    calls.add(() -> HttpRequests.execute(
-        HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-            .withBody(GSON.toJson(request1)).build(),
-        new DefaultHttpRequestConfig(false)));
-
-    calls.add(() -> HttpRequests.execute(
-        HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-            .withBody(GSON.toJson(request2)).build(),
-        new DefaultHttpRequestConfig(false)));
-
-    List<Future<HttpResponse>> responses = Executors.newFixedThreadPool(2)
-        .invokeAll(calls);
-    int okResponse = 0;
-    int connectionRefusedCount = 0;
-    for (int i = 0; i < 2; i++) {
-      try {
-        final int responseCode = responses.get(i).get().getResponseCode();
-        if (responseCode == HttpResponseStatus.OK.code()) {
-          okResponse++;
-        }
-      } catch (ExecutionException ex) {
-        if (ex.getCause() instanceof ConnectException) {
-          connectionRefusedCount++;
-        } else {
-          throw ex;
-        }
-      }
-    }
-
-    Tasks.waitFor(false, taskWorkerService::isRunning, 3,
-        TimeUnit.SECONDS);
-    // The task that completes within the deadline should be successful.
-    Assert.assertEquals(1, okResponse);
-    // The task that exceeds the deadline should have the connection broken due
-    // to the task worker service stopping.
-    Assert.assertEquals(1, connectionRefusedCount);
-  }
-
-  @Test
-  public void testStopAfterLameDuckMode() throws Exception {
-    CConfiguration cConf = createCconf();
-    cConf.setInt(TaskWorker.REQUEST_LIMIT, 5);
-    cConf.setBoolean(TaskWorker.USER_CODE_ISOLATION_ENABLED, false);
-    cConf.setInt(TaskWorker.TASK_EXECUTION_DEADLINE_SECOND, 1);
-
-    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
-    TaskWorkerService taskWorkerService = new TaskWorkerService(cConf,
-        createSconf(), discoveryService, discoveryService,
-        metricsCollectionService,
-        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
-    taskWorkerService.startAndWait();
-    InetSocketAddress addr = taskWorkerService.getBindAddress();
-    URI uri = URI.create(
-        String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
-
-    RunnableTaskRequest slowTaskRequest = RunnableTaskRequest.getBuilder(
-            TestRunnableClass.class.getName()).withParam("30000")
-        .withNamespace("testNamespace").build();
-
-    ExecutorService executorService = Executors.newFixedThreadPool(2);
-
-    // Submit a task that exceeds the deadline.
-    executorService.submit(() -> {
-      String reqBody = GSON.toJson(slowTaskRequest);
-      try {
-        HttpRequests.execute(
-            HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-                .withBody(reqBody).build(),
-            new DefaultHttpRequestConfig(false));
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    });
-
-    // Verify that lame duck mode gets enabled.
-    Tasks.waitFor(HttpResponseStatus.TOO_MANY_REQUESTS.code(), () -> {
-      RunnableTaskRequest request = RunnableTaskRequest.getBuilder(
-              TestRunnableClass.class.getName()).withNamespace("testNamespace")
-          .withParam("").build();
-      String reqBody = GSON.toJson(request);
-      return executorService.submit(() -> HttpRequests.execute(
-              HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-                  .withBody(reqBody).build(), new DefaultHttpRequestConfig(false))
-          .getResponseCode()).get();
-    }, 3, TimeUnit.SECONDS, 500, TimeUnit.MILLISECONDS);
-
-    // Wait for task worker to stop after entering lame duck mode.
-    Tasks.waitFor(false, taskWorkerService::isRunning, 3,
-        TimeUnit.SECONDS);
-  }
-
-
-  @Test
-  public void recoverFromLameDuckMode() throws Exception {
-    CConfiguration cConf = createCconf();
-    cConf.setInt(TaskWorker.REQUEST_LIMIT, 5);
-    cConf.setBoolean(TaskWorker.USER_CODE_ISOLATION_ENABLED, false);
-    cConf.setInt(TaskWorker.TASK_EXECUTION_DEADLINE_SECOND, 1);
-
-    InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
-    TaskWorkerService taskWorkerService = new TaskWorkerService(cConf,
-        createSconf(), discoveryService, discoveryService,
-        metricsCollectionService,
-        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
-    taskWorkerService.startAndWait();
-    InetSocketAddress addr = taskWorkerService.getBindAddress();
-    URI uri = URI.create(
-        String.format("http://%s:%s", addr.getHostName(), addr.getPort()));
-
-    // Submit a task that runs for 2.5 seconds.
-    // At t=1 second, the task will have run for < 1s, so it will not get flagged.
-    // At t=2s, the task will get flagged and the task worker will wait for an additional
-    // 1s before stopping.
-    // Before t=3s, the task will end and call off the shutdown.
-    RunnableTaskRequest initialRequest = RunnableTaskRequest.getBuilder(
-            TestRunnableClass.class.getName()).withParam("2500")
-        .withNamespace("testNamespace").build();
-
-    ExecutorService executorService = Executors.newFixedThreadPool(2);
-
-    executorService.submit(() -> {
-      String reqBody = GSON.toJson(initialRequest);
-      try {
-        HttpRequests.execute(
-            HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-                .withBody(reqBody).build(),
-            new DefaultHttpRequestConfig(false));
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    });
-
-    // Verify that lame duck mode gets enabled before stopping.
-    Tasks.waitFor(HttpResponseStatus.TOO_MANY_REQUESTS.code(), () -> {
-      RunnableTaskRequest request = RunnableTaskRequest.getBuilder(
-              TestRunnableClass.class.getName()).withNamespace("testNamespace")
-          .withParam("").build();
-      String reqBody = GSON.toJson(request);
-      return executorService.submit(() -> HttpRequests.execute(
-              HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-                  .withBody(reqBody).build(), new DefaultHttpRequestConfig(false))
-          .getResponseCode()).get();
-    }, 3, TimeUnit.SECONDS, 200, TimeUnit.MILLISECONDS);
-
-    // Verify that lame duck mode gets disabled.
-    Tasks.waitFor(HttpResponseStatus.OK.code(), () -> {
-      RunnableTaskRequest request = RunnableTaskRequest.getBuilder(
-              TestRunnableClass.class.getName()).withNamespace("testNamespace")
-          .withParam("").build();
-      String reqBody = GSON.toJson(request);
-      return executorService.submit(() -> HttpRequests.execute(
-              HttpRequest.post(uri.resolve("/v3Internal/worker/run").toURL())
-                  .withBody(reqBody).build(), new DefaultHttpRequestConfig(false))
-          .getResponseCode()).get();
-    }, 3, TimeUnit.SECONDS, 500, TimeUnit.MILLISECONDS);
-
-    taskWorkerService.stopAndWait();
-  }
-
   public static class TestRunnableClass implements RunnableTask {
 
     @Override
     public void run(RunnableTaskContext context) throws Exception {
-      if (!Strings.isNullOrEmpty(context.getParam())) {
+      if (!context.getParam().equals("")) {
         Thread.sleep(Integer.parseInt(context.getParam()));
       }
       context.writeResult(context.getParam().getBytes(StandardCharsets.UTF_8));

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -506,6 +506,8 @@ public final class Constants {
         "task.worker.container.kill.after.duration.second";
     public static final String REQUEST_LIMIT = "task.worker.request.limit";
     public static final String USER_CODE_ISOLATION_ENABLED = "task.worker.request.userCodeIsolation.enabled";
+    public static final String TASK_EXECUTION_DEADLINE_SECOND =
+        "task.worker.taskExecutionDeadline.second";
     public static final String CONTAINER_RUN_AS_USER = "task.worker.container.run.as.user";
     public static final String CONTAINER_RUN_AS_GROUP = "task.worker.container.run.as.group";
     public static final String CONTAINER_DISK_READONLY = "task.worker.container.disk.readonly";

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -504,6 +504,8 @@ public final class Constants {
         "task.worker.container.kill.after.request.count";
     public static final String CONTAINER_KILL_AFTER_DURATION_SECOND =
         "task.worker.container.kill.after.duration.second";
+    public static final String TASK_EXECUTION_DEADLINE_SECOND =
+        "task.worker.taskExecutionDeadline.second";
     public static final String REQUEST_LIMIT = "task.worker.request.limit";
     public static final String USER_CODE_ISOLATION_ENABLED = "task.worker.request.userCodeIsolation.enabled";
     public static final String CONTAINER_RUN_AS_USER = "task.worker.container.run.as.user";

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -504,8 +504,6 @@ public final class Constants {
         "task.worker.container.kill.after.request.count";
     public static final String CONTAINER_KILL_AFTER_DURATION_SECOND =
         "task.worker.container.kill.after.duration.second";
-    public static final String TASK_EXECUTION_DEADLINE_SECOND =
-        "task.worker.taskExecutionDeadline.second";
     public static final String REQUEST_LIMIT = "task.worker.request.limit";
     public static final String USER_CODE_ISOLATION_ENABLED = "task.worker.request.userCodeIsolation.enabled";
     public static final String CONTAINER_RUN_AS_USER = "task.worker.container.run.as.user";

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
@@ -167,7 +167,7 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
     int lowerBound = (int) (duration - duration * DURATION_FRACTION);
     int upperBound = (int) (duration + duration * DURATION_FRACTION);
 
-    if (lowerBound <= 0) {
+    if (duration <= 0) {
       return;
     }
     int waitTime = (new Random()).nextInt(upperBound - lowerBound) + lowerBound;

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
@@ -44,7 +44,11 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -81,7 +85,7 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
       new BasicThrowableCodec()).create();
 
   private final RunnableTaskLauncher runnableTaskLauncher;
-  private final BiConsumer<Boolean, TaskDetails> taskCompletionConsumer;
+  private final BiConsumer<Boolean, RunningTaskDetails> taskCompletionConsumer;
 
   /**
    * Holds the total number of requests that have been executed by this handler
@@ -99,6 +103,11 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
    */
   private final AtomicBoolean mustRestart = new AtomicBoolean(false);
   private final int requestLimit;
+  private final ConcurrentMap<RunningTaskDetails, Long> runningTasks;
+  /**
+   * If true, the task worker will not accept new tasks as it is about to shut down.
+   */
+  private final AtomicBoolean isInLameDuckMode = new AtomicBoolean(false);
 
   /**
    * Constructs the {@link TaskWorkerHttpHandlerInternal}.
@@ -115,6 +124,7 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
     this.metricsCollectionService = metricsCollectionService;
     this.metadataServiceEndpoint = cConf.get(
         Constants.TaskWorker.METADATA_SERVICE_END_POINT);
+    this.runningTasks = new ConcurrentHashMap<>();
     boolean enableUserCodeIsolationEnabled = cConf.getBoolean(
         TaskWorker.USER_CODE_ISOLATION_ENABLED);
     if (enableUserCodeIsolationEnabled) {
@@ -122,10 +132,12 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
       this.requestLimit = 1;
       // Restart the service to clean up and re-claim resources after user code
       // execution.
-      this.taskCompletionConsumer = (succeeded, taskDetails) -> {
+      this.taskCompletionConsumer = (succeeded, runningTaskDetails) -> {
+        TaskDetails taskDetails = runningTaskDetails.getTaskDetails();
         taskDetails.emitMetrics(succeeded);
         runningRequestCount.decrementAndGet();
         requestProcessedCount.incrementAndGet();
+        runningTasks.remove(runningTaskDetails);
 
         String className = taskDetails.getClassName();
 
@@ -148,10 +160,20 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
       enablePeriodicRestart(cConf, stopper);
     } else {
       this.requestLimit = cConf.getInt(TaskWorker.REQUEST_LIMIT);
-      this.taskCompletionConsumer = (succeeded, taskDetails) -> {
-        taskDetails.emitMetrics(succeeded);
-        runningRequestCount.decrementAndGet();
+      this.taskCompletionConsumer = (succeeded, runningTaskDetails) -> {
+        runningTaskDetails.getTaskDetails().emitMetrics(succeeded);
+        int remainingTasks = runningRequestCount.decrementAndGet();
+        runningTasks.remove(runningTaskDetails);
+        // If the stuck task has completed while waiting, we can call off the pending shutdown.
+        if (remainingTasks > 0 || !isInLameDuckMode.get()) {
+          return;
+        }
+        if (isInLameDuckMode.compareAndSet(true, false)) {
+          LOG.debug(
+              "All pending tasks are completed, task worker can accept new requests");
+        }
       };
+      monitorStuckTasks(cConf, stopper);
     }
   }
 
@@ -166,34 +188,94 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
   private void enablePeriodicRestart(CConfiguration cConf,
       Consumer<String> stopper) {
     int duration = cConf.getInt(
-        Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 0);
+        TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 0);
     int lowerBound = (int) (duration - duration * DURATION_FRACTION);
     int upperBound = (int) (duration + duration * DURATION_FRACTION);
-    if (lowerBound > 0) {
-      int waitTime =
-          (new Random()).nextInt(upperBound - lowerBound) + lowerBound;
-      Executors.newSingleThreadScheduledExecutor(
-              Threads.createDaemonThreadFactory("task-worker-restart"))
-          .scheduleWithFixedDelay(
-              () -> {
-                if (mustRestart.get()) {
-                  // We force pod restart as the ongoing request has not finished since last
-                  // periodic restart check.
-                  stopper.accept("");
-                  return;
-                }
-                // we restart once ongoing request (which has set runningRequestCount to 1)
-                // finishes.
-                mustRestart.set(true);
-                if (runningRequestCount.compareAndSet(0, 1)) {
-                  // there is no ongoing request. pod gets restarted.
-                  stopper.accept("");
-                }
-              },
-              waitTime,
-              waitTime,
-              TimeUnit.SECONDS);
+    if (lowerBound <= 0) {
+      return;
     }
+    int waitTime = (new Random()).nextInt(upperBound - lowerBound) + lowerBound;
+    Executors.newSingleThreadScheduledExecutor(
+            Threads.createDaemonThreadFactory("task-worker-restart"))
+        .scheduleWithFixedDelay(() -> {
+          if (mustRestart.get()) {
+            // We force pod restart as the ongoing request has not finished since last
+            // periodic restart check.
+            stopper.accept("");
+            return;
+          }
+          // we restart once ongoing request (which has set runningRequestCount to 1)
+          // finishes.
+          mustRestart.set(true);
+          if (runningRequestCount.compareAndSet(0, 1)) {
+            // there is no ongoing request. pod gets restarted.
+            stopper.accept("");
+          }
+        }, waitTime, waitTime, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Each task needs to complete withing a configured deadline. There can be
+   * multiple tasks running concurrently when user code isolation is disabled.
+   * If any task doesn't complete within the deadline, this method will try to
+   * restart the service to kill it while ensuring healthy tasks get time to
+   * complete gracefully. By randomizing the deadline, it is guaranteed that
+   * pods do not get restarted at the same time.
+   */
+  private void monitorStuckTasks(CConfiguration cConf,
+      Consumer<String> stopper) {
+    int duration = cConf.getInt(
+        TaskWorker.TASK_EXECUTION_DEADLINE_SECOND, 0);
+    if (duration <= 0) {
+      return;
+    }
+    int lowerBound = duration;
+    int upperBound = (int) (duration + duration * DURATION_FRACTION);
+    int executionDeadlineSeconds =
+        lowerBound + (upperBound > lowerBound ? (new Random()).nextInt(
+            upperBound - lowerBound) : 0);
+    LOG.debug("Deadline for tasks is {} seconds", executionDeadlineSeconds);
+
+    Executors.newSingleThreadScheduledExecutor(
+            Threads.createDaemonThreadFactory("task-worker-stuck-tasks-monitor"))
+        .scheduleWithFixedDelay(() -> {
+          // Check if all the running tasks are withing deadline.
+          boolean deadlineExceeded = isAnyTaskExceedingDeadline(
+              executionDeadlineSeconds);
+          if (!deadlineExceeded) {
+            isInLameDuckMode.set(false);
+            return;
+          }
+
+          // If no task was exceeding the deadline last time, stop accepting any new
+          // tasks and wait for "deadline" seconds to elapse before stopping.
+          // By not accepting new tasks and waiting, we ensure that only tasks
+          // that have exceeded the deadline are terminated by the shutdown.
+          if (isInLameDuckMode.compareAndSet(false, true)) {
+            LOG.debug(
+                "Task worker will not accept new tasks in preparation for a shutdown.");
+            return;
+          }
+
+          // If we have already waited for the running task to complete, force the
+          // service to restart. This will cause all the executing tasks to fail.
+          if (isInLameDuckMode.get()) {
+            LOG.debug(
+                "Requesting task worker to be stopped to kill stuck task(s).");
+            stopper.accept("");
+          }
+        }, executionDeadlineSeconds, executionDeadlineSeconds, TimeUnit.SECONDS);
+  }
+
+  private boolean isAnyTaskExceedingDeadline(long deadlineSeconds) {
+    final long currentTimeMillis = System.currentTimeMillis();
+    final long deadlineMillis = TimeUnit.SECONDS.toMillis(deadlineSeconds);
+    for (Long startTimeMillis : runningTasks.values()) {
+      if (currentTimeMillis - startTimeMillis > deadlineMillis) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -205,13 +287,17 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
   @POST
   @Path("/run")
   public void run(FullHttpRequest request, HttpResponder responder) {
-    if (runningRequestCount.incrementAndGet() > requestLimit) {
+    if (isInLameDuckMode.get()
+        || runningRequestCount.incrementAndGet() > requestLimit) {
       responder.sendStatus(HttpResponseStatus.TOO_MANY_REQUESTS);
       runningRequestCount.decrementAndGet();
       return;
     }
 
-    long startTime = System.currentTimeMillis();
+    long startTimeMillis = System.currentTimeMillis();
+    // As tasks don't have a unique ID, assign an ephemeral ID to each task for
+    // tracking its execution and completion status.
+    String taskId = UUID.randomUUID().toString();
     try {
       RunnableTaskRequest runnableTaskRequest = GSON.fromJson(
           request.content().toString(StandardCharsets.UTF_8),
@@ -223,19 +309,24 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
         if (runnableTaskRequest.getParam().getEmbeddedTaskRequest() != null) {
           // For system app tasks
           namespaceId = new NamespaceId(
-              runnableTaskRequest.getParam().getEmbeddedTaskRequest().getNamespace());
+              runnableTaskRequest.getParam().getEmbeddedTaskRequest()
+                  .getNamespace());
         } else {
           namespaceId = new NamespaceId(runnableTaskRequest.getNamespace());
         }
         // set the GcpMetadataTaskContext before running the task.
-        GcpMetadataTaskContextUtil.setGcpMetadataTaskContext(namespaceId, cConf);
-        runnableTaskLauncher.launchRunnableTask(runnableTaskContext);
+        GcpMetadataTaskContextUtil.setGcpMetadataTaskContext(namespaceId,
+            cConf);
         TaskDetails taskDetails = new TaskDetails(metricsCollectionService,
-            startTime,
-            runnableTaskContext.isTerminateOnComplete(), runnableTaskRequest);
+            startTimeMillis, runnableTaskContext.isTerminateOnComplete(),
+            runnableTaskRequest);
+        final RunningTaskDetails runningTaskDetails = new RunningTaskDetails(
+            startTimeMillis, taskId, taskDetails);
+        runningTasks.put(runningTaskDetails, startTimeMillis);
+        runnableTaskLauncher.launchRunnableTask(runnableTaskContext);
         responder.sendContent(HttpResponseStatus.OK,
             new RunnableTaskBodyProducer(runnableTaskContext,
-                taskCompletionConsumer, taskDetails),
+                taskCompletionConsumer, runningTaskDetails),
             new DefaultHttpHeaders().add(HttpHeaders.CONTENT_TYPE,
                 MediaType.APPLICATION_OCTET_STREAM));
       } catch (ClassNotFoundException | ClassCastException ex) {
@@ -244,9 +335,11 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
             new DefaultHttpHeaders().set(HttpHeaders.CONTENT_TYPE,
                 "application/json"));
         // Since the user class is not even loaded, no user code ran, hence it's ok to not terminate the runner
+        final TaskDetails taskDetails = new TaskDetails(
+            metricsCollectionService, startTimeMillis, false,
+            runnableTaskRequest);
         taskCompletionConsumer.accept(false,
-            new TaskDetails(metricsCollectionService,
-                startTime, false, runnableTaskRequest));
+            new RunningTaskDetails(startTimeMillis, taskId, taskDetails));
       } finally {
         // clear the GcpMetadataTaskContext after the task is completed.
         GcpMetadataTaskContextUtil.clearGcpMetadataTaskContext(cConf);
@@ -259,8 +352,10 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
           new DefaultHttpHeaders().set(HttpHeaders.CONTENT_TYPE,
               "application/json"));
       // Potentially ran user code, hence terminate the runner.
+      final TaskDetails taskDetails = new TaskDetails(metricsCollectionService,
+          startTimeMillis, true, null);
       taskCompletionConsumer.accept(false,
-          new TaskDetails(metricsCollectionService, startTime, true, null));
+          new RunningTaskDetails(startTimeMillis, taskId, taskDetails));
     }
   }
 
@@ -315,13 +410,13 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
   private static class RunnableTaskBodyProducer extends BodyProducer {
 
     private final RunnableTaskContext context;
-    private final BiConsumer<Boolean, TaskDetails> taskCompletionConsumer;
-    private final TaskDetails taskDetails;
+    private final BiConsumer<Boolean, RunningTaskDetails> taskCompletionConsumer;
+    private final RunningTaskDetails taskDetails;
     private boolean done;
 
     RunnableTaskBodyProducer(RunnableTaskContext context,
-        BiConsumer<Boolean, TaskDetails> taskCompletionConsumer,
-        TaskDetails taskDetails) {
+        BiConsumer<Boolean, RunningTaskDetails> taskCompletionConsumer,
+        RunningTaskDetails taskDetails) {
       this.context = context;
       this.taskCompletionConsumer = taskCompletionConsumer;
       this.taskDetails = taskDetails;
@@ -348,6 +443,45 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
       LOG.error("Error when sending chunks", cause);
       context.executeCleanupTask();
       taskCompletionConsumer.accept(false, taskDetails);
+    }
+  }
+
+  /**
+   * Details for tracking presently running tasks.
+   */
+  private class RunningTaskDetails {
+
+    private final long executionStartTimeMillis;
+    private final String taskId;
+    private final TaskDetails taskDetails;
+
+    RunningTaskDetails(long executionStartTimeMillis, String taskId,
+        TaskDetails taskDetails) {
+      this.executionStartTimeMillis = executionStartTimeMillis;
+      this.taskId = taskId;
+      this.taskDetails = taskDetails;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof RunningTaskDetails)) {
+        return false;
+      }
+      RunningTaskDetails that = (RunningTaskDetails) o;
+      return executionStartTimeMillis == that.executionStartTimeMillis
+             && taskId.equals(that.taskId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(taskId);
+    }
+
+    public TaskDetails getTaskDetails() {
+      return taskDetails;
     }
   }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/TaskWorkerHttpHandlerInternal.java
@@ -46,6 +46,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -77,8 +78,7 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
   private static final Logger LOG = LoggerFactory.getLogger(
       TaskWorkerHttpHandlerInternal.class);
   private static final Gson GSON = new GsonBuilder().registerTypeAdapter(
-      BasicThrowable.class,
-      new BasicThrowableCodec()).create();
+      BasicThrowable.class, new BasicThrowableCodec()).create();
 
   private final RunnableTaskLauncher runnableTaskLauncher;
   private final BiConsumer<Boolean, TaskDetails> taskCompletionConsumer;
@@ -120,39 +120,36 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
     if (enableUserCodeIsolationEnabled) {
       // Run only one request at a time in user code isolation mode.
       this.requestLimit = 1;
-      // Restart the service to clean up and re-claim resources after user code
-      // execution.
-      this.taskCompletionConsumer = (succeeded, taskDetails) -> {
-        taskDetails.emitMetrics(succeeded);
-        runningRequestCount.decrementAndGet();
-        requestProcessedCount.incrementAndGet();
-
-        String className = taskDetails.getClassName();
-
-        if (mustRestart.get()) {
-          stopper.accept(className);
-          return;
-        }
-
-        if (!taskDetails.isTerminateOnComplete() || className == null
-            || killAfterRequestCount <= 0) {
-          // No need to restart.
-          return;
-        }
-
-        if (requestProcessedCount.get() >= killAfterRequestCount) {
-          stopper.accept(className);
-        }
-      };
-
-      enablePeriodicRestart(cConf, stopper);
     } else {
       this.requestLimit = cConf.getInt(TaskWorker.REQUEST_LIMIT);
-      this.taskCompletionConsumer = (succeeded, taskDetails) -> {
-        taskDetails.emitMetrics(succeeded);
-        runningRequestCount.decrementAndGet();
-      };
     }
+
+    // Restart the service to clean up and re-claim resources after user code
+    // execution.
+    this.taskCompletionConsumer = (succeeded, taskDetails) -> {
+      taskDetails.emitMetrics(succeeded);
+      final int pendingRequests = runningRequestCount.decrementAndGet();
+      requestProcessedCount.incrementAndGet();
+
+      String className = taskDetails.getClassName();
+      if (mustRestart.get() && pendingRequests == 0) {
+        stopper.accept(className);
+        return;
+      }
+
+      if (!enableUserCodeIsolationEnabled
+          || !taskDetails.isTerminateOnComplete()
+          || className == null || killAfterRequestCount <= 0) {
+        // No need to restart.
+        return;
+      }
+
+      if (requestProcessedCount.get() >= killAfterRequestCount) {
+        stopper.accept(className);
+      }
+    };
+
+    enablePeriodicRestart(cConf, stopper);
   }
 
   /**
@@ -169,31 +166,49 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
         Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, 0);
     int lowerBound = (int) (duration - duration * DURATION_FRACTION);
     int upperBound = (int) (duration + duration * DURATION_FRACTION);
-    if (lowerBound > 0) {
-      int waitTime =
-          (new Random()).nextInt(upperBound - lowerBound) + lowerBound;
-      Executors.newSingleThreadScheduledExecutor(
-              Threads.createDaemonThreadFactory("task-worker-restart"))
-          .scheduleWithFixedDelay(
-              () -> {
-                if (mustRestart.get()) {
-                  // We force pod restart as the ongoing request has not finished since last
-                  // periodic restart check.
-                  stopper.accept("");
-                  return;
-                }
-                // we restart once ongoing request (which has set runningRequestCount to 1)
-                // finishes.
-                mustRestart.set(true);
-                if (runningRequestCount.compareAndSet(0, 1)) {
-                  // there is no ongoing request. pod gets restarted.
-                  stopper.accept("");
-                }
-              },
-              waitTime,
-              waitTime,
-              TimeUnit.SECONDS);
+
+    if (lowerBound <= 0) {
+      return;
     }
+    int waitTime = (new Random()).nextInt(upperBound - lowerBound) + lowerBound;
+
+    int taskDeadlineSeconds = cConf.getInt(
+        TaskWorker.TASK_EXECUTION_DEADLINE_SECOND,
+        0);
+
+    if (taskDeadlineSeconds < 0) {
+      LOG.info(
+          "Task deadline is {}, using {} value {} as the deadline instead.",
+          taskDeadlineSeconds,
+          Constants.TaskWorker.CONTAINER_KILL_AFTER_DURATION_SECOND, duration);
+      taskDeadlineSeconds = duration;
+    }
+    int finalTaskDeadlineSeconds = taskDeadlineSeconds;
+
+    ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor(
+    Threads.createDaemonThreadFactory("task-worker-restart"));
+
+    executorService.scheduleWithFixedDelay(() -> {
+      // we restart once all ongoing requests finish, i.e. runningRequestCount is 0.
+      mustRestart.set(true);
+      LOG.debug(
+          "Task worker service is about to restart in {} seconds, no new tasks will be accepted.",
+          finalTaskDeadlineSeconds);
+      if (runningRequestCount.get() == 0) {
+        stopper.accept("");
+        executorService.shutdown();
+        return;
+      }
+      try {
+        Thread.sleep(TimeUnit.SECONDS.toMillis(finalTaskDeadlineSeconds));
+      } catch (InterruptedException e) {
+        LOG.warn(
+            "Interrupted while waiting for task completion. Stopping immediately",
+            e);
+      }
+      stopper.accept("");
+      executorService.shutdown();
+    }, waitTime, waitTime, TimeUnit.SECONDS);
   }
 
   /**
@@ -205,6 +220,10 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
   @POST
   @Path("/run")
   public void run(FullHttpRequest request, HttpResponder responder) {
+    if (mustRestart.get()) {
+      responder.sendStatus(HttpResponseStatus.TOO_MANY_REQUESTS);
+      return;
+    }
     if (runningRequestCount.incrementAndGet() > requestLimit) {
       responder.sendStatus(HttpResponseStatus.TOO_MANY_REQUESTS);
       runningRequestCount.decrementAndGet();
@@ -223,16 +242,18 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
         if (runnableTaskRequest.getParam().getEmbeddedTaskRequest() != null) {
           // For system app tasks
           namespaceId = new NamespaceId(
-              runnableTaskRequest.getParam().getEmbeddedTaskRequest().getNamespace());
+              runnableTaskRequest.getParam().getEmbeddedTaskRequest()
+                  .getNamespace());
         } else {
           namespaceId = new NamespaceId(runnableTaskRequest.getNamespace());
         }
         // set the GcpMetadataTaskContext before running the task.
-        GcpMetadataTaskContextUtil.setGcpMetadataTaskContext(namespaceId, cConf);
+        GcpMetadataTaskContextUtil.setGcpMetadataTaskContext(namespaceId,
+            cConf);
         runnableTaskLauncher.launchRunnableTask(runnableTaskContext);
         TaskDetails taskDetails = new TaskDetails(metricsCollectionService,
-            startTime,
-            runnableTaskContext.isTerminateOnComplete(), runnableTaskRequest);
+            startTime, runnableTaskContext.isTerminateOnComplete(),
+            runnableTaskRequest);
         responder.sendContent(HttpResponseStatus.OK,
             new RunnableTaskBodyProducer(runnableTaskContext,
                 taskCompletionConsumer, taskDetails),
@@ -245,8 +266,8 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
                 "application/json"));
         // Since the user class is not even loaded, no user code ran, hence it's ok to not terminate the runner
         taskCompletionConsumer.accept(false,
-            new TaskDetails(metricsCollectionService,
-                startTime, false, runnableTaskRequest));
+            new TaskDetails(metricsCollectionService, startTime, false,
+                runnableTaskRequest));
       } finally {
         // clear the GcpMetadataTaskContext after the task is completed.
         GcpMetadataTaskContextUtil.clearGcpMetadataTaskContext(cConf);
@@ -267,7 +288,7 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
   /**
    * Returns a new token from metadata server.
    *
-   * @param request The {@link io.netty.handler.codec.http.HttpRequest}.
+   * @param request   The {@link io.netty.handler.codec.http.HttpRequest}.
    * @param responder a {@link HttpResponder} for sending response.
    */
   @GET
@@ -284,12 +305,10 @@ public class TaskWorkerHttpHandlerInternal extends AbstractHttpHandler {
     try {
       URL url = new URL(metadataServiceEndpoint);
       HttpRequest tokenRequest = HttpRequest.get(url)
-          .addHeader("Metadata-Flavor", "Google")
-          .build();
+          .addHeader("Metadata-Flavor", "Google").build();
       HttpResponse tokenResponse = HttpRequests.execute(tokenRequest);
       responder.sendByteArray(HttpResponseStatus.OK,
-          tokenResponse.getResponseBody(),
-          EmptyHttpHeaders.INSTANCE);
+          tokenResponse.getResponseBody(), EmptyHttpHeaders.INSTANCE);
     } catch (Exception ex) {
       LOG.warn("Failed to fetch token from metadata service", ex);
       responder.sendJson(HttpResponseStatus.INTERNAL_SERVER_ERROR,

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -247,7 +247,10 @@
 
   <property>
     <name>twill.jvm.gc.opts</name>
-    <value>-XX:+UseG1GC -verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=1M</value>
+    <value>-XX:+UseG1GC -verbose:gc -Xloggc:&lt;LOG_DIR&gt;/gc.log -XX:+PrintGCDetails
+      -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10
+      -XX:GCLogFileSize=1M
+    </value>
     <activation>
       <jdk>(,9)</jdk>
     </activation>
@@ -2611,7 +2614,9 @@
 
   <property>
     <name>messaging.system.topics</name>
-    <value>${audit.topic},${metadata.messaging.topic},${data.event.topic},${metrics.topic.prefix}:${metrics.messaging.topic.num},${metrics.admin.topic},${time.event.topic},${program.status.event.topic},${program.status.event.topic}:${program.status.event.topic.num.partitions},${operation.status.event.topic}:${operation.status.event.topic.num.partitions},${program.status.record.event.topic},${log.tms.topic.prefix}:${log.publish.num.partitions},${preview.messaging.topic},previewlog0</value>
+    <value>
+      ${audit.topic},${metadata.messaging.topic},${data.event.topic},${metrics.topic.prefix}:${metrics.messaging.topic.num},${metrics.admin.topic},${time.event.topic},${program.status.event.topic},${program.status.event.topic}:${program.status.event.topic.num.partitions},${operation.status.event.topic}:${operation.status.event.topic.num.partitions},${program.status.record.event.topic},${log.tms.topic.prefix}:${log.publish.num.partitions},${preview.messaging.topic},previewlog0
+    </value>
     <description>
       A comma-separated list of topics that are always available in the
       system namespace. Multiple topics sharing the same prefix and
@@ -3268,7 +3273,9 @@
 
   <property>
     <name>app.program.runtime.monitor.topics.configs</name>
-    <value>audit.topic,data.event.topic,metadata.messaging.topic,metrics.topic.prefix:${metrics.messaging.topic.num},program.status.event.topic,program.status.event.topic:${program.status.event.topic.num.partitions},log.tms.topic.prefix:${log.publish.num.partitions}</value>
+    <value>
+      audit.topic,data.event.topic,metadata.messaging.topic,metrics.topic.prefix:${metrics.messaging.topic.num},program.status.event.topic,program.status.event.topic:${program.status.event.topic.num.partitions},log.tms.topic.prefix:${log.publish.num.partitions}
+    </value>
     <description>
       A comma-separated list of topic config to be monitored by runtime monitor
     </description>
@@ -3420,7 +3427,8 @@
     <name>app.program.runtime.monitor.metrics.aggregation.window.secs</name>
     <value>5</value>
     <description>
-      When metrics aggregation in runtime client service is enabled, this property controls the max time difference
+      When metrics aggregation in runtime client service is enabled, this property controls the max
+      time difference
       between two metrics which can be aggregated.
     </description>
   </property>
@@ -3429,7 +3437,8 @@
     <name>app.program.runtime.monitor.metrics.aggregation.polltime.ms</name>
     <value>5000</value>
     <description>
-      Polling time in milliseconds to poll updates from a runtime when metrics aggregation is enabled.
+      Polling time in milliseconds to poll updates from a runtime when metrics aggregation is
+      enabled.
       This enables setting longer poll intervals to have better aggregation of metrics.
     </description>
   </property>
@@ -3752,7 +3761,7 @@
     <name>preview.runner.internal.router.enabled</name>
     <value>false</value>
     <description>
-     Whether to route requests from preview runners through the internal router service. This
+      Whether to route requests from preview runners through the internal router service. This
       is only applicable for k8s environment presently. By default, it is disabled.
     </description>
   </property>
@@ -5305,6 +5314,16 @@
   </property>
 
   <property>
+    <name>task.worker.taskExecutionDeadline.second</name>
+    <value>1200</value>
+    <description>
+      Duration (in seconds) to wait for a task executing before stopping the task worker service.
+      If the value is less than or equal 0, ${task.worker.container.kill.after.duration.second} is
+      used instead.
+    </description>
+  </property>
+
+  <property>
     <name>task.worker.request.userCodeIsolation.enabled</name>
     <value>true</value>
     <description>
@@ -5357,7 +5376,7 @@
     <name>task.worker.internal.router.enabled</name>
     <value>false</value>
     <description>
-     Whether to route requests from task workers through the internal router service. This
+      Whether to route requests from task workers through the internal router service. This
       is only applicable for k8s environment presently. By default, it is disabled.
     </description>
   </property>
@@ -5548,7 +5567,7 @@
     <name>system.worker.internal.router.enabled</name>
     <value>false</value>
     <description>
-     Whether to route requests from system workers through the internal router service. This
+      Whether to route requests from system workers through the internal router service. This
       is only applicable for k8s environment presently. By default, it is disabled.
     </description>
   </property>
@@ -6164,7 +6183,7 @@
     </description>
   </property>
 
-<!--  Artifact localizer settings -->
+  <!--  Artifact localizer settings -->
   <property>
     <name>artifact.localizer.preload.list</name>
     <value></value>
@@ -6208,7 +6227,9 @@
 
   <property>
     <name>artifact.localizer.metadata.service.token.endpoint</name>
-    <value>http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token</value>
+    <value>
+      http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
+    </value>
     <description>
       The GCE metadata server token endpoint.
     </description>
@@ -6284,7 +6305,8 @@
     <name>hsts.include.sub.domains</name>
     <value>true</value>
     <description>
-      Whether to include the includeSubDomains directive, which makes this policy extend to subdomains.
+      Whether to include the includeSubDomains directive, which makes this policy extend to
+      subdomains.
     </description>
   </property>
 
@@ -6296,7 +6318,7 @@
     </description>
   </property>
 
-<!--  Operation configurations -->
+  <!--  Operation configurations -->
 
   <property>
     <name>operation.status.retry.policy.base.delay.ms</name>
@@ -6346,7 +6368,7 @@
       Topic prefix for publishing status transitioning events of operation runs to
       the messaging system.
     </description>
-  </property>f
+  </property>
 
   <property>
     <name>operation.status.event.topic.num.partitions</name>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5328,7 +5328,7 @@
     <value>true</value>
     <description>
       Whether user code isolation is enabled in task worker. When enabled, task workers will ensure
-      multiple requests that run user code are not executed concurrently.
+      only 1 request is accepted at max and later after the task worker is restarted it can take next request.
     </description>
   </property>
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5297,19 +5297,6 @@
   </property>
 
   <property>
-    <name>task.worker.taskExecutionDeadline.second</name>
-    <value>1200</value>
-    <description>
-      Duration (in seconds) to wait for a task executing before stopping the task worker service.
-      Actual duration varies randomly within a defined range. The task worker can wait for double the
-      deadline for remaining tasks to finish before stopping. This property is applicable only when
-      userCodeIsolation is disabled, i.e. task worker is running concurrent requests.
-      Zero or negative values result in no deadline.
-    </description>
-  </property>
-
-
-  <property>
     <name>task.worker.request.limit</name>
     <value>10</value>
     <description>

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -5297,6 +5297,19 @@
   </property>
 
   <property>
+    <name>task.worker.taskExecutionDeadline.second</name>
+    <value>1200</value>
+    <description>
+      Duration (in seconds) to wait for a task executing before stopping the task worker service.
+      Actual duration varies randomly within a defined range. The task worker can wait for double the
+      deadline for remaining tasks to finish before stopping. This property is applicable only when
+      userCodeIsolation is disabled, i.e. task worker is running concurrent requests.
+      Zero or negative values result in no deadline.
+    </description>
+  </property>
+
+
+  <property>
     <name>task.worker.request.limit</name>
     <value>10</value>
     <description>


### PR DESCRIPTION
## [CDAP-20832](https://cdap.atlassian.net/browse/CDAP-20832)
This PR introduces a deadline for all task worker executions. The task worker now does a periodic restart even when "user code isolation" is disabled, i.e. its running concurrent requests. When a periodic restart is scheduled, the task worker stops accepting new requests. It waits for the new configuration "task.worker.taskExecutionDeadline.second" time to elapse. If all executing tasks finish, the task worker is restarted immediately. Otherwise the task worker is restarted after the deadline expires.

[CDAP-20832]: https://cdap.atlassian.net/browse/CDAP-20832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ