### PR TITLE
CDAP-21114   Disable messaging service pod for new CDAP instances with Cloud Spanner enabled

### DIFF
--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/guice/AppFabricTestModule.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/guice/AppFabricTestModule.java
@@ -92,7 +92,7 @@ public final class AppFabricTestModule extends AbstractModule {
     install(new IOModule());
     install(new InMemoryDiscoveryModule());
     install(new AppFabricServiceRuntimeModule(cConf).getInMemoryModules());
-    install(new MonitorHandlerModule(false));
+    install(new MonitorHandlerModule(false, cConf));
     install(new ProgramRunnerRuntimeModule().getInMemoryModules());
     install(new NonCustomLocationUnitTestModule());
     install(new LocalLogAppenderModule());

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -2121,6 +2121,7 @@ public final class Constants {
     public static final String EXTENSIONS_DIR = "messaging.service.extensions.dir";
 
     public static final String MESSAGING_SERVICE_NAME = "messaging.service.name";
+    public static final String MESSAGING_SERVICE_ENABLED = "messaging.service.enabled";
     public static final String CACHE_SIZE_MB = "messaging.cache.size.mb";
 
     public static final String HBASE_MAX_SCAN_THREADS = "messaging.hbase.max.scan.threads";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2406,6 +2406,11 @@
   <!-- Messaging System Configuration -->
 
   <property>
+    <name>messaging.service.enabled</name>
+    <value>true</value>
+  </property>
+
+  <property>
     <name>messaging.service.extensions.dir</name>
     <value>/opt/cdap/master/ext/messagingproviders</value>
   </property>

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
@@ -78,7 +78,6 @@ import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.operations.OperationalStatsService;
 import io.cdap.cdap.operations.guice.OperationalStatsModule;
-import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.TokenSecureStoreRenewer;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AccessControllerInstantiator;
@@ -548,7 +547,7 @@ public class MasterServiceMain extends DaemonMain {
         new AuthorizationEnforcementModule().getMasterModule(),
         new TwillModule(),
         new AppFabricServiceRuntimeModule(cConf).getDistributedModules(),
-        new MonitorHandlerModule(true),
+        new MonitorHandlerModule(true, cConf),
         new ProgramRunnerRuntimeModule().getDistributedModules(),
         new SecureStoreServerModule(),
         new SupportBundleServiceModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricProcessorServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricProcessorServiceMain.java
@@ -107,7 +107,7 @@ public class AppFabricProcessorServiceMain extends AbstractServiceMain<Environme
               }
             }),
         new ProgramRunnerRuntimeModule().getDistributedModules(true),
-        new MonitorHandlerModule(false),
+        new MonitorHandlerModule(false, cConf),
         new SecureStoreServerModule(),
         new OperationalStatsModule(),
         getDataFabricModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -107,7 +107,7 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
               }
             }),
         new ProgramRunnerRuntimeModule().getDistributedModules(true),
-        new MonitorHandlerModule(false),
+        new MonitorHandlerModule(false, cConf),
         new SecureStoreServerModule(),
         new OperationalStatsModule(),
         getDataFabricModule(),

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -565,7 +565,7 @@ public class StandaloneMain {
         new PreviewRunnerManagerModule().getStandaloneModules(),
         new MessagingServerRuntimeModule().getStandaloneModules(),
         new AppFabricServiceRuntimeModule(cConf).getStandaloneModules(),
-        new MonitorHandlerModule(false),
+        new MonitorHandlerModule(false, cConf),
         new RuntimeServerModule(),
         new OperationalStatsModule(),
         new MetricsWriterModule(),

--- a/cdap-support-bundle/src/test/java/io/cdap/cdap/SupportBundleTestModule.java
+++ b/cdap-support-bundle/src/test/java/io/cdap/cdap/SupportBundleTestModule.java
@@ -86,7 +86,7 @@ public class SupportBundleTestModule extends AbstractModule {
     install(new IOModule());
     install(new InMemoryDiscoveryModule());
     install(new AppFabricServiceRuntimeModule(cConf).getInMemoryModules());
-    install(new MonitorHandlerModule(false));
+    install(new MonitorHandlerModule(false, cConf));
     install(new ProgramRunnerRuntimeModule().getInMemoryModules());
     install(new NonCustomLocationUnitTestModule());
     install(new LocalLogAppenderModule());

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -302,7 +302,7 @@ public class TestBase {
         new LocalLocationModule(),
         new InMemoryDiscoveryModule(),
         new AppFabricServiceRuntimeModule(cConf).getInMemoryModules(),
-        new MonitorHandlerModule(false),
+        new MonitorHandlerModule(false, cConf),
         new AuthenticationContextModules().getMasterModule(),
         new AuthorizationModule(),
         new AuthorizationEnforcementModule().getInMemoryModules(),


### PR DESCRIPTION
conditionally add messaging service to MonitorHandlerModule

tested with http calls:
![image](https://github.com/user-attachments/assets/a27b7659-f1e6-4c5b-a265-b1d750ba4007)

and messaging service is no longer visible here:
![image](https://github.com/user-attachments/assets/0e15d855-7f37-40b8-a2ce-06ef282bd966)

