### PR TITLE
A pull request analysis cannot have the branch analysis parameter 'sonar.branch.name'

### DIFF
--- a/.github/workflows/build-sonar-report.yml
+++ b/.github/workflows/build-sonar-report.yml
@@ -50,7 +50,6 @@ jobs:
        env:
          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
          JAVA_HOME: /usr/lib/jvm/java-17-openjdk-amd64
-         BRANCH: ${{ github.event.workflow_run.head_branch }}
        run: >-
          mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -fae -T 2 -B -V
          -Dmaven.repo.local=$HOME/.m2/repository11
@@ -61,7 +60,6 @@ jobs:
          -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
          -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
          -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
-         -Dsonar.branch.name=$BRANCH
 
      - name: Sonar report
        if: ${{ github.event.workflow_run.pull_requests[0].head.ref == github.event.workflow_run.pull_requests[0].base.ref }}

--- a/.github/workflows/build-sonar.yml
+++ b/.github/workflows/build-sonar.yml
@@ -25,6 +25,18 @@ jobs:
   build:
     runs-on: k8s-runner-build
 
+    # We allow builds:
+    # 1) When it's a merge into a branch
+    # 2) For PRs that are labeled as build and
+    #  - It's a code change
+    #  - A build label was just added
+    # A bit complex, but prevents builds when other labels are manipulated
+    if: >
+      github.event_name == 'push'
+      || (contains(github.event.pull_request.labels.*.name, 'build')
+         && (github.event.action != 'labeled' || github.event.label.name == 'build')
+         )
+
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
context:

```
Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:4.0.0.4121:sonar (default-cli) on project cdap: A pull request analysis cannot have the branch analysis parameter 'sonar.branch.name'
```

ref: https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/pull-request-analysis/setting-up-the-pull-request-analysis/#setup-pull-request-parameters