### PR TITLE
[CDAP-20852] : Dataplane Audit Logging Milestone 2 : Process audit log events via cdap and publish to ext 

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramTwillRunnableModuleTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/ProgramTwillRunnableModuleTest.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.app.runtime.spark.SparkRuntimeContextProvider;
 import io.cdap.cdap.app.runtime.spark.distributed.SparkTwillRunnable;
 import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.test.MockTwillContext;
 import io.cdap.cdap.internal.app.runtime.BasicArguments;
 import io.cdap.cdap.internal.app.runtime.ProgramOptionConstants;
@@ -100,7 +101,7 @@ public class ProgramTwillRunnableModuleTest {
       }
     }.createModule(CConfiguration.create(), new Configuration(),
                    createProgramOptions(programRunId), programRunId);
-    Injector injector = Guice.createInjector(module);
+    Injector injector = Guice.createInjector(module, new NoOpAuditLogModule());
     injector.getInstance(ServiceProgramRunner.class);
     injector.getInstance(ProgramStateWriter.class);
   }
@@ -151,7 +152,8 @@ public class ProgramTwillRunnableModuleTest {
       }
     }.createModule(CConfiguration.create(), new Configuration(),
                    createProgramOptions(programRunId), programRunId);
-    Injector injector = Guice.createInjector(module);
+
+    Injector injector = Guice.createInjector(module,new NoOpAuditLogModule());
     injector.getInstance(SparkProgramRunner.class);
     injector.getInstance(ProgramStateWriter.class);
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AuditLogWriterModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AuditLogWriterModule.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package io.cdap.cdap.app.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.cdap.cdap.api.auditlogging.AuditLogWriter;
+import io.cdap.cdap.api.feature.FeatureFlagsProvider;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.feature.DefaultFeatureFlagsProvider;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
+import io.cdap.cdap.common.runtime.RuntimeModule;
+import io.cdap.cdap.features.Feature;
+import io.cdap.cdap.security.auth.MessagingAuditLogWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AuditLogWriterModule extends RuntimeModule {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AuditLogWriterModule.class);
+
+  private final boolean auditLoggingEnabled;
+  private final boolean securityEnabled;
+
+  @Inject
+  public AuditLogWriterModule(CConfiguration cConf) {
+    FeatureFlagsProvider featureFlagsProvider = new DefaultFeatureFlagsProvider(cConf);
+    this.auditLoggingEnabled = Feature.DATAPLANE_AUDIT_LOGGING.isEnabled(featureFlagsProvider) ;
+
+    this.securityEnabled = cConf.getBoolean(Constants.Security.ENABLED);
+  }
+
+  /**
+   * Guice modules for In Memory use case of AuditLogWriter.
+   * Returns No Op for now. This may change in the future.
+   */
+  @Override
+  public Module getInMemoryModules() {
+    return new NoOpAuditLogModule();
+  }
+
+  /**
+   * Guice modules for Standalone use case of AuditLogWriter.
+   * Returns No Op for now. This may change in the future.
+   */
+  @Override
+  public Module getStandaloneModules() {
+    return new NoOpAuditLogModule();
+  }
+
+  /**
+   * Guice modules for Distributed use case where the audit events would be written to a messaging queue like tms.
+   */
+  @Override
+  public Module getDistributedModules() {
+
+    if (auditLoggingEnabled && securityEnabled) {
+      LOG.info("Audit Logging feature is ENABLED. Injecting an audit message writer");
+      return new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(AuditLogWriter.class).to(MessagingAuditLogWriter.class).in(Scopes.SINGLETON);
+        }
+      };
+    }
+
+    LOG.debug("Audit Logging feature or Instance security is DISABLED.");
+    return new NoOpAuditLogModule();
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
@@ -32,6 +32,7 @@ import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.KafkaClientModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.SupplierProviderBridge;
 import io.cdap.cdap.common.guice.ZkClientModule;
 import io.cdap.cdap.common.guice.ZkDiscoveryModule;
@@ -133,7 +134,6 @@ public class DistributedProgramContainerModule extends AbstractModule {
   @Override
   protected void configure() {
     List<Module> modules = getCoreModules();
-
     RuntimeMonitorType runtimeMonitorType = SystemArguments.getRuntimeMonitorType(cConf,
         programOpts);
     modules.add(RuntimeMonitors.getRemoteAuthenticatorModule(runtimeMonitorType, programOpts));
@@ -159,6 +159,7 @@ public class DistributedProgramContainerModule extends AbstractModule {
 
     List<Module> modules = new ArrayList<>();
 
+    modules.add(new NoOpAuditLogModule());
     modules.add(new ConfigModule(cConf, hConf));
     modules.add(new IOModule());
     modules.add(new DFSLocationModule());

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/DefaultPreviewRunnerManager.java
@@ -28,6 +28,7 @@ import com.google.inject.Scopes;
 import com.google.inject.name.Named;
 import com.google.inject.util.Modules;
 import io.cdap.cdap.api.security.store.SecureStore;
+import io.cdap.cdap.app.guice.AuditLogWriterModule;
 import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -175,6 +176,7 @@ public class DefaultPreviewRunnerManager extends AbstractIdleService implements
         new IOModule(),
         RemoteAuthenticatorModules.getDefaultModule(),
         new CoreSecurityRuntimeModule().getInMemoryModules(),
+        new AuditLogWriterModule(previewCConf).getInMemoryModules(),
         new AuthenticationContextModules().getMasterWorkerModule(),
         new PreviewSecureStoreModule(secureStore),
         new PreviewDiscoveryRuntimeModule(discoveryServiceClient),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewManager.java
@@ -33,6 +33,7 @@ import com.google.inject.util.Modules;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.api.security.AccessException;
+import io.cdap.cdap.app.guice.AuditLogWriterModule;
 import io.cdap.cdap.app.preview.PreviewConfigModule;
 import io.cdap.cdap.app.preview.PreviewManager;
 import io.cdap.cdap.app.preview.PreviewRequest;
@@ -312,6 +313,7 @@ public class DefaultPreviewManager extends AbstractIdleService implements Previe
         new PreviewDataModules().getDataFabricModule(transactionSystemClient,
             previewLevelDBTableService),
         new PreviewDataModules().getDataSetsModule(datasetFramework),
+        new AuditLogWriterModule(previewCConf).getInMemoryModules(),
         new AuthenticationContextModules().getMasterModule(),
         new LocalLocationModule(),
         new PreviewDiscoveryRuntimeModule(discoveryServiceClient),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -32,6 +32,7 @@ import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.app.deploy.Configurator;
+import io.cdap.cdap.app.guice.AuditLogWriterModule;
 import io.cdap.cdap.app.preview.PreviewConfigModule;
 import io.cdap.cdap.app.preview.PreviewRunner;
 import io.cdap.cdap.app.preview.PreviewRunnerManager;
@@ -247,6 +248,7 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
 
     modules.add(new AuthenticationContextModules().getMasterWorkerModule());
     modules.add(new AuthorizationEnforcementModule().getNoOpModules());
+    modules.add(new AuditLogWriterModule(cConf).getInMemoryModules());
 
     byte[] pollerInfoBytes = Bytes.toBytes(new Gson().toJson(pollerInfo));
     modules.add(new AbstractModule() {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
@@ -26,6 +26,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.app.guice.AuditLogWriterModule;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
@@ -97,6 +98,7 @@ public class TaskWorkerTwillRunnable extends AbstractTwillRunnable {
     modules.add(new MessagingServiceModule(cConf));
     modules.add(new SystemAppModule());
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
+    modules.add(new AuditLogWriterModule(cConf).getDistributedModules());
 
     // If MasterEnvironment is not available, assuming it is the old hadoop stack with ZK, Kafka
     MasterEnvironment masterEnv = MasterEnvironments.getMasterEnvironment();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerTwillRunnable.java
@@ -26,6 +26,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import io.cdap.cdap.api.feature.FeatureFlagsProvider;
+import io.cdap.cdap.app.guice.AuditLogWriterModule;
 import io.cdap.cdap.app.guice.DistributedArtifactManagerModule;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
@@ -114,6 +115,7 @@ public class ArtifactLocalizerTwillRunnable extends AbstractTwillRunnable {
     modules.add(coreSecurityModule);
     modules.add(new MessagingServiceModule(cConf));
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
+    modules.add(new AuditLogWriterModule(cConf).getInMemoryModules());
 
     // If MasterEnvironment is not available, assuming it is the old hadoop stack with ZK, Kafka
     MasterEnvironment masterEnv = MasterEnvironments.getMasterEnvironment();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerTwillRunnable.java
@@ -33,6 +33,7 @@ import com.google.inject.util.Modules;
 import io.cdap.cdap.api.artifact.ArtifactManager;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule;
+import io.cdap.cdap.app.guice.AuditLogWriterModule;
 import io.cdap.cdap.app.guice.AuthorizationModule;
 import io.cdap.cdap.app.guice.DistributedArtifactManagerModule;
 import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
@@ -154,6 +155,7 @@ public class SystemWorkerTwillRunnable extends AbstractTwillRunnable {
         new MessagingServiceModule(cConf),
         new AuthorizationModule(),
         new AuthorizationEnforcementModule().getMasterModule(),
+        new AuditLogWriterModule(cConf).getDistributedModules(),
         Modules.override(new AppFabricServiceRuntimeModule(cConf).getDistributedModules())
             .with(new AbstractModule() {
               // To enable localisation of artifacts

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/AbstractServiceMain.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/AbstractServiceMain.java
@@ -27,6 +27,7 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.app.guice.AuditLogWriterModule;
 import io.cdap.cdap.app.preview.PreviewConfigModule;
 import io.cdap.cdap.common.app.MainClassLoader;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -168,6 +169,7 @@ public abstract class AbstractServiceMain<T extends EnvironmentOptions> extends 
     modules.add(new PreviewConfigModule(cConf, hConf, sConf));
     modules.add(new IOModule());
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
+    modules.add(new AuditLogWriterModule(cConf).getDistributedModules());
     modules.add(new AbstractModule() {
       @Override
       protected void configure() {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/security/auth/AuditLogSingleTopicSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/security/auth/AuditLogSingleTopicSubscriberService.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.auth;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import io.cdap.cdap.api.messaging.Message;
+import io.cdap.cdap.api.messaging.MessagingContext;
+import io.cdap.cdap.api.messaging.TopicAlreadyExistsException;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.common.utils.ImmutablePair;
+import io.cdap.cdap.internal.app.store.AppMetadataStore;
+import io.cdap.cdap.messaging.DefaultTopicMetadata;
+import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.messaging.subscriber.AbstractMessagingSubscriberService;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
+import io.cdap.cdap.security.spi.authorization.AccessControllerSpi;
+import io.cdap.cdap.security.spi.authorization.AuditLogContext;
+import io.cdap.cdap.security.spi.authorization.AuditLoggerSpi;
+import io.cdap.cdap.spi.data.StructuredTableContext;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import org.apache.tephra.TxConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Queue;
+import javax.annotation.Nullable;
+
+/**
+ * This class subscribes to the audit log messaging topic, reads and processes the messages into {@link AuditLogContext}
+ * and delegates the batch of AuditLogContexts to External Auth service using {@link AuditLoggerSpi}, which would
+ * further publish as configured.
+ */
+public class AuditLogSingleTopicSubscriberService extends AbstractMessagingSubscriberService<AuditLogContext> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AuditLogSingleTopicSubscriberService.class);
+  private static final Gson GSON = new Gson();
+
+  private final MessagingService messagingService;
+  private final MultiThreadMessagingContext messagingContext;
+  private final TransactionRunner transactionRunner;
+  private final AccessControllerInstantiator accessControllerInstantiator;
+
+  AuditLogSingleTopicSubscriberService(CConfiguration cConf, MessagingService messagingService,
+                                       MetricsCollectionService metricsCollectionService,
+                                       TransactionRunner transactionRunner,
+                                       AccessControllerInstantiator accessControllerInstantiator,
+                                       String topicName) {
+
+    super(
+      NamespaceId.SYSTEM.topic(topicName),
+      cConf.getInt(Constants.AuditLogging.AUDIT_LOG_FETCH_SIZE),
+      cConf.getInt(TxConstants.Manager.CFG_TX_TIMEOUT),
+      cConf.getInt(Constants.AuditLogging.AUDIT_LOG_POLL_DELAY_MILLIS),
+      RetryStrategies.fromConfiguration(cConf, Constants.AuditLogging.AUDIT_LOG_WRITER_RETRY_PREFIX),
+      metricsCollectionService.getContext(ImmutableMap.of(
+        Constants.Metrics.Tag.COMPONENT, Constants.Service.MASTER_SERVICES,
+        Constants.Metrics.Tag.INSTANCE_ID, "0",
+        Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace(),
+        Constants.Metrics.Tag.TOPIC, topicName,
+        Constants.Metrics.Tag.CONSUMER, Constants.AuditLogging.AUDIT_LOG_CONSUMER_WRITER_SUBSCRIBER
+      )));
+    this.messagingService = messagingService;
+    this.messagingContext = new MultiThreadMessagingContext(messagingService);
+    this.transactionRunner = transactionRunner;
+    this.accessControllerInstantiator = accessControllerInstantiator;
+  }
+
+  /**
+   * Returns the {@link TransactionRunner} for executing tasks in transaction.
+   */
+  @Override
+  protected TransactionRunner getTransactionRunner() {
+    return transactionRunner;
+  }
+
+  /**
+   * Loads last persisted message id within a transaction for the topic of AUDIT LOG EVENTS.
+   * The returned message id will be used as the starting message id (exclusive) for the first fetch.
+   */
+  @Nullable
+  @Override
+  protected String loadMessageId(StructuredTableContext context) throws Exception {
+    AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
+    return appMetadataStore.retrieveSubscriberState(getTopicId().getTopic(),
+                                                    Constants.AuditLogging.AUDIT_LOG_WRITER_SUBSCRIBER);
+  }
+
+  /**
+   * Persists the given message id after the Audit Log events are processed successfully within `processMessages`
+   * method. This also runs in the same transaction as `processMessages`
+   */
+  @Override
+  protected void storeMessageId(StructuredTableContext context, String messageId) throws Exception {
+    AppMetadataStore appMetadataStore = AppMetadataStore.create(context);
+    appMetadataStore.persistSubscriberState(getTopicId().getTopic(),
+                                            Constants.AuditLogging.AUDIT_LOG_WRITER_SUBSCRIBER, messageId);
+  }
+
+  /**
+   * This does the actual processing of Audit Log events fetched from the messaging topic.
+   * If the audit event is required to be published, we add it to a queue and then each event is published via
+   * {@link AccessControllerSpi} acquired through {@link AccessControllerInstantiator}
+   * It If {@link Exception} is raised from this method, the messages as provided through the {@code messages} parameter
+   * will be replayed in the next call.
+   */
+  @Override
+  protected void processMessages(StructuredTableContext structuredTableContext,
+                                 Iterator<ImmutablePair<String, AuditLogContext>> messages) throws Exception {
+
+    Queue<AuditLogContext> auditLogContextQueue = new ArrayDeque<>();
+
+    while (messages.hasNext()) {
+      ImmutablePair<String, AuditLogContext> next = messages.next();
+      AuditLogContext auditLogContext = next.getSecond();
+      if (auditLogContext.isAuditLoggingRequired()){
+        auditLogContextQueue.add(auditLogContext);
+      }
+    }
+
+    if (!auditLogContextQueue.isEmpty()) {
+      LOG.debug("Publishing a queue of Audit Log events of size {} events.", auditLogContextQueue.size());
+      AuditLoggerSpi.PublishStatus publishStatus =
+        this.accessControllerInstantiator.get().publishAuditLogs(auditLogContextQueue);
+      // TODO : This logic can change based on how Auth Ext publishes a batch.
+      if (publishStatus.equals(AuditLoggerSpi.PublishStatus.UNSUCCESSFUL)) {
+        throw new Exception("The publishing of audit log events Failed.");
+      }
+    }
+
+    LOG.trace("Publishing a queue of Audit Log events of size {} events is successful.", auditLogContextQueue.size());
+  }
+
+  /**
+   * Returns the {@link MessagingContext} that this service used for interacting with TMS.
+   */
+  @Override
+  protected MessagingContext getMessagingContext() {
+    return messagingContext;
+  }
+
+  /**
+   * Decodes the raw {@link Message} into an object of type {@link AuditLogContext}.
+   */
+  @Override
+  protected AuditLogContext decodeMessage(Message message) throws Exception {
+    return message.decodePayload(r -> GSON.fromJson(r, AuditLogContext.class));
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/security/auth/AuditLogSubscriberService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/security/auth/AuditLogSubscriberService.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.auth;
+
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.Service;
+import com.google.inject.Inject;
+import io.cdap.cdap.api.messaging.TopicAlreadyExistsException;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.messaging.DefaultTopicMetadata;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.TopicId;
+import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import org.apache.twill.internal.CompositeService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+
+/**
+ * Audit Log Service that creates children services, each to handle a single partition of audit log events topic.
+ */
+public class AuditLogSubscriberService extends AbstractIdleService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AuditLogSubscriberService.class);
+
+  private final MessagingService messagingService;
+  private final CConfiguration cConf;
+  private final TransactionRunner transactionRunner;
+  private final AccessControllerInstantiator accessControllerInstantiator;
+  private final MetricsCollectionService metricsCollectionService;
+  private Service delegate;
+
+  @Inject
+  public AuditLogSubscriberService(CConfiguration cConf, MessagingService messagingService,
+                                   MetricsCollectionService metricsCollectionService,
+                                   TransactionRunner transactionRunner,
+                                   AccessControllerInstantiator accessControllerInstantiator) {
+    this.messagingService = messagingService;
+    this.cConf = cConf;
+    this.metricsCollectionService = metricsCollectionService;
+    this.transactionRunner = transactionRunner;
+    this.accessControllerInstantiator = accessControllerInstantiator;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    List<Service> children = new ArrayList<>();
+    String topicPrefix = cConf.get(Constants.AuditLogging.AUDIT_LOG_EVENT_TOPIC);
+    int numPartitions = cConf.getInt(Constants.AuditLogging.AUDIT_LOG_EVENT_NUM_PARTITIONS);
+    IntStream.range(0, numPartitions)
+      .forEach(i -> children.add(createChildService(topicPrefix + i)));
+    delegate = new CompositeService(children);
+
+    delegate.startAndWait();
+    LOG.debug("Started Audit Log subscriber service for {} partitions.", numPartitions);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    delegate.stopAndWait();
+  }
+
+  private AuditLogSingleTopicSubscriberService createChildService(String topicName) {
+
+    createTopicIfNeeded(NamespaceId.SYSTEM.topic(topicName));
+
+    return new AuditLogSingleTopicSubscriberService(
+      this.cConf,
+      this.messagingService,
+      this.metricsCollectionService,
+      this.transactionRunner,
+      this.accessControllerInstantiator,
+      topicName
+    );
+  }
+
+  private void createTopicIfNeeded(TopicId topicId) {
+    try {
+      messagingService.createTopic(new DefaultTopicMetadata(topicId, Collections.emptyMap()));
+      LOG.info("Created topic {}", topicId.getTopic());
+    } catch (TopicAlreadyExistsException ex) {
+      // no-op
+    } catch (IOException e) {
+      //Converting to unchecked exception
+      throw new RuntimeException(String.format("Failed to create topic %s.", topicId.getTopic(), e));
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/security/auth/MessagingAuditLogWriter.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/security/auth/MessagingAuditLogWriter.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.auth;
+
+import com.google.gson.Gson;
+import com.google.inject.Inject;
+import io.cdap.cdap.api.auditlogging.AuditLogWriter;
+import io.cdap.cdap.api.messaging.TopicAlreadyExistsException;
+import io.cdap.cdap.api.messaging.TopicNotFoundException;
+import io.cdap.cdap.api.retry.RetryableException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.service.Retries;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.common.service.RetryStrategy;
+import io.cdap.cdap.messaging.DefaultTopicMetadata;
+import io.cdap.cdap.messaging.client.StoreRequestBuilder;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.messaging.spi.StoreRequest;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.TopicId;
+import io.cdap.cdap.security.spi.authorization.AuditLogContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Queue;
+import java.util.Random;
+import javax.annotation.Nullable;
+
+/**
+ * This class receives a collection of {@link AuditLogContext} and writes them in order to a
+ * messaging service / topic  ( ex - tms )
+ */
+public class MessagingAuditLogWriter implements AuditLogWriter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MessagingAuditLogWriter.class);
+  private static final Gson GSON = new Gson();
+
+  private final String topicPrefix;
+  private final int noOfTopicPartitions;
+  private final int randomId;
+  private final MessagingService messagingService;
+  private final RetryStrategy retryStrategy;
+
+  @Inject
+  public MessagingAuditLogWriter(CConfiguration cConf, MessagingService messagingService) {
+    this(
+      messagingService,
+      cConf.get(Constants.AuditLogging.AUDIT_LOG_EVENT_TOPIC),
+      cConf.getInt(Constants.AuditLogging.AUDIT_LOG_EVENT_NUM_PARTITIONS),
+      RetryStrategies.fromConfiguration(cConf, Constants.AuditLogging.AUDIT_LOG_WRITER_RETRY_PREFIX)
+    );
+  }
+
+  /**
+   * Create a publisher that writes {@link AuditLogContext}s to MessagingService topics.
+   */
+  public MessagingAuditLogWriter(MessagingService messagingService,
+                                 String topicPrefix, int numTopics, RetryStrategy retryStrategy) {
+    this.messagingService = messagingService;
+    this.topicPrefix = topicPrefix;
+    this.noOfTopicPartitions = numTopics;
+    this.retryStrategy = retryStrategy;
+    this.randomId = new Random().nextInt(100);
+  }
+
+  /**
+   * pushes the collection of log entry to respective messaging topic
+   *
+   * @param auditLogContexts
+   */
+  @Override
+  public void publish(@Nullable Queue<AuditLogContext> auditLogContexts) throws IOException {
+
+    if (auditLogContexts != null && auditLogContexts.isEmpty()){
+      return;
+    }
+
+    TopicId topic = generateTopic();
+
+    auditLogContexts.forEach(auditLogContext -> {
+      StoreRequest storeRequest = StoreRequestBuilder.of(topic)
+        .addPayload(GSON.toJson(auditLogContext))
+        .build();
+
+      try {
+        Retries.runWithRetries(() -> {
+          try {
+            messagingService.publish(storeRequest);
+          } catch (TopicNotFoundException e) {
+            createTopicIfNeeded(topic);
+            throw new RetryableException(e);
+          }
+        }, retryStrategy, Retries.ALWAYS_TRUE);
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to publish audit log event to TMS.", e);
+      }
+    });
+  }
+
+  private void createTopicIfNeeded(TopicId topic) throws IOException {
+    try {
+      messagingService.createTopic(new DefaultTopicMetadata(topic, Collections.emptyMap()));
+      LOG.info("Created topic {}", topic.getTopic());
+    } catch (TopicAlreadyExistsException ex) {
+      // no-op
+    }
+  }
+
+  /**
+   *  Every operation / event for a Call should be published to a particular topic.
+   *  The Topic name is determined from which POD (using thread name) + the writer class ( using a random number for
+   *  this object ). A hash code is generated using these 2 values and the topic name is chosen based on number of
+   *  partitions defined for the given topic prefix.
+   */
+  private TopicId generateTopic() {
+
+    //Determine a topic based on "ThreadName" + Fixed random value for this writer + No of partitions
+    String hashName = Thread.currentThread().getName() + this.randomId;
+    int hash = hashName.hashCode();
+    int result = Math.abs(hash % noOfTopicPartitions);
+    String topicName = topicPrefix + result;
+
+    return NamespaceId.SYSTEM.topic(topicName);
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/AuthorizationHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/gateway/handlers/AuthorizationHandlerTest.java
@@ -40,7 +40,6 @@ import io.cdap.cdap.proto.security.Role;
 import io.cdap.cdap.proto.security.StandardPermission;
 import io.cdap.cdap.security.auth.context.MasterAuthenticationContext;
 import io.cdap.cdap.security.authorization.AuthorizationContextFactory;
-//import io.cdap.cdap.security.authorization.InMemoryAccessController;
 import io.cdap.cdap.security.authorization.InMemoryPermissionManager;
 import io.cdap.cdap.security.authorization.InMemoryRoleController;
 import io.cdap.cdap.security.authorization.NoOpAuthorizationContextFactory;
@@ -85,7 +84,8 @@ public class AuthorizationHandlerTest {
     final InMemoryPermissionManager auth = new InMemoryPermissionManager();
     final InMemoryRoleController inMemoryRoleController = new InMemoryRoleController();
     //    auth.initialize(FACTORY.create(properties)); //Will be used on migration to SPI implementation
-    service = new CommonNettyHttpServiceBuilder(conf, getClass().getSimpleName(), new NoOpMetricsCollectionService())
+    service = new CommonNettyHttpServiceBuilder(conf, getClass().getSimpleName(), new NoOpMetricsCollectionService(),
+                                                auditLogContexts -> {})
       .setHttpHandlers(new AuthorizationHandler(auth, conf, new MasterAuthenticationContext(), inMemoryRoleController))
       .setChannelPipelineModifier(new ChannelPipelineModifier() {
         @Override
@@ -134,7 +134,8 @@ public class AuthorizationHandlerTest {
     final InMemoryPermissionManager accessController = new InMemoryPermissionManager();
     final InMemoryRoleController inMemoryRoleController = new InMemoryRoleController();
     NettyHttpService service = new CommonNettyHttpServiceBuilder(cConf, getClass().getSimpleName(),
-                                                                 new NoOpMetricsCollectionService())
+                                                                 new NoOpMetricsCollectionService(),
+                                                                 auditLogContexts -> {})
       .setHttpHandlers(new AuthorizationHandler(
         accessController, cConf, new MasterAuthenticationContext(), inMemoryRoleController))
       .build();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/deploy/RemoteConfiguratorTest.java
@@ -118,7 +118,8 @@ public class RemoteConfiguratorTest {
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     remoteClientFactory = new RemoteClientFactory(discoveryService,
                                                   new DefaultInternalAuthenticator(new AuthenticationTestContext()));
-    httpService = new CommonNettyHttpServiceBuilder(cConf, "test", new NoOpMetricsCollectionService())
+    httpService = new CommonNettyHttpServiceBuilder(cConf, "test", new NoOpMetricsCollectionService(),
+                                                    auditLogContexts -> {})
       .setHttpHandlers(
           new TaskWorkerHttpHandlerInternal(cConf, discoveryService, discoveryService, className -> { },
                                           new NoOpMetricsCollectionService()),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/RemoteAppStateStoreTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/RemoteAppStateStoreTest.java
@@ -91,7 +91,8 @@ public class RemoteAppStateStoreTest {
     namespaceAdmin.create(testNameSpace);
     remoteClientFactory = new RemoteClientFactory(discoveryService,
                                                   new DefaultInternalAuthenticator(new AuthenticationTestContext()));
-    httpService = new CommonNettyHttpServiceBuilder(cConf, "appfabric", new NoOpMetricsCollectionService())
+    httpService = new CommonNettyHttpServiceBuilder(cConf, "appfabric", new NoOpMetricsCollectionService(),
+                                                    auditLogContexts -> {})
       .setHttpHandlers(new AppStateHandler(applicationLifecycleService, namespaceAdmin)).build();
     httpService.start();
     cancellable = discoveryService

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJobTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/runtimejob/DefaultRuntimeJobTest.java
@@ -73,33 +73,33 @@ public class DefaultRuntimeJobTest {
   public void testVerifySuccessfulProgramCompletion() {
     DefaultRuntimeJob runtimeJob = new DefaultRuntimeJob();
     runtimeJob.verifySuccessfulProgramCompletion(
-        new ProgramId("ns1", "app-id", ProgramType.WORKFLOW, "program"),
-        () -> new ProgramRunCompletionDetails(1234,
-            ProgramRunStatus.COMPLETED));
+      new ProgramId("ns1", "app-id", ProgramType.WORKFLOW, "program"),
+      () -> new ProgramRunCompletionDetails(1234,
+                                            ProgramRunStatus.COMPLETED));
   }
 
   @Test(expected = ProgramRunFailureException.class)
   public void testVerifyKilledProgramCompletion() {
     DefaultRuntimeJob runtimeJob = new DefaultRuntimeJob();
     runtimeJob.verifySuccessfulProgramCompletion(
-        new ProgramId("ns1", "app-id", ProgramType.WORKFLOW, "program"),
-        () -> new ProgramRunCompletionDetails(1234, ProgramRunStatus.KILLED));
+      new ProgramId("ns1", "app-id", ProgramType.WORKFLOW, "program"),
+      () -> new ProgramRunCompletionDetails(1234, ProgramRunStatus.KILLED));
   }
 
   @Test
   public void testVerifyNullProgramCompletion() {
     DefaultRuntimeJob runtimeJob = new DefaultRuntimeJob();
     runtimeJob.verifySuccessfulProgramCompletion(
-        new ProgramId("ns1", "app-id", ProgramType.WORKFLOW, "program"),
-        () -> null);
+      new ProgramId("ns1", "app-id", ProgramType.WORKFLOW, "program"),
+      () -> null);
   }
 
   @Test(expected = ProgramRunFailureException.class)
   public void testVerifyFailedProgramCompletion() {
     DefaultRuntimeJob runtimeJob = new DefaultRuntimeJob();
     runtimeJob.verifySuccessfulProgramCompletion(
-        new ProgramId("ns1", "app-id", ProgramType.WORKFLOW, "program"),
-        () -> new ProgramRunCompletionDetails(1234, ProgramRunStatus.FAILED));
+      new ProgramId("ns1", "app-id", ProgramType.WORKFLOW, "program"),
+      () -> new ProgramRunCompletionDetails(1234, ProgramRunStatus.FAILED));
   }
 
   private void testInjector(LaunchMode launchMode) throws IOException {
@@ -107,49 +107,49 @@ public class DefaultRuntimeJobTest {
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().toString());
 
     LocationFactory locationFactory = new LocalLocationFactory(
-        TEMP_FOLDER.newFile());
+      TEMP_FOLDER.newFile());
 
     DefaultRuntimeJob defaultRuntimeJob = new DefaultRuntimeJob();
     Arguments systemArgs = new BasicArguments(
-        Collections.singletonMap(SystemArguments.PROFILE_NAME, "test"));
+      Collections.singletonMap(SystemArguments.PROFILE_NAME, "test"));
     Node node = new Node("test", Node.Type.MASTER, "127.0.0.1",
-        System.currentTimeMillis(), Collections.emptyMap());
+                         System.currentTimeMillis(), Collections.emptyMap());
     Cluster cluster = new Cluster("test", ClusterStatus.RUNNING,
-        Collections.singleton(node), Collections.emptyMap());
+                                  Collections.singleton(node), Collections.emptyMap());
     ProgramRunId programRunId = NamespaceId.DEFAULT.app("app")
-        .workflow("workflow").run(RunIds.generate());
+      .workflow("workflow").run(RunIds.generate());
     SimpleProgramOptions programOpts = new SimpleProgramOptions(
-        programRunId.getParent(), systemArgs, new BasicArguments());
+      programRunId.getParent(), systemArgs, new BasicArguments());
 
     Injector injector = Guice.createInjector(
-        defaultRuntimeJob.createModules(new RuntimeJobEnvironment() {
+      defaultRuntimeJob.createModules(new RuntimeJobEnvironment() {
 
-          @Override
-          public LocationFactory getLocationFactory() {
-            return locationFactory;
-          }
+        @Override
+        public LocationFactory getLocationFactory() {
+          return locationFactory;
+        }
 
-          @Override
-          public TwillRunner getTwillRunner() {
-            return new NoopTwillRunnerService();
-          }
+        @Override
+        public TwillRunner getTwillRunner() {
+          return new NoopTwillRunnerService();
+        }
 
-          @Override
-          public Map<String, String> getProperties() {
-            return Collections.emptyMap();
-          }
+        @Override
+        public Map<String, String> getProperties() {
+          return Collections.emptyMap();
+        }
 
-          @Override
-          public LaunchMode getLaunchMode() {
-            return launchMode;
-          }
-        }, cConf, programRunId, programOpts));
+        @Override
+        public LaunchMode getLaunchMode() {
+          return launchMode;
+        }
+      }, cConf, programRunId, programOpts));
 
     injector.getInstance(LogAppenderInitializer.class);
     defaultRuntimeJob.createCoreServices(injector, systemArgs, cluster);
     injector.getInstance(ConfiguratorFactory.class);
     ProgramRunnerFactory programRunnerFactory = injector.getInstance(
-        ProgramRunnerFactory.class);
+      ProgramRunnerFactory.class);
     programRunnerFactory.create(ProgramType.WORKFLOW);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/InternalServiceRoutingHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/InternalServiceRoutingHandlerTest.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.common.discovery.URIScheme;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.InternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.NoOpInternalAuthenticator;
@@ -85,6 +86,7 @@ public class InternalServiceRoutingHandlerTest {
         new ConfigModule(cConf),
         new LocalLocationModule(),
         new InMemoryDiscoveryModule(),
+        new NoOpAuditLogModule(),
         new AbstractModule() {
           @Override
           protected void configure() {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServerTest.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.messaging.DefaultTopicMetadata;
@@ -112,6 +113,7 @@ public class RuntimeClientServerTest {
     Injector injector = Guice.createInjector(
       new ConfigModule(cConf),
       RemoteAuthenticatorModules.getNoOpModule(),
+      new NoOpAuditLogModule(),
       new InMemoryDiscoveryModule(),
       new LocalLocationModule(),
       new MessagingServerRuntimeModule().getInMemoryModules(),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeClientServiceTest.java
@@ -44,6 +44,7 @@ import io.cdap.cdap.common.conf.Constants.RuntimeMonitor;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.io.DatumReader;
 import io.cdap.cdap.common.io.DatumWriter;
@@ -189,7 +190,8 @@ public class RuntimeClientServiceTest {
             bind(DiscoveryService.class).toInstance(discoveryService);
             bind(DiscoveryServiceClient.class).toInstance(discoveryService);
           }
-        }
+        },
+        new NoOpAuditLogModule()
     );
 
     messagingService = injector.getInstance(MessagingService.class);
@@ -222,6 +224,7 @@ public class RuntimeClientServiceTest {
         new AuthorizationEnforcementModule().getNoOpModules(),
         new AuthenticationContextModules().getNoOpModule(),
         new IOModule(),
+        new NoOpAuditLogModule(),
         new AbstractModule() {
           @Override
           protected void configure() {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/monitor/RuntimeServiceRoutingTest.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.common.discovery.URIScheme;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.internal.remote.NoOpRemoteAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClient;
@@ -134,7 +135,8 @@ public class RuntimeServiceRoutingTest {
         protected void configure() {
           bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
         }
-      }
+      },
+      new NoOpAuditLogModule()
     );
 
     messagingService = injector.getInstance(MessagingService.class);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -58,6 +58,7 @@ import io.cdap.cdap.common.conf.Constants.Gateway;
 import io.cdap.cdap.common.discovery.EndpointStrategy;
 import io.cdap.cdap.common.discovery.RandomEndpointStrategy;
 import io.cdap.cdap.common.discovery.URIScheme;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.id.Id;
 import io.cdap.cdap.common.internal.remote.DefaultInternalAuthenticator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
@@ -245,6 +246,7 @@ public abstract class AppFabricTestBase {
         // needed because we set Kerberos to true in DefaultNamespaceAdminTest
         bind(UGIProvider.class).to(CurrentUGIProvider.class);
         bind(MetadataSubscriberService.class).in(Scopes.SINGLETON);
+        install(new NoOpAuditLogModule());
       }
     });
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/state/AppStateHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/store/state/AppStateHandlerTest.java
@@ -110,7 +110,8 @@ public class AppStateHandlerTest extends AppFabricTestBase {
   @Before
   public void setUp() throws Exception {
     NettyHttpService service = new CommonNettyHttpServiceBuilder(CConfiguration.create(), getClass().getSimpleName(),
-                                                                 new NoOpMetricsCollectionService())
+                                                                 new NoOpMetricsCollectionService(),
+                                                                 auditLogContexts -> {})
       .setHttpHandlers(new AppStateHandler(applicationLifecycleService, namespaceAdmin))
       .build();
     service.start();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerMetricsTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerMetricsTest.java
@@ -86,7 +86,8 @@ public class TaskWorkerMetricsTest {
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     taskWorkerService = new TaskWorkerService(cConf, sConf, discoveryService, discoveryService,
                                               mockMetricsCollector,
-                                              new CommonNettyHttpServiceFactory(cConf, mockMetricsCollector));
+                                              new CommonNettyHttpServiceFactory(cConf, mockMetricsCollector,
+                                                                                auditLogContexts -> {}));
     taskWorkerStateFuture = TaskWorkerTestUtil.getServiceCompletionFuture(taskWorkerService);
     // start the service
     taskWorkerService.startAndWait();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/TaskWorkerServiceTest.java
@@ -96,7 +96,7 @@ public class TaskWorkerServiceTest {
     TaskWorkerService taskWorkerService = new TaskWorkerService(
         cConf, sConf, discoveryService, discoveryService,
         metricsCollectionService,
-        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService, auditLogContexts -> {}));
     serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
         taskWorkerService);
     // start the service
@@ -123,7 +123,7 @@ public class TaskWorkerServiceTest {
     TaskWorkerService taskWorkerService = new TaskWorkerService(
         cConf, sConf, discoveryService, discoveryService,
         metricsCollectionService,
-        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService, auditLogContexts -> {}));
     serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
         taskWorkerService);
     // start the service
@@ -144,7 +144,7 @@ public class TaskWorkerServiceTest {
     TaskWorkerService taskWorkerService = new TaskWorkerService(
         cConf, sConf, discoveryService, discoveryService,
         metricsCollectionService,
-        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService, auditLogContexts -> {}));
     serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
         taskWorkerService);
     // start the service
@@ -187,7 +187,7 @@ public class TaskWorkerServiceTest {
             discoveryService,
             discoveryService,
             metricsCollectionService,
-            new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+            new CommonNettyHttpServiceFactory(cConf, metricsCollectionService, auditLogContexts -> {}));
     serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
         taskWorkerService);
     // start the service
@@ -232,7 +232,7 @@ public class TaskWorkerServiceTest {
     TaskWorkerService taskWorkerService = new TaskWorkerService(
         cConf, sConf, discoveryService, discoveryService,
         metricsCollectionService,
-        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService, auditLogContexts -> {}));
     serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
         taskWorkerService);
     // start the service
@@ -361,7 +361,7 @@ public class TaskWorkerServiceTest {
     TaskWorkerService taskWorkerService = new TaskWorkerService(cConf,
         createSConf(), discoveryService, discoveryService,
         metricsCollectionService,
-        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService, auditLogContexts -> {}));
     taskWorkerService.startAndWait();
     InetSocketAddress addr = taskWorkerService.getBindAddress();
     URI uri = URI.create(
@@ -422,7 +422,7 @@ public class TaskWorkerServiceTest {
     TaskWorkerService taskWorkerService = new TaskWorkerService(cConf,
         createSConf(), discoveryService, discoveryService,
         metricsCollectionService,
-        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService));
+        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService, auditLogContexts -> {}));
     serviceCompletionFuture = TaskWorkerTestUtil.getServiceCompletionFuture(
         taskWorkerService);
     taskWorkerService.startAndWait();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/ArtifactLocalizerServiceTest.java
@@ -85,7 +85,7 @@ public class ArtifactLocalizerServiceTest extends AppFabricTestBase {
     ArtifactLocalizerService artifactLocalizerService = new ArtifactLocalizerService(
       cConf, new ArtifactLocalizer(cConf, remoteClientFactory, (namespaceId, retryStrategy) -> {
       return new NoOpArtifactManager();
-    }), new CommonNettyHttpServiceFactory(cConf, new NoOpMetricsCollectionService()),
+    }), new CommonNettyHttpServiceFactory(cConf, new NoOpMetricsCollectionService(), auditLogContexts -> {}),
         remoteClientFactory, new NoOpRemoteAuthenticator());
     // start the service
     artifactLocalizerService.startAndWait();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternalTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/sidecar/GcpMetadataHttpHandlerInternalTest.java
@@ -68,7 +68,7 @@ public class GcpMetadataHttpHandlerInternalTest {
 
     RemoteClientFactory remoteClientFactory = Mockito.mock(RemoteClientFactory.class);
     httpService = new CommonNettyHttpServiceBuilder(cConf, "test",
-        new NoOpMetricsCollectionService())
+        new NoOpMetricsCollectionService(), auditLogContexts -> {})
         .setHttpHandlers(
             new GcpMetadataHttpHandlerInternal(cConf, remoteClientFactory,
                 new NoOpRemoteAuthenticator())

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/worker/system/SystemWorkerServiceTest.java
@@ -105,7 +105,7 @@ public class SystemWorkerServiceTest extends AppFabricTestBase {
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
     SystemWorkerService service = new SystemWorkerService(cConf, sConf,
         discoveryService, metricsCollectionService,
-        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService),
+        new CommonNettyHttpServiceFactory(cConf, metricsCollectionService, auditLogContexts -> {}),
         injector.getInstance(TokenManager.class), new NoopTwillRunnerService(),
         new NoopTwillRunnerService(),
         getInjector().getInstance(ProvisioningService.class),

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/guice/AppFabricTestModule.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.NonCustomLocationUnitTestModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.twill.NoopTwillRunnerService;
@@ -108,6 +109,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new MetadataReaderWriterModules().getInMemoryModules());
     install(new MessagingServerRuntimeModule().getInMemoryModules());
     install(new MockProvisionerModule());
+    install(new NoOpAuditLogModule());
     // Needed by MonitorHandlerModuler
     bind(TwillRunner.class).to(NoopTwillRunnerService.class);
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/ArtifactCacheServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/ArtifactCacheServiceTest.java
@@ -79,7 +79,7 @@ public class ArtifactCacheServiceTest extends AppFabricTestBase {
     DiscoveryService discoveryService = getInjector().getInstance(DiscoveryService.class);
     artifactCacheService = new ArtifactCacheService(
       cConf, artifactCache, tetheringStore, null, discoveryService,
-      new CommonNettyHttpServiceFactory(cConf, new NoOpMetricsCollectionService()));
+      new CommonNettyHttpServiceFactory(cConf, new NoOpMetricsCollectionService(), auditLogContexts -> {}));
     artifactCacheService.startAndWait();
     getInjector().getInstance(ArtifactRepository.class).clear(NamespaceId.DEFAULT);
     LocationFactory locationFactory = getInjector().getInstance(LocationFactory.class);

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringClientHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringClientHandlerTest.java
@@ -213,7 +213,7 @@ public class TetheringClientHandlerTest {
     CConfiguration conf = CConfiguration.create();
     serverHandler = new MockTetheringServerHandler();
     serverService = new CommonNettyHttpServiceBuilder(conf, getClass().getSimpleName() + "_server",
-                                                      new NoOpMetricsCollectionService())
+                                                      new NoOpMetricsCollectionService(), auditLogContexts -> {})
       .setHttpHandlers(serverHandler).build();
     serverService.start();
     serverConfig = ClientConfig.builder()
@@ -238,7 +238,7 @@ public class TetheringClientHandlerTest {
 
     messagingService = injector.getInstance(MessagingService.class);
     clientService = new CommonNettyHttpServiceBuilder(conf, getClass().getSimpleName() + "_client",
-                                                      new NoOpMetricsCollectionService())
+                                                      new NoOpMetricsCollectionService(), auditLogContexts -> {})
       .setHttpHandlers(new TetheringClientHandler(cConf, tetheringStore, contextAccessEnforcer, namespaceAdmin,
                                                   injector.getInstance(RemoteAuthenticator.class), messagingService),
                        new TetheringHandler(cConf, tetheringStore, messagingService, profileService))

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringServerHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/TetheringServerHandlerTest.java
@@ -212,7 +212,7 @@ public class TetheringServerHandlerTest {
         new CommonNettyHttpServiceBuilder(
                 CConfiguration.create(),
                 getClass().getSimpleName(),
-                new NoOpMetricsCollectionService())
+                new NoOpMetricsCollectionService(), auditLogContexts -> {})
             .setHttpHandlers(
                 new TetheringServerHandler(
                     cConf,

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringProvisionerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/provisioner/TetheringProvisionerTest.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.data.runtime.StorageModule;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -66,6 +67,7 @@ public class TetheringProvisionerTest {
       new ProvisionerModule(),
       new AuthorizationEnforcementModule().getNoOpModules(),
       new MessagingServerRuntimeModule().getInMemoryModules(),
+      new NoOpAuditLogModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManagerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/tethering/runtime/spi/runtimejob/TetheringRuntimeJobManagerTest.java
@@ -38,6 +38,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.data.runtime.StorageModule;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
@@ -123,6 +124,7 @@ public class TetheringRuntimeJobManagerTest {
       new SystemDatasetRuntimeModule().getInMemoryModules(),
       new TransactionModules().getInMemoryModules(),
       new StorageModule(),
+      new NoOpAuditLogModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/security/auth/AuditLogSingleTopicSubscriberServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/security/auth/AuditLogSingleTopicSubscriberServiceTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.auth;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closeables;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.ConfigModule;
+import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
+import io.cdap.cdap.common.utils.ImmutablePair;
+import io.cdap.cdap.data.runtime.StorageModule;
+import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
+import io.cdap.cdap.security.authorization.AccessControllerInstantiatorTest;
+import io.cdap.cdap.security.authorization.AuthorizationContextFactory;
+import io.cdap.cdap.security.spi.authorization.AccessControllerSpi;
+import io.cdap.cdap.security.spi.authorization.AuditLogContext;
+import io.cdap.cdap.spi.data.TableAlreadyExistsException;
+import io.cdap.cdap.spi.data.sql.PostgresInstantiator;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+public class AuditLogSingleTopicSubscriberServiceTest {
+
+  private static CConfiguration cConf;
+  private static TransactionRunner transactionRunner;
+  private static Queue<AuditLogContext> auditLogContextsStore;
+  private static EmbeddedPostgres pg;
+
+  @ClassRule
+  public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+  @BeforeClass
+  public static void beforeClass() throws IOException, TableAlreadyExistsException {
+    cConf = CConfiguration.create();
+    cConf.set(Constants.AuditLogging.AUDIT_LOG_FETCH_SIZE, "3");
+    cConf.set(Constants.AuditLogging.AUDIT_LOG_POLL_DELAY_MILLIS, "1");
+    pg = PostgresInstantiator.createAndStart(cConf, TEMP_FOLDER.newFolder());
+    Injector injector = Guice.createInjector(
+      new ConfigModule(cConf),
+      new LocalLocationModule(),
+      new SystemDatasetRuntimeModule().getInMemoryModules(),
+      new StorageModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class)
+            .in(Scopes.SINGLETON);
+        }
+      }
+    );
+
+    transactionRunner = injector.getInstance(TransactionRunner.class);
+    auditLogContextsStore = new ArrayDeque<>();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    Closeables.closeQuietly(pg);
+  }
+
+
+  @Before
+  public void beforeTest(){
+    auditLogContextsStore = new ArrayDeque<>();
+  }
+
+  /**
+   * Create an iterator of AuditLogContexts and pass it to get published.
+   * In the mock publishing, it would store the objects in auditLogContextsStore.
+   * And we assert that original queue matches auditLogContextsStore.
+   */
+  @Test
+  public void testProcessMessages() throws Exception {
+    MessagingService mockMsgService = Mockito.mock(MessagingService.class);
+    AccessControllerInstantiatorMock accessControllerInstantiatorMock =
+      new AccessControllerInstantiatorMock(cConf, null);
+    AuditLogSingleTopicSubscriberService auditLogSingleTopicSubscriberService =
+      new AuditLogSingleTopicSubscriberService(
+        cConf,
+        mockMsgService,
+        Mockito.mock(MetricsCollectionService.class),
+        transactionRunner,
+        accessControllerInstantiatorMock,
+        "topic"
+      );
+    List<AuditLogContext> auditLogContextsOrg = new LinkedList<>();
+    auditLogContextsOrg.add(AuditLogContext.Builder.defaultNotRequired());
+    auditLogContextsOrg.add(new AuditLogContext.Builder()
+                              .setAuditLoggingRequired(true)
+                              .setAuditLogBody("Test Audit Logs")
+                              .build());
+
+    Iterator<ImmutablePair<String, AuditLogContext>> messages =
+      ImmutableList.of(ImmutablePair.of("1", auditLogContextsOrg.get(0)),
+                       ImmutablePair.of("2", auditLogContextsOrg.get(1))).iterator();
+
+    TransactionRunners.run(transactionRunner, (context) -> {
+      auditLogSingleTopicSubscriberService.processMessages(
+        context, messages);
+    }, Exception.class);
+
+    // Expected will only contain 1 audit log
+    Assert.assertEquals(Arrays.asList(auditLogContextsOrg.get(1)), new LinkedList<>(auditLogContextsStore));
+
+  }
+
+  public static void setAuditLogContextsStore(Queue<AuditLogContext> auditLogContexts) {
+    AuditLogSingleTopicSubscriberServiceTest.auditLogContextsStore = auditLogContexts;
+  }
+
+  private static class AccessControllerInstantiatorMock extends AccessControllerInstantiator {
+
+    public AccessControllerInstantiatorMock(CConfiguration cConf,
+                                            AuthorizationContextFactory authorizationContextFactory) {
+      super(cConf, authorizationContextFactory);
+    }
+
+    @Override
+    public AccessControllerSpi get() {
+      return new AccessControllerSpiMock();
+    }
+  }
+
+  private static class AccessControllerSpiMock extends AccessControllerInstantiatorTest.AccessControllerSpiImp {
+    @Override
+    public PublishStatus publishAuditLogs(Queue<AuditLogContext> auditLogContexts) {
+      AuditLogSingleTopicSubscriberServiceTest.setAuditLogContextsStore(auditLogContexts);
+      return PublishStatus.PUBLISHED;
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/security/auth/MessagingAuditLogWriterTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/security/auth/MessagingAuditLogWriterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.auth;
+
+import io.cdap.cdap.api.messaging.TopicNotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.security.spi.authorization.AuditLogContext;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+public class MessagingAuditLogWriterTest {
+  @Test
+  public void testPublish() throws Exception {
+    MessagingService mockMsgService = Mockito.mock(MessagingService.class);
+
+    Mockito.when(mockMsgService.publish(Mockito.any()))
+        .thenThrow(new TopicNotFoundException("namespace", "topic"))
+          .thenReturn(null);
+
+    Mockito.doNothing().when(mockMsgService).createTopic(Mockito.any());
+
+    MessagingAuditLogWriter messagingAuditLogWriter = new MessagingAuditLogWriter(CConfiguration.create(),
+                                                                                  mockMsgService);
+    Queue<AuditLogContext> auditLogContexts = new ArrayDeque<>();
+    auditLogContexts.add(AuditLogContext.Builder.defaultNotRequired());
+    auditLogContexts.add(new AuditLogContext.Builder()
+                              .setAuditLoggingRequired(true)
+                              .setAuditLogBody("Test Audit Logs")
+                              .build());
+    messagingAuditLogWriter.publish(auditLogContexts);
+
+    //There should be at least 3 invocations. 1st will be a TopicNotFoundException , then 2 audit log events.
+    Mockito.verify(mockMsgService, Mockito.atLeast(3)).publish(Mockito.any());
+    //Single invocation to create a topic.
+    Mockito.verify(mockMsgService, Mockito.times(1)).createTopic(Mockito.any());
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/api/auditlogging/AuditLogWriter.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/api/auditlogging/AuditLogWriter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.auditlogging;
+
+import io.cdap.cdap.security.spi.authorization.AuditLogContext;
+
+import java.io.IOException;
+import java.util.Queue;
+
+/**
+ * An interface to write/ persist a collection of {@link AuditLogContext} to a
+ * messaging service / topic  ( ex - tms )
+ */
+public interface AuditLogWriter {
+
+  /**
+   * pushes the log entry to respective messaging topic
+   */
+  void publish(Queue<AuditLogContext> auditLogContexts) throws IOException;
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -2540,4 +2540,25 @@ public final class Constants {
     public static final String ERROR_NOTIFICATION_KEY = "operation.notification.error";
     public static final String USER_ID_NOTIFICATION_KEY = "userId";
   }
+
+
+  /**
+   * Constants for Data Plane Audit Logging
+   */
+  public static final class AuditLogging {
+    public static final String AUDIT_LOG_PUBLISH_INTERVAL_SECONDS = "auditlog.publish.interval.seconds";
+
+    /**
+     * Topic prefix for publishing log events  of audited operations to the messaging system.
+     */
+    public static final String AUDIT_LOG_EVENT_TOPIC = "auditlog.event.topic";
+    public static final String AUDIT_LOG_EVENT_NUM_PARTITIONS = "auditlog.event.topic.num.partitions";
+    public static final String AUDIT_LOG_FETCH_SIZE = "auditlog.messaging.fetch.size";
+    public static final String AUDIT_LOG_POLL_DELAY_MILLIS = "auditlog.messaging.poll.delay.millis";
+    public static final String AUDIT_LOG_CONSUMER_WRITER_SUBSCRIBER = "auditlog.consumer.publisher";
+    public static final String AUDIT_LOG_WRITER_SUBSCRIBER = "auditlog.subscriber";
+
+    public static final String AUDIT_LOG_WRITER_RETRY_PREFIX = "system.auditlog.";
+
+  }
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/guice/NoOpAuditLogModule.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/guice/NoOpAuditLogModule.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.common.guice;
+
+import com.google.inject.AbstractModule;
+import io.cdap.cdap.api.auditlogging.AuditLogWriter;
+
+/**
+ * A NO OPERATION guice module for {@link AuditLogWriter}.
+ * This is to be used in modules where AUDIT LOGGING is not expected, but it is a part of common netty layer binding,
+ * So it needs to be included.
+ */
+public class NoOpAuditLogModule extends AbstractModule {
+  @Override
+  protected void configure() {
+    bind(AuditLogWriter.class).toInstance(auditLogContexts -> {});
+  }
+}

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceBuilder.java
@@ -15,12 +15,16 @@
  */
 package io.cdap.cdap.common.http;
 
+import io.cdap.cdap.api.auditlogging.AuditLogWriter;
+import io.cdap.cdap.api.feature.FeatureFlagsProvider;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.common.HttpExceptionHandler;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.feature.DefaultFeatureFlagsProvider;
 import io.cdap.cdap.common.metrics.MetricsReporterHook;
 import io.cdap.http.ChannelPipelineModifier;
+import io.cdap.cdap.features.Feature;
 import io.cdap.http.NettyHttpService;
 import io.netty.channel.ChannelPipeline;
 import io.netty.util.concurrent.EventExecutor;
@@ -38,9 +42,12 @@ public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
   private ChannelPipelineModifier additionalModifier;
 
   public CommonNettyHttpServiceBuilder(CConfiguration cConf, String serviceName,
-      MetricsCollectionService metricsCollectionService) {
+      MetricsCollectionService metricsCollectionService, AuditLogWriter auditLogWriter) {
     super(serviceName);
     if (cConf.getBoolean(Constants.Security.ENABLED)) {
+      FeatureFlagsProvider featureFlagsProvider = new DefaultFeatureFlagsProvider(cConf);
+      boolean auditLoggingEnabled = Feature.DATAPLANE_AUDIT_LOGGING.isEnabled(featureFlagsProvider) ;
+
       pipelineModifier = new ChannelPipelineModifier() {
         @Override
         public void modify(ChannelPipeline pipeline) {
@@ -50,8 +57,8 @@ public class CommonNettyHttpServiceBuilder extends NettyHttpService.Builder {
           // to remember the user id.
           EventExecutor executor = pipeline.context("dispatcher").executor();
           pipeline.addBefore(executor, "dispatcher", AUTHENTICATOR_NAME,
-              new AuthenticationChannelHandler(cConf.getBoolean(Constants.Security
-                  .INTERNAL_AUTH_ENABLED)));
+                             new AuthenticationChannelHandler(cConf.getBoolean(Constants.Security
+                                 .INTERNAL_AUTH_ENABLED), auditLoggingEnabled, auditLogWriter));
         }
       };
     }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceFactory.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/http/CommonNettyHttpServiceFactory.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.common.http;
 
 import com.google.inject.Inject;
+import io.cdap.cdap.api.auditlogging.AuditLogWriter;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.common.conf.CConfiguration;
 
@@ -28,12 +29,15 @@ public class CommonNettyHttpServiceFactory {
 
   private final CConfiguration cConf;
   private final MetricsCollectionService metricsCollectionService;
+  private final AuditLogWriter auditLogWriter;
 
   @Inject
   public CommonNettyHttpServiceFactory(CConfiguration cConf,
-      MetricsCollectionService metricsCollectionService) {
+                                       MetricsCollectionService metricsCollectionService,
+                                        AuditLogWriter auditLogWriter) {
     this.cConf = cConf;
     this.metricsCollectionService = metricsCollectionService;
+    this.auditLogWriter = auditLogWriter;
   }
 
   /**
@@ -43,6 +47,6 @@ public class CommonNettyHttpServiceFactory {
    * @return {@link CommonNettyHttpServiceBuilder}
    */
   public CommonNettyHttpServiceBuilder builder(String serviceName) {
-    return new CommonNettyHttpServiceBuilder(cConf, serviceName, metricsCollectionService);
+    return new CommonNettyHttpServiceBuilder(cConf, serviceName, metricsCollectionService, auditLogWriter);
   }
 }

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -4442,6 +4442,47 @@
     </description>
   </property>
 
+  <property>
+    <name>system.auditlog.retry.policy.base.delay.ms</name>
+    <value>100</value>
+    <description>
+      The base delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>system.auditlog.retry.policy.max.delay.ms</name>
+    <value>2000</value>
+    <description>
+      The maximum delay between retries in milliseconds
+    </description>
+  </property>
+
+  <property>
+    <name>system.auditlog.retry.policy.max.retries</name>
+    <value>100</value>
+    <description>
+      The maximum number of retries to attempt before aborting
+    </description>
+  </property>
+
+  <property>
+    <name>system.auditlog.retry.policy.max.time.secs</name>
+    <value>2147483647</value>
+    <description>
+      The maximum elapsed time in seconds before retries are aborted
+    </description>
+  </property>
+
+  <property>
+    <name>system.auditlog.retry.policy.type</name>
+    <value>exponential.backoff</value>
+    <description>
+      The type of retry policy for workers. Allowed options: "none",
+      "fixed.delay", or "exponential.backoff".
+    </description>
+  </property>
+
   <!-- Router Configuration -->
 
   <property>
@@ -6022,6 +6063,14 @@
   </property>
 
   <property>
+    <name>feature.dataplane.audit.logging.enabled</name>
+    <value>true</value>
+    <description>
+      Enables dataplane audit logging for RBAC instances.
+    </description>
+  </property>
+
+  <property>
     <name>artifact.cache.bind.address</name>
     <value>0.0.0.0</value>
     <description>
@@ -6425,6 +6474,47 @@
     <description>
       The delay in milliseconds to check again for new operation status events
       after it detects there was no event
+    </description>
+  </property>
+
+  <property>
+    <name>auditlog.publish.interval.seconds</name>
+    <value>20</value>
+    <description>
+      The interval between Audit log publish calls to external auth in seconds.
+    </description>
+  </property>
+
+  <property>
+    <name>auditlog.event.topic</name>
+    <value>auditlogevent</value>
+    <description>
+      Topic prefix for publishing audit log events.
+    </description>
+  </property>
+
+  <property>
+    <name>auditlog.event.topic.num.partitions</name>
+    <value>3</value>
+    <description>
+      Number of topics to use for writing and reading audit log events.
+      All events related to same call should always go to same topic.
+    </description>
+  </property>
+
+  <property>
+    <name>auditlog.messaging.fetch.size</name>
+    <value>50</value>
+    <description>
+      Number of messages to fetch from messaging system for each batch to consume by Audit log consumer.
+    </description>
+  </property>
+
+  <property>
+    <name>auditlog.messaging.poll.delay.millis</name>
+    <value>4000</value>
+    <description>
+      The delay in milliseconds to check again for new audit log events from messaging system.
     </description>
   </property>
 

--- a/cdap-common/src/test/java/io/cdap/cdap/common/http/AuthenticationChannelHandlerTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/http/AuthenticationChannelHandlerTest.java
@@ -22,26 +22,37 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.cdap.cdap.api.auditlogging.AuditLogWriter;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.proto.security.Credential;
 import io.cdap.cdap.security.spi.authentication.UnauthenticatedException;
+import io.cdap.cdap.security.spi.authorization.AuditLogContext;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.DefaultChannelPromise;
 import io.netty.handler.codec.http.DefaultHttpRequest;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpVersion;
+import io.netty.util.AttributeKey;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
 
 public class AuthenticationChannelHandlerTest {
 
   private DefaultHttpRequest req;
   private AuthenticationChannelHandler handler;
   private ChannelHandlerContext ctx;
+  private static final String AUDIT_LOG_QUEUE_ATTR_NAME = "AUDIT_LOG_QUEUE";
+
 
   @Before
   public void initHandler() {
     boolean internalAuthEnabled = true;
-    handler = new AuthenticationChannelHandler(internalAuthEnabled);
+    handler = new AuthenticationChannelHandler(internalAuthEnabled, false, null);
     ctx = mock(ChannelHandlerContext.class, RETURNS_DEEP_STUBS);
     req = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "foo");
   }
@@ -89,5 +100,40 @@ public class AuthenticationChannelHandlerTest {
 
     handler.channelRead(ctx, req);
     verify(ctx, times(1)).fireChannelRead(any());
+  }
+
+  @Test
+  public void testWriteWithAuditLogging() throws Exception {
+    boolean internalAuthEnabled = true;
+    AuditLogWriter auditLogWriterMock = Mockito.mock(AuditLogWriter.class);
+    Mockito.when(ctx.channel().attr(AttributeKey.valueOf(AUDIT_LOG_QUEUE_ATTR_NAME)).get())
+      .thenReturn(getAuditLogContexts());
+    handler = new AuthenticationChannelHandler(internalAuthEnabled, true, auditLogWriterMock);
+    handler.write(ctx, "msg", new DefaultChannelPromise(ctx.channel()));
+
+    verify(auditLogWriterMock, times(1)).publish(any());
+  }
+
+  @Test
+  public void testCloseWithAuditLogging() throws Exception {
+    boolean internalAuthEnabled = true;
+    AuditLogWriter auditLogWriterMock = Mockito.mock(AuditLogWriter.class);
+    Mockito.when(ctx.channel().attr(AttributeKey.valueOf(AUDIT_LOG_QUEUE_ATTR_NAME)).get())
+      .thenReturn(getAuditLogContexts());
+    handler = new AuthenticationChannelHandler(internalAuthEnabled, true, auditLogWriterMock);
+    handler.close(ctx, new DefaultChannelPromise(ctx.channel()));
+
+    verify(auditLogWriterMock, times(1)).publish(any());
+  }
+
+  private Queue<AuditLogContext> getAuditLogContexts() {
+    Queue<AuditLogContext> auditLogContexts = new ArrayDeque<>();
+    auditLogContexts.add(AuditLogContext.Builder.defaultNotRequired());
+    auditLogContexts.add(new AuditLogContext.Builder()
+                           .setAuditLoggingRequired(true)
+                           .setAuditLogBody("Test Audit Logs")
+                           .build());
+
+    return auditLogContexts;
   }
 }

--- a/cdap-common/src/test/java/io/cdap/cdap/common/internal/remote/RemoteTaskExecutorTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/internal/remote/RemoteTaskExecutorTest.java
@@ -65,7 +65,8 @@ public class RemoteTaskExecutorTest {
     discoveryService = new InMemoryDiscoveryService();
     remoteClientFactory = new RemoteClientFactory(discoveryService, new NoOpInternalAuthenticator());
     InMemoryDiscoveryService discoveryService = new InMemoryDiscoveryService();
-    httpService = new CommonNettyHttpServiceBuilder(cConf, "test", new NoOpMetricsCollectionService())
+    httpService = new CommonNettyHttpServiceBuilder(cConf, "test", new NoOpMetricsCollectionService(),
+                                                    auditLogContexts -> {})
       .setHttpHandlers(
         new TaskWorkerHttpHandlerInternal(cConf, discoveryService, discoveryService, className -> {
         }, new NoOpMetricsCollectionService())

--- a/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
+++ b/cdap-features/src/main/java/io/cdap/cdap/features/Feature.java
@@ -44,7 +44,8 @@ public enum Feature {
   WRANGLER_SCHEMA_MANAGEMENT("6.10.0"),
   NAMESPACED_SERVICE_ACCOUNTS("6.10.0"),
   WRANGLER_KRYO_SERIALIZATION("6.10.1"),
-  SOURCE_CONTROL_MANAGEMENT_GITLAB_BITBUCKET("6.10.1");
+  SOURCE_CONTROL_MANAGEMENT_GITLAB_BITBUCKET("6.10.1"),
+  DATAPLANE_AUDIT_LOGGING("6.10.1");
 
   private final PlatformInfo.Version versionIntroduced;
   private final boolean defaultAfterIntroduction;

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.KafkaClientModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.guice.ZkClientModule;
 import io.cdap.cdap.common.guice.ZkDiscoveryModule;
@@ -124,6 +125,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
         new SecureStoreClientModule(),
         new AuthorizationEnforcementModule().getDistributedModules(),
         new AuthenticationContextModules().getMasterModule(),
+        new NoOpAuditLogModule(),
         new AbstractModule() {
           @Override
           protected void configure() {

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/LogSaverTwillRunnable.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/LogSaverTwillRunnable.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.KafkaClientModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.guice.ZkClientModule;
 import io.cdap.cdap.common.guice.ZkDiscoveryModule;
@@ -118,6 +119,7 @@ public final class LogSaverTwillRunnable extends AbstractMasterTwillRunnable {
         new AuthorizationEnforcementModule().getDistributedModules(),
         new AuthenticationContextModules().getMasterModule(),
         new MessagingClientModule(),
+        new NoOpAuditLogModule(),
         new AbstractModule() {
           @Override
           protected void configure() {

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
@@ -30,6 +30,7 @@ import com.google.inject.Injector;
 import com.google.inject.Key;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule;
+import io.cdap.cdap.app.guice.AuditLogWriterModule;
 import io.cdap.cdap.app.guice.AuthorizationModule;
 import io.cdap.cdap.app.guice.MonitorHandlerModule;
 import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
@@ -539,6 +540,7 @@ public class MasterServiceMain extends DaemonMain {
         new MetricsStoreModule(),
         new MessagingClientModule(),
         new AuditModule(),
+        new AuditLogWriterModule(cConf).getDistributedModules(),
         CoreSecurityRuntimeModule.getDistributedModule(cConf),
         new AuthenticationContextModules().getMasterModule(),
         new AuthorizationModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MetricsProcessorTwillRunnable.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MetricsProcessorTwillRunnable.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.KafkaClientModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.guice.ZkClientModule;
 import io.cdap.cdap.common.guice.ZkDiscoveryModule;
@@ -135,6 +136,7 @@ public final class MetricsProcessorTwillRunnable extends AbstractMasterTwillRunn
         new AuthorizationEnforcementModule().getDistributedModules(),
         new AuthenticationContextModules().getMasterModule(),
         new MetricsWriterModule(),
+        new NoOpAuditLogModule(),
         new AbstractModule() {
           @Override
           protected void configure() {

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MetricsTwillRunnable.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MetricsTwillRunnable.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.KafkaClientModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.guice.ZkClientModule;
 import io.cdap.cdap.common.guice.ZkDiscoveryModule;
@@ -126,6 +127,7 @@ public class MetricsTwillRunnable extends AbstractMasterTwillRunnable {
         new AuditModule(),
         new AuthorizationEnforcementModule().getDistributedModules(),
         new AuthenticationContextModules().getMasterModule(),
+        new NoOpAuditLogModule(),
         new AbstractModule() {
           @Override
           protected void configure() {

--- a/cdap-master/src/main/java/io/cdap/cdap/master/startup/ConfigurationCheck.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/startup/ConfigurationCheck.java
@@ -181,6 +181,7 @@ class ConfigurationCheck extends AbstractMasterCheck {
     validateMessagingTopic(Constants.AppFabric.PROGRAM_STATUS_EVENT_TOPIC, problemKeys);
     validateMessagingTopic(Constants.AppFabric.PROGRAM_STATUS_RECORD_EVENT_TOPIC, problemKeys);
     validateMessagingTopic(Constants.Operation.STATUS_EVENT_TOPIC, problemKeys);
+    validateMessagingTopic(Constants.AuditLogging.AUDIT_LOG_EVENT_TOPIC, problemKeys);
   }
 
   private void checkProgramConfigurations(Set<String> problemKeys) {

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authentication/SecurityRequestContext.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authentication/SecurityRequestContext.java
@@ -131,4 +131,17 @@ public final class SecurityRequestContext {
   public static void clearAuditLogQueue(AuditLogContext auditLog) {
     auditLogContextQueue.remove();
   }
+
+  /**
+   * Get the collection of {@link AuditLogContext}s for this thread.
+   * @return AuditLogContexts
+   */
+  public static Queue<AuditLogContext> getAuditLogQueue() {
+    Queue<AuditLogContext> queue = auditLogContextQueue.get();
+    if (queue == null) {
+      return new ArrayDeque<>();
+    }
+    return queue;
+  }
+
 }

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AccessControllerSpi.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AccessControllerSpi.java
@@ -50,7 +50,8 @@ import java.util.jar.Attributes;
  * This is newer version of {@link AccessController}
  */
 @Beta
-public interface AccessControllerSpi extends PermissionManagerSpi, RoleControllerSpi, AccessEnforcerSpi {
+public interface AccessControllerSpi extends PermissionManagerSpi, RoleControllerSpi, AccessEnforcerSpi,
+  AuditLoggerSpi {
 
   /**
    * Initialize the {@link AccessControllerSpi}. Authorization extensions can use this method to access

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AuditLogContext.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AuditLogContext.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.security.spi.authorization;
 
+import java.util.Objects;
 import javax.annotation.Nullable;
 
 /**
@@ -88,5 +89,18 @@ public class AuditLogContext {
     public AuditLogContext build() {
       return new AuditLogContext(this);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof AuditLogContext)) return false;
+    AuditLogContext that = (AuditLogContext) o;
+    return auditLoggingRequired == that.auditLoggingRequired && Objects.equals(auditLogBody, that.auditLogBody);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(auditLoggingRequired, auditLogBody);
   }
 }

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AuditLoggerSpi.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AuditLoggerSpi.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.security.spi.authorization;
+
+import io.cdap.cdap.api.annotation.Beta;
+
+import java.util.Queue;
+
+/**
+ * An SPI that delegates the collection of {@link AuditLogContext}s to an extension that will publish the log events
+ * to the respective destination.
+ */
+@Beta
+public interface AuditLoggerSpi {
+  /**
+   * The status of a call for authorization check.
+   */
+  enum PublishStatus {
+    PUBLISHED,
+    UNSUCCESSFUL
+  }
+
+  /**
+   * TODO : THIS IS WIP : Needs to be modified based on how auth extension works.
+   * Specially w.r.t to Retry.
+   * If the auth ext is able to publish a batch all together vs needs to publish one by one.
+   * @return {@link PublishStatus}
+   */
+  PublishStatus publishAuditLogs(Queue<AuditLogContext> auditLogContexts);
+
+}

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AccessControllerWrapper.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/AccessControllerWrapper.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.security.spi.authorization.AuthorizedResult;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -258,5 +259,15 @@ public class AccessControllerWrapper implements AccessControllerSpi {
       .setIncludePrincipal(e.includePrincipal())
       .setAddendum(e.getAddendum())
       .build();
+  }
+
+  /**
+   * TODO : THIS IS WIP : Needs to be modified based on how auth extension works.
+   *
+   * @return {@link PublishStatus}
+   */
+  @Override
+  public PublishStatus publishAuditLogs(Queue<AuditLogContext> auditLogContexts) {
+    return PublishStatus.PUBLISHED;
   }
 }

--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/NoOpAccessControllerV2.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/NoOpAccessControllerV2.java
@@ -24,10 +24,12 @@ import io.cdap.cdap.proto.security.Permission;
 import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.proto.security.Role;
 import io.cdap.cdap.security.spi.authorization.AccessControllerSpi;
+import io.cdap.cdap.security.spi.authorization.AuditLogContext;
 import io.cdap.cdap.security.spi.authorization.AuthorizationResponse;
 import io.cdap.cdap.security.spi.authorization.AuthorizedResult;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -118,5 +120,16 @@ public class NoOpAccessControllerV2 implements AccessControllerSpi {
   @Override
   public AuthorizedResult<Set<GrantedPermission>> listGrants(Principal principal, Principal caller) {
     return new AuthorizedResult<>(Collections.emptySet(), AuthorizationResponse.Builder.defaultNotRequired());
+  }
+
+  /**
+   * TODO : THIS IS WIP : Needs to be modified based on how auth extension works.
+   *
+   * @return {@link PublishStatus}
+   */
+  @Override
+  public PublishStatus publishAuditLogs(Queue<AuditLogContext> auditLogContexts) {
+    //no-op
+    return PublishStatus.PUBLISHED;
   }
 }

--- a/cdap-security/src/test/java/io/cdap/cdap/security/auth/context/RemoteClientAuthenticatorTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/auth/context/RemoteClientAuthenticatorTest.java
@@ -83,7 +83,8 @@ public class RemoteClientAuthenticatorTest {
 
     // Setup test HTTP handler and register the service.
     testHttpHandler = new TestHttpHandler();
-    httpService = new CommonNettyHttpServiceBuilder(cConf, TEST_SERVICE, new NoOpMetricsCollectionService())
+    httpService = new CommonNettyHttpServiceBuilder(cConf, TEST_SERVICE, new NoOpMetricsCollectionService(),
+                                                    auditLogContexts -> {})
       .setHttpHandlers(testHttpHandler).build();
     httpService.start();
     discoveryService.register(new Discoverable(TEST_SERVICE, httpService.getBindAddress()));

--- a/cdap-security/src/test/java/io/cdap/cdap/security/authorization/AccessControllerInstantiatorTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/authorization/AccessControllerInstantiatorTest.java
@@ -36,6 +36,7 @@ import io.cdap.cdap.security.auth.context.AuthenticationTestContext;
 import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
 import io.cdap.cdap.security.spi.authorization.AccessController;
 import io.cdap.cdap.security.spi.authorization.AccessControllerSpi;
+import io.cdap.cdap.security.spi.authorization.AuditLogContext;
 import io.cdap.cdap.security.spi.authorization.AuthorizationContext;
 import io.cdap.cdap.security.spi.authorization.AuthorizationResponse;
 import io.cdap.cdap.security.spi.authorization.AuthorizedResult;
@@ -48,6 +49,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Queue;
 import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarEntry;
@@ -522,7 +524,7 @@ public class AccessControllerInstantiatorTest extends AuthorizationTestBase {
     }
   }
 
-  public static final class AccessControllerSpiImp implements AccessControllerSpi {
+  public static class AccessControllerSpiImp implements AccessControllerSpi {
 
     @Override
     public AuthorizationResponse enforce(EntityId entity, Principal principal, Set<? extends Permission> permissions)
@@ -594,6 +596,11 @@ public class AccessControllerInstantiatorTest extends AuthorizationTestBase {
     @Override
     public AuthorizedResult<Set<GrantedPermission>> listGrants(Principal caller, Principal principal)
       throws AccessException {
+      return null;
+    }
+
+    @Override
+    public PublishStatus publishAuditLogs(Queue<AuditLogContext> auditLogContexts) {
       return null;
     }
   }

--- a/cdap-security/src/test/java/io/cdap/cdap/security/authorization/AuthorizationTestModule.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/authorization/AuthorizationTestModule.java
@@ -20,8 +20,10 @@ import com.google.inject.PrivateModule;
 import com.google.inject.Scopes;
 import io.cdap.cdap.api.Admin;
 import io.cdap.cdap.api.Transactional;
+import io.cdap.cdap.api.auditlogging.AuditLogWriter;
 import io.cdap.cdap.api.data.DatasetContext;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.security.spi.authorization.AuthorizationContext;
 import io.cdap.cdap.security.spi.authorization.PermissionManager;
 
@@ -42,5 +44,7 @@ public class AuthorizationTestModule extends PrivateModule {
     expose(PermissionManager.class);
     bind(RoleController.class).to(DelegatingRoleController.class).in(Scopes.SINGLETON);;
     expose(RoleController.class);
+    install(new NoOpAuditLogModule());
+    expose(AuditLogWriter.class);
   }
 }

--- a/cdap-security/src/test/java/io/cdap/cdap/security/authorization/InMemoryAccessControllerV2.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/authorization/InMemoryAccessControllerV2.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -284,6 +285,17 @@ public class InMemoryAccessControllerV2 implements AccessControllerSpi {
       }
     }
     return true;
+  }
+
+  /**
+   * TODO : THIS IS WIP : Needs to be modified based on how auth extension works.
+   *
+   * @param auditLogContexts
+   * @return {@link PublishStatus}
+   */
+  @Override
+  public PublishStatus publishAuditLogs(Queue<AuditLogContext> auditLogContexts) {
+    return PublishStatus.PUBLISHED;
   }
 
   public final class AuthorizableEntityId {

--- a/cdap-security/src/test/java/io/cdap/cdap/security/store/SecureStoreTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/store/SecureStoreTest.java
@@ -107,7 +107,7 @@ public class SecureStoreTest {
     injector.getInstance(NamespaceAdmin.class).create(NamespaceMeta.DEFAULT);
 
     httpServer = new CommonNettyHttpServiceBuilder(injector.getInstance(CConfiguration.class), "SecureStore",
-                                                   new NoOpMetricsCollectionService())
+                                                   new NoOpMetricsCollectionService(), auditLogContexts -> {})
       .setHttpHandlers(Collections.singleton(injector.getInstance(SecureStoreHandler.class)))
       .build();
     httpServer.start();

--- a/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunnerTest.java
+++ b/cdap-source-control/src/test/java/io/cdap/cdap/sourcecontrol/operationrunner/RemoteSourceControlOperationRunnerTest.java
@@ -136,7 +136,8 @@ public class RemoteSourceControlOperationRunnerTest extends SourceControlTestBas
                                                                                FileSecureStoreService.CURRENT_CODEC
                                                                                  .newInstance());
 
-    httpService = new CommonNettyHttpServiceBuilder(cConf, "test", new NoOpMetricsCollectionService())
+    httpService = new CommonNettyHttpServiceBuilder(cConf, "test", new NoOpMetricsCollectionService(),
+                                                    auditLogContexts -> {})
       .setHttpHandlers(
         new TaskWorkerHttpHandlerInternal(cConf, discoveryService, discoveryService, className -> {
         }, new NoOpMetricsCollectionService()),

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/k8s/SparkContainerDriverLauncher.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/k8s/SparkContainerDriverLauncher.java
@@ -37,6 +37,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.IOModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.guice.SupplierProviderBridge;
 import io.cdap.cdap.common.http.CommonNettyHttpServiceFactory;
@@ -260,6 +261,8 @@ public class SparkContainerDriverLauncher {
     modules.add(coreSecurityModule);
     modules.add(new MessagingClientModule());
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
+    //Need for guice binding, but No Audit Log action required.
+    modules.add(new NoOpAuditLogModule());
 
     modules.add(new AbstractModule() {
       @Override

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -49,6 +49,7 @@ import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.guice.KafkaClientModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.guice.ZkClientModule;
 import io.cdap.cdap.common.io.URLConnections;
@@ -548,6 +549,7 @@ public class StandaloneMain {
         new AuditModule(),
         new AuthenticationContextModules().getMasterModule(),
         new AuthorizationModule(),
+        new NoOpAuditLogModule(),
         new AuthorizationEnforcementModule().getStandaloneModules(),
         new PreviewConfigModule(cConf, new Configuration(), SConfiguration.create()),
         new PreviewManagerModule(false),

--- a/cdap-support-bundle/src/test/java/io/cdap/cdap/SupportBundleTestModule.java
+++ b/cdap-support-bundle/src/test/java/io/cdap/cdap/SupportBundleTestModule.java
@@ -27,6 +27,7 @@ import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.NonCustomLocationUnitTestModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.twill.NoopTwillRunnerService;
@@ -102,6 +103,7 @@ public class SupportBundleTestModule extends AbstractModule {
     install(new MetadataReaderWriterModules().getInMemoryModules());
     install(new MessagingServerRuntimeModule().getInMemoryModules());
     install(new MockProvisionerModule());
+    install(new NoOpAuditLogModule());
     // Needed by MonitorHandlerModuler
     bind(TwillRunner.class).to(NoopTwillRunnerService.class);
   }

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/distributed/LeaderElectionMessagingServiceTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/distributed/LeaderElectionMessagingServiceTest.java
@@ -30,6 +30,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.DFSLocationModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.ZkClientModule;
 import io.cdap.cdap.common.guice.ZkDiscoveryModule;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
@@ -50,6 +51,7 @@ import io.cdap.cdap.messaging.store.cache.MessageTableCacheProvider;
 import io.cdap.cdap.messaging.store.leveldb.LevelDBTableFactory;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.TopicId;
+import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import java.io.IOException;
@@ -296,7 +298,8 @@ public class LeaderElectionMessagingServiceTest {
                 .in(Scopes.SINGLETON);
             expose(MessagingService.class);
           }
-        }
+        },
+        new NoOpAuditLogModule()
     );
   }
 }

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/server/MessagingHttpServiceTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/server/MessagingHttpServiceTest.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
@@ -117,6 +118,7 @@ public class MessagingHttpServiceTest {
       new AuthenticationContextModules().getNoOpModule(),
       new AuthorizationEnforcementModule().getNoOpModules(),
       new MessagingServerRuntimeModule().getInMemoryModules(),
+      new NoOpAuditLogModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -69,6 +69,7 @@ import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.guice.RemoteAuthenticatorModules;
 import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
 import io.cdap.cdap.common.namespace.NamespaceAdmin;
@@ -321,6 +322,7 @@ public class TestBase {
         new PreviewManagerModule(false),
         new PreviewRunnerManagerModule().getInMemoryModules(),
         new MockProvisionerModule(),
+        new NoOpAuditLogModule(),
         new AbstractModule() {
           @Override
           protected void configure() {

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/tms/TestTMSLogging.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/tms/TestTMSLogging.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.logging.LoggingContext;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
@@ -94,6 +95,7 @@ public class TestTMSLogging {
       new InMemoryDiscoveryModule(),
       new AuthorizationEnforcementModule().getNoOpModules(),
       new MessagingServerRuntimeModule().getInMemoryModules(),
+      new NoOpAuditLogModule(),
       new AbstractModule() {
         @Override
         protected void configure() {

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/collect/MessagingMetricsCollectionServiceTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/collect/MessagingMetricsCollectionServiceTest.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.api.metrics.MetricValues;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.io.BinaryDecoder;
 import io.cdap.cdap.internal.io.ReflectionDatumReader;
 import io.cdap.cdap.messaging.DefaultMessageFetchRequest;
@@ -38,7 +39,7 @@ import io.cdap.cdap.proto.id.TopicId;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.Assert;
@@ -136,6 +137,10 @@ public class MessagingMetricsCollectionServiceTest extends MetricsTestBase {
 
   @Override
   protected List<Module> getAdditionalModules() {
-    return Collections.singletonList(new AuthorizationEnforcementModule().getNoOpModules());
+    List<Module> modules = new ArrayList<>();
+    modules.add(new AuthorizationEnforcementModule().getNoOpModules());
+    modules.add(new NoOpAuditLogModule());
+
+    return modules;
   }
 }

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MetricsAdminSubscriberServiceTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MetricsAdminSubscriberServiceTest.java
@@ -31,6 +31,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.guice.InMemoryDiscoveryModule;
+import io.cdap.cdap.common.guice.NoOpAuditLogModule;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.messaging.spi.MessagingService;
@@ -104,7 +105,8 @@ public class MetricsAdminSubscriberServiceTest {
           bind(MetricsAdminSubscriberService.class).in(Scopes.SINGLETON);
           expose(MetricsAdminSubscriberService.class);
         }
-      }
+      },
+      new NoOpAuditLogModule()
     );
 
     messagingService = injector.getInstance(MessagingService.class);


### PR DESCRIPTION
This is Milestone 2 of  Dataplane audit logging. 
That is continuation of  milestone 1 : https://github.com/cdapio/cdap/pull/15372

In the 1st Milestone we added a new SPI, that would support returning a Response from the External Auth service. This response would contain : 1. If we need to do audit logging for the requested action. 2. If yes, then it would also give us the audit log body. 3. We process the response store the event logs  in SecurityRequestContext. 

In this milestone 2 : 
1. we will process the event logs from SecurityRequestContext in our netty layer to persist the events into a messaging system ( currently TMS )
  - Adding a new interface for writing to tms and binding the default implementation at required places. 
  - This will run on every service. (POD)
  - incase we get audit log events we publish to tms queue and then return success response to the HTTP call.  

2. A new subscriber service to the audit log topic that runs in app fabric. 
 - It will consume audit log messages from the tms topic at a regular interval with retries. 
 - for every batch it consumes it will try to publish the logs using the new SPI mentioned below. 

3. Adding a new SPI to handle publishing the processed audit log events from CDAP to the ext auth service which would do the actual publishing of audit logs. 
4. Added a new feature flag for this. 