### PR TITLE
[CDAP-21096] Split Appfabric into stateless service and stateful processor

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/MonitorHandlerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/MonitorHandlerModule.java
@@ -40,8 +40,10 @@ import io.cdap.cdap.data2.dataset2.lib.kv.InMemoryKVTableDefinition;
 import io.cdap.cdap.data2.dataset2.lib.kv.LevelDBKVTableDefinition;
 import io.cdap.cdap.gateway.handlers.DatasetServiceStore;
 import io.cdap.cdap.gateway.handlers.MonitorHandler;
+import io.cdap.cdap.internal.app.runtime.distributed.AppFabricProcessorManager;
 import io.cdap.cdap.internal.app.runtime.distributed.AppFabricServiceManager;
 import io.cdap.cdap.internal.app.runtime.distributed.TransactionServiceManager;
+import io.cdap.cdap.internal.app.runtime.monitor.NonHadoopAppFabricProcessorManager;
 import io.cdap.cdap.internal.app.runtime.monitor.NonHadoopAppFabricServiceManager;
 import io.cdap.cdap.internal.app.runtime.monitor.RuntimeServiceManager;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
@@ -92,7 +94,7 @@ public class MonitorHandlerModule extends AbstractModule {
     });
 
     Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(
-        binder(), HttpHandler.class, Names.named(Constants.AppFabric.HANDLERS_BINDING));
+        binder(), HttpHandler.class, Names.named(Constants.AppFabric.SERVER_HANDLERS_BINDING));
 
     handlerBinder.addBinding().to(MonitorHandler.class);
   }
@@ -117,6 +119,9 @@ public class MonitorHandlerModule extends AbstractModule {
     mapBinder.addBinding(Constants.Service.APP_FABRIC_HTTP)
         .toProvider(
             new NonHadoopMasterServiceManagerProvider(NonHadoopAppFabricServiceManager.class));
+    mapBinder.addBinding(Constants.Service.APP_FABRIC_PROCESSOR)
+        .toProvider(
+            new NonHadoopMasterServiceManagerProvider(NonHadoopAppFabricProcessorManager.class));
     mapBinder.addBinding(Constants.Service.DATASET_EXECUTOR)
         .toProvider(new NonHadoopMasterServiceManagerProvider(DatasetExecutorServiceManager.class));
     mapBinder.addBinding(Constants.Service.METADATA_SERVICE)
@@ -144,6 +149,7 @@ public class MonitorHandlerModule extends AbstractModule {
         .to(MetricsProcessorStatusServiceManager.class);
     mapBinder.addBinding(Constants.Service.METRICS).to(MetricsServiceManager.class);
     mapBinder.addBinding(Constants.Service.APP_FABRIC_HTTP).to(AppFabricServiceManager.class);
+    mapBinder.addBinding(Constants.Service.APP_FABRIC_PROCESSOR).to(AppFabricProcessorManager.class);
     mapBinder.addBinding(Constants.Service.DATASET_EXECUTOR)
         .to(DatasetExecutorServiceManager.class);
     mapBinder.addBinding(Constants.Service.METADATA_SERVICE).to(MetadataServiceManager.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AppFabricProcessorManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/distributed/AppFabricProcessorManager.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.distributed;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.AppFabric;
+import io.cdap.cdap.common.twill.AbstractMasterServiceManager;
+import org.apache.twill.api.TwillRunner;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+/**
+ * App Fabric Processor Service Management in Distributed Mode.
+ */
+public class AppFabricProcessorManager extends AbstractMasterServiceManager {
+
+  @Inject
+  AppFabricProcessorManager(CConfiguration cConf, TwillRunner twillRunner,
+      DiscoveryServiceClient discoveryClient) {
+    super(cConf, discoveryClient, Constants.Service.APP_FABRIC_PROCESSOR, twillRunner);
+  }
+
+  @Override
+  public String getDescription() {
+    return AppFabric.PROCESSOR_DESCRIPTION;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/NonHadoopAppFabricProcessorManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/monitor/NonHadoopAppFabricProcessorManager.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.monitor;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.twill.AbstractMasterServiceManager;
+import org.apache.twill.api.TwillRunner;
+import org.apache.twill.discovery.DiscoveryServiceClient;
+
+/**
+ * Service for managing app fabric processor service.
+ */
+public class NonHadoopAppFabricProcessorManager extends AbstractMasterServiceManager {
+
+  @Inject
+  NonHadoopAppFabricProcessorManager(CConfiguration cConf, DiscoveryServiceClient discoveryClient,
+      TwillRunner twillRunner) {
+    super(cConf, discoveryClient, Constants.Service.APP_FABRIC_PROCESSOR, twillRunner);
+  }
+
+  @Override
+  public String getDescription() {
+    return Constants.AppFabric.PROCESSOR_DESCRIPTION;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisioningService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/ProvisioningService.java
@@ -111,6 +111,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Service for provisioning related operations.
+ *
+ * TODO (CDAP-21111): Split ProvisioningService for Appfabric Server and Appfabric Processor.
  */
 public class ProvisioningService extends AbstractIdleService {
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/CoreSchedulerService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/scheduler/CoreSchedulerService.java
@@ -98,7 +98,6 @@ public class CoreSchedulerService extends AbstractIdleService implements Schedul
 
   @Inject
   CoreSchedulerService(TimeSchedulerService timeSchedulerService,
-      ScheduleNotificationSubscriberService scheduleNotificationSubscriberService,
       ConstraintCheckerService constraintCheckerService,
       MessagingService messagingService,
       CConfiguration cConf, Store store, Impersonator impersonator,
@@ -124,14 +123,12 @@ public class CoreSchedulerService extends AbstractIdleService implements Schedul
         timeSchedulerService.startAndWait();
         cleanupJobs();
         constraintCheckerService.startAndWait();
-        scheduleNotificationSubscriberService.startAndWait();
         startedLatch.countDown();
         LOG.info("Started core scheduler service.");
       }
 
       @Override
       protected void shutDown() {
-        scheduleNotificationSubscriberService.stopAndWait();
         constraintCheckerService.stopAndWait();
         timeSchedulerService.stopAndWait();
         LOG.info("Stopped core scheduler service.");

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/AppFabricProcessorServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/AppFabricProcessorServiceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.services;
+
+import com.google.common.util.concurrent.Service;
+import com.google.inject.Injector;
+import io.cdap.cdap.internal.AppFabricTestHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AppFabricProcessorServiceTest {
+
+  @Test
+  public void startStopService() {
+    try {
+      Injector injector = AppFabricTestHelper.getInjector();
+      AppFabricProcessorService service = injector.getInstance(AppFabricProcessorService.class);
+      Service.State state = service.startAndWait();
+      Assert.assertSame(state, Service.State.RUNNING);
+
+      state = service.stopAndWait();
+      Assert.assertSame(state, Service.State.TERMINATED);
+    } finally {
+      AppFabricTestHelper.shutdown();
+    }
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/DefaultSecureStoreServiceTest.java
@@ -77,6 +77,7 @@ public class DefaultSecureStoreServiceTest {
   private static SecureStore secureStore;
   private static SecureStoreManager secureStoreManager;
   private static AppFabricServer appFabricServer;
+  private static AppFabricProcessorService appFabricProcessor;
   private static RoleController roleController;
   private static PermissionManager permissionManager;
   private static DiscoveryServiceClient discoveryServiceClient;
@@ -93,6 +94,8 @@ public class DefaultSecureStoreServiceTest {
     discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
+    appFabricProcessor = injector.getInstance(AppFabricProcessorService.class);
+    appFabricProcessor.startAndWait();
     waitForService(Constants.Service.DATASET_MANAGER);
     secureStore = injector.getInstance(SecureStore.class);
     secureStoreManager = injector.getInstance(SecureStoreManager.class);
@@ -125,6 +128,7 @@ public class DefaultSecureStoreServiceTest {
   @AfterClass
   public static void cleanup() {
     appFabricServer.stopAndWait();
+    appFabricProcessor.stopAndWait();
     AppFabricTestHelper.shutdown();
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramLifecycleServiceAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramLifecycleServiceAuthorizationTest.java
@@ -69,6 +69,7 @@ public class ProgramLifecycleServiceAuthorizationTest {
   private static CConfiguration cConf;
   private static PermissionManager permissionManager;
   private static AppFabricServer appFabricServer;
+  private static AppFabricProcessorService appFabricProcessor;
   private static ProgramLifecycleService programLifecycleService;
 
   @BeforeClass
@@ -78,6 +79,8 @@ public class ProgramLifecycleServiceAuthorizationTest {
     permissionManager = injector.getInstance(PermissionManager.class);
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
+    appFabricProcessor = injector.getInstance(AppFabricProcessorService.class);
+    appFabricProcessor.startAndWait();
     programLifecycleService = injector.getInstance(ProgramLifecycleService.class);
 
     // Wait for the default namespace creation
@@ -159,6 +162,7 @@ public class ProgramLifecycleServiceAuthorizationTest {
   @AfterClass
   public static void tearDown() {
     appFabricServer.stopAndWait();
+    appFabricProcessor.stopAndWait();
     AppFabricTestHelper.shutdown();
   }
 

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -78,6 +78,7 @@ import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleStatus;
 import io.cdap.cdap.internal.app.runtime.schedule.store.Schedulers;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
+import io.cdap.cdap.internal.app.services.AppFabricProcessorService;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.internal.schedule.constraint.Constraint;
@@ -212,6 +213,7 @@ public abstract class AppFabricTestBase {
   private static MessagingService messagingService;
   private static TransactionManager txManager;
   private static AppFabricServer appFabricServer;
+  private static AppFabricProcessorService appFabricProcessorService;
   private static MetricsCollectionService metricsCollectionService;
   private static DatasetOpExecutorService dsOpService;
   private static DatasetService datasetService;
@@ -277,6 +279,8 @@ public abstract class AppFabricTestBase {
 
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
+    appFabricProcessorService = injector.getInstance(AppFabricProcessorService.class);
+    appFabricProcessorService.startAndWait();
     DiscoveryServiceClient discoveryClient = injector.getInstance(DiscoveryServiceClient.class);
     appFabricEndpointStrategy = new RandomEndpointStrategy(
       () -> discoveryClient.discover(Constants.Service.APP_FABRIC_HTTP));
@@ -315,6 +319,7 @@ public abstract class AppFabricTestBase {
   @AfterClass
   public static void afterClass() {
     appFabricServer.stopAndWait();
+    appFabricProcessorService.stopAndWait();
     metricsCollectionService.stopAndWait();
     datasetService.stopAndWait();
     dsOpService.stopAndWait();

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/MonitorHandlerTest.java
@@ -66,7 +66,7 @@ public class MonitorHandlerTest extends AppFabricTestBase {
     List<SystemServiceMeta> actual = GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()),
                                                        Charsets.UTF_8), token);
 
-    Assert.assertEquals(9, actual.size());
+    Assert.assertEquals(10, actual.size());
     urlConn.disconnect();
   }
 
@@ -81,7 +81,7 @@ public class MonitorHandlerTest extends AppFabricTestBase {
 
     Map<String, String> result = GSON.fromJson(new String(ByteStreams.toByteArray(urlConn.getInputStream()),
                                                Charsets.UTF_8), token);
-    Assert.assertEquals(9, result.size());
+    Assert.assertEquals(10, result.size());
     urlConn.disconnect();
     Assert.assertEquals("OK", result.get(Constants.Service.APP_FABRIC_HTTP));
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/MetadataAdminAuthorizationTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/metadata/MetadataAdminAuthorizationTest.java
@@ -28,6 +28,7 @@ import io.cdap.cdap.common.namespace.NamespaceAdmin;
 import io.cdap.cdap.common.test.AppJarHelper;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.internal.AppFabricTestHelper;
+import io.cdap.cdap.internal.app.services.AppFabricProcessorService;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ApplicationId;
@@ -71,6 +72,7 @@ public class MetadataAdminAuthorizationTest {
   private static RoleController roleController;
   private static PermissionManager permissionManager;
   private static AppFabricServer appFabricServer;
+  private static AppFabricProcessorService appFabricProcessor;
 
   @BeforeClass
   public static void setup() throws Exception {
@@ -82,6 +84,8 @@ public class MetadataAdminAuthorizationTest {
 
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
+    appFabricProcessor = injector.getInstance(AppFabricProcessorService.class);
+    appFabricProcessor.startAndWait();
 
     // Wait for the default namespace creation
     String user = AuthorizationUtil.getEffectiveMasterUser(cConf);
@@ -170,6 +174,7 @@ public class MetadataAdminAuthorizationTest {
   @AfterClass
   public static void tearDown() {
     appFabricServer.stopAndWait();
+    appFabricProcessor.stopAndWait();
     AppFabricTestHelper.shutdown();
   }
 

--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -237,7 +237,7 @@ public class HydratorTestBase extends TestBase {
       } catch (ApplicationNotFoundException exception) {
         throw new RetryableException(String.format("App %s not yet deployed", pipeline));
       }
-    }, RetryStrategies.limit(10, RetryStrategies.fixDelay(15, TimeUnit.SECONDS)));
+    }, RetryStrategies.limit(20, RetryStrategies.fixDelay(15, TimeUnit.SECONDS)));
   }
 
 }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -121,6 +121,7 @@ public final class Constants {
   public static final class Service {
 
     public static final String APP_FABRIC_HTTP = "appfabric";
+    public static final String APP_FABRIC_PROCESSOR = "appfabric.processor";
     public static final String TRANSACTION = "transaction";
     public static final String TRANSACTION_HTTP = "transaction.http";
     public static final String METRICS = "metrics";
@@ -302,7 +303,8 @@ public final class Constants {
     /**
      * Guice named bindings.
      */
-    public static final String HANDLERS_BINDING = "appfabric.http.handler";
+    public static final String SERVER_HANDLERS_BINDING = "appfabric.http.handler";
+    public static final String PROCESSOR_HANDLERS_BINDING = "appfabric.processor.http.handler";
 
     /**
      * Defaults.
@@ -333,7 +335,9 @@ public final class Constants {
      */
     public static final String QUERY_PARAM_LIMIT = "limit";
 
-    public static final String SERVICE_DESCRIPTION = "Service for managing application lifecycle.";
+    public static final String SERVICE_DESCRIPTION = "Service for managing HTTP handlers.";
+
+    public static final String PROCESSOR_DESCRIPTION = "Service for managing application lifecycle.";
 
     /**
      * Configuration setting to set the maximum size of a workflow token in MB.

--- a/cdap-docs/reference-manual/source/http-restful-api/monitor.rst
+++ b/cdap-docs/reference-manual/source/http-restful-api/monitor.rst
@@ -105,6 +105,9 @@ The status of these CDAP system services can be checked:
    * - ``App Fabric``
      - ``appfabric``
      - Service that handles application fabric requests
+   * - ``App Fabric Processor``
+     - ``appfabric.processor``
+     - Service that handles application lifecycle
    * - ``Log Saver``
      - ``log.saver``
      - Service that aggregates all system and application logs

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayTestBase.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/GatewayTestBase.java
@@ -38,6 +38,7 @@ import io.cdap.cdap.data2.datafabric.dataset.service.DatasetService;
 import io.cdap.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
 import io.cdap.cdap.gateway.handlers.log.MockLogReader;
 import io.cdap.cdap.gateway.router.NettyRouter;
+import io.cdap.cdap.internal.app.services.AppFabricProcessorService;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.internal.guice.AppFabricTestModule;
 import io.cdap.cdap.logging.read.LogReader;
@@ -106,6 +107,7 @@ public abstract class GatewayTestBase {
 
   private static Injector injector;
   private static AppFabricServer appFabricServer;
+  private static AppFabricProcessorService appFabricProcessorService;
   private static NettyRouter router;
   private static LogQueryService logQueryService;
   private static MetricsQueryService metricsQueryService;
@@ -194,6 +196,8 @@ public abstract class GatewayTestBase {
     datasetService.startAndWait();
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
+    appFabricProcessorService = injector.getInstance(AppFabricProcessorService.class);
+    appFabricProcessorService.startAndWait();
     logQueryService = injector.getInstance(LogQueryService.class);
     logQueryService.startAndWait();
     metricsQueryService = injector.getInstance(MetricsQueryService.class);
@@ -217,6 +221,7 @@ public abstract class GatewayTestBase {
     namespaceAdmin.delete(new NamespaceId(TEST_NAMESPACE2));
     namespaceAdmin.delete(NamespaceId.DEFAULT);
     appFabricServer.stopAndWait();
+    appFabricProcessorService.stopAndWait();
     metricsCollectionService.stopAndWait();
     metricsQueryService.stopAndWait();
     logQueryService.stopAndWait();

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
@@ -48,7 +48,7 @@ public class RouterPathLookupTest {
     String path = "/v3/bootstrap";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), path);
     RouteDestination result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
   }
 
   @Test
@@ -56,7 +56,7 @@ public class RouterPathLookupTest {
     String path = "/v3/namespaces/n1/runs";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), path);
     RouteDestination result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
   }
 
   @Test
@@ -165,13 +165,13 @@ public class RouterPathLookupTest {
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), servicePath);
     httpRequest.headers().set(Constants.Gateway.API_KEY, API_KEY);
     RouteDestination result = pathLookup.getRoutingService(servicePath, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
 
     servicePath = "v3/namespaces/some/apps/otherAppName/services/CatalogLookup//methods////";
     httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), servicePath);
     httpRequest.headers().set(Constants.Gateway.API_KEY, API_KEY);
     result = pathLookup.getRoutingService(servicePath, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
 
     // v3 servicePaths
     servicePath = "/v3/namespaces/testnamespace/apps//PurchaseHistory///services/CatalogLookup///methods//ping/1";
@@ -207,13 +207,13 @@ public class RouterPathLookupTest {
     httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), servicePath);
     httpRequest.headers().set(Constants.Gateway.API_KEY, API_KEY);
     result = pathLookup.getRoutingService(servicePath, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
 
     servicePath = "v3/namespaces/testnamespace/apps/AppName/services/CatalogLookup////methods////";
     httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), servicePath);
     httpRequest.headers().set(Constants.Gateway.API_KEY, API_KEY);
     result = pathLookup.getRoutingService(servicePath, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
   }
 
   @Test
@@ -226,7 +226,7 @@ public class RouterPathLookupTest {
     String path = "/v3/namespaces/default//apps/ResponseCodeAnalytics/services/LogAnalyticsService/status";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), path);
     RouteDestination result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
   }
 
   @Test
@@ -234,7 +234,7 @@ public class RouterPathLookupTest {
     String path = "/v3/namespaces/default/apps///PurchaseHistory///workflows/PurchaseHistoryWorkflow/status";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), path);
     RouteDestination result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP,  result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR,  result);
   }
 
   @Test
@@ -242,7 +242,7 @@ public class RouterPathLookupTest {
     String path = "/v3/namespaces/default//apps/";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), path);
     RouteDestination result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP,  result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR,  result);
   }
 
   @Test
@@ -250,7 +250,7 @@ public class RouterPathLookupTest {
     String path = "/v3/namespaces/default//apps/WordCount/services/WordCountService/instances";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), path);
     RouteDestination result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP,  result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR,  result);
   }
 
   @Test
@@ -376,6 +376,8 @@ public class RouterPathLookupTest {
                   RouterPathLookup.METRICS);
     assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.APP_FABRIC_HTTP),
                   RouterPathLookup.APP_FABRIC_HTTP);
+    assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.APP_FABRIC_PROCESSOR),
+        RouterPathLookup.APP_FABRIC_PROCESSOR);
     assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.DATASET_EXECUTOR),
                   RouterPathLookup.DATASET_EXECUTOR);
     assertRouting(String.format("/v3/system/services/%s/status", Constants.Service.METADATA_SERVICE),
@@ -416,6 +418,39 @@ public class RouterPathLookupTest {
     assertRouting("v3/namespaces/default/profiles/p", RouterPathLookup.APP_FABRIC_HTTP);
     assertRouting("v3/namespaces/default/profiles/p/enable", RouterPathLookup.APP_FABRIC_HTTP);
     assertRouting("v3/namespaces/default/profiles/p/disable", RouterPathLookup.APP_FABRIC_HTTP);
+  }
+
+  @Test
+  public void testAppLifecycleAndWorkflowPaths() {
+    assertRouting("v3/namespaces/default/apps", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/default/apps/myapp", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/default/upgrade", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/default/appdetail", RouterPathLookup.APP_FABRIC_PROCESSOR);
+  }
+
+  @Test
+  public void testProgramLifecyclePaths() {
+    for (String part : RouterPathLookup.APP_FABRIC_PROCESSOR_PATH_PARTS) {
+      assertRouting("v3/namespaces/default/" + part, RouterPathLookup.APP_FABRIC_PROCESSOR);
+    }
+  }
+
+  @Test
+  public void testProgramLifecycleInternalAndAppLifecycleInternalPaths() {
+    assertRouting("v3Internal/namespaces//apps//versions//workflows/DataPipelineWorkflow/runs/",
+        RouterPathLookup.APP_FABRIC_PROCESSOR);
+  }
+
+  @Test
+  public void testUsagePaths() {
+    assertRouting("v3/namespaces//apps//datasets", RouterPathLookup.APP_FABRIC_HTTP);
+    assertRouting("v3/namespaces//apps////datasets", RouterPathLookup.APP_FABRIC_HTTP);
+  }
+
+  @Test
+  public void testAppPreferencesPaths() {
+    assertRouting("v3/namespaces//apps//preferences", RouterPathLookup.APP_FABRIC_HTTP);
+    assertRouting("v3/namespaces//apps////preferences", RouterPathLookup.APP_FABRIC_HTTP);
   }
 
   @Test

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RoutingToDataSetsTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RoutingToDataSetsTest.java
@@ -49,11 +49,13 @@ import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * TODO: Eventually this can be removed, since we do not have any proxy rules anymore for datasets.
  */
+@Ignore
 public class RoutingToDataSetsTest {
 
   private static NettyRouter nettyRouter;

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
@@ -68,6 +68,7 @@ import io.cdap.cdap.data2.metadata.writer.MessagingMetadataPublisher;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
 import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
 import io.cdap.cdap.internal.app.runtime.monitor.RuntimeServer;
+import io.cdap.cdap.internal.app.services.AppFabricProcessorService;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
@@ -653,6 +654,7 @@ public class MasterServiceMain extends DaemonMain {
       services.add(new RetryOnStartFailureService(() -> injector.getInstance(DatasetService.class),
           RetryStrategies.exponentialDelay(200, 5000, TimeUnit.MILLISECONDS)));
       services.add(injector.getInstance(AppFabricServer.class));
+      services.add(injector.getInstance(AppFabricProcessorService.class));
       executor = Executors.newSingleThreadScheduledExecutor(
           Threads.createDaemonThreadFactory("master-runner"));
 

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricProcessorServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricProcessorServiceMain.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.master.environment.k8s;
+
+import com.google.common.util.concurrent.Service;
+import com.google.inject.AbstractModule;
+import com.google.inject.Binding;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.google.inject.util.Modules;
+import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule;
+import io.cdap.cdap.app.guice.AuthorizationModule;
+import io.cdap.cdap.app.guice.MonitorHandlerModule;
+import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
+import io.cdap.cdap.app.store.ServiceStore;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.SystemWorker;
+import io.cdap.cdap.common.guice.DFSLocationModule;
+import io.cdap.cdap.common.guice.SupplierProviderBridge;
+import io.cdap.cdap.common.logging.LoggingContext;
+import io.cdap.cdap.common.logging.ServiceLoggingContext;
+import io.cdap.cdap.common.service.RetryOnStartFailureService;
+import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.data.runtime.DataSetServiceModules;
+import io.cdap.cdap.data.runtime.DataSetsModules;
+import io.cdap.cdap.data2.audit.AuditModule;
+import io.cdap.cdap.data2.datafabric.dataset.service.DatasetService;
+import io.cdap.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
+import io.cdap.cdap.data2.metadata.writer.DefaultMetadataServiceClient;
+import io.cdap.cdap.data2.metadata.writer.MessagingMetadataPublisher;
+import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
+import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
+import io.cdap.cdap.internal.app.namespace.LocalStorageProviderNamespaceAdmin;
+import io.cdap.cdap.internal.app.namespace.StorageProviderNamespaceAdmin;
+import io.cdap.cdap.internal.app.services.AppFabricProcessorService;
+import io.cdap.cdap.internal.app.worker.TaskWorkerServiceLauncher;
+import io.cdap.cdap.internal.app.worker.system.SystemWorkerServiceLauncher;
+import io.cdap.cdap.internal.events.EventPublishManager;
+import io.cdap.cdap.master.spi.environment.MasterEnvironment;
+import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
+import io.cdap.cdap.messaging.guice.MessagingServiceModule;
+import io.cdap.cdap.metrics.guice.MetricsStoreModule;
+import io.cdap.cdap.operations.OperationalStatsService;
+import io.cdap.cdap.operations.guice.OperationalStatsModule;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
+import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
+import io.cdap.cdap.security.guice.SecureStoreServerModule;
+import io.cdap.cdap.security.store.SecureStoreService;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.twill.api.TwillRunner;
+import org.apache.twill.api.TwillRunnerService;
+import org.apache.twill.zookeeper.ZKClientService;
+
+/**
+ * The main class to run appfabric processor and other supporting services.
+ */
+public class AppFabricProcessorServiceMain extends AbstractServiceMain<EnvironmentOptions> {
+
+  /**
+   * Main entry point.
+   */
+  public static void main(String[] args) throws Exception {
+    main(AppFabricProcessorServiceMain.class, args);
+  }
+
+  @Override
+  protected List<Module> getServiceModules(MasterEnvironment masterEnv,
+      EnvironmentOptions options, CConfiguration cConf) {
+    return Arrays.asList(
+        // Always use local table implementations, which use LevelDB.
+        // In K8s, there won't be HBase and the cdap-site should be set to use SQL store for StructuredTable.
+        new DataSetServiceModules().getStandaloneModules(),
+        // The Dataset set modules are only needed to satisfy dependency injection
+        new DataSetsModules().getStandaloneModules(),
+        new MetricsStoreModule(),
+        new MessagingServiceModule(cConf),
+        new AuditModule(),
+        new AuthorizationModule(),
+        new AuthorizationEnforcementModule().getMasterModule(),
+        Modules.override(new AppFabricServiceRuntimeModule(cConf).getDistributedModules())
+            .with(new AbstractModule() {
+              @Override
+              protected void configure() {
+                bind(StorageProviderNamespaceAdmin.class).to(
+                    LocalStorageProviderNamespaceAdmin.class);
+              }
+            }),
+        new ProgramRunnerRuntimeModule().getDistributedModules(true),
+        new MonitorHandlerModule(false),
+        new SecureStoreServerModule(),
+        new OperationalStatsModule(),
+        getDataFabricModule(),
+        new DFSLocationModule(),
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(TwillRunnerService.class).toProvider(
+                new SupplierProviderBridge<>(masterEnv.getTwillRunnerSupplier()))
+                .in(Scopes.SINGLETON);
+            bind(TwillRunner.class).to(TwillRunnerService.class);
+
+            // TODO (CDAP-14677): find a better way to inject metadata publisher
+            bind(MetadataPublisher.class).to(MessagingMetadataPublisher.class);
+            bind(MetadataServiceClient.class).to(DefaultMetadataServiceClient.class);
+          }
+        }
+    );
+  }
+
+  @Override
+  protected void addServices(Injector injector, List<? super Service> services,
+      List<? super AutoCloseable> closeableResources,
+      MasterEnvironment masterEnv, MasterEnvironmentContext masterEnvContext,
+      EnvironmentOptions options) {
+    final CConfiguration cConf = injector.getInstance(CConfiguration.class);
+    closeableResources.add(injector.getInstance(AccessControllerInstantiator.class));
+    services.add(injector.getInstance(OperationalStatsService.class));
+    services.add(injector.getInstance(SecureStoreService.class));
+    services.add(injector.getInstance(DatasetOpExecutorService.class));
+    services.add(injector.getInstance(ServiceStore.class));
+
+    Binding<ZKClientService> zkBinding = injector.getExistingBinding(
+        Key.get(ZKClientService.class));
+    if (zkBinding != null) {
+      services.add(zkBinding.getProvider().get());
+    }
+
+    // Start both the remote TwillRunnerService and regular TwillRunnerService
+    TwillRunnerService remoteTwillRunner = injector.getInstance(Key.get(TwillRunnerService.class,
+        Constants.AppFabric.RemoteExecution.class));
+    services.add(new TwillRunnerServiceWrapper(remoteTwillRunner));
+    services.add(new TwillRunnerServiceWrapper(injector.getInstance(TwillRunnerService.class)));
+    services.add(new RetryOnStartFailureService(() -> injector.getInstance(DatasetService.class),
+        RetryStrategies.exponentialDelay(200, 5000, TimeUnit.MILLISECONDS)));
+    services.add(injector.getInstance(AppFabricProcessorService.class));
+    services.add(new RetryOnStartFailureService(
+        () -> injector.getInstance(NamespaceInitializerService.class),
+        RetryStrategies.exponentialDelay(200, 5000, TimeUnit.MILLISECONDS)));
+
+    if (cConf.getBoolean(Constants.TaskWorker.POOL_ENABLE)) {
+      services.add(injector.getInstance(TaskWorkerServiceLauncher.class));
+    }
+
+    if (cConf.getBoolean(SystemWorker.POOL_ENABLE)) {
+      services.add(injector.getInstance(SystemWorkerServiceLauncher.class));
+    }
+
+    // Event publisher could rely on task workers for token generated for security enabled deployments
+    services.add(injector.getInstance(EventPublishManager.class));
+
+    // Adds the master environment tasks
+    masterEnv.getTasks()
+        .forEach(task -> services.add(new MasterTaskExecutorService(task, masterEnvContext)));
+  }
+
+  @Nullable
+  @Override
+  protected LoggingContext getLoggingContext(EnvironmentOptions options) {
+    return new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
+        Constants.Logging.COMPONENT_NAME,
+        Constants.Service.APP_FABRIC_PROCESSOR);
+  }
+}

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
@@ -117,6 +117,7 @@ public class MasterServiceMainTestBase {
             MetadataServiceMain.class,
             RuntimeServiceMain.class,
             AppFabricServiceMain.class,
+            AppFabricProcessorServiceMain.class,
             SupportBundleServiceMain.class,
             SystemMetricsExporterServiceMain.class,
             ArtifactCacheServiceMain.class,

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -68,6 +68,7 @@ import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
 import io.cdap.cdap.gateway.router.NettyRouter;
 import io.cdap.cdap.gateway.router.RouterModules;
 import io.cdap.cdap.internal.app.runtime.monitor.RuntimeServer;
+import io.cdap.cdap.internal.app.services.AppFabricProcessorService;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerService;
 import io.cdap.cdap.internal.events.EventPublishManager;
@@ -134,6 +135,7 @@ public class StandaloneMain {
   private final MetricsQueryService metricsQueryService;
   private final LogQueryService logQueryService;
   private final AppFabricServer appFabricServer;
+  private final AppFabricProcessorService appFabricProcessorService;
   private final ServiceStore serviceStore;
   private final MetricsCollectionService metricsCollectionService;
   private final LogAppenderInitializer logAppenderInitializer;
@@ -174,6 +176,7 @@ public class StandaloneMain {
     metricsQueryService = injector.getInstance(MetricsQueryService.class);
     logQueryService = injector.getInstance(LogQueryService.class);
     appFabricServer = injector.getInstance(AppFabricServer.class);
+    appFabricProcessorService = injector.getInstance(AppFabricProcessorService.class);
     logAppenderInitializer = injector.getInstance(LogAppenderInitializer.class);
     metricsCollectionService = injector.getInstance(MetricsCollectionService.class);
     datasetService = injector.getInstance(DatasetService.class);
@@ -277,6 +280,11 @@ public class StandaloneMain {
       throw new Exception("Failed to start Application Fabric");
     }
 
+    state = appFabricProcessorService.startAndWait();
+    if (state != Service.State.RUNNING) {
+      throw new Exception("Failed to start Application Fabric Processor");
+    }
+
     artifactLocalizerService.startAndWait();
     // NOTE: As the artifact localizer client does not use service discovery for port discovery,
     // We need to set the port after starting the localizer service.
@@ -347,6 +355,7 @@ public class StandaloneMain {
       eventSubscriberManager.stopAndWait();
       // app fabric will also stop all programs
       appFabricServer.stopAndWait();
+      appFabricProcessorService.stopAndWait();
       runtimeServer.stopAndWait();
       // all programs are stopped: dataset service, metrics, transactions can stop now
       datasetService.stopAndWait();

--- a/cdap-support-bundle/src/test/java/io/cdap/cdap/SupportBundleTestBase.java
+++ b/cdap-support-bundle/src/test/java/io/cdap/cdap/SupportBundleTestBase.java
@@ -51,6 +51,7 @@ import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
 import io.cdap.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
+import io.cdap.cdap.internal.app.services.AppFabricProcessorService;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.internal.schedule.constraint.Constraint;
 import io.cdap.cdap.logging.service.LogQueryService;
@@ -129,6 +130,7 @@ public abstract class SupportBundleTestBase {
   private static MessagingService messagingService;
   private static TransactionManager txManager;
   private static AppFabricServer appFabricServer;
+  private static AppFabricProcessorService appFabricProcessor;
   private static MetricsCollectionService metricsCollectionService;
   private static DatasetOpExecutorService dsOpService;
   private static DatasetService datasetService;
@@ -200,6 +202,8 @@ public abstract class SupportBundleTestBase {
 
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
+    appFabricProcessor = injector.getInstance(AppFabricProcessorService.class);
+    appFabricProcessor.startAndWait();
     DiscoveryServiceClient discoveryClient = injector.getInstance(DiscoveryServiceClient.class);
     appFabricEndpointStrategy = new RandomEndpointStrategy(
       () -> discoveryClient.discover(Constants.Service.APP_FABRIC_HTTP));
@@ -231,6 +235,7 @@ public abstract class SupportBundleTestBase {
   @AfterClass
   public static void afterClass() throws IOException {
     appFabricServer.stopAndWait();
+    appFabricProcessor.stopAndWait();
     metricsCollectionService.stopAndWait();
     datasetService.stopAndWait();
     dsOpService.stopAndWait();

--- a/cdap-support-bundle/src/test/java/io/cdap/cdap/support/tasks/SupportBundleSystemLogTaskTest.java
+++ b/cdap-support-bundle/src/test/java/io/cdap/cdap/support/tasks/SupportBundleSystemLogTaskTest.java
@@ -85,7 +85,7 @@ public class SupportBundleSystemLogTaskTest extends SupportBundleTestBase {
     List<File> systemLogFiles = DirUtils.listFiles(systemLogFolder,
                                                    file -> !file.isHidden() && !file.getParentFile().isHidden());
 
-    Assert.assertEquals(9, systemLogFiles.size());
+    Assert.assertEquals(10, systemLogFiles.size());
   }
 
   @Before

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -86,6 +86,7 @@ import io.cdap.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorS
 import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
 import io.cdap.cdap.gateway.handlers.AuthorizationHandler;
 import io.cdap.cdap.internal.app.runtime.AppStateStoreProvider;
+import io.cdap.cdap.internal.app.services.AppFabricProcessorService;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.internal.app.worker.sidecar.ArtifactLocalizerService;
 import io.cdap.cdap.internal.capability.CapabilityConfig;
@@ -231,6 +232,7 @@ public class TestBase {
   private static FieldLineageAdmin fieldLineageAdmin;
   private static LineageAdmin lineageAdmin;
   private static AppFabricServer appFabricServer;
+  private static AppFabricProcessorService appFabricProcessorService;
   private static PreferencesService preferencesService;
   private static ArtifactLocalizerService artifactLocalizerService;
   private static AppStateStoreProvider appStateStoreProvider;
@@ -424,6 +426,8 @@ public class TestBase {
     previewRunnerManager.startAndWait();
     appFabricServer = injector.getInstance(AppFabricServer.class);
     appFabricServer.startAndWait();
+    appFabricProcessorService = injector.getInstance(AppFabricProcessorService.class);
+    appFabricProcessorService.startAndWait();
     preferencesService = injector.getInstance(PreferencesService.class);
 
     scheduler = injector.getInstance(Scheduler.class);
@@ -646,6 +650,7 @@ public class TestBase {
       ((Service) messagingService).stopAndWait();
     }
     appFabricServer.stopAndWait();
+    appFabricProcessorService.stopAndWait();
   }
 
   protected MetricsManager getMetricsManager() {

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteProgramRunRecordFetcher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteProgramRunRecordFetcher.java
@@ -45,8 +45,11 @@ public class RemoteProgramRunRecordFetcher implements ProgramRunRecordFetcher {
 
   @Inject
   public RemoteProgramRunRecordFetcher(RemoteClientFactory remoteClientFactory) {
+    // TODO (CDAP-21112): Move HTTP handler from Appfabric processor to server after fixing
+    //  ProgramRuntimeService and RunRecordMonitorService.
+    // Use APP_FABRIC_HTTP instead of APP_FABRIC_PROCESSOR after the fix.
     this.remoteClient = remoteClientFactory.createRemoteClient(
-        Constants.Service.APP_FABRIC_HTTP,
+        Constants.Service.APP_FABRIC_PROCESSOR,
         new DefaultHttpRequestConfig(false),
         Constants.Gateway.INTERNAL_API_VERSION_3);
   }


### PR DESCRIPTION
### Context

Make appfabric service stateless by splitting it into appfabric service to server HTTP requests and appfabric processor to run subscriber services and process message.

### Change Description

* Added new main class `AppFabricProcessorServiceMain` for appfabric processor.
* Added `AppFabricProcessorService` which is used by `AppFabricProcessorServiceMain`.
* Removed messaging subscriber services from `AppFabricServer` and moved them to `AppFabricProcessorService`.
* HTTP handlers are hosted only in `AppFabricServer` and `AppFabricProcessorService` does not have any HTTP handlers.
* Updated test classes to run Appfabric Processor along with Appfabric Server wherever needed.

### Verification

- [x] Unit Tests:
    - Updated test classes to run Appfabric Processor along with Appfabric Server wherever needed.
    - Added UT for `AppFabricProcessorServiceTest` to test Start and Stop (similar to `AppFabricServerTest`).
    - Note: UT cannot be added for `AppFabricProcessorServiceMain` as it does not host and HTTP handlers and runs only subscriber services.
- [x] CDAP sandbox: Tested basic flows.
- [x] Deployed locally built image to a k8s cluster and verified by deployed CRD and CR. (https://github.com/cdapio/cdap-operator/pull/123)