### PR TITLE
[CDAP-21099] Add validation_exception in error classifier for validation errors

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/FailureDetailsProvider.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/FailureDetailsProvider.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.api.exception;
+
+import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
+import javax.annotation.Nullable;
+
+/**
+ * Interface for providing failure details.
+ */
+public interface FailureDetailsProvider {
+
+  /**
+   * Returns the reason for the error.
+   *
+   * <p>The reason usually explains why the error occurred, such as a specific validation failure
+   * or an unexpected condition.
+   *
+   * @return a {@String} representing the error reason.
+   */
+  @Nullable
+  default String getErrorReason() {
+    return null;
+  }
+
+  /**
+   * Returns the stage where the failure occurred.
+   */
+  @Nullable
+  default String getFailureStage() {
+    return null;
+  }
+
+  /**
+   * Returns the category of the error.
+   *
+   * <p>This typically provides a high-level classification of the error,
+   * such as plugin, provisioning, etc.
+   * If the category or reason is not known - it will be marked as  ‘Others’.
+   *
+   * @return a {@String} representing the error category.
+   */
+  default ErrorCategory getErrorCategory() {
+    return new ErrorCategory(ErrorCategoryEnum.OTHERS);
+  }
+
+  /**
+   * Returns the type of the error.
+   *
+   * <p>This method provides information on whether the error is classified as a
+   * system-level error, a user-caused error, or an unknown type of error.
+   *
+   * @return an {@ErrorType} enum value representing the type of the error.
+   */
+  default ErrorType getErrorType() {
+    return ErrorType.UNKNOWN;
+  }
+}

--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/ProgramFailureException.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/ProgramFailureException.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.api.exception;
 
+import javax.annotation.Nullable;
+
 /**
  * Exception class representing a program failure with detailed error information.
  * <p>
@@ -38,7 +40,7 @@ package io.cdap.cdap.api.exception;
  *   dependent service.</li>
  * </ul>
  **/
-public class ProgramFailureException extends RuntimeException {
+public class ProgramFailureException extends RuntimeException implements FailureDetailsProvider {
   private final ErrorCategory errorCategory;
   private final String errorReason;
   private final ErrorType errorType;
@@ -60,39 +62,18 @@ public class ProgramFailureException extends RuntimeException {
     this.supportedDocumentationUrl = supportedDocumentationUrl;
   }
 
-  /**
-   * Returns the category of the error.
-   *
-   * <p>This typically provides a high-level classification of the error,
-   * such as plugin, provisioning, etc.
-   * If the category or reason is not known - it will be marked as  ‘Others’.
-   *
-   * @return a {@String} representing the error category.
-   */
-  public String getErrorCategory() {
-    return errorCategory.getErrorCategory();
-  }
-
-  /**
-   * Returns the reason for the error.
-   *
-   * <p>The reason usually explains why the error occurred, such as a specific validation failure
-   * or an unexpected condition.
-   *
-   * @return a {@String} representing the error reason.
-   */
+  @Nullable
+  @Override
   public String getErrorReason() {
     return errorReason;
   }
 
-  /**
-   * Returns the type of the error.
-   *
-   * <p>This method provides information on whether the error is classified as a
-   * system-level error, a user-caused error, or an unknown type of error.
-   *
-   * @return an {@ErrorType} enum value representing the type of the error.
-   */
+  @Override
+  public ErrorCategory getErrorCategory() {
+    return errorCategory;
+  }
+
+  @Override
   public ErrorType getErrorType() {
     return errorType == null ? ErrorType.UNKNOWN : errorType;
   }

--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/WrappedStageException.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/WrappedStageException.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.api.exception;
 
+import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
+
 /**
  * Exception class that wraps another exception and includes the name of the stage
  * where the failure occurred.
@@ -26,7 +28,7 @@ package io.cdap.cdap.api.exception;
  * included for better error tracking.
  * </p>
  */
-public class WrappedStageException extends RuntimeException {
+public class WrappedStageException extends RuntimeException implements FailureDetailsProvider {
 
   private final String stageName;
 
@@ -58,5 +60,20 @@ public class WrappedStageException extends RuntimeException {
   @Override
   public String getMessage() {
     return String.format("Stage '%s' encountered : %s", stageName, super.getMessage());
+  }
+
+  @Override
+  public String getErrorReason() {
+    return getMessage();
+  }
+
+  @Override
+  public String getFailureStage() {
+    return stageName;
+  }
+
+  @Override
+  public ErrorCategory getErrorCategory() {
+    return new ErrorCategory(ErrorCategoryEnum.PLUGIN);
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>cdap-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidationException.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidationException.java
@@ -17,15 +17,20 @@
 package io.cdap.cdap.etl.api.validation;
 
 import io.cdap.cdap.api.annotation.Beta;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.FailureDetailsProvider;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Validation exception that carries multiple validation failures.
  */
 @Beta
-public class ValidationException extends RuntimeException {
+public class ValidationException extends RuntimeException implements FailureDetailsProvider {
 
   private final List<ValidationFailure> failures;
 
@@ -49,5 +54,27 @@ public class ValidationException extends RuntimeException {
   private static String generateMessage(List<ValidationFailure> failures) {
     return String.format("Errors were encountered during validation. %s",
         failures.isEmpty() ? "" : failures.iterator().next().getMessage());
+  }
+
+  @Override
+  public String getErrorReason() {
+    return String.format("Stage '%s' encountered %s validation failures.", getFailureStage(),
+        failures.size());
+  }
+
+  @Nullable
+  @Override
+  public String getFailureStage() {
+    return !failures.isEmpty() ? failures.get(0).getStageName() : null;
+  }
+
+  @Override
+  public ErrorCategory getErrorCategory() {
+    return new ErrorCategory(ErrorCategoryEnum.PLUGIN, "Validation");
+  }
+
+  @Override
+  public ErrorType getErrorType() {
+    return ErrorType.USER;
   }
 }

--- a/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidationFailure.java
+++ b/cdap-app-templates/cdap-etl/cdap-etl-api/src/main/java/io/cdap/cdap/etl/api/validation/ValidationFailure.java
@@ -268,6 +268,13 @@ public class ValidationFailure {
     return causes;
   }
 
+  /**
+   * Returns the stageName in which failure occurred.
+   */
+  String getStageName() {
+    return stageName;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/cdap-app-templates/cdap-etl/cdap-etl-core/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-core/pom.xml
@@ -55,6 +55,12 @@
       <artifactId>cdap-proto</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-unit-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-templates/cdap-etl/cdap-etl-proto/pom.xml
+++ b/cdap-app-templates/cdap-etl/cdap-etl-proto/pom.xml
@@ -51,6 +51,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/cdap-app-templates/cdap-etl/hydrator-spark-core3_2.12/pom.xml
+++ b/cdap-app-templates/cdap-etl/hydrator-spark-core3_2.12/pom.xml
@@ -87,6 +87,12 @@
       <artifactId>spark-sql_2.12</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-unit-test</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-app-templates/cdap-etl/pom.xml
+++ b/cdap-app-templates/cdap-etl/pom.xml
@@ -269,12 +269,6 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-unit-test</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-common-unit-test</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/cdap-proto/src/main/java/io/cdap/cdap/proto/ErrorClassificationResponse.java
+++ b/cdap-proto/src/main/java/io/cdap/cdap/proto/ErrorClassificationResponse.java
@@ -16,10 +16,12 @@
 
 package io.cdap.cdap.proto;
 
+import java.util.Objects;
+
 /**
  * Represents the response for classifying error logs.
  */
-public class ErrorClassificationResponse {
+public final class ErrorClassificationResponse {
   private final String stageName;
   private final String errorCategory;
   private final String errorReason;
@@ -29,10 +31,11 @@ public class ErrorClassificationResponse {
   private final String errorCodeType;
   private final String errorCode;
   private final String supportedDocumentationUrl;
+  private transient String throwableClassName;
 
   private ErrorClassificationResponse(String stageName, String errorCategory, String errorReason,
       String errorMessage, String errorType, String dependency, String errorCodeType,
-      String errorCode, String supportedDocumentationUrl) {
+      String errorCode, String supportedDocumentationUrl, String throwableClassName) {
     this.stageName = stageName;
     this.errorCategory = errorCategory;
     this.errorReason = errorReason;
@@ -42,6 +45,7 @@ public class ErrorClassificationResponse {
     this.errorCodeType = errorCodeType;
     this.errorCode = errorCode;
     this.supportedDocumentationUrl = supportedDocumentationUrl;
+    this.throwableClassName = throwableClassName;
   }
 
   /**
@@ -108,6 +112,36 @@ public class ErrorClassificationResponse {
   }
 
   /**
+   * Gets the throwable class name for ErrorClassificationResponse.
+   */
+  public String getThrowableClassName() {
+    return throwableClassName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof ErrorClassificationResponse)) {
+      return false;
+    }
+    ErrorClassificationResponse that = (ErrorClassificationResponse) o;
+    return Objects.equals(this.stageName, that.stageName)
+        && Objects.equals(this.errorCategory, that.errorCategory)
+        && Objects.equals(this.errorReason, that.errorReason)
+        && Objects.equals(this.errorMessage, that.errorMessage)
+        && Objects.equals(this.errorType, that.errorType)
+        && Objects.equals(this.dependency, that.dependency)
+        && Objects.equals(this.errorCodeType, that.errorCodeType)
+        && Objects.equals(this.errorCode, that.errorCode)
+        && Objects.equals(this.supportedDocumentationUrl, that.supportedDocumentationUrl);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(stageName, errorCategory, errorReason, errorMessage, errorType,
+        dependency, errorCodeType, errorCode, supportedDocumentationUrl);
+  }
+
+  /**
    * Builder for {@link ErrorClassificationResponse}.
    */
   public static class Builder {
@@ -120,6 +154,7 @@ public class ErrorClassificationResponse {
     private String errorCodeType;
     private String errorCode;
     private String supportedDocumentationUrl;
+    private String throwableClassName;
 
     /**
      * Sets the stage name for ErrorClassificationResponse.
@@ -194,11 +229,20 @@ public class ErrorClassificationResponse {
     }
 
     /**
+     * Sets the throwable class name for ErrorClassificationResponse.
+     */
+    public Builder setThrowableClassName(String throwableClassName) {
+      this.throwableClassName = throwableClassName;
+      return this;
+    }
+
+    /**
      * Builds and returns a new instance of ErrorClassificationResponse.
      */
     public ErrorClassificationResponse build() {
       return new ErrorClassificationResponse(stageName, errorCategory, errorReason, errorMessage,
-          errorType, dependency, errorCodeType, errorCode, supportedDocumentationUrl);
+          errorType, dependency, errorCodeType, errorCode, supportedDocumentationUrl,
+          throwableClassName);
     }
   }
 }


### PR DESCRIPTION
Jira : [CDAP-21099](https://cdap.atlassian.net/browse/CDAP-21099)

### Description

This PR adds support for error classification of validation exception.

#### context: 
- The classloader used for `ValidationException` is `ProgramClassLoader` so cannot do `instanceof` directly.

### Unit Tests

Added `ErrorLogsClassifierTest#testErrorClassificationTagsArePresentWithValidationException`

### Tested in CDAP Sandbox
![image](https://github.com/user-attachments/assets/1fcb7652-9b24-400f-81da-7bc1afeeadc3)

[CDAP-21099]: https://cdap.atlassian.net/browse/CDAP-21099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ