### PR TITLE
[CDAP-21061] wrap all plugin methods to throw WrappedStageException

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/WrappedStageException.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/WrappedStageException.java
@@ -49,4 +49,14 @@ public class WrappedStageException extends RuntimeException {
   public String getStageName() {
     return stageName;
   }
+
+  /**
+   * Returns the detail message string of this exception.
+   *
+   * @return the detail message as a {@String}.
+   */
+  @Override
+  public String getMessage() {
+    return String.format("Stage '%s' encountered : %s", stageName, super.getMessage());
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/ExceptionWrappingCaller.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/ExceptionWrappingCaller.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common.plugin;
+
+import io.cdap.cdap.api.exception.WrappedStageException;
+import java.util.concurrent.Callable;
+
+/**
+ * A caller wrapper that catches exceptions thrown during execution of a callable
+ * and wraps them in a {@link WrappedStageException}.
+ * This class is primarily used to associate the exception with a specific stage name in a pipeline,
+ * helping in better debugging and error tracking.
+ *
+ * <p>
+ * The class delegates the actual calling operation to another {@link Caller} instance and
+ * ensures that any exceptions thrown are caught and rethrown as a {@link WrappedStageException},
+ * which includes the stage name where the error occurred.
+ * </p>
+ */
+public class ExceptionWrappingCaller extends Caller {
+  private final Caller delegate;
+  private final String stageName;
+
+  /**
+   * Constructs an ExceptionWrappingCaller.
+   *
+   * @param delegate The {@link Caller} instance that performs the actual calling of the callable.
+   * @param stageName The name of the stage associated with the exception,
+   *                  for easier identification of where the error occurred.
+   */
+  public ExceptionWrappingCaller(Caller delegate, String stageName) {
+    this.delegate = delegate;
+    this.stageName = stageName;
+  }
+
+  /**
+   * Executes the given {@link Callable}, wrapping any exceptions thrown
+   * during execution in a {@link WrappedStageException}.
+   *
+   * @param callable The callable task to execute.
+   * @param <T> The return type of the callable.
+   * @return The result of the callable task.
+   * @throws Exception if an exception occurs during the callable execution.
+   */
+  @Override
+  public <T> T call(Callable<T> callable) throws Exception {
+    try {
+      return delegate.call(callable);
+    } catch (Exception e) {
+      throw new WrappedStageException(e, stageName);
+    }
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/PipelinePluginContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/plugin/PipelinePluginContext.java
@@ -115,7 +115,7 @@ public class PipelinePluginContext implements PluginContext {
   }
 
   public Caller getCaller(String pluginId) {
-    Caller caller = Caller.DEFAULT;
+    Caller caller = new ExceptionWrappingCaller(Caller.DEFAULT, pluginId);
     if (stageLoggingEnabled) {
       caller = StageLoggingCaller.wrap(caller, pluginId);
     }


### PR DESCRIPTION
JIRA: [CDAP-21061](https://cdap.atlassian.net/browse/CDAP-21061)

Refactoring so that any known plugin type instantiated by the pipeline is wrapped so that it throws wrapped stage exception which will be later on used by `LogAppender` to add MDC tags.

Tested in CDAP Sandbox:
```
Caused by: io.cdap.cdap.api.exception.WrappedStageException: Stage 'NYT Best Sellers Raw Data' encountered : java.lang.IllegalArgumentException: Invalid bucket name in path 'top_rated_$inexpensive'. Bucket name should only contain lower case alphanumeric, '-'. '_' and '.'. Please follow GCS naming convention: https://cloud.google.com/storage/docs/naming-buckets
	at io.cdap.cdap.etl.common.plugin.ExceptionWrappingCaller.call(ExceptionWrappingCaller.java:64)
	at io.cdap.cdap.etl.common.plugin.StageLoggingCaller.call(StageLoggingCaller.java:40)
	at io.cdap.cdap.etl.common.plugin.WrappedBatchSource.prepareRun(WrappedBatchSource.java:52)
	at io.cdap.cdap.etl.common.plugin.WrappedBatchSource.prepareRun(WrappedBatchSource.java:35)
	at io.cdap.cdap.etl.common.submit.SubmitterPlugin.lambda$prepareRun$2(SubmitterPlugin.java:74)
	at io.cdap.cdap.internal.app.runtime.AbstractContext.lambda$execute$5(AbstractContext.java:558)
	at io.cdap.cdap.data2.transaction.Transactions$CacheBasedTransactional.finishExecute(Transactions.java:234)
	... 21 common frames omitted
```

[CDAP-21061]: https://cdap.atlassian.net/browse/CDAP-21061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ