### PR TITLE
[CDAP-21010] fix get application count metric to not count different versions as different application

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/AppMetadataStore.java
@@ -404,7 +404,13 @@ public class AppMetadataStore {
             Range.Bound.EXCLUSIVE),
         Range.create(fields, Range.Bound.EXCLUSIVE, null,
             Range.Bound.INCLUSIVE));
-    return getApplicationSpecificationTable().count(ranges);
+    // Count the latest version of app,
+    // we treat latest=["true",null] as latest for backward compatibility.
+    // Prior to 6.8, all versions of an application were returned in the list apps api, not just the latest version.
+    Collection<Field<?>> filterIndexes =
+        ImmutableList.of(Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, null),
+            Fields.booleanField(StoreDefinition.AppMetadataStore.LATEST_FIELD, true));
+    return getApplicationSpecificationTable().count(ranges, filterIndexes);
   }
 
   /**

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/AppMetadataStoreTest.java
@@ -1065,6 +1065,21 @@ public abstract class AppMetadataStoreTest {
                                new ChangeDetail(null, null, null, creationTimeMillis), null);
       });
     }
+
+    // create new version of the application and mark older version as false
+    for (int i = 0; i < 20; i++) {
+      String appName = "test" + i;
+      TransactionRunners.run(transactionRunner, context -> {
+        AppMetadataStore store = AppMetadataStore.create(context);
+        store.writeApplication(NamespaceId.DEFAULT.getNamespace(), appName,
+            ApplicationId.DEFAULT_VERSION, appSpec,
+            new ChangeDetail(null, null, null, creationTimeMillis), null, false);
+        store.writeApplication(NamespaceId.DEFAULT.getNamespace(), appName,
+            ApplicationId.DEFAULT_VERSION + "1", appSpec,
+            new ChangeDetail(null, null, null, creationTimeMillis), null);
+      });
+    }
+
     TransactionRunners.run(transactionRunner, context -> {
       AppMetadataStore store = AppMetadataStore.create(context);
       long count =  store.getApplicationCount();

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/MetricStructuredTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/common/MetricStructuredTable.java
@@ -355,6 +355,27 @@ public class MetricStructuredTable implements StructuredTable {
   }
 
   @Override
+  public long count(Collection<Range> keyRanges,
+      Collection<Field<?>> filterIndexes) throws IOException {
+    try {
+      long count = 0;
+      if (!emitTimeMetrics) {
+        count = structuredTable.count(keyRanges, filterIndexes);
+      } else {
+        long curTime = System.nanoTime();
+        count = structuredTable.count(keyRanges, filterIndexes);
+        long duration = System.nanoTime() - curTime;
+        metricsCollector.increment(metricPrefix + "count.time", duration);
+      }
+      metricsCollector.increment(metricPrefix + "count.count", 1L);
+      return count;
+    } catch (Exception e) {
+      metricsCollector.increment(metricPrefix + "count.error", 1L);
+      throw e;
+    }
+  }
+
+  @Override
   public void close() throws IOException {
     structuredTable.close();
   }

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTable.java
@@ -299,4 +299,20 @@ public interface StructuredTable extends Closeable {
    * @throws IOException if there is an error reading from the table
    */
   long count(Collection<Range> keyRanges) throws IOException;
+
+  /**
+   * Get the number of records from the table matching the key range of specified
+   * index field.
+   *
+   * @param keyRanges key ranges of the rows to count
+   * @param filterIndexes the index to filter upon
+   * @return a {@link CloseableIterator} of rows
+   * @throws InvalidFieldException if the field is not part of the table schema, or is not an
+   *     indexed column, or the type does not match the schema
+   * @throws IOException if there is an error scanning the table
+   */
+  default long count(Collection<Range> keyRanges,
+      Collection<Field<?>> filterIndexes) throws InvalidFieldException, IOException {
+    throw new UnsupportedOperationException("No supported implementation.");
+  }
 }


### PR DESCRIPTION
JIRA: [CDAP-21010](https://cdap.atlassian.net/browse/CDAP-21010)

context: 

With LCM, we introduced versioning while creating applications.
The `system.application.count` metric returns the count of same application with different versions multiple times.
This PR fixes the metric to only count `latest` version.

This is how the query looks now for `PostgreSqlStructuredTable`:
```
SELECT COUNT(*) FROM application_specs WHERE ((namespace)<('system') OR (namespace)>('system')) AND (latest is NULL OR latest = 'TRUE')
```
Tested in sandbox:
![image](https://github.com/cdapio/cdap/assets/88528384/e051716d-6688-4549-9d89-4077a3ba1d36)
![image](https://github.com/cdapio/cdap/assets/88528384/4562e697-9d26-4064-b389-903ca7a79efa)


[CDAP-21010]: https://cdap.atlassian.net/browse/CDAP-21010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ