### PR TITLE
[CDAP-20834] Replace usage of printStack with logger

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
@@ -51,11 +51,14 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * OAuth handler.
  */
 public class OAuthHandler extends AbstractSystemHttpServiceHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(OAuthHandler.class);
   private static final String API_VERSION = "v1";
   private static final Gson GSON = new GsonBuilder()
     .setPrettyPrinting()
@@ -362,7 +365,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
 
     void respond(HttpServiceResponder responder) {
       if (status == HttpURLConnection.HTTP_INTERNAL_ERROR) {
-        printStackTrace();
+        LOG.error("An internal error has occurred", this);
         responder.sendError(status, "Internal error");
       } else {
         responder.sendError(status, getMessage());


### PR DESCRIPTION
This pull request introduces the substitution of `printStackTrace` with Logger in the `OAuthHandler`.

### Testing:
- Demonstrated behavior when `OAuthServiceException` is instantiated with a throwable cause.
  ![Screenshot 1](https://github.com/cdapio/cdap/assets/63417899/8b865cfc-5c0f-499f-b123-1a244d97d3a3)

- Illustrated behavior when `OAuthServiceException` is instantiated without a throwable cause.
  ![Screenshot 2](https://github.com/cdapio/cdap/assets/63417899/b67f192f-ff46-43bf-b640-89797450e1df)

This PR aims to enhance code maintainability and clarity by adopting Logger for error handling, replacing direct print statements.