### PR TITLE
[CDAP-21041] add dataproc job status when stopped or failed

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -121,12 +121,13 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
         }
 
         if (jobDetail != null
-            && jobDetail.getStatus() == RuntimeJobStatus.FAILED
+            && jobDetail.getStatus() != RuntimeJobStatus.COMPLETED
             && (jobDetail instanceof DataprocRuntimeJobDetail)) {
           // Status details is specific to dataproc jobs, so it was not added to RuntimeJobDetail spi.
           String statusDetails = ((DataprocRuntimeJobDetail) jobDetail).getJobStatusDetails();
           if (statusDetails != null) {
-            LOG.error("Dataproc job failed with the status details: {}", statusDetails);
+            LOG.error("Dataproc job '{}' with the status details: {}",
+                jobDetail.getStatus().name(), statusDetails);
           }
         }
       } finally {


### PR DESCRIPTION
```
INFO 2024-07-10T12:10:37.064Z Twill program terminated: program_run:default.alertusersdistribuations.-SNAPSHOT.workflow.DataPipelineWorkflow.55371f56-3eb5-11ef-a29e-2ab1c5601f87, twill runId: b6fe15f2-c6d0-4f82-bdf9-b6d6deda8bdf, status: null

Tool finished with DriverExitStatus([Driver received SIGTERM/SIGKILL signal and exited with 143 code, which potentially signifies a memory pressure.
Google Cloud Dataproc Agent reports job failure.
```