### PR TITLE
Add bitbucket cloud and server support

### DIFF
--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/AuthConfig.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/AuthConfig.java
@@ -52,7 +52,7 @@ public class AuthConfig {
 
    * @return a collection of {@link RepositoryValidationFailure}.
    */
-  public Collection<RepositoryValidationFailure> validate() {
+  public Collection<RepositoryValidationFailure> validate(Provider provider) {
     Collection<RepositoryValidationFailure> failures = new ArrayList<>();
     if (type == null) {
       failures.add(new RepositoryValidationFailure("'type' must be specified in 'auth'."));
@@ -62,7 +62,7 @@ public class AuthConfig {
       if (patConfig == null) {
         failures.add(new RepositoryValidationFailure("'patConfig' must be specified in 'auth'."));
       } else {
-        failures.addAll(patConfig.validate());
+        failures.addAll(patConfig.validate(provider));
       }
     }
 

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/Provider.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/Provider.java
@@ -22,4 +22,6 @@ package io.cdap.cdap.proto.sourcecontrol;
 public enum Provider {
   GITHUB,
   GITLAB,
+  BITBUCKET_CLOUD,
+  BITBUCKET_SERVER
 }

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfig.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/RepositoryConfig.java
@@ -84,7 +84,7 @@ public class RepositoryConfig {
     if (auth == null) {
       failures.add(new RepositoryValidationFailure("'auth' field must be specified."));
     } else {
-      failures.addAll(auth.validate());
+      failures.addAll(auth.validate(provider));
     }
 
     if (!failures.isEmpty()) {

--- a/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/PatAuthenticationStrategy.java
+++ b/cdap-source-control/src/main/java/io/cdap/cdap/sourcecontrol/PatAuthenticationStrategy.java
@@ -22,7 +22,6 @@ import io.cdap.cdap.proto.sourcecontrol.PatConfig;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import joptsimple.internal.Strings;
 import org.eclipse.jgit.errors.UnsupportedCredentialItem;
 import org.eclipse.jgit.transport.CredentialItem;
 import org.eclipse.jgit.transport.URIish;
@@ -32,8 +31,6 @@ import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
  * An {@link AuthenticationStrategy} to use with GitHub/GitLab and Personal Access Tokens.
  */
 public class PatAuthenticationStrategy implements AuthenticationStrategy {
-
-  private static final String DEFAULT_USER_NAME = "x-token-auth";
 
   private final SecureStorePasswordProvider credentialsProvider;
 
@@ -47,11 +44,8 @@ public class PatAuthenticationStrategy implements AuthenticationStrategy {
   public PatAuthenticationStrategy(SecureStore secureStore, RepositoryConfig config,
       String namespaceId) {
     PatConfig patConfig = config.getAuth().getPatConfig();
-    String username =
-        Strings.isNullOrEmpty(patConfig.getUsername()) ? DEFAULT_USER_NAME : patConfig.getUsername();
     this.credentialsProvider =
-        new SecureStorePasswordProvider(secureStore, username,
-            patConfig.getPasswordName(), namespaceId);
+        new SecureStorePasswordProvider(secureStore, patConfig.getUsername(), patConfig.getPasswordName(), namespaceId);
   }
 
   @Override


### PR DESCRIPTION
Adding support for bitbucket cloud and bitbucket server as source control provider
Also username now defaults to x-token-auth when not provided as part of PAT config

- [x] unit test for validation
- [x] manual test for validation and git operation for bitbucket cloud