### PR TITLE
[CDAP-21007] Add an option to disable cdap field lineage emission

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/WorkflowDriver.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/workflow/WorkflowDriver.java
@@ -57,6 +57,7 @@ import io.cdap.cdap.app.runtime.ProgramRunnerFactory;
 import io.cdap.cdap.app.runtime.ProgramStateWriter;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.FieldLineage;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.lang.Exceptions;
 import io.cdap.cdap.common.lang.InstantiatorFactory;
@@ -313,7 +314,8 @@ final class WorkflowDriver extends AbstractExecutionThreadService {
       LOG.error("Failed to store the final workflow token of Workflow {}", workflowRunId, t);
     }
 
-    if (ProgramStatus.COMPLETED != workflowContext.getState().getStatus()) {
+    if (ProgramStatus.COMPLETED != workflowContext.getState().getStatus()
+        || (!cConf.getBoolean(FieldLineage.FIELD_LINEAGE_EMISSION_ENABLED))) {
       return;
     }
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -2242,6 +2242,9 @@ public final class Constants {
       OUTGOING,
       BOTH
     }
+
+    public static final String FIELD_LINEAGE_EMISSION_ENABLED =
+        "metadata.messaging.field.lineage.emission.enabled";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2762,6 +2762,15 @@
     </description>
   </property>
 
+  <property>
+    <name>metadata.messaging.field.lineage.emission.enabled</name>
+    <value>true</value>
+    <description>
+      Enable or disable publishing of field level lineage,
+      by default set to true.
+    </description>
+  </property>
+
   <!-- Metrics Configuration -->
 
   <property>


### PR DESCRIPTION
Tested:

- In CDAP sandbox, after turning the flag off, no field lineage events per published when we ran datafusion quickstart pipeline.

Next Steps:

- In longer term, limit message fetching in metadata service batch to some amount globally, e.g. return no more than 5MB of messages in 1 batch (but at least 1 message).
- Or by splitting long lists of lineage operations into multiple messages.