### PR TITLE
[CDAP-21096] Exclude Bootstrap execution from Appfabric server

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -289,7 +289,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
         new MasterCredentialProviderModule(),
         new OperationModule(),
         new DataStorageAeadEncryptionModule(),
-        BootstrapModules.getFileBasedModule(),
+        serviceTypes.contains(ServiceType.PROCESSOR) ? BootstrapModules.getFileBasedModule() :
+            BootstrapModules.getNoOpModule(),
         new AbstractModule() {
           @Override
           protected void configure() {
@@ -352,7 +353,8 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
         new MasterCredentialProviderModule(),
         new OperationModule(),
         new DataStorageAeadEncryptionModule(),
-        BootstrapModules.getFileBasedModule(),
+        serviceTypes.contains(ServiceType.PROCESSOR) ? BootstrapModules.getFileBasedModule() :
+            BootstrapModules.getNoOpModule(),
         new AbstractModule() {
           @Override
           protected void configure() {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/BootstrapService.java
@@ -82,6 +82,13 @@ public class BootstrapService extends AbstractIdleService {
   protected void startUp() {
     LOG.info("Starting {}", getClass().getSimpleName());
     config = bootstrapConfigProvider.getConfig();
+
+    // Do not start other services if no bootstrap steps were executed.
+    if (config.getSteps().isEmpty()) {
+      LOG.info("Skipping execution of bootstrap steps as bootstrap config has no steps.");
+      return;
+    }
+
     executorService = Executors.newSingleThreadExecutor(
         Threads.createDaemonThreadFactory("bootstrap-service"));
     executorService.execute(() -> {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/guice/BootstrapModules.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/bootstrap/guice/BootstrapModules.java
@@ -73,6 +73,23 @@ public class BootstrapModules {
   }
 
   /**
+   * Module with empty config to not perform any bootstrap steps.
+   *
+   * @return bootstrap module that do not need to execute bootstrap steps.
+   */
+  public static Module getNoOpModule() {
+    return new BaseModule() {
+      @Override
+      protected void configure() {
+        super.configure();
+        BootstrapConfigProvider inMemoryProvider = new InMemoryBootstrapConfigProvider(
+            BootstrapConfig.EMPTY);
+        bind(BootstrapConfigProvider.class).toInstance(inMemoryProvider);
+      }
+    };
+  }
+
+  /**
    * Bindings common to all modules
    */
   private abstract static class BaseModule extends AbstractModule {

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MasterServiceMainTestBase.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.security.KeyStores;
 import io.cdap.cdap.common.security.KeyStoresTest;
 import io.cdap.cdap.gateway.router.NettyRouter;
+import io.cdap.cdap.internal.bootstrap.executor.DefaultNamespaceCreator;
 import io.cdap.cdap.logging.gateway.handlers.ProgramRunRecordFetcher;
 import io.cdap.cdap.logging.gateway.handlers.RemoteProgramRunRecordFetcher;
 import io.cdap.cdap.security.impersonation.SecurityUtil;
@@ -129,6 +130,11 @@ public class MasterServiceMainTestBase {
     for (Class<? extends AbstractServiceMain> serviceMainClass : serviceMainClasses) {
       startService(serviceMainClass);
     }
+
+    // Creates default namespace from appfabric service required for tests.
+    getServiceMainInstance(AppFabricServiceMain.class).getInjector()
+        .getInstance(DefaultNamespaceCreator.class)
+        .execute(null);
   }
 
   @AfterClass


### PR DESCRIPTION
### Issues

1. `BootstrapService` should run only in the Appfabric Processor service:
Bootstrap steps and `SystemAppManagementService#bootStrapSystemAppConfigDir` are slow and should run in Appfabric Processor only as per https://github.com/cdapio/cdap/pull/15773#discussion_r1906171525.

2. In addition to the bootstrap steps, the `BootstrapService` also starts `SystemAppManagementService`, `CapabilityManagementService`, `SystemProgramManagementService`. These services have dependency on `ProgramRuntimeService` which does not run inside `Appfabric` service in distributed mode. Hence, it fails to starts programs and apply capabilities like (like `dataprep`, `studio`) with the error message:

```
[SystemProgramManagementService:i.c.c.i.a.s.SystemProgramManagementService@129] - Could not start program program:system.pipeline.-SNAPSHOT.service.studio , will be retried in next run.
java.lang.NullPointerException: null
    at io.cdap.cdap.app.runtime.AbstractProgramRuntimeService.run(AbstractProgramRuntimeService.java:133)
    at io.cdap.cdap.internal.app.services.ProgramLifecycleService.startInternal(ProgramLifecycleService.java:916)
    at io.cdap.cdap.internal.app.services.ProgramLifecycleService.start(ProgramLifecycleService.java:873)
    at io.cdap.cdap.internal.app.services.SystemProgramManagementService.startPrograms(SystemProgramManagementService.java:124)
    ...
    ...
```


4. `MasterServiceMainTestBase` based tests require bootstrap steps to be performed as part of AppfabricService to create the default namespace in the appfabric service storage.

### Change Description

* Introduced `BootstrapModule.getNoOpModule()` which uses empty bootstrap config and does not execute bootstrap steps.
    * This is used by the Appfabric service in standalone and distributed module.
* For fixing the `MasterServiceMainTestBase` based tests, the `DefaultNamespaceCreator` of Appfabric service is executed to create the default namespace.

### Verification

- [x] Unit Tests
- [x] CDAP Sandbox
- [x] CDAP Docker Image
