### PR TITLE
[CDAP-21129] Add enableDefaultPagination query param to list apps call

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandler.java
@@ -244,7 +244,8 @@ public class AppLifecycleHttpHandler extends AbstractAppLifecycleHttpHandler {
       @QueryParam("nameFilter") String nameFilter,
       @QueryParam("nameFilterType") NameFilterType nameFilterType,
       @QueryParam("latestOnly") @DefaultValue("true") Boolean latestOnly,
-      @QueryParam("sortCreationTime") Boolean sortCreationTime)
+      @QueryParam("sortCreationTime") Boolean sortCreationTime,
+      @QueryParam("enableDefaultPagination") @DefaultValue("false") boolean enableDefaultPagination)
       throws Exception {
 
     validateNamespace(namespaceId);
@@ -256,13 +257,12 @@ public class AppLifecycleHttpHandler extends AbstractAppLifecycleHttpHandler {
       }
     }
 
-    if (pageSize == null) {
+    if (pageSize == null && enableDefaultPagination) {
       pageSize = configuration.getInt(Constants.GET_APPS_DEFAULT_PAGE_SIZE);
       LOG.debug("Paginating GET apps call with page size as {}", pageSize);
     }
-    pageSize = Math.max(pageSize, 0);
 
-    if (Optional.ofNullable(pageSize).orElse(0) != 0) {
+    if (Optional.ofNullable(pageSize).orElse(0) > 0) {
       Integer finalPageSize = pageSize;
       JsonPaginatedListResponder.respond(GSON, responder, APP_LIST_PAGINATED_KEY,
           jsonListResponder -> {

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandlerInternal.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/AppLifecycleHttpHandlerInternal.java
@@ -56,6 +56,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -109,19 +110,20 @@ public class AppLifecycleHttpHandlerInternal extends AbstractAppLifecycleHttpHan
       @QueryParam("pageToken") String pageToken,
       @QueryParam("pageSize") Integer pageSize,
       @QueryParam("orderBy") SortOrder orderBy,
-      @QueryParam("nameFilter") String nameFilter) throws Exception {
+      @QueryParam("nameFilter") String nameFilter,
+      @QueryParam("enableDefaultPagination") @DefaultValue("false") boolean enableDefaultPagination
+  ) throws Exception {
 
     NamespaceId namespaceId = new NamespaceId(namespace);
     if (!namespaceQueryAdmin.exists(namespaceId)) {
       throw new NamespaceNotFoundException(namespaceId);
     }
 
-    if (pageSize == null) {
+    if (pageSize == null && enableDefaultPagination) {
       pageSize = configuration.getInt(Constants.GET_APPS_DEFAULT_PAGE_SIZE);
     }
-    pageSize = Math.max(pageSize, 0);
 
-    if (Optional.ofNullable(pageSize).orElse(0) != 0) {
+    if (Optional.ofNullable(pageSize).orElse(0) > 0) {
       Integer finalPageSize = pageSize;
       JsonPaginatedListResponder.respond(GSON, responder, APP_LIST_PAGINATED_KEY,
           jsonListResponder -> {

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/AppFabricTestBase.java
@@ -646,18 +646,6 @@ public abstract class AppFabricTestBase {
     return readResponse(response, LIST_JSON_OBJECT_TYPE);
   }
 
-  protected JsonObject getAppListForPaginatedApi(String namespace, int pageSize, String token,
-                                                 String filter) throws Exception {
-    return getAppListForPaginatedApi(namespace, pageSize, token, null, filter, null, null, null);
-  }
-
-  protected JsonObject getAppListForPaginatedApi(String namespace, int pageSize, String token,
-                                                 String filter, String nameFilterType,
-                                                 Boolean latestOnly, Boolean sortCreationTime) throws Exception {
-    return getAppListForPaginatedApi(namespace, pageSize, token, null, filter, nameFilterType, latestOnly,
-                                     sortCreationTime);
-  }
-
   protected List<JsonObject> getAppListForNegativePaginatedApi(String namespace, int pageSize) throws Exception {
     String uri = "apps/?pageSize=" + pageSize;
 
@@ -667,10 +655,38 @@ public abstract class AppFabricTestBase {
     return readResponse(response, LIST_JSON_OBJECT_TYPE);
   }
 
-  protected JsonObject getAppListForPaginatedApi(String namespace, int pageSize, String token,
+  protected List<JsonObject> getAppListForDefaultPaginationDisabledApi(String namespace,
+      Boolean enabledDefaultPagination) throws Exception {
+    String uri = "apps/?enabledDefaultPagination=" + enabledDefaultPagination;
+
+    HttpResponse response = doGet(getVersionedApiPath(uri,
+        Constants.Gateway.API_VERSION_3_TOKEN, namespace));
+    assertResponseCode(200, response);
+    return readResponse(response, LIST_JSON_OBJECT_TYPE);
+  }
+
+  protected JsonObject getAppListForPaginatedApi(String namespace, Integer pageSize, String token,
+      String filter) throws Exception {
+    return getAppListForPaginatedApi(namespace, pageSize, token, null, filter, null, null, null, false);
+  }
+
+  protected JsonObject getAppListForPaginatedApi(String namespace, Integer pageSize, String token,
+      String filter, String nameFilterType,
+      Boolean latestOnly, Boolean sortCreationTime,
+      boolean enableDefaultPagination) throws Exception {
+    return getAppListForPaginatedApi(namespace, pageSize, token, null, filter, nameFilterType, latestOnly,
+        sortCreationTime, enableDefaultPagination);
+  }
+
+  protected JsonObject getAppListForPaginatedApi(String namespace, Integer pageSize, String token,
                                                  String orderBy, String filter, String nameFilterType,
-                                                 Boolean latestOnly, Boolean sortCreationTime) throws Exception {
-    String uri = "apps/?pageSize=" + pageSize;
+                                                 Boolean latestOnly, Boolean sortCreationTime,
+      boolean enableDefaultPagination) throws Exception {
+    String uri = "apps/?";
+
+    if (pageSize != null) {
+      uri += ("&pageSize=" + pageSize);
+    }
 
     if (token != null) {
       uri += ("&pageToken=" + token);
@@ -696,6 +712,11 @@ public abstract class AppFabricTestBase {
       uri += ("&sortCreationTime=" + sortCreationTime);
     }
 
+    if (enableDefaultPagination) {
+      uri += ("&enableDefaultPagination=" + enableDefaultPagination);
+    }
+
+    uri = uri.replace("?&", "?");
     HttpResponse response = doGet(getVersionedApiPath(uri,
                                                       Constants.Gateway.API_VERSION_3_TOKEN, namespace));
     assertResponseCode(200, response);


### PR DESCRIPTION
After adding default pagination (https://github.com/cdapio/cdap/pull/15745) to list apps using a flag, the form of response changed from array to object. In many places in UI, the paginated response is not handled currently. 
Example 1: In service status page, namespaces/system/apps API is called which doesn’t handle the paginated response.
Example 2: When we open replication tab from home page after enabling CDC accelerator, namespaces/default/apps?artifactName=delta-app API is called which lists replication pipelines. Here, the UI doesn’t handle paginated response.

To fix this, we will add a query param enableDefaultPagination in list apps call. By default, it will be false. When true, it will add default pagination during list apps.