### PR TITLE
Implement cdap-tms-spanner extension - Part 1

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -109,6 +109,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-tms-spanner</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.tephra</groupId>
       <artifactId>tephra-api</artifactId>
     </dependency>
@@ -245,6 +250,7 @@
         <stage.storage.ext.dir>${stage.opt.dir}/ext/storageproviders</stage.storage.ext.dir>
         <stage.authenticators.ext.dir>${stage.opt.dir}/ext/authenticators</stage.authenticators.ext.dir>
         <stage.credential.provider.extensions.dir>${stage.opt.dir}/ext/credentialproviders</stage.credential.provider.extensions.dir>
+        <stage.messaging.ext.dir>${stage.opt.dir}/ext/messagingproviders</stage.messaging.ext.dir>
         <stage.metricswriters.ext.dir>${stage.opt.dir}/ext/metricswriters/google_cloud_monitoring_writer
         </stage.metricswriters.ext.dir>
         <stage.eventwriters.ext.dir>${stage.opt.dir}/ext/eventwriters/google_cloud_pubsub_writer
@@ -674,6 +680,28 @@
                     <resource>
                       <directory>
                         ${project.parent.basedir}/cdap-securestore-ext-gcp-secretstore/target/libexec/
+                      </directory>
+                      <includes>
+                        <include>*.jar</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+        </execution>
+
+              <!-- Copy messaging extensions -->
+              <execution>
+                <id>copy-messaging-ext-spanner</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <outputDirectory>${stage.messaging.ext.dir}/gcp-spanner</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>
+                        ${project.parent.basedir}/cdap-tms-spanner/target/libexec/
                       </directory>
                       <includes>
                         <include>*.jar</include>

--- a/cdap-messaging-spi/src/main/java/io/cdap/cdap/messaging/spi/MessagingContext.java
+++ b/cdap-messaging-spi/src/main/java/io/cdap/cdap/messaging/spi/MessagingContext.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.spi;
+
+import java.util.Map;
+
+public interface MessagingContext {
+
+  /**
+   * System properties are derived from the CDAP configuration. Anything in the CDAP configuration
+   * will be added as an entry in the system properties.
+   *
+   * @return unmodifiable system properties for the messaging service.
+   */
+  Map<String, String> getProperties();
+
+}

--- a/cdap-messaging-spi/src/main/java/io/cdap/cdap/messaging/spi/MessagingService.java
+++ b/cdap-messaging-spi/src/main/java/io/cdap/cdap/messaging/spi/MessagingService.java
@@ -36,6 +36,14 @@ import javax.annotation.Nullable;
 public interface MessagingService {
 
   /**
+   * Initialize the messaging service. This method is guaranteed to be called before any other
+   * method is called. It will only be called once for the lifetime of the messaging service.
+   *
+   * @param context the context that can be used to initialize the messaging service.
+   */
+  void initialize(MessagingContext context) throws IOException;
+
+  /**
    * Returns the name of this MessagingService. The name needs to match with the configuration
    * provided through {@code messaging.service.name}.
    */
@@ -46,7 +54,7 @@ public interface MessagingService {
    *
    * @param topicMetadata topic to be created
    * @throws TopicAlreadyExistsException if the topic to be created already exist
-   * @throws IOException if failed to create the topic
+   * @throws IOException                 if failed to create the topic
    * @throws ServiceUnavailableException if the messaging service is not available
    */
   void createTopic(TopicMetadata topicMetadata)
@@ -56,8 +64,8 @@ public interface MessagingService {
    * Updates the metadata of a topic.
    *
    * @param topicMetadata the topic metadata to be updated
-   * @throws TopicNotFoundException if the topic doesn't exist
-   * @throws IOException if failed to update the topic metadata
+   * @throws TopicNotFoundException      if the topic doesn't exist
+   * @throws IOException                 if failed to update the topic metadata
    * @throws ServiceUnavailableException if the messaging service is not available
    */
   void updateTopic(TopicMetadata topicMetadata)
@@ -67,8 +75,8 @@ public interface MessagingService {
    * Deletes a topic
    *
    * @param topicId the topic to be deleted
-   * @throws TopicNotFoundException if the topic doesn't exist
-   * @throws IOException if failed to delete the topic
+   * @throws TopicNotFoundException      if the topic doesn't exist
+   * @throws IOException                 if failed to delete the topic
    * @throws ServiceUnavailableException if the messaging service is not available
    */
   void deleteTopic(TopicId topicId)
@@ -79,8 +87,8 @@ public interface MessagingService {
    *
    * @param topicId message topic
    * @return the {@link TopicMetadata} of the given topic.
-   * @throws TopicNotFoundException if the topic doesn't exist
-   * @throws IOException if failed to retrieve topic metadata.
+   * @throws TopicNotFoundException      if the topic doesn't exist
+   * @throws IOException                 if failed to retrieve topic metadata.
    * @throws ServiceUnavailableException if the messaging service is not available
    */
   Map<String, String> getTopicMetadataProperties(TopicId topicId)
@@ -91,7 +99,7 @@ public interface MessagingService {
    *
    * @param namespaceId the namespace to list topics under it
    * @return a {@link List} of {@link TopicId}.
-   * @throws IOException if failed to retrieve topics.
+   * @throws IOException                 if failed to retrieve topics.
    * @throws ServiceUnavailableException if the messaging service is not available
    */
   List<TopicId> listTopics(NamespaceId namespaceId) throws IOException, UnauthorizedException;
@@ -101,9 +109,9 @@ public interface MessagingService {
    *
    * @param request the {@link StoreRequest} containing messages to be published
    * @return if the store request is transactional, then returns a {@link RollbackDetail} containing
-   *     information for rollback; otherwise {@code null} will be returned.
-   * @throws TopicNotFoundException if the topic doesn't exist
-   * @throws IOException if failed to publish messages
+   * information for rollback; otherwise {@code null} will be returned.
+   * @throws TopicNotFoundException      if the topic doesn't exist
+   * @throws IOException                 if failed to publish messages
    * @throws ServiceUnavailableException if the messaging service is not available
    */
   @Nullable
@@ -115,8 +123,8 @@ public interface MessagingService {
    * publishing use case.
    *
    * @param request the {@link StoreRequest} containing messages to be stored
-   * @throws TopicNotFoundException if the topic doesn't exist
-   * @throws IOException if failed to store messages
+   * @throws TopicNotFoundException      if the topic doesn't exist
+   * @throws IOException                 if failed to store messages
    * @throws ServiceUnavailableException if the messaging service is not available
    */
   @Deprecated
@@ -126,11 +134,12 @@ public interface MessagingService {
   /**
    * Rollbacks messages published to the given topic with the given transaction.
    *
-   * @param topicId the topic where the messages were published under
-   * @param rollbackDetail the {@link RollbackDetail} as returned by the {@link
-   *     #publish(StoreRequest)} call, which contains information needed for the rollback
-   * @throws TopicNotFoundException if the topic doesn't exist
-   * @throws IOException if failed to rollback changes
+   * @param topicId        the topic where the messages were published under
+   * @param rollbackDetail the {@link RollbackDetail} as returned by the
+   *                       {@link #publish(StoreRequest)} call, which contains information needed
+   *                       for the rollback
+   * @throws TopicNotFoundException      if the topic doesn't exist
+   * @throws IOException                 if failed to rollback changes
    * @throws ServiceUnavailableException if the messaging service is not available
    */
   @Deprecated
@@ -142,10 +151,18 @@ public interface MessagingService {
    * system.
    *
    * @param messageFetchRequest the request for fetching messages
-   * @throws TopicNotFoundException if the topic does not exist
-   * @throws IOException if it fails to create the iterator
+   * @throws TopicNotFoundException      if the topic does not exist
+   * @throws IOException                 if it fails to create the iterator
    * @throws ServiceUnavailableException if the messaging service is not available
    */
   CloseableIterator<RawMessage> fetch(MessageFetchRequest messageFetchRequest)
       throws TopicNotFoundException, IOException;
+
+  /**
+   * Cleans up initialized resources. It will only be called once for the lifetime of the messaging
+   * service.
+   *
+   * @param messagingContext messaging service context
+   */
+  void destroy(MessagingContext messagingContext);
 }

--- a/cdap-tms-spanner/pom.xml
+++ b/cdap-tms-spanner/pom.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2016-2018 Cask Data, Inc.
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.cdap.cdap</groupId>
+    <artifactId>cdap</artifactId>
+    <version>6.11.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cdap-tms-spanner</artifactId>
+  <name>CDAP Google Cloud Spanner TMS Extension</name>
+  <packaging>jar</packaging>
+
+  <properties>
+    <guava.version>30.1.1-jre</guava.version>
+    <spanner.version>6.12.2</spanner.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>22.0.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-messaging-spi</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-spanner</artifactId>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>dist</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.8</version>
+            <executions>
+              <execution>
+                <id>copy-dependencies</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>copy-dependencies</goal>
+                </goals>
+                <configuration combine.self="override">
+                  <outputDirectory>${project.build.directory}/libexec</outputDirectory>
+                  <overWriteReleases>false</overWriteReleases>
+                  <overWriteSnapshots>false</overWriteSnapshots>
+                  <overWriteIfNewer>true</overWriteIfNewer>
+                  <prependGroupId>true</prependGroupId>
+                  <silent>true</silent>
+                  <includeScope>runtime</includeScope>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <version>2.4</version>
+            <executions>
+              <execution>
+                <id>jar</id>
+                <phase>prepare-package</phase>
+                <configuration combine.self="override">
+                  <outputDirectory>${project.build.directory}/libexec</outputDirectory>
+                  <finalName>${project.groupId}.${project.build.finalName}</finalName>
+                </configuration>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/cdap-tms-spanner/src/main/java/io.cdap.cdap.messaging/SpannerMessagingService.java
+++ b/cdap-tms-spanner/src/main/java/io.cdap.cdap.messaging/SpannerMessagingService.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging;
+
+import com.google.api.gax.longrunning.OperationFuture;
+import com.google.cloud.ByteArray;
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.Mutation;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerException;
+import com.google.spanner.admin.database.v1.UpdateDatabaseDdlMetadata;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.api.messaging.TopicAlreadyExistsException;
+import io.cdap.cdap.api.messaging.TopicNotFoundException;
+import io.cdap.cdap.messaging.spi.MessageFetchRequest;
+import io.cdap.cdap.messaging.spi.MessagingContext;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.messaging.spi.RawMessage;
+import io.cdap.cdap.messaging.spi.RollbackDetail;
+import io.cdap.cdap.messaging.spi.StoreRequest;
+import io.cdap.cdap.messaging.spi.TopicMetadata;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.TopicId;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Spanner based implementation of {@link MessagingService}.
+ */
+public class SpannerMessagingService implements MessagingService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SpannerMessagingService.class);
+
+  private Map<String, String> cConf;
+
+  private Spanner spanner;
+
+  private DatabaseClient client;
+
+  private DatabaseAdminClient adminClient;
+
+  private final ConcurrentLinkedQueue<StoreRequest> batch = new ConcurrentLinkedQueue<>();
+
+  public static final String PAYLOAD_FIELD = "payload";
+  public static final String PUBLISH_TS_FIELD = "publish_ts";
+  public static final String PAYLOAD_SEQUENCE_ID = "payload_sequence_id";
+  public static final String SEQUENCE_ID_FIELD = "sequence_id";
+
+  @Override
+  public void initialize(MessagingContext context) throws IOException {
+    this.cConf = context.getProperties();
+    this.spanner = SpannerUtil.getSpannerService(cConf);
+    this.client = SpannerUtil.getSpannerDbClient(cConf, spanner);
+    this.adminClient = SpannerUtil.getSpannerDbAdminClient(spanner);
+    LOG.info("Spanner messaging service started.");
+  }
+
+  @Override
+  public String getName() {
+    return this.getClass().getSimpleName();
+  }
+
+  @Override
+  public void createTopic(TopicMetadata topicMetadata)
+      throws TopicAlreadyExistsException, IOException, UnauthorizedException {
+    createTopic(topicMetadata.getTopicId());
+  }
+
+  private void createTopic(TopicId topicId) {
+    String topicSQL = String.format("CREATE TABLE IF NOT EXISTS %s ( %s INT64, %s INT64, %s"
+            + " TIMESTAMP NOT NULL OPTIONS (allow_commit_timestamp=true), %s BYTES(MAX) )"
+            + " PRIMARY KEY (sequence_id, payload_sequence_id, publish_ts), ROW DELETION POLICY"
+            + " (OLDER_THAN(publish_ts, INTERVAL 7 DAY))", getTableName(topicId), SEQUENCE_ID_FIELD,
+        PAYLOAD_SEQUENCE_ID, PUBLISH_TS_FIELD, PAYLOAD_FIELD);
+    OperationFuture<Void, UpdateDatabaseDdlMetadata> future = adminClient.updateDatabaseDdl(
+        SpannerUtil.getInstanceID(cConf), SpannerUtil.getDatabaseID(cConf),
+        Collections.singletonList(topicSQL), null);
+    try {
+      future.get();
+    } catch (InterruptedException | ExecutionException e) {
+      LOG.error("Error when executing {}", topicSQL, e);
+    }
+  }
+
+  public static String getTableName(TopicId topicId) {
+    return topicId.getNamespace() + topicId.getTopic();
+  }
+
+  @Override
+  public void updateTopic(TopicMetadata topicMetadata)
+      throws TopicNotFoundException, IOException, UnauthorizedException {
+    throw new IOException("NOT IMPLEMENTED");
+  }
+
+  @Override
+  public void deleteTopic(TopicId topicId)
+      throws TopicNotFoundException, IOException, UnauthorizedException {
+    throw new IOException("NOT IMPLEMENTED");
+  }
+
+  @Override
+  public Map<String, String> getTopicMetadataProperties(TopicId topicId)
+      throws TopicNotFoundException, IOException, UnauthorizedException {
+    return null;
+  }
+
+  @Override
+  public List<TopicId> listTopics(NamespaceId namespaceId)
+      throws IOException, UnauthorizedException {
+    throw new IOException("NOT IMPLEMENTED");
+  }
+
+  @Nullable
+  @Override
+  public RollbackDetail publish(StoreRequest request)
+      throws TopicNotFoundException, IOException, UnauthorizedException {
+    long start = System.currentTimeMillis();
+    createTopic(request.getTopicId());
+
+    batch.add(request);
+    if (!batch.isEmpty()) {
+      int i = 0;
+      List<Mutation> batchCopy = new ArrayList<>(batch.size());
+      // We need to batch less than fetch limit since we read for publish_ts >= last_message.publish_ts
+      // see fetch for explanation of why we read for publish_ts >= last_message.publish_ts and
+      // not publish_ts > last_message.publish_ts
+      while (!batch.isEmpty()) {
+        StoreRequest headRequest = batch.poll();
+        for (byte[] payload : headRequest) {
+          Mutation mutation = Mutation.newInsertBuilder(getTableName(headRequest.getTopicId()))
+              .set(SEQUENCE_ID_FIELD).to(i++).set(PAYLOAD_SEQUENCE_ID).to(0).set(PUBLISH_TS_FIELD)
+              .to("spanner.commit_timestamp()").set(PAYLOAD_FIELD).to(ByteArray.copyFrom(payload))
+              .build();
+          batchCopy.add(mutation);
+        }
+
+        if (batch.isEmpty() && (i < 50 || System.currentTimeMillis() - start < 50)) {
+          try {
+            Thread.sleep(5);
+          } catch (InterruptedException e) {
+            LOG.error("error during sleep", e);
+          }
+        }
+      }
+      if (!batchCopy.isEmpty()) {
+        try {
+          client.write(batchCopy);
+        } catch (SpannerException e) {
+          LOG.error("Cannot commit mutations ", e);
+        }
+      }
+
+    }
+
+    return null;
+  }
+
+  @Override
+  public void storePayload(StoreRequest request)
+      throws TopicNotFoundException, IOException, UnauthorizedException {
+    throw new IOException("NOT IMPLEMENTED");
+  }
+
+  @Override
+  public void rollback(TopicId topicId, RollbackDetail rollbackDetail)
+      throws TopicNotFoundException, IOException, UnauthorizedException {
+    throw new IOException("NOT IMPLEMENTED");
+  }
+
+  @Override
+  public CloseableIterator<RawMessage> fetch(MessageFetchRequest messageFetchRequest)
+      throws TopicNotFoundException, IOException {
+    throw new IOException("NOT IMPLEMENTED");
+  }
+
+  @Override
+  public void destroy(MessagingContext messagingContext) {
+    // TODO: Call destroy() at appropriate place.
+    this.spanner.close();
+  }
+}

--- a/cdap-tms-spanner/src/main/java/io.cdap.cdap.messaging/SpannerUtil.java
+++ b/cdap-tms-spanner/src/main/java/io.cdap.cdap.messaging/SpannerUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging;
+
+import com.google.cloud.spanner.DatabaseAdminClient;
+import com.google.cloud.spanner.DatabaseClient;
+import com.google.cloud.spanner.DatabaseId;
+import com.google.cloud.spanner.Spanner;
+import com.google.cloud.spanner.SpannerOptions;
+import java.util.Map;
+
+/**
+ * Utility class for spanner messaging service.
+ */
+public class SpannerUtil {
+
+  public static DatabaseClient getSpannerDbClient(Map<String, String> cConf, Spanner spanner) {
+    String projectID = cConf.get("project");
+    String instanceID = getInstanceID(cConf);
+    String databaseID = getDatabaseID(cConf);
+    DatabaseId db = DatabaseId.of(projectID, instanceID, databaseID);
+    return spanner.getDatabaseClient(db);
+  }
+
+  public static DatabaseAdminClient getSpannerDbAdminClient(Spanner spanner) {
+    return spanner.getDatabaseAdminClient();
+  }
+
+  public static String getInstanceID(Map<String, String> cConf) {
+    return cConf.get("instance");
+  }
+
+  public static String getDatabaseID(Map<String, String> cConf) {
+    return cConf.get("database");
+  }
+
+  public static Spanner getSpannerService(Map<String, String> cConf) {
+    String projectID = cConf.get("project");
+    return SpannerOptions.newBuilder().setProjectId(projectID).build().getService();
+  }
+}

--- a/cdap-tms-spanner/src/main/resources/METAINF/services/io.cdap.cdap.messaging.MessagingService
+++ b/cdap-tms-spanner/src/main/resources/METAINF/services/io.cdap.cdap.messaging.MessagingService
@@ -1,0 +1,17 @@
+#
+# Copyright © 2022 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+io.cdap.cdap.messaging.client.SpannerMessagingService

--- a/cdap-tms/pom.xml
+++ b/cdap-tms/pom.xml
@@ -133,6 +133,12 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-messaging-spi</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-security</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/ClientMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/ClientMessagingService.java
@@ -38,6 +38,7 @@ import io.cdap.cdap.common.internal.remote.RemoteClient;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.internal.io.ExposedByteArrayOutputStream;
 import io.cdap.cdap.messaging.spi.MessageFetchRequest;
+import io.cdap.cdap.messaging.spi.MessagingContext;
 import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.messaging.spi.RollbackDetail;
 import io.cdap.cdap.messaging.Schemas;
@@ -88,7 +89,7 @@ import org.apache.tephra.TransactionCodec;
 /**
  * The client implementation of {@link MessagingService}. This client is intended for internal
  * higher level API implementation only.
- *
+ * <p>
  * NOTE: This class shouldn't expose to end user (e.g. cdap-client module).
  */
 public final class ClientMessagingService implements MessagingService {
@@ -115,6 +116,10 @@ public final class ClientMessagingService implements MessagingService {
     this.remoteClient = remoteClientFactory.createRemoteClient(
         Constants.Service.MESSAGING_SERVICE, HTTP_REQUEST_CONFIG, "/v1/namespaces/");
     this.compressPayload = compressPayload;
+  }
+
+  @Override
+  public void initialize(MessagingContext context) throws IOException {
   }
 
   @Override
@@ -252,7 +257,7 @@ public final class ClientMessagingService implements MessagingService {
    * @param request contains information about what to write
    * @param publish {@code true} to make publish call, {@code false} to make store call.
    * @return the response from the server
-   * @throws IOException if failed to perform the write operation
+   * @throws IOException            if failed to perform the write operation
    * @throws TopicNotFoundException if the topic to write to does not exist
    */
   private HttpResponse performWriteRequest(StoreRequest request,
@@ -338,8 +343,8 @@ public final class ClientMessagingService implements MessagingService {
   }
 
   /**
-   * Converts the payloads carried by the given {@link StoreRequest} into a {@link List} of {@link
-   * ByteBuffer}, which is needed by the avro record.
+   * Converts the payloads carried by the given {@link StoreRequest} into a {@link List} of
+   * {@link ByteBuffer}, which is needed by the avro record.
    */
   private List<ByteBuffer> convertPayloads(StoreRequest request) {
     return StreamSupport.stream(request.spliterator(), false).map(ByteBuffer::wrap)
@@ -348,9 +353,9 @@ public final class ClientMessagingService implements MessagingService {
 
   /**
    * Encodes the given {@link RollbackDetail} as expected by the rollback call. This method is
-   * rarely used as the call to {@link #rollback(TopicId, RollbackDetail)} expects a {@link
-   * ClientRollbackDetail} which already contains the encoded bytes.
-   *
+   * rarely used as the call to {@link #rollback(TopicId, RollbackDetail)} expects a
+   * {@link ClientRollbackDetail} which already contains the encoded bytes.
+   * <p>
    * This method looks very similar to the {@code StoreHandler.encodeRollbackDetail} method, but is
    * intended to have them separated. This is to allow client side classes be moved to separate
    * module without any dependency on the server side (this can also be done with a util method in a
@@ -515,9 +520,13 @@ public final class ClientMessagingService implements MessagingService {
     };
   }
 
+  @Override
+  public void destroy(MessagingContext messagingContext) {
+  }
+
   /**
-   * Based on the given {@link HttpURLConnection} content encoding, optionally wrap the given {@link
-   * InputStream} with either gzip or deflate decompression.
+   * Based on the given {@link HttpURLConnection} content encoding, optionally wrap the given
+   * {@link InputStream} with either gzip or deflate decompression.
    */
   private InputStream decompressIfNeeded(HttpURLConnection urlConn, InputStream is)
       throws IOException {

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/DefaultMessagingContext.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/DefaultMessagingContext.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.client;
+
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.messaging.spi.MessagingContext;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultMessagingContext implements MessagingContext {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultMessagingContext.class);
+
+  private final CConfiguration cConf;
+
+  private static final String storageImpl = "gcp-spanner";
+
+  DefaultMessagingContext(CConfiguration cConf) {
+    this.cConf = cConf;
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    String spannerPropertiesPrefix =
+        Constants.Dataset.STORAGE_EXTENSION_PROPERTY_PREFIX + storageImpl + ".";
+    Map<String, String> propertiesMap = new HashMap<>(
+        cConf.getPropsWithPrefix(spannerPropertiesPrefix));
+    return Collections.unmodifiableMap(propertiesMap);
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/DelegatingMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/DelegatingMessagingService.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.api.messaging.TopicNotFoundException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants.MessagingSystem;
 import io.cdap.cdap.messaging.spi.MessageFetchRequest;
+import io.cdap.cdap.messaging.spi.MessagingContext;
 import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.messaging.spi.RawMessage;
 import io.cdap.cdap.messaging.spi.RollbackDetail;
@@ -72,6 +73,10 @@ public class DelegatingMessagingService implements MessagingService {
   }
 
   @Override
+  public void initialize(MessagingContext context) throws IOException {
+  }
+
+  @Override
   public String getName() {
     return cConf.get(MessagingSystem.MESSAGING_SERVICE_NAME);
   }
@@ -93,6 +98,11 @@ public class DelegatingMessagingService implements MessagingService {
   public CloseableIterator<RawMessage> fetch(MessageFetchRequest messageFetchRequest)
       throws TopicNotFoundException, IOException {
     return getDelegate().fetch(messageFetchRequest);
+  }
+
+  @Override
+  public void destroy(MessagingContext messagingContext) {
+    getDelegate().destroy(messagingContext);
   }
 
   @Override
@@ -130,6 +140,11 @@ public class DelegatingMessagingService implements MessagingService {
             "Unsupported messaging service implementation " + getName());
       }
       LOG.info("Messaging service {} is loaded", messagingService.getName());
+      try {
+        messagingService.initialize(new DefaultMessagingContext(this.cConf));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
 
       this.delegate = messagingService;
       return messagingService;

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/distributed/LeaderElectionMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/distributed/LeaderElectionMessagingService.java
@@ -25,16 +25,15 @@ import io.cdap.cdap.api.messaging.TopicNotFoundException;
 import io.cdap.cdap.api.service.ServiceUnavailableException;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.messaging.server.MessagingHttpService;
+import io.cdap.cdap.messaging.service.CoreMessagingService;
 import io.cdap.cdap.messaging.spi.MessageFetchRequest;
+import io.cdap.cdap.messaging.spi.MessagingContext;
 import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.messaging.spi.RawMessage;
 import io.cdap.cdap.messaging.spi.RollbackDetail;
 import io.cdap.cdap.messaging.spi.StoreRequest;
 import io.cdap.cdap.messaging.spi.TopicMetadata;
-import io.cdap.cdap.messaging.spi.RawMessage;
-import io.cdap.cdap.messaging.server.MessagingHttpService;
-import io.cdap.cdap.messaging.service.CoreMessagingService;
-import io.cdap.cdap.messaging.store.ForwardingTableFactory;
-import io.cdap.cdap.messaging.store.TableFactory;
 import io.cdap.cdap.messaging.store.cache.MessageTableCacheProvider;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.TopicId;
@@ -81,6 +80,10 @@ public class LeaderElectionMessagingService extends AbstractIdleService implemen
     this.cacheProvider = cacheProvider;
     this.zkClient = zkClient;
     this.delegate = new AtomicMarkableReference<>(null, false);
+  }
+
+  @Override
+  public void initialize(MessagingContext context) throws IOException {
   }
 
   @Override
@@ -174,6 +177,10 @@ public class LeaderElectionMessagingService extends AbstractIdleService implemen
   public CloseableIterator<RawMessage> fetch(MessageFetchRequest messageFetchRequest)
       throws TopicNotFoundException, IOException {
     return getMessagingService().fetch(messageFetchRequest);
+  }
+
+  @Override
+  public void destroy(MessagingContext messagingContext) {
   }
 
   @Override

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/service/CoreMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/service/CoreMessagingService.java
@@ -38,6 +38,7 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.utils.TimeProvider;
 import io.cdap.cdap.messaging.DefaultTopicMetadata;
 import io.cdap.cdap.messaging.spi.MessageFetchRequest;
+import io.cdap.cdap.messaging.spi.MessagingContext;
 import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.messaging.MessagingServiceUtils;
 import io.cdap.cdap.messaging.MessagingUtils;
@@ -128,6 +129,10 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
             cConf.getLong(
                 TxConstants.Manager.CFG_TX_MAX_LIFETIME,
                 TxConstants.Manager.DEFAULT_TX_MAX_LIFETIME));
+  }
+
+  @Override
+  public void initialize(MessagingContext context) throws IOException {
   }
 
   @Override
@@ -455,6 +460,10 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
       closeQuietly(messageTable);
       throw t;
     }
+  }
+
+  @Override
+  public void destroy(MessagingContext messagingContext) {
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -2603,6 +2603,7 @@
         <module>cdap-system-app-api</module>
         <module>cdap-system-app-unit-test</module>
         <module>cdap-tms</module>
+        <module>cdap-tms-spanner</module>
         <module>cdap-messaging-spi</module>
         <module>cdap-gateway</module>
         <module>cdap-unit-test</module>


### PR DESCRIPTION
This PR contains initial implementation of spanner extension of messaging service.

For now conf property : messaging.service.name will decide if spanner messaging service will be used. This part resides in the DelegatingMessagingService implemented earlier.

Follow up PR to contain implementation of other methods in the SpannerMessagingService : especially fetch() and appropriately call destroy() to close spanner clients.

Reference Masoud's POC : https://github.com/cdapio/cdap/compare/develop...features/spanner-tms