### PR TITLE
Exclude Vulnerable Dependency org.apache.mina:mina-core

### DIFF
--- a/cdap-security/pom.xml
+++ b/cdap-security/pom.xml
@@ -106,6 +106,12 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-jaas</artifactId>
       <version>${jetty9.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.mina</groupId>
+          <artifactId>mina-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/cdap-source-control/pom.xml
+++ b/cdap-source-control/pom.xml
@@ -27,11 +27,6 @@
   <artifactId>cdap-source-control</artifactId>
   <name>CDAP Source Control Management</name>
 
-  <properties>
-    <!-- Used only for unit tests -->
-    <jetty.version>9.4.50.v20221201</jetty.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
@@ -65,25 +60,25 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty9.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-security</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty9.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-servlet</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty9.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
-      <version>${jetty.version}</version>
+      <version>${jetty9.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,6 @@
     <hsql.version>2.2.4</hsql.version>
     <jackson.version>2.15.1</jackson.version>
     <jsch.version>0.1.54</jsch.version>
-    <jetty.version>6.1.22</jetty.version>
     <jetty9.version>9.4.51.v20230217</jetty9.version>
     <jline.version>2.12</jline.version>
     <junit.version>4.11</junit.version>
@@ -1028,16 +1027,6 @@
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
         <version>${mysql.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>jetty</artifactId>
-        <version>${jetty.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>jetty-management</artifactId>
-        <version>${jetty.version}</version>
       </dependency>
       <dependency>
         <groupId>org.quartz-scheduler</groupId>


### PR DESCRIPTION
This PR addresses a known vulnerability in `org.apache.mina:mina-core` that affects the `cdap-security-extn` module. 

**Vulnerability**: Deserialization of Untrusted Data affecting org.apache.mina:mina-core.

### Testing
- Tested by creating the image with the modified code and running pipelines.

