### PR TITLE
CDAP-21004: SCM migration service

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -508,10 +508,10 @@ public interface Store {
   /**
    * Update an applications with provided SourceControlMeta.
    *
-   * @param appId the application ID
+   * @param appRef the application reference
    * @param sourceControlMeta the source control metadata of the application synced with linked repository.
    */
-  void setAppSourceControlMeta(ApplicationId appId, SourceControlMeta sourceControlMeta);
+  void setAppSourceControlMeta(ApplicationReference appRef, SourceControlMeta sourceControlMeta);
 
   /**
    * Get source control metadata of provided application.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.common.logging.ServiceLoggingContext;
 import io.cdap.cdap.common.metrics.MetricsReporterHook;
 import io.cdap.cdap.common.security.HttpsEnabler;
 import io.cdap.cdap.features.Feature;
+import io.cdap.cdap.internal.app.sourcecontrol.SourceControlMetadataMigrationService;
 import io.cdap.cdap.internal.app.store.AppMetadataStore;
 import io.cdap.cdap.internal.bootstrap.BootstrapService;
 import io.cdap.cdap.internal.credential.CredentialProviderService;
@@ -95,6 +96,7 @@ public class AppFabricServer extends AbstractIdleService {
   private final SourceControlOperationRunner sourceControlOperationRunner;
   private final RepositoryCleanupService repositoryCleanupService;
   private final OperationNotificationSubscriberService operationNotificationSubscriberService;
+  private final SourceControlMetadataMigrationService sourceControlMetadataMigrationService;
   private final CConfiguration cConf;
   private final SConfiguration sConf;
   private final boolean sslEnabled;
@@ -134,7 +136,8 @@ public class AppFabricServer extends AbstractIdleService {
       RunRecordTimeToLiveService runRecordTimeToLiveService,
       SourceControlOperationRunner sourceControlOperationRunner,
       RepositoryCleanupService repositoryCleanupService,
-      OperationNotificationSubscriberService operationNotificationSubscriberService) {
+      OperationNotificationSubscriberService operationNotificationSubscriberService,
+      SourceControlMetadataMigrationService sourceControlMetadataMigrationService) {
     this.hostname = hostname;
     this.discoveryService = discoveryService;
     this.handlers = handlers;
@@ -163,6 +166,7 @@ public class AppFabricServer extends AbstractIdleService {
     this.sourceControlOperationRunner = sourceControlOperationRunner;
     this.repositoryCleanupService = repositoryCleanupService;
     this.operationNotificationSubscriberService = operationNotificationSubscriberService;
+    this.sourceControlMetadataMigrationService = sourceControlMetadataMigrationService;
   }
 
   /**
@@ -194,7 +198,8 @@ public class AppFabricServer extends AbstractIdleService {
         runRecordTimeToLiveService.start(),
         sourceControlOperationRunner.start(),
         repositoryCleanupService.start(),
-        operationNotificationSubscriberService.start()
+        operationNotificationSubscriberService.start(),
+        sourceControlMetadataMigrationService.start()
     ));
     Futures.allAsList(futuresList).get();
 
@@ -256,6 +261,7 @@ public class AppFabricServer extends AbstractIdleService {
     credentialProviderService.stopAndWait();
     namespaceCredentialProviderService.stopAndWait();
     operationNotificationSubscriberService.stopAndWait();
+    sourceControlMetadataMigrationService.stopAndWait();
   }
 
   private Cancellable startHttpService(NettyHttpService httpService) throws Exception {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SourceControlManagementService.java
@@ -296,7 +296,7 @@ public class SourceControlManagementService {
     SourceControlMeta sourceControlMeta = new SourceControlMeta(appMeta.getFileHash(),
         pushResponse.getCommitId(), clock.instant());
     ApplicationId appId = appRef.app(appDetail.getAppVersion());
-    store.setAppSourceControlMeta(appId, sourceControlMeta);
+    store.setAppSourceControlMeta(appId.getAppReference(), sourceControlMeta);
 
     return pushResponse;
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/sourcecontrol/SourceControlMetadataMigrationService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/sourcecontrol/SourceControlMetadataMigrationService.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.sourcecontrol;
+
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.inject.Inject;
+import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.internal.app.store.AppMetadataStore;
+import io.cdap.cdap.internal.app.store.NamespaceSourceControlMetadataStore;
+import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.twill.common.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service for migrating source control metadata from app_spec table to source control table.
+ * Starting from 6.10.1 we have introduced a separate table for storing scm metadata. As this
+ * information was previously stored in app_spec table we need to run this migration
+ */
+public class SourceControlMetadataMigrationService extends AbstractScheduledService {
+
+  private ScheduledExecutorService executor;
+  private final long runInterval;
+  private final TransactionRunner transactionRunner;
+  private final Store store;
+
+  private static final Logger LOG = LoggerFactory.getLogger(SourceControlMetadataMigrationService.class);
+
+  @Inject
+  SourceControlMetadataMigrationService(CConfiguration cConf, Store store,
+      TransactionRunner transactionRunner) {
+    this.runInterval = cConf.getLong(
+        Constants.SourceControlManagement.METADATA_MIGRATION_INTERVAL_SECONDS);
+    this.transactionRunner = transactionRunner;
+    this.store = store;
+  }
+
+  @Override
+  protected final ScheduledExecutorService executor() {
+    executor = Executors.newSingleThreadScheduledExecutor(
+        Threads.createDaemonThreadFactory("scm-metadata-migration"));
+    return executor;
+  }
+
+  @Override
+  protected void runOneIteration() {
+    try {
+      migrateMetadata();
+      // stop if the migration is successfull otherwise retry after delay
+      this.stop();
+    } catch (Exception e) {
+      // Log and retry on exception
+      LOG.error("Failed to migrate source control metadata", e);
+    }
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedDelaySchedule(0, runInterval, TimeUnit.SECONDS);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    if (executor != null) {
+      executor.shutdownNow();
+    }
+  }
+
+  private void migrateMetadata() {
+    LOG.info("Starting source control metadata migration at {}", Instant.now());
+    // Get all current metadata from app_spec table.
+    // This is to avoid running recursive transaction while trying to update scm table
+    Map<ApplicationReference, SourceControlMeta> metaMap = new HashMap<>();
+    TransactionRunners.run(transactionRunner, context -> {
+      metaMap.putAll(AppMetadataStore.create(context).getAllSourceControlMeta());
+    });
+
+    // For each metadata Update source control table with the metadata
+    // only if there is no current metadata in source control table
+    metaMap.forEach((appRef, scmMeta) -> {
+      TransactionRunners.run(transactionRunner, context -> {
+        NamespaceSourceControlMetadataStore metadataStore = NamespaceSourceControlMetadataStore.create(
+            context);
+        SourceControlMeta currentMeta = metadataStore.get(appRef);
+        if (currentMeta == null) {
+          LOG.debug("Migrating scm metadata {} for application {}", appRef, scmMeta);
+          if (scmMeta == null) {
+            // If the app_spec_table entry does not have any scm meta that means the app
+            // was never pushed/pulled
+            metadataStore.write(appRef, SourceControlMeta.createDefaultMeta());
+          } else {
+            store.setAppSourceControlMeta(appRef, scmMeta);
+          }
+        }
+      });
+    });
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -954,9 +954,9 @@ public class DefaultStore implements Store {
   }
 
   @Override
-  public void setAppSourceControlMeta(ApplicationId appId, SourceControlMeta sourceControlMeta) {
+  public void setAppSourceControlMeta(ApplicationReference appRef, SourceControlMeta sourceControlMeta) {
     TransactionRunners.run(transactionRunner, context -> {
-      getNamespaceSourceControlMetadataStore(context).write(appId.getAppReference(),
+      getNamespaceSourceControlMetadataStore(context).write(appRef,
           SourceControlMeta.builder(sourceControlMeta).setSyncStatus(true).build());
     });
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ApplicationLifecycleServiceTest.java
@@ -838,7 +838,6 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     // deploy an app, then update its scm meta
     deploy(AllProgramsApp.class, 200, Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1);
     ApplicationDetail applicationDetail = getAppDetails(TEST_NAMESPACE1, AllProgramsApp.NAME);
-    Assert.assertNull(applicationDetail.getSourceControlMeta());
 
     applicationLifecycleService.updateSourceControlMeta(
         new NamespaceId(TEST_NAMESPACE1),
@@ -880,9 +879,6 @@ public class ApplicationLifecycleServiceTest extends AppFabricTestBase {
     Assert.assertNotNull(updatedDetail.getSourceControlMeta());
     Assert.assertEquals("updated-file-hash", updatedDetail.getSourceControlMeta().getFileHash());
     Assert.assertEquals("updated-commit-id", updatedDetail.getSourceControlMeta().getCommitId());
-
-    deleteAppAndData(new ApplicationId(TEST_NAMESPACE1, AllProgramsApp.NAME,
-        applicationDetail.getAppVersion()));
   }
 
   @Test(expected = BadRequestException.class)

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -1060,7 +1060,6 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
     apps = getAppList(TEST_NAMESPACE2);
     Assert.assertEquals(2, apps.size());
 
-
     //get and verify app details in testnamespace1
     ApplicationDetail applicationDetail = getAppDetails(TEST_NAMESPACE1, AllProgramsApp.NAME);
     ApplicationSpecification spec = Specifications.from(new AllProgramsApp());

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/sourcecontrol/SourceControlMetadataMigrationServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/sourcecontrol/SourceControlMetadataMigrationServiceTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.sourcecontrol;
+
+import com.google.gson.Gson;
+import com.google.inject.Injector;
+import io.cdap.cdap.AllProgramsApp;
+import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants.SourceControlManagement;
+import io.cdap.cdap.internal.AppFabricTestHelper;
+import io.cdap.cdap.internal.app.deploy.Specifications;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
+import io.cdap.cdap.internal.app.store.NamespaceSourceControlMetadataStore;
+import io.cdap.cdap.proto.artifact.ChangeDetail;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.sourcecontrol.SourceControlMeta;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import io.cdap.cdap.store.StoreDefinition;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SourceControlMetadataMigrationServiceTest {
+
+  private static TransactionRunner transactionRunner;
+  private static CConfiguration cConf;
+
+  private static Store store;
+
+  private static final Gson GSON = new Gson();
+
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Injector injector = AppFabricTestHelper.getInjector();
+    AppFabricTestHelper.ensureNamespaceExists(NamespaceId.DEFAULT);
+    store = injector.getInstance(Store.class);
+    transactionRunner = injector.getInstance(TransactionRunner.class);
+    cConf = injector.getInstance(CConfiguration.class);
+    cConf.set(SourceControlManagement.METADATA_MIGRATION_INTERVAL_SECONDS, "250");
+  }
+
+  @Test
+  public void testMigration() {
+    Instant now = Instant.now();
+    ApplicationSpecification appSpec = Specifications.from(new AllProgramsApp());
+    SourceControlMeta metaNew = new SourceControlMeta("hash1", "commit1", now);
+    SourceControlMeta metaPresent = new SourceControlMeta("hash", "commit", now);
+
+    // Add 10 applications with scm metadata
+    for (int i = 0; i < 10; i++) {
+      ApplicationId appId = NamespaceId.DEFAULT.app("appName" + i, "1");
+      TransactionRunners.run(transactionRunner, context -> {
+        StructuredTable table = context.getTable(
+            StoreDefinition.AppMetadataStore.APPLICATION_SPECIFICATIONS);
+        ApplicationMeta applicationMeta = new ApplicationMeta(appId.toString(), appSpec,
+            new ChangeDetail(null, null, null, now.toEpochMilli()),
+            metaNew);
+
+        // Latest with version 2 and metaPresent
+        List<Field<?>> fields = getApplicationFields(
+            NamespaceId.DEFAULT.getNamespace(),
+            appId.getApplication(), "2", applicationMeta,
+            new ChangeDetail(null, null, null, now.toEpochMilli()), metaPresent, true);
+        table.upsert(fields);
+
+        // Non latest with version 1 and metaNew
+        fields = getApplicationFields(
+            NamespaceId.DEFAULT.getNamespace(),
+            appId.getApplication(), "1", applicationMeta,
+            new ChangeDetail(null, null, null, now.toEpochMilli()), metaNew, false);
+        table.upsert(fields);
+      });
+    }
+
+    // Add 5 applications without scm metadata
+    for (int i = 10; i < 15; i++) {
+      ApplicationId appId = NamespaceId.DEFAULT.app("appName" + i, "1");
+      TransactionRunners.run(transactionRunner, context -> {
+        StructuredTable table = context.getTable(
+            StoreDefinition.AppMetadataStore.APPLICATION_SPECIFICATIONS);
+        ApplicationMeta applicationMeta = new ApplicationMeta(appId.toString(), appSpec,
+            new ChangeDetail(null, null, null, now.toEpochMilli()),
+            metaNew);
+
+        List<Field<?>> fields = getApplicationFields(
+            NamespaceId.DEFAULT.getNamespace(),
+            appId.getApplication(), "1", applicationMeta,
+            new ChangeDetail(null, null, null, now.toEpochMilli()), null, true);
+        table.upsert(fields);
+      });
+    }
+
+    // Add some scm metadata in new table for even id application
+    for (int i = 0; i < 10; i += 2) {
+      ApplicationReference appRef = NamespaceId.DEFAULT.appReference("appName" + i);
+      store.setAppSourceControlMeta(appRef, metaNew);
+    }
+
+    // Run one iteration of the migration service.
+    SourceControlMetadataMigrationService migrationService =
+        new SourceControlMetadataMigrationService(cConf, store, transactionRunner);
+    migrationService.runOneIteration();
+
+    // Verify that the scm metadata has been migrated.
+    for (int i = 0; i < 10; i++) {
+      ApplicationReference appRef = NamespaceId.DEFAULT.appReference("appName" + i);
+      // even id applications should have scm metadata not updated
+      SourceControlMeta expectedMeta = i % 2 == 0 ? metaNew : metaPresent;
+      expectedMeta = SourceControlMeta.builder(expectedMeta).setSyncStatus(true).build();
+      Assert.assertEquals(expectedMeta, store.getAppSourceControlMeta(appRef));
+    }
+
+    // Verify that the scm metadata has been migrated for applications without scm metadata.
+    for (int i = 10; i < 15; i++) {
+      ApplicationReference appId = NamespaceId.DEFAULT.appReference("appName" + i);
+      TransactionRunners.run(transactionRunner, context -> {
+        NamespaceSourceControlMetadataStore store = NamespaceSourceControlMetadataStore.create(
+            context);
+        SourceControlMeta gotMeta = store.get(appId);
+        org.junit.Assert.assertEquals(SourceControlMeta.createDefaultMeta(), gotMeta);
+      });
+    }
+  }
+
+
+  // Needed as the current write application don't store scm metadata anymore
+  private List<Field<?>> getApplicationFields(String namespaceId, String appId, String versionId,
+      ApplicationMeta appMeta, ChangeDetail change, SourceControlMeta scmMeta,
+      boolean markAsLatest) {
+    List<Field<?>> fields = new ArrayList<>();
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.NAMESPACE_FIELD, namespaceId));
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_FIELD, appId));
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.VERSION_FIELD, versionId));
+    fields.add(
+        Fields.stringField(StoreDefinition.AppMetadataStore.APPLICATION_DATA_FIELD,
+            GSON.toJson(appMeta)));
+    if (change != null) {
+      fields.add(
+          Fields.stringField(StoreDefinition.AppMetadataStore.AUTHOR_FIELD, change.getAuthor()));
+      fields.add(Fields.longField(StoreDefinition.AppMetadataStore.CREATION_TIME_FIELD,
+          change.getCreationTimeMillis()));
+      fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.CHANGE_SUMMARY_FIELD,
+          change.getDescription()));
+    }
+    fields.add(Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, markAsLatest));
+    fields.add(Fields.stringField(StoreDefinition.AppMetadataStore.SOURCE_CONTROL_META,
+        GSON.toJson(scmMeta)));
+    return fields;
+  }
+}

--- a/cdap-client-tests/src/test/java/io/cdap/cdap/client/ApplicationClientTestRun.java
+++ b/cdap-client-tests/src/test/java/io/cdap/cdap/client/ApplicationClientTestRun.java
@@ -305,10 +305,10 @@ public class ApplicationClientTestRun extends ClientTestBase {
       Set<ApplicationRecord> expected = ImmutableSet.of(
         new ApplicationRecord(new ArtifactSummary("fake", "1.0.0-SNAPSHOT"), appId1.getApplication(),
                               fakeAppDetail2.getAppVersion(), "", null,
-                              fakeAppDetail2.getChange(), appId3Detail.getSourceControlMeta()),
+                              fakeAppDetail2.getChange(), null),
         new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT"), appId2.getApplication(),
                               appId2Detail.getAppVersion(), "", null,
-                              appId2Detail.getChange(), appId2Detail.getSourceControlMeta())
+                              appId2Detail.getChange(), null)
       );
       Assert.assertEquals(expected, apps);
 
@@ -316,7 +316,7 @@ public class ApplicationClientTestRun extends ClientTestBase {
       expected = ImmutableSet.of(
         new ApplicationRecord(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT"), appId3.getApplication(),
                               appId3Detail.getAppVersion(), "", null,
-                              appId3Detail.getChange(), appId3Detail.getSourceControlMeta())
+                              appId3Detail.getChange(), null)
       );
       Assert.assertEquals(expected, apps);
 
@@ -325,13 +325,13 @@ public class ApplicationClientTestRun extends ClientTestBase {
       expected = ImmutableSet.of(
         new ApplicationRecord(new ArtifactSummary("fake", "1.0.0-SNAPSHOT"), appId1.getApplication(),
                               fakeAppDetail2.getAppVersion(), "", null,
-                              fakeAppDetail2.getChange(), fakeAppDetail2.getSourceControlMeta()),
+                              fakeAppDetail2.getChange(), null),
         new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT"), appId2.getApplication(),
                               appId2Detail.getAppVersion(), "", null,
-                              appId2Detail.getChange(), appId2Detail.getSourceControlMeta()),
+                              appId2Detail.getChange(), null),
         new ApplicationRecord(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT"), appId3.getApplication(),
                               appId3Detail.getAppVersion(), "", null,
-                              appId3Detail.getChange(), appId3Detail.getSourceControlMeta())
+                              appId3Detail.getChange(), null)
       );
       Assert.assertEquals(expected, apps);
 
@@ -340,7 +340,7 @@ public class ApplicationClientTestRun extends ClientTestBase {
       expected = ImmutableSet.of(new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT"),
                                                        appId2.getApplication(), appId2Detail.getAppVersion(),
                                                        "", null,
-                                                       appId2Detail.getChange(), appId2Detail.getSourceControlMeta())
+                                                       appId2Detail.getChange(), null)
       );
       Assert.assertEquals(expected, apps);
 
@@ -348,10 +348,10 @@ public class ApplicationClientTestRun extends ClientTestBase {
       expected = ImmutableSet.of(
         new ApplicationRecord(new ArtifactSummary("fake", "1.0.0-SNAPSHOT"), appId1.getApplication(),
                               fakeAppDetail2.getAppVersion(), "", null,
-                              fakeAppDetail2.getChange(), fakeAppDetail2.getSourceControlMeta()),
+                              fakeAppDetail2.getChange(), null),
         new ApplicationRecord(new ArtifactSummary("otherfake", "1.0.0-SNAPSHOT"), appId3.getApplication(),
                               appId3Detail.getAppVersion(), "", null,
-                              appId3Detail.getChange(), appId3Detail.getSourceControlMeta())
+                              appId3Detail.getChange(), null)
       );
       Assert.assertEquals(expected, apps);
 
@@ -360,7 +360,7 @@ public class ApplicationClientTestRun extends ClientTestBase {
       expected = ImmutableSet.of(new ApplicationRecord(new ArtifactSummary("fake", "0.1.0-SNAPSHOT"),
                                                        appId2.getApplication(), appId2Detail.getAppVersion(),
                                                        "", null,
-                                                       appId2Detail.getChange(), appId2Detail.getSourceControlMeta()));
+                                                       appId2Detail.getChange(), null));
       Assert.assertEquals(expected, apps);
     } finally {
       appClient.deleteAll(NamespaceId.DEFAULT);

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -2480,6 +2480,8 @@ public final class Constants {
     public static final String REPOSITORY_CLEANUP_INTERVAL_SECONDS =
         "source.control.repository.cleanup.interval.seconds";
     public static final String REPOSITORY_TTL_SECONDS = "source.control.repository.ttl.seconds";
+    public static final String METADATA_MIGRATION_INTERVAL_SECONDS =
+        "source.control.metadata.migration.interval.seconds";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -6117,6 +6117,14 @@
       Scheduler interval for repository cleanup service, by default 1 hour
     </description>
   </property>
+  <property>
+    <name>source.control.metadata.migration.interval.seconds</name>
+    <value>300</value>
+    <description>
+      Scheduler interval for scm metadata migration service, by default 5 min
+      The service only retries when the migration job fails.
+    </description>
+  </property>
 
   <!--Configuration for the Internal Router service -->
   <property>

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/SourceControlMeta.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/sourcecontrol/SourceControlMeta.java
@@ -35,8 +35,8 @@ public class SourceControlMeta {
   /**
    * Default constructor for SourceControlMeta.
    *
-   * @param fileHash     the git-hash of the config in git after push
-   * @param commitId     the commit in git form/to application was pulled/pushed
+   * @param fileHash the git-hash of the config in git after push
+   * @param commitId the commit in git form/to application was pulled/pushed
    * @param lastSyncedAt last time the application was pulled/pushed
    */
   public SourceControlMeta(String fileHash, @Nullable String commitId,
@@ -47,13 +47,13 @@ public class SourceControlMeta {
   /**
    * Constructs a new instance of {@code SourceControlMeta} with the specified parameters.
    *
-   * @param fileHash     The hash value of the file associated with the metadata.
-   * @param commitId     The ID of the commit associated with the metadata, or {@code null} if not
-   *                     available.
+   * @param fileHash The hash value of the file associated with the metadata.
+   * @param commitId The ID of the commit associated with the metadata, or {@code null} if not
+   *     available.
    * @param lastSyncedAt The timestamp when the metadata was last synced, or {@code null} if not
-   *                     available.
-   * @param syncStatus   The synchronization status indicating whether the metadata is synchronized,
-   *                     represented as a boolean value.
+   *     available.
+   * @param syncStatus The synchronization status indicating whether the metadata is
+   *     synchronized, represented as a boolean value.
    */
   public SourceControlMeta(String fileHash, @Nullable String commitId,
       @Nullable Instant lastSyncedAt, @Nullable Boolean syncStatus) {
@@ -88,12 +88,12 @@ public class SourceControlMeta {
 
   @Override
   public String toString() {
-    return "SourceControlMeta{" +
-        "fileHash='" + fileHash + '\'' +
-        ", commitId='" + commitId + '\'' +
-        ", lastSyncedAt=" + lastSyncedAt +
-        ", syncStatus=" + syncStatus +
-        '}';
+    return "SourceControlMeta{"
+        + "fileHash='" + fileHash + '\''
+        + ", commitId='" + commitId + '\''
+        + ", lastSyncedAt=" + lastSyncedAt
+        + ", syncStatus=" + syncStatus
+        + '}';
   }
 
   @Nullable
@@ -128,6 +128,7 @@ public class SourceControlMeta {
    * Builds the SourceControlMeta.
    */
   public static class Builder {
+
     private String fileHash;
     private String commitId;
     private Instant lastSyncedAt;


### PR DESCRIPTION
Added a new service that runs periodically to migrate existing metadata from `ApplicationSpecification` table to `NamespaceSourceControlMetadata` table. 

This is not added as part of startup tasks to avoid blocking the system startup for a non-critical feature. As the scm metadata is considered to be eventually consistent anyway.