### PR TITLE
[CDAP-21083] Add default pagination for list apps API

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -256,12 +256,19 @@ public class AppLifecycleHttpHandler extends AbstractAppLifecycleHttpHandler {
       }
     }
 
+    if (pageSize == null) {
+      pageSize = configuration.getInt(Constants.GET_APPS_DEFAULT_PAGE_SIZE);
+      LOG.debug("Paginating GET apps call with page size as {}", pageSize);
+    }
+    pageSize = Math.max(pageSize, 0);
+
     if (Optional.ofNullable(pageSize).orElse(0) != 0) {
+      Integer finalPageSize = pageSize;
       JsonPaginatedListResponder.respond(GSON, responder, APP_LIST_PAGINATED_KEY,
           jsonListResponder -> {
             AtomicReference<ApplicationRecord> lastRecord = new AtomicReference<>(null);
             ScanApplicationsRequest scanRequest = getScanRequest(namespaceId, artifactVersion,
-                pageToken, pageSize,
+                pageToken, finalPageSize,
                 orderBy, nameFilter, names, nameFilterType, latestOnly,
                 sortCreationTime);
             boolean pageLimitReached = applicationLifecycleService.scanApplications(scanRequest,

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandlerInternal.java
@@ -116,11 +116,18 @@ public class AppLifecycleHttpHandlerInternal extends AbstractAppLifecycleHttpHan
       throw new NamespaceNotFoundException(namespaceId);
     }
 
+    if (pageSize == null) {
+      pageSize = configuration.getInt(Constants.GET_APPS_DEFAULT_PAGE_SIZE);
+    }
+    pageSize = Math.max(pageSize, 0);
+
     if (Optional.ofNullable(pageSize).orElse(0) != 0) {
+      Integer finalPageSize = pageSize;
       JsonPaginatedListResponder.respond(GSON, responder, APP_LIST_PAGINATED_KEY,
           jsonListResponder -> {
             AtomicReference<ApplicationRecord> lastRecord = new AtomicReference<>(null);
-            ScanApplicationsRequest scanRequest = getScanRequest(namespace, pageToken, pageSize,
+            ScanApplicationsRequest scanRequest = getScanRequest(namespace, pageToken,
+                finalPageSize,
                 orderBy, nameFilter);
             boolean pageLimitReached = applicationLifecycleService.scanApplications(scanRequest,
                 appDetail -> {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -653,6 +653,15 @@ public abstract class AppFabricTestBase {
                                      sortCreationTime);
   }
 
+  protected List<JsonObject> getAppListForNegativePaginatedApi(String namespace, int pageSize) throws Exception {
+    String uri = "apps/?pageSize=" + pageSize;
+
+    HttpResponse response = doGet(getVersionedApiPath(uri,
+        Constants.Gateway.API_VERSION_3_TOKEN, namespace));
+    assertResponseCode(200, response);
+    return readResponse(response, LIST_JSON_OBJECT_TYPE);
+  }
+
   protected JsonObject getAppListForPaginatedApi(String namespace, int pageSize, String token,
                                                  String orderBy, String filter, String nameFilterType,
                                                  Boolean latestOnly, Boolean sortCreationTime) throws Exception {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -687,6 +687,34 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
   }
 
   @Test
+  public void testListAppsWithNegativePageSize() throws Exception {
+    for (int i = 0; i < 10; i++) {
+      String ns1AppName = AllProgramsApp.NAME + i;
+      Id.Namespace ns1 = Id.Namespace.from(TEST_NAMESPACE1);
+      Id.Artifact ns1ArtifactId = Id.Artifact.from(ns1, AllProgramsApp.class.getSimpleName(),
+          "1.0.0-SNAPSHOT");
+
+      HttpResponse response = addAppArtifact(ns1ArtifactId, AllProgramsApp.class);
+      Assert.assertEquals(200, response.getResponseCode());
+      Id.Application appId = Id.Application.from(ns1, ns1AppName);
+      response = deploy(appId,
+          new AppRequest<>(ArtifactSummary.from(ns1ArtifactId.toArtifactId())));
+      Assert.assertEquals(200, response.getResponseCode());
+    }
+
+    List<JsonObject> result = getAppListForNegativePaginatedApi(TEST_NAMESPACE1, -3);
+    int resultSize = result.size();
+    Assert.assertEquals(10, resultSize);
+
+    // delete the apps in testnamespace1
+    HttpResponse response = doDelete(getVersionedApiPath("apps/",
+        Constants.Gateway.API_VERSION_3_TOKEN, TEST_NAMESPACE1));
+    Assert.assertEquals(200, response.getResponseCode());
+    List<JsonObject> apps = getAppList(TEST_NAMESPACE1);
+    Assert.assertEquals(0, apps.size());
+  }
+
+  @Test
   public void testListAndGetForPaginatedAPIWithEmptyLastPage() throws Exception {
     for (int i = 0; i < 9; i++) {
       //deploy with name to testnamespace1

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -69,6 +69,10 @@ public final class Constants {
   public static final String LOCATION_CACHE_EXPIRATION_MS = "location.cache.expiration.ms";
 
   public static final String CLUSTER_NAME = "cluster.name";
+
+  /* This represents the default value of pageSize during list apps call. */
+  public static final String GET_APPS_DEFAULT_PAGE_SIZE = "app.list.default.page.size";
+
   /* Used by the user to specify what part of a path should be replaced by the current user's name. */
   public static final String USER_NAME_SPECIFIER = "${name}";
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -452,6 +452,15 @@
 
 
   <!-- Applications Configuration -->
+
+  <property>
+    <name>app.list.default.page.size</name>
+    <value>0</value>
+    <description>
+      This represents the default value of pageSize during list apps call.
+    </description>
+  </property>
+
   <property>
     <name>app.artifact.compute.hash.time.bucket.days</name>
     <value>15</value>


### PR DESCRIPTION
If a namespace has huge number of deployed pipelines, calling GET /apps API would make appfabric and router consume high CPU and memory usages and would make the service unresponsive for a period of time. So, we should add default pagination in GET /apps API call for those instances.

Testing
- Built an image and added it in GKE of an instance which overrides the `apps.list.default.page.size` property with a value 25. Deployed 60+ pipelines in a default namespaces. Called GET /apps API from the router and it returned a paginated result with 25 pipelines -
```
cdap@cdap-boosted-latest-enterprise-2-router-785c9b7f4c-kbft4:/$ curl localhost:11015/v3/namespaces/default/apps
{"applications":[{"type":"App","name":"DataFusionQuickstart1","version":"f6f55993-ac45-11ef-a4a3-12e79014ed8e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732660196972,"latest":true}},{"type":"App","name":"DataFusionQuickstart2","version":"1cd4efe4-ac46-11ef-9f35-12e79014ed8e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732660260511,"latest":true}},{"type":"App","name":"testPipeline1","version":"97330882-ac50-11ef-85aa-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664760594,"latest":true,"description":""}},{"type":"App","name":"testPipeline10","version":"c0ac676b-ac50-11ef-a3c3-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664830172,"latest":true,"description":""}},{"type":"App","name":"testPipeline11","version":"c4e7c72c-ac50-11ef-a3f3-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664837271,"latest":true,"description":""}},{"type":"App","name":"testPipeline12","version":"c91e930d-ac50-11ef-b786-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664844340,"latest":true,"description":""}},{"type":"App","name":"testPipeline13","version":"cd58e15e-ac50-11ef-88da-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664851434,"latest":true,"description":""}},{"type":"App","name":"testPipeline14","version":"d189e0df-ac50-11ef-965d-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664858467,"latest":true,"description":""}},{"type":"App","name":"testPipeline15","version":"d5bd7870-ac50-11ef-b9be-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664865514,"latest":true,"description":""}},{"type":"App","name":"testPipeline16","version":"d9eb91c1-ac50-11ef-8543-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664872527,"latest":true,"description":""}},{"type":"App","name":"testPipeline17","version":"de1c9142-ac50-11ef-b6ec-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664879558,"latest":true,"description":""}},{"type":"App","name":"testPipeline18","version":"e24b94f3-ac50-11ef-83d6-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664886579,"latest":true,"description":""}},{"type":"App","name":"testPipeline19","version":"e67e1b14-ac50-11ef-8a82-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664893621,"latest":true,"description":""}},{"type":"App","name":"testPipeline2","version":"9f2ad403-ac50-11ef-b6aa-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664773962,"latest":true,"description":""}},{"type":"App","name":"testPipeline20","version":"eab6e2c5-ac50-11ef-8487-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664900703,"latest":true,"description":""}},{"type":"App","name":"testPipeline21","version":"eee8a596-ac50-11ef-be78-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664907743,"latest":true,"description":""}},{"type":"App","name":"testPipeline22","version":"f31d4e97-ac50-11ef-9462-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664914800,"latest":true,"description":""}},{"type":"App","name":"testPipeline23","version":"f75ec8d8-ac50-11ef-8ccd-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664921936,"latest":true,"description":""}},{"type":"App","name":"testPipeline24","version":"faf5f959-ac50-11ef-829c-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664927960,"latest":true,"description":""}},{"type":"App","name":"testPipeline25","version":"ff22da2a-ac50-11ef-9add-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664934966,"latest":true,"description":""}},{"type":"App","name":"testPipeline26","version":"035a424b-ac51-11ef-b83f-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664942039,"latest":true,"description":""}},{"type":"App","name":"testPipeline27","version":"078b41cc-ac51-11ef-8c33-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664949071,"latest":true,"description":""}},{"type":"App","name":"testPipeline28","version":"0bc8282d-ac51-11ef-aab3-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664956187,"latest":true,"description":""}},{"type":"App","name":"testPipeline29","version":"0ff5cc4e-ac51-11ef-864f-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664963191,"latest":true,"description":""}},{"type":"App","name":"testPipeline3","version":"a35a9b04-ac50-11ef-b91f-b6d10962d65e","description":"Data Pipeline Application","artifact":{"name":"cdap-data-pipeline","version":"6.11.0-SNAPSHOT","scope":"SYSTEM"},"change":{"author":"cdap","creationTimeMillis":1732664780982,"latest":true,"description":""}}],"nextPageToken":"testPipeline3.a35a9b04-ac50-11ef-b91f-b6d10962d65e"}
```
-  There are a total of 62 deployed pipelines 
```
boosted-latest-enterprise-2-router-785c9b7f4c-kbft4:/$ curl -X POST localhost:11015/v3/metrics/query?metric=system.application.count
{"startTime":0,"endTime":1732685789,"series":[{"metricName":"system.application.count","grouping":{},"data":[{"time":0,"value":62}]}],"resolution":"2147483647s"}
```
- Ran multiple pipelines successfully -
<img width="1627" alt="Screenshot 2024-11-27 at 11 43 53 AM" src="https://github.com/user-attachments/assets/7603bbc5-fbba-4f38-98d2-3f7bd9e693b1">


