### PR TITLE
[CDAP-21118] Enable gzip compression for PreviewHttpServer

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -465,6 +465,7 @@ public final class Constants {
     public static final String CONTAINER_JVM_OPTS = "preview.runner.container.jvm.opts";
     public static final String GCE_METADATA_HOST_ENV_VAR = "GCE_METADATA_HOST";
     public static final String INTERNAL_ROUTER_ENABLED = "preview.runner.internal.router.enabled";
+    public static final String HTTP_COMPRESS_PAYLOAD = "preview.http.compress.payload";
   }
 
   /**

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -3796,6 +3796,14 @@
   </property>
 
   <property>
+    <name>preview.http.compress.payload</name>
+    <value>true</value>
+    <description>
+      Compress payload for HTTP calls in the preview http handler.
+    </description>
+  </property>
+
+  <property>
     <name>service.retry.policy.base.delay.ms</name>
     <value>100</value>
     <description>

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/PreviewRunnerClientMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/PreviewRunnerClientMessagingService.java
@@ -17,6 +17,8 @@
 package io.cdap.cdap.messaging.client;
 
 import com.google.inject.Inject;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.Constants.Service;
 import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
 import org.slf4j.Logger;
@@ -31,10 +33,11 @@ public class PreviewRunnerClientMessagingService extends AbstractClientMessaging
       PreviewRunnerClientMessagingService.class);
 
   @Inject
-  public PreviewRunnerClientMessagingService(RemoteClientFactory remoteClientFactory) {
-    // TODO (CDAP-21118) - enable gzip compression for preview http server.
+  public PreviewRunnerClientMessagingService(CConfiguration cConf,
+      RemoteClientFactory remoteClientFactory) {
     super(remoteClientFactory.createRemoteClient(Service.PREVIEW_HTTP, HTTP_REQUEST_CONFIG,
-        "/v1/namespaces/"), false);
+            "/v1/namespaces/"),
+        cConf.getBoolean(Constants.Preview.HTTP_COMPRESS_PAYLOAD));
     LOG.info("PreviewRunnerClientMessagingService initialised");
   }
 }


### PR DESCRIPTION
Verified by running preview + batch pipeline.

This compression is required as the logs sent from preview runners -> preview managers can have large size.
This was already enabled in current flow (instances < 6.11) that uses messaging service for this communication.