### PR TITLE
[CDAP-21046][CDAP-21048] Fixing flow control metrics on startup:

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricTestHelper.java
@@ -131,6 +131,15 @@ public class AppFabricTestHelper {
     });
   }
 
+  public static <T extends Service> T getService(Class<T> clazz) {
+    for (Service service : services) {
+      if (clazz.isAssignableFrom(service.getClass())) {
+        return (T) service;
+      }
+    }
+    return null;
+  }
+
   public static Injector getInjector(CConfiguration cConf, Module overrides) {
     return getInjector(cConf, null, overrides);
   }


### PR DESCRIPTION
Due to the following bugs:
1. https://cdap.atlassian.net/browse/CDAP-21048
2. https://cdap.atlassian.net/browse/CDAP-21046

launching and running count metrics are calculated incorrectly on service restarts.

Moving the logic to launch active runs and compute metrics to non sharded main class `ProgramNotificationSubscriberService`.
Also publishing launching count metric on every cleanup not just when records are removed. 
On startup the latest metrics are recomputed and published as well.

## Testing

* Tested by replicating current scenario on a dummy pipeline. 
* Pushed local code changes to the server.
Launching pipeline :
![6SLsR9vBXsU4ZG2](https://github.com/user-attachments/assets/f6b4aa11-5c29-4c67-86f5-deb179cbd477)
* Restarted a running/launching pipeline. 
* Post restart metrics were computed correclty.
Post restart:
![6CGNcmE3KQCceij](https://github.com/user-attachments/assets/4fd743d7-1030-4923-ba5d-529833b9deee)
* Post completion the running count went back to 0.
Post completion:
![BLiLK5VzLVdK4NB](https://github.com/user-attachments/assets/5fd12beb-dc8e-4fad-9811-83095dbe3c1b)
