### PR TITLE
[cherrypick][CDAP-21089] OAuthHandler should not return 5xx on 4xx errors to skip retries and throw errors for invalid macros based on stage validation request.

### DIFF
--- a/cdap-api/src/main/java/io/cdap/cdap/api/macro/MacroParserOptions.java
+++ b/cdap-api/src/main/java/io/cdap/cdap/api/macro/MacroParserOptions.java
@@ -33,16 +33,18 @@ public class MacroParserOptions {
   private final boolean skipInvalid;
   private final int maxRecurseDepth;
   private final Set<String> functionWhitelist;
+  private final Set<String> doNotSkipInvalidMacroForFunctions;
 
   private MacroParserOptions(boolean evaluateLookups, boolean evaluateFunctions,
       boolean escapingEnabled, boolean skipInvalid,
-      int maxRecurseDepth, Set<String> functionWhitelist) {
+      int maxRecurseDepth, Set<String> functionWhitelist, Set<String> doNotSkipInvalidMacroForFunctions) {
     this.evaluateLookups = evaluateLookups;
     this.evaluateFunctions = evaluateFunctions;
     this.escapingEnabled = escapingEnabled;
     this.maxRecurseDepth = maxRecurseDepth;
     this.skipInvalid = skipInvalid;
     this.functionWhitelist = functionWhitelist;
+    this.doNotSkipInvalidMacroForFunctions = doNotSkipInvalidMacroForFunctions;
   }
 
   public boolean shouldEvaluateLookups() {
@@ -69,6 +71,10 @@ public class MacroParserOptions {
     return functionWhitelist;
   }
 
+  public Set<String> getDoNotSkipInvalidMacroForFunctions() {
+    return doNotSkipInvalidMacroForFunctions;
+  }
+
   /**
    * @return Builder to create options
    */
@@ -87,6 +93,7 @@ public class MacroParserOptions {
     private boolean skipInvalid;
     private int maxRecurseDepth = 10;
     private final Set<String> functionWhitelist = new HashSet<>();
+    private final Set<String> doNotSkipInvalidMacroForFunctions = new HashSet<>();
 
     public Builder disableLookups() {
       evaluateLookups = false;
@@ -113,6 +120,16 @@ public class MacroParserOptions {
       return this;
     }
 
+    public Builder setDoNotSkipInvalidMacroForFunctions(Collection<String> whitelist) {
+      doNotSkipInvalidMacroForFunctions.clear();
+      doNotSkipInvalidMacroForFunctions.addAll(whitelist);
+      return this;
+    }
+
+    public Builder setDoNotSkipInvalidMacroForFunctions(String... whitelist) {
+      return setDoNotSkipInvalidMacroForFunctions(Arrays.asList(whitelist));
+    }
+
     public Builder setFunctionWhitelist(Collection<String> whitelist) {
       functionWhitelist.clear();
       functionWhitelist.addAll(whitelist);
@@ -122,10 +139,10 @@ public class MacroParserOptions {
     public Builder setFunctionWhitelist(String... whitelist) {
       return setFunctionWhitelist(Arrays.asList(whitelist));
     }
-
+    
     public MacroParserOptions build() {
       return new MacroParserOptions(evaluateLookups, evaluateFunctions, escapingEnabled,
-          skipInvalid, maxRecurseDepth, functionWhitelist);
+          skipInvalid, maxRecurseDepth, functionWhitelist, doNotSkipInvalidMacroForFunctions);
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParser.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParser.java
@@ -43,6 +43,7 @@ public class MacroParser {
   private final boolean functionsEnabled;
   private final boolean skipInvalid;
   private final Set<String> functionWhitelist;
+  private final Set<String> doNotSkipInvalidMacroForFunctions;
 
   public MacroParser(MacroEvaluator macroEvaluator) {
     this(macroEvaluator, MacroParserOptions.DEFAULT);
@@ -55,6 +56,7 @@ public class MacroParser {
     this.functionsEnabled = options.shouldEvaluateFunctions();
     this.functionWhitelist = options.getFunctionWhitelist();
     this.skipInvalid = options.shouldSkipInvalid();
+    this.doNotSkipInvalidMacroForFunctions = options.getDoNotSkipInvalidMacroForFunctions();
   }
 
   /**
@@ -242,7 +244,7 @@ public class MacroParser {
         }
 
       } catch (InvalidMacroException e) {
-        if (!skipInvalid) {
+        if (!skipInvalid || doNotSkipInvalidMacroForFunctions.contains(macroFunction)) {
           throw e;
         }
       }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParserTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParserTest.java
@@ -562,4 +562,28 @@ public class MacroParserTest {
     MacroParser macroParser = new MacroParser(macroEvaluator);
     Assert.assertEquals(expected, macroParser.parse(macro));
   }
+
+  @Test
+  public void testDoNotSkipInvalidMacrosInMacroFunctions() {
+    MacroEvaluator evaluator = new TestMacroEvaluator(Collections.emptyMap(), Collections.emptyMap(), false);
+
+    //TestMacroEvaluator will throw InvalidMacroException if macro function is other than 't' or 'test'
+    // but skip invalid flag will suppress this exception.
+    MacroParser parser = new MacroParser(evaluator, MacroParserOptions.builder().skipInvalidMacros().build());
+    Assert.assertEquals("${oauthAccessToken(provider,credentials)}",
+                        parser.parse("${oauthAccessToken(provider,credentials)}"));
+    
+    // If doNotSkipInvalidMacroForFunctions set has that macro, it will not skip validation and will throw Exception
+    MacroParser parserWithDoNotSkipInvalidSet = new MacroParser(evaluator,
+                                                                MacroParserOptions.builder().skipInvalidMacros()
+                                                                  .setDoNotSkipInvalidMacroForFunctions(
+                                                                    "oauthAccessToken", "oauth").build());
+    boolean exceptionThrown = false;
+    try {
+      parserWithDoNotSkipInvalidSet.parse("${oauthAccessToken(provider,credentials)}");
+    } catch (InvalidMacroException e) {
+      exceptionThrown = true;
+    }
+    Assert.assertTrue(exceptionThrown);
+  }
 }

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
@@ -185,7 +185,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
 
       if (response.getResponseCode() != 200) {
         throw new OAuthServiceException(
-            HttpURLConnection.HTTP_INTERNAL_ERROR,
+          response.getResponseCode(),
             "Request for refresh token did not return 200. Response code: "
                 + response.getResponseCode()
                 + " , response message: "
@@ -243,7 +243,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
 
       if (response.getResponseCode() != 200) {
         throw new OAuthServiceException(
-            HttpURLConnection.HTTP_INTERNAL_ERROR,
+          response.getResponseCode(),
             "Request for refresh token did not return 200. Response code: "
                 + response.getResponseCode()
                 + " , response message: "

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteValidationTask.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/RemoteValidationTask.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -96,10 +97,12 @@ public class RemoteValidationTask implements RunnableTask {
     );
     MacroEvaluator macroEvaluator = new DefaultMacroEvaluator(new BasicArguments(arguments), evaluators,
                                                               DefaultMacroEvaluator.MAP_FUNCTIONS);
+    Set<String> doNotSkipInvalidMacroForFunctions = validationRequest.getDoNotSkipInvalidMacroForFunctions();
     MacroParserOptions macroParserOptions = MacroParserOptions.builder()
-      .skipInvalidMacros()
       .setEscaping(false)
       .setFunctionWhitelist(evaluators.keySet())
+      .skipInvalidMacros()
+      .setDoNotSkipInvalidMacroForFunctions(doNotSkipInvalidMacroForFunctions)
       .build();
     Function<Map<String, String>, Map<String, String>> macroFn =
       macroProperties -> systemAppContext

--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ValidationHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/ValidationHandler.java
@@ -61,6 +61,7 @@ import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -169,11 +170,14 @@ public class ValidationHandler extends AbstractSystemHttpServiceHandler {
     );
     MacroEvaluator macroEvaluator = new DefaultMacroEvaluator(new BasicArguments(arguments), evaluators,
                                                               DefaultMacroEvaluator.MAP_FUNCTIONS);
+    Set<String> doNotSkipInvalidMacroForFunctions = validationRequest.getDoNotSkipInvalidMacroForFunctions();
     MacroParserOptions macroParserOptions = MacroParserOptions.builder()
-      .skipInvalidMacros()
       .setEscaping(false)
       .setFunctionWhitelist(evaluators.keySet())
+      .skipInvalidMacros()
+      .setDoNotSkipInvalidMacroForFunctions(doNotSkipInvalidMacroForFunctions)
       .build();
+
     Function<Map<String, String>, Map<String, String>> macroFn =
       macroProperties -> getContext().evaluateMacros(namespace, macroProperties, macroEvaluator, macroParserOptions);
     String validationResponse = GSON.toJson(ValidationUtils.validate(

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/validation/StageValidationRequest.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/src/main/java/io/cdap/cdap/etl/proto/v2/validation/StageValidationRequest.java
@@ -17,9 +17,15 @@
 
 package io.cdap.cdap.etl.proto.v2.validation;
 
+import com.google.common.base.Strings;
 import io.cdap.cdap.etl.proto.v2.ETLStage;
+
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Request to validate a pipeline stage.
@@ -29,13 +35,21 @@ public class StageValidationRequest {
   private final ETLStage stage;
   private final List<StageSchema> inputSchemas;
   private final Boolean resolveMacrosFromPreferences;
+  private final String doNotSkipInvalidMacroForFunctions;
 
   public StageValidationRequest(ETLStage stage,
+                                List<StageSchema> inputSchemas,
+                                boolean resolveMacrosFromPreferences) {
+    this(stage, inputSchemas, resolveMacrosFromPreferences, null);
+  }
+  public StageValidationRequest(ETLStage stage,
       List<StageSchema> inputSchemas,
-      boolean resolveMacrosFromPreferences) {
+      boolean resolveMacrosFromPreferences,
+      String doNotSkipInvalidMacroForFunctions) {
     this.stage = stage;
     this.inputSchemas = inputSchemas;
     this.resolveMacrosFromPreferences = resolveMacrosFromPreferences;
+    this.doNotSkipInvalidMacroForFunctions = doNotSkipInvalidMacroForFunctions;
   }
 
   public ETLStage getStage() {
@@ -48,6 +62,21 @@ public class StageValidationRequest {
 
   public boolean getResolveMacrosFromPreferences() {
     return resolveMacrosFromPreferences != null ? resolveMacrosFromPreferences : false;
+  }
+
+  /**
+   *  This method will return macro function names for which invalid macros should not be skipped.
+   * @return Set of macro function names
+   */
+  public Set<String> getDoNotSkipInvalidMacroForFunctions() {
+    Set<String> doNotSkipInvalidMacroForFunctionsSet = new HashSet<>();
+    if (!Strings.isNullOrEmpty(doNotSkipInvalidMacroForFunctions)) {
+      doNotSkipInvalidMacroForFunctionsSet.addAll(Arrays.stream(doNotSkipInvalidMacroForFunctions.split(","))
+                                                    .map(String::trim)
+                                                    .filter(s -> !s.isEmpty())
+                                                    .collect(Collectors.toSet()));
+    }
+    return doNotSkipInvalidMacroForFunctionsSet;
   }
 
   /**


### PR DESCRIPTION
[cherrypick] [CDAP-21089] OAuthHandler should not return 5xx on 4xx errors to skip retries. Also added a doNotSkipInvalidMacroForFunctions in StageValidationRequest method to throw error in case provided macros are invalid.

This PR is cherrypicked from PR: https://github.com/cdapio/cdap/pull/15758

[CDAP-21089]: https://cdap.atlassian.net/browse/CDAP-21089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ