### PR TITLE
export error_details_provider_spec in hydrator-test-base

### DIFF
--- a/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
+++ b/cdap-app-templates/cdap-etl/hydrator-test/src/main/java/io/cdap/cdap/etl/mock/test/HydratorTestBase.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.etl.api.engine.sql.SQLEngine;
 import io.cdap.cdap.etl.api.engine.sql.capability.PushCapability;
 import io.cdap.cdap.etl.api.engine.sql.dataset.SQLDataset;
 import io.cdap.cdap.etl.api.engine.sql.request.SQLPushRequest;
+import io.cdap.cdap.etl.api.exception.ErrorDetailsProviderSpec;
 import io.cdap.cdap.etl.api.join.AutoJoiner;
 import io.cdap.cdap.etl.api.join.error.JoinError;
 import io.cdap.cdap.etl.api.lineage.AccessType;
@@ -177,6 +178,7 @@ public class HydratorTestBase extends TestBase {
         PushCapability.class.getPackage().getName(),
         SparkRecordCollection.class.getPackage().getName(),
         Connector.class.getPackage().getName(),
+        ErrorDetailsProviderSpec.class.getPackage().getName(),
         "org.apache.avro.mapred", "org.apache.avro", "org.apache.avro.generic",
         "org.apache.avro.io");
 
@@ -210,6 +212,7 @@ public class HydratorTestBase extends TestBase {
         SparkCompute.class.getPackage().getName(),
         InvalidStageException.class.getPackage().getName(),
         PipelineConfigurable.class.getPackage().getName(),
+        ErrorDetailsProviderSpec.class.getPackage().getName(),
         // have to export this package, otherwise getting ClassCastException in unit test
         FieldOperation.class.getPackage().getName());
 


### PR DESCRIPTION
### Description

Export the package for `ErrorDetailsProviderSpec` so that it is accessible to
plugins in unit tests.

#### context:
```
06:27:12.415 [SparkRunner-phase-1] ERROR io.cdap.cdap.internal.app.runtime.ProgramControllerServiceAdapter - Spark Program 'phase-1' failed.
java.lang.Exception: loader constraint violation: loader (instance of io/cdap/cdap/internal/app/runtime/ProgramClassLoader) previously initiated loading for a different type with name "io/cdap/cdap/etl/api/exception/ErrorDetailsProviderSpec"
        at io.cdap.cdap.internal.app.runtime.AbstractContext.lambda$initializeProgram$8(AbstractContext.java:655) ~[?:?]
        at io.cdap.cdap.internal.app.runtime.AbstractContext.execute(AbstractContext.java:608) ~[?:?]
        at io.cdap.cdap.internal.app.runtime.AbstractContext.initializeProgram(AbstractContext.java:647) ~[?:?]
        at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.initialize(SparkRuntimeService.java:550) ~[cdap-spark-core3_2.12-6.11.0-20250102.100732-476.jar:?]
        at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.startUp(SparkRuntimeService.java:234) ~[cdap-spark-core3_2.12-6.11.0-20250102.100732-476.jar:?]
        at com.google.common.util.concurrent.AbstractExecutionThreadService$1$1.run(AbstractExecutionThreadService.java:47) ~[guava-13.0.1.jar:?]
        at io.cdap.cdap.app.runtime.spark.SparkRuntimeService.lambda$null$2(SparkRuntimeService.java:525) ~[cdap-spark-core3_2.12-6.11.0-20250102.100732-476.jar:?]
        at java.lang.Thread.run(Thread.java:750) ~[?:1.8.0_322]
```