### PR TITLE
[CDAP-21096] Split ProgramLifecycleService for Appfabric service and processor

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/ProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/runtime/ProgramRuntimeService.java
@@ -18,13 +18,19 @@ package io.cdap.cdap.app.runtime;
 
 import com.google.common.util.concurrent.Service;
 import io.cdap.cdap.app.program.ProgramDescriptor;
+import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.proto.ProgramLiveInfo;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 import org.apache.twill.api.RunId;
+import org.apache.twill.api.logging.LogEntry;
 
 /**
  * Service for interacting with the runtime system.
@@ -47,7 +53,9 @@ public interface ProgramRuntimeService extends Service {
   }
 
   /**
-   * Starts the given program and return a {@link RuntimeInfo} about the running program.
+   * Runs the given program and return a {@link RuntimeInfo} about the running program. The program
+   * is run if it is not already running, otherwise the {@link RuntimeInfo} of the already running
+   * program is returned.
    *
    * @param programDescriptor describing the program to run
    * @param options {@link ProgramOptions} that are needed by the program.
@@ -97,4 +105,60 @@ public interface ProgramRuntimeService extends Service {
    * @param types Types of program to check returns List of info about running programs.
    */
   List<RuntimeInfo> listAll(ProgramType... types);
+
+  /**
+   * Reset log levels for the given program. Only supported program types for this action are {@link
+   * ProgramType#SERVICE} and {@link ProgramType#WORKER}.
+   *
+   * @param programId the {@link ProgramId} of the program for which log levels are to be
+   *     reset.
+   * @param loggerNames the {@link String} set of the logger names to be updated, empty means
+   *     reset for all loggers.
+   * @param runId the run id of the program.
+   * @throws InterruptedException if there is an error while asynchronously resetting log
+   *     levels.
+   * @throws ExecutionException if there is an error while asynchronously resetting log levels.
+   * @throws UnauthorizedException if the user does not have privileges to reset log levels for
+   *     the specified program. To reset log levels for a program, a user needs {@link
+   *     StandardPermission#UPDATE} on the program.
+   */
+   void resetProgramLogLevels(ProgramId programId, Set<String> loggerNames, @Nullable String runId) throws Exception;
+
+  /**
+   * Update log levels for the given program. Only supported program types for this action are
+   * {@link ProgramType#SERVICE} and {@link ProgramType#WORKER}.
+   *
+   * @param programId the {@link ProgramId} of the program for which log levels are to be
+   *     updated
+   * @param logLevels the {@link Map} of the log levels to be updated.
+   * @param runId the run id of the program.
+   * @throws InterruptedException if there is an error while asynchronously updating log
+   *     levels.
+   * @throws ExecutionException if there is an error while asynchronously updating log levels.
+   * @throws BadRequestException if the log level is not valid or the program type is not
+   *     supported.
+   * @throws UnauthorizedException if the user does not have privileges to update log levels for
+   *     the specified program. To update log levels for a program, a user needs {@link
+   *     StandardPermission#UPDATE} on the program.
+   */
+  void updateProgramLogLevels(ProgramId programId, Map<String, LogEntry.Level> logLevels, @Nullable String runId)
+      throws Exception;
+
+  /**
+   * Set instances for the given program. Only supported program types for this action are {@link
+   * ProgramType#SERVICE} and {@link ProgramType#WORKER}.
+   *
+   * @param programId the {@link ProgramId} of the program for which instances are to be
+   *     updated
+   * @param instances the number of instances to be updated.
+   * @param instances the previous number of instances.
+   *
+   * @throws InterruptedException if there is an error while asynchronously updating instances
+   * @throws ExecutionException if there is an error while asynchronously updating instances
+   * @throws BadRequestException if the number of instances specified is less than 0
+   * @throws UnauthorizedException if the user does not have privileges to set instances for the
+   *     specified program. To set instances for a program, a user needs {@link
+   *     StandardPermission#UPDATE} on the program.
+   */
+  void setInstances(ProgramId programId, int instances, int oldInstances) throws Exception;
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/store/Store.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.api.workflow.WorkflowToken;
 import io.cdap.cdap.app.program.Program;
 import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.common.ApplicationNotFoundException;
+import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.ProgramNotFoundException;
@@ -463,6 +464,16 @@ public interface Store {
    */
   @Nullable
   ApplicationMeta getLatest(ApplicationReference appRef);
+
+  /**
+   * Gets the ApplicationId with the latest version for the given ApplicationReference.
+   *
+   * @param appRef ApplicationReference
+   * @return ApplicationId for the latest version
+   *
+   * @throws ApplicationNotFoundException if the app was not found for the given application reference.
+   */
+  ApplicationId getLatestApp(ApplicationReference appRef) throws ApplicationNotFoundException;
 
   /**
    * Scans for the latest applications across all namespaces.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramRuntimeHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramRuntimeHttpHandler.java
@@ -1,0 +1,566 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers;
+
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.app.runtime.ProgramRuntimeService;
+import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.ApplicationNotFoundException;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.common.security.AuditDetail;
+import io.cdap.cdap.common.security.AuditPolicy;
+import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import io.cdap.cdap.gateway.handlers.util.NamespaceHelper;
+import io.cdap.cdap.gateway.handlers.util.ProgramHandlerUtil;
+import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
+import io.cdap.cdap.internal.app.store.RunRecordDetail;
+import io.cdap.cdap.proto.BatchRunnable;
+import io.cdap.cdap.proto.BatchRunnableInstances;
+import io.cdap.cdap.proto.Containers;
+import io.cdap.cdap.proto.Instances;
+import io.cdap.cdap.proto.NotRunningProgramLiveInfo;
+import io.cdap.cdap.proto.ProgramLiveInfo;
+import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.ServiceInstances;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
+import io.cdap.cdap.proto.security.StandardPermission;
+import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
+import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import io.cdap.http.HttpResponder;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * {@link io.cdap.http.HttpHandler} to manage runtime of Programs for v3 REST APIs
+ *
+ * Only supported program types for this handler are {@link ProgramType#SERVICE} and {@link ProgramType#WORKER}.
+ */
+@Singleton
+@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
+public class ProgramRuntimeHttpHandler extends AbstractAppFabricHttpHandler {
+
+  private final ProgramLifecycleService lifecycleService;
+  private final ProgramRuntimeService runtimeService;
+  private final Store store;
+  private final NamespaceQueryAdmin namespaceQueryAdmin;
+  private final AccessEnforcer accessEnforcer;
+  private final AuthenticationContext authenticationContext;
+
+  @Inject
+  public ProgramRuntimeHttpHandler(ProgramLifecycleService lifecycleService, Store store,
+      ProgramRuntimeService runtimeService, NamespaceQueryAdmin namespaceQueryAdmin, AccessEnforcer accessEnforcer,
+      AuthenticationContext authenticationContext) {
+    this.lifecycleService = lifecycleService;
+    this.runtimeService = runtimeService;
+    this.store = store;
+    this.namespaceQueryAdmin = namespaceQueryAdmin;
+    this.accessEnforcer = accessEnforcer;
+    this.authenticationContext = authenticationContext;
+  }
+
+  private static final Type BATCH_RUNNABLES_TYPE = new TypeToken<List<BatchRunnable>>() {
+  }.getType();
+
+  /**
+   * Returns the number of instances for all program runnables that are passed into the data. The
+   * data is an array of Json objects where each object must contain the following three elements:
+   * appId, programType, and programId (flow name, service name). Retrieving instances only applies
+   * to flows, and user services. For flows, another parameter, "runnableId", must be provided. This
+   * corresponds to the flowlet/runnable for which to retrieve the instances.
+   * <p>
+   * Example input:
+   * <pre><code>
+   * [{"appId": "App1", "programType": "Service", "programId": "Service1", "runnableId": "Runnable1"},
+   *  {"appId": "App1", "programType": "Mapreduce", "programId": "Mapreduce2"}]
+   * </code></pre>
+   * </p><p>
+   * The response will be an array of JsonObjects each of which will contain the three input
+   * parameters as well as 3 fields:
+   * <ul>
+   * <li>"provisioned" which maps to the number of instances actually provided for the input runnable;</li>
+   * <li>"requested" which maps to the number of instances the user has requested for the input runnable; and</li>
+   * <li>"statusCode" which maps to the http status code for the data in that JsonObjects (200, 400, 404).</li>
+   * </ul>
+   * </p><p>
+   * If an error occurs in the input (for the example above, Flowlet1 does not exist), then all JsonObjects for
+   * which the parameters have a valid instances will have the provisioned and requested fields status code fields
+   * but all JsonObjects for which the parameters are not valid will have an error message and statusCode.
+   * </p><p>
+   * For example, if there is no Flowlet1 in the above data, then the response could be 200 OK with the following data:
+   * </p>
+   * <pre><code>
+   * [{"appId": "App1", "programType": "Service", "programId": "Service1", "runnableId": "Runnable1",
+   *   "statusCode": 200, "provisioned": 2, "requested": 2},
+   *  {"appId": "App1", "programType": "Mapreduce", "programId": "Mapreduce2", "statusCode": 400,
+   *   "error": "Program type 'Mapreduce' is not a valid program type to get instances"}]
+   * </code></pre>
+   */
+  @POST
+  @Path("/instances")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void getInstances(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId) throws IOException, BadRequestException {
+
+    List<BatchRunnable> runnables = ProgramHandlerUtil.validateAndGetBatchInput(request, BATCH_RUNNABLES_TYPE);
+
+    // cache app specs to perform fewer store lookups
+    Map<ApplicationId, ApplicationSpecification> appSpecs = new HashMap<>();
+
+    List<BatchRunnableInstances> output = new ArrayList<>(runnables.size());
+    for (BatchRunnable runnable : runnables) {
+      // cant get instances for things that are not services, or workers
+      if (!canHaveInstances(runnable.getProgramType())) {
+        output.add(
+            new BatchRunnableInstances(runnable, HttpResponseStatus.BAD_REQUEST.code(),
+                String.format("Program type '%s' is not a valid program type to get instances",
+                    runnable.getProgramType().getPrettyName())));
+        continue;
+      }
+
+      ApplicationId appId = new ApplicationId(namespaceId, runnable.getAppId());
+      try {
+        appId = store.getLatestApp(new ApplicationReference(namespaceId, runnable.getAppId()));
+      } catch (ApplicationNotFoundException e) {
+        output.add(new BatchRunnableInstances(runnable, HttpResponseStatus.NOT_FOUND.code(),
+            String.format("App: %s not found", appId)));
+        continue;
+      }
+
+      // populate spec cache if this is the first time we've seen the appid.
+      if (!appSpecs.containsKey(appId)) {
+        appSpecs.put(appId, store.getApplication(appId));
+      }
+
+      ApplicationSpecification spec = appSpecs.get(appId);
+      ProgramId programId = appId.program(runnable.getProgramType(), runnable.getProgramId());
+      output.add(getProgramInstances(runnable, spec, programId));
+    }
+    responder.sendJson(HttpResponseStatus.OK, ProgramHandlerUtil.toJson(output));
+  }
+
+  /**
+   * Return the number of instances of a service.
+   */
+  @GET
+  @Path("/apps/{app-id}/services/{service-id}/instances")
+  public void getServiceInstances(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-id") String appId,
+      @PathParam("service-id") String serviceId) throws Exception {
+    try {
+      NamespaceHelper.validateNamespace(namespaceQueryAdmin, namespaceId);
+      ProgramId programId = store.getLatestApp(new ApplicationReference(namespaceId, appId)).service(serviceId);
+      lifecycleService.ensureProgramExists(programId);
+      int instances = store.getServiceInstances(programId);
+      responder.sendJson(HttpResponseStatus.OK,
+          ProgramHandlerUtil.toJson(new ServiceInstances(instances, getInstanceCount(programId, serviceId))));
+    } catch (SecurityException e) {
+      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
+    }
+  }
+
+  /**
+   * Set instances of a service.
+   */
+  @PUT
+  @Path("/apps/{app-id}/services/{service-id}/instances")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void setServiceInstances(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-id") String appId,
+      @PathParam("service-id") String serviceId) throws Exception {
+    try {
+      ProgramId programId = store.getLatestApp(new ApplicationReference(namespaceId, appId))
+          .program(ProgramType.SERVICE, serviceId);
+      Store.ensureProgramExists(programId, store.getApplication(programId.getParent()));
+      int instances = getInstances(request);
+      accessEnforcer.enforce(programId, authenticationContext.getPrincipal(), StandardPermission.UPDATE);
+      setInstances(programId, instances);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (SecurityException e) {
+      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
+    } catch (Throwable throwable) {
+      if (respondIfElementNotFound(throwable, responder)) {
+        return;
+      }
+      throw throwable;
+    }
+  }
+
+  /**
+   * Returns number of instances of a worker.
+   */
+  @GET
+  @Path("/apps/{app-id}/workers/{worker-id}/instances")
+  public void getWorkerInstances(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-id") String appId,
+      @PathParam("worker-id") String workerId) throws Exception {
+    try {
+      NamespaceHelper.validateNamespace(namespaceQueryAdmin, namespaceId);
+      ProgramId programId = store.getLatestApp(new ApplicationReference(namespaceId, appId)).worker(workerId);
+      lifecycleService.ensureProgramExists(programId);
+      int count = store.getWorkerInstances(programId);
+      responder.sendJson(HttpResponseStatus.OK, ProgramHandlerUtil.toJson(new Instances(count)));
+    } catch (SecurityException e) {
+      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
+    } catch (Throwable e) {
+      if (respondIfElementNotFound(e, responder)) {
+        return;
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Sets the number of instances of a worker.
+   */
+  @PUT
+  @Path("/apps/{app-id}/workers/{worker-id}/instances")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void setWorkerInstances(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-id") String appId,
+      @PathParam("worker-id") String workerId) throws Exception {
+    int instances = getInstances(request);
+    try {
+      ProgramId programId = store.getLatestApp(new ApplicationReference(namespaceId, appId))
+          .program(ProgramType.WORKER, workerId);
+      Store.ensureProgramExists(programId, store.getApplication(programId.getParent()));
+      accessEnforcer.enforce(programId, authenticationContext.getPrincipal(), StandardPermission.UPDATE);
+      setInstances(programId, instances);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (SecurityException e) {
+      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
+    } catch (Throwable e) {
+      if (respondIfElementNotFound(e, responder)) {
+        return;
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Gets runtime information about a running program.
+   *
+   * @param request the HTTP request
+   * @param responder the HTTP responder
+   * @param namespaceId namespaceId for the program
+   * @param appId appId for the program
+   * @param programCategory program type
+   * @param programId the program Id
+   *
+   * @throws BadRequestException
+   * @throws ApplicationNotFoundException
+   */
+  @GET
+  @Path("/apps/{app-id}/{program-category}/{program-id}/live-info")
+  @SuppressWarnings("unused")
+  public void liveInfo(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-id") String appId, @PathParam("program-category") String programCategory,
+      @PathParam("program-id") String programId)
+      throws BadRequestException, ApplicationNotFoundException {
+    ProgramType type = ProgramType.valueOfCategoryName(programCategory, BadRequestException::new);
+    ProgramId program = store.getLatestApp(new ApplicationReference(namespaceId, appId))
+        .program(type, programId);
+    getLiveInfo(responder, program, runtimeService);
+  }
+
+  /**
+   * Update the log level for a running program according to the request body. Currently supported
+   * program types are {@link ProgramType#SERVICE} and {@link ProgramType#WORKER}. The request body
+   * is expected to contain a map of log levels, where key is loggername, value is one of the valid
+   * {@link org.apache.twill.api.logging.LogEntry.Level} or null.
+   *
+   */
+  @PUT
+  @Path("/apps/{app-name}/{program-type}/{program-name}/runs/{run-id}/loglevels")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void updateProgramLogLevels(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace,
+      @PathParam("app-name") String appName,
+      @PathParam("program-type") String type,
+      @PathParam("program-name") String programName,
+      @PathParam("run-id") String runId) throws Exception {
+    RunRecordDetail run = getRunRecordDetailFromId(namespace, appName, type, programName, runId);
+    updateLogLevels(request, responder, namespace, appName, run.getVersion(), type, programName,
+        runId);
+  }
+
+  /**
+   * Update the log level for a running program according to the request body.
+   * Deprecated : Run-id is sufficient to identify a program run.
+   */
+  @Deprecated
+  @PUT
+  @Path("/apps/{app-name}/versions/{app-version}/{program-type}/{program-name}/runs/{run-id}/loglevels")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void updateProgramLogLevelsVersioned(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace,
+      @PathParam("app-name") String appName,
+      @PathParam("app-version") String appVersion,
+      @PathParam("program-type") String type,
+      @PathParam("program-name") String programName,
+      @PathParam("run-id") String runId) throws Exception {
+    updateLogLevels(request, responder, namespace, appName, appVersion, type, programName, runId);
+  }
+
+  /**
+   * Reset the log level for a running program back to where it starts. Currently supported program
+   * types are {@link ProgramType#SERVICE} and {@link ProgramType#WORKER}. The request body can
+   * either be empty, which will reset all loggers for the program, or contain a list of logger
+   * names, which will reset for these particular logger names for the program.
+   */
+  @POST
+  @Path("/apps/{app-name}/{program-type}/{program-name}/runs/{run-id}/resetloglevels")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void resetProgramLogLevels(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace,
+      @PathParam("app-name") String appName,
+      @PathParam("program-type") String type,
+      @PathParam("program-name") String programName,
+      @PathParam("run-id") String runId) throws Exception {
+    RunRecordDetail run = getRunRecordDetailFromId(namespace, appName, type, programName, runId);
+    resetLogLevels(request, responder, namespace, appName, run.getVersion(), type, programName,
+        runId);
+  }
+
+  /**
+   * Reset the log level for a running program back to where it starts.
+   *
+   * Deprecated : Run-id is sufficient to identify a program run.
+   */
+  @POST
+  @Path("/apps/{app-name}/versions/{app-version}/{program-type}/{program-name}/runs/{run-id}/resetloglevels")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void resetProgramLogLevelsVersioned(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace,
+      @PathParam("app-name") String appName,
+      @PathParam("app-version") String appVersion,
+      @PathParam("program-type") String type,
+      @PathParam("program-name") String programName,
+      @PathParam("run-id") String runId) throws Exception {
+    resetLogLevels(request, responder, namespace, appName, appVersion, type, programName, runId);
+  }
+
+  private void getLiveInfo(HttpResponder responder, ProgramId programId,
+      ProgramRuntimeService runtimeService) {
+    try {
+      responder.sendJson(HttpResponseStatus.OK, ProgramHandlerUtil.toJson(runtimeService.getLiveInfo(programId)));
+    } catch (SecurityException e) {
+      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
+    }
+  }
+
+  /**
+   * Returns the number of instances currently running for different runnables for different
+   * programs
+   */
+  private int getInstanceCount(ProgramId programId, String runnableId) {
+    ProgramLiveInfo info = runtimeService.getLiveInfo(programId);
+    int count = 0;
+    if (info instanceof NotRunningProgramLiveInfo) {
+      return count;
+    }
+    if (info instanceof Containers) {
+      Containers containers = (Containers) info;
+      for (Containers.ContainerInfo container : containers.getContainers()) {
+        if (container.getName().equals(runnableId)) {
+          count++;
+        }
+      }
+      return count;
+    }
+    // TODO: CDAP-1091: For standalone mode, returning the requested instances instead of provisioned only for services.
+    // Doing this only for services to keep it consistent with the existing contract for flowlets right now.
+    // The get instances contract for both flowlets and services should be re-thought and fixed as part of CDAP-1091
+    if (programId.getType() == ProgramType.SERVICE) {
+      return getRequestedServiceInstances(programId);
+    }
+
+    // Not running on YARN default 1
+    return 1;
+  }
+
+  /**
+   * Get requested and provisioned instances for a program type. The program type passed here should
+   * be one that can have instances (flows, services, ...) Requires caller to do this validation.
+   */
+  private BatchRunnableInstances getProgramInstances(BatchRunnable runnable,
+      ApplicationSpecification spec,
+      ProgramId programId) {
+    int requested;
+    String programName = programId.getProgram();
+    ProgramType programType = programId.getType();
+    if (programType == ProgramType.WORKER) {
+      if (!spec.getWorkers().containsKey(programName)) {
+        return new BatchRunnableInstances(runnable, HttpResponseStatus.NOT_FOUND.code(),
+            "Worker: " + programName + " not found");
+      }
+      requested = spec.getWorkers().get(programName).getInstances();
+
+    } else if (programType == ProgramType.SERVICE) {
+      if (!spec.getServices().containsKey(programName)) {
+        return new BatchRunnableInstances(runnable, HttpResponseStatus.NOT_FOUND.code(),
+            "Service: " + programName + " not found");
+      }
+      requested = spec.getServices().get(programName).getInstances();
+
+    } else {
+      return new BatchRunnableInstances(runnable, HttpResponseStatus.BAD_REQUEST.code(),
+          "Instances not supported for program type + " + programType);
+    }
+    int provisioned = getInstanceCount(programId, programName);
+    // use the pretty name of program types to be consistent
+    return new BatchRunnableInstances(runnable, HttpResponseStatus.OK.code(), provisioned,
+        requested);
+  }
+
+  private int getRequestedServiceInstances(ProgramId serviceId) {
+    // Not running on YARN, get it from store
+    return store.getServiceInstances(serviceId);
+  }
+
+  private boolean canHaveInstances(ProgramType programType) {
+    return EnumSet.of(ProgramType.SERVICE, ProgramType.WORKER).contains(programType);
+  }
+
+  private void resetLogLevels(FullHttpRequest request, HttpResponder responder, String namespace,
+      String appName,
+      String appVersion, String type, String programName,
+      String runId) throws Exception {
+    ProgramType programType = ProgramType.valueOfCategoryName(type, BadRequestException::new);
+    try {
+      Set<String> loggerNames = parseBody(request, SET_STRING_TYPE);
+      ProgramId programId = new ApplicationId(namespace, appName, appVersion).program(programType, programName);
+      accessEnforcer.enforce(programId, authenticationContext.getPrincipal(), StandardPermission.UPDATE);
+      runtimeService.resetProgramLogLevels(
+          new ApplicationId(namespace, appName, appVersion).program(programType, programName),
+          loggerNames == null ? Collections.emptySet() : loggerNames, runId);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (JsonSyntaxException e) {
+      throw new BadRequestException("Invalid JSON in body");
+    } catch (SecurityException e) {
+      throw new UnauthorizedException("Unauthorized to reset the log levels");
+    }
+  }
+
+  private void updateLogLevels(FullHttpRequest request, HttpResponder responder, String namespace,
+      String appName,
+      String appVersion, String type, String programName,
+      String runId) throws Exception {
+    ProgramType programType = ProgramType.valueOfCategoryName(type, BadRequestException::new);
+    try {
+      // we are decoding the body to Map<String, String> instead of Map<String, LogEntry.Level> here since Gson will
+      // serialize invalid enum values to null, which is allowed for log level, instead of throw an Exception.
+      ProgramId programId = new ApplicationId(namespace, appName, appVersion).program(programType, programName);
+      accessEnforcer.enforce(programId, authenticationContext.getPrincipal(), StandardPermission.UPDATE);
+      runtimeService.updateProgramLogLevels(
+          new ApplicationId(namespace, appName, appVersion).program(programType, programName),
+          transformLogLevelsMap(decodeArguments(request)), runId);
+      responder.sendStatus(HttpResponseStatus.OK);
+    } catch (JsonSyntaxException e) {
+      throw new BadRequestException("Invalid JSON in body");
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e.getMessage());
+    } catch (SecurityException e) {
+      throw new UnauthorizedException("Unauthorized to update the log levels");
+    }
+  }
+
+  /**
+   * Set instances for the given program. Only supported program types for this action are {@link
+   * ProgramType#SERVICE} and {@link ProgramType#WORKER}.
+   *
+   * @param programId the {@link ProgramId} of the program for which instances are to be
+   *     updated
+   * @param instances the number of instances to be updated.
+   * @throws InterruptedException if there is an error while asynchronously updating instances
+   * @throws ExecutionException if there is an error while asynchronously updating instances
+   * @throws BadRequestException if the number of instances specified is less than 0
+   * @throws UnauthorizedException if the user does not have privileges to set instances for the
+   *     specified program. To set instances for a program, a user needs {@link
+   *     StandardPermission#UPDATE} on the program.
+   */
+  private void setInstances(ProgramId programId, int instances) throws Exception {
+    if (instances < 1) {
+      throw new BadRequestException(
+          String.format("Instance count should be greater than 0. Got %s.", instances));
+    }
+    switch (programId.getType()) {
+      case SERVICE:
+        int oldInstances = store.getServiceInstances(programId);
+        if (oldInstances != instances) {
+          store.setServiceInstances(programId, instances);
+          runtimeService.setInstances(programId, instances, instances);
+        }
+        break;
+      case WORKER:
+        oldInstances = store.getWorkerInstances(programId);
+        if (oldInstances != instances) {
+          store.setWorkerInstances(programId, instances);
+          runtimeService.setInstances(programId, instances, instances);
+        }
+        break;
+      default:
+        throw new BadRequestException(
+            String.format("Setting instances for program type %s is not supported",
+                programId.getType().getPrettyName()));
+    }
+  }
+
+  private RunRecordDetail getRunRecordDetailFromId(String namespaceId, String appName, String type,
+      String programName, String runId) throws NotFoundException, BadRequestException {
+    ProgramType programType = ProgramType.valueOfCategoryName(type, BadRequestException::new);
+    ProgramReference programRef = new ApplicationReference(namespaceId, appName).program(programType,
+        programName);
+    RunRecordDetail runRecordMeta = store.getRun(programRef, runId);
+    if (runRecordMeta == null) {
+      throw new NotFoundException(
+          String.format("No run record found for program %s and runID: %s", programRef, runId));
+    }
+    return runRecordMeta;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/util/NamespaceHelper.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/util/NamespaceHelper.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers.util;
+
+import com.google.common.base.Throwables;
+import io.cdap.cdap.common.NamespaceNotFoundException;
+import io.cdap.cdap.common.namespace.NamespaceQueryAdmin;
+import io.cdap.cdap.proto.id.NamespaceId;
+
+/**
+ * Helper class for Namespace operations.
+ */
+public class NamespaceHelper {
+
+  private NamespaceHelper() {
+  }
+
+  /**
+   * Validates that the namespace exists and gets the NamespaceId
+   *
+   * @param namespaceQueryAdmin query admin for namespace operations
+   * @param namespace the namespace to validate
+   * @return NamespaceId
+   *
+   * @throws NamespaceNotFoundException if namespace is not found
+   */
+  public static NamespaceId validateNamespace(NamespaceQueryAdmin namespaceQueryAdmin, String namespace)
+      throws NamespaceNotFoundException {
+    NamespaceId namespaceId = new NamespaceId(namespace);
+    try {
+      namespaceQueryAdmin.get(namespaceId);
+    } catch (NamespaceNotFoundException e) {
+      throw e;
+    } catch (Exception e) {
+      // This can only happen when NamespaceAdmin uses HTTP to interact with namespaces.
+      // Within AppFabric, NamespaceAdmin is bound to DefaultNamespaceAdmin which directly interacts with MDS.
+      // Hence, this should never happen.
+      throw Throwables.propagate(e);
+    }
+    return namespaceId;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/util/ProgramHandlerUtil.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/util/ProgramHandlerUtil.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
+import com.google.inject.Inject;
+import io.cdap.cdap.api.schedule.Trigger;
+import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.io.CaseInsensitiveEnumTypeAdapterFactory;
+import io.cdap.cdap.internal.app.ApplicationSpecificationAdapter;
+import io.cdap.cdap.internal.app.runtime.schedule.constraint.ConstraintCodec;
+import io.cdap.cdap.internal.app.runtime.schedule.trigger.SatisfiableTrigger;
+import io.cdap.cdap.internal.app.runtime.schedule.trigger.TriggerCodec;
+import io.cdap.cdap.internal.schedule.constraint.Constraint;
+import io.cdap.cdap.proto.BatchProgram;
+import io.cdap.cdap.security.spi.authentication.AuthenticationContext;
+import io.cdap.cdap.security.spi.authorization.AccessEnforcer;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.handler.codec.http.FullHttpRequest;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+public class ProgramHandlerUtil {
+
+  private ProgramHandlerUtil() {
+  }
+
+  /**
+   * Json serializer/deserializer.
+   */
+  private static final Gson GSON = ApplicationSpecificationAdapter
+      .addTypeAdapters(new GsonBuilder())
+      .registerTypeAdapter(Trigger.class, new TriggerCodec())
+      .registerTypeAdapter(SatisfiableTrigger.class, new TriggerCodec())
+      .registerTypeAdapter(Constraint.class, new ConstraintCodec())
+      .create();
+
+  /**
+   * Json serde for decoding request. It uses a case insensitive enum adapter.
+   */
+  private static final Gson DECODE_GSON = ApplicationSpecificationAdapter
+      .addTypeAdapters(new GsonBuilder())
+      .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
+      .registerTypeAdapter(Trigger.class, new TriggerCodec())
+      .registerTypeAdapter(SatisfiableTrigger.class, new TriggerCodec())
+      .registerTypeAdapter(Constraint.class, new ConstraintCodec())
+      .create();
+
+  public static String toJson(Object object) {
+    return GSON.toJson(object);
+  }
+
+  public static String toJson(Object object, @NotNull Type type) {
+    return GSON.toJson(object, type);
+  }
+
+  public static <T> T fromJson(@NotNull Reader reader, Class<T> type) {
+    return DECODE_GSON.fromJson(reader, type);
+  }
+
+  public static <T> T fromJson(@Nullable JsonElement json, Class<T> type) {
+    return DECODE_GSON.fromJson(json, type);
+  }
+
+  public static <T extends BatchProgram> List<T> validateAndGetBatchInput(FullHttpRequest request,
+      Type type)
+      throws BadRequestException, IOException {
+
+    List<T> programs;
+    try (Reader reader = new InputStreamReader(new ByteBufInputStream(request.content()),
+        StandardCharsets.UTF_8)) {
+      try {
+        programs = DECODE_GSON.fromJson(reader, type);
+        if (programs == null) {
+          throw new BadRequestException(
+              "Request body is invalid json, please check that it is a json array.");
+        }
+      } catch (JsonSyntaxException e) {
+        throw new BadRequestException("Request body is invalid json: " + e.getMessage());
+      }
+    }
+
+    // validate input
+    for (BatchProgram program : programs) {
+      try {
+        program.validate();
+      } catch (IllegalArgumentException e) {
+        throw new BadRequestException(
+            "Must provide valid appId, programType, and programId for each object: "
+                + e.getMessage());
+      }
+    }
+    return programs;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/DefaultPreviewRunner.java
@@ -46,6 +46,7 @@ import io.cdap.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorS
 import io.cdap.cdap.data2.dataset2.lib.table.leveldb.LevelDBTableService;
 import io.cdap.cdap.internal.app.deploy.ProgramTerminator;
 import io.cdap.cdap.internal.app.runtime.AbstractListener;
+import io.cdap.cdap.internal.app.runtime.ProgramStartRequest;
 import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
 import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
 import io.cdap.cdap.internal.app.services.ProgramNotificationSubscriberService;
@@ -208,7 +209,10 @@ public class DefaultPreviewRunner extends AbstractIdleService implements Preview
     }
 
     LOG.debug("Starting preview for {}", programId);
-    ProgramController controller = programLifecycleService.start(programId, userProps, false, true);
+    ProgramStartRequest startRequest = programLifecycleService.prepareStart(programId, userProps, false, true);
+    ProgramController controller = programRuntimeService.run(
+        startRequest.getProgramDescriptor(), startRequest.getProgramOptions(), startRequest.getRunId())
+          .getController();
 
     long startTimeMillis = System.currentTimeMillis();
     AtomicBoolean timeout = new AtomicBoolean();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramStartRequest.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/ProgramStartRequest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime;
+
+import io.cdap.cdap.app.program.ProgramDescriptor;
+import io.cdap.cdap.app.runtime.ProgramOptions;
+import io.cdap.cdap.common.app.RunIds;
+import io.cdap.cdap.proto.id.ProgramRunId;
+import org.apache.twill.api.RunId;
+
+/**
+ * Request object for starting a new Program run.
+ */
+public class ProgramStartRequest {
+
+  private final ProgramOptions programOptions;
+  private final ProgramDescriptor programDescriptor;
+  private final RunId runId;
+
+  public ProgramStartRequest(ProgramOptions programOptions,
+      ProgramDescriptor programDescriptor,
+      ProgramRunId programRunId) {
+    this.programOptions = programOptions;
+    this.programDescriptor = programDescriptor;
+    this.runId = RunIds.fromString(programRunId.getRun());
+  }
+
+  public ProgramOptions getProgramOptions() {
+    return programOptions;
+  }
+
+  public ProgramDescriptor getProgramDescriptor() {
+    return programDescriptor;
+  }
+
+  public RunId getRunId() {
+    return runId;
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/InMemoryProgramRuntimeService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/service/InMemoryProgramRuntimeService.java
@@ -47,9 +47,8 @@ public final class InMemoryProgramRuntimeService extends AbstractProgramRuntimeS
 
   @Inject
   InMemoryProgramRuntimeService(CConfiguration cConf, ProgramRunnerFactory programRunnerFactory,
-      ProgramStateWriter programStateWriter,
-      ProgramRunDispatcherFactory programRunDispatcherFactory) {
-    super(cConf, programRunnerFactory, programStateWriter, programRunDispatcherFactory);
+      ProgramStateWriter programStateWriter, ProgramRunDispatcherFactory programRunDispatcherFactory) {
+    super(cConf, programRunnerFactory, programStateWriter, programRunDispatcherFactory  );
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SystemProgramManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/SystemProgramManagementService.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.service.AbstractRetryableScheduledService;
 import io.cdap.cdap.common.service.RetryStrategies;
+import io.cdap.cdap.internal.app.runtime.ProgramStartRequest;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
@@ -121,7 +122,10 @@ public class SystemProgramManagementService extends AbstractRetryableScheduledSe
       Map<String, String> overrides = enabledProgramsMap.get(programId).asMap();
       LOG.debug("Starting program {} with args {}", programId, overrides);
       try {
-        programLifecycleService.start(programId, overrides, false, false);
+        ProgramStartRequest startRequest = programLifecycleService.prepareStart(programId, overrides, false, false);
+        programRuntimeService.run(
+            startRequest.getProgramDescriptor(), startRequest.getProgramOptions(), startRequest.getRunId())
+            .getController();
       } catch (ConflictException ex) {
         // Ignore if the program is already running.
         LOG.debug("Program {} is already running.", programId);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/store/DefaultStore.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.app.program.ProgramDescriptor;
 import io.cdap.cdap.app.store.ScanApplicationsRequest;
 import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.ApplicationNotFoundException;
+import io.cdap.cdap.common.BadRequestException;
 import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.common.NotFoundException;
 import io.cdap.cdap.common.ProgramNotFoundException;
@@ -937,6 +938,18 @@ public class DefaultStore implements Store {
     return TransactionRunners.run(transactionRunner, context -> {
       return getAppMetadataStore(context).getLatest(appRef);
     });
+  }
+
+  @Override
+  public ApplicationId getLatestApp(ApplicationReference appRef) throws ApplicationNotFoundException {
+    ApplicationMeta appMeta = getLatest(appRef);
+    if (appMeta == null) {
+      throw new ApplicationNotFoundException(appRef);
+    }
+
+    return new ApplicationId(appRef.getNamespace(),
+        appRef.getApplication(),
+        appMeta.getSpec().getAppVersion());
   }
 
   @Override

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityManagementService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/capability/CapabilityManagementService.java
@@ -24,7 +24,6 @@ import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.service.AbstractRetryableScheduledService;
 import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.common.utils.DirUtils;
-import io.cdap.cdap.internal.app.services.SystemProgramManagementService;
 import java.io.File;
 import java.io.FileReader;
 import java.io.Reader;
@@ -46,8 +45,7 @@ public class CapabilityManagementService extends AbstractRetryableScheduledServi
   private final CapabilityApplier capabilityApplier;
 
   @Inject
-  CapabilityManagementService(CConfiguration cConf, CapabilityApplier capabilityApplier,
-      SystemProgramManagementService systemProgramManagementService) {
+  CapabilityManagementService(CConfiguration cConf, CapabilityApplier capabilityApplier) {
     super(RetryStrategies
         .fixDelay(cConf.getLong(Constants.Capability.DIR_SCAN_INTERVAL_MINUTES), TimeUnit.MINUTES));
     this.cConf = cConf;

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/app/runtime/AbstractProgramRuntimeServiceTest.java
@@ -287,7 +287,8 @@ public class AbstractProgramRuntimeServiceTest {
     InMemoryProgramRunDispatcher launchDispatcher =
       new TestProgramRunDispatcher(cConf, runnerFactory, program, locationFactory,
                                    remoteClientFactory, true);
-    ProgramRuntimeService runtimeService = new TestProgramRuntimeService(cConf, runnerFactory, null, launchDispatcher);
+    ProgramRuntimeService runtimeService = new TestProgramRuntimeService(cConf, runnerFactory, null,
+        launchDispatcher);
     runtimeService.startAndWait();
     try {
       ProgramDescriptor descriptor = new ProgramDescriptor(program.getId(), null,

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricClient.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/AppFabricClient.java
@@ -33,6 +33,7 @@ import io.cdap.cdap.common.test.AppJarHelper;
 import io.cdap.cdap.gateway.handlers.AppLifecycleHttpHandler;
 import io.cdap.cdap.gateway.handlers.NamespaceHttpHandler;
 import io.cdap.cdap.gateway.handlers.ProgramLifecycleHttpHandler;
+import io.cdap.cdap.gateway.handlers.ProgramRuntimeHttpHandler;
 import io.cdap.cdap.gateway.handlers.WorkflowHttpHandler;
 import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import io.cdap.cdap.internal.app.BufferFileInputStream;
@@ -106,6 +107,7 @@ public class AppFabricClient {
   private final LocationFactory locationFactory;
   private final AppLifecycleHttpHandler appLifecycleHttpHandler;
   private final ProgramLifecycleHttpHandler programLifecycleHttpHandler;
+  private final ProgramRuntimeHttpHandler programRuntimeHttpHandler;
   private final WorkflowHttpHandler workflowHttpHandler;
   private final NamespaceHttpHandler namespaceHttpHandler;
   private final NamespaceQueryAdmin namespaceQueryAdmin;
@@ -114,12 +116,14 @@ public class AppFabricClient {
   public AppFabricClient(LocationFactory locationFactory,
                          AppLifecycleHttpHandler appLifecycleHttpHandler,
                          ProgramLifecycleHttpHandler programLifecycleHttpHandler,
+                         ProgramRuntimeHttpHandler programRuntimeHttpHandler,
                          NamespaceHttpHandler namespaceHttpHandler,
                          NamespaceQueryAdmin namespaceQueryAdmin,
                          WorkflowHttpHandler workflowHttpHandler) {
     this.locationFactory = locationFactory;
     this.appLifecycleHttpHandler = appLifecycleHttpHandler;
     this.programLifecycleHttpHandler = programLifecycleHttpHandler;
+    this.programRuntimeHttpHandler = programRuntimeHttpHandler;
     this.namespaceHttpHandler = namespaceHttpHandler;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
     this.workflowHttpHandler = workflowHttpHandler;
@@ -241,7 +245,7 @@ public class AppFabricClient {
     json.addProperty("instances", instances);
     request.content().writeCharSequence(json.toString(), StandardCharsets.UTF_8);
     HttpUtil.setContentLength(request, request.content().readableBytes());
-    programLifecycleHttpHandler.setWorkerInstances(request, responder, namespaceId, appId, workerId);
+    programRuntimeHttpHandler.setWorkerInstances(request, responder, namespaceId, appId, workerId);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Set worker instances failed");
   }
 
@@ -249,7 +253,7 @@ public class AppFabricClient {
     MockResponder responder = new MockResponder();
     String uri = String.format("%s/apps/%s/worker/%s/instances", getNamespacePath(namespaceId), appId, workerId);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    programLifecycleHttpHandler.getWorkerInstances(request, responder, namespaceId, appId, workerId);
+    programRuntimeHttpHandler.getWorkerInstances(request, responder, namespaceId, appId, workerId);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Get worker instances failed");
     return responder.decodeResponseContent(Instances.class);
   }
@@ -264,7 +268,7 @@ public class AppFabricClient {
     json.addProperty("instances", instances);
     request.content().writeCharSequence(json.toString(), StandardCharsets.UTF_8);
     HttpUtil.setContentLength(request, request.content().readableBytes());
-    programLifecycleHttpHandler.setServiceInstances(request, responder, namespaceId, applicationId, serviceName);
+    programRuntimeHttpHandler.setServiceInstances(request, responder, namespaceId, applicationId, serviceName);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Set service instances failed");
   }
 
@@ -274,7 +278,7 @@ public class AppFabricClient {
     String uri = String.format("%s/apps/%s/services/%s/instances",
                                getNamespacePath(namespaceId), applicationId, serviceName);
     HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri);
-    programLifecycleHttpHandler.getServiceInstances(request, responder, namespaceId, applicationId, serviceName);
+    programRuntimeHttpHandler.getServiceInstances(request, responder, namespaceId, applicationId, serviceName);
     verifyResponse(HttpResponseStatus.OK, responder.getStatus(), "Get service instances failed");
     return responder.decodeResponseContent(ServiceInstances.class);
   }

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramLifecycleServiceTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/ProgramLifecycleServiceTest.java
@@ -87,7 +87,7 @@ public class ProgramLifecycleServiceTest extends AppFabricTestBase {
 
   @Test
   public void testEmptyRunsIsStopped() {
-    Assert.assertEquals(ProgramStatus.STOPPED, ProgramLifecycleService.getProgramStatus(Collections.emptyList()));
+    Assert.assertEquals(ProgramStatus.STOPPED, programLifecycleService.getProgramStatus(Collections.emptyList()));
   }
 
   @Test
@@ -101,33 +101,33 @@ public class ProgramLifecycleServiceTest extends AppFabricTestBase {
       .build();
 
     // pending or starting -> starting
-    ProgramStatus status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    ProgramStatus status = programLifecycleService.getProgramStatus(Collections.singleton(record));
     Assert.assertEquals(ProgramStatus.STARTING, status);
 
     record = RunRecordDetail.builder(record).setStatus(ProgramRunStatus.STARTING).build();
-    status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    status = programLifecycleService.getProgramStatus(Collections.singleton(record));
     Assert.assertEquals(ProgramStatus.STARTING, status);
 
     // running, suspended, resuming -> running
     record = RunRecordDetail.builder(record).setStatus(ProgramRunStatus.RUNNING).build();
-    status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    status = programLifecycleService.getProgramStatus(Collections.singleton(record));
     Assert.assertEquals(ProgramStatus.RUNNING, status);
 
     record = RunRecordDetail.builder(record).setStatus(ProgramRunStatus.SUSPENDED).build();
-    status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    status = programLifecycleService.getProgramStatus(Collections.singleton(record));
     Assert.assertEquals(ProgramStatus.RUNNING, status);
 
     // failed, killed, completed -> stopped
     record = RunRecordDetail.builder(record).setStatus(ProgramRunStatus.FAILED).build();
-    status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    status = programLifecycleService.getProgramStatus(Collections.singleton(record));
     Assert.assertEquals(ProgramStatus.STOPPED, status);
 
     record = RunRecordDetail.builder(record).setStatus(ProgramRunStatus.KILLED).build();
-    status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    status = programLifecycleService.getProgramStatus(Collections.singleton(record));
     Assert.assertEquals(ProgramStatus.STOPPED, status);
 
     record = RunRecordDetail.builder(record).setStatus(ProgramRunStatus.COMPLETED).build();
-    status = ProgramLifecycleService.getProgramStatus(Collections.singleton(record));
+    status = programLifecycleService.getProgramStatus(Collections.singleton(record));
     Assert.assertEquals(ProgramStatus.STOPPED, status);
   }
 
@@ -158,18 +158,18 @@ public class ProgramLifecycleServiceTest extends AppFabricTestBase {
       .setStatus(ProgramRunStatus.COMPLETED).build();
 
     // running takes precedence over others
-    ProgramStatus status = ProgramLifecycleService.getProgramStatus(
+    ProgramStatus status = programLifecycleService.getProgramStatus(
       Arrays.asList(pending, starting, running, killed, failed, completed));
     Assert.assertEquals(ProgramStatus.RUNNING, status);
 
     // starting takes precedence over stopped
-    status = ProgramLifecycleService.getProgramStatus(Arrays.asList(pending, killed, failed, completed));
+    status = programLifecycleService.getProgramStatus(Arrays.asList(pending, killed, failed, completed));
     Assert.assertEquals(ProgramStatus.STARTING, status);
-    status = ProgramLifecycleService.getProgramStatus(Arrays.asList(starting, killed, failed, completed));
+    status = programLifecycleService.getProgramStatus(Arrays.asList(starting, killed, failed, completed));
     Assert.assertEquals(ProgramStatus.STARTING, status);
 
     // end states are stopped
-    status = ProgramLifecycleService.getProgramStatus(Arrays.asList(killed, failed, completed));
+    status = programLifecycleService.getProgramStatus(Arrays.asList(killed, failed, completed));
     Assert.assertEquals(ProgramStatus.STOPPED, status);
   }
 

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
@@ -56,7 +56,7 @@ public class RouterPathLookupTest {
     String path = "/v3/namespaces/n1/runs";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), path);
     RouteDestination result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
   }
 
   @Test
@@ -165,13 +165,13 @@ public class RouterPathLookupTest {
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), servicePath);
     httpRequest.headers().set(Constants.Gateway.API_KEY, API_KEY);
     RouteDestination result = pathLookup.getRoutingService(servicePath, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
 
     servicePath = "v3/namespaces/some/apps/otherAppName/services/CatalogLookup//methods////";
     httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), servicePath);
     httpRequest.headers().set(Constants.Gateway.API_KEY, API_KEY);
     result = pathLookup.getRoutingService(servicePath, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
 
     // v3 servicePaths
     servicePath = "/v3/namespaces/testnamespace/apps//PurchaseHistory///services/CatalogLookup///methods//ping/1";
@@ -207,13 +207,13 @@ public class RouterPathLookupTest {
     httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), servicePath);
     httpRequest.headers().set(Constants.Gateway.API_KEY, API_KEY);
     result = pathLookup.getRoutingService(servicePath, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
 
     servicePath = "v3/namespaces/testnamespace/apps/AppName/services/CatalogLookup////methods////";
     httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), servicePath);
     httpRequest.headers().set(Constants.Gateway.API_KEY, API_KEY);
     result = pathLookup.getRoutingService(servicePath, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
   }
 
   @Test
@@ -226,7 +226,7 @@ public class RouterPathLookupTest {
     String path = "/v3/namespaces/default//apps/ResponseCodeAnalytics/services/LogAnalyticsService/status";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), path);
     RouteDestination result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR, result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP, result);
   }
 
   @Test
@@ -234,7 +234,7 @@ public class RouterPathLookupTest {
     String path = "/v3/namespaces/default/apps///PurchaseHistory///workflows/PurchaseHistoryWorkflow/status";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), path);
     RouteDestination result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR,  result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP,  result);
   }
 
   @Test
@@ -242,7 +242,7 @@ public class RouterPathLookupTest {
     String path = "/v3/namespaces/default//apps/";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("PUT"), path);
     RouteDestination result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.APP_FABRIC_PROCESSOR,  result);
+    Assert.assertEquals(RouterPathLookup.APP_FABRIC_HTTP,  result);
   }
 
   @Test
@@ -422,23 +422,16 @@ public class RouterPathLookupTest {
 
   @Test
   public void testAppLifecycleAndWorkflowPaths() {
-    assertRouting("v3/namespaces/default/apps", RouterPathLookup.APP_FABRIC_PROCESSOR);
-    assertRouting("v3/namespaces/default/apps/myapp", RouterPathLookup.APP_FABRIC_PROCESSOR);
-    assertRouting("v3/namespaces/default/upgrade", RouterPathLookup.APP_FABRIC_PROCESSOR);
-    assertRouting("v3/namespaces/default/appdetail", RouterPathLookup.APP_FABRIC_PROCESSOR);
-  }
-
-  @Test
-  public void testProgramLifecyclePaths() {
-    for (String part : RouterPathLookup.APP_FABRIC_PROCESSOR_PATH_PARTS) {
-      assertRouting("v3/namespaces/default/" + part, RouterPathLookup.APP_FABRIC_PROCESSOR);
-    }
+    assertRouting("v3/namespaces/default/apps", RouterPathLookup.APP_FABRIC_HTTP);
+    assertRouting("v3/namespaces/default/apps/myapp", RouterPathLookup.APP_FABRIC_HTTP);
+    assertRouting("v3/namespaces/default/upgrade", RouterPathLookup.APP_FABRIC_HTTP);
+    assertRouting("v3/namespaces/default/appdetail", RouterPathLookup.APP_FABRIC_HTTP);
   }
 
   @Test
   public void testProgramLifecycleInternalAndAppLifecycleInternalPaths() {
     assertRouting("v3Internal/namespaces//apps//versions//workflows/DataPipelineWorkflow/runs/",
-        RouterPathLookup.APP_FABRIC_PROCESSOR);
+        RouterPathLookup.APP_FABRIC_HTTP);
   }
 
   @Test
@@ -451,6 +444,18 @@ public class RouterPathLookupTest {
   public void testAppPreferencesPaths() {
     assertRouting("v3/namespaces//apps//preferences", RouterPathLookup.APP_FABRIC_HTTP);
     assertRouting("v3/namespaces//apps////preferences", RouterPathLookup.APP_FABRIC_HTTP);
+  }
+
+  @Test
+  public void testProgramRuntimeLifecyclePaths() {
+    assertRouting("v3/namespaces//instances", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces//apps//services//instances", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces//apps//workers//instances", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces//apps////live-info", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces//apps////runs//loglevels", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces//apps////runs//resetloglevels", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces//apps//versions////runs//loglevels", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces//apps//versions////runs//resetloglevels", RouterPathLookup.APP_FABRIC_PROCESSOR);
   }
 
   @Test

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteProgramRunRecordFetcher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteProgramRunRecordFetcher.java
@@ -49,7 +49,7 @@ public class RemoteProgramRunRecordFetcher implements ProgramRunRecordFetcher {
     //  ProgramRuntimeService and RunRecordMonitorService.
     // Use APP_FABRIC_HTTP instead of APP_FABRIC_PROCESSOR after the fix.
     this.remoteClient = remoteClientFactory.createRemoteClient(
-        Constants.Service.APP_FABRIC_PROCESSOR,
+        Constants.Service.APP_FABRIC_HTTP,
         new DefaultHttpRequestConfig(false),
         Constants.Gateway.INTERNAL_API_VERSION_3);
   }


### PR DESCRIPTION
### Context

Multiple instances of `ProgramLifecycleService` cannot be run as they use `ProgramRuntimeService` which contains in-memory cache of `runtimeInfos`. Due to this `ProgramLifecycleHttpHandler` was temporarily moved to singleton Appfabric processor. More details: https://github.com/cdapio/cdap/pull/15773#discussion_r1909327683

### Change Description

1. Split `ProgramLifecycleHttpHandler` into -> `ProgramLifecycleHttpHandler` (which runs on `Appfabric` server) and `ProgramRuntimeHttpHandler` (which runs on `Appfabric` processor).
    * `ProgramRuntimeHttpHandler` has handlers for managing `runtimeInfo`. 
    * All the common methods were moved to `ProgramUtil` to avoid duplication.
    * All methods were moved without any modification.
2. Split `ProgramLifecycleService` into -> `ProgramLifecycleService`(used by `ProgramLifecycleHttpHandler`) and `ProgramUtil`
    * `ProgramUtil` contains common utility for Programs used by handlers and services. Does not reference runtimeInfo.
    * All methods were moved without any modification, except for `checkConcurrentExecution`.
        *  `ProgramLifecycleService.checkConcurrentExecution()` -> uses store implementation instead of using `runtimeInfo`.
4. Made `RouterLookupPath` changes to route paths for `ProgramRuntimeHttpHandler` to `Appfabric` processor.
5. Moved these handlers back to `AppfabricServer` (This was temporary change made as per: https://github.com/cdapio/cdap/pull/15773#discussion_r1909327683):
    * `AppLifecycleHttpHandler`
    * `AppLifecycleHttpHandlerInternal`
    * `ProgramLifecycleHttpHandler`
    * `ProgramLifecycleHttpHandlerInternal`
    * `WorkflowHttpHandler`

### Verification

- [x] Unit Tests
- [x] CDAP sandbox
- [x] Distributed docker image
