### PR TITLE
fix audit log setter hook to return correct start and endTime for the request

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/auditlogging/AuditLogSetterHook.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/auditlogging/AuditLogSetterHook.java
@@ -57,13 +57,15 @@ public class AuditLogSetterHook extends AbstractHandlerHook {
     }
 
     String startTimeStr = request.headers().get(HttpHeaderNames.CDAP_REQ_TIMESTAMP_HDR);
-    Long currTime = System.nanoTime();
-    Long startTime = null;
+    Long endTimeNanos = System.nanoTime();
+    Long startTimeNanos = null;
     if (startTimeStr != null) {
-      startTime = Long.parseLong(startTimeStr);
+      startTimeNanos = Long.parseLong(startTimeStr);
     } else {
-      startTime = currTime;
+      startTimeNanos = endTimeNanos;
     }
+    long endTime = System.currentTimeMillis() * 1000000;
+    long startTime = endTime - (endTimeNanos - startTimeNanos);
 
     LOG.trace("Setting a Audit Log event to published in SecurityRequestContext");
     SecurityRequestContext.setAuditLogRequest(
@@ -76,7 +78,7 @@ public class AuditLogSetterHook extends AbstractHandlerHook {
         request.method().name(),
         SecurityRequestContext.getAuditLogQueue(),
         startTime,
-        currTime
+        endTime
       )
     );
   }


### PR DESCRIPTION
context:

`System.nanoTime()` method provides nanosecond precision, but not necessarily nanosecond resolution (that is, how frequently the value changes) - no guarantees are made except that the resolution is at least as good as that of `System.currentTimeMillis()`.