### PR TITLE
[CDAP-21105] Collecting Audit Log Meta Data independently at ACH's readChannel's finally and AuditLogSetterHook. And Create AuditLogRequest in write/close call.

### DIFF
--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authentication/SecurityRequestContext.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authentication/SecurityRequestContext.java
@@ -22,7 +22,6 @@ import io.cdap.cdap.proto.security.Principal;
 import io.cdap.cdap.security.spi.authorization.AuditLogContext;
 import io.cdap.cdap.security.spi.authorization.AuditLogRequest;
 import io.cdap.cdap.security.spi.authorization.AuthorizationResponse;
-
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,8 +41,7 @@ public final class SecurityRequestContext {
   private static final ThreadLocal<Queue<AuditLogContext>> auditLogContextQueue = new InheritableThreadLocal<>();
   private static final ThreadLocal<Map<? extends EntityId, AuthorizationResponse>> entityToAuthResponseMap =
     new InheritableThreadLocal<>();
-  // This will be used by AuthenticationChannelHandler to finally write the audit log event to a messaging queue.
-  private static final ThreadLocal<AuditLogRequest> auditLogRequest = new InheritableThreadLocal<>();
+  private static final ThreadLocal<AuditLogRequest.Builder> auditLogRequestBuilder = new InheritableThreadLocal<>();
 
   private SecurityRequestContext() {
   }
@@ -79,16 +77,6 @@ public final class SecurityRequestContext {
   }
 
   /**
-   * Get the {@link AuditLogRequest} for this thread.
-   *
-   * @return {@link AuditLogRequest}
-   */
-  @Nullable
-  public static AuditLogRequest getAuditLogRequest() {
-    return auditLogRequest.get();
-  }
-
-  /**
    * Set the userId on the current thread.
    *
    * @param userIdParam userId to be set
@@ -116,15 +104,6 @@ public final class SecurityRequestContext {
   }
 
   /**
-   * Set the {@link AuditLogRequest} on the current thread.
-   *
-   * @param auditLogReq
-   */
-  public static void setAuditLogRequest(AuditLogRequest auditLogReq) {
-    auditLogRequest.set(auditLogReq);
-  }
-
-  /**
    * Returns a {@link Principal} for the user set on the current thread.
    */
   public static Principal toPrincipal() {
@@ -139,8 +118,8 @@ public final class SecurityRequestContext {
     userIP.remove();
     userCredential.remove();
     auditLogContextQueue.remove();
-    auditLogRequest.remove();
     entityToAuthResponseMap.remove();
+    auditLogRequestBuilder.remove();
   }
 
   /**
@@ -220,5 +199,20 @@ public final class SecurityRequestContext {
    */
   public static void clearEntityToAuthResponseMap() {
     entityToAuthResponseMap.remove();
+  }
+
+  /**
+   *  Set the Builder for AuditLogRequest.
+   */
+  public static void setAuditLogRequestBuilder(AuditLogRequest.Builder builder) {
+    auditLogRequestBuilder.set(builder);
+  }
+
+  /**
+   *  Get the Builder for AuditLogRequest.
+   */
+  @Nullable
+  public static AuditLogRequest.Builder getAuditLogRequestBuilder() {
+    return auditLogRequestBuilder.get();
   }
 }

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AuditLogContext.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AuditLogContext.java
@@ -93,8 +93,14 @@ public class AuditLogContext {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (!(o instanceof AuditLogContext)) return false;
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof AuditLogContext)) {
+      return false;
+    }
+
     AuditLogContext that = (AuditLogContext) o;
     return auditLoggingRequired == that.auditLoggingRequired && Objects.equals(auditLogBody, that.auditLogBody);
   }
@@ -102,5 +108,12 @@ public class AuditLogContext {
   @Override
   public int hashCode() {
     return Objects.hash(auditLoggingRequired, auditLogBody);
+  }
+
+  @Override
+  public String toString() {
+    return "AuditLogContext{"
+      + "auditLoggingRequired=" + auditLoggingRequired + ", auditLogBody='" + auditLogBody + '\''
+      + '}';
   }
 }

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AuditLogRequest.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authorization/AuditLogRequest.java
@@ -85,4 +85,70 @@ public class AuditLogRequest {
   public long getEndTimeNanos() {
     return endTimeNanos;
   }
+
+  /**
+   * A Builder class to store metadata as in when fetched along the netty pipeline. And later used to build at the last
+   * stage.
+   */
+  public static class Builder {
+    private int operationResponseCode;
+    private String userIp;
+    private String uri;
+    private String handler;
+    private String method;
+    private String methodType;
+    private Queue<AuditLogContext> auditLogContextQueue;
+    private Long startTimeNanos;
+    private Long endTimeNanos;
+
+    public Builder operationResponseCode(int operationResponseCode) {
+      this.operationResponseCode = operationResponseCode;
+      return this;
+    }
+
+    public Builder userIp(String userIp) {
+      this.userIp = userIp;
+      return this;
+    }
+
+    public Builder uri(String uri) {
+      this.uri = uri;
+      return this;
+    }
+
+    public Builder handler(String handler) {
+      this.handler = handler;
+      return this;
+    }
+
+    public Builder method(String method) {
+      this.method = method;
+      return this;
+    }
+
+    public Builder methodType(String methodType) {
+      this.methodType = methodType;
+      return this;
+    }
+
+    public Builder auditLogContextQueue(Queue<AuditLogContext> auditLogContextQueue) {
+      this.auditLogContextQueue = auditLogContextQueue;
+      return this;
+    }
+
+    public Builder startTimeNanos(Long startTimeNanos) {
+      this.startTimeNanos = startTimeNanos;
+      return this;
+    }
+
+    public Builder endTimeNanos(Long endTimeNanos) {
+      this.endTimeNanos = endTimeNanos;
+      return this;
+    }
+
+    public AuditLogRequest build() {
+      return new AuditLogRequest(operationResponseCode, userIp, uri, handler,  method, methodType, auditLogContextQueue,
+                                 startTimeNanos, endTimeNanos);
+    }
+  }
 }


### PR DESCRIPTION
#### The Existing flow / Expectation :

`ABCHttpHandler` (gets AuditLogs in SecurityRequestContext[SRC] )  
  ->  `AuditLogSetterHook` (populates Metadata + gets  AuditLogs from SRC and creates AuditLogReq and sets in SRC)
  -->   `AuthChannelHandler#readChannel's Finally` (Sets the AuditLogRequest in Attribute of channel)
  --->   `AuthChannelHandler#write` (gets the AuditLogRequest from Attribute of channel and publishes)

#### Problem incase of ArtifactHttpHandler#addArtifact:

The `AuditLogSetterHook` is called after `AuthChannelHandler#readChannel's Finally`

`ArtifactHttpHandler` (gets AuditLogs in SecurityRequestContext[SRC] )  
  ->   `AuthChannelHandler#readChannel's Finally` (Sets the AuditLogRequest in Attribute of channel `BUT THIS IS NULL`)
  -->  `AuditLogSetterHook` (populates Metadata + gets  AuditLogs from SRC and creates AuditLogReq and sets in SRC)
  --->   `AuthChannelHandler#write` (gets the AuditLogRequest from Attribute of channel and publishes)

#### The Fix : 

Independently Collect info in `AuditLogSetterHook` and `AuthChannelHandler#readChannel's Finally` and Later construct the `AuditLogRequest` by collecting info stored by above methods. 
 
 
 Testing : 
 - validated that audit logs are published in DEV ENV of googlecloud for AddArtifact / Createnamespace.  
