### PR TITLE
[CDAP-21006] Create OAuth Provider reusing existing secrets in GCP Secret Manager

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/oauth/OAuthProvider.java
@@ -15,6 +15,7 @@
 package io.cdap.cdap.datapipeline.oauth;
 
 import com.google.common.base.Preconditions;
+import javax.annotation.Nullable;
 
 /**
  * OAuth provider POJO.
@@ -23,9 +24,13 @@ public class OAuthProvider {
   private final String name;
   private final String loginURL;
   private final String tokenRefreshURL;
+  @Nullable
   private final OAuthClientCredentials clientCreds;
 
-  public OAuthProvider(String name, String loginURL, String tokenRefreshURL, OAuthClientCredentials clientCreds) {
+  public OAuthProvider(String name,
+                       String loginURL,
+                       String tokenRefreshURL,
+                       @Nullable OAuthClientCredentials clientCreds) {
     this.name = name;
     this.loginURL = loginURL;
     this.tokenRefreshURL = tokenRefreshURL;
@@ -44,6 +49,7 @@ public class OAuthProvider {
     return tokenRefreshURL;
   }
 
+  @Nullable
   public OAuthClientCredentials getClientCredentials() {
     return clientCreds;
   }
@@ -78,7 +84,7 @@ public class OAuthProvider {
       return this;
     }
 
-    public Builder withClientCredentials(OAuthClientCredentials clientCredentials) {
+    public Builder withClientCredentials(@Nullable OAuthClientCredentials clientCredentials) {
       this.clientCreds = clientCredentials;
       return this;
     }
@@ -87,7 +93,6 @@ public class OAuthProvider {
       Preconditions.checkNotNull(name, "OAuth provider name missing");
       Preconditions.checkNotNull(loginURL, "Login URL missing");
       Preconditions.checkNotNull(tokenRefreshURL, "Token refresh URL missing");
-      Preconditions.checkNotNull(clientCreds, "OAuth client credentials missing");
       return new OAuthProvider(name, loginURL, tokenRefreshURL, clientCreds);
     }
   }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/OAuthServiceTest.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/test/java/io/cdap/cdap/datapipeline/OAuthServiceTest.java
@@ -53,6 +53,105 @@ public class OAuthServiceTest extends DataPipelineServiceTest {
   }
 
   @Test
+  public void testCreateProviderWithClientCredentialsMissing() throws IOException {
+    // Attempt to create provider with missing client credentials should fail with 400 status code.
+    String loginURL = "http://www.example.com/login";
+    String tokenRefreshURL = "http://www.example.com/token";
+    PutOAuthProviderRequest request = new PutOAuthProviderRequest(loginURL, tokenRefreshURL, null, null);
+    HttpResponse createResponse = makePutCall("provider/testprovider", request);
+    Assert.assertEquals(400, createResponse.getResponseCode());
+  }
+
+  @Test
+  public void testCreateProviderWithReuseClientCredentialsTrue() throws IOException {
+    // Attempt to create provider with no client credentials and 'reuse_client_credentials' query
+    // param 'true' should succeed with 200 status code.
+    String loginURL = "http://www.example.com/login";
+    String tokenRefreshURL = "http://www.example.com/token";
+    PutOAuthProviderRequest request = new PutOAuthProviderRequest(loginURL, tokenRefreshURL, null, null);
+    HttpResponse createResponse = makePutCall("provider/testprovider10?reuse_client_credentials=true", request);
+    Assert.assertEquals(500, createResponse.getResponseCode());
+  }
+
+  @Test
+  public void testCreateProviderReuseCredentialsWithReuseClientCredentialsTrue() throws IOException {
+    // Attempt to create provider with client credentials.
+    String loginURL = "http://www.example.com/login20";
+    String tokenRefreshURL = "http://www.example.com/token20";
+    String clientId = "clientid";
+    String clientSecret = "clientsecret";
+    PutOAuthProviderRequest request = new PutOAuthProviderRequest(loginURL, tokenRefreshURL, clientId, clientSecret);
+    HttpResponse createResponse = makePutCall("provider/testprovider20", request);
+    Assert.assertEquals(200, createResponse.getResponseCode());
+
+    // Attempt to update provider with no client credentials and 'reuse_client_credentials' query
+    // param 'true' should succeed with 200 status code.
+    loginURL = "http://www.example.com/login21";
+    tokenRefreshURL = "http://www.example.com/token21";
+    request = new PutOAuthProviderRequest(loginURL, tokenRefreshURL, null, null);
+    createResponse = makePutCall("provider/testprovider20?reuse_client_credentials=true", request);
+    Assert.assertEquals(200, createResponse.getResponseCode());
+  }
+
+  @Test
+  public void testCreateProviderWithReuseClientCredentialsFalse() throws IOException {
+    // Attempt to create provider with missing client credentials and 'reuse_client_credentials'
+    // query param 'false' should fail with 400 status code.
+    String loginURL = "http://www.example.com/login30";
+    String tokenRefreshURL = "http://www.example.com/token30";
+    PutOAuthProviderRequest request = new PutOAuthProviderRequest(loginURL, tokenRefreshURL, null, null);
+    HttpResponse createResponse = makePutCall("provider/testprovider30?reuse_client_credentials=false", request);
+    Assert.assertEquals(400, createResponse.getResponseCode());
+  }
+
+  @Test
+  public void testGetAuthURLForMissingClientCredentials() throws IOException {
+    // Attempt to create provider with missing client credentials and 'reuse_client_credentials'
+    // query param 'true'.
+    String loginURL = "http://www.example.com/login40";
+    String tokenRefreshURL = "http://www.example.com/token40";
+    PutOAuthProviderRequest request = new PutOAuthProviderRequest(loginURL, tokenRefreshURL, null, null);
+    HttpResponse createResponse = makePutCall("provider/testprovider40?reuse_client_credentials=false", request);
+    Assert.assertEquals(400, createResponse.getResponseCode());
+
+    // Get OAuth login URL should fail with 404 as client credentials are not configured.
+    HttpResponse getResponse = makeGetCall("provider/testprovider40/authurl");
+    Assert.assertEquals(404, getResponse.getResponseCode());
+  }
+
+  @Test
+  public void testGetAuthURLForReusedClientCredentials() throws IOException {
+    // Attempt to create provider with client credentials.
+    String loginURL = "http://www.example.com/login50";
+    String tokenRefreshURL = "http://www.example.com/token50";
+    String clientId = "clientid";
+    String clientSecret = "clientsecret";
+    PutOAuthProviderRequest request = new PutOAuthProviderRequest(loginURL, tokenRefreshURL, clientId, clientSecret);
+    HttpResponse createResponse = makePutCall("provider/testprovider50", request);
+    Assert.assertEquals(200, createResponse.getResponseCode());
+
+    // Grab OAuth login URL to verify write succeeded.
+    HttpResponse getResponse = makeGetCall("provider/testprovider50/authurl");
+    Assert.assertEquals(200, getResponse.getResponseCode());
+    String authURL = getResponse.getResponseBodyAsString();
+    Assert.assertEquals("http://www.example.com/login50?client_id=clientid&redirect_uri=null", authURL);
+
+    // Attempt to update provider with with missing credentials and 'reuse_client_credentials' query
+    // param 'true' should succeed with 200 status code.
+    loginURL = "http://www.example.com/login51";
+    tokenRefreshURL = "http://www.example.com/token51";
+    request = new PutOAuthProviderRequest(loginURL, tokenRefreshURL, null, null);
+    createResponse = makePutCall("provider/testprovider50?reuse_client_credentials=true", request);
+    Assert.assertEquals(200, createResponse.getResponseCode());
+
+    // Grab OAuth login URL to verify write succeeded.
+    getResponse = makeGetCall("provider/testprovider50/authurl");
+    Assert.assertEquals(200, getResponse.getResponseCode());
+    authURL = getResponse.getResponseBodyAsString();
+    Assert.assertEquals("http://www.example.com/login51?client_id=clientid&redirect_uri=null", authURL);
+  }
+
+  @Test
   public void testCreateProviderBadLoginURL() throws IOException {
     // Attempt to create provider
     String loginURL = "badurl";


### PR DESCRIPTION
### Jira Issue

* [CDAP-21006](https://cdap.atlassian.net/browse/CDAP-21006)

### Problem Statement

Allow users to add provider using OAuthHandler while reusing credentials stored in GCP Secret Manager. 

### Solution

Add a query param `reuse_client_credentials` to skip credential update when adding a provider.

Pros:
* User controls when to skip update of client credentials.
* Can be used to add / update provider when reusing credentials in GCP Secret Manager.
* Can be used to update login / refresh token url without modifying the client credentials for any Secure Store provider (like KMS).

### Alternative Approaches

#### Approach #1: Make client id and client secret optional.

Con: Ambiguity about when to unset client credentials vs. when to skip it.

#### Approach #2: Make client id and client secret optional only when provider is GCP Secret Manager.

Con: Not a generic solution.

### Verification

[x] Added Unit Tests in `OAuthServiceTest`.
[x] Manually tested using CDAP sandbox with GCP Secret Manager and KMS providers.

[CDAP-21006]: https://cdap.atlassian.net/browse/CDAP-21006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ