### PR TITLE
[CDAP-21087] Optimize spanner create table operations

### DIFF
--- a/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableAdminTest.java
+++ b/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableAdminTest.java
@@ -35,8 +35,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Unit tests for GCP spanner implementation of the {@link StructuredTableAdmin}. This test needs the following
- * Java properties to run. If they are not provided, tests will be ignored.
+ * Unit tests for GCP spanner implementation of the {@link StructuredTableAdmin}. This test needs
+ * the following Java properties to run. If they are not provided, tests will be ignored.
  *
  * <ul>
  *   <li>gcp.project - GCP project name</li>
@@ -127,7 +127,7 @@ public class SpannerStructuredTableAdminTest extends StructuredTableAdminTest {
     Assert.assertFalse(admin.exists(SIMPLE_TABLE));
 
     // Calling to createOrUpdate the same SIMPLE_TABLE spec twice to mimic the scenario of
-    // connecting to an exsting DB and make sure the second time passes the equality check after
+    // connecting to an existing DB and make sure the second time passes the equality check after
     // schema compatibility conversion
     admin.createOrUpdate(SIMPLE_TABLE_SPEC);
     admin.createOrUpdate(SIMPLE_TABLE_SPEC);
@@ -136,6 +136,44 @@ public class SpannerStructuredTableAdminTest extends StructuredTableAdminTest {
     // Assert SIMPLE_TABLE schema
     StructuredTableSchema simpleTableSchema = admin.getSchema(SIMPLE_TABLE);
     Assert.assertEquals(simpleTableSchema, convertSpecToCompatibleSchema(SIMPLE_TABLE_SPEC));
+  }
+
+  @Test
+  public void testCreateOrUpdateWithListOfSpecs() throws Exception {
+    StructuredTableAdmin admin = getStructuredTableAdmin();
+
+    // Assert SIMPLE_TABLE Empty
+    Assert.assertFalse(admin.exists(SIMPLE_TABLE));
+
+    admin.createOrUpdate(Collections.singletonList(SIMPLE_TABLE_SPEC));
+    Assert.assertTrue(admin.exists(SIMPLE_TABLE));
+
+    // Assert SIMPLE_TABLE schema
+    StructuredTableSchema simpleTableSchema = admin.getSchema(SIMPLE_TABLE);
+    Assert.assertEquals(simpleTableSchema, convertSpecToCompatibleSchema(SIMPLE_TABLE_SPEC));
+  }
+
+  @Test
+  public void testCreateOrUpdateWithListOfSpecsTwice() throws Exception {
+    StructuredTableAdmin admin = getStructuredTableAdmin();
+
+    // Assert SIMPLE_TABLE Empty
+    Assert.assertFalse(admin.exists(SIMPLE_TABLE));
+
+    admin.createOrUpdate(Collections.singletonList(SIMPLE_TABLE_SPEC));
+    // Assert SIMPLE_TABLE schema: checking equality after compatible conversion because of INT/LONG
+    // to INT64 conversion in Spanner
+    Assert.assertTrue(admin.exists(SIMPLE_TABLE));
+    StructuredTableSchema simpleTableSchema = admin.getSchema(SIMPLE_TABLE);
+    Assert.assertEquals(simpleTableSchema, convertSpecToCompatibleSchema(SIMPLE_TABLE_SPEC));
+
+    admin.createOrUpdate(Collections.singletonList(SIMPLE_TABLE_SPEC));
+
+    // Assert UPDATED_SIMPLE_TABLE_SPEC schema
+    StructuredTableSchema updateSimpleTableSchema = admin.getSchema(SIMPLE_TABLE);
+    Assert.assertEquals(
+        updateSimpleTableSchema, convertSpecToCompatibleSchema(UPDATED_SIMPLE_TABLE_SPEC));
+
   }
 
   @Test

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTableAdmin.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/StructuredTableAdmin.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.spi.data.table.StructuredTableId;
 import io.cdap.cdap.spi.data.table.StructuredTableSchema;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Defines admin operations on a {@link StructuredTable}.
@@ -38,20 +39,37 @@ public interface StructuredTableAdmin {
   void create(StructuredTableSpecification spec) throws IOException, TableAlreadyExistsException;
 
   /**
-   * If the table does not exist, create a StructuredTable using the {@link
-   * StructuredTableSpecification}. If the table exists, check the columns and update the schema if
-   * necessary using the {@link StructuredTableSpecification}. Currently, only non-primary keys are
-   * allowed to be added to the existing table schema. The passed in StructuredTableSpecification
-   * has to be backward compatible with the existing table schema.
+   * If the table does not exist, create a StructuredTable using the
+   * {@link StructuredTableSpecification}. If the table exists, check the columns and update the
+   * schema if necessary using the {@link StructuredTableSpecification}. Currently, only non-primary
+   * keys are allowed to be added to the existing table schema. The passed in
+   * StructuredTableSpecification has to be backward compatible with the existing table schema.
    *
    * @param spec table specification
-   * @throws IOException if there is an error creating the table
+   * @throws IOException                      if there is an error creating the table
    * @throws TableSchemaIncompatibleException if the new table schema is incompatible with the
-   *     existing one
+   *                                          existing one
    */
   default void createOrUpdate(StructuredTableSpecification spec)
       throws IOException, TableSchemaIncompatibleException {
     throw new UnsupportedOperationException("Storage SPI did not implement createOrUpdate.");
+  }
+
+  /**
+   * This method is similar to {@link #createOrUpdate(StructuredTableSpecification)}. It offers
+   * potential performance improvements by allowing batching of table operations. The specific
+   * implementation will determine whether to batch operations or execute them sequentially.
+   *
+   * @param specs list of table specifications
+   * @throws IOException                      if there is an error creating the table
+   * @throws TableSchemaIncompatibleException if the new table schema is incompatible with the
+   *                                          existing one
+   */
+  default void createOrUpdate(List<StructuredTableSpecification> specs)
+      throws IOException, TableSchemaIncompatibleException {
+    for (StructuredTableSpecification spec : specs) {
+      createOrUpdate(spec);
+    }
   }
 
   /**
@@ -68,7 +86,7 @@ public interface StructuredTableAdmin {
    *
    * @param tableId the name of the table
    * @return the {@link StructuredTableSchema} of the table
-   * @throws IOException if there is an error for getting the table schema
+   * @throws IOException            if there is an error for getting the table schema
    * @throws TableNotFoundException if the table doesn't exist
    */
   StructuredTableSchema getSchema(StructuredTableId tableId)


### PR DESCRIPTION
Table creation for Cloud Spanner is currently taking around 5-6 mins. This is adding delays when service pods come up and this in turn increases CDAP instance creation time. The table creation time in case of Cloud SQL is just 3s.

Current logs:
```
2024-11-13 13:09:52,307 - INFO  [main:i.c.c.m.e.k.StorageMain@69] - Creating storages
.
.
2024-11-13 13:14:21,632 - INFO  [main:i.c.c.m.e.k.StorageMain@113] - Storage creation completed
```

This PR aims to optimize the spanner table creation. 
UpdateDDL statements are costlier in cloud spanner than cloud sql  and it is recommended that we should try to batch these statements and execute together rather than individual calls for every create().

Batching is not needed in case of other supported Storage types. So we should not update the current flow for them.

End result: With these changes, table creation time has reduced to 1min, for the pod which does the major heavy lifting. Other pods are up in 20-40s.

Add unit test:
<img width="1181" alt="Screenshot 2024-12-03 at 11 59 57 AM" src="https://github.com/user-attachments/assets/9ae638fa-c8ae-4a65-b765-eb9e284a23f9">
