### PR TITLE
[CDAP-20988] fix maxConcurrentRuns constraint in pipeline schedules

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -321,6 +321,30 @@ public interface Store {
   Map<ProgramRunId, RunRecordDetail> getActiveRuns(ProgramId programId);
 
   /**
+   * Fetches the number of active (i.e PENDING or STARTING or RUNNING or SUSPENDED or STOPPING)
+   * run records against a given {@link ProgramReference} across versions of the program.
+   * If the number of active runs is higher than limit, then the limit value is returned.
+   *
+   * @param programRef the {@link ProgramReference} to match against
+   * @param limit int value acting as an upper bound for the active runs count, useful when we
+   *     only want to check if the number of active runs is lower than the limit. It ensures
+   *     that we do not scan more than limit number of active run records.
+   * @return int number of logged runs
+   */
+  int getProgramActiveRunsCount(ProgramReference programRef, int limit);
+
+  /**
+   * Fetches the number of active (i.e PENDING or STARTING or RUNNING or SUSPENDED or STOPPING)
+   * run records against a given {@link ProgramReference} across versions of the program.
+   *
+   * @param programRef the {@link ProgramReference} to match against
+   * @return int number of logged runs
+   */
+  default int getProgramActiveRunsCount(ProgramReference programRef) {
+    return getProgramActiveRunsCount(programRef, Integer.MAX_VALUE);
+  }
+
+  /**
    * Fetches the latest active runs for a set of programs.
    *
    * @param programRefs collection of program ids for fetching active run records.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/ConcurrencyConstraint.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/ConcurrencyConstraint.java
@@ -17,10 +17,7 @@
 package io.cdap.cdap.internal.app.runtime.schedule.constraint;
 
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramSchedule;
-import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.proto.ProtoConstraint;
-import io.cdap.cdap.proto.id.ProgramRunId;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,10 +36,12 @@ public class ConcurrencyConstraint extends ProtoConstraint.ConcurrencyConstraint
 
   @Override
   public ConstraintResult check(ProgramSchedule schedule, ConstraintContext context) {
-    Map<ProgramRunId, RunRecordDetail> activeRuns = context.getActiveRuns(schedule.getProgramId());
-    if (activeRuns.size() >= maxConcurrency) {
-      LOG.debug("Skipping run of program {} from schedule {} because there are {} active runs.",
-          schedule.getProgramId(), schedule.getName(), activeRuns.size());
+    int numActiveRuns = context.getProgramActiveRunsCount(
+        schedule.getProgramId().getProgramReference(), maxConcurrency + 1);
+    if (numActiveRuns >= maxConcurrency) {
+      LOG.debug("Skipping run of program {} from schedule {} "
+              + "because there are at least {} active runs.",
+          schedule.getProgramId(), schedule.getName(), numActiveRuns);
       return notSatisfied(context);
     }
     return ConstraintResult.SATISFIED;

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/ConstraintContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/ConstraintContext.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.internal.app.runtime.schedule.queue.Job;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import java.util.Map;
 
@@ -43,8 +44,8 @@ public final class ConstraintContext {
     return checkTimeMillis;
   }
 
-  public Map<ProgramRunId, RunRecordDetail> getActiveRuns(ProgramId programId) {
-    return store.getActiveRuns(programId);
+  public int getProgramActiveRunsCount(ProgramReference programRef, int limit) {
+    return store.getProgramActiveRunsCount(programRef, limit);
   }
 
   public Map<ProgramRunId, RunRecordDetail> getProgramRuns(ProgramId programId,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -1719,6 +1719,36 @@ public class AppMetadataStore {
   }
 
   /**
+   * Get number of active runs of the given program irrespective of the versions of the programs.
+   * Active runs means program run with status PENDING, STARTING, RUNNING, SUSPENDED or STOPPING.
+   *
+   * @param programRef {@link ProgramReference} of the given program
+   * @return int number of active runs
+   */
+  public int getProgramActiveRunsCount(ProgramReference programRef)
+      throws IOException {
+    return getProgramActiveRunsCount(programRef, Integer.MAX_VALUE);
+  }
+
+  /**
+   * Get number of active runs of the given program irrespective of the versions of the programs.
+   * Active runs means program run with status PENDING, STARTING, RUNNING, SUSPENDED or STOPPING.
+   * If the number of active runs is higher than limit, then the limit value is returned.
+   *
+   * @param programRef {@link ProgramReference} of the given program
+   * @param limit int value acting as an upper bound for the active runs count, useful when we
+   *        only want to check if the number of active runs is lower than the limit. It ensures
+   *        that we do not scan more than limit number of active run records.
+   * @return int number of active runs
+   */
+  public int getProgramActiveRunsCount(ProgramReference programRef, int limit)
+      throws IOException {
+    AtomicInteger result = new AtomicInteger();
+    scanProgramActiveRuns(programRef, r -> result.getAndIncrement(), limit);
+    return result.get();
+  }
+
+  /**
    * Get active runs in the given program, active runs means program run with status STARTING,
    * PENDING, RUNNING or SUSPENDED.
    *
@@ -1746,6 +1776,27 @@ public class AppMetadataStore {
 
     try (CloseableIterator<RunRecordDetail> iterator = queryProgramRuns(Range.singleton(prefix),
         null, null, Integer.MAX_VALUE)) {
+      iterator.forEachRemaining(consumer);
+    }
+  }
+
+  /**
+   * Scans active runs of the given program irrespective of the versions of the programs.
+   * Active runs means program run with status PENDING, STARTING, RUNNING, SUSPENDED or STOPPING.
+   * This method is similar to the {@link #scanActiveRuns(ProgramId, Consumer)},
+   * but takes a {@link ProgramReference} instead.
+   *
+   * @param programRef {@link ProgramReference} given program
+   * @param consumer a {@link Consumer} for processing the {@link RunRecordDetail} of each
+   *     active run.
+   * @param limit int value to limit the number of records scanned
+   */
+  public void scanProgramActiveRuns(ProgramReference programRef,
+      Consumer<RunRecordDetail> consumer, int limit) throws IOException {
+    List<Field<?>> prefix = getRunRecordProgramRefPrefix(TYPE_RUN_RECORD_ACTIVE, programRef);
+
+    try (CloseableIterator<RunRecordDetail> iterator = queryProgramRuns(Range.singleton(prefix),
+        null, null, limit)) {
       iterator.forEachRemaining(consumer);
     }
   }
@@ -2708,35 +2759,39 @@ public class AppMetadataStore {
     return fields;
   }
 
+  private List<Field<?>> getRunRecordProgramRefPrefix(String status,
+      ProgramReference programReference) {
+    return  getRunRecordProgramPrefix(status, programReference, null);
+  }
+
   private List<Field<?>> getRunRecordProgramPrefix(String status, @Nullable ProgramId programId) {
-    List<Field<?>> fields = getRunRecordStatusPrefix(status);
     if (programId == null) {
+      return getRunRecordStatusPrefix(status);
+    }
+
+    return getRunRecordProgramPrefix(status, programId.getProgramReference(),
+        programId.getVersion());
+  }
+  
+  private List<Field<?>> getRunRecordProgramPrefix(String status,
+      @Nullable ProgramReference programRef, @Nullable String version) {
+    List<Field<?>> fields = getRunRecordStatusPrefix(status);
+    if (programRef == null) {
       return fields;
     }
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD,
-        programId.getNamespace()));
+        programRef.getNamespace()));
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_FIELD,
-        programId.getApplication()));
-    fields.add(
-        Fields.stringField(StoreDefinition.AppMetadataStore.VERSION_FIELD, programId.getVersion()));
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_TYPE_FIELD,
-        programId.getType().name()));
-    fields.add(
-        Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_FIELD, programId.getProgram()));
-    return fields;
-  }
+        programRef.getApplication()));
 
-  private List<Field<?>> getRunRecordProgramRefPrefix(String status,
-      ProgramReference programReference) {
-    List<Field<?>> fields = getRunRecordStatusPrefix(status);
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD,
-        programReference.getNamespace()));
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_FIELD,
-        programReference.getApplication()));
+    if (version != null) {
+      fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.VERSION_FIELD, version));
+    }
+
     fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_TYPE_FIELD,
-        programReference.getType().name()));
-    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_FIELD,
-        programReference.getProgram()));
+        programRef.getType().name()));
+    fields.add(
+        Fields.stringField(StoreDefinition.AppMetadataStore.PROGRAM_FIELD, programRef.getProgram()));
     return fields;
   }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -546,6 +546,13 @@ public class DefaultStore implements Store {
   }
 
   @Override
+  public int getProgramActiveRunsCount(ProgramReference programRef, int limit) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      return getAppMetadataStore(context).getProgramActiveRunsCount(programRef, limit);
+    });
+  }
+
+  @Override
   public Map<ProgramId, Collection<RunRecordDetail>> getActiveRuns(
       Collection<ProgramReference> programRefs) {
     return TransactionRunners.run(transactionRunner, context -> {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/ConcurrencyConstraintTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/schedule/constraint/ConcurrencyConstraintTest.java
@@ -46,15 +46,15 @@ import org.junit.Test;
  */
 public class ConcurrencyConstraintTest {
   private static final NamespaceId TEST_NS = new NamespaceId("ConcurrencyConstraintTest");
-  private static final ApplicationId APP_ID = TEST_NS.app("app1");
+  private static final ApplicationId APP_ID = TEST_NS.app("app1", "non-default-test-version");
   private static final ArtifactId ARTIFACT_ID = TEST_NS.artifact("test", "1.0").toApiArtifactId();
   private static final WorkflowId WORKFLOW_ID = APP_ID.workflow("wf1");
   private static final DatasetId DATASET_ID = TEST_NS.dataset("pfs1");
 
   private static final Map<String, String> EMPTY_MAP = ImmutableMap.of();
-  
+
   private int sourceId;
-  
+
   private void setStartAndRunning(Store store, ProgramRunId id) {
     setStartAndRunning(store, id, EMPTY_MAP, EMPTY_MAP);
 


### PR DESCRIPTION
Currently the `maxConcurrentRuns` constraint in the pipeline schedules is not behaving as expected. This issue started happening when uuid based application versions were introduced in LCM. The schedules handler saves the scheduled program details with the default `-SNAPSHOT` version and the scheduler tries to find the active runs of the saved program details. This returns an empty collection of run records, as the actual run record of the program would have a uuid version string instead of `-SNAPSHOT`. Because of this, the `maxConcurrentRuns` constraint was failing (i.e. it was triggering new runs of the program even when the number of active runs was actually higher than the constraint).

In this PR, we fix this issue by scanning the active runs across versions for a program, when checking the concurrency constraint.


**JIRA**: [CDAP-20988](https://cdap.atlassian.net/browse/CDAP-20988)

[CDAP-20988]: https://cdap.atlassian.net/browse/CDAP-20988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ