### PR TITLE
[CDAP-21118] Task workers & Preview runners should not communicate with Spanner Messaging Service directly

### DIFF
--- a/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
+++ b/cdap-app-fabric-tests/src/test/java/io/cdap/cdap/internal/app/runtime/distributed/DistributedWorkflowProgramRunnerTest.java
@@ -25,7 +25,6 @@ import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.app.DefaultAppConfigurer;
 import io.cdap.cdap.app.DefaultApplicationContext;
 import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule;
-import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule.ServiceType;
 import io.cdap.cdap.app.guice.AuthorizationModule;
 import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
 import io.cdap.cdap.app.guice.TwillModule;
@@ -56,7 +55,7 @@ import io.cdap.cdap.internal.app.runtime.BasicArguments;
 import io.cdap.cdap.internal.app.runtime.SimpleProgramOptions;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.logging.guice.LocalLogAppenderModule;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.client.DefaultMessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.operations.guice.OperationalStatsModule;
@@ -70,7 +69,6 @@ import io.cdap.cdap.security.guice.CoreSecurityRuntimeModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import java.io.IOException;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.twill.api.Configs;
@@ -284,7 +282,7 @@ public class DistributedWorkflowProgramRunnerTest {
         new DataSetsModules().getDistributedModules(),
         new MetricsClientRuntimeModule().getDistributedModules(),
         new MetricsStoreModule(),
-        new MessagingClientModule(),
+        new DefaultMessagingClientModule(),
         new AuditModule(),
         CoreSecurityRuntimeModule.getDistributedModule(cConf),
         new AuthenticationContextModules().getNoOpModule(),

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/DistributedProgramContainerModule.java
@@ -64,8 +64,8 @@ import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
 import io.cdap.cdap.logging.guice.TMSLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
-import io.cdap.cdap.messaging.client.ClientMessagingService;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.client.DefaultClientMessagingService;
+import io.cdap.cdap.messaging.guice.client.DefaultMessagingClientModule;
 import io.cdap.cdap.messaging.guice.MessagingServiceModule;
 import io.cdap.cdap.metadata.MetadataReaderWriterModules;
 import io.cdap.cdap.metadata.PreferencesFetcher;
@@ -327,7 +327,7 @@ public class DistributedProgramContainerModule extends AbstractModule {
       return new MessagingServiceModule(cConf);
     }
 
-    return new MessagingClientModule();
+    return new DefaultMessagingClientModule();
   }
 
   /**
@@ -389,7 +389,7 @@ public class DistributedProgramContainerModule extends AbstractModule {
           internalAuthenticator);
 
       return new MessagingProgramStatePublisher(cConf,
-          new ClientMessagingService(cConf, remoteClientFactory));
+          new DefaultClientMessagingService(cConf, remoteClientFactory));
     }
   }
 }

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/preview/PreviewRunnerTwillRunnable.java
@@ -67,7 +67,7 @@ import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.twill.ExtendedTwillContext;
-import io.cdap.cdap.messaging.guice.MessagingServiceModule;
+import io.cdap.cdap.messaging.guice.client.PreviewRunnerMessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
@@ -237,7 +237,7 @@ public class PreviewRunnerTwillRunnable extends AbstractTwillRunnable {
     }
 
     modules.add(new PreviewRunnerManagerModule().getDistributedModules());
-    modules.add(new MessagingServiceModule(cConf));
+    modules.add(new PreviewRunnerMessagingClientModule(cConf));
     modules.add(new SecureStoreClientModule());
     // Needed for InMemoryProgramRunnerModule. We use local metadata reader/publisher to avoid conflicting with
     // metadata stored in AppFabric.

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/worker/TaskWorkerTwillRunnable.java
@@ -45,7 +45,7 @@ import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
 import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
-import io.cdap.cdap.messaging.guice.MessagingServiceModule;
+import io.cdap.cdap.messaging.guice.client.TaskWorkerMessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
@@ -95,7 +95,7 @@ public class TaskWorkerTwillRunnable extends AbstractTwillRunnable {
     modules.add(new IOModule());
     modules.add(new AuthenticationContextModules().getMasterWorkerModule());
     modules.add(coreSecurityModule);
-    modules.add(new MessagingServiceModule(cConf));
+    modules.add(new TaskWorkerMessagingClientModule(cConf));
     modules.add(new SystemAppModule());
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
     modules.add(new AuditLogWriterModule(cConf).getDistributedModules());

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/DatasetOpExecutorServerTwillRunnable.java
@@ -51,7 +51,7 @@ import io.cdap.cdap.internal.app.store.DefaultStore;
 import io.cdap.cdap.internal.metadata.MetadataConsumerSubscriberService;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.client.DefaultMessagingClientModule;
 import io.cdap.cdap.metadata.MetadataService;
 import io.cdap.cdap.metadata.MetadataServiceModule;
 import io.cdap.cdap.metadata.MetadataSubscriberService;
@@ -111,7 +111,7 @@ public class DatasetOpExecutorServerTwillRunnable extends AbstractMasterTwillRun
         new ZkClientModule(),
         new ZkDiscoveryModule(),
         new KafkaClientModule(),
-        new MessagingClientModule(),
+        new DefaultMessagingClientModule(),
         new MetricsClientRuntimeModule().getDistributedModules(),
         new DFSLocationModule(),
         new NamespaceQueryAdminModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/LogSaverTwillRunnable.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/LogSaverTwillRunnable.java
@@ -42,7 +42,7 @@ import io.cdap.cdap.logging.framework.distributed.DistributedLogFramework;
 import io.cdap.cdap.logging.guice.DistributedLogFrameworkModule;
 import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
 import io.cdap.cdap.logging.service.LogSaverStatusService;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.client.DefaultMessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
@@ -118,7 +118,7 @@ public final class LogSaverTwillRunnable extends AbstractMasterTwillRunnable {
         new AuditModule(),
         new AuthorizationEnforcementModule().getDistributedModules(),
         new AuthenticationContextModules().getMasterModule(),
-        new MessagingClientModule(),
+        new DefaultMessagingClientModule(),
         new NoOpAuditLogModule(),
         new AbstractModule() {
           @Override

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MasterServiceMain.java
@@ -73,7 +73,7 @@ import io.cdap.cdap.internal.app.services.AppFabricServer;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
 import io.cdap.cdap.master.startup.ServiceResourceKeys;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.client.DefaultMessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.operations.OperationalStatsService;
@@ -538,7 +538,7 @@ public class MasterServiceMain extends DaemonMain {
         new DataSetsModules().getDistributedModules(),
         new MetricsClientRuntimeModule().getDistributedModules(),
         new MetricsStoreModule(),
-        new MessagingClientModule(),
+        new DefaultMessagingClientModule(),
         new AuditModule(),
         new AuditLogWriterModule(cConf).getDistributedModules(),
         CoreSecurityRuntimeModule.getDistributedModule(cConf),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MetricsProcessorTwillRunnable.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MetricsProcessorTwillRunnable.java
@@ -45,7 +45,7 @@ import io.cdap.cdap.data.runtime.SystemDatasetRuntimeModule;
 import io.cdap.cdap.data2.audit.AuditModule;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.client.DefaultMessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsProcessorStatusServiceModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
@@ -121,7 +121,7 @@ public final class MetricsProcessorTwillRunnable extends AbstractMasterTwillRunn
         new ZkClientModule(),
         new ZkDiscoveryModule(),
         new KafkaClientModule(),
-        new MessagingClientModule(),
+        new DefaultMessagingClientModule(),
         new MetricsClientRuntimeModule().getDistributedModules(),
         new MetricsStoreModule(),
         new KafkaLogAppenderModule(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MetricsTwillRunnable.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/MetricsTwillRunnable.java
@@ -45,7 +45,7 @@ import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
 import io.cdap.cdap.logging.guice.LogQueryRuntimeModule;
 import io.cdap.cdap.logging.guice.LogReaderRuntimeModules;
 import io.cdap.cdap.logging.service.LogQueryService;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.client.DefaultMessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsHandlerModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
@@ -110,7 +110,7 @@ public class MetricsTwillRunnable extends AbstractMasterTwillRunnable {
         new ZkClientModule(),
         new ZkDiscoveryModule(),
         new KafkaClientModule(),
-        new MessagingClientModule(),
+        new DefaultMessagingClientModule(),
         new DataFabricModules(txClientId).getDistributedModules(),
         new DataSetsModules().getDistributedModules(),
         // For the injection of DatasetDefinition of MetricsTable directly

--- a/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/TransactionServiceTwillRunnable.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/runtime/main/TransactionServiceTwillRunnable.java
@@ -44,7 +44,7 @@ import io.cdap.cdap.data.runtime.main.transaction.TransactionPingHandler;
 import io.cdap.cdap.data2.audit.AuditModule;
 import io.cdap.cdap.logging.appender.LogAppenderInitializer;
 import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.client.DefaultMessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
@@ -105,7 +105,7 @@ public class TransactionServiceTwillRunnable extends AbstractMasterTwillRunnable
         new ZkClientModule(),
         new ZkDiscoveryModule(),
         new KafkaClientModule(),
-        new MessagingClientModule(),
+        new DefaultMessagingClientModule(),
         new DataFabricModules(txClientId).getDistributedModules(),
         new DataSetsModules().getDistributedModules(),
         new SystemDatasetRuntimeModule().getDistributedModules(),

--- a/cdap-master/src/main/java/io/cdap/cdap/data/tools/JobQueueDebugger.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/data/tools/JobQueueDebugger.java
@@ -33,7 +33,6 @@ import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.api.schedule.Trigger;
 import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule;
-import io.cdap.cdap.app.guice.AppFabricServiceRuntimeModule.ServiceType;
 import io.cdap.cdap.app.guice.AuthorizationModule;
 import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
 import io.cdap.cdap.app.guice.TwillModule;
@@ -63,7 +62,7 @@ import io.cdap.cdap.internal.app.store.DefaultStore;
 import io.cdap.cdap.internal.schedule.constraint.Constraint;
 import io.cdap.cdap.logging.guice.KafkaLogAppenderModule;
 import io.cdap.cdap.messaging.data.MessageId;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.client.DefaultMessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.metrics.guice.MetricsStoreModule;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
@@ -74,7 +73,6 @@ import io.cdap.cdap.security.impersonation.SecurityUtil;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunners;
 import java.io.IOException;
-import java.util.EnumSet;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.commons.cli.BasicParser;
@@ -361,7 +359,7 @@ public class JobQueueDebugger extends AbstractIdleService {
         new AuthorizationModule(),
         new AuthorizationEnforcementModule().getMasterModule(),
         new SecureStoreServerModule(),
-        new MessagingClientModule(),
+        new DefaultMessagingClientModule(),
         new AbstractModule() {
           @Override
           protected void configure() {

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/PreviewServiceMain.java
@@ -52,7 +52,6 @@ import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.guice.SecureStoreClientModule;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -124,9 +123,9 @@ public class PreviewServiceMain extends AbstractServiceMain<EnvironmentOptions> 
     ));
 
     if (cConf.getInt(Constants.Preview.CONTAINER_COUNT) > 0) {
-      modules.add(new PreviewManagerModule(true));
+      modules.add(new PreviewManagerModule(cConf, true));
     } else {
-      modules.add(new PreviewManagerModule(false));
+      modules.add(new PreviewManagerModule(cConf, false));
       modules.add(new PreviewRunnerManagerModule().getStandaloneModules());
     }
 

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/TetheringAgentServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/TetheringAgentServiceMain.java
@@ -39,7 +39,7 @@ import io.cdap.cdap.internal.tethering.TetheringProgramEventPublisher;
 import io.cdap.cdap.logging.gateway.handlers.ProgramRunRecordFetcher;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.client.DefaultMessagingClientModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import java.util.Arrays;
@@ -66,7 +66,7 @@ public class TetheringAgentServiceMain extends AbstractServiceMain<EnvironmentOp
         RemoteAuthenticatorModules.getDefaultModule(
             TetheringAgentService.REMOTE_TETHERING_AUTHENTICATOR,
             Constants.Tethering.CLIENT_AUTHENTICATOR_NAME),
-        new MessagingClientModule(),
+        new DefaultMessagingClientModule(),
         new NamespaceQueryAdminModule(),
         getDataFabricModule(),
         // Always use local table implementations, which use LevelDB.

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MessagingServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/MessagingServiceMainTest.java
@@ -21,9 +21,9 @@ import io.cdap.cdap.api.dataset.lib.CloseableIterator;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.messaging.DefaultMessageFetchRequest;
 import io.cdap.cdap.messaging.DefaultTopicMetadata;
-import io.cdap.cdap.messaging.spi.MessagingService;
-import io.cdap.cdap.messaging.client.ClientMessagingService;
+import io.cdap.cdap.messaging.client.DefaultClientMessagingService;
 import io.cdap.cdap.messaging.client.StoreRequestBuilder;
+import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.messaging.spi.RawMessage;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.TopicId;
@@ -50,7 +50,7 @@ public class MessagingServiceMainTest extends MasterServiceMainTestBase {
 
     // Use a separate TMS client to create topic, then publish and then poll some messages
     TopicId topicId = NamespaceId.SYSTEM.topic("test");
-    MessagingService messagingService = new ClientMessagingService(remoteClientFactory, true);
+    MessagingService messagingService = new DefaultClientMessagingService(remoteClientFactory, true);
     messagingService.createTopic(new DefaultTopicMetadata(topicId));
 
     // Publish 10 messages

--- a/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/k8s/SparkContainerDriverLauncher.java
+++ b/cdap-spark-core-base/src/main/java/io/cdap/cdap/app/runtime/spark/distributed/k8s/SparkContainerDriverLauncher.java
@@ -53,7 +53,7 @@ import io.cdap.cdap.logging.guice.RemoteLogAppenderModule;
 import io.cdap.cdap.master.environment.MasterEnvironments;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
-import io.cdap.cdap.messaging.guice.MessagingClientModule;
+import io.cdap.cdap.messaging.guice.client.DefaultMessagingClientModule;
 import io.cdap.cdap.metrics.guice.MetricsClientRuntimeModule;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
@@ -259,7 +259,7 @@ public class SparkContainerDriverLauncher {
     modules.add(new IOModule());
     modules.add(new AuthenticationContextModules().getMasterWorkerModule());
     modules.add(coreSecurityModule);
-    modules.add(new MessagingClientModule());
+    modules.add(new DefaultMessagingClientModule());
     modules.add(new MetricsClientRuntimeModule().getDistributedModules());
     //Need for guice binding, but No Audit Log action required.
     modules.add(new NoOpAuditLogModule());

--- a/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
+++ b/cdap-standalone/src/main/java/io/cdap/cdap/StandaloneMain.java
@@ -561,7 +561,7 @@ public class StandaloneMain {
         new NoOpAuditLogModule(),
         new AuthorizationEnforcementModule().getStandaloneModules(),
         new PreviewConfigModule(cConf, new Configuration(), SConfiguration.create()),
-        new PreviewManagerModule(false),
+        new PreviewManagerModule(cConf, false),
         new PreviewRunnerManagerModule().getStandaloneModules(),
         new MessagingServerRuntimeModule().getStandaloneModules(),
         new AppFabricServiceRuntimeModule(cConf, AppFabricServiceRuntimeModule.ALL_SERVICE_TYPES)

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/DefaultClientMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/DefaultClientMessagingService.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.client;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The client implementation of {@link MessagingService} that uses Messaging service endpoint.
+ */
+public class DefaultClientMessagingService extends AbstractClientMessagingService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultClientMessagingService.class);
+
+  @Inject
+  public DefaultClientMessagingService(CConfiguration cConf,
+      RemoteClientFactory remoteClientFactory) {
+    super(remoteClientFactory.createRemoteClient(Constants.Service.MESSAGING_SERVICE,
+            HTTP_REQUEST_CONFIG, "/v1/namespaces/"),
+        cConf.getBoolean(Constants.MessagingSystem.HTTP_COMPRESS_PAYLOAD));
+    LOG.info("DefaultClientMessagingService initialised.");
+  }
+
+  @VisibleForTesting
+  public DefaultClientMessagingService(RemoteClientFactory remoteClientFactory,
+      boolean compressPayload) {
+    super(remoteClientFactory.createRemoteClient(Constants.Service.MESSAGING_SERVICE,
+        HTTP_REQUEST_CONFIG, "/v1/namespaces/"), compressPayload);
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/PreviewRunnerClientMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/PreviewRunnerClientMessagingService.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.client;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.Constants.Service;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This helps Preview runner pods to communicate with MessagingService via Preview Manager.
+ */
+public class PreviewRunnerClientMessagingService extends AbstractClientMessagingService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      PreviewRunnerClientMessagingService.class);
+
+  @Inject
+  public PreviewRunnerClientMessagingService(RemoteClientFactory remoteClientFactory) {
+    // TODO (CDAP-21118) - enable gzip compression for preview http server.
+    super(remoteClientFactory.createRemoteClient(Service.PREVIEW_HTTP, HTTP_REQUEST_CONFIG,
+        "/v1/namespaces/"), false);
+    LOG.info("PreviewRunnerClientMessagingService initialised");
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/TaskWorkerClientMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/TaskWorkerClientMessagingService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.messaging.client;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.Constants.Service;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This helps Task worker pods to communicate with MessagingService via Preview Manager.
+ */
+public class TaskWorkerClientMessagingService extends AbstractClientMessagingService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TaskWorkerClientMessagingService.class);
+
+  @Inject
+  public TaskWorkerClientMessagingService(RemoteClientFactory remoteClientFactory) {
+    super(remoteClientFactory.createRemoteClient(Service.APP_FABRIC_HTTP, HTTP_REQUEST_CONFIG,
+        "/v1/namespaces/"), false);
+    LOG.info("TaskWorkerClientMessagingService initialised");
+  }
+}

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/guice/client/DefaultMessagingClientModule.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/guice/client/DefaultMessagingClientModule.java
@@ -14,21 +14,21 @@
  * the License.
  */
 
-package io.cdap.cdap.messaging.guice;
+package io.cdap.cdap.messaging.guice.client;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
+import io.cdap.cdap.messaging.client.DefaultClientMessagingService;
 import io.cdap.cdap.messaging.spi.MessagingService;
-import io.cdap.cdap.messaging.client.ClientMessagingService;
 
 /**
  * The Guice module to provide binding for messaging system client. This module should only be used
  * in containers in distributed mode.
  */
-public class MessagingClientModule extends AbstractModule {
+public class DefaultMessagingClientModule extends AbstractModule {
 
   @Override
   protected void configure() {
-    bind(MessagingService.class).to(ClientMessagingService.class).in(Scopes.SINGLETON);
+    bind(MessagingService.class).to(DefaultClientMessagingService.class).in(Scopes.SINGLETON);
   }
 }

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/guice/client/TaskWorkerMessagingClientModule.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/guice/client/TaskWorkerMessagingClientModule.java
@@ -14,39 +14,35 @@
  * the License.
  */
 
-package io.cdap.cdap.messaging.guice;
+package io.cdap.cdap.messaging.guice.client;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Scopes;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants.MessagingSystem;
 import io.cdap.cdap.messaging.client.DefaultClientMessagingService;
-import io.cdap.cdap.messaging.client.DelegatingMessagingService;
+import io.cdap.cdap.messaging.client.TaskWorkerClientMessagingService;
 import io.cdap.cdap.messaging.spi.MessagingService;
 
 /**
- * The Guice module to bind messaging service based on
- * {@link MessagingSystem#MESSAGING_SERVICE_NAME} if set in cConf. Otherwise, binds to
- * {@link DefaultClientMessagingService}.
+ * The Guice module to provide binding for messaging system client in task workers and is based on
+ * {@link MessagingSystem#MESSAGING_SERVICE_ENABLED}. If set in cConf it binds to
+ * {@link DefaultClientMessagingService} to prevent redundant network calls.
  */
-public class MessagingServiceModule extends AbstractModule {
+public class TaskWorkerMessagingClientModule extends AbstractModule {
 
-  private static final String DEFAULT_MESSAGING_SERVICE_NAME =
-      DefaultClientMessagingService.class.getSimpleName();
-  private final String messagingService;
+  private final boolean messagingServiceEnabled;
 
-  public MessagingServiceModule(CConfiguration cConf) {
-    messagingService =
-        cConf
-            .get(MessagingSystem.MESSAGING_SERVICE_NAME, DEFAULT_MESSAGING_SERVICE_NAME);
+  public TaskWorkerMessagingClientModule(CConfiguration cConf) {
+    this.messagingServiceEnabled = cConf.getBoolean(MessagingSystem.MESSAGING_SERVICE_ENABLED);
   }
 
   @Override
   protected void configure() {
-    if (messagingService.equals(DEFAULT_MESSAGING_SERVICE_NAME)) {
+    if (messagingServiceEnabled) {
       bind(MessagingService.class).to(DefaultClientMessagingService.class).in(Scopes.SINGLETON);
     } else {
-      bind(MessagingService.class).to(DelegatingMessagingService.class).in(Scopes.SINGLETON);
+      bind(MessagingService.class).to(TaskWorkerClientMessagingService.class).in(Scopes.SINGLETON);
     }
   }
 }

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/server/MessagingHttpServiceTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/server/MessagingHttpServiceTest.java
@@ -37,16 +37,16 @@ import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import io.cdap.cdap.common.metrics.NoOpMetricsCollectionService;
 import io.cdap.cdap.messaging.DefaultMessageFetchRequest;
 import io.cdap.cdap.messaging.DefaultTopicMetadata;
+import io.cdap.cdap.messaging.client.DefaultClientMessagingService;
+import io.cdap.cdap.messaging.client.StoreRequestBuilder;
+import io.cdap.cdap.messaging.data.MessageId;
+import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
 import io.cdap.cdap.messaging.spi.MessageFetchRequest;
 import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.messaging.spi.RawMessage;
 import io.cdap.cdap.messaging.spi.RollbackDetail;
 import io.cdap.cdap.messaging.spi.StoreRequest;
 import io.cdap.cdap.messaging.spi.TopicMetadata;
-import io.cdap.cdap.messaging.client.ClientMessagingService;
-import io.cdap.cdap.messaging.client.StoreRequestBuilder;
-import io.cdap.cdap.messaging.data.MessageId;
-import io.cdap.cdap.messaging.spi.RawMessage;
-import io.cdap.cdap.messaging.guice.MessagingServerRuntimeModule;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.TopicId;
 import io.cdap.cdap.security.auth.context.AuthenticationContextModules;
@@ -129,7 +129,7 @@ public class MessagingHttpServiceTest {
 
     httpService = injector.getInstance(MessagingHttpService.class);
     httpService.startAndWait();
-    client = new ClientMessagingService(injector.getInstance(RemoteClientFactory.class), compressPayload);
+    client = new DefaultClientMessagingService(injector.getInstance(RemoteClientFactory.class), compressPayload);
   }
 
   @After

--- a/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
+++ b/cdap-unit-test/src/main/java/io/cdap/cdap/test/TestBase.java
@@ -322,7 +322,7 @@ public class TestBase {
         new LogReaderRuntimeModules().getInMemoryModules(),
         new MessagingServerRuntimeModule().getInMemoryModules(),
         new PreviewConfigModule(cConf, new Configuration(), SConfiguration.create()),
-        new PreviewManagerModule(false),
+        new PreviewManagerModule(cConf, false),
         new PreviewRunnerManagerModule().getInMemoryModules(),
         new MockProvisionerModule(),
         new NoOpAuditLogModule(),


### PR DESCRIPTION
Task workers + preview runner pods which use user-sa should not have access to SpannerMessagingService.

Task workers should communicate with MessagingService via AppFabric
Whereas preview runners should communicate via PreviewManager

Verified:
```
$ kubectl logs cdap-sidhdirenge-jan30-rbac-task-worker-7-df827687c3-1 | grep initialised
2025-01-30 14:16:01,505 - INFO  [main:i.c.c.m.c.TaskWorkerClientMessagingService@36] - TaskWorkerClientMessagingService initialised

$ kubectl logs cdap-sidhdirenge-jan30-rbac-preview-runne-306c4aea9b-0 | grep initialised
2025-01-30 15:08:53,320 - INFO  [main:i.c.c.m.c.PreviewRunnerClientMessagingService@38] - PreviewRunnerClientMessagingService initialised
```

In case of upgrade (from versions < 6.11) to latest / 6.11, we will still use cloudSql + TMS, hence in such scenarios, the workers will bind to DefaultClientMessagingService.

Verified:
```
$ kubectl logs cdap-sidhdirenge-jan30-upgrade-task-worke-5fb64b9c5a-0 | grep initialised
2025-01-30 14:53:03,912 - INFO  [main:i.c.c.m.c.DefaultClientMessagingService@41] - DefaultClientMessagingService initialised.

$ kubectl logs cdap-sidhdirenge-jan30-upgrade-preview-ru-fe5ad27017-0 | grep initialised
2025-01-30 14:55:47,016 - INFO  [main:i.c.c.m.c.DefaultClientMessagingService@41] - DefaultClientMessagingService initialised.
```