### PR TITLE
[CDAP-21107] Reseting only user details while switching to internal user inside GcpWorkloadIdentityHttpHandler

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/handler/GcpWorkloadIdentityHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/namespace/credential/handler/GcpWorkloadIdentityHttpHandler.java
@@ -222,7 +222,7 @@ public class GcpWorkloadIdentityHttpHandler extends AbstractHttpHandler {
   }
 
   private void switchToInternalUser() {
-    SecurityRequestContext.reset();
+    SecurityRequestContext.resetUserDetails();
   }
 
   private CredentialIdentityId createIdentityIdOrPropagate(String namespace, String name)

--- a/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authentication/SecurityRequestContext.java
+++ b/cdap-security-spi/src/main/java/io/cdap/cdap/security/spi/authentication/SecurityRequestContext.java
@@ -144,6 +144,16 @@ public final class SecurityRequestContext {
   }
 
   /**
+   * Clears security state related to user details for this thread.
+   * This is useful to switch to internal user within a call.
+   */
+  public static void resetUserDetails() {
+    userId.remove();
+    userIP.remove();
+    userCredential.remove();
+  }
+
+  /**
    * Creates a queue if not present and adds the {@link AuditLogContext} to it.
    */
   public static void enqueueAuditLogContext(AuditLogContext auditLog) {


### PR DESCRIPTION
In `GcpWorkloadIdentityHttpHandler` : 
- first the call uses ENFORCE 
- this adds a Audit Log to `SecurityRequestContext` 
- but then it calls `switchToInternalUser` , which does : `SecurityRequestContext.reset()` 
- This removed all the audit logs 

Small workaround : Instead of using a complete reset, reset only User Details. 

Testing : 
- Validated that audit log is published for `GcpWorkloadIdentityHttpHandler.validateIdentity` in dev env of gcp