### PR TITLE
Expose REST API for pipeline summarization and add java docs

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -857,4 +857,42 @@ public class AppLifecycleHttpHandler extends AbstractAppLifecycleHttpHandler {
       throws BadRequestException, NamespaceNotFoundException, AccessException {
     return validateApplicationVersionId(validateNamespace(namespace), appId, versionId);
   }
+
+  /**
+   * Endpoint to summarize deployed applications.
+   *
+   * @param request The HTTP request object.
+   * @param responder The HTTP responder object.
+   * @param namespaceId The namespace ID where the application is deployed.
+   * @param appName The name of the deployed application.
+   * @param format The format in which the summary should be returned (default is markdown).
+   * @throws NotImplementedException Thrown if the method is not implemented yet.
+   */
+  @POST
+  @Path("/apps/{app-id}/summarize")
+  public void getAppSummaryDeployedApp(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") final String namespaceId,
+      @PathParam("app-id") final String appName,
+      @PathParam("format") @DefaultValue("markdown") String format)
+      throws NotImplementedException {
+      throw  new NotImplementedException("This api request is not implemented.");
+  }
+
+  /**
+   * Endpoint to summarize drafted applications.
+   *
+   * @param request The HTTP request object.
+   * @param responder The HTTP responder object.
+   * @param namespaceId The namespace ID where the application is drafted.
+   * @param format The format in which the summary should be returned (default is markdown).
+   * @throws NotImplementedException Thrown if the method is not implemented yet.
+   */
+  @POST
+  @Path("/apps/summarize")
+  public void getAppSummaryDraftedApp(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") final String namespaceId,
+      @PathParam("format") @DefaultValue("markdown") String format)
+      throws NotImplementedException{
+      throw  new NotImplementedException("This api request is not implemented.");
+  }
 }


### PR DESCRIPTION
In AppLifecycleHttpHandler file of cdap-app-fabric,added REST API handler for API requests for deployed and drafted pipeline summarization along with java doc.