### PR TITLE
[CDAP-20905] do not throw invalid macro exception because it skips failures when skip invalid macros is enabled

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Class which contains common logic about retry logic
+ * Class which contains common logic about retry logic.
  */
 abstract class AbstractServiceRetryableMacroEvaluator implements MacroEvaluator {
 
@@ -150,7 +150,8 @@ abstract class AbstractServiceRetryableMacroEvaluator implements MacroEvaluator 
               + 1)));
           delay = Math.min(delay, RETRY_MAX_DELAY_MILLIS);
         } catch (IOException e) {
-          throw new InvalidMacroException(e);
+          throw new RuntimeException("Failed to evaluate the macro function '" + functionName
+              + "' with args " + Arrays.asList(args), e);
         }
       }
     } catch (InterruptedException e) {


### PR DESCRIPTION
JIRA: [CDAP-20905](https://cdap.atlassian.net/browse/CDAP-20905)

context: 

Because we do not want to evaluate `OAuth Macros` during appspec regeneration, the [macro parser](https://github.com/cdapio/cdap/blob/fbdbe51048b43c6d1e9cdba9ae8940c0fd267f95/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/PipelinePhase.java#L207) skips invalid macros when registering plugins.

If we throw `InvalidMacroException` at this [point](https://github.com/cdapio/cdap/blob/f2b5bf42bd5d5b09d82ee52414e24c80395b0363/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/AbstractServiceRetryableMacroEvaluator.java#L153) in macro evaluator, it ends up skipping errors [here](https://github.com/cdapio/cdap/blob/e81bb233fa54e757ace4bbd36a91eec48d967675/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParser.java#L244), manifesting in very confusing logs.

[CDAP-20905]: https://cdap.atlassian.net/browse/CDAP-20905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ