### PR TITLE
[CDAP-20987] OAuthHandler should return response details in the exception other than response code when request fails

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
@@ -177,7 +177,12 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
       if (response.getResponseCode() != 200) {
         throw new OAuthServiceException(
             HttpURLConnection.HTTP_INTERNAL_ERROR,
-            "Request to fetch refresh token returned code " + response.getResponseCode());
+            "Request for refresh token did not return 200. Response code: "
+                + response.getResponseCode()
+                + " , response message: "
+                + response.getResponseMessage()
+                + " , respone body: "
+                + response.getResponseBodyAsString());
       }
 
       RefreshTokenResponse refreshTokenResponse;


### PR DESCRIPTION
This pull request enhances error handling by including additional response details in the exception when a request fails, beyond just the response code.

### Testing
<img width="1629" alt="Screenshot 2024-04-05 at 1 53 23 PM" src="https://github.com/cdapio/cdap/assets/63417899/87ec2918-3af8-4db3-a405-41ac323b6fd6">

