### PR TITLE
[CDAP-21070] Introduce error details provider to get more information about exceptions from plugins

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/batch/BatchContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/batch/BatchContext.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.InstanceConflictException;
 import io.cdap.cdap.etl.api.TransformContext;
 import io.cdap.cdap.etl.api.action.SettableArguments;
+import io.cdap.cdap.etl.api.exception.ErrorDetailsProviderSpec;
 
 /**
  * Context passed to Batch Source and Sink.
@@ -61,4 +62,13 @@ public interface BatchContext extends DatasetContext, TransformContext {
    */
   @Override
   SettableArguments getArguments();
+
+  /**
+   * Overrides the error details provider specified in the stage.
+   *
+   * @param errorDetailsProviderSpec the error details provider spec.
+   */
+  default void setErrorDetailsProvider(ErrorDetailsProviderSpec errorDetailsProviderSpec) {
+    // no-op
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/exception/ErrorContext.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/exception/ErrorContext.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.exception;
+
+/**
+ * Context for error details provider.
+ *
+ * <p>
+ * This class provides the context for the error details provider.
+ * </p>
+ */
+public class ErrorContext {
+  private final ErrorPhase phase;
+
+  public ErrorContext(ErrorPhase phase) {
+    this.phase = phase;
+  }
+
+  public ErrorPhase getPhase() {
+    return phase;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/exception/ErrorDetailsProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/exception/ErrorDetailsProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.exception;
+
+import io.cdap.cdap.api.exception.ProgramFailureException;
+import javax.annotation.Nullable;
+
+/**
+ * Interface for providing error details.
+ *
+ * <p>
+ * Implementations of this interface can be used to provide more detailed error information
+ * for exceptions that occur within the code using {@link ProgramFailureException}.
+ * </p>
+ */
+public interface ErrorDetailsProvider {
+
+  /**
+   * Returns a {@link ProgramFailureException} that wraps the given exception
+   * with more detailed information.
+   *
+   * @param e the exception to wrap.
+   * @param context the context of the error.
+   * @return {@link ProgramFailureException} that wraps the given exception
+   * with more detailed information.
+   */
+  @Nullable
+  ProgramFailureException getExceptionDetails(Exception e, ErrorContext context);
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/exception/ErrorDetailsProviderSpec.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/exception/ErrorDetailsProviderSpec.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.exception;
+
+public class ErrorDetailsProviderSpec {
+  private final String className;
+
+  public ErrorDetailsProviderSpec(String className) {
+    this.className = className;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/exception/ErrorPhase.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/exception/ErrorPhase.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.exception;
+
+/**
+ * Enum representing the different phases of a stage where error can occur.
+ */
+public enum ErrorPhase {
+  SPLITTING("Splitting"),
+  READING("Reading"),
+  VALIDATING_OUTPUT_SPECS("Validating Output Specs"),
+  WRITING("Writing"),
+  COMMITTING("Committing");
+
+  private final String displayName;
+
+  ErrorPhase(String displayName) {
+    this.displayName = displayName;
+  }
+
+  /**
+   * Returns a string representation of the error phase enum.
+   */
+  @Override
+  public String toString() {
+    return displayName;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/exception/NoopErrorDetailsProvider.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/exception/NoopErrorDetailsProvider.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.api.exception;
+
+import io.cdap.cdap.api.exception.ProgramFailureException;
+import javax.annotation.Nullable;
+
+/**
+ * Noop implementation of {@link ErrorDetailsProvider}.
+ */
+public class NoopErrorDetailsProvider implements ErrorDetailsProvider {
+
+  @Nullable
+  @Override
+  public ProgramFailureException getExceptionDetails(Exception e, ErrorContext context) {
+    return null;
+  }
+}

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ErrorDetails.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/src/main/java/io/cdap/cdap/etl/common/ErrorDetails.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.etl.common;
+
+import io.cdap.cdap.api.exception.ProgramFailureException;
+import io.cdap.cdap.api.exception.WrappedStageException;
+import io.cdap.cdap.etl.api.exception.ErrorContext;
+import io.cdap.cdap.etl.api.exception.ErrorDetailsProvider;
+import io.cdap.cdap.etl.api.exception.ErrorPhase;
+import io.cdap.cdap.etl.api.exception.NoopErrorDetailsProvider;
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for handling exceptions.
+ */
+public class ErrorDetails {
+  private static final Logger LOG = LoggerFactory.getLogger(ErrorDetails.class);
+  public static final String ERROR_DETAILS_PROVIDER_CLASS_NAME_KEY =
+      "io.cdap.pipeline.error.details.provider.classname";
+
+  /**
+   * Gets the {@link ErrorDetailsProvider} from the given {@link Configuration}.
+   *
+   * @param conf the configuration to get the error details provider from.
+   * @return the error details provider.
+   */
+  public static ErrorDetailsProvider getErrorDetailsProvider(Configuration conf) {
+    String errorDetailsProviderClassName =
+      conf.get(ERROR_DETAILS_PROVIDER_CLASS_NAME_KEY);
+    if (errorDetailsProviderClassName == null) {
+      return new NoopErrorDetailsProvider();
+    }
+    try {
+      return (ErrorDetailsProvider) conf.getClassLoader()
+        .loadClass(errorDetailsProviderClassName)
+        .newInstance();
+    } catch (Exception e) {
+      LOG.warn(String.format("Unable to instantiate errorDetailsProvider class '%s'.",
+          errorDetailsProviderClassName), e);
+      return new NoopErrorDetailsProvider();
+    }
+  }
+
+  /**
+   * Handles the given exception, wrapping it in a {@link WrappedStageException}.
+   *
+   * @param e the exception to handle.
+   * @param stageName the name of the stage where the exception occurred.
+   * @param errorDetailsProvider the error details provider.
+   * @param phase the phase of the stage where the exception occurred.
+   * @return the wrapped stage exception.
+   */
+  public static WrappedStageException handleException(Exception e, String stageName,
+    ErrorDetailsProvider errorDetailsProvider, ErrorPhase phase) {
+    ProgramFailureException exception = null;
+
+    if (!(e instanceof ProgramFailureException)) {
+      exception = errorDetailsProvider == null ? null :
+        errorDetailsProvider.getExceptionDetails(e, new ErrorContext(phase));
+    }
+    return new WrappedStageException(exception == null ? e : exception, stageName);
+  }
+}

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/StageTrackingOutputCommitter.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/StageTrackingOutputCommitter.java
@@ -16,7 +16,9 @@
 
 package io.cdap.cdap.etl.spark.io;
 
-import io.cdap.cdap.api.exception.WrappedStageException;
+import io.cdap.cdap.etl.api.exception.ErrorDetailsProvider;
+import io.cdap.cdap.etl.api.exception.ErrorPhase;
+import io.cdap.cdap.etl.common.ErrorDetails;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
@@ -38,10 +40,13 @@ public class StageTrackingOutputCommitter extends OutputCommitter {
 
   private final OutputCommitter delegate;
   private final String stageName;
+  private final ErrorDetailsProvider errorDetailsProvider;
 
-  public StageTrackingOutputCommitter(OutputCommitter delegate, String stageName) {
+  public StageTrackingOutputCommitter(OutputCommitter delegate, String stageName,
+    ErrorDetailsProvider errorDetailsProvider) {
     this.delegate = delegate;
     this.stageName = stageName;
+    this.errorDetailsProvider = errorDetailsProvider;
   }
 
   @Override
@@ -49,7 +54,8 @@ public class StageTrackingOutputCommitter extends OutputCommitter {
     try {
       delegate.setupJob(jobContext);
     } catch (Exception e) {
-      throw new WrappedStageException(e, stageName);
+      throw ErrorDetails.handleException(e, stageName, errorDetailsProvider,
+        ErrorPhase.COMMITTING);
     }
   }
 
@@ -58,7 +64,8 @@ public class StageTrackingOutputCommitter extends OutputCommitter {
     try {
       delegate.setupTask(taskAttemptContext);
     } catch (Exception e) {
-      throw new WrappedStageException(e, stageName);
+      throw ErrorDetails.handleException(e, stageName, errorDetailsProvider,
+        ErrorPhase.COMMITTING);
     }
   }
 
@@ -67,7 +74,8 @@ public class StageTrackingOutputCommitter extends OutputCommitter {
     try {
       return delegate.needsTaskCommit(taskAttemptContext);
     } catch (Exception e) {
-      throw new WrappedStageException(e, stageName);
+      throw ErrorDetails.handleException(e, stageName, errorDetailsProvider,
+        ErrorPhase.COMMITTING);
     }
   }
 
@@ -76,7 +84,8 @@ public class StageTrackingOutputCommitter extends OutputCommitter {
     try {
       delegate.commitTask(taskAttemptContext);
     } catch (Exception e) {
-      throw new WrappedStageException(e, stageName);
+      throw ErrorDetails.handleException(e, stageName, errorDetailsProvider,
+        ErrorPhase.COMMITTING);
     }
   }
 
@@ -85,7 +94,8 @@ public class StageTrackingOutputCommitter extends OutputCommitter {
     try {
       delegate.abortTask(taskAttemptContext);
     } catch (Exception e) {
-      throw new WrappedStageException(e, stageName);
+      throw ErrorDetails.handleException(e, stageName, errorDetailsProvider,
+        ErrorPhase.COMMITTING);
     }
   }
 
@@ -99,7 +109,8 @@ public class StageTrackingOutputCommitter extends OutputCommitter {
     try {
       delegate.recoverTask(taskContext);
     } catch (Exception e) {
-      throw new WrappedStageException(e, stageName);
+      throw ErrorDetails.handleException(e, stageName, errorDetailsProvider,
+        ErrorPhase.COMMITTING);
     }
   }
 }

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/StageTrackingRecordReader.java
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core-base/src/main/java/io/cdap/cdap/etl/spark/io/StageTrackingRecordReader.java
@@ -16,7 +16,9 @@
 
 package io.cdap.cdap.etl.spark.io;
 
-import io.cdap.cdap.api.exception.WrappedStageException;
+import io.cdap.cdap.etl.api.exception.ErrorDetailsProvider;
+import io.cdap.cdap.etl.api.exception.ErrorPhase;
+import io.cdap.cdap.etl.common.ErrorDetails;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
@@ -42,10 +44,13 @@ public class StageTrackingRecordReader<K, V> extends RecordReader<K, V> {
 
   private final RecordReader<K, V> delegate;
   private final String stageName;
+  private final ErrorDetailsProvider errorDetailsProvider;
 
-  public StageTrackingRecordReader(RecordReader<K, V> delegate, String stageName) {
+  public StageTrackingRecordReader(RecordReader<K, V> delegate, String stageName,
+    ErrorDetailsProvider errorDetailsProvider) {
     this.delegate = delegate;
     this.stageName = stageName;
+    this.errorDetailsProvider = errorDetailsProvider;
   }
 
   @Override
@@ -53,7 +58,8 @@ public class StageTrackingRecordReader<K, V> extends RecordReader<K, V> {
     try {
       delegate.initialize(split, new TrackingTaskAttemptContext(context));
     } catch (Exception e) {
-      throw new WrappedStageException(e, stageName);
+      throw ErrorDetails.handleException(e, stageName, errorDetailsProvider,
+        ErrorPhase.READING);
     }
   }
 
@@ -62,7 +68,8 @@ public class StageTrackingRecordReader<K, V> extends RecordReader<K, V> {
     try {
       return delegate.nextKeyValue();
     } catch (Exception e) {
-      throw new WrappedStageException(e, stageName);
+      throw ErrorDetails.handleException(e, stageName, errorDetailsProvider,
+        ErrorPhase.READING);
     }
   }
 
@@ -71,7 +78,8 @@ public class StageTrackingRecordReader<K, V> extends RecordReader<K, V> {
     try {
       return delegate.getCurrentKey();
     } catch (Exception e) {
-      throw new WrappedStageException(e, stageName);
+      throw ErrorDetails.handleException(e, stageName, errorDetailsProvider,
+        ErrorPhase.READING);
     }
   }
 
@@ -80,7 +88,8 @@ public class StageTrackingRecordReader<K, V> extends RecordReader<K, V> {
     try {
       return delegate.getCurrentValue();
     } catch (Exception e) {
-      throw new WrappedStageException(e, stageName);
+      throw ErrorDetails.handleException(e, stageName, errorDetailsProvider,
+        ErrorPhase.READING);
     }
   }
 
@@ -89,7 +98,8 @@ public class StageTrackingRecordReader<K, V> extends RecordReader<K, V> {
     try {
       return delegate.getProgress();
     } catch (Exception e) {
-      throw new WrappedStageException(e, stageName);
+      throw ErrorDetails.handleException(e, stageName, errorDetailsProvider,
+        ErrorPhase.READING);
     }
   }
 
@@ -98,7 +108,8 @@ public class StageTrackingRecordReader<K, V> extends RecordReader<K, V> {
     try {
       delegate.close();
     } catch (Exception e) {
-      throw new WrappedStageException(e, stageName);
+      throw ErrorDetails.handleException(e, stageName, errorDetailsProvider,
+        ErrorPhase.READING);
     }
   }
 }


### PR DESCRIPTION
Tested in CDAP Sandbox:

#### GCS Source
```
Caused by: io.cdap.cdap.api.exception.WrappedStageException: Stage 'NYT Best Sellers Raw Data' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Splitting'. Error message: xxxxx.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ExceptionUtils.java:77)
	at io.cdap.cdap.etl.spark.io.StageTrackingInputFormat.getSplits(StageTrackingInputFormat.java:55)
	at org.apache.spark.rdd.NewHadoopRDD.getPartitions(NewHadoopRDD.scala:136)
	..................................
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Splitting'. Error message: xxxxxx.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:186)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:161)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getProgramFailureException(GCPErrorDetailsProvider.java:80)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getExceptionDetails(GCPErrorDetailsProvider.java:52)
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ExceptionUtils.java:75)
	... 66 common frames omitted
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
GET https://storage.googleapis.com/storage/v1/b/cdf_example/o?delimiter=/&fields=items(bucket,name,size,updated),prefixes,nextPageToken&includeTrailingDelimiter=true&maxResults=5000
{
  "code" : 403,
  "errors" : [ {
    "domain" : "global",
    "message" : "xxxxxx.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist).",
    "reason" : "forbidden"
  } ],
  "message" : "xxxxx.iam.gserviceaccount.com does not have storage.objects.list access to the Google Cloud Storage bucket. Permission 'storage.objects.list' denied on resource (or it may not exist)."
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:118)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:37)
```
#### GCS Sink
```
Caused by: io.cdap.cdap.api.exception.WrappedStageException: Stage 'GCS2' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Validating Output Specs'. Error message: xxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).
	at io.cdap.cdap.etl.common.ExceptionUtils.handleException(ExceptionUtils.java:77)
	at io.cdap.cdap.etl.spark.io.StageTrackingOutputFormat.checkOutputSpecs(StageTrackingOutputFormat.java:67)
	at io.cdap.cdap.etl.common.output.MultiOutputFormat.checkOutputSpecs(MultiOutputFormat.java:114)
	.......................................
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Validating Output Specs'. Error message: xxxxxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:186)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:161)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getProgramFailureException(GCPErrorDetailsProvider.java:80)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getExceptionDetails(GCPErrorDetailsProvider.java:52)
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ExceptionUtils.java:75)
	... 47 common frames omitted
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
GET https://storage.googleapis.com/storage/v1/b/cdf_example/o/2024-10-15-08-53?fields=bucket,name,timeCreated,updated,generation,metageneration,size,contentType,contentEncoding,md5Hash,crc32c,metadata
{
  "code" : 403,
  "errors" : [ {
    "domain" : "global",
    "message" : "xxxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).",
    "reason" : "forbidden"
  } ],
  "message" : "xxxxxxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist)."
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:146)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:118)
	at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:37)
	at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:428)
	at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1111)
```
#### GCS Multi Sink
```
Caused by: io.cdap.cdap.api.exception.WrappedStageException: Stage 'GCS Multi File' encountered : io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Committing'. Error message: xxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).
	at io.cdap.cdap.etl.common.ExceptionUtils.handleException(ExceptionUtils.java:77)
	at io.cdap.cdap.etl.spark.io.StageTrackingOutputCommitter.setupJob(StageTrackingOutputCommitter.java:57)
	at org.apache.spark.internal.io.HadoopMapReduceCommitProtocol.setupJob(HadoopMapReduceCommitProtocol.scala:188)
	...............
Caused by: io.cdap.cdap.api.exception.ProgramFailureException: Error occurred in the phase: 'Committing'. Error message: xxxxxx.iam.gserviceaccount.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist).
	at io.cdap.cdap.api.exception.ProgramFailureException$Builder.build(ProgramFailureException.java:186)
	at io.cdap.cdap.api.exception.ErrorUtils.getProgramFailureException(ErrorUtils.java:161)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getProgramFailureException(GCPErrorDetailsProvider.java:80)
	at io.cdap.plugin.gcp.common.GCPErrorDetailsProvider.getExceptionDetails(GCPErrorDetailsProvider.java:52)
	at io.cdap.cdap.etl.common.ErrorDetails.handleException(ExceptionUtils.java:75)
	... 47 common frames omitted
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: null
	at com.google.cloud.hadoop.gcsio.GoogleCloudStorageExceptions.createJsonResponseException(GoogleCloudStorageExceptions.java:89)
	at com.google.cloud.hadoop.gcsio.GoogleCloudStorageImpl$9.onFailure(GoogleCloudStorageImpl.java:1944)
	at com.google.cloud.hadoop.gcsio.BatchHelper.execute(BatchHelper.java:199)
	at com.google.cloud.hadoop.gcsio.BatchHelper.lambda$queue$0(BatchHelper.java:178)
	
````