### PR TITLE
[Security Vulnerability] CVE-2024-47561: Upgrade org.apache.avro:avro to version 1.11.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <apache.jdbm1.version>2.0.0-M2</apache.jdbm1.version>
     <asm.version>7.1</asm.version>
     <async.http.version>1.9.40</async.http.version>
-    <avro.version>1.11.0</avro.version>
+    <avro.version>1.11.4</avro.version>
     <bouncycastle.version>1.70</bouncycastle.version>
     <cdap.common.version>0.13.1</cdap.common.version>
     <cdap.client.version>1.4.0</cdap.client.version>


### PR DESCRIPTION
context: [CVE-2024-47561](https://nvd.nist.gov/vuln/detail/CVE-2024-47561)