### PR TITLE
[CDAP-20999] Encode schedule names in the schedule client

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteScheduleFetcher.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/metadata/RemoteScheduleFetcher.java
@@ -21,6 +21,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.schedule.Trigger;
+import io.cdap.cdap.client.ScheduleClient;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.ProgramNotFoundException;
 import io.cdap.cdap.common.conf.Constants;
@@ -73,7 +74,8 @@ public class RemoteScheduleFetcher implements ScheduleFetcher {
       throws IOException, ScheduleNotFoundException, UnauthorizedException {
     String url = String.format(
         "namespaces/%s/apps/%s/schedules/%s",
-        scheduleId.getNamespace(), scheduleId.getApplication(), scheduleId.getSchedule());
+        scheduleId.getNamespace(), scheduleId.getApplication(),
+        ScheduleClient.getEncodedScheduleName(scheduleId.getSchedule()));
     HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.GET, url);
     HttpResponse httpResponse;
     try {

--- a/cdap-client/src/main/java/io/cdap/cdap/client/ApplicationClient.java
+++ b/cdap-client/src/main/java/io/cdap/cdap/client/ApplicationClient.java
@@ -704,7 +704,7 @@ public class ApplicationClient {
       UnauthorizedException, BadRequestException {
     String path = String.format("apps/%s/versions/%s/schedules/%s", app.getApplication(),
         app.getVersion(),
-        scheduleDetail.getName());
+        ScheduleClient.getEncodedScheduleName(scheduleDetail.getName()));
     HttpResponse response = restClient.execute(HttpMethod.PUT,
         config.resolveNamespacedURLV3(app.getParent(), path),
         GSON.toJson(scheduleDetail), ImmutableMap.<String, String>of(),

--- a/cdap-client/src/main/java/io/cdap/cdap/client/ScheduleClient.java
+++ b/cdap-client/src/main/java/io/cdap/cdap/client/ScheduleClient.java
@@ -41,9 +41,12 @@ import io.cdap.common.http.HttpRequest;
 import io.cdap.common.http.HttpResponse;
 import io.cdap.common.http.ObjectResponse;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
@@ -134,7 +137,7 @@ public class ScheduleClient {
       throws IOException, UnauthenticatedException, NotFoundException,
       UnauthorizedException {
     String path = String.format("apps/%s/schedules/%s/suspend", scheduleId.getApplication(),
-        scheduleId.getSchedule());
+        getEncodedScheduleName(scheduleId.getSchedule()));
     URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
         HttpURLConnection.HTTP_NOT_FOUND);
@@ -147,7 +150,7 @@ public class ScheduleClient {
       throws IOException, UnauthenticatedException, NotFoundException,
       UnauthorizedException {
     String path = String.format("apps/%s/schedules/%s/resume", scheduleId.getApplication(),
-        scheduleId.getSchedule());
+        getEncodedScheduleName(scheduleId.getSchedule()));
     URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpResponse response = restClient.execute(HttpMethod.POST, url, config.getAccessToken(),
         HttpURLConnection.HTTP_NOT_FOUND);
@@ -165,7 +168,7 @@ public class ScheduleClient {
       throws IOException, UnauthenticatedException, NotFoundException,
       UnauthorizedException {
     String path = String.format("apps/%s/schedules/%s", scheduleId.getApplication(),
-        scheduleId.getSchedule());
+        getEncodedScheduleName(scheduleId.getSchedule()));
     URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpResponse response = restClient.execute(HttpMethod.DELETE, url, config.getAccessToken(),
         HttpURLConnection.HTTP_NOT_FOUND);
@@ -178,7 +181,7 @@ public class ScheduleClient {
       throws IOException, UnauthenticatedException, NotFoundException,
       UnauthorizedException {
     String path = String.format("apps/%s/schedules/%s/status", scheduleId.getApplication(),
-        scheduleId.getSchedule());
+        getEncodedScheduleName(scheduleId.getSchedule()));
     URL url = config.resolveNamespacedURLV3(scheduleId.getParent().getParent(), path);
     HttpResponse response = restClient.execute(HttpMethod.GET, url, config.getAccessToken(),
         HttpURLConnection.HTTP_NOT_FOUND);
@@ -219,7 +222,7 @@ public class ScheduleClient {
       UnauthenticatedException, NotFoundException, UnauthorizedException, AlreadyExistsException {
 
     String path = String.format("apps/%s/schedules/%s", scheduleId.getApplication(),
-        scheduleId.getSchedule());
+        getEncodedScheduleName(scheduleId.getSchedule()));
     URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpRequest request = HttpRequest.put(url).withBody(json).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(),
@@ -236,7 +239,7 @@ public class ScheduleClient {
       UnauthenticatedException, NotFoundException, UnauthorizedException, AlreadyExistsException {
 
     String path = String.format("apps/%s/schedules/%s/update", scheduleId.getApplication(),
-        scheduleId.getSchedule());
+        getEncodedScheduleName(scheduleId.getSchedule()));
     URL url = config.resolveNamespacedURLV3(scheduleId.getNamespaceId(), path);
     HttpRequest request = HttpRequest.post(url).withBody(json).build();
     HttpResponse response = restClient.execute(request, config.getAccessToken(),
@@ -263,4 +266,8 @@ public class ScheduleClient {
     return objectResponse.getResponseObject();
   }
 
+  public static String getEncodedScheduleName(String scheduleName)
+      throws UnsupportedEncodingException {
+    return URLEncoder.encode(scheduleName, StandardCharsets.UTF_8.toString()).replace("+", "%20");
+  }
 }


### PR DESCRIPTION
JIRA: [CDAP-20999](https://cdap.atlassian.net/browse/CDAP-20999)

context: 
```
Caused by: java.lang.IllegalArgumentException: Illegal character in path at index 72: /v3/namespaces/namespace_name/apps/app_name/schedules/No.10 - 0014002 AND No.16 0015006/status
        at java.net.URI.create(URI.java:852)
        at java.net.URI.resolve(URI.java:1036)
        at io.cdap.cdap.client.config.ConnectionConfig.resolveNamespacedURI(ConnectionConfig.java:98)
        at io.cdap.cdap.client.config.ClientConfig.resolveNamespacedURLV3(ClientConfig.java:132)
        at io.cdap.cdap.client.ScheduleClient.getStatus(ScheduleClient.java:182)
        at io.cdap.cdap.master.upgrade.UpgradeJobMain.suspendSchedulesAndStopPipelines(UpgradeJobMain.java:134)
        at io.cdap.cdap.master.upgrade.UpgradeJobMain.lambda$main$0(UpgradeJobMain.java:96)
        at io.cdap.cdap.common.service.Retries.lambda$callWithRetries$2(Retries.java:195)
        at io.cdap.cdap.common.service.Retries.callWithRetries(Retries.java:228)
        at io.cdap.cdap.common.service.Retries.callWithRetries(Retries.java:195)
        at io.cdap.cdap.master.upgrade.UpgradeJobMain.main(UpgradeJobMain.java:94)
        Suppressed: io.cdap.cdap.api.retry.RetryFailedException: Retry failed. Encountered non retryable exception.
                at io.cdap.cdap.common.service.Retries.callWithRetries(Retries.java:236)
                ... 2 more
Caused by: java.net.URISyntaxException: Illegal character in path at index 72: /v3/namespaces/sf_crm/apps/0001001_BQ_SF_API_INTEGRATION/schedules/No.10 - 0014002 AND No.16 0015006/status
        at java.net.URI$Parser.fail(URI.java:2847)
        at java.net.URI$Parser.checkChars(URI.java:3020)
        at java.net.URI$Parser.parseHierarchical(URI.java:3104)
        at java.net.URI$Parser.parse(URI.java:3062)
        at java.net.URI.<init>(URI.java:588)
        at java.net.URI.create(URI.java:850)
        ... 10 more
```

We do not impose any [limitations](https://github.com/cdapio/cdap/blob/fbdbe51048b43c6d1e9cdba9ae8940c0fd267f95/cdap-proto/src/main/java/io/cdap/cdap/proto/id/ScheduleId.java#L54) on schedule names, allowing users to set arbitrary schedule names.

[CDAP-20999]: https://cdap.atlassian.net/browse/CDAP-20999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ