### PR TITLE
[CDAP-21093] Add error classification info in mdc tags

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1529,6 +1529,10 @@ public final class Constants {
 
     public static final String EVENT_TYPE_TAG = "MDC:eventType";
     public static final String USER_LOG_TAG_VALUE = "userLog";
+    public static final String TAG_FAILED_STAGE = "failedStage";
+    public static final String TAG_ERROR_CATEGORY = "errorCategory";
+    public static final String TAG_ERROR_REASON = "errorReason";
+    public static final String TAG_ERROR_TYPE = "errorType";
   }
 
   /**

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/ErrorClassificationLoggingTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/ErrorClassificationLoggingTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2024 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.logging.appender;
+
+import com.google.inject.Injector;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.ProgramFailureException;
+import io.cdap.cdap.api.exception.WrappedStageException;
+import io.cdap.cdap.common.conf.Constants.Logging;
+import io.cdap.cdap.common.logging.LoggingContext;
+import io.cdap.cdap.common.logging.LoggingContextAccessor;
+import io.cdap.cdap.logging.context.WorkerLoggingContext;
+import io.cdap.cdap.logging.filter.Filter;
+import io.cdap.cdap.logging.filter.FilterParser;
+import io.cdap.cdap.logging.framework.local.LocalLogAppender;
+import io.cdap.cdap.logging.read.FileLogReader;
+import io.cdap.cdap.logging.read.LogEvent;
+import io.cdap.cdap.logging.read.LogOffset;
+import io.cdap.cdap.logging.read.ReadRange;
+import java.util.Map;
+import org.apache.tephra.TransactionManager;
+import org.joda.time.DateTime;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This test class verifies that error classification tags are correctly added to log events when
+ * exceptions of type {@link ProgramFailureException} and {@link WrappedStageException} are thrown.
+ */
+public class ErrorClassificationLoggingTest {
+  private static Injector injector;
+  private static TransactionManager txManager;
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  @BeforeClass
+  public static void setUpContext() throws Exception {
+    injector = LoggingTester.createInjector(TMP_FOLDER);
+    txManager = LoggingTester.createTransactionManager(injector);
+  }
+
+  @Test
+  public void testErrorClassificationTagsArePresent() {
+    LogAppender appender = injector.getInstance(LocalLogAppender.class);
+    new LogAppenderInitializer(appender).initialize("ErrorClassificationLoggingTest");
+    Logger logger = LoggerFactory.getLogger("ErrorClassificationLoggingTest");
+
+    LoggingContext context = new WorkerLoggingContext("namespace", "app",
+        "workerid", "runid", null);
+    LoggingContextAccessor.setLoggingContext(context);
+    logger.error("Some message", new WrappedStageException(
+        new ProgramFailureException.Builder()
+            .withErrorCategory(new ErrorCategory(ErrorCategory.ErrorCategoryEnum.PLUGIN))
+            .withErrorReason("error Reason")
+            .withErrorType(ErrorType.USER)
+            .build(), "stageName"));
+    appender.stop();
+
+    FileLogReader logReader = injector.getInstance(FileLogReader.class);
+    Filter filter = FilterParser.parse("");
+    ReadRange readRange = new ReadRange(0, new DateTime().getMillis(),
+        LogOffset.INVALID_KAFKA_OFFSET);
+
+    CloseableIterator<LogEvent> logIter = logReader.getLog(context, readRange.getFromMillis(),
+        readRange.getToMillis(), filter);
+
+    LogEvent logEvent = logIter.next();
+    Map<String, String> mdc = logEvent.getLoggingEvent().getMDCPropertyMap();
+    String failedStage = mdc.get(Logging.TAG_FAILED_STAGE);
+    String errorCategory = mdc.get(Logging.TAG_ERROR_CATEGORY);
+    String errorReason = mdc.get(Logging.TAG_ERROR_REASON);
+    String errorType = mdc.get(Logging.TAG_ERROR_TYPE);
+    Assert.assertEquals("stageName", failedStage);
+    Assert.assertEquals("Plugin", errorCategory);
+    Assert.assertEquals("error Reason", errorReason);
+    Assert.assertEquals("USER", errorType);
+  }
+
+  @AfterClass
+  public static void cleanUp() throws Exception {
+    txManager.stopAndWait();
+  }
+}


### PR DESCRIPTION
Jira : [CDAP-21093](https://cdap.atlassian.net/browse/CDAP-21093)

### Description

This PR adds support for adding error classification info in mdc tags.

### Unit Tests

- Added `ErrorClassificationLoggingTest.java`

### Tested in CDAP Sandbox

![image](https://github.com/user-attachments/assets/bcb59792-0e7c-4ae1-8268-e26b11ec4622)


[CDAP-21093]: https://cdap.atlassian.net/browse/CDAP-21093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ