### PR TITLE
[CDAP-21110] Implement FailureDetailsProvider in DataprocRuntimeException to cover provisioning errors

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/ErrorCategory.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/ErrorCategory.java
@@ -16,6 +16,9 @@
 
 package io.cdap.cdap.api.exception;
 
+import java.util.Objects;
+import javax.annotation.Nullable;
+
 /**
  * Class representing the category of an error.
  *
@@ -25,6 +28,7 @@ package io.cdap.cdap.api.exception;
  */
 public class ErrorCategory {
   private final ErrorCategoryEnum errorCategory;
+  @Nullable
   private final String subCategory;
 
   /**
@@ -33,8 +37,7 @@ public class ErrorCategory {
    * @param errorCategory The category of the error.
    */
   public ErrorCategory(ErrorCategoryEnum errorCategory) {
-    this.errorCategory = errorCategory;
-    this.subCategory = null;
+    this(errorCategory, null);
   }
 
   /**
@@ -43,7 +46,7 @@ public class ErrorCategory {
    * @param errorCategory The category of the error.
    * @param subCategory The sub-category of the error.
    */
-  public ErrorCategory(ErrorCategoryEnum errorCategory, String subCategory) {
+  public ErrorCategory(ErrorCategoryEnum errorCategory, @Nullable String subCategory) {
     this.errorCategory = errorCategory;
     this.subCategory = subCategory;
   }
@@ -52,8 +55,24 @@ public class ErrorCategory {
    * Returns the category of the error.
    */
   public String getErrorCategory() {
-    return errorCategory == null ? ErrorCategoryEnum.OTHERS.toString() : subCategory == null ?
-        errorCategory.toString() : String.format("%s-'%s'", errorCategory, subCategory);
+    return errorCategory == null ? ErrorCategoryEnum.OTHERS.toString() : subCategory == null
+        ? errorCategory.toString() : String.format("%s-'%s'", errorCategory, subCategory);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof ErrorCategory)) {
+      return false;
+    }
+
+    ErrorCategory that = (ErrorCategory) o;
+    return Objects.equals(this.errorCategory, that.errorCategory)
+        && Objects.equals(this.subCategory, that.subCategory);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.errorCategory, this.subCategory);
   }
 
   /*
@@ -65,15 +84,24 @@ public class ErrorCategory {
   }
 
   /**
+   * Returns the parent category of the error.
+   */
+  public ErrorCategoryEnum getParentCategory() {
+    return errorCategory == null ? ErrorCategoryEnum.OTHERS : errorCategory;
+  }
+
+  /**
    * Enum representing the different categories of errors.
    */
   public enum ErrorCategoryEnum {
-    PLUGIN("Plugin"),
-    NETWORKING("Networking"),
-    PROVISIONING("Provisioning"),
     ACCESS("Access"),
+    DEPROVISIONING("Deprovisioning"),
+    NETWORKING("Networking"),
+    OTHERS("Others"),
+    PLUGIN("Plugin"),
+    PROVISIONING("Provisioning"),
     SCHEDULES_AND_TRIGGERS("Schedules and Triggers"),
-    OTHERS("Others");
+    STARTING("Starting");
 
     private final String displayName;
 

--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/FailureDetailsProvider.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/FailureDetailsProvider.java
@@ -21,6 +21,8 @@ import javax.annotation.Nullable;
 
 /**
  * Interface for providing failure details.
+ * While implementing the interface, please don't forget to add the class the in
+ * {io.cdap.cdap.logging.ErrorLogsClassifier#ALLOWLIST_CLASSES} list.
  */
 public interface FailureDetailsProvider {
 
@@ -68,5 +70,44 @@ public interface FailureDetailsProvider {
    */
   default ErrorType getErrorType() {
     return ErrorType.UNKNOWN;
+  }
+
+  /**
+   * Returns whether the error is coming from a dependent service.
+   *
+   * @return true if the error is a dependency service error, false otherwise.
+   */
+  default boolean isDependency() {
+    return false;
+  }
+
+  /**
+   * Returns the type of error code.
+   *
+   * @return the type of error code.
+   */
+  @Nullable
+  default ErrorCodeType getErrorCodeType() {
+    return null;
+  }
+
+  /**
+   * Returns the error code.
+   *
+   * @return the error code.
+   */
+  @Nullable
+  default String getErrorCode() {
+    return null;
+  }
+
+  /**
+   * Returns the URL to the documentation.
+   *
+   * @return the URL to the documentation.
+   */
+  @Nullable
+  default String getSupportedDocumentationUrl() {
+    return null;
   }
 }

--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/ProgramFailureException.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/ProgramFailureException.java
@@ -70,46 +70,39 @@ public class ProgramFailureException extends RuntimeException implements Failure
 
   @Override
   public ErrorCategory getErrorCategory() {
+    if (errorCategory == null) {
+      return FailureDetailsProvider.super.getErrorCategory();
+    }
     return errorCategory;
   }
 
   @Override
   public ErrorType getErrorType() {
-    return errorType == null ? ErrorType.UNKNOWN : errorType;
+    if (errorType == null) {
+      return FailureDetailsProvider.super.getErrorType();
+    }
+    return errorType;
   }
 
-  /**
-   * Returns whether the error is coming from a dependent service.
-   *
-   * @return true if the error is a dependency service error, false otherwise.
-   */
+  @Override
   public boolean isDependency() {
     return dependency;
   }
 
-  /**
-   * Returns the type of error code.
-   *
-   * @return the type of error code.
-   */
+  @Nullable
+  @Override
   public ErrorCodeType getErrorCodeType() {
     return errorCodeType;
   }
 
-  /**
-   * Returns the error code.
-   *
-   * @return the error code.
-   */
+  @Nullable
+  @Override
   public String getErrorCode() {
     return errorCode;
   }
 
-  /**
-   * Returns the URL to the documentation.
-   *
-   * @return the URL to the documentation.
-   */
+  @Nullable
+  @Override
   public String getSupportedDocumentationUrl() {
     return supportedDocumentationUrl;
   }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/DefaultProvisionerContext.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/provision/DefaultProvisionerContext.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.internal.provision;
 
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.logging.LoggingContext;
@@ -62,6 +64,7 @@ public class DefaultProvisionerContext implements ProvisionerContext {
   private final String profileName;
   private final LoggingContext loggingContext;
   private final Executor executor;
+  private final ErrorCategory errorCategory;
 
   DefaultProvisionerContext(ProgramRunId programRunId, String provisionerName,
       Map<String, String> properties,
@@ -69,7 +72,7 @@ public class DefaultProvisionerContext implements ProvisionerContext {
       @Nullable VersionInfo appCDAPVersion, LocationFactory locationFactory,
       RuntimeMonitorType runtimeMonitorType, MetricsCollectionService metricsCollectionService,
       @Nullable String profileName, Executor executor,
-      LoggingContext loggingContext) {
+      LoggingContext loggingContext, ErrorCategory errorCategory) {
     this.programRun = new ProgramRun(programRunId.getNamespace(), programRunId.getApplication(),
         programRunId.getProgram(), programRunId.getRun());
     this.programRunInfo = new ProgramRunInfo.Builder()
@@ -92,6 +95,7 @@ public class DefaultProvisionerContext implements ProvisionerContext {
     this.metricsCollectionService = metricsCollectionService;
     this.provisionerName = provisionerName;
     this.executor = executor;
+    this.errorCategory = errorCategory;
   }
 
   @Override
@@ -144,6 +148,11 @@ public class DefaultProvisionerContext implements ProvisionerContext {
   @Override
   public String getProfileName() {
     return profileName;
+  }
+
+  @Override
+  public ErrorCategory getErrorCategory() {
+    return errorCategory == null ? new ErrorCategory(ErrorCategoryEnum.OTHERS) : errorCategory;
   }
 
   @Override

--- a/cdap-common/src/main/java/io/cdap/cdap/extension/AbstractExtensionLoader.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/extension/AbstractExtensionLoader.java
@@ -340,12 +340,16 @@ public abstract class AbstractExtensionLoader<EXTENSION_TYPE, EXTENSION> {
     return new FilterClassLoader(getClass().getClassLoader(), new FilterClassLoader.Filter() {
       @Override
       public boolean acceptResource(String resource) {
-        return resource.startsWith("org/slf4j") || filter.acceptResource(resource);
+        return resource.startsWith("org/slf4j")
+            || resource.startsWith("io/cdap/cdap/api/exception")
+            || filter.acceptResource(resource);
       }
 
       @Override
       public boolean acceptPackage(String packageName) {
-        return packageName.startsWith("org.slf4j") || filter.acceptPackage(packageName);
+        return packageName.startsWith("org.slf4j")
+            || packageName.startsWith("io.cdap.cdap.api.exception")
+            || filter.acceptPackage(packageName);
       }
     });
   }

--- a/cdap-coverage/pom.xml
+++ b/cdap-coverage/pom.xml
@@ -110,16 +110,6 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-hbase-spi</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-hbase-compat-base</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-tms</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -235,11 +225,6 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-hbase-compat-1.0</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-data-fabric-tests</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -281,26 +266,6 @@
     <dependency>
       <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-app-fabric-tests</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-hbase-compat-1.0-cdh5.5.0</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-hbase-compat-1.0-cdh</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-hbase-compat-1.1</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-hbase-compat-1.2-cdh5.7.0</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -22,6 +22,7 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
+import io.cdap.cdap.api.exception.ErrorCategory;
 import io.cdap.cdap.runtime.spi.common.DataprocImageVersion;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import io.cdap.cdap.runtime.spi.provisioner.Capabilities;
@@ -71,7 +72,7 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
   /**
    * In reuse scenario we can't find "our" cluster by cluster name, so let's put it into the label
    *
-   * @see {@link DataprocProvisioner#getAllocatedClusterName(ProvisionerContext)}
+   * @see DataprocProvisioner#findCluster(String, DataprocClient)
    */
   public static final String LABEL_RUN_KEY = "cdap-run-key";
 
@@ -237,7 +238,6 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
     }
     return ImmutableSet.of(DataprocConf.RUNTIME_JOB_MANAGER, DataprocUtils.BUCKET,
         DataprocConf.TOKEN_ENDPOINT_KEY,
-        DataprocUtils.TROUBLESHOOTING_DOCS_URL_KEY,
         DataprocConf.ENCRYPTION_KEY_NAME, DataprocConf.ROOT_URL,
         DataprocConf.COMPUTE_HTTP_REQUEST_CONNECTION_TIMEOUT,
         DataprocConf.COMPUTE_HTTP_REQUEST_READ_TIMEOUT).contains(property);

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClientFactory.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocClientFactory.java
@@ -16,6 +16,8 @@
 
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
@@ -28,11 +30,13 @@ public interface DataprocClientFactory {
    * Create a {@link DataprocClient} for clusters that do not need SSH access.
    *
    * @param conf configuration about the dataproc clusters to operate on
+   * @param errorCategory error category
    * @return a DataprocClient
    * @throws IOException if there was an exception reading the credentials
    */
-  default DataprocClient create(DataprocConf conf) throws GeneralSecurityException, IOException {
-    return create(conf, false);
+  default DataprocClient create(DataprocConf conf, ErrorCategory errorCategory)
+      throws GeneralSecurityException, IOException, RetryableProvisionException {
+    return create(conf, false, errorCategory);
   }
 
   /**
@@ -41,9 +45,10 @@ public interface DataprocClientFactory {
    * @param conf configuration about the dataproc clusters to operate on
    * @param requireSSH whether the cluster should be open to SSH connections. When false, the
    *     client can avoid making various Compute calls to fetch additional information.
+   * @param errorCategory error category
    * @return a DataprocClient
    * @throws IOException if there was an exception reading the credentials
    */
-  DataprocClient create(DataprocConf conf, boolean requireSSH)
-      throws IOException, GeneralSecurityException;
+  DataprocClient create(DataprocConf conf, boolean requireSSH, ErrorCategory errorCategory)
+      throws IOException, GeneralSecurityException, RetryableProvisionException;
 }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocConf.java
@@ -175,17 +175,12 @@ final class DataprocConf {
   private final long clusterReuseUpdateMaxMs;
   private final String clusterReuseKey;
   private final boolean enablePredefinedAutoScaling;
+
   private final boolean disableLocalCaching;
+  private final boolean gcsCacheEnabled;
 
   private final int computeReadTimeout;
   private final int computeConnectionTimeout;
-
-  private final boolean gcsCacheEnabled;
-  private final String troubleshootingDocsUrl;
-
-  public String getTroubleshootingDocsUrl() {
-    return troubleshootingDocsUrl;
-  }
 
   private DataprocConf(@Nullable String accountKey, String region, String zone, String projectId,
       @Nullable String networkHostProjectId, @Nullable String network, @Nullable String subnet,
@@ -209,8 +204,7 @@ final class DataprocConf {
       long clusterReuseThresholdMinutes, long clusterReuseRetryDelayMs, long clusterReuseRetryMaxMs,
       long clusterReuseUpdateMaxMs, @Nullable String clusterReuseKey,
       boolean enablePredefinedAutoScaling, int computeReadTimeout, int computeConnectionTimeout,
-      @Nullable String rootUrl, boolean gcsCacheEnabled, boolean disableLocalCaching,
-      String troubleshootingDocsUrl) {
+      @Nullable String rootUrl, boolean gcsCacheEnabled, boolean disableLocalCaching) {
     this.accountKey = accountKey;
     this.region = region;
     this.zone = zone;
@@ -272,7 +266,6 @@ final class DataprocConf {
     this.rootUrl = rootUrl;
     this.gcsCacheEnabled = gcsCacheEnabled;
     this.disableLocalCaching = disableLocalCaching;
-    this.troubleshootingDocsUrl = troubleshootingDocsUrl;
   }
 
   String getRegion() {
@@ -587,7 +580,8 @@ final class DataprocConf {
     String projectId = getString(properties, PROJECT_ID_KEY);
     if (projectId == null || AUTO_DETECT.equals(projectId)) {
       projectId = DataprocUtils.getSystemProjectId(
-          (url -> (HttpURLConnection) url.openConnection()));
+          (url -> (HttpURLConnection) url.openConnection()),
+          DataprocRuntimeException.ERROR_CATEGORY_PROVISIONING_CONFIGURATION);
     }
 
     String zone = getString(properties, "zone");
@@ -776,10 +770,8 @@ final class DataprocConf {
         properties.getOrDefault(DataprocUtils.GCS_CACHE_ENABLED, "true"));
     // If true, artifacts will not be cached locally.
     final boolean disableLocalCaching =
-        Boolean.parseBoolean(properties.getOrDefault(DataprocUtils.LOCAL_CACHE_DISABLED, "false"));
-    final String troubleshootingDocsUrl =
-        properties.getOrDefault(DataprocUtils.TROUBLESHOOTING_DOCS_URL_KEY,
-            DataprocUtils.TROUBLESHOOTING_DOCS_URL_DEFAULT);
+        Boolean.parseBoolean(properties.getOrDefault(DataprocUtils.LOCAL_CACHE_DISABLED,
+            "false"));
 
     final String scopesProperty = String.format("%s,%s",
         Optional.ofNullable(getString(properties, SCOPES)).orElse(""), CLOUD_PLATFORM_SCOPE);
@@ -806,7 +798,7 @@ final class DataprocConf {
         clusterReuseEnabled, clusterReuseThresholdMinutes, clusterReuseRetryDelayMs,
         clusterReuseRetryMaxMs, clusterReuseUpdateMaxMs, clusterReuseKey,
         enablePredefinedAutoScaling, computeReadTimeout, computeConnectionTimeout, rootUrl,
-        gcsCacheEnabled, disableLocalCaching, troubleshootingDocsUrl);
+        gcsCacheEnabled, disableLocalCaching);
   }
 
   // the UI never sends nulls, it only sends empty strings.

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocRuntimeException.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocRuntimeException.java
@@ -16,13 +16,13 @@
 
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
+import com.google.api.gax.rpc.ApiException;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
-import io.cdap.cdap.error.api.ErrorTagProvider;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import io.cdap.cdap.api.exception.ErrorCategory;
+import io.cdap.cdap.api.exception.ErrorCategory.ErrorCategoryEnum;
+import io.cdap.cdap.api.exception.ErrorCodeType;
+import io.cdap.cdap.api.exception.ErrorType;
+import io.cdap.cdap.api.exception.FailureDetailsProvider;
 import javax.annotation.Nullable;
 
 /**
@@ -30,64 +30,250 @@ import javax.annotation.Nullable;
  * #toString()} implementation that doesn't include this exception class name and with the root
  * cause error message.
  */
-public class DataprocRuntimeException extends RuntimeException implements ErrorTagProvider {
+public class DataprocRuntimeException extends RuntimeException implements FailureDetailsProvider {
 
-  private final Set<ErrorTag> errorTags = new HashSet<>();
+  private static final String TROUBLESHOOTING_MESSAGE_FORMAT =
+    "For troubleshooting Dataproc errors, refer to %s";
+  public static final String TROUBLESHOOTING_DOC_URL =
+      "https://cloud.google.com/dataproc/docs/support/troubleshoot-cluster-creation";
+  public static final ErrorCategory ERROR_CATEGORY_PROVISIONING_CONFIGURATION =
+      new ErrorCategory(ErrorCategoryEnum.PROVISIONING, "Configuration");
 
-  public DataprocRuntimeException(String message, ErrorTag... tags) {
-    super(message);
-    errorTags.addAll(Arrays.asList(tags));
-    errorTags.add(ErrorTag.DEPENDENCY);
+  private final ErrorCategory errorCategory;
+  private final String errorReason;
+  private final ErrorType errorType;
+  private final boolean dependency;
+  private final ErrorCodeType errorCodeType;
+  private final String errorCode;
+  private final String supportedDocumentationUrl;
+
+  private DataprocRuntimeException(@Nullable String operationId, Throwable cause,
+      ErrorCategory errorCategory, String errorReason, String errorMessage, ErrorType errorType,
+      boolean dependency, ErrorCodeType errorCodeType, String errorCode,
+      String supportedDocumentationUrl) {
+    super(createMessage(operationId, errorMessage, dependency), cause);
+    this.errorCategory = errorCategory;
+    this.errorReason = errorReason;
+    this.errorType = errorType;
+    this.dependency = dependency;
+    this.errorCodeType = errorCodeType;
+    this.errorCode = errorCode;
+    this.supportedDocumentationUrl = supportedDocumentationUrl;
   }
 
-  public DataprocRuntimeException(Throwable cause, String message, ErrorTag... tags) {
-    super(message, cause);
-    errorTags.addAll(Arrays.asList(tags));
-    errorTags.add(ErrorTag.DEPENDENCY);
-  }
-
-  public DataprocRuntimeException(Throwable cause, ErrorTag... tags) {
-    this(cause, "", tags);
-  }
-
-  public DataprocRuntimeException(@Nullable String operationId, Throwable cause, ErrorTag... tags) {
-    this(operationId, null, cause, tags);
-  }
-
-  public DataprocRuntimeException(@Nullable String operationId,
-      @Nullable String troubleshootingMessage,
-      Throwable cause, ErrorTag... tags) {
-    super(createMessage(operationId, troubleshootingMessage, cause), cause);
-    errorTags.addAll(Arrays.asList(tags));
-  }
-
-  @Override
-  public String toString() {
-    return String.format("ErrorTags: %s,  Msg: %s", errorTags,
-        getMessage() != null ? getMessage() : "");
-  }
-
-  private static String createMessage(@Nullable String operationId,
-      @Nullable String troubleShootingMessage, Throwable cause) {
+  private static String createMessage(@Nullable String operationId, String errorMessage,
+      boolean dependency) {
     StringBuilder message = new StringBuilder();
     if (operationId != null) {
       message.append("Dataproc operation ")
           .append(operationId)
           .append(" failure: ")
-          .append(Throwables.getRootCause(cause).getMessage());
-    } else {
+          .append(errorMessage);
+    } else if (dependency) {
       message.append("Dataproc operation failure: ")
-          .append(Throwables.getRootCause(cause).getMessage());
-    }
-    if (!Strings.isNullOrEmpty(troubleShootingMessage)) {
-      message.append("\n")
-          .append(troubleShootingMessage);
+          .append(errorMessage);
+    } else {
+      message.append(errorMessage);
     }
     return message.toString();
   }
 
+  @Nullable
   @Override
-  public Set<ErrorTag> getErrorTags() {
-    return Collections.unmodifiableSet(errorTags);
+  public String getErrorReason() {
+    if (!Strings.isNullOrEmpty(errorReason)) {
+      if (errorReason.endsWith(".") && !Strings.isNullOrEmpty(getSupportedDocumentationUrl())) {
+       return String.format("%s %s", errorReason,
+           String.format(TROUBLESHOOTING_MESSAGE_FORMAT, getSupportedDocumentationUrl()));
+      }
+    }
+    return errorReason;
+  }
+
+  @Nullable
+  @Override
+  public String getFailureStage() {
+    return null;
+  }
+
+  @Override
+  public ErrorCategory getErrorCategory() {
+    if (errorCategory == null) {
+      return FailureDetailsProvider.super.getErrorCategory();
+    }
+    return errorCategory;
+  }
+
+  @Override
+  public ErrorType getErrorType() {
+    if (errorType == null) {
+      return FailureDetailsProvider.super.getErrorType();
+    }
+    return errorType;
+  }
+
+  @Override
+  public boolean isDependency() {
+    return dependency;
+  }
+
+  @Nullable
+  @Override
+  public ErrorCodeType getErrorCodeType() {
+    return errorCodeType;
+  }
+
+  @Nullable
+  @Override
+  public String getErrorCode() {
+    return errorCode;
+  }
+
+  @Nullable
+  @Override
+  public String getSupportedDocumentationUrl() {
+    Throwable cause = getCause();
+    if (cause != null & cause instanceof ApiException) {
+      if (Strings.isNullOrEmpty(supportedDocumentationUrl)) {
+        return TROUBLESHOOTING_DOC_URL;
+      }
+    }
+    return supportedDocumentationUrl;
+  }
+
+  /**
+   * Builder class for DataprocRuntimeException.
+   */
+  public static class Builder {
+    private ErrorCategory errorCategory;
+    private String errorReason;
+    private String errorMessage;
+    private ErrorType errorType;
+    private Throwable cause;
+    private ErrorCodeType errorCodeType;
+    private String errorCode;
+    private boolean dependency;
+    private String supportedDocumentationUrl;
+    private String operationId;
+
+    /**
+     * Sets the error category for the DataprocRuntimeException.
+     *
+     * @param errorCategory The category of the error.
+     * @return The current Builder instance.
+     */
+    public Builder withErrorCategory(ErrorCategory errorCategory) {
+      this.errorCategory = errorCategory;
+      return this;
+    }
+
+    /**
+     * Sets the error reason for the DataprocRuntimeException.
+     *
+     * @param errorReason The reason for the error.
+     * @return The current Builder instance.
+     */
+    public Builder withErrorReason(String errorReason) {
+      this.errorReason = errorReason;
+      return this;
+    }
+
+    /**
+     * Sets the error message for the ProgramFailureException.
+     *
+     * @param errorMessage The detailed error message.
+     * @return The current Builder instance.
+     */
+    public Builder withErrorMessage(String errorMessage) {
+      this.errorMessage = errorMessage;
+      return this;
+    }
+
+    /**
+     * Sets the error type for the DataprocRuntimeException.
+     *
+     * @param errorType The type of error (SYSTEM, USER, UNKNOWN).
+     * @return The current Builder instance.
+     */
+    public Builder withErrorType(ErrorType errorType) {
+      this.errorType = errorType;
+      return this;
+    }
+
+    /**
+     * Sets the cause for the DataprocRuntimeException.
+     *
+     * @param cause the cause (which is saved for later retrieval by the getCause() method).
+     * @return The current Builder instance.
+     */
+    public Builder withCause(Throwable cause) {
+      this.cause = cause;
+      return this;
+    }
+
+    /**
+     * Sets the dependency flag for the DataprocRuntimeException.
+     *
+     * @param dependency True if the error is from a dependent service, false otherwise.
+     * @return The current Builder instance.
+     */
+    public Builder withDependency(boolean dependency) {
+      this.dependency = dependency;
+      return this;
+    }
+
+    /**
+     * Sets the error code type for the DataprocRuntimeException.
+     *
+     * @param errorCodeType The type of error code.
+     * @return The current Builder instance.
+     */
+    public Builder withErrorCodeType(ErrorCodeType errorCodeType) {
+      this.errorCodeType = errorCodeType;
+      return this;
+    }
+
+    /**
+     * Sets the error code for the DataprocRuntimeException.
+     *
+     * @param errorCode The error code.
+     * @return The current Builder instance.
+     */
+    public Builder withErrorCode(String errorCode) {
+      this.errorCode = errorCode;
+      return this;
+    }
+
+    /**
+     * Sets the supported documentation URL for the DataprocRuntimeException.
+     *
+     * @param supportedDocumentationUrl The URL to the documentation.
+     * @return The current Builder instance.
+     */
+    public Builder withSupportedDocumentationUrl(String supportedDocumentationUrl) {
+      this.supportedDocumentationUrl = supportedDocumentationUrl;
+      return this;
+    }
+
+    /**
+     * Sets the dataproc operationId for the DataprocRuntimeException.
+     *
+     * @param operationId the dataproc operationId.
+     * @return The current Builder instance.
+     */
+    public Builder withOperationId(String operationId) {
+      this.operationId = operationId;
+      return this;
+    }
+
+    /**
+     * Builds and returns a new instance of DataprocRuntimeException.
+     *
+     * @return A new DataprocRuntimeException instance.
+     */
+    public DataprocRuntimeException build() {
+      return new DataprocRuntimeException(operationId, cause, errorCategory, errorReason,
+          errorMessage, errorType, dependency, errorCodeType, errorCode, supportedDocumentationUrl);
+    }
   }
 }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocTool.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocTool.java
@@ -118,7 +118,7 @@ public class DataprocTool {
     String name = commandLine.getOptionValue('n');
     DataprocClientFactory clientFactory = new DefaultDataprocClientFactory(
         new GoogleComputeFactory());
-    try (DataprocClient client = clientFactory.create(conf, commandLine.hasOption('l'))) {
+    try (DataprocClient client = clientFactory.create(conf, commandLine.hasOption('l'), null)) {
       if (PROVISION.equalsIgnoreCase(command)) {
         ClusterOperationMetadata createOp = client.createCluster(name, imageVersion,
             Collections.emptyMap(), false,

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/RuntimeMonitorDataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/RuntimeMonitorDataprocClient.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
 import com.google.cloud.dataproc.v1.ClusterControllerClient;
+import io.cdap.cdap.api.exception.ErrorCategory;
 import io.cdap.cdap.runtime.spi.provisioner.Node;
 import java.util.Collections;
 
@@ -26,8 +27,8 @@ import java.util.Collections;
 class RuntimeMonitorDataprocClient extends DataprocClient {
 
   RuntimeMonitorDataprocClient(DataprocConf conf, ClusterControllerClient client,
-      ComputeFactory computeFactory) {
-    super(conf, client, computeFactory);
+      ComputeFactory computeFactory, ErrorCategory errorCategory) {
+    super(conf, client, computeFactory, errorCategory);
   }
 
   @Override

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockDataprocClient.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockDataprocClient.java
@@ -19,12 +19,14 @@ package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 import com.google.api.services.compute.Compute;
 import com.google.cloud.dataproc.v1.ClusterControllerClient;
 import com.google.cloud.dataproc.v1.GceClusterConfig;
+import io.cdap.cdap.api.exception.ErrorCategory;
 import io.cdap.cdap.runtime.spi.provisioner.Node;
 import java.util.Collections;
 
 public class MockDataprocClient extends DataprocClient {
-  public MockDataprocClient(DataprocConf conf, ClusterControllerClient client, ComputeFactory computeFactory) {
-    super(conf, client, computeFactory);
+  public MockDataprocClient(DataprocConf conf, ClusterControllerClient client,
+      ComputeFactory computeFactory,ErrorCategory errorCategory) {
+    super(conf, client, computeFactory, errorCategory);
   }
 
   @Override

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerContext.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/MockProvisionerContext.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.runtime.spi.provisioner.dataproc;
 
+import io.cdap.cdap.api.exception.ErrorCategory;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.RuntimeMonitorType;
 import io.cdap.cdap.runtime.spi.SparkCompat;
@@ -41,6 +42,7 @@ public class MockProvisionerContext implements ProvisionerContext {
   private VersionInfo appCDAPVersionInfo;
   private String cdapVersion;
   private String profileName;
+  private ErrorCategory errorCategory;
 
   public MockProvisionerContext() {
     this(null);
@@ -91,6 +93,10 @@ public class MockProvisionerContext implements ProvisionerContext {
 
   public void setSparkCompat(SparkCompat sparkCompat) {
     this.sparkCompat = sparkCompat;
+  }
+
+  public void setErrorCategory(ErrorCategory errorCategory) {
+    this.errorCategory = errorCategory;
   }
 
   @Override
@@ -155,5 +161,11 @@ public class MockProvisionerContext implements ProvisionerContext {
       result.completeExceptionally(e);
     }
     return result;
+  }
+
+  @Nullable
+  @Override
+  public ErrorCategory getErrorCategory() {
+    return errorCategory;
   }
 }

--- a/cdap-runtime-spi/pom.xml
+++ b/cdap-runtime-spi/pom.xml
@@ -39,11 +39,16 @@
       <groupId>io.cdap.twill</groupId>
       <artifactId>twill-api</artifactId>
     </dependency>
-      <dependency>
-        <groupId>io.cdap.cdap</groupId>
-        <artifactId>cdap-error-api</artifactId>
-        <version>${project.version}</version>
-      </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-error-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-api-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerContext.java
+++ b/cdap-runtime-spi/src/main/java/io/cdap/cdap/runtime/spi/provisioner/ProvisionerContext.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.runtime.spi.provisioner;
 
+import io.cdap.cdap.api.exception.ErrorCategory;
 import io.cdap.cdap.runtime.spi.ProgramRunInfo;
 import io.cdap.cdap.runtime.spi.RuntimeMonitorType;
 import io.cdap.cdap.runtime.spi.SparkCompat;
@@ -118,4 +119,10 @@ public interface ProvisionerContext {
    */
   @Nullable
   String getProfileName();
+
+  /**
+   * @return error category.
+   */
+  @Nullable
+  ErrorCategory getErrorCategory();
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/LogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/LogAppender.java
@@ -133,22 +133,20 @@ public abstract class LogAppender extends AppenderBase<ILoggingEvent> {
       if (throwable instanceof FailureDetailsProvider) {
         FailureDetailsProvider provider = (FailureDetailsProvider) throwable;
         boolean stageKeyAbsent = !modifiableMdc.containsKey(Constants.Logging.TAG_FAILED_STAGE);
-        if (stageKeyAbsent) {
+        if (stageKeyAbsent && provider.getFailureStage() != null) {
           modifiableMdc.put(Constants.Logging.TAG_FAILED_STAGE, provider.getFailureStage());
         }
         modifiableMdc.put(Constants.Logging.TAG_ERROR_CATEGORY,
             provider.getErrorCategory().getErrorCategory());
-        modifiableMdc.put(Constants.Logging.TAG_ERROR_REASON, provider.getErrorReason());
+        if (provider.getErrorReason() != null) {
+          modifiableMdc.put(Constants.Logging.TAG_ERROR_REASON, provider.getErrorReason());
+        }
         modifiableMdc.put(Constants.Logging.TAG_ERROR_TYPE, provider.getErrorType().name());
-      }
-
-      if (throwable instanceof ProgramFailureException) {
-        modifiableMdc.put(Constants.Logging.TAG_DEPENDENCY,
-            String.valueOf(((ProgramFailureException) throwable).isDependency()));
-        ErrorCodeType errorCodeType = ((ProgramFailureException) throwable).getErrorCodeType();
-        String errorCode = ((ProgramFailureException) throwable).getErrorCode();
-        String supportedDocUrl =
-            ((ProgramFailureException) throwable).getSupportedDocumentationUrl();
+        modifiableMdc.put(Constants.Logging.TAG_DEPENDENCY, String.valueOf(
+            provider.isDependency()));
+        ErrorCodeType errorCodeType = provider.getErrorCodeType();
+        String errorCode = provider.getErrorCode();
+        String supportedDocUrl = provider.getSupportedDocumentationUrl();
         if (errorCodeType != null) {
           modifiableMdc.put(Constants.Logging.TAG_ERROR_CODE_TYPE, errorCodeType.name());
         }


### PR DESCRIPTION
Jira : [CDAP-21110](https://cdap.atlassian.net/browse/CDAP-21110)

### Description

This PR adds support for error classification of dataproc_runtime_exception.

### Tested in CDAP Sandbox
![image](https://github.com/user-attachments/assets/71462f90-1d88-42fe-8b21-2338e7ee27e8)

[CDAP-21110]: https://cdap.atlassian.net/browse/CDAP-21110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ