### PR TITLE
[CDAP-21070] Introduce error details provider to get more information about exceptons from plugins

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/ErrorDetailsProvider.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/ErrorDetailsProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.exception;
+
+import javax.annotation.Nullable;
+
+/**
+ * Interface for providing error details.
+ *
+ * <p>
+ * Implementations of this interface can be used to provide more detailed error information
+ * for exceptions that occur within the code using {@link ProgramFailureException}.
+ * </p>
+ */
+public interface ErrorDetailsProvider<T> {
+
+  /**
+   * Returns a {@link RuntimeException} that wraps the given exception
+   * with more detailed information.
+   *
+   * @param e the exception to wrap
+   * @param conf configuration object
+   * @return {@link RuntimeException} that wraps the given exception
+   *         with more detailed information.
+   */
+  RuntimeException getExceptionDetails(Throwable e, @Nullable T conf);
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingOutputCommitter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingOutputCommitter.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.etl.spark.io;
 
+import io.cdap.cdap.api.exception.ErrorDetailsProvider;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.JobStatus;
 import org.apache.hadoop.mapreduce.OutputCommitter;
@@ -27,7 +28,7 @@ import java.io.IOException;
  * A {@link OutputCommitter} that delegate all operations to another {@link OutputCommitter}, with counter metrics
  * sending to Spark metrics.
  */
-public class TrackingOutputCommitter extends OutputCommitter {
+public class TrackingOutputCommitter extends OutputCommitter implements ErrorDetailsProvider<Void> {
 
   private final OutputCommitter delegate;
 
@@ -84,5 +85,13 @@ public class TrackingOutputCommitter extends OutputCommitter {
   @Override
   public void recoverTask(TaskAttemptContext taskContext) throws IOException {
     delegate.recoverTask(new TrackingTaskAttemptContext(taskContext));
+  }
+
+  @Override
+  public RuntimeException getExceptionDetails(Throwable e, Void conf) {
+    if (delegate instanceof ErrorDetailsProvider<?>) {
+      return ((ErrorDetailsProvider<?>) delegate).getExceptionDetails(e, null);
+    }
+    return null;
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingRecordReader.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingRecordReader.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.etl.spark.io;
 
+import io.cdap.cdap.api.exception.ErrorDetailsProvider;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
@@ -29,7 +30,8 @@ import java.io.IOException;
  * @param <K> type of key to read
  * @param <V> type of value to read
  */
-public class TrackingRecordReader<K, V> extends RecordReader<K, V> {
+public class TrackingRecordReader<K, V> extends RecordReader<K, V>
+  implements ErrorDetailsProvider<Void> {
 
   private final RecordReader<K, V> delegate;
 
@@ -65,5 +67,13 @@ public class TrackingRecordReader<K, V> extends RecordReader<K, V> {
   @Override
   public void close() throws IOException {
     delegate.close();
+  }
+
+  @Override
+  public RuntimeException getExceptionDetails(Throwable e, Void conf) {
+    if (delegate instanceof ErrorDetailsProvider<?>) {
+      return ((ErrorDetailsProvider<?>) delegate).getExceptionDetails(e, null);
+    }
+    return null;
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingRecordWriter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/TrackingRecordWriter.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.etl.spark.io;
 
+import io.cdap.cdap.api.exception.ErrorDetailsProvider;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
@@ -28,7 +29,8 @@ import java.io.IOException;
  * @param <K> type of key to write
  * @param <V> type of value to write
  */
-public class TrackingRecordWriter<K, V> extends RecordWriter<K, V> {
+public class TrackingRecordWriter<K, V> extends RecordWriter<K, V>
+  implements ErrorDetailsProvider<Void> {
 
   private final RecordWriter<K, V> delegate;
 
@@ -44,5 +46,13 @@ public class TrackingRecordWriter<K, V> extends RecordWriter<K, V> {
   @Override
   public void close(TaskAttemptContext context) throws IOException, InterruptedException {
     delegate.close(new TrackingTaskAttemptContext(context));
+  }
+
+  @Override
+  public RuntimeException getExceptionDetails(Throwable e, Void conf) {
+    if (delegate instanceof ErrorDetailsProvider<?>) {
+      return ((ErrorDetailsProvider<?>) delegate).getExceptionDetails(e, null);
+    }
+    return null;
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/io/StageTrackingInputFormatTest.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/io/StageTrackingInputFormatTest.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.etl.spark.io;
 
-import io.cdap.cdap.api.exception.WrappedStageException;
+import io.cdap.cdap.api.exception.ProgramFailureException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.InputFormat;
@@ -58,7 +58,7 @@ public class StageTrackingInputFormatTest {
     Assert.assertEquals(1, splits.size());
   }
 
-  @Test (expected = WrappedStageException.class)
+  @Test (expected = ProgramFailureException.class)
   public void testMissingDelegate() throws IOException, InterruptedException {
     Configuration hConf = new Configuration();
     Job job = Job.getInstance(hConf);
@@ -66,7 +66,7 @@ public class StageTrackingInputFormatTest {
     inputFormat.getSplits(job);
   }
 
-  @Test (expected = WrappedStageException.class)
+  @Test (expected = ProgramFailureException.class)
   public void testSelfDelegate() throws IOException, InterruptedException {
     Configuration hConf = new Configuration();
     hConf.setClass(StageTrackingInputFormat.DELEGATE_CLASS_NAME, StageTrackingInputFormat.class,

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/io/StageTrackingOutputFormatTest.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/test/java/io/cdap/cdap/etl/spark/io/StageTrackingOutputFormatTest.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.etl.spark.io;
 
-import io.cdap.cdap.api.exception.WrappedStageException;
+import io.cdap.cdap.api.exception.ProgramFailureException;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.Job;
@@ -28,7 +28,7 @@ import org.junit.Test;
  */
 public class StageTrackingOutputFormatTest {
 
-  @Test(expected = WrappedStageException.class)
+  @Test(expected = ProgramFailureException.class)
   public void testMissingDelegate() throws IOException {
     Configuration hConf = new Configuration();
     Job job = Job.getInstance(hConf);
@@ -36,7 +36,7 @@ public class StageTrackingOutputFormatTest {
     outputFormat.checkOutputSpecs(job);
   }
 
-  @Test(expected = WrappedStageException.class)
+  @Test(expected = ProgramFailureException.class)
   public void testSelfDelegate() throws IOException {
     Configuration hConf = new Configuration();
     hConf.setClass(StageTrackingOutputFormat.DELEGATE_CLASS_NAME, StageTrackingOutputFormat.class,


### PR DESCRIPTION
Tested in CDAP Sandbox:

```
2024-10-04 06:42:38,079 - ERROR [SparkRunner-phase-1:i.c.c.i.a.r.ProgramControllerServiceAdapter@98] - Spark Program 'phase-1' failed.
java.util.concurrent.ExecutionException: io.cdap.cdap.api.exception.WrappedStageException: Stage 'GCS2' encountered : io.cdap.cdap.api.exception.ProgramFailureException: xxxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).
	at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:357)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1908)
	at io.cdap.cdap.app.runtime.spark.submit.AbstractSparkJobFuture.get(AbstractSparkJobFuture.java:119)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.run(SparkRuntimeService.java:444)
	at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:52)
	at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.lambda$null$2(SparkRuntimeService.java:525)
	at java.lang.Thread.run(Thread.java:750)
Caused by: io.cdap.cdap.api.exception.WrappedStageException: Stage 'GCS2' encountered : io.cdap.cdap.api.exception.ProgramFailureException: xxxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).
	at io.cdap.cdap.etl.spark.io.StageTrackingOutputFormat.getExceptionDetails(StageTrackingOutputFormat.java:101)
	at io.cdap.cdap.etl.spark.io.StageTrackingOutputFormat.checkOutputSpecs(StageTrackingOutputFormat.java:67)
	at io.cdap.cdap.etl.common.output.MultiOutputFormat.checkOutputSpecs(MultiOutputFormat.java:114)
	at org.apache.spark.internal.io.HadoopMapReduceWriteConfigUtil.assertConf(SparkHadoopWriter.scala:403)
	at org.apache.spark.internal.io.SparkHadoopWriter$.write(SparkHadoopWriter.scala:71)
```