### PR TITLE
[CDAP-14950] : Periodic clean up for program heart beat table

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/reporting/ProgramHeartbeatTable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/reporting/ProgramHeartbeatTable.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.reporting;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
@@ -33,6 +34,7 @@ import io.cdap.cdap.spi.data.table.field.Fields;
 import io.cdap.cdap.spi.data.table.field.Range;
 import io.cdap.cdap.store.StoreDefinition;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -224,5 +226,23 @@ public class ProgramHeartbeatTable {
             row.getString(StoreDefinition.ProgramHeartbeatStore.PROGRAM_TYPE_FIELD)),
         row.getString(StoreDefinition.ProgramHeartbeatStore.PROGRAM_FIELD),
         row.getString(StoreDefinition.ProgramHeartbeatStore.RUN_FIELD));
+  }
+
+
+  /**
+   * Delete the program heartbeat records that started before the {@param endTime}.
+   */
+  public void deleteRecordsBefore(Instant endTime) throws IOException {
+    long endTimeEpochSecond = endTime.getEpochSecond();
+    table.scanDeleteAll(createTimestampEndRange(endTimeEpochSecond));
+  }
+
+  /**
+   * Create a range starting from all to the END TIME.
+   */
+  private Range createTimestampEndRange(long endTime) {
+    ImmutableList<Field<?>> end = ImmutableList.of(
+      Fields.longField(StoreDefinition.ProgramHeartbeatStore.TIMESTAMP_SECONDS_FIELD, endTime));
+    return Range.to(end, Range.Bound.EXCLUSIVE);
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/reporting/NoSqlProgramHeartBeatTableTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/reporting/NoSqlProgramHeartBeatTableTest.java
@@ -20,8 +20,12 @@ import com.google.inject.Injector;
 import io.cdap.cdap.internal.AppFabricTestHelper;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.time.Instant;
 
 public class NoSqlProgramHeartBeatTableTest extends ProgramHeartBeatTableTest {
 
@@ -35,5 +39,14 @@ public class NoSqlProgramHeartBeatTableTest extends ProgramHeartBeatTableTest {
   @AfterClass
   public static void tearDown() {
     AppFabricTestHelper.shutdown();
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testDeleteRecordsBeforeThrowsException() {
+    final Instant cutOffTime = Instant.now();
+    TransactionRunners.run(transactionRunner, context -> {
+      ProgramHeartbeatTable programHeartbeatTable = new ProgramHeartbeatTable(context);
+      programHeartbeatTable.deleteRecordsBefore(cutOffTime);
+    });
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/reporting/SqlProgramHeartBeatTableTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/reporting/SqlProgramHeartBeatTableTest.java
@@ -21,22 +21,35 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
+import io.cdap.cdap.common.app.RunIds;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.guice.ConfigModule;
 import io.cdap.cdap.common.guice.LocalLocationModule;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.data.runtime.StorageModule;
 import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
+import io.cdap.cdap.internal.app.store.RunRecordDetail;
+import io.cdap.cdap.messaging.data.MessageId;
+import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.sql.PostgresInstantiator;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import io.cdap.cdap.store.StoreDefinition;
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres;
 import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class SqlProgramHeartBeatTableTest extends ProgramHeartBeatTableTest {
@@ -70,5 +83,34 @@ public class SqlProgramHeartBeatTableTest extends ProgramHeartBeatTableTest {
   @AfterClass
   public static void teardown() throws IOException {
     pg.close();
+  }
+
+  @Test
+  public void testDeleteRecordsBefore() {
+    RunRecordDetail runRecord = RunRecordDetail.builder()
+      .setProgramRunId(NamespaceId.DEFAULT.app("app").spark("spark").run(RunIds.generate()))
+      .setStartTime(System.currentTimeMillis())
+      .setSourceId(new byte[MessageId.RAW_ID_SIZE])
+      .build();
+    final Instant cutOffTime = Instant.now();
+    final Instant timeBefore5min = cutOffTime.minus(Duration.ofMinutes(5));
+    final Instant timeAfterCutOff = Instant.now().plus(Duration.ofMinutes(5));
+
+    TransactionRunners.run(transactionRunner, context -> {
+      ProgramHeartbeatTable programHeartbeatTable = new ProgramHeartbeatTable(context);
+      //Insert 4 Records with different times
+      programHeartbeatTable.writeRunRecordMeta(runRecord, timeBefore5min.getEpochSecond());
+      programHeartbeatTable.writeRunRecordMeta(runRecord, timeBefore5min.getEpochSecond());
+      programHeartbeatTable.writeRunRecordMeta(runRecord, cutOffTime.getEpochSecond());
+      programHeartbeatTable.writeRunRecordMeta(runRecord, timeAfterCutOff.getEpochSecond());
+
+      //Now delete all records <= cutOffTime
+      programHeartbeatTable.deleteRecordsBefore(cutOffTime);
+      Collection<RunRecordDetail> result =
+        programHeartbeatTable.scan(0, Long.MAX_VALUE, new HashSet<>(Arrays.asList("default")));
+
+      //This should contain only 1 record i.e. the last with timeAfterCutOff
+      Assert.assertEquals(1, result.size());
+    });
   }
 }


### PR DESCRIPTION
Testing : 
- a CDAP instance had records in the table from nov 11 onwards 
<img width="891" alt="Screenshot 2024-11-15 at 8 59 34 PM" src="https://github.com/user-attachments/assets/39965e79-4cc4-4372-a93d-dac45b9ea8b4">
- Total records : 43
<img width="544" alt="Screenshot 2024-11-15 at 9 00 38 PM" src="https://github.com/user-attachments/assets/f11e57f0-1669-4e99-9ec8-3d6581342c51">

- For testing purpose : setting `ttlMaxAge` to 1 day . 

On restarting instance : 
- in app fabric : 
```
2024-11-15 13:15:48,783 - INFO  [Records TTL janitor:i.c.c.i.a.s.RunDataTimeToLiveService$ProgramHeartbeatCleanupService@198] - Doing scheduled cleanup, deleting all ProgramHeartbeat records before 2024-11-14T13:15:48.736Z


[Records TTL janitor:i.c.c.i.a.s.RunDataTimeToLiveService@127] - io.cdap.cdap.internal.app.services.RunDataTimeToLiveService$ProgramHeartbeatCleanupService cleanup completed in 0.006 seconds
```

- In DB : all records older to `2024-11-14T13:15:48` were deleted
<img width="898" alt="Screenshot 2024-11-15 at 9 03 15 PM" src="https://github.com/user-attachments/assets/41def9e6-6cb8-404f-9add-80c01162a8ce">

<img width="561" alt="Screenshot 2024-11-15 at 9 03 30 PM" src="https://github.com/user-attachments/assets/f5b826b4-76f0-45ac-af5e-74beab7fd35d">
