### PR TITLE
[CDAP-21079] Fix messaging module used by dataproc

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
@@ -65,7 +65,7 @@ import io.cdap.cdap.logging.guice.TMSLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.messaging.client.ClientMessagingService;
-import io.cdap.cdap.messaging.guice.MessagingServiceModule;
+import io.cdap.cdap.messaging.guice.MessagingClientModule;
 import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.metadata.RemotePreferencesFetcherInternal;
@@ -164,7 +164,7 @@ public class DistributedProgramContainerModule extends AbstractModule {
     modules.add(new IOModule());
     modules.add(new DFSLocationModule());
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
-    modules.add(new MessagingServiceModule(cConf));
+    modules.add(new MessagingClientModule());
     modules.add(new AuditModule());
     modules.add(new AuthorizationEnforcementModule().getDistributedModules());
     modules.add(new SecureStoreClientModule());


### PR DESCRIPTION
When I created pipeline for testing spanner messaging service changes, pipeline was stuck at STARTING state for 40 mins after which it failed.

Property "messaging.service.name" was set to SpannerMessagingService.

**Investigation:**

Dataproc cluster logs showed following error:
```
Unsupported messaging service implementation SpannerMessagingService    at io.cdap.cdap.messaging.client.DelegatingMessagingService.getDelegate(DelegatingMessagingService.java:141)    at io.cdap.cdap.messaging.client.DelegatingMessagingService.publish(DelegatingMessagingService.java:100)    at io.cdap.cdap.internal.app.runtime.workflow.MessagingWorkflowStateWriter.lambda$setWorkflowToken$0(MessagingWorkflowStateWriter.java:60)    at io.cdap.cdap.common.service.Retries.lambda$callWithRetries$2(Retries.java:195)    at io.cdap.cdap.common.service.Retries.callWithRetries(Retries.java:228)    at io.cdap.cdap.common.service.Retries.callWithRetries(Retries.java:195)    at io.cdap.cdap.internal.app.runtime.workflow.MessagingWorkflowStateWriter.setWorkflowToken(MessagingWorkflowStateWriter.java:60)    at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.initializeWorkflow(WorkflowDriver.java:239)    at io.cdap.cdap.internal.app.runtime.workflow.WorkflowDriver.startUp(WorkflowDriver.java:215)    at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:47)    at java.base/java.lang.Thread.run(Thread.java:829)    Suppressed: io.cdap.cdap.api.retry.RetriesExhaustedException: Retries exhausted after 1001 failures and 1989463 ms.        at io.cdap.cdap.common.service.Retries.callWithRetries(Retries.java:247)        ... 6 common frames omitted
```

Once I updated the binding to use ClientMessagingService, pipeline run was SUCCESSFUL.
Dataproc is supposed to publish logs via Client messaging service and not Spanner directly.

**This change has no impact on TMS as by default TMS uses ClientMessagingService.**