### PR TITLE
[CDAP-21096] Write appfabric server port to tmp file for k8s readiness probe

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -53,8 +53,12 @@ import io.cdap.cdap.store.DefaultNamespaceStore;
 import io.cdap.http.AbstractHandlerHook;
 import io.cdap.http.HttpHandler;
 import io.cdap.http.NettyHttpService;
+import java.io.File;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -242,6 +246,9 @@ public class AppFabricServer extends AbstractIdleService {
           ResolvingDiscoverable.of(uriScheme.createDiscoverable(serviceName, socketAddress))));
     }
 
+    writeServerPortToFile(Constants.Service.APP_FABRIC_HTTP, announcePort);
+    LOG.debug("AppFabric HTTP server started.");
+
     return () -> {
       LOG.debug("Stopping AppFabric HTTP service.");
       for (Cancellable cancellable : cancellables) {
@@ -258,5 +265,13 @@ public class AppFabricServer extends AbstractIdleService {
 
       LOG.info("AppFabric HTTP service stopped.");
     };
+  }
+
+  private void writeServerPortToFile(String service, int port) throws IOException {
+    String dir = cConf.get(Constants.Service.SERVER_PORT_DIR);
+    String filename = service + ".port";
+    File file = new File(dir, filename);
+    LOG.debug("Writing server port {} to file: {}", port, file.getAbsolutePath());
+    Files.write(file.toPath(), String.valueOf(port).getBytes());
   }
 }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/AppFabricServerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/AppFabricServerTest.java
@@ -22,14 +22,17 @@ import com.google.inject.Injector;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.SConfiguration;
+import io.cdap.cdap.common.conf.StringUtils;
 import io.cdap.cdap.common.discovery.EndpointStrategy;
 import io.cdap.cdap.common.discovery.RandomEndpointStrategy;
 import io.cdap.cdap.common.discovery.URIScheme;
 import io.cdap.cdap.common.utils.Tasks;
 import io.cdap.cdap.internal.AppFabricTestHelper;
 import io.cdap.cdap.security.server.LdapLoginModule;
+import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.file.Files;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import javax.net.ssl.SSLSocket;
@@ -92,6 +95,37 @@ public class AppFabricServerTest {
       // "javax.net.ssl.SSLException: Unrecognized SSL message, plaintext connection?"
       socket.startHandshake();
       appFabricServer.stopAndWait();
+    } finally {
+      AppFabricTestHelper.shutdown();
+    }
+  }
+
+  @Test
+  public void testServerPortFile() throws Exception {
+    Injector injector = AppFabricTestHelper.getInjector();
+    try {
+      AppFabricServer server = injector.getInstance(AppFabricServer.class);
+      DiscoveryServiceClient discoveryServiceClient = injector.getInstance(DiscoveryServiceClient.class);
+      Service.State state = server.startAndWait();
+      Assert.assertSame(state, Service.State.RUNNING);
+
+      final EndpointStrategy endpointStrategy = new RandomEndpointStrategy(
+          () -> discoveryServiceClient.discover(Constants.Service.APP_FABRIC_HTTP));
+      Assert.assertNotNull(endpointStrategy.pick(5, TimeUnit.SECONDS));
+
+      // Check file exists and port number is in range of 0 to 65535.
+      File file = new File("/tmp/appfabric.port");
+      Assert.assertTrue("server port file doesn't exist",
+          file.exists() && !file.isDirectory());
+      byte[] bytes = Files.readAllBytes(file.toPath());
+      String content = new String(bytes);
+      Assert.assertTrue(Integer.valueOf(content) > 0);
+      Assert.assertTrue(Integer.valueOf(content) < 65535);
+
+      state = server.stopAndWait();
+      Assert.assertSame(state, Service.State.TERMINATED);
+
+      Tasks.waitFor(true, () -> endpointStrategy.pick() == null, 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     } finally {
       AppFabricTestHelper.shutdown();
     }

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -158,6 +158,8 @@ public final class Constants {
     public static final String REMOTE_AGENT_SERVICE = "remote.agent.service";
     public static final String ARTIFACT_CACHE_SERVICE = "artifact.cache.service";
     public static final String RUNTIME_MONITOR_RETRY_PREFIX = "system.runtime.monitor.";
+
+    public static final String SERVER_PORT_DIR = "system.services.server.dir";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -6563,4 +6563,12 @@
     </description>
   </property>
 
+  <property>
+    <name>system.services.server.dir</name>
+    <value>/tmp</value>
+    <description>
+      Directory for storing files related to server for system services.
+    </description>
+  </property>
+
 </configuration>


### PR DESCRIPTION
[CDAP-21096] Add support for startupProbe in CDAP master

### Context

In addition to the rolling upgrade strategy, for high availability of APIs, startup probe need to be implemented to ensure that the CDAP service pods (eg. Appfabric) accepts requests only when the server has started.

CDAP services (eg. Appfabric) run on dynamic port and announces the port after the server has started. For this [command probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes) can be configured to check the status of system service using the URL ‘/v3/system/services/<service>/status’.

CDAP services will write the port to a temp file in the container after startup. Here is a code snippet for startup probe using the port written to the temp file:

```
startupProbe:
          exec:
            command:
            - sh
            - -c
            - curl -s -f -k https://localhost:$(cat /tmp/appfabric.port)/v3/system/services/appfabric/status
          failureThreshold: 60
          periodSeconds: 3
          successThreshold: 1
          timeoutSeconds: 1
```

**NOTE**: Corresponding `cdapio/cdap-operator` PR: https://github.com/cdapio/cdap-operator/pull/127

### Change Description

* Introduced `StartupProbe` as an optional field in the `CDAPServiceSpec`.
* The `StartupProbe` config of type `corev1.Probe` will be set to the container spec.
* Auto-generated:
    * api/v1alpha1/zz_generated.deepcopy.go
    * config/crd/bases/cdap.cdap.io_cdapmasters.yaml
* Makefile: To fix unit tests, the max request size of etcd database used by `controller-runtime/tools/setup-envtest` had to be increased from default 1.5 MB to 2.5 MB. This is due to the increase in size of generated CRD.

### Verification

- [x] Unit tests
- [x] CDAP Sandbox 
- [x] Docker image: deployed locally built docker image and edited the cdapmaster manifest to add startupProbe to appfabric spec.


[CDAP-21096]: https://cdap.atlassian.net/browse/CDAP-21096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ