### PR TITLE
fix github token input typo

### DIFF
--- a/.github/workflows/build-sonar-report.yml
+++ b/.github/workflows/build-sonar-report.yml
@@ -40,10 +40,9 @@ jobs:
      - name: Download artifact
        uses: actions/download-artifact@v4
        with:
-        name: reports-${{ github.event.workflow_run.id }}
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         run-id: ${{ github.event.workflow_run.id }}
-        path: ./downloaded-artifact
+        path: artifacts/
 
      - name: Validate PR
        id: validate_pr


### PR DESCRIPTION
```
github-token:
    description: 'The GitHub token used to authenticate with the GitHub API.
      This is required when downloading artifacts from a different repository or from a different workflow run.
      If this is not specified, the action will attempt to download artifacts from the current repository and the current workflow run.'
```