### PR TITLE
[CDAP-21104] Add CompositeLogAppender with SPI Integration and Guice Configuration for LogPublisher

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1505,6 +1505,12 @@ public final class Constants {
     public static final String LOG_APPENDER_EXT_DIR = "app.program.log.appender.extensions.dir";
     public static final String LOG_APPENDER_PROPERTY_PREFIX = "app.program.log.appender.system.properties.";
 
+    // Log publisher configs.
+    public static final String LOG_PUBLISHER_PROVIDER = "log.publisher.provider";
+    public static final String LOG_PUBLISHER_ENABLED = "log.publisher.enabled";
+    public static final String LOG_PUBLISHER_EXT_DIR = "log.publisher.extensions.dir";
+    public static final String LOG_PUBLISHER_PREFIX = "log.publisher";
+
     // Property key in the logger context to indicate it is performing pipeline validation
     public static final String PIPELINE_VALIDATION = "log.pipeline.validation";
 
@@ -2557,7 +2563,7 @@ public final class Constants {
 
 
   /**
-   * Constants for Data Plane Audit Logging
+   * Constants for Data Plane Audit Logging.
    */
   public static final class AuditLogging {
     public static final String AUDIT_LOG_PUBLISH_INTERVAL_SECONDS = "auditlog.publish.interval.seconds";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2804,6 +2804,16 @@
     </description>
   </property>
 
+  <property>
+    <name>log.publisher.enabled</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>log.publisher.extensions.dir</name>
+    <value>/opt/cdap/master/ext/log-publisher</value>
+  </property>
+
   <!-- Metrics Configuration -->
 
   <property>

--- a/cdap-log-publisher-spi/pom.xml
+++ b/cdap-log-publisher-spi/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2025 Cask Data, Inc.
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>cdap</artifactId>
+    <groupId>io.cdap.cdap</groupId>
+    <version>6.11.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>cdap-log-publisher-spi</artifactId>
+  <name>CDAP Log Publisher SPI</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <artifactId>logback-classic</artifactId>
+      <groupId>ch.qos.logback</groupId>
+    </dependency>
+  </dependencies>
+</project>

--- a/cdap-log-publisher-spi/src/main/java/io/cdap/cdap/spi/logs/LogPublisher.java
+++ b/cdap-log-publisher-spi/src/main/java/io/cdap/cdap/spi/logs/LogPublisher.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.logs;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+/**
+ * Publishes log events to a destination.
+ */
+public interface LogPublisher extends AutoCloseable {
+
+  /**
+   * Returns the name of the log publisher.
+   *
+   * @return the name of the publisher.
+   */
+  String getName();
+
+  /**
+   * Publishes a logging event.
+   *
+   * @param event the logging event to publish.
+   */
+  void publish(ILoggingEvent event);
+
+  /**
+   * Initializes the log publisher with the required context.
+   *
+   * @param context the context to initialize the publisher with.
+   */
+  void initialize(LogPublisherContext context);
+
+  /**
+   * Closes the log publisher and releases associated resources.
+   */
+  @Override
+  void close();
+}

--- a/cdap-log-publisher-spi/src/main/java/io/cdap/cdap/spi/logs/LogPublisherContext.java
+++ b/cdap-log-publisher-spi/src/main/java/io/cdap/cdap/spi/logs/LogPublisherContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Cask Data, Inc.
+ * Copyright © 2025 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -14,20 +14,20 @@
  * the License.
  */
 
-package io.cdap.cdap.logging.guice;
+package io.cdap.cdap.spi.logs;
 
-import com.google.inject.AbstractModule;
-import com.google.inject.Scopes;
-import io.cdap.cdap.logging.appender.LogAppender;
-import io.cdap.cdap.logging.framework.local.LocalLogAppender;
+import java.util.Map;
 
 /**
- * A Guice module to provide bindings for {@link LogAppender} implementations.
+ * Provides context information for {@link LogPublisher} initialization.
  */
-public class LocalLogAppenderModule extends AbstractModule {
+public interface LogPublisherContext {
 
-  @Override
-  protected void configure() {
-    bind(LogAppender.class).to(LocalLogAppender.class).in(Scopes.SINGLETON);
-  }
+  /**
+   * Properties are derived from the CDAP configuration. Configuration file path will be added as an
+   * entry in the  properties.
+   *
+   * @return unmodifiable properties for the log publisher.
+   */
+  Map<String, String> getProperties();
 }

--- a/cdap-watchdog/pom.xml
+++ b/cdap-watchdog/pom.xml
@@ -46,6 +46,11 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-log-publisher-spi</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-watchdog-api</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -137,6 +142,14 @@
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
     </dependency>
   </dependencies>
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/CompositeLogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/CompositeLogAppender.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.logging.appender;
+
+import ch.qos.logback.core.Context;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * A log appender that delegates logging events to a list of other log appenders.
+ */
+public class CompositeLogAppender extends LogAppender {
+
+  private final List<LogAppender> appenders;
+
+  /**
+   * Constructs a CompositeLogAppender with the given list of appenders.
+   *
+   * @param appenders the list of {@link LogAppender} instances to delegate logging events to
+   */
+  public CompositeLogAppender(List<LogAppender> appenders) {
+    if (appenders == null) {
+      throw new IllegalArgumentException("Appenders list cannot be null");
+    }
+
+    // Make the appenders list unmodifiable to ensure thread safety and prevent external
+    // modifications.
+    this.appenders = Collections.unmodifiableList(new ArrayList<>(appenders));
+    setName(getClass().getName());
+  }
+
+  @Override
+  public void start() {
+    executeOnAppenders("start", LogAppender::start);
+    super.start();
+  }
+
+  @Override
+  public void stop() {
+    super.stop();
+    executeOnAppenders("stop", LogAppender::stop);
+  }
+
+  @Override
+  protected void appendEvent(LogMessage logMessage) {
+    executeOnAppenders("appendEvent", appender -> appender.appendEvent(logMessage));
+  }
+
+  @Override
+  public void setContext(Context context) {
+    executeOnAppenders("setContext", appender -> appender.setContext(context));
+    super.setContext(context);
+  }
+
+  /**
+   * Executes a specified action on all appenders and handles any exceptions.
+   *
+   * @param actionName the name of the action being performed (for logging purposes)
+   * @param action     the action to execute on each appender
+   * @throws RuntimeException if one or more appenders fail to perform the action
+   */
+  private void executeOnAppenders(String actionName, Consumer<LogAppender> action) {
+    RuntimeException exceptions = null;
+    for (LogAppender appender : appenders) {
+      try {
+        action.accept(appender);
+      } catch (Exception e) {
+        if (exceptions == null) {
+          exceptions = new RuntimeException("One or more appenders failed to " + actionName);
+        }
+        exceptions.addSuppressed(e);
+      }
+    }
+
+    if (exceptions != null) {
+      throw exceptions;
+    }
+  }
+}

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/ExtensionLogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/ExtensionLogAppender.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.logging.appender;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.logging.publisher.DefaultLogPublisherContext;
+import io.cdap.cdap.logging.publisher.LogPublisherExtensionLoader;
+import io.cdap.cdap.spi.logs.LogPublisher;
+import io.cdap.cdap.spi.logs.LogPublisherContext;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link LogAppender} that delegates log messages to a dynamically loaded log publisher.
+ */
+public class ExtensionLogAppender extends LogAppender {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ExtensionLogAppender.class);
+  private static final LogPublisher NO_OP_LOG_PUBLISHER = new NoOpLogPublisher();
+  private static final String APPENDER_NAME = ExtensionLogAppender.class.getName();
+
+  @VisibleForTesting
+  final AtomicReference<LogPublisher> publisher;
+  private final String provider;
+  private final CConfiguration cConf;
+
+  /**
+   * Constructs an ExtensionLogAppender with the given configuration.
+   *
+   * @param cConf The configuration object containing the properties to configure the appender.
+   */
+  @Inject
+  public ExtensionLogAppender(CConfiguration cConf) {
+    this.cConf = cConf;
+    this.provider = cConf.get(Constants.Logging.LOG_PUBLISHER_PROVIDER);
+    this.publisher = new AtomicReference<>(NO_OP_LOG_PUBLISHER);
+    setName(APPENDER_NAME);
+  }
+
+  /**
+   * Starts the appender and initializes the log publisher.
+   */
+  @Override
+  public void start() {
+    LogPublisher newPublisher = loadLogPublisher();
+    publisher.getAndSet(newPublisher).close();
+    publisher.get().initialize(new DefaultLogPublisherContext(cConf, provider));
+    super.start();
+    LOG.info("Successfully started {}.", APPENDER_NAME);
+  }
+
+  /**
+   * Stops the appender and releases resources associated with the log publisher.
+   */
+  @Override
+  public void stop() {
+    super.stop();
+    publisher.getAndSet(NO_OP_LOG_PUBLISHER).close();
+    LOG.info("Successfully stopped {}.", APPENDER_NAME);
+  }
+
+  /**
+   * Appends a log message by delegating to the log publisher.
+   *
+   * @param logMessage The log message to append.
+   */
+  @Override
+  protected void appendEvent(LogMessage logMessage) {
+    logMessage.prepareForDeferredProcessing();
+    logMessage.getCallerData();
+    publisher.get().publish(logMessage);
+  }
+
+  /**
+   * Loads the log publisher using the extension loader.
+   *
+   * @return the {@link LogPublisher} instance
+   */
+  private LogPublisher loadLogPublisher() {
+    if (!cConf.getBoolean(Constants.Logging.LOG_PUBLISHER_ENABLED)) {
+      LOG.debug("Log publisher is disabled; using NoOpPublisher.");
+      return NO_OP_LOG_PUBLISHER;
+    }
+
+    LogPublisher logPublisher = Optional.ofNullable(
+            new LogPublisherExtensionLoader(cConf).get(provider))
+        .orElseThrow(() -> new RuntimeException("Failed to load log publisher: " + provider));
+
+    LOG.debug("Loaded log publisher: {}", logPublisher.getName());
+    return logPublisher;
+  }
+
+  /**
+   * A no-operation implementation of LogPublisher to handle cases where no publisher is
+   * configured.
+   */
+  private static class NoOpLogPublisher implements LogPublisher {
+
+    @Override
+    public String getName() {
+      return "NoOpPublisher";
+    }
+
+    @Override
+    public void publish(ILoggingEvent event) {
+      // No-op
+    }
+
+    @Override
+    public void initialize(LogPublisherContext context) {
+      // No-op
+    }
+
+    @Override
+    public void close() {
+      // No-op
+    }
+  }
+}

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/framework/local/LocalLogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/framework/local/LocalLogAppender.java
@@ -143,7 +143,7 @@ public class LocalLogAppender extends LogAppender {
   }
 
   /**
-   * The log processing pipeline for writing logs to configured logger context
+   * The log processing pipeline for writing logs to configured logger context.
    */
   private final class LocalLogProcessorPipeline extends AbstractExecutionThreadService {
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/publisher/DefaultLogPublisherContext.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/publisher/DefaultLogPublisherContext.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.logging.publisher;
+
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.spi.logs.LogPublisherContext;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * A context implementation for log publishers that provides configuration properties scoped to a
+ * specific log publisher provider.
+ */
+public class DefaultLogPublisherContext implements LogPublisherContext {
+
+  private final Map<String, String> properties;
+
+  /**
+   * Constructs a DefaultLogPublisherContext with configuration properties specific to the
+   * provider.
+   *
+   * @param cConf        The configuration object containing the properties.
+   * @param providerName The name of the log publisher.
+   */
+  public DefaultLogPublisherContext(CConfiguration cConf, String providerName) {
+    String prefix = String.format("%s.%s.", Constants.Logging.LOG_PUBLISHER_PREFIX, providerName);
+    this.properties = Collections.unmodifiableMap(cConf.getPropsWithPrefix(prefix));
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+}

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/publisher/LogPublisherExtensionLoader.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/publisher/LogPublisherExtensionLoader.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.logging.publisher;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.lang.ClassPathResources;
+import io.cdap.cdap.common.lang.FilterClassLoader;
+import io.cdap.cdap.extension.AbstractExtensionLoader;
+import io.cdap.cdap.spi.logs.LogPublisher;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Extension loader for {@link LogPublisher} implementations.
+ */
+public class LogPublisherExtensionLoader extends AbstractExtensionLoader<String, LogPublisher> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LogPublisherExtensionLoader.class);
+  private static final Set<String> ALLOWED_RESOURCES = createAllowedResources();
+  private static final Set<String> ALLOWED_PACKAGES = createPackageSets(ALLOWED_RESOURCES);
+
+  private final boolean isLogPublisherEnabled;
+
+  /**
+   * Constructs a {@link LogPublisherExtensionLoader} to manage the loading of log publisher
+   * extensions.
+   *
+   * @param cConf The configuration object containing properties for loading log publisher
+   *              extensions.
+   */
+  @Inject
+  public LogPublisherExtensionLoader(CConfiguration cConf) {
+    super(cConf.get(Constants.Logging.LOG_PUBLISHER_EXT_DIR));
+    this.isLogPublisherEnabled = cConf.getBoolean(Constants.Logging.LOG_PUBLISHER_ENABLED);
+    LOG.debug("Log Publisher is {}.", this.isLogPublisherEnabled ? "enabled" : "not enabled");
+  }
+
+  private static Set<String> createAllowedResources() {
+    try {
+      return ClassPathResources.getResourcesWithDependencies(LogPublisher.class.getClassLoader(),
+          LogPublisher.class);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to trace dependencies for Log Publisher extension.", e);
+    }
+  }
+
+  @Override
+  protected Set<String> getSupportedTypesForProvider(LogPublisher logPublisher) {
+    if (isLogPublisherEnabled) {
+      return Collections.singleton(logPublisher.getName());
+    }
+
+    return Collections.emptySet();
+  }
+
+  @Override
+  protected FilterClassLoader.Filter getExtensionParentClassLoaderFilter() {
+    return new FilterClassLoader.Filter() {
+      @Override
+      public boolean acceptResource(String resource) {
+        return ALLOWED_RESOURCES.contains(resource);
+      }
+
+      @Override
+      public boolean acceptPackage(String packageName) {
+        return ALLOWED_PACKAGES.contains(packageName);
+      }
+    };
+  }
+}

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/CompositeLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/CompositeLogAppenderTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.logging.appender;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import ch.qos.logback.core.Context;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * Tests for {@link CompositeLogAppender}
+ */
+public class CompositeLogAppenderTest {
+
+  @Mock
+  private LogAppender mockAppender1;
+
+  @Mock
+  private LogAppender mockAppender2;
+
+  private CompositeLogAppender compositeLogAppender;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    compositeLogAppender = new CompositeLogAppender(
+        Arrays.asList(mockAppender1, mockAppender2));
+  }
+
+  @Test
+  public void testStart() {
+    doNothing().when(mockAppender1).start();
+    doNothing().when(mockAppender2).start();
+
+    compositeLogAppender.start();
+
+    assertTrue("CompositeLogAppender should be started", compositeLogAppender.isStarted());
+    verify(mockAppender1, times(1)).start();
+    verify(mockAppender2, times(1)).start();
+  }
+
+  @Test
+  public void testStop() {
+    doNothing().when(mockAppender1).stop();
+    doNothing().when(mockAppender2).stop();
+
+    compositeLogAppender.stop();
+
+    assertFalse("CompositeLogAppender should be stopped", compositeLogAppender.isStarted());
+    verify(mockAppender1, times(1)).stop();
+    verify(mockAppender2, times(1)).stop();
+  }
+
+  @Test
+  public void testAppendEvent() throws Exception {
+    LogMessage logMessage = mock(LogMessage.class);
+    doNothing().when(mockAppender1).appendEvent(logMessage);
+    doNothing().when(mockAppender2).appendEvent(logMessage);
+
+    compositeLogAppender.appendEvent(logMessage);
+
+    verify(mockAppender1, times(1)).appendEvent(logMessage);
+    verify(mockAppender2, times(1)).appendEvent(logMessage);
+  }
+
+  @Test
+  public void testSetContext() {
+    Context context = mock(Context.class);
+
+    compositeLogAppender.setContext(context);
+
+    verify(mockAppender1, times(1)).setContext(context);
+    verify(mockAppender2, times(1)).setContext(context);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testStartWhenOneFails() {
+    doThrow(new RuntimeException("Start failed")).when(mockAppender1).start();
+    doNothing().when(mockAppender2).start();
+
+    compositeLogAppender.start();
+
+    verify(mockAppender1, times(1)).start();
+    verify(mockAppender2, times(1)).start();
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testStopWhenOneFails() {
+    doThrow(new RuntimeException("Stop failed")).when(mockAppender1).stop();
+    doNothing().when(mockAppender2).stop();
+
+    compositeLogAppender.stop();
+
+    assertFalse("CompositeLogAppender should be stopped", compositeLogAppender.isStarted());
+    verify(mockAppender1, times(1)).stop();
+    verify(mockAppender2, times(1)).stop();
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testAppendEventWhenOneFails() {
+    LogMessage logMessage = mock(LogMessage.class);
+    doThrow(new RuntimeException("Append failed")).when(mockAppender1).appendEvent(logMessage);
+    doNothing().when(mockAppender2).appendEvent(logMessage);
+
+    compositeLogAppender.appendEvent(logMessage);
+
+    verify(mockAppender1, times(1)).appendEvent(logMessage);
+    verify(mockAppender2, times(1)).appendEvent(logMessage);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testSetContextWhenOneFails() {
+    Context context = mock(Context.class);
+    doThrow(new RuntimeException("Set context failed")).when(mockAppender1).setContext(context);
+    doNothing().when(mockAppender2).setContext(context);
+
+    compositeLogAppender.setContext(context);
+
+    verify(mockAppender1, times(1)).setContext(context);
+    verify(mockAppender2, times(1)).setContext(context);
+  }
+
+  @Test
+  public void testNoAppenders() {
+    compositeLogAppender = new CompositeLogAppender(Collections.emptyList());
+    compositeLogAppender.start();
+    assertTrue("CompositeLogAppender should be started", compositeLogAppender.isStarted());
+
+    compositeLogAppender.stop();
+    assertFalse("CompositeLogAppender should be stopped", compositeLogAppender.isStarted());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullAppenders() {
+    compositeLogAppender = new CompositeLogAppender(null);
+    assertNull("Appender name should not be set", compositeLogAppender.getName());
+  }
+}

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/ExtensionLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/ExtensionLogAppenderTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.logging.appender;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.logging.publisher.DefaultLogPublisherContext;
+import io.cdap.cdap.logging.publisher.LogPublisherExtensionLoader;
+import io.cdap.cdap.spi.logs.LogPublisher;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+/**
+ * Unit tests for {@link ExtensionLogAppender} class.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ExtensionLogAppender.class, LogPublisherExtensionLoader.class})
+public class ExtensionLogAppenderTest {
+
+  @Mock
+  private LogPublisherExtensionLoader mockLoader;
+
+  @Mock
+  private CConfiguration mockConf;
+
+  @Mock
+  private LogMessage mockLogMessage;
+
+  @Mock
+  private LogPublisher mockLogPublisher;
+
+  private ExtensionLogAppender appender;
+
+  @Before
+  public void setup() throws Exception {
+    MockitoAnnotations.openMocks(this);
+    when(mockConf.get(Constants.Logging.LOG_PUBLISHER_PROVIDER)).thenReturn("testProvider");
+    when(mockConf.getBoolean(Constants.Logging.LOG_PUBLISHER_ENABLED)).thenReturn(true);
+    PowerMockito.whenNew(LogPublisherExtensionLoader.class).withArguments(mockConf)
+        .thenReturn(mockLoader);
+    appender = new ExtensionLogAppender(mockConf);
+  }
+
+  @Test
+  public void testStartInitializesLogPublisher() {
+    when(mockLoader.get("testProvider")).thenReturn(mockLogPublisher);
+    doNothing().when(mockLogPublisher).initialize(any());
+
+    appender.start();
+
+    verify(mockLogPublisher, times(1)).initialize(any(DefaultLogPublisherContext.class));
+    assertTrue(appender.isStarted());
+  }
+
+  @Test
+  public void testStopClosesLogPublisher() {
+    when(mockLoader.get("testProvider")).thenReturn(mockLogPublisher);
+    doNothing().when(mockLogPublisher).close();
+
+    appender.start();
+    appender.stop();
+
+    verify(mockLogPublisher, times(1)).close();
+    assertFalse(appender.isStarted());
+  }
+
+  @Test
+  public void testAppendEventDelegatesToLogPublisher() {
+    when(mockLoader.get("testProvider")).thenReturn(mockLogPublisher);
+
+    appender.start();
+
+    doNothing().when(mockLogMessage).prepareForDeferredProcessing();
+    when(mockLogMessage.getCallerData()).thenReturn(null);
+    doNothing().when(mockLogPublisher).publish(mockLogMessage);
+
+    appender.appendEvent(mockLogMessage);
+
+    verify(mockLogMessage, times(1)).prepareForDeferredProcessing();
+    verify(mockLogMessage, times(1)).getCallerData();
+    verify(mockLogPublisher, times(1)).publish(mockLogMessage);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testLoadLogPublisherThrowsExceptionWhenProviderNotFound() {
+    when(mockLoader.get("testProvider")).thenReturn(null);
+    appender.start();
+  }
+
+  @Test
+  public void testLoadLogPublisherReturnsNoOpWhenDisabled() {
+    when(mockConf.getBoolean(Constants.Logging.LOG_PUBLISHER_ENABLED)).thenReturn(false);
+
+    appender.start();
+
+    assertEquals("NoOpPublisher", appender.publisher.get().getName());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -2635,6 +2635,7 @@
         <module>cdap-authenticator-ext-gcp</module>
         <module>cdap-source-control</module>
         <module>cdap-encryption-ext-tink</module>
+        <module>cdap-log-publisher-spi</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
### Description:

This PR introduces the `CompositeLogAppender` and integrates it with the existing logging framework using Guice dependency injection. Key changes include:

- **CompositeLogAppender**: A new class that extends `LogAppender` and holds a list of `LogAppender` instances. It delegates the operations (such as starting, stopping, and appending events) to all the appenders in the list. This provides a mechanism to handle multiple appenders as a unified entity.

- **DefaultLogAppender**: This class acts as a wrapper around `ILogAppender`, enabling the use of `ILogAppender` within the `LogAppender` framework. It ensures that the `ILogAppender` is properly initialized and wrapped into the logging pipeline.

- **Guice Configuration**: The `LogAppender` is now bound to the `CompositeLogAppender` in the Guice module. This allows the application to use the `CompositeLogAppender` as the default implementation for log handling, supporting multiple appender configurations.

### Testing:
- **Unit Test**: Test cases have been updated and added for verifying the integration and functionality of the new `CompositeLogAppender` and `DefaultLogAppender`, ensuring that both behave as expected in different scenarios.
- **Local Testing**: Tested the changes by creating the image with the new code.
