### PR TITLE
[CDAP-20989] Add API implementations for Namespace and Repository Source Control Metadata

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/ScanSourceControlMetadataRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/ScanSourceControlMetadataRequest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.store;
+
+import io.cdap.cdap.proto.sourcecontrol.SortBy;
+import io.cdap.cdap.spi.data.SortOrder;
+
+/**
+ * Represents a request to scan source control metadata.
+ */
+public class ScanSourceControlMetadataRequest {
+
+  private final String namespace;
+  private final SortOrder sortOrder;
+  private final SortBy sortOn;
+  private final String scanAfter;
+  private final int limit;
+  private final SourceControlMetadataFilter filter;
+
+
+  /**
+   * Constructs a new ScanSourceControlMetadataRequest.
+   *
+   * @param namespace The namespace to scan for metadata.
+   * @param sortOrder The sorting order for the results.
+   * @param sortOn    The field to sort the results on.
+   * @param scanAfter The cursor for scanning after a certain point.
+   * @param limit     The maximum number of results to return.
+   * @param filter    The filter criteria for metadata.
+   */
+  public ScanSourceControlMetadataRequest(String namespace, SortOrder sortOrder,
+      SortBy sortOn, String scanAfter, int limit, SourceControlMetadataFilter filter) {
+    this.namespace = namespace;
+    this.sortOrder = sortOrder;
+    this.sortOn = sortOn;
+    this.scanAfter = scanAfter;
+    this.limit = limit;
+    this.filter = filter;
+  }
+
+  public SortOrder getSortOrder() {
+    return sortOrder;
+  }
+
+  public SortBy getSortOn() {
+    return sortOn;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public int getLimit() {
+    return limit;
+  }
+
+  public String getScanAfter() {
+    return scanAfter;
+  }
+
+  public SourceControlMetadataFilter getFilter() {
+    return filter;
+  }
+
+  public static ScanSourceControlMetadataRequest.Builder builder() {
+    return new ScanSourceControlMetadataRequest.Builder();
+  }
+
+  public static ScanSourceControlMetadataRequest.Builder builder(
+      ScanSourceControlMetadataRequest request) {
+    return new ScanSourceControlMetadataRequest.Builder(request);
+  }
+
+  /**
+   * Builder pattern for constructing instances of {@link ScanSourceControlMetadataRequest}.
+   */
+  public static class Builder {
+
+    private String namespace;
+    private SortOrder sortOrder = SortOrder.ASC;
+    private String scanAfter;
+    private SortBy sortOn;
+    private int limit = Integer.MAX_VALUE;
+    private SourceControlMetadataFilter filter;
+
+    private Builder() {
+    }
+
+    private Builder(ScanSourceControlMetadataRequest request) {
+      this.namespace = request.namespace;
+      this.sortOn = request.sortOn;
+      this.sortOrder = request.sortOrder;
+      this.scanAfter = request.scanAfter;
+      this.limit = request.limit;
+      this.filter = request.filter;
+    }
+
+    public Builder setNamespace(String namespace) {
+      this.namespace = namespace;
+      return this;
+    }
+
+    public Builder setSortOrder(SortOrder sortOrder) {
+      this.sortOrder = sortOrder;
+      return this;
+    }
+
+    public Builder setSortOn(SortBy sortOn) {
+      this.sortOn = sortOn;
+      return this;
+    }
+
+    public Builder setScanAfter(String scanAfter) {
+      this.scanAfter = scanAfter;
+      return this;
+    }
+
+    public Builder setLimit(int limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public Builder setFilter(SourceControlMetadataFilter filter) {
+      this.filter = filter;
+      return this;
+    }
+
+    /**
+     * Builds an instance of {@link ScanSourceControlMetadataRequest} based on the provided
+     * parameters. If no filter is specified, an empty filter is applied.
+     *
+     * @return An instance of {@link ScanSourceControlMetadataRequest} configured with the builder's
+     *         parameters.
+     */
+    public ScanSourceControlMetadataRequest build() {
+      if (filter == null) {
+        filter = SourceControlMetadataFilter.emptyFilter();
+      }
+      return new ScanSourceControlMetadataRequest(namespace, sortOrder, sortOn, scanAfter, limit,
+          filter);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/SourceControlMetadataFilter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/SourceControlMetadataFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.app.store;
+
+/**
+ * A filter for source control metadata.
+ */
+public class SourceControlMetadataFilter {
+  private final String nameContains;
+  private final Boolean isSynced;
+
+  public String getNameContains() {
+    return nameContains;
+  }
+
+  public Boolean getIsSynced() {
+    return isSynced;
+  }
+
+  public SourceControlMetadataFilter(String nameContains, Boolean syncStatus) {
+    this.nameContains = nameContains;
+    this.isSynced = syncStatus;
+  }
+
+  public static SourceControlMetadataFilter emptyFilter() {
+    return new SourceControlMetadataFilter(null, null);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.proto.ProgramHistory;
 import io.cdap.cdap.proto.ProgramRunClusterStatus;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.RunCountResult;
+import io.cdap.cdap.proto.SourceControlMetadataRecord;
 import io.cdap.cdap.proto.WorkflowNodeStateDetail;
 import io.cdap.cdap.proto.WorkflowStatistics;
 import io.cdap.cdap.proto.id.ApplicationId;
@@ -464,6 +465,9 @@ public interface Store {
   @Nullable
   ApplicationMeta getLatest(ApplicationReference appRef);
 
+  @Nullable
+  SourceControlMetadataRecord getNamespaceSourceControlMetadataRecord(ApplicationReference appRef);
+
   /**
    * Scans for the latest applications across all namespaces.
    *
@@ -484,6 +488,14 @@ public interface Store {
    */
   boolean scanApplications(ScanApplicationsRequest request, int txBatchSize,
                            BiConsumer<ApplicationId, ApplicationMeta> consumer);
+
+  int scanAppSourceControlMetadata(ScanSourceControlMetadataRequest request,
+      Consumer<SourceControlMetadataRecord> consumer);
+
+  int scanRepositorySourceControlMetadata(ScanSourceControlMetadataRequest request,
+      Consumer<SourceControlMetadataRecord> consumer);
+
+  void updateSourceControlMeta(ApplicationReference appRef, String repoFileHash);
 
   /**
    * Returns a Map of {@link ApplicationMeta} for the given set of {@link ApplicationId}.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.api.security.AccessException;
 import io.cdap.cdap.app.runtime.ProgramRuntimeService;
 import io.cdap.cdap.app.store.ApplicationFilter;
 import io.cdap.cdap.app.store.ScanApplicationsRequest;
+import io.cdap.cdap.app.store.ScanSourceControlMetadataRequest;
 import io.cdap.cdap.common.ApplicationNotFoundException;
 import io.cdap.cdap.common.ArtifactAlreadyExistsException;
 import io.cdap.cdap.common.BadRequestException;
@@ -46,6 +47,7 @@ import io.cdap.cdap.common.ServiceException;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.AppFabric;
 import io.cdap.cdap.common.feature.DefaultFeatureFlagsProvider;
 import io.cdap.cdap.common.http.AbstractBodyConsumer;
 import io.cdap.cdap.common.id.Id;
@@ -55,6 +57,7 @@ import io.cdap.cdap.common.security.AuditDetail;
 import io.cdap.cdap.common.security.AuditPolicy;
 import io.cdap.cdap.common.utils.DirUtils;
 import io.cdap.cdap.features.Feature;
+import io.cdap.cdap.gateway.handlers.util.SourceControlMetadataHelper;
 import io.cdap.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import io.cdap.cdap.internal.app.runtime.artifact.WriteConflictException;
 import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
@@ -62,6 +65,7 @@ import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.ApplicationRecord;
 import io.cdap.cdap.proto.ApplicationUpdateDetail;
 import io.cdap.cdap.proto.BatchApplicationDetail;
+import io.cdap.cdap.proto.SourceControlMetadataRecord;
 import io.cdap.cdap.proto.artifact.AppRequest;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ApplicationReference;
@@ -125,6 +129,7 @@ public class AppLifecycleHttpHandler extends AbstractAppLifecycleHttpHandler {
    * Key in json paginated applications list response.
    */
   public static final String APP_LIST_PAGINATED_KEY = "applications";
+  public static final String APP_LIST_PAGINATED_KEY_SHORT = "apps";
 
   /**
    * Runtime program service for running and managing programs.
@@ -133,6 +138,7 @@ public class AppLifecycleHttpHandler extends AbstractAppLifecycleHttpHandler {
   private final AccessEnforcer accessEnforcer;
   private final AuthenticationContext authenticationContext;
   private final FeatureFlagsProvider featureFlagsProvider;
+  private final int batchSize;
 
   @Inject
   AppLifecycleHttpHandler(CConfiguration configuration,
@@ -147,6 +153,7 @@ public class AppLifecycleHttpHandler extends AbstractAppLifecycleHttpHandler {
     this.accessEnforcer = accessEnforcer;
     this.authenticationContext = authenticationContext;
     this.featureFlagsProvider = new DefaultFeatureFlagsProvider(configuration);
+    this.batchSize = configuration.getInt(AppFabric.STREAMING_BATCH_SIZE);
   }
 
   /**
@@ -285,6 +292,75 @@ public class AppLifecycleHttpHandler extends AbstractAppLifecycleHttpHandler {
               d -> jsonListResponder.send(new ApplicationRecord(d)))
       );
     }
+  }
+
+  /**
+   * Retrieves all namespace source control metadata for applications within the specified namespace.
+   *
+   * @param request      The HTTP request containing parameters for retrieving metadata.
+   * @param responder    The HTTP responder for sending the response.
+   * @param namespaceId  The ID of the namespace for which to retrieve metadata.
+   * @param pageToken    A token for paginating through results.
+   * @param pageSize     The size of each page for pagination.
+   * @param sortOrder    The sort order for the metadata.
+   * @param sortOn  The field on which to sort the metadata.
+   * @param filter       A filter string for filtering the metadata.
+   *                     filter query format - "name=&lt;name-filter&gt; AND syncStatus=&lt;SYNCED/UNSYNCED&gt;".
+   * @throws Exception If an error occurs during the metadata retrieval process.
+   */
+  @GET
+  @Path("/sourcecontrol/apps")
+  public void getAllNamespaceSourceControlMetadata(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @QueryParam("pageToken") String pageToken,
+      @QueryParam("pageSize") Integer pageSize,
+      @QueryParam("sortOrder") SortOrder sortOrder,
+      @QueryParam("sortOn") SortBy sortOn,
+      @QueryParam("filter") String filter
+  ) throws Exception {
+    validateNamespace(namespaceId);
+
+    JsonPaginatedListResponder.respond(GSON, responder, APP_LIST_PAGINATED_KEY_SHORT,
+        jsonListResponder -> {
+          AtomicReference<SourceControlMetadataRecord> lastRecord = new AtomicReference<>(null);
+          ScanSourceControlMetadataRequest scanRequest = SourceControlMetadataHelper.getScmStatusScanRequest(
+              namespaceId,
+              pageToken, pageSize, sortOrder, sortOn, filter);
+          boolean pageLimitReached = false;
+          try {
+            pageLimitReached = applicationLifecycleService.scanSourceControlMetadata(
+                scanRequest, batchSize,
+                scmMetaRecord -> {
+                  jsonListResponder.send(scmMetaRecord);
+                  lastRecord.set(scmMetaRecord);
+                });
+          } catch (IOException e) {
+            responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+          }
+          SourceControlMetadataRecord record = lastRecord.get();
+          return !pageLimitReached || record == null ? null : record.getName();
+        });
+  }
+
+  /**
+   * Retrieves the source control metadata for the specified application within the specified namespace.
+   *
+   * @param request      The HTTP request containing parameters for retrieving metadata.
+   * @param responder    The HTTP responder for sending the response.
+   * @param namespaceId  The ID of the namespace containing the application.
+   * @param appName      The ID of the application for which to retrieve metadata.
+   * @throws Exception If an error occurs during the metadata retrieval process.
+   */
+  @GET
+  @Path("/apps/{app-id}/sourcecontrol")
+  public void getNamespaceSourceControlMetadata(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") final String namespaceId,
+      @PathParam("app-id") final String appName) throws Exception {
+    validateApplicationId(namespaceId, appName);
+
+    responder.sendJson(HttpResponseStatus.OK,
+        GSON.toJson(applicationLifecycleService.getSourceControlMetadataRecord(
+            new ApplicationReference(namespaceId, appName))));
   }
 
   private ScanApplicationsRequest getScanRequest(String namespaceId, String artifactVersion,
@@ -659,34 +735,6 @@ public class AppLifecycleHttpHandler extends AbstractAppLifecycleHttpHandler {
       }
     }
     responder.sendJson(HttpResponseStatus.OK, GSON.toJson(result));
-  }
-
-  /**
-   * Returns the source control metadata and sync status of all applications
-   * filter query format - "name=&lt;name-filter&gt; AND syncStatus=&lt;SYNCED/UNSYNCED&gt;".
-   */
-  @GET
-  @Path("/sourcecontrol/apps")
-  public void getAllNamespaceSourceControlMetadata(FullHttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespace,
-      @QueryParam("pageToken") String pageToken,
-      @QueryParam("pageSize") Integer pageSize,
-      @QueryParam("orderBy") SortOrder orderBy,
-      @QueryParam("orderByOption") SortBy orderByOption,
-      @QueryParam("filter") String filter
-     ) throws Exception {
-    // TODO(CDAP-20989): Implement the API handler
-  }
-
-  /**
-   * Returns the source control metadata and sync status of a specific application.
-   */
-  @GET
-  @Path("/apps/{app-id}/sourcecontrol")
-  public void getNamespaceSourceControlMetadata(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") final String namespaceId,
-      @PathParam("app-id") final String appName) throws Exception {
-    // TODO(CDAP-20989): Implement the API handler
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/SourceControlManagementHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/SourceControlManagementHttpHandler.java
@@ -21,17 +21,22 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.feature.FeatureFlagsProvider;
+import io.cdap.cdap.app.store.ScanSourceControlMetadataRequest;
 import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.ForbiddenException;
+import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.AppFabric;
 import io.cdap.cdap.common.feature.DefaultFeatureFlagsProvider;
 import io.cdap.cdap.common.security.AuditDetail;
 import io.cdap.cdap.common.security.AuditPolicy;
 import io.cdap.cdap.features.Feature;
 import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import io.cdap.cdap.gateway.handlers.util.SourceControlMetadataHelper;
 import io.cdap.cdap.internal.app.services.SourceControlManagementService;
 import io.cdap.cdap.proto.ApplicationRecord;
+import io.cdap.cdap.proto.SourceControlMetadataRecord;
 import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.operation.OperationMeta;
@@ -44,19 +49,23 @@ import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigRequest;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfigValidationException;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryMeta;
 import io.cdap.cdap.proto.sourcecontrol.SetRepositoryResponse;
+import io.cdap.cdap.proto.sourcecontrol.SortBy;
 import io.cdap.cdap.sourcecontrol.NoChangesToPullException;
 import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
 import io.cdap.cdap.sourcecontrol.operationrunner.PushAppsResponse;
-import io.cdap.cdap.sourcecontrol.operationrunner.RepositoryAppsResponse;
+import io.cdap.cdap.spi.data.SortOrder;
 import io.cdap.http.HttpResponder;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
 
 /**
  * {@link io.cdap.http.HttpHandler} for source control management.
@@ -66,12 +75,15 @@ public class SourceControlManagementHttpHandler extends AbstractAppFabricHttpHan
   private final SourceControlManagementService sourceControlService;
   private final FeatureFlagsProvider featureFlagsProvider;
   private static final Gson GSON = new Gson();
+  public static final String APP_LIST_PAGINATED_KEY_SHORT = "apps";
+  private final int batchSize;
 
   @Inject
   SourceControlManagementHttpHandler(CConfiguration cConf,
                                      SourceControlManagementService sourceControlService) {
     this.sourceControlService = sourceControlService;
     this.featureFlagsProvider = new DefaultFeatureFlagsProvider(cConf);
+    this.batchSize = cConf.getInt(AppFabric.STREAMING_BATCH_SIZE);
   }
 
   /**
@@ -130,27 +142,42 @@ public class SourceControlManagementHttpHandler extends AbstractAppFabricHttpHan
   }
 
   /**
-   * Lists applications found in linked repository for the given namespace.
-   * Returns the application name and git-filehash for each application config file found
-   * <pre>
-   * {
-   *  apps:[
-   *    {
-   *      "name": "xyz",
-   *      "fileHash": "abc"
-   *    }
-   *  ]
-   * }
-   * </pre>
+   * Retrieves a list of applications from the provided repository.
    */
   @GET
   @Path("/apps")
-  public void listApplications(FullHttpRequest request, HttpResponder responder,
-                               @PathParam("namespace-id") String namespaceId) throws Exception {
+  public void listAllApplications(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @QueryParam("pageToken") String pageToken,
+      @QueryParam("pageSize") Integer pageSize,
+      @QueryParam("sortOrder") SortOrder sortOrder,
+      @QueryParam("sortOn") SortBy sortOn,
+      @QueryParam("filter") String filter) throws Exception {
     checkSourceControlFeatureFlag();
-    NamespaceId namespace = validateNamespaceId(namespaceId);
-    RepositoryAppsResponse listResponse = sourceControlService.listApps(namespace);
-    responder.sendJson(HttpResponseStatus.OK, GSON.toJson(listResponse));
+    validateNamespaceId(namespaceId);
+    JsonPaginatedListResponder.respond(GSON, responder, APP_LIST_PAGINATED_KEY_SHORT,
+        jsonListResponder -> {
+          AtomicReference<SourceControlMetadataRecord> lastRecord = new AtomicReference<>(null);
+          ScanSourceControlMetadataRequest scanRequest = SourceControlMetadataHelper.getScmStatusScanRequest(
+              namespaceId,
+              pageToken, pageSize, sortOrder, sortOn, filter);
+          boolean pageLimitReached = false;
+          try {
+            pageLimitReached = sourceControlService.scanRepoMetadata(
+                scanRequest, batchSize,
+                record -> {
+                  jsonListResponder.send(record);
+                  lastRecord.set(record);
+                });
+          } catch (IOException e) {
+            responder.sendString(HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+          } catch (NotFoundException e) {
+            responder.sendString(HttpResponseStatus.NOT_FOUND, e.getMessage());
+          }
+          SourceControlMetadataRecord record = lastRecord.get();
+          return !pageLimitReached || record == null ? null :
+              record.getName();
+        });
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/util/SourceControlMetadataHelper.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/util/SourceControlMetadataHelper.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers.util;
+
+import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.app.store.ScanSourceControlMetadataRequest;
+import io.cdap.cdap.app.store.SourceControlMetadataFilter;
+import io.cdap.cdap.proto.sourcecontrol.SortBy;
+import io.cdap.cdap.spi.data.SortOrder;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Helper class for building ScanSourceControlMetadataRequest.
+ */
+public class SourceControlMetadataHelper {
+
+  private static final String FILTER_SPLITTER = "AND";
+  private static final Pattern KEY_VALUE_PATTERN = Pattern.compile("(\"?)(\\w+)=(\\w+)(\"?)");
+
+
+  /**
+   * Constructs a ScanSourceControlMetadataRequest for retrieving source control metadata status.
+   * This method creates a ScanSourceControlMetadataRequest object with specified parameters for
+   * fetching source control metadata status.
+   *
+   * @param namespace The namespace to filter the metadata.
+   * @param pageToken The token for pagination.
+   * @param pageSize  The size of each page for pagination.
+   * @param orderBy   The sorting order for the metadata.
+   * @param sortOn    The field to sort the metadata on.
+   * @param filter    The filter criteria for the metadata.
+   * @return A ScanSourceControlMetadataRequest configured with the provided parameters.
+   */
+  public static ScanSourceControlMetadataRequest getScmStatusScanRequest(String namespace,
+      String pageToken,
+      Integer pageSize, SortOrder orderBy, SortBy sortOn, String filter) {
+    ScanSourceControlMetadataRequest.Builder builder = ScanSourceControlMetadataRequest.builder();
+    builder.setNamespace(namespace);
+    if (pageSize != null) {
+      builder.setLimit(pageSize);
+    }
+    if (pageToken != null && !pageToken.isEmpty()) {
+      builder.setScanAfter(pageToken);
+    }
+    if (orderBy != null) {
+      builder.setSortOrder(orderBy);
+    }
+    if (sortOn != null) {
+      builder.setSortOn(sortOn);
+    }
+    if (filter != null && !filter.isEmpty()) {
+      builder.setFilter(getFilter(filter));
+    }
+
+    return builder.build();
+  }
+
+  private static SourceControlMetadataFilter getFilter(String filterStr)
+      throws IllegalArgumentException {
+    ImmutableMap<String, String> filterKeyValMap = parseKeyValStr(filterStr, FILTER_SPLITTER);
+    String name = null;
+    Boolean isSynced = null;
+
+    for (Map.Entry<String, String> entry : filterKeyValMap.entrySet()) {
+      String filterValue = entry.getValue();
+      SourceControlMetadataFilterKey filterKey = SourceControlMetadataFilterKey.valueOf(
+          entry.getKey());
+
+      try {
+        switch (filterKey) {
+          case NAME_CONTAINS:
+            name = filterValue;
+            break;
+          case IS_SYNCED:
+            if (filterValue.equals("TRUE")) {
+              isSynced = true;
+            } else if (filterValue.equals("FALSE")) {
+              isSynced = false;
+            } else {
+              throw new IllegalArgumentException("Invalid value for IS_SYNCED: " + filterValue);
+            }
+            break;
+          default:
+            throw new IllegalArgumentException("Unknown filter key: " + filterKey);
+        }
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Invalid " + filterKey.name() + ": " + filterValue, e);
+      }
+    }
+    return new SourceControlMetadataFilter(name, isSynced);
+  }
+
+  private static ImmutableMap<String, String> parseKeyValStr(String input, String splitter) {
+    ImmutableMap.Builder<String, String> keyValMap = ImmutableMap.<String, String>builder();
+    String[] keyValPairs = input.split(splitter);
+
+    for (String keyValPair : keyValPairs) {
+      Matcher matcher = KEY_VALUE_PATTERN.matcher(keyValPair.trim());
+
+      if (matcher.matches()) {
+        keyValMap.put(matcher.group(2).trim().toUpperCase(), matcher.group(3).trim().toUpperCase());
+      } else {
+        throw new IllegalArgumentException("Invalid filter key=val pair: " + keyValPair);
+      }
+    }
+    return keyValMap.build();
+  }
+
+  /**
+   * Enum representing the filter keys for source control metadata.
+   */
+  public enum SourceControlMetadataFilterKey {
+    NAME_CONTAINS,
+    IS_SYNCED
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleService.java
@@ -51,6 +51,7 @@ import io.cdap.cdap.app.deploy.Manager;
 import io.cdap.cdap.app.deploy.ManagerFactory;
 import io.cdap.cdap.app.store.ApplicationFilter;
 import io.cdap.cdap.app.store.ScanApplicationsRequest;
+import io.cdap.cdap.app.store.ScanSourceControlMetadataRequest;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.ApplicationNotFoundException;
 import io.cdap.cdap.common.ArtifactAlreadyExistsException;
@@ -59,6 +60,7 @@ import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.CannotBeDeletedException;
 import io.cdap.cdap.common.InvalidArtifactException;
 import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.SourceControlMetadataNotFoundException;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
@@ -91,6 +93,7 @@ import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.PluginInstanceDetail;
 import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.SourceControlMetadataRecord;
 import io.cdap.cdap.proto.app.AppVersion;
 import io.cdap.cdap.proto.app.MarkLatestAppsRequest;
 import io.cdap.cdap.proto.app.UpdateMultiSourceControlMetaReqeust;
@@ -119,6 +122,8 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.spi.metadata.MetadataMutation;
 import java.io.File;
 import java.io.IOException;
@@ -182,6 +187,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
   private final int batchSize;
   private final MetricsCollectionService metricsCollectionService;
   private final FeatureFlagsProvider featureFlagsProvider;
+  private final TransactionRunner transactionRunner;
 
   /**
    * Construct the ApplicationLifeCycleService with service factory and cConf coming from guice
@@ -197,7 +203,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
       AccessEnforcer accessEnforcer, AuthenticationContext authenticationContext,
       MessagingService messagingService, Impersonator impersonator,
       CapabilityReader capabilityReader,
-      MetricsCollectionService metricsCollectionService) {
+      MetricsCollectionService metricsCollectionService, TransactionRunner transactionRunner) {
     this.cConf = cConf;
     this.appUpdateSchedules = cConf.getBoolean(Constants.AppFabric.APP_UPDATE_SCHEDULES,
         Constants.AppFabric.DEFAULT_APP_UPDATE_SCHEDULES);
@@ -219,6 +225,7 @@ public class ApplicationLifecycleService extends AbstractIdleService {
         new MultiThreadMessagingContext(messagingService));
     this.metricsCollectionService = metricsCollectionService;
     this.featureFlagsProvider = new DefaultFeatureFlagsProvider(cConf);
+    this.transactionRunner = transactionRunner;
   }
 
   @Override
@@ -299,6 +306,45 @@ public class ApplicationLifecycleService extends AbstractIdleService {
     }
   }
 
+  /**
+   * Scans source control metadata based on the provided request and processes it in batches. This
+   * method scans source control metadata based on the specified request parameters.
+   *
+   * @param request     The request specifying the metadata to scan.
+   * @param txBatchSize The transaction batch size for processing metadata in each iteration.
+   * @param consumer    The consumer to process the scanned source control metadata records.
+   * @return True if the page limit has reached, false otherwise.
+   * @throws IOException If an I/O error occurs during the scanning process.
+   */
+  public boolean scanSourceControlMetadata(ScanSourceControlMetadataRequest request,
+      int txBatchSize,
+      Consumer<SourceControlMetadataRecord> consumer) throws IOException {
+    String lastKey = request.getScanAfter();
+    int currentLimit = request.getLimit();
+
+    while (currentLimit > 0) {
+      int maxLimit = Math.min(txBatchSize, currentLimit);
+      ScanSourceControlMetadataRequest batchRequest = ScanSourceControlMetadataRequest
+          .builder(request)
+          .setScanAfter(lastKey)
+          .setLimit(maxLimit)
+          .build();
+
+      request = batchRequest;
+
+      int count = TransactionRunners.run(transactionRunner, context -> {
+        return store.scanAppSourceControlMetadata(batchRequest, consumer);
+      }, IOException.class);
+
+      if (count < maxLimit) {
+        return false;
+      }
+
+      currentLimit -= txBatchSize;
+    }
+    return true;
+  }
+
   private void processApplications(List<Map.Entry<ApplicationId, ApplicationMeta>> list,
       Consumer<ApplicationDetail> consumer) {
 
@@ -358,6 +404,23 @@ public class ApplicationLifecycleService extends AbstractIdleService {
   public ApplicationDetail getLatestAppDetail(ApplicationReference appRef)
       throws IOException, NotFoundException {
     return getLatestAppDetail(appRef, true);
+  }
+
+  /**
+   * Retrieves the source control metadata detail for the specified application reference.
+   *
+   * @param appRef The application reference for which to retrieve the metadata detail.
+   * @return The {@link SourceControlMetadataRecord} for the specified application reference.
+   * @throws SourceControlMetadataNotFoundException If the metadata record for the application
+   *                                                reference is not found.
+   */
+  public SourceControlMetadataRecord getSourceControlMetadataRecord(ApplicationReference appRef)
+      throws SourceControlMetadataNotFoundException {
+    SourceControlMetadataRecord record = store.getNamespaceSourceControlMetadataRecord(appRef);
+    if (record == null) {
+      throw new SourceControlMetadataNotFoundException(appRef);
+    }
+    return record;
   }
 
   /**

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.api.workflow.WorkflowSpecification;
 import io.cdap.cdap.api.workflow.WorkflowToken;
 import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.app.store.ScanApplicationsRequest;
+import io.cdap.cdap.app.store.ScanSourceControlMetadataRequest;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.ApplicationNotFoundException;
 import io.cdap.cdap.common.ConflictException;
@@ -54,8 +55,10 @@ import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.RunCountResult;
 import io.cdap.cdap.proto.RunRecord;
+import io.cdap.cdap.proto.SourceControlMetadataRecord;
 import io.cdap.cdap.proto.WorkflowNodeStateDetail;
 import io.cdap.cdap.proto.WorkflowStatistics;
+import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.DatasetId;
@@ -147,6 +150,11 @@ public class DefaultStore implements Store {
   private NamespaceSourceControlMetadataStore getNamespaceSourceControlMetadataStore(
       StructuredTableContext context) {
     return NamespaceSourceControlMetadataStore.create(context);
+  }
+
+  private RepositorySourceControlMetadataStore getRepoSourceControlMetadataStore(
+      StructuredTableContext context) {
+    return RepositorySourceControlMetadataStore.create(context);
   }
 
   private WorkflowTable getWorkflowTable(StructuredTableContext context)
@@ -645,6 +653,14 @@ public class DefaultStore implements Store {
     }, IOException.class);
   }
 
+  @Override
+  public SourceControlMetadataRecord getNamespaceSourceControlMetadataRecord(
+      ApplicationReference appRef) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      return getNamespaceSourceControlMetadataStore(context).getRecord(appRef);
+    });
+  }
+
   // todo: this method should be moved into DeletedProgramHandlerState, bad design otherwise
   @Override
   public List<ProgramSpecification> getDeletedProgramSpecifications(ApplicationReference appRef,
@@ -767,7 +783,7 @@ public class DefaultStore implements Store {
   @Override
   public void removeApplication(ApplicationId id) {
     LOG.trace("Removing application: namespace: {}, application: {}", id.getNamespace(),
-              id.getApplication(), id.getVersion());
+        id.getApplication(), id.getVersion());
 
     TransactionRunners.run(transactionRunner, context -> {
       getAppStateTable(context).deleteAll(id.getNamespaceId(), id.getApplication());
@@ -973,6 +989,54 @@ public class DefaultStore implements Store {
       SourceControlMeta sourceControlMeta = getNamespaceSourceControlMetadataStore(context)
           .get(appRef);
       return new ApplicationMeta(meta.getId(), meta.getSpec(), meta.getChange(), sourceControlMeta);
+    });
+  }
+
+  @Override
+  public void updateSourceControlMeta(ApplicationReference appRef, String repoFileHash) {
+    TransactionRunners.run(transactionRunner, context -> {
+      RepositorySourceControlMetadataStore repoMetadataStore = getRepoSourceControlMetadataStore(
+          context);
+      NamespaceSourceControlMetadataStore namespaceMetadataStore = getNamespaceSourceControlMetadataStore(
+          context);
+      SourceControlMeta namespaceSourceControlMeta = namespaceMetadataStore.get(appRef);
+
+      if (namespaceSourceControlMeta == null || namespaceSourceControlMeta.getFileHash() == null) {
+        repoMetadataStore.write(appRef, false, 0L);
+        return;
+      }
+      Boolean isSynced = namespaceSourceControlMeta.getFileHash().equals(repoFileHash);
+      if (isSynced) {
+        namespaceMetadataStore.write(appRef,
+            new SourceControlMeta(namespaceSourceControlMeta.getFileHash(),
+                namespaceSourceControlMeta.getCommitId(),
+                namespaceSourceControlMeta.getLastSyncedAt(), isSynced));
+        repoMetadataStore.write(appRef,
+            isSynced, namespaceSourceControlMeta.getLastSyncedAt().toEpochMilli());
+      } else {
+        repoMetadataStore.write(appRef, isSynced, 0L);
+      }
+    });
+  }
+
+  @Override
+  public int scanRepositorySourceControlMetadata(ScanSourceControlMetadataRequest request,
+      Consumer<SourceControlMetadataRecord> consumer) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      String type = EntityType.APPLICATION.toString();
+      return getRepoSourceControlMetadataStore(context).scan(request, type,
+          consumer);
+    });
+  }
+
+  @Override
+  public int scanAppSourceControlMetadata(ScanSourceControlMetadataRequest request,
+      Consumer<SourceControlMetadataRecord> consumer) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      String type = EntityType.APPLICATION.toString();
+      return getNamespaceSourceControlMetadataStore(context).scan(request,
+          type,
+          consumer);
     });
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/NamespaceSourceControlMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/NamespaceSourceControlMetadataStore.java
@@ -18,8 +18,14 @@ package io.cdap.cdap.internal.app.store;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.app.store.ScanSourceControlMetadataRequest;
+import io.cdap.cdap.proto.SourceControlMetadataRecord;
+import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.proto.sourcecontrol.SortBy;
 import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
+import io.cdap.cdap.spi.data.SortOrder;
 import io.cdap.cdap.spi.data.StructuredRow;
 import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.StructuredTableContext;
@@ -34,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 /**
@@ -100,7 +107,93 @@ public class NamespaceSourceControlMetadataStore {
   }
 
   /**
-   * Sets the source control metadata for the specified application ID in the namespace.  Source
+   * Scans the source control metadata records based on the specified request parameters, and
+   * invokes the provided consumer for each matched record.
+   *
+   * @param request  The {@link ScanSourceControlMetadataRequest} object specifying the criteria for
+   *                 scanning the metadata records.
+   * @param type     The type of metadata records to scan. Currently, it is
+   *                 {@code APPLICATIONREFERENCE} by default.
+   * @param consumer The consumer to be invoked for each matched metadata record.
+   * @return The number of metadata records scanned and processed.
+   * @throws IOException If an I/O error occurs while scanning the metadata records.
+   */
+  public int scan(ScanSourceControlMetadataRequest request,
+      String type, Consumer<SourceControlMetadataRecord> consumer) throws IOException {
+    Range.Bound startBound = Range.Bound.INCLUSIVE;
+    final Range.Bound endBound = Range.Bound.INCLUSIVE;
+    Collection<Field<?>> startFields = new ArrayList<>();
+    StructuredTable table = getNamespaceSourceControlMetadataTable();
+
+    startFields.add(
+        Fields.stringField(StoreDefinition.NamespaceSourceControlMetadataStore.NAMESPACE_FIELD,
+            request.getNamespace())
+    );
+    startFields.add(
+        Fields.stringField(StoreDefinition.NamespaceSourceControlMetadataStore.TYPE_FIELD, type)
+    );
+
+    if (request.getFilter().getIsSynced() != null) {
+      startFields.add(
+          Fields.booleanField(StoreDefinition.NamespaceSourceControlMetadataStore.IS_SYNCED_FIELD,
+              request.getFilter().getIsSynced()));
+    }
+
+    Collection<Field<?>> endFields = startFields;
+
+    if (request.getScanAfter() != null) {
+      startBound = Range.Bound.EXCLUSIVE;
+      startFields = getRangeFields(request, type);
+    }
+
+    Range range;
+    if (request.getSortOrder() == SortOrder.ASC) {
+      range = Range.create(startFields, startBound, endFields, endBound);
+    } else {
+      range = Range.create(endFields, endBound, startFields, startBound);
+    }
+
+    int limit = request.getLimit();
+    int count = 0;
+    try (CloseableIterator<StructuredRow> iterator = getScanIterator(
+        table, range,
+        request.getSortOrder(), request.getSortOn())
+    ) {
+      while (iterator.hasNext() && limit > 0) {
+        StructuredRow row = iterator.next();
+        SourceControlMetadataRecord record = decodeRow(row);
+        boolean nameContainsFilterMatch = request.getFilter().getNameContains() == null
+            || record.getName().toLowerCase()
+                .contains(request.getFilter().getNameContains().toLowerCase());
+
+        if (nameContainsFilterMatch) {
+          consumer.accept(record);
+          limit--;
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+
+  /**
+   * Retrieves the source control metadata record for the specified application reference.
+   *
+   * @param appRef The {@link ApplicationReference} for which to retrieve the metadata record.
+   * @return The {@link SourceControlMetadataRecord} associated with the specified application
+   *         reference, or {@code null} if no record is found.
+   * @throws IOException If an I/O error occurs while retrieving the record.
+   */
+  public SourceControlMetadataRecord getRecord(ApplicationReference appRef)
+      throws IOException {
+    List<Field<?>> primaryKey = getPrimaryKey(appRef);
+    return getNamespaceSourceControlMetadataTable().read(primaryKey)
+        .map(row -> decodeRow(row)
+        ).orElse(null);
+  }
+
+  /**
+   * Sets the source control metadata for the specified application ID in the namespace. Source
    * control metadata will be null when the application is deployed in the namespace. It will be
    * non-null when the application is pulled from the remote repository and deployed in the
    * namespace.
@@ -123,6 +216,9 @@ public class NamespaceSourceControlMetadataStore {
     // Instead of doing filtering, searching, sorting in memory, it will happen at
     // database level.
     StructuredTable scmTable = getNamespaceSourceControlMetadataTable();
+    if (sourceControlMeta == null || sourceControlMeta.getSyncStatus() == null) {
+      throw new IllegalArgumentException("Source control metadata or sync status cannot be null");
+    }
     SourceControlMeta existingSourceControlMeta = get(appRef);
     if (sourceControlMeta.getLastSyncedAt() != null && existingSourceControlMeta != null
         && sourceControlMeta.getLastSyncedAt()
@@ -159,6 +255,59 @@ public class NamespaceSourceControlMetadataStore {
     getNamespaceSourceControlMetadataTable().deleteAll(getNamespaceRange(namespace));
   }
 
+  private CloseableIterator<StructuredRow> getScanIterator(
+      StructuredTable table,
+      Range range,
+      SortOrder sortOrder,
+      SortBy sortBy) throws IOException {
+    if (sortBy == SortBy.LAST_SYNCED_DATE) {
+      return table.scan(range, Integer.MAX_VALUE,
+          StoreDefinition.NamespaceSourceControlMetadataStore.LAST_MODIFIED_FIELD, sortOrder);
+    }
+    return table.scan(range, Integer.MAX_VALUE,
+        StoreDefinition.NamespaceSourceControlMetadataStore.NAME_FIELD, sortOrder);
+  }
+
+  private List<Field<?>> getRangeFields(
+      ScanSourceControlMetadataRequest request, String type) throws IOException {
+    List<Field<?>> fields = new ArrayList<>();
+    fields.add(
+        Fields.stringField(StoreDefinition.NamespaceSourceControlMetadataStore.NAMESPACE_FIELD,
+            request.getNamespace()));
+    fields.add(
+        Fields.stringField(StoreDefinition.NamespaceSourceControlMetadataStore.TYPE_FIELD, type));
+    if (request.getSortOn() == SortBy.LAST_SYNCED_DATE) {
+      SourceControlMeta meta = get(
+          new ApplicationReference(request.getNamespace(), request.getScanAfter()));
+      fields.add(Fields.longField(
+          StoreDefinition.NamespaceSourceControlMetadataStore.LAST_MODIFIED_FIELD,
+          meta == null || meta.getLastSyncedAt() == null ? 0L : meta.getLastSyncedAt().toEpochMilli()));
+    }
+    fields.add(Fields.stringField(StoreDefinition.NamespaceSourceControlMetadataStore.NAME_FIELD,
+        request.getScanAfter()));
+    return fields;
+  }
+
+  private SourceControlMetadataRecord decodeRow(StructuredRow row) {
+    String namespace = row.getString(
+        StoreDefinition.NamespaceSourceControlMetadataStore.NAMESPACE_FIELD);
+    String type = row.getString(StoreDefinition.NamespaceSourceControlMetadataStore.TYPE_FIELD);
+    String name = row.getString(StoreDefinition.NamespaceSourceControlMetadataStore.NAME_FIELD);
+    String specificationHash = row.getString(
+        StoreDefinition.NamespaceSourceControlMetadataStore.SPECIFICATION_HASH_FIELD);
+    String commitId = row.getString(
+        StoreDefinition.NamespaceSourceControlMetadataStore.COMMIT_ID_FIELD);
+    Long lastModified = row.getLong(
+        StoreDefinition.NamespaceSourceControlMetadataStore.LAST_MODIFIED_FIELD);
+    if (lastModified == 0L) {
+      lastModified = null;
+    }
+    Boolean isSynced = row.getBoolean(
+        StoreDefinition.NamespaceSourceControlMetadataStore.IS_SYNCED_FIELD);
+    return new SourceControlMetadataRecord(namespace, type, name, specificationHash, commitId,
+        lastModified, isSynced);
+  }
+
   private Collection<Field<?>> getAllFields(ApplicationReference appRef,
       SourceControlMeta newSourceControlMeta, SourceControlMeta existingSourceControlMeta) {
     List<Field<?>> fields = getPrimaryKey(appRef);
@@ -181,11 +330,13 @@ public class NamespaceSourceControlMetadataStore {
 
   private long getLastModifiedValue(SourceControlMeta newSourceControlMeta,
       SourceControlMeta existingSourceControlMeta) {
-    if (newSourceControlMeta.getLastSyncedAt() == null && existingSourceControlMeta == null) {
+    if (newSourceControlMeta.getLastSyncedAt() == null && (existingSourceControlMeta == null
+        || existingSourceControlMeta.getLastSyncedAt() == null)) {
       return 0L;
     }
     SourceControlMeta metaToUse =
-        newSourceControlMeta.getLastSyncedAt() != null ? newSourceControlMeta : existingSourceControlMeta;
+        newSourceControlMeta.getLastSyncedAt() != null ? newSourceControlMeta
+            : existingSourceControlMeta;
     return metaToUse.getLastSyncedAt().toEpochMilli();
   }
 
@@ -196,7 +347,7 @@ public class NamespaceSourceControlMetadataStore {
             appRef.getNamespace()));
     primaryKey.add(
         Fields.stringField(StoreDefinition.NamespaceSourceControlMetadataStore.TYPE_FIELD,
-            appRef.getEntityType().toString()));
+            EntityType.APPLICATION.toString()));
     primaryKey.add(
         Fields.stringField(StoreDefinition.NamespaceSourceControlMetadataStore.NAME_FIELD,
             appRef.getEntityName()));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/RepositorySourceControlMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/RepositorySourceControlMetadataStore.java
@@ -17,23 +17,35 @@
 package io.cdap.cdap.internal.app.store;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.app.store.ScanSourceControlMetadataRequest;
 import io.cdap.cdap.common.utils.ImmutablePair;
+import io.cdap.cdap.proto.SourceControlMetadataRecord;
+import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.proto.sourcecontrol.SortBy;
+import io.cdap.cdap.spi.data.SortOrder;
+import io.cdap.cdap.spi.data.StructuredRow;
 import io.cdap.cdap.spi.data.StructuredTable;
 import io.cdap.cdap.spi.data.StructuredTableContext;
 import io.cdap.cdap.spi.data.TableNotFoundException;
 import io.cdap.cdap.spi.data.table.field.Field;
 import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.table.field.Range;
 import io.cdap.cdap.store.StoreDefinition;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * Store for repository source control metadata.
  */
 public class RepositorySourceControlMetadataStore {
+
   private StructuredTable repositorySourceControlMetadataTable;
   private final StructuredTableContext context;
 
@@ -59,13 +71,84 @@ public class RepositorySourceControlMetadataStore {
   }
 
   /**
+   * Scans the source control metadata records based on the specified request parameters, and
+   * invokes the provided consumer for each matched record.
+   *
+   * @param request  The {@link ScanSourceControlMetadataRequest} object specifying the criteria for
+   *                 scanning the metadata records.
+   * @param type     The type of metadata records to scan. Currently, it is
+   *                 {@code APPLICATIONREFERENCE} by default.
+   * @param consumer The consumer to be invoked for each matched metadata record.
+   * @return The number of metadata records scanned and processed.
+   * @throws IOException If an I/O error occurs while scanning the metadata records.
+   */
+  public int scan(ScanSourceControlMetadataRequest request,
+      String type, Consumer<SourceControlMetadataRecord> consumer) throws IOException {
+    Range.Bound startBound = Range.Bound.INCLUSIVE;
+    final Range.Bound endBound = Range.Bound.INCLUSIVE;
+    Collection<Field<?>> startFields = new ArrayList<>();
+
+    startFields.add(
+        Fields.stringField(StoreDefinition.RepositorySourceControlMetadataStore.NAMESPACE_FIELD,
+            request.getNamespace())
+    );
+    startFields.add(
+        Fields.stringField(StoreDefinition.RepositorySourceControlMetadataStore.TYPE_FIELD,
+            type)
+    );
+
+    if (request.getFilter().getIsSynced() != null) {
+      startFields.add(
+          Fields.booleanField(StoreDefinition.RepositorySourceControlMetadataStore.IS_SYNCED_FIELD,
+              request.getFilter().getIsSynced()));
+    }
+
+    Collection<Field<?>> endFields = startFields;
+
+    if (request.getScanAfter() != null) {
+      startBound = Range.Bound.EXCLUSIVE;
+      startFields = getRangeFields(request, type);
+    }
+
+    Range range;
+    if (request.getSortOrder() == SortOrder.ASC) {
+      range = Range.create(startFields, startBound, endFields, endBound);
+    } else {
+      range = Range.create(endFields, endBound, startFields, startBound);
+    }
+
+    StructuredTable table = getRepositorySourceControlMetadataTable();
+    int limit = request.getLimit();
+    int count = 0;
+    try (CloseableIterator<StructuredRow> iterator = getScanIterator(table,
+        range,
+        request.getSortOrder(), request.getSortOn())
+    ) {
+      while (iterator.hasNext() && limit > 0) {
+        StructuredRow row = iterator.next();
+        SourceControlMetadataRecord record = decodeRow(row);
+        boolean nameContainsFilterMatch =
+            request.getFilter().getNameContains() == null || record.getName().toLowerCase()
+                .contains(request.getFilter().getNameContains().toLowerCase());
+
+        if (nameContainsFilterMatch) {
+          consumer.accept(record);
+          limit--;
+          count++;
+        }
+      }
+    }
+    return count;
+  }
+
+  /**
    * Writes or updates the source control metadata for the specified repository metadata ID.
    *
-   * @param appRef The {@link ApplicationReference} for which source control metadata needs to be
-   *                       written or updated.
-   * @param isSynced       A boolean indicating whether the entity in repository is synced with the
-   *                       one in namespace
-   * @param lastSynced     The timestamp of the last git pull/push of the entity
+   * @param appRef     The {@link ApplicationReference} for which source control metadata needs to
+   *                   be written or updated.
+   * @param isSynced   A boolean indicating whether the entity in repository is synced with the one
+   *                   in namespace
+   * @param lastSynced The timestamp of the last git pull/push of the entity
    * @throws IOException If an I/O error occurs while writing the source control metadata.
    */
   public void write(ApplicationReference appRef, Boolean isSynced,
@@ -78,12 +161,67 @@ public class RepositorySourceControlMetadataStore {
    * Deletes the source control metadata associated with the specified repository metadata ID.
    *
    * @param appRef The {@link ApplicationReference} for which source control metadata needs to be
-   *                       deleted.
+   *               deleted.
    * @throws IOException If an I/O error occurs while deleting the source control metadata.
    */
   public void delete(ApplicationReference appRef) throws IOException {
     getRepositorySourceControlMetadataTable().delete(
         getPrimaryKey(appRef));
+  }
+
+  /**
+   * Cleans up repository source control metadata. This method removes metadata records for
+   * repository files that are no longer present in the repository.
+   *
+   * @param namespace The namespace for which to clean up the repository source control metadata.
+   * @param repoFiles The set of repository files to retain metadata records for.
+   * @throws IOException If an I/O error occurs during the cleanup process.
+   */
+  public void cleanupRepoSourceControlMeta(String namespace, HashSet<String> repoFiles)
+      throws IOException {
+    ScanSourceControlMetadataRequest request = ScanSourceControlMetadataRequest
+        .builder()
+        .setNamespace(namespace)
+        .setLimit(Integer.MAX_VALUE)
+        .build();
+    ArrayList<SourceControlMetadataRecord> records = new ArrayList<>();
+    String type = EntityType.APPLICATION.toString();
+    scan(request, type, records::add);
+    for (SourceControlMetadataRecord record : records) {
+      if (!repoFiles.contains(record.getName())) {
+        delete(
+            new ApplicationReference(record.getNamespace(), record.getName()));
+      }
+    }
+  }
+
+  private CloseableIterator<StructuredRow> getScanIterator(
+      StructuredTable table,
+      Range range,
+      SortOrder sortOrder,
+      SortBy sortBy) throws IOException {
+    if (sortBy == SortBy.LAST_SYNCED_DATE) {
+      return table.scan(range, Integer.MAX_VALUE,
+          StoreDefinition.RepositorySourceControlMetadataStore.LAST_MODIFIED_FIELD, sortOrder);
+    }
+    return table.scan(range, Integer.MAX_VALUE,
+        StoreDefinition.RepositorySourceControlMetadataStore.NAME_FIELD, sortOrder);
+  }
+
+  private SourceControlMetadataRecord decodeRow(StructuredRow row) {
+    String namespace = row.getString(
+        StoreDefinition.RepositorySourceControlMetadataStore.NAMESPACE_FIELD);
+    String type = row.getString(StoreDefinition.RepositorySourceControlMetadataStore.TYPE_FIELD);
+    String name = row.getString(StoreDefinition.RepositorySourceControlMetadataStore.NAME_FIELD);
+    Long lastModified = row.getLong(
+        StoreDefinition.RepositorySourceControlMetadataStore.LAST_MODIFIED_FIELD);
+    if (lastModified == 0L) {
+      lastModified = null;
+    }
+    Boolean isSynced = row.getBoolean(
+        StoreDefinition.RepositorySourceControlMetadataStore.IS_SYNCED_FIELD);
+    return new SourceControlMetadataRecord(namespace, type, name, null, null, lastModified,
+        isSynced);
   }
 
   private Collection<Field<?>> getAllFields(ApplicationReference appRef,
@@ -98,6 +236,27 @@ public class RepositorySourceControlMetadataStore {
     return fields;
   }
 
+  private List<Field<?>> getRangeFields(ScanSourceControlMetadataRequest request,
+      String type) throws IOException {
+    List<Field<?>> fields = new ArrayList<>();
+
+    fields.add(
+        Fields.stringField(StoreDefinition.RepositorySourceControlMetadataStore.NAMESPACE_FIELD,
+            request.getNamespace()));
+    fields.add(
+        Fields.stringField(StoreDefinition.RepositorySourceControlMetadataStore.TYPE_FIELD, type));
+    if (request.getSortOn() == SortBy.LAST_SYNCED_DATE) {
+      ImmutablePair<Long, Boolean> lastModifiedAndStatusPair = get(
+          new ApplicationReference(request.getNamespace(), request.getScanAfter()));
+      fields.add(Fields.longField(
+          StoreDefinition.RepositorySourceControlMetadataStore.LAST_MODIFIED_FIELD,
+          lastModifiedAndStatusPair.getFirst()));
+    }
+    fields.add(Fields.stringField(StoreDefinition.RepositorySourceControlMetadataStore.NAME_FIELD,
+        request.getScanAfter()));
+    return fields;
+  }
+
   private List<Field<?>> getPrimaryKey(ApplicationReference appRef) {
     List<Field<?>> primaryKey = new ArrayList<>();
     primaryKey.add(
@@ -105,7 +264,7 @@ public class RepositorySourceControlMetadataStore {
             appRef.getNamespace()));
     primaryKey.add(
         Fields.stringField(StoreDefinition.RepositorySourceControlMetadataStore.TYPE_FIELD,
-            appRef.getEntityType().toString()));
+            EntityType.APPLICATION.toString()));
     primaryKey.add(
         Fields.stringField(StoreDefinition.RepositorySourceControlMetadataStore.NAME_FIELD,
             appRef.getEntityName()));
@@ -123,5 +282,19 @@ public class RepositorySourceControlMetadataStore {
           StoreDefinition.RepositorySourceControlMetadataStore.IS_SYNCED_FIELD);
       return new ImmutablePair(lastSynced, syncStatus);
     }).orElse(null);
+  }
+
+  /**
+   * Deletes all repository source control metadata records for a given namespace.
+   *
+   * @param namespace The namespace for which to delete all repository source control metadata
+   *                  records.
+   * @throws IOException If an I/O error occurs during the deletion process.
+   */
+  @VisibleForTesting
+  public void deleteAll(String namespace) throws IOException {
+    getRepositorySourceControlMetadataTable().deleteAll(Range.singleton(
+        ImmutableList.of(
+            Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD, namespace))));
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.internal.app.services;
 
+import static org.junit.Assert.assertEquals;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
@@ -30,10 +32,14 @@ import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.metadata.MetadataEntity;
 import io.cdap.cdap.api.metadata.MetadataScope;
+import io.cdap.cdap.app.store.ScanSourceControlMetadataRequest;
+import io.cdap.cdap.app.store.SourceControlMetadataFilter;
 import io.cdap.cdap.common.ApplicationNotFoundException;
 import io.cdap.cdap.common.ArtifactNotFoundException;
 import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.SourceControlMetadataNotFoundException;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.AppFabric;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.id.Id.Namespace;
 import io.cdap.cdap.common.io.Locations;
@@ -48,6 +54,7 @@ import io.cdap.cdap.internal.app.deploy.ProgramTerminator;
 import io.cdap.cdap.internal.app.deploy.Specifications;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.store.NamespaceSourceControlMetadataStore;
 import io.cdap.cdap.internal.capability.CapabilityConfig;
 import io.cdap.cdap.internal.capability.CapabilityNotAvailableException;
 import io.cdap.cdap.internal.capability.CapabilityStatus;
@@ -57,15 +64,20 @@ import io.cdap.cdap.proto.NamespaceMeta;
 import io.cdap.cdap.proto.ProgramRecord;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.SourceControlMetadataRecord;
 import io.cdap.cdap.proto.app.AppVersion;
 import io.cdap.cdap.proto.app.MarkLatestAppsRequest;
 import io.cdap.cdap.proto.app.UpdateMultiSourceControlMetaReqeust;
 import io.cdap.cdap.proto.app.UpdateSourceControlMetaRequest;
 import io.cdap.cdap.proto.artifact.AppRequest;
+import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.ArtifactId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.spi.metadata.Metadata;
 import io.cdap.cdap.spi.metadata.MetadataKind;
 import io.cdap.cdap.spi.metadata.MetadataStorage;
@@ -77,13 +89,16 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.zip.ZipOutputStream;
@@ -102,11 +117,14 @@ import org.junit.Test;
  */
 public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
   private static final String FEATURE_FLAG_PREFIX = "feature.";
+  private static final String NAMESPACE = "testNamespace";
+  private static final String TYPE = EntityType.APPLICATION.toString();
   private static ApplicationLifecycleService applicationLifecycleService;
   private static LocationFactory locationFactory;
   private static ArtifactRepository artifactRepository;
   private static MetadataStorage metadataStorage;
   private static CapabilityWriter capabilityWriter;
+  private static int batchSize;
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -115,6 +133,7 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     artifactRepository = getInjector().getInstance(ArtifactRepository.class);
     metadataStorage = getInjector().getInstance(MetadataStorage.class);
     capabilityWriter = getInjector().getInstance(CapabilityWriter.class);
+    batchSize = cConf.getInt(AppFabric.STREAMING_BATCH_SIZE);
   }
 
   @AfterClass
@@ -385,6 +404,115 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     appId.workflow(AppWithProgramsUsingGuava.NoOpWorkflow.NAME);
     startProgram(Id.Program.fromEntityId(workflow), ImmutableMap.of("fail.in.workflow.initialize", "true"));
     waitForRuns(1, workflow, ProgramRunStatus.FAILED);
+  }
+
+  @Test
+  public void testScanSourceControlMetadata() throws IOException {
+    ScanSourceControlMetadataRequest request;
+    List<SourceControlMetadataRecord> expectedRecords = new ArrayList<>();
+    List<SourceControlMetadataRecord> insertedRecords = insertTests();
+    // get a filtered list of testNamespace apps
+    List<SourceControlMetadataRecord> testNamespaceRecords = insertedRecords.stream()
+        .filter(record -> record.getNamespace().equals(NAMESPACE))
+        .collect(Collectors.toList());
+    // get a list testNamespace apps sorted on name in asc order which is the default state
+    List<SourceControlMetadataRecord> testNamespaceRecordsDefault = insertedRecords.stream()
+        .filter(record -> record.getNamespace().equals(NAMESPACE))
+        .sorted(Comparator.comparing(SourceControlMetadataRecord::getName))
+        .collect(Collectors.toList());
+    request =  ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).build();
+    List<SourceControlMetadataRecord> gotRecords = new ArrayList<>();
+    applicationLifecycleService.scanSourceControlMetadata(request, batchSize, gotRecords::add);
+    expectedRecords = testNamespaceRecordsDefault;
+    Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+    // verify limit
+    gotRecords.clear();
+    request = ScanSourceControlMetadataRequest.builder()
+        .setNamespace(NAMESPACE).setLimit(2).build();
+    applicationLifecycleService.scanSourceControlMetadata(request, batchSize, gotRecords::add);
+    expectedRecords = testNamespaceRecordsDefault.stream().limit(2).collect(Collectors.toList());
+    Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+    // verify name filter
+    gotRecords.clear();
+    String nameContainsFilter = "1";
+    request = ScanSourceControlMetadataRequest.builder()
+        .setNamespace(NAMESPACE)
+        .setFilter(new SourceControlMetadataFilter(nameContainsFilter, null)).build();
+    applicationLifecycleService.scanSourceControlMetadata(request, batchSize, gotRecords::add);
+    expectedRecords = testNamespaceRecordsDefault.stream()
+        .filter(record -> record.getName().contains(nameContainsFilter))
+        .collect(Collectors.toList());
+    Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+    // verify SYCNED sync status filter
+    gotRecords.clear();
+    request = ScanSourceControlMetadataRequest.builder()
+        .setNamespace(NAMESPACE)
+        .setFilter(new SourceControlMetadataFilter(null, true)).build();
+    applicationLifecycleService.scanSourceControlMetadata(request, batchSize, gotRecords::add);
+    expectedRecords = testNamespaceRecordsDefault.stream()
+        .filter(record -> record.getIsSynced() == true)
+        .collect(Collectors.toList());
+    Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+    // verify page token with limit
+    gotRecords.clear();
+    request = ScanSourceControlMetadataRequest.builder()
+        .setNamespace(NAMESPACE).setScanAfter("test2").setLimit(2).build();
+    applicationLifecycleService.scanSourceControlMetadata(request, batchSize, gotRecords::add);
+    expectedRecords = testNamespaceRecordsDefault.stream()
+        .filter(record -> record.getName().equals("test3") || record.getName().equals("test4"))
+        .collect(Collectors.toList());
+    Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+    deleteAllRecords(NAMESPACE);
+  }
+
+  @Test
+  public void testGetSourceControlMetadataRecord() throws SourceControlMetadataNotFoundException {
+    SourceControlMetadataRecord expectedRecord = insertTests().get(0);
+    SourceControlMetadataRecord actualRecord = applicationLifecycleService.getSourceControlMetadataRecord(
+        new ApplicationReference(NAMESPACE, "test0"));
+    assertEquals(expectedRecord, actualRecord);
+    deleteAllRecords(NAMESPACE);
+  }
+
+  private List<SourceControlMetadataRecord> insertTests() {
+    List<SourceControlMetadataRecord> records = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      records.add(insertRecord(NAMESPACE, "test" + i, TYPE, "fileHash" + i, "commitId" + i,
+          Instant.now(), i % 2 == 0));
+      records.add(
+          insertRecord(Namespace.DEFAULT.getId(), "test" + i, TYPE, "fileHash" + i, "commitId" + i,
+              Instant.now(), i % 2 == 0));
+    }
+    for (int i = 5; i < 10; i++) {
+      records.add(
+          insertRecord(NAMESPACE, "test" + i, TYPE, null, null, null, false));
+      records.add(
+          insertRecord(Namespace.DEFAULT.getId(), "test" + i, TYPE, null, null, null, false));
+    }
+    return records;
+  }
+
+  private SourceControlMetadataRecord insertRecord(String namespace, String name, String type,
+      String specHash, String commitId, Instant lastModified, Boolean isSycned) {
+    AtomicReference<SourceControlMetadataRecord> record = new AtomicReference<>(null);
+    ApplicationReference appRef = new ApplicationReference(namespace, name);
+    SourceControlMeta sourceControlMeta = new SourceControlMeta(specHash, commitId, lastModified, isSycned);
+    TransactionRunners.run(transactionRunner, context -> {
+      NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(
+          context);
+      store.write(appRef, sourceControlMeta);
+      record.set(store.getRecord(appRef));
+    });
+    return record.get();
+  }
+
+  private void deleteAllRecords(String namespace) {
+    TransactionRunners.run(transactionRunner, context -> {
+      NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(
+          context);
+      store.deleteAll(namespace);
+    });
   }
 
   @Test

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SourceControlManagementServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/SourceControlManagementServiceTest.java
@@ -26,21 +26,29 @@ import io.cdap.cdap.ConfigTestApp;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.app.store.ScanSourceControlMetadataRequest;
+import io.cdap.cdap.app.store.SourceControlMetadataFilter;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.ApplicationNotFoundException;
 import io.cdap.cdap.common.NamespaceNotFoundException;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.RepositoryNotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants.AppFabric;
 import io.cdap.cdap.common.id.Id;
+import io.cdap.cdap.common.id.Id.Namespace;
 import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
+import io.cdap.cdap.internal.app.store.NamespaceSourceControlMetadataStore;
+import io.cdap.cdap.internal.app.store.RepositorySourceControlMetadataStore;
 import io.cdap.cdap.internal.operation.OperationLifecycleManager;
 import io.cdap.cdap.metadata.MetadataSubscriberService;
 import io.cdap.cdap.proto.ApplicationDetail;
 import io.cdap.cdap.proto.ApplicationRecord;
 import io.cdap.cdap.proto.NamespaceMeta;
+import io.cdap.cdap.proto.SourceControlMetadataRecord;
 import io.cdap.cdap.proto.artifact.AppRequest;
+import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ApplicationReference;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.sourcecontrol.AuthConfig;
@@ -49,6 +57,7 @@ import io.cdap.cdap.proto.sourcecontrol.PatConfig;
 import io.cdap.cdap.proto.sourcecontrol.Provider;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryConfig;
 import io.cdap.cdap.proto.sourcecontrol.RepositoryMeta;
+import io.cdap.cdap.proto.sourcecontrol.SortBy;
 import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.UGIProvider;
@@ -70,10 +79,13 @@ import io.cdap.cdap.sourcecontrol.operationrunner.PushAppsResponse;
 import io.cdap.cdap.sourcecontrol.operationrunner.RepositoryApp;
 import io.cdap.cdap.sourcecontrol.operationrunner.RepositoryAppsResponse;
 import io.cdap.cdap.sourcecontrol.operationrunner.SourceControlOperationRunner;
+import io.cdap.cdap.spi.data.SortOrder;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -90,6 +102,7 @@ import org.mockito.Mockito;
 public class SourceControlManagementServiceTest extends AppFabricTestBase {
 
   private static CConfiguration cConf;
+  private static final  String TYPE = EntityType.APPLICATION.toString();
   private static NamespaceAdmin namespaceAdmin;
   private static SourceControlManagementService sourceControlService;
   private static final RepositoryConfig REPOSITORY_CONFIG = new RepositoryConfig.Builder()
@@ -102,6 +115,8 @@ public class SourceControlManagementServiceTest extends AppFabricTestBase {
       Mockito.spy(new MockSourceControlOperationRunner());
 
   private static final Instant fixedInstant = Instant.ofEpochSecond(1646358109);
+  private static final Instant fixedInstant2 = Instant.ofEpochSecond(1646788109);
+  private static int batchSize;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -110,6 +125,7 @@ public class SourceControlManagementServiceTest extends AppFabricTestBase {
     namespaceAdmin = getInjector().getInstance(NamespaceAdmin.class);
     sourceControlService =
         getInjector().getInstance(SourceControlManagementService.class);
+    batchSize = cConf.getInt(AppFabric.STREAMING_BATCH_SIZE);
   }
 
   protected static void initializeAndStartServices(CConfiguration cConf) throws Exception {
@@ -384,6 +400,7 @@ public class SourceControlManagementServiceTest extends AppFabricTestBase {
 
   @Test(expected = RepositoryNotFoundException.class)
   public void testPullAndDeployRepoNotFoundException() throws Exception {
+    sourceControlService.deleteRepository(new NamespaceId(Id.Namespace.DEFAULT.getId()));
     Id.Application appId1 = Id.Application.from(Id.Namespace.DEFAULT, "ConfigApp");
     // Deploy app artifact in default namespace
     Id.Artifact artifactId = Id.Artifact.from(Id.Namespace.DEFAULT, "appWithConfig",
@@ -506,39 +523,157 @@ public class SourceControlManagementServiceTest extends AppFabricTestBase {
     sourceControlService.deleteRepository(namespaceId);
   }
 
-  @Test
-  public void testListAppsSucceed() throws Exception {
-    RepositoryApp app1 = new RepositoryApp("app1", "hash1");
-    RepositoryApp app2 = new RepositoryApp("app2", "hash2");
-    RepositoryAppsResponse expectedListResult = new RepositoryAppsResponse(
-        Arrays.asList(app1, app2));
-    NamespaceId namespaceId = new NamespaceId(Id.Namespace.DEFAULT.getId());
-    sourceControlService.setRepository(namespaceId, REPOSITORY_CONFIG);
-
-    Mockito.doReturn(expectedListResult)
-        .when(sourceControlOperationRunnerSpy).list(Mockito.any(NamespaceRepository.class));
-
-    RepositoryAppsResponse result = sourceControlService.listApps(namespaceId);
-    List<RepositoryApp> actualAppsList = result.getApps().stream()
-        .sorted(Comparator.comparing(RepositoryApp::getName)).collect(Collectors.toList());
-
-    Assert.assertEquals(actualAppsList, expectedListResult.getApps());
-  }
-
   @Test(expected = SourceControlException.class)
-  public void testListAppsFailed() throws Exception {
+  public void testScanRepoMetadataFailed() throws Exception {
     NamespaceId namespaceId = new NamespaceId(Id.Namespace.DEFAULT.getId());
     sourceControlService.setRepository(namespaceId, REPOSITORY_CONFIG);
 
     Mockito.doThrow(SourceControlException.class)
         .when(sourceControlOperationRunnerSpy).list(Mockito.any(NamespaceRepository.class));
 
-    sourceControlService.listApps(namespaceId);
+    List<SourceControlMetadataRecord> gotRecords = new ArrayList<>();
+    ScanSourceControlMetadataRequest request = ScanSourceControlMetadataRequest.builder()
+        .setNamespace(Namespace.DEFAULT.getId()).build();
+    sourceControlService.scanRepoMetadata(request, batchSize, gotRecords::add);
+    sourceControlService.deleteRepository(namespaceId);
   }
 
   @Test
   public void testOperationRunnerStarted() {
     Assert.assertTrue(sourceControlOperationRunnerSpy.isRunning());
+  }
+
+  @Test
+  public void testScanRepoMetadata() throws Exception {
+    RepositoryApp app1 = new RepositoryApp("app1", "hash1");
+    RepositoryApp app3 = new RepositoryApp("app3", "hash3");
+    RepositoryApp app4 = new RepositoryApp("app4", "hash4");
+    RepositoryAppsResponse expectedListResult = new RepositoryAppsResponse(
+        Arrays.asList(app1, app3, app4));
+    NamespaceId namespaceId = new NamespaceId(Id.Namespace.DEFAULT.getId());
+    sourceControlService.setRepository(namespaceId, REPOSITORY_CONFIG);
+
+    Mockito.doReturn(expectedListResult)
+        .when(sourceControlOperationRunnerSpy).list(Mockito.any(NamespaceRepository.class));
+
+    insertRepoSourceControlMetadataTests();
+    insertNamespaceSourceControlTests();
+    List<SourceControlMetadataRecord> gotRecords = new ArrayList<>();
+    List<SourceControlMetadataRecord> insertedRecords = getInsertedRecords();
+    List<SourceControlMetadataRecord> expectedRecords = new ArrayList<>();
+
+    // verify the scan without filters picks all apps for default namespace
+    ScanSourceControlMetadataRequest request = ScanSourceControlMetadataRequest.builder()
+        .setNamespace(Namespace.DEFAULT.getId()).build();
+    sourceControlService.scanRepoMetadata(request, batchSize, gotRecords::add);
+    expectedRecords = insertedRecords;
+    Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+    // verify limit
+    gotRecords.clear();
+    request = ScanSourceControlMetadataRequest.builder().setNamespace(Namespace.DEFAULT.getId())
+        .setLimit(2).build();
+    sourceControlService.scanRepoMetadata(request, batchSize, gotRecords::add);
+    expectedRecords = insertedRecords.stream().limit(2).collect(Collectors.toList());
+    Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+    // verify pageToken with limit
+    gotRecords.clear();
+    request = ScanSourceControlMetadataRequest.builder().setNamespace(Namespace.DEFAULT.getId())
+        .setLimit(5).setScanAfter("app3").build();
+    sourceControlService.scanRepoMetadata(request, batchSize, gotRecords::add);
+    expectedRecords = insertedRecords.stream().filter(rec -> rec.getName().equals("app4")).collect(
+        Collectors.toList());
+    Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+    // verify pageToken with limit
+    gotRecords.clear();
+    request = ScanSourceControlMetadataRequest.builder().setNamespace(Namespace.DEFAULT.getId())
+        .setFilter(new SourceControlMetadataFilter("1", null)).build();
+    sourceControlService.scanRepoMetadata(request, batchSize, gotRecords::add);
+    expectedRecords = insertedRecords.stream().filter(rec -> rec.getName().equals("app1")).collect(
+        Collectors.toList());
+    Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+    // verify sorting by desc order on last modified
+    gotRecords.clear();
+    request = ScanSourceControlMetadataRequest.builder().setNamespace(Namespace.DEFAULT.getId())
+        .setSortOrder(
+            SortOrder.DESC).setSortOn(SortBy.LAST_SYNCED_DATE).build();
+    sourceControlService.scanRepoMetadata(request, batchSize, gotRecords::add);
+    expectedRecords = insertedRecords.stream()
+        .sorted(Comparator.nullsFirst(
+            Comparator.comparing(
+                (SourceControlMetadataRecord record) -> record.getLastModified(),
+                Comparator.nullsFirst(Comparator.naturalOrder())
+            ).reversed()))
+        .collect(Collectors.toList());
+    Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+    deleteAllNamespaceSourceControlRecords(Namespace.DEFAULT.getId());
+    deleteAllRepoSourceControlRecords(Namespace.DEFAULT.getId());
+    sourceControlService.deleteRepository(new NamespaceId(Namespace.DEFAULT.getId()));
+  }
+
+  private void deleteAllNamespaceSourceControlRecords(String namespace) {
+    TransactionRunners.run(transactionRunner, context -> {
+      NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(
+          context);
+      store.deleteAll(namespace);
+    });
+  }
+
+  private void deleteAllRepoSourceControlRecords(String namespace) {
+    TransactionRunners.run(transactionRunner, context -> {
+      RepositorySourceControlMetadataStore store = RepositorySourceControlMetadataStore.create(
+          context);
+      store.deleteAll(namespace);
+    });
+  }
+
+  private List<SourceControlMetadataRecord> getInsertedRecords() {
+    SourceControlMetadataRecord record1 = new SourceControlMetadataRecord(Namespace.DEFAULT.getId(),
+        TYPE, "app1", null, null, fixedInstant.toEpochMilli(), true);
+    SourceControlMetadataRecord record2 = new SourceControlMetadataRecord(Namespace.DEFAULT.getId(),
+        TYPE, "app3", null, null, null, false);
+    SourceControlMetadataRecord record3 = new SourceControlMetadataRecord(Namespace.DEFAULT.getId(),
+        TYPE, "app4", null, null, fixedInstant2.toEpochMilli(), true);
+    List<SourceControlMetadataRecord> insertedRecords = Arrays.asList(record1, record2, record3);
+    return insertedRecords;
+  }
+
+  private void insertRepoSourceControlMetadataTests() {
+    insertRepoRecord(Namespace.DEFAULT.getId(), "app1", TYPE, null, null, 0L, false);
+    insertRepoRecord(Namespace.DEFAULT.getId(), "app2", TYPE, null, null,
+        Instant.now().toEpochMilli(), false);
+  }
+
+  private void insertRepoRecord(String namespace, String name, String type,
+      String specHash, String commitId, Long lastModified, Boolean isSycned) {
+    TransactionRunners.run(transactionRunner, context -> {
+      RepositorySourceControlMetadataStore store = RepositorySourceControlMetadataStore.create(
+          context);
+      store.write(new ApplicationReference(namespace, name), isSycned, lastModified);
+    });
+  }
+
+  private void insertNamespaceSourceControlTests() {
+    insertNamespaceRecord(Namespace.DEFAULT.getId(), "app1", TYPE, "hash1", "commit1",
+        fixedInstant.toEpochMilli(), false);
+    insertNamespaceRecord(Namespace.DEFAULT.getId(), "app3", TYPE, "hash4", "commit1",
+        fixedInstant.toEpochMilli(), false);
+    insertNamespaceRecord(Namespace.DEFAULT.getId(), "app4", TYPE, "hash4", "commit1",
+        fixedInstant2.toEpochMilli(), true);
+  }
+
+  private void insertNamespaceRecord(String namespace, String name, String type,
+      String specHash, String commitId, Long lastModified, Boolean isSycned) {
+    TransactionRunners.run(transactionRunner, context -> {
+      NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(
+          context);
+      store.write(new ApplicationReference(namespace, name),
+          new SourceControlMeta(specHash, commitId, Instant.ofEpochMilli(lastModified), isSycned));
+    });
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -82,6 +82,7 @@ import io.cdap.cdap.security.impersonation.OwnerAdmin;
 import io.cdap.cdap.security.impersonation.UGIProvider;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.common.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -142,12 +143,12 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
           MetadataServiceClient metadataServiceClient,
           AccessEnforcer accessEnforcer, AuthenticationContext authenticationContext,
           MessagingService messagingService, Impersonator impersonator,
-          CapabilityReader capabilityReader) {
+          CapabilityReader capabilityReader, TransactionRunner transactionRunner) {
 
         return Mockito.spy(new ApplicationLifecycleService(cConf, store, scheduler,
             usageRegistry, preferencesService, metricsSystemClient, ownerAdmin, artifactRepository,
             managerFactory, metadataServiceClient, accessEnforcer, authenticationContext,
-            messagingService, impersonator, capabilityReader, new NoOpMetricsCollectionService()));
+            messagingService, impersonator, capabilityReader, new NoOpMetricsCollectionService(), transactionRunner));
       }
     });
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/SourceControlManagementHttpHandlerTests.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/SourceControlManagementHttpHandlerTests.java
@@ -26,6 +26,7 @@ import com.google.inject.Singleton;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.app.store.ScanSourceControlMetadataRequest;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -65,8 +66,6 @@ import io.cdap.cdap.sourcecontrol.NoChangesToPushException;
 import io.cdap.cdap.sourcecontrol.SourceControlException;
 import io.cdap.cdap.sourcecontrol.operationrunner.PushAppMeta;
 import io.cdap.cdap.sourcecontrol.operationrunner.PushAppsResponse;
-import io.cdap.cdap.sourcecontrol.operationrunner.RepositoryApp;
-import io.cdap.cdap.sourcecontrol.operationrunner.RepositoryAppsResponse;
 import io.cdap.cdap.sourcecontrol.operationrunner.SourceControlOperationRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.common.http.HttpResponse;
@@ -513,42 +512,32 @@ public class SourceControlManagementHttpHandlerTests extends AppFabricTestBase {
   }
 
   @Test
-  public void testListAppsSucceed() throws Exception {
-    RepositoryApp app1 = new RepositoryApp("app1", "hash1");
-    RepositoryApp app2 = new RepositoryApp("app2", "hash2");
-    RepositoryAppsResponse expectedListResult = new RepositoryAppsResponse(Arrays.asList(app1, app2));
-    Mockito.doReturn(expectedListResult).when(sourceControlService)
-      .listApps(Mockito.any());
-
-    HttpResponse response = listApplicationsFromRepository(Id.Namespace.DEFAULT.getId());
-    assertResponseCode(200, response);
-    RepositoryAppsResponse result = readResponse(response, RepositoryAppsResponse.class);
-
-    Assert.assertEquals(result.getApps(), expectedListResult.getApps());
-  }
-
-  @Test
-  public void testListAppsFailed() throws Exception {
-    Mockito.doThrow(SourceControlException.class).when(sourceControlService)
-      .listApps(Mockito.any());
-
+  public void testScanRepoMetadataFailed() throws Exception {
+    Mockito.doThrow(SourceControlException.class)
+        .when(sourceControlService)
+        .scanRepoMetadata(Mockito.notNull(ScanSourceControlMetadataRequest.class),
+            Mockito.anyInt(),
+            Mockito.any());
     HttpResponse response = listApplicationsFromRepository(Id.Namespace.DEFAULT.getId());
     assertResponseCode(500, response);
   }
 
   @Test
-  public void testListAppsFailedAuth() throws Exception {
+  public void testScanRepoMetadataFailedAuth() throws Exception {
     Mockito.doThrow(AuthenticationConfigException.class).when(sourceControlService)
-      .listApps(Mockito.any());
-
+        .scanRepoMetadata(Mockito.notNull(ScanSourceControlMetadataRequest.class),
+            Mockito.anyInt(),
+            Mockito.any());
     HttpResponse response = listApplicationsFromRepository(Id.Namespace.DEFAULT.getId());
     assertResponseCode(500, response);
   }
 
   @Test
-  public void testListAppsNotFound() throws Exception {
+  public void testScanRepoMetadataNotFound() throws Exception {
     Mockito.doThrow(new NotFoundException("apps not found")).when(sourceControlService)
-      .listApps(Mockito.any());
+        .scanRepoMetadata(Mockito.notNull(ScanSourceControlMetadataRequest.class),
+            Mockito.anyInt(),
+            Mockito.any());
     HttpResponse response = listApplicationsFromRepository(Id.Namespace.DEFAULT.getId());
     assertResponseCode(404, response);
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/NamespaceSourceControlMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/NamespaceSourceControlMetadataStoreTest.java
@@ -18,11 +18,21 @@ package io.cdap.cdap.internal.app.store;
 
 import static org.junit.Assert.assertEquals;
 
+import io.cdap.cdap.app.store.ScanSourceControlMetadataRequest;
+import io.cdap.cdap.app.store.SourceControlMetadataFilter;
+import io.cdap.cdap.proto.SourceControlMetadataRecord;
+import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.proto.sourcecontrol.SortBy;
 import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
+import io.cdap.cdap.spi.data.SortOrder;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,9 +43,11 @@ public abstract class NamespaceSourceControlMetadataStoreTest {
   private static final String SPEC_HASH = "testSpecHash";
   private static final Instant LAST_MODIFIED = Instant.now();
   private static final String NAME = "testName";
+  private static final Boolean IS_SYNCED = true;
+  private static final String TYPE = EntityType.APPLICATION.toString();
   private static final ApplicationReference APP_REF = new ApplicationReference(NAMESPACE, NAME);
   private static final SourceControlMeta SOURCE_CONTROL_META = new SourceControlMeta(SPEC_HASH,
-      COMMIT_ID, LAST_MODIFIED, true);
+      COMMIT_ID, LAST_MODIFIED, IS_SYNCED);
 
   protected static TransactionRunner transactionRunner;
 
@@ -45,10 +57,257 @@ public abstract class NamespaceSourceControlMetadataStoreTest {
       NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(context);
       store.deleteNamespaceSourceControlMetadataTable();
     });
+  }
+
+  @Test
+  public void testScanWithFiltering() {
+    List<SourceControlMetadataRecord> insertedRecords = insertTests();
+    List<SourceControlMetadataRecord> testNamespaceRecords =
+        SourceControlMetadataTestUtil.filterAndCollectRecords(insertedRecords, NAMESPACE);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnNameAsc =
+        SourceControlMetadataTestUtil.sortByNameAscending(testNamespaceRecords);
 
     TransactionRunners.run(transactionRunner, context -> {
-      NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(context);
-      store.write(APP_REF, SOURCE_CONTROL_META);
+      List<SourceControlMetadataRecord> gotRecords = new ArrayList<>();
+      ScanSourceControlMetadataRequest request;
+      NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(
+          context);
+
+      // verify name filter for testNamespaceRecordsSortedOnNameAsc
+      gotRecords.clear();
+      String nameContainsFilter = "te";
+      List<SourceControlMetadataRecord> expectedRecords;
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setFilter(new SourceControlMetadataFilter(nameContainsFilter, null)).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream()
+          .filter(record -> record.getName().toLowerCase().contains(nameContainsFilter))
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify UNSYCNED sync status filter for testNamespaceRecordsSortedOnNameAsc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setFilter(new SourceControlMetadataFilter(null, false)).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream()
+          .filter(record -> record.getIsSynced() == false).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify SYCNED sync status and name filter for testNamespaceRecordsSortedOnNameAsc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setFilter(new SourceControlMetadataFilter(nameContainsFilter, true))
+          .build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream().filter(
+          record -> record.getIsSynced() == true && record.getName().toLowerCase()
+              .contains(nameContainsFilter)).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      store.deleteAll(NAMESPACE);
+    });
+  }
+
+  @Test
+  public void testScanWithDifferentLimit() {
+    List<SourceControlMetadataRecord> insertedRecords = insertTests();
+    List<SourceControlMetadataRecord> testNamespaceRecords = SourceControlMetadataTestUtil.filterAndCollectRecords(
+        insertedRecords, NAMESPACE);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnNameAsc =
+        SourceControlMetadataTestUtil.sortByNameAscending(testNamespaceRecords);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnNameDesc =
+        SourceControlMetadataTestUtil.sortByNameDescending(testNamespaceRecords);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnLastModifiedDesc =
+        SourceControlMetadataTestUtil.sortByLastModifiedDescending(testNamespaceRecords);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnLastModifiedAsc =
+        SourceControlMetadataTestUtil.sortByLastModifiedAscending(testNamespaceRecords);
+
+    TransactionRunners.run(transactionRunner, context -> {
+      List<SourceControlMetadataRecord> gotRecords = new ArrayList<>();
+      ScanSourceControlMetadataRequest request;
+      NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(
+          context);
+
+      // verify the scan without filters which picks all apps for testNamespace
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).build();
+      List<SourceControlMetadataRecord> expectedRecords;
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc;
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify the scan without filters which picks all apps for testNamespace
+      // when last modified is in desc order
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setSortOrder(SortOrder.DESC).setSortOn(SortBy.LAST_SYNCED_DATE).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedDesc;
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify the scan without filters which picks all apps for testNamespace
+      // when last modified is in asc order
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setSortOrder(SortOrder.ASC).setSortOn(SortBy.LAST_SYNCED_DATE).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedAsc;
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify limit for testNamespaceRecordsSortedOnNameDesc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).setLimit(3)
+          .setSortOrder(SortOrder.DESC).setSortOn(SortBy.PIPELINE_NAME).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameDesc.stream().limit(3)
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+      store.deleteAll(NAMESPACE);
+    });
+  }
+
+  @Test
+  public void testScanWithPagination() {
+    List<SourceControlMetadataRecord> insertedRecords = insertTests();
+    List<SourceControlMetadataRecord> testNamespaceRecords =
+        SourceControlMetadataTestUtil.filterAndCollectRecords(insertedRecords, NAMESPACE);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnNameAsc =
+        SourceControlMetadataTestUtil.sortByNameAscending(testNamespaceRecords);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnNameDesc =
+        SourceControlMetadataTestUtil.sortByNameDescending(testNamespaceRecords);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnLastModifiedDesc =
+        SourceControlMetadataTestUtil.sortByLastModifiedDescending(testNamespaceRecords);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnLastModifiedAsc =
+        SourceControlMetadataTestUtil.sortByLastModifiedAscending(testNamespaceRecords);
+    TransactionRunners.run(transactionRunner, context -> {
+      List<SourceControlMetadataRecord> gotRecords = new ArrayList<>();
+      ScanSourceControlMetadataRequest request;
+      NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(
+          context);
+
+      // verify name filter with pageToken and limit for testNamespaceRecordsSortedOnNameAsc
+      gotRecords.clear();
+      String nameContains = "d";
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).setLimit(1)
+          .setScanAfter("datafusionquickstart")
+          .setFilter(new SourceControlMetadataFilter(nameContains, null)).build();
+      List<SourceControlMetadataRecord> expectedRecords;
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream()
+          .filter(record -> record.getName().equals("dependent100")).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify UNSYNCED filter with pageToken and limit for testNamespaceRecordsSortedOnNameAsc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).setLimit(1)
+          .setScanAfter("datafusionquickstart")
+          .setFilter(new SourceControlMetadataFilter(null, false)).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream()
+          .filter(record -> record.getName().equals("dependent101")).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify SYNCED and name filter with pageToken and limit for testNamespaceRecordsSortedOnLastModifiedDesc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).setLimit(1)
+          .setScanAfter("dependent100").setSortOrder(SortOrder.DESC).setSortOn(SortBy.PIPELINE_NAME)
+          .setFilter(new SourceControlMetadataFilter("t", true)).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedDesc.stream()
+          .filter(record -> record.getName().equals("datafusionquickstart"))
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify UNSYNCED and name filter with pageToken and limit for testNamespaceRecordsSortedOnLastModifiedDesc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).setLimit(1)
+          .setScanAfter("dependent100").setSortOn(SortBy.LAST_SYNCED_DATE)
+          .setSortOrder(SortOrder.DESC)
+          .setFilter(new SourceControlMetadataFilter("t", false)).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedDesc.stream()
+          .filter(record -> record.getName().equals("dependent101")).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnNameAsc - test 1
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setScanAfter("datafusionquickstart").setLimit(3).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream().filter(
+              record -> record.getName().equals("dependent101") || record.getName()
+                  .equals("dependent100") || record.getName().equals("newapp"))
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnNameAsc - test 2
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setScanAfter("newapp").setLimit(3).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream().filter(
+          record -> record.getName().equals("scm-test") || record.getName().equals("zapapp")
+              || record.getName().equals("test")).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnLastModifiedDesc - test 1
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setScanAfter("zapapp").setLimit(5).setSortOrder(SortOrder.DESC)
+          .setSortOn(SortBy.LAST_SYNCED_DATE).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedDesc.stream().filter(
+          record -> record.getName().equals("newapp") || record.getName().equals("scm-test")
+              || record.getName().equals("datafusionquickstart")).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnLastModifiedDesc - test 2
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setScanAfter("test").setLimit(3).setSortOrder(SortOrder.DESC)
+          .setSortOn(SortBy.LAST_SYNCED_DATE).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedDesc.stream().filter(
+              record -> record.getName().equals("dependent100") || record.getName()
+                  .equals("dependent101") || record.getName().equals("newapp"))
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnNameDesc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setSortOrder(SortOrder.DESC).setSortOn(SortBy.PIPELINE_NAME).setScanAfter("test")
+          .setLimit(3).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameDesc.stream().filter(
+          record -> record.getName().equals("scm-test") || record.getName().equals("dependent101")
+              || record.getName().equals("newapp")).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnLastModifiedAsc - test 1
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setScanAfter("scm-test").setLimit(4).setSortOrder(SortOrder.ASC)
+          .setSortOn(SortBy.LAST_SYNCED_DATE).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedAsc.stream().filter(
+              record -> record.getName().equals("zapapp") || record.getName().equals("newapp")
+                  || record.getName().equals("dependent101") || record.getName().equals("dependent100"))
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnLastModifiedAsc - test 2
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setScanAfter("datafusionquickstart").setLimit(2).setSortOrder(SortOrder.ASC)
+          .setSortOn(SortBy.LAST_SYNCED_DATE).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedAsc.stream().filter(
+              record -> record.getName().equals("newapp") || record.getName().equals("scm-test"))
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      store.deleteAll(NAMESPACE);
     });
   }
 
@@ -60,6 +319,7 @@ public abstract class NamespaceSourceControlMetadataStoreTest {
       store.write(appRef, SOURCE_CONTROL_META);
       SourceControlMeta sourceControlMeta = store.get(appRef);
       assertEquals(SOURCE_CONTROL_META, sourceControlMeta);
+      store.deleteAll(NAMESPACE);
     });
   }
 
@@ -67,15 +327,19 @@ public abstract class NamespaceSourceControlMetadataStoreTest {
   public void testGet() {
     TransactionRunners.run(transactionRunner, context -> {
       NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(context);
+      store.write(APP_REF, SOURCE_CONTROL_META);
       SourceControlMeta scmMeta = store.get(APP_REF);
       assertEquals(SOURCE_CONTROL_META, scmMeta);
+      store.deleteAll(NAMESPACE);
     });
   }
 
   @Test
   public void testDelete() {
     TransactionRunners.run(transactionRunner, context -> {
-      NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(context);
+      NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(
+          context);
+      store.write(APP_REF, SOURCE_CONTROL_META);
       SourceControlMeta scmMeta = store.get(APP_REF);
       assertEquals(SOURCE_CONTROL_META, scmMeta);
       store.delete(APP_REF);
@@ -84,4 +348,45 @@ public abstract class NamespaceSourceControlMetadataStoreTest {
     });
   }
 
+  private List<SourceControlMetadataRecord> insertTests() {
+    List<SourceControlMetadataRecord> records = new ArrayList<>();
+    records.add(
+        insertRecord(NAMESPACE, "datafusionquickstart", TYPE, null, null,
+            Instant.ofEpochSecond(0), true));
+    records.add(
+        insertRecord(NAMESPACE, "scm-test", TYPE, "hash", "commit",
+            Instant.ofEpochSecond(1646358109), false));
+    records.add(
+        insertRecord(NAMESPACE, "dependent100", TYPE, "hash", "commit",
+            Instant.ofEpochSecond(1646358113), true));
+    records.add(
+        insertRecord(NAMESPACE, "dependent101", TYPE, "hash", "commit",
+            Instant.ofEpochSecond(1646358111), false));
+    records.add(
+        insertRecord(NAMESPACE, "newapp", TYPE, "hash", "commit",
+            Instant.ofEpochSecond(1646358110), false));
+    records.add(
+        insertRecord(NAMESPACE, "zapapp", TYPE, "hash", "commit",
+            Instant.ofEpochSecond(1646358110), true));
+    records.add(
+        insertRecord(NAMESPACE, "test", TYPE, "hash", "commit",
+            Instant.ofEpochSecond(1646358114), true));
+    return records;
+  }
+
+  private SourceControlMetadataRecord insertRecord(String namespace, String name, String type,
+      String specHash, String commitId, Instant lastModified, Boolean isSycned) {
+    SourceControlMetadataRecord record = new SourceControlMetadataRecord(namespace, type, name,
+        specHash, commitId, lastModified.toEpochMilli() == 0L ? null : lastModified.toEpochMilli(),
+        isSycned);
+    ApplicationReference appRef = new ApplicationReference(namespace, name);
+    SourceControlMeta sourceControlMeta =
+        new SourceControlMeta(specHash, commitId, lastModified, isSycned);
+    TransactionRunners.run(transactionRunner, context -> {
+      NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(
+          context);
+      store.write(appRef, sourceControlMeta);
+    });
+    return record;
+  }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/NoSqlNamespaceSourceControlMetadataTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/NoSqlNamespaceSourceControlMetadataTest.java
@@ -22,14 +22,23 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
-public class NoSqlNamespaceSourceControlMetadataTest extends NamespaceSourceControlMetadataStoreTest {
+public class NoSqlNamespaceSourceControlMetadataTest extends
+    NamespaceSourceControlMetadataStoreTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     Injector injector = AppFabricTestHelper.getInjector();
     AppFabricTestHelper.ensureNamespaceExists(NamespaceId.DEFAULT);
     transactionRunner = injector.getInstance(TransactionRunner.class);
+  }
+
+  // TODO (CDAP-21005): Currently, implementation for sorting on strings is broken for NoSQL StructuredTable
+  // During pagination, the output records are not right due to incorrect sorting
+  @Override
+  @Test
+  public void testScanWithPagination() {
   }
 
   @AfterClass

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/NoSqlRepositorySourceControlMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/NoSqlRepositorySourceControlMetadataStoreTest.java
@@ -22,6 +22,7 @@ import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class NoSqlRepositorySourceControlMetadataStoreTest extends
     RepositorySourceControlMetadataStoreTest {
@@ -31,6 +32,13 @@ public class NoSqlRepositorySourceControlMetadataStoreTest extends
     Injector injector = AppFabricTestHelper.getInjector();
     AppFabricTestHelper.ensureNamespaceExists(NamespaceId.DEFAULT);
     transactionRunner = injector.getInstance(TransactionRunner.class);
+  }
+
+  // TODO (CDAP-21005): Currently, implementation for sorting on strings is broken for NoSQL StructuredTable.
+  // During pagination, the output records are not right due to incorrect sorting
+  @Override
+  @Test
+  public void testScanWithPagination() {
   }
 
   @AfterClass

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/RepositorySourceControlMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/RepositorySourceControlMetadataStoreTest.java
@@ -18,11 +18,22 @@ package io.cdap.cdap.internal.app.store;
 
 import static org.junit.Assert.assertEquals;
 
+import io.cdap.cdap.app.store.ScanSourceControlMetadataRequest;
+import io.cdap.cdap.app.store.SourceControlMetadataFilter;
+import io.cdap.cdap.common.id.Id.Namespace;
 import io.cdap.cdap.common.utils.ImmutablePair;
+import io.cdap.cdap.proto.SourceControlMetadataRecord;
+import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.proto.sourcecontrol.SortBy;
+import io.cdap.cdap.spi.data.SortOrder;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Assert;
 import org.junit.Test;
 
 public abstract class RepositorySourceControlMetadataStoreTest {
@@ -33,7 +44,261 @@ public abstract class RepositorySourceControlMetadataStoreTest {
   private static final ApplicationReference APP_REF = new ApplicationReference(NAMESPACE, NAME);
   private static final Boolean IS_SYNCED = true;
 
+  private static final String TYPE = EntityType.APPLICATION.toString();
+
   protected static TransactionRunner transactionRunner;
+
+  @Test
+  public void testScanWithFiltering() {
+    List<SourceControlMetadataRecord> insertedRecords = insertTests();
+    List<SourceControlMetadataRecord> testNamespaceRecords =
+        SourceControlMetadataTestUtil.filterAndCollectRecords(insertedRecords, NAMESPACE);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnNameAsc =
+        SourceControlMetadataTestUtil.sortByNameAscending(testNamespaceRecords);
+
+    TransactionRunners.run(transactionRunner, context -> {
+      List<SourceControlMetadataRecord> gotRecords = new ArrayList<>();
+      ScanSourceControlMetadataRequest request;
+      RepositorySourceControlMetadataStore store = RepositorySourceControlMetadataStore.create(
+          context);
+
+      // verify name filter for testNamespaceRecordsSortedOnNameAsc
+      gotRecords.clear();
+      String nameContainsFilter = "te";
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setFilter(new SourceControlMetadataFilter(nameContainsFilter, null)).build();
+      List<SourceControlMetadataRecord> expectedRecords;
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream()
+          .filter(record -> record.getName().toLowerCase().contains(nameContainsFilter))
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify UNSYCNED sync status filter for testNamespaceRecordsSortedOnNameAsc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setFilter(new SourceControlMetadataFilter(null, false)).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream()
+          .filter(record -> !record.getIsSynced()).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify SYCNED sync status and name filter for testNamespaceRecordsSortedOnNameAsc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setFilter(new SourceControlMetadataFilter(nameContainsFilter, true))
+          .build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream().filter(
+          record -> record.getIsSynced() && record.getName().toLowerCase()
+              .contains(nameContainsFilter)).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      store.deleteAll(NAMESPACE);
+    });
+  }
+
+  @Test
+  public void testScanWithDifferentLimit() {
+    List<SourceControlMetadataRecord> insertedRecords = insertTests();
+    List<SourceControlMetadataRecord> testNamespaceRecords =
+        SourceControlMetadataTestUtil.filterAndCollectRecords(insertedRecords, NAMESPACE);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnNameAsc =
+        SourceControlMetadataTestUtil.sortByNameAscending(testNamespaceRecords);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnNameDesc =
+        SourceControlMetadataTestUtil.sortByNameDescending(testNamespaceRecords);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnLastModifiedDesc =
+        SourceControlMetadataTestUtil.sortByLastModifiedDescending(testNamespaceRecords);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnLastModifiedAsc =
+        SourceControlMetadataTestUtil.sortByLastModifiedAscending(testNamespaceRecords);
+
+    TransactionRunners.run(transactionRunner, context -> {
+      List<SourceControlMetadataRecord> gotRecords = new ArrayList<>();
+      ScanSourceControlMetadataRequest request;
+      RepositorySourceControlMetadataStore store = RepositorySourceControlMetadataStore.create(
+          context);
+
+      // verify the scan without filters which picks all apps for testNamespace
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).build();
+      List<SourceControlMetadataRecord> expectedRecords;
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc;
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify the scan without filters which picks all apps for testNamespace
+      // when last modified is in desc order
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setSortOrder(SortOrder.DESC).setSortOn(SortBy.LAST_SYNCED_DATE).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedDesc;
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify the scan without filters which picks all apps for testNamespace
+      // when last modified is in asc order
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setSortOrder(SortOrder.ASC).setSortOn(SortBy.LAST_SYNCED_DATE).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedAsc;
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify limit for testNamespaceRecordsSortedOnNameDesc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).setLimit(3)
+          .setSortOrder(SortOrder.DESC).setSortOn(SortBy.PIPELINE_NAME).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameDesc.stream().limit(3)
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+      store.deleteAll(NAMESPACE);
+    });
+  }
+
+  @Test
+  public void testScanWithPagination() {
+    List<SourceControlMetadataRecord> insertedRecords = insertTests();
+    List<SourceControlMetadataRecord> testNamespaceRecords =
+        SourceControlMetadataTestUtil.filterAndCollectRecords(insertedRecords, NAMESPACE);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnNameAsc =
+        SourceControlMetadataTestUtil.sortByNameAscending(testNamespaceRecords);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnNameDesc =
+        SourceControlMetadataTestUtil.sortByNameDescending(testNamespaceRecords);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnLastModifiedDesc =
+        SourceControlMetadataTestUtil.sortByLastModifiedDescending(testNamespaceRecords);
+    List<SourceControlMetadataRecord> testNamespaceRecordsSortedOnLastModifiedAsc =
+        SourceControlMetadataTestUtil.sortByLastModifiedAscending(testNamespaceRecords);
+    TransactionRunners.run(transactionRunner, context -> {
+      List<SourceControlMetadataRecord> gotRecords = new ArrayList<>();
+      ScanSourceControlMetadataRequest request;
+      RepositorySourceControlMetadataStore store = RepositorySourceControlMetadataStore.create(
+          context);
+
+      // verify name filter with pageToken and limit for testNamespaceRecordsSortedOnNameAsc
+      gotRecords.clear();
+      String nameContains = "d";
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).setLimit(1)
+          .setScanAfter("datafusionquickstart")
+          .setFilter(new SourceControlMetadataFilter(nameContains, null)).build();
+      List<SourceControlMetadataRecord> expectedRecords;
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream()
+          .filter(record -> record.getName().equals("dependent100")).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify UNSYNCED filter with pageToken and limit for testNamespaceRecordsSortedOnNameAsc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).setLimit(1)
+          .setScanAfter("datafusionquickstart")
+          .setFilter(new SourceControlMetadataFilter(null, false)).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream()
+          .filter(record -> record.getName().equals("dependent101")).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify SYNCED and name filter with pageToken and limit for testNamespaceRecordsSortedOnLastModifiedDesc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).setLimit(1)
+          .setScanAfter("dependent100").setSortOrder(SortOrder.DESC).setSortOn(SortBy.PIPELINE_NAME)
+          .setFilter(new SourceControlMetadataFilter("t", true)).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedDesc.stream()
+          .filter(record -> record.getName().equals("datafusionquickstart"))
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify UNSYNCED and name filter with pageToken and limit for testNamespaceRecordsSortedOnLastModifiedDesc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE).setLimit(1)
+          .setScanAfter("dependent100").setSortOn(SortBy.LAST_SYNCED_DATE)
+          .setSortOrder(SortOrder.DESC)
+          .setFilter(new SourceControlMetadataFilter("t", false)).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedDesc.stream()
+          .filter(record -> record.getName().equals("dependent101")).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnNameAsc - test 1
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setScanAfter("datafusionquickstart").setLimit(3).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream().filter(
+              record -> record.getName().equals("dependent101") || record.getName()
+                  .equals("dependent100") || record.getName().equals("newapp"))
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnNameAsc - test 2
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setScanAfter("newapp").setLimit(3).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameAsc.stream().filter(
+          record -> record.getName().equals("scm-test") || record.getName().equals("zapapp")
+              || record.getName().equals("test")).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnLastModifiedDesc - test 1
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setScanAfter("zapapp").setLimit(5).setSortOrder(SortOrder.DESC)
+          .setSortOn(SortBy.LAST_SYNCED_DATE).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedDesc.stream().filter(
+          record -> record.getName().equals("newapp") || record.getName().equals("scm-test")
+              || record.getName().equals("datafusionquickstart")).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnLastModifiedDesc - test 2
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setScanAfter("test").setLimit(3).setSortOrder(SortOrder.DESC)
+          .setSortOn(SortBy.LAST_SYNCED_DATE).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedDesc.stream().filter(
+              record -> record.getName().equals("dependent100") || record.getName()
+                  .equals("dependent101") || record.getName().equals("newapp"))
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnNameDesc
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setSortOrder(SortOrder.DESC).setSortOn(SortBy.PIPELINE_NAME).setScanAfter("test")
+          .setLimit(3).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnNameDesc.stream().filter(
+          record -> record.getName().equals("scm-test") || record.getName().equals("dependent101")
+              || record.getName().equals("newapp")).collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnLastModifiedAsc - test 1
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setScanAfter("scm-test").setLimit(4).setSortOrder(SortOrder.ASC)
+          .setSortOn(SortBy.LAST_SYNCED_DATE).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedAsc.stream().filter(
+              record -> record.getName().equals("zapapp") || record.getName().equals("newapp")
+                  || record.getName().equals("dependent101") || record.getName().equals("dependent100"))
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      // verify page token for testNamespaceRecordsSortedOnLastModifiedAsc - test 2
+      gotRecords.clear();
+      request = ScanSourceControlMetadataRequest.builder().setNamespace(NAMESPACE)
+          .setScanAfter("datafusionquickstart").setLimit(2).setSortOrder(SortOrder.ASC)
+          .setSortOn(SortBy.LAST_SYNCED_DATE).build();
+      store.scan(request, TYPE, gotRecords::add);
+      expectedRecords = testNamespaceRecordsSortedOnLastModifiedAsc.stream().filter(
+              record -> record.getName().equals("newapp") || record.getName().equals("scm-test"))
+          .collect(Collectors.toList());
+      Assert.assertArrayEquals(expectedRecords.toArray(), gotRecords.toArray());
+
+      store.deleteAll(NAMESPACE);
+    });
+  }
 
   @Test
   public void testWrite() {
@@ -44,6 +309,7 @@ public abstract class RepositorySourceControlMetadataStoreTest {
       ImmutablePair pair = store.get(APP_REF);
       assertEquals(IS_SYNCED, pair.getSecond());
       assertEquals(LAST_MODIFIED.toEpochMilli(), pair.getFirst());
+      store.deleteAll(NAMESPACE);
     });
   }
 
@@ -59,5 +325,46 @@ public abstract class RepositorySourceControlMetadataStoreTest {
       pair = store.get(APP_REF);
       assertEquals(null, pair);
     });
+  }
+
+  private List<SourceControlMetadataRecord> insertTests() {
+    List<SourceControlMetadataRecord> records = new ArrayList<>();
+    records.add(
+        insertRecord(NAMESPACE, "datafusionquickstart", TYPE, null, null, Instant.ofEpochSecond(0),
+            true));
+    records.add(
+        insertRecord(NAMESPACE, "scm-test", TYPE, null, null, Instant.ofEpochSecond(1646358109),
+            false));
+    records.add(
+        insertRecord(NAMESPACE, "dependent100", TYPE, null, null, Instant.ofEpochSecond(1646358113),
+            true));
+    records.add(
+        insertRecord(NAMESPACE, "dependent101", TYPE, null, null, Instant.ofEpochSecond(1646358111),
+            false));
+    records.add(
+        insertRecord(NAMESPACE, "newapp", TYPE, null, null, Instant.ofEpochSecond(1646358110),
+            false));
+    records.add(
+        insertRecord(NAMESPACE, "zapapp", TYPE, null, null, Instant.ofEpochSecond(1646358110),
+            true));
+    records.add(
+        insertRecord(NAMESPACE, "test", TYPE, null, null, Instant.ofEpochSecond(1646358114), true));
+    records.add(insertRecord(Namespace.DEFAULT.getId(), "test", TYPE, null, null,
+        Instant.ofEpochSecond(1646358116), true));
+    return records;
+  }
+
+  private SourceControlMetadataRecord insertRecord(String namespace, String name, String type,
+      String specHash, String commitId, Instant lastModified, Boolean isSynced) {
+    SourceControlMetadataRecord record = new SourceControlMetadataRecord(namespace, type, name,
+        specHash, commitId, lastModified.toEpochMilli() == 0L ? null : lastModified.toEpochMilli(),
+        isSynced);
+    ApplicationReference appRef = new ApplicationReference(namespace, name);
+    TransactionRunners.run(transactionRunner, context -> {
+      RepositorySourceControlMetadataStore store = RepositorySourceControlMetadataStore.create(
+          context);
+      store.write(appRef, isSynced, lastModified.toEpochMilli());
+    });
+    return record;
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/SourceControlMetadataTestUtil.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/SourceControlMetadataTestUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.store;
+
+import io.cdap.cdap.proto.SourceControlMetadataRecord;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SourceControlMetadataTestUtil {
+  public static List<SourceControlMetadataRecord> sortByNameAscending(
+      List<SourceControlMetadataRecord> records) {
+    return records.stream().sorted(Comparator.comparing(record -> record.getName().toLowerCase()))
+        .collect(Collectors.toList());
+  }
+
+  public static  List<SourceControlMetadataRecord> sortByNameDescending(
+      List<SourceControlMetadataRecord> records) {
+    return records.stream().sorted(
+        Comparator.comparing((SourceControlMetadataRecord record) -> record.getName().toLowerCase())
+            .reversed()).collect(Collectors.toList());
+  }
+
+  public static  List<SourceControlMetadataRecord> sortByLastModifiedDescending(
+      List<SourceControlMetadataRecord> records) {
+    return records.stream().sorted(Comparator.nullsFirst(
+            Comparator.comparing(SourceControlMetadataRecord::getLastModified,
+                Comparator.nullsFirst(Comparator.naturalOrder())).reversed()))
+        .collect(Collectors.toList());
+  }
+
+  public static  List<SourceControlMetadataRecord> sortByLastModifiedAscending(
+      List<SourceControlMetadataRecord> records) {
+    return records.stream().sorted(Comparator.nullsFirst(
+        Comparator.comparing(SourceControlMetadataRecord::getLastModified,
+            Comparator.nullsFirst(Comparator.naturalOrder())))).collect(Collectors.toList());
+  }
+
+  public static  List<SourceControlMetadataRecord> filterAndCollectRecords(
+      List<SourceControlMetadataRecord> records, String targetNamespace) {
+    return records.stream().filter(record -> record.getNamespace().equals(targetNamespace))
+        .collect(Collectors.toList());
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/SourceControlMetadataNotFoundException.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/SourceControlMetadataNotFoundException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common;
+
+import io.cdap.cdap.proto.id.ApplicationReference;
+
+
+/**
+ * Exception thrown when source control metadata for an application is not found.
+ */
+public class SourceControlMetadataNotFoundException extends NotFoundException {
+
+  private final ApplicationReference appRef;
+
+  /**
+   * Constructs a new {@link SourceControlMetadataNotFoundException}.
+   *
+   * @param appRef The application reference for which the metadata was not found.
+   */
+  public SourceControlMetadataNotFoundException(ApplicationReference appRef) {
+    super("SourceControlMetadata of appId(" + appRef.getApplication()
+        + ").getApplication() was not found");
+    this.appRef = appRef;
+  }
+}

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/SourceControlMetadataRecord.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/SourceControlMetadataRecord.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.proto;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Represents a record of source control metadata.
+ * This class includes all fields corresponding to the {@code NamespaceSourceControlMetadataStore}
+ * and {@code RepositorySourceControlMetadataStore} tables.
+ */
+public class SourceControlMetadataRecord {
+
+  private final String namespace;
+  private final String type;
+  private final String name;
+  private final String specificationHash;
+  @Nullable
+  private final String commitId;
+  @Nullable
+  private final Long lastModified;
+  private final Boolean isSynced;
+
+  /**
+   * Creates a new {@link SourceControlMetadataRecord}.
+   */
+  public SourceControlMetadataRecord(String namespace, String type, String name,
+      String specificationHash, @Nullable String commitId, @Nullable Long lastModified, Boolean isSynced) {
+    this.namespace = namespace;
+    this.type = type;
+    this.name = name;
+    this.specificationHash = specificationHash;
+    this.commitId = commitId;
+    this.lastModified = lastModified;
+    this.isSynced = isSynced;
+  }
+
+  public String getNamespace() {
+    return namespace;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getSpecificationHash() {
+    return specificationHash;
+  }
+
+  @Nullable
+  public String getCommitId() {
+    return commitId;
+  }
+
+  @Nullable
+  public Long getLastModified() {
+    return lastModified;
+  }
+
+  public Boolean getIsSynced() {
+    return isSynced;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SourceControlMetadataRecord record = (SourceControlMetadataRecord) o;
+    return Objects.equals(namespace, record.namespace) && Objects.equals(type,
+        record.type) && Objects.equals(name, record.name) && Objects.equals(
+        specificationHash, record.specificationHash) && Objects.equals(commitId,
+        record.commitId) && Objects.equals(lastModified, record.lastModified)
+        && Objects.equals(isSynced, record.isSynced);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(namespace, type, name, specificationHash, commitId, lastModified, isSynced);
+  }
+}


### PR DESCRIPTION
- Implemented APIs to get namespace source control metadata 
- Implemented API to retrieve repository source control metadata
- Added Pagination, filtering (based on name, sync status), sorting (based on name and last modified)
- Added unit tests for the above