### PR TITLE
[🍒][CDAP-21096] Keep TaskWorkerServiceLauncher, SystemWorkerServiceLauncher, CoreSchedulerService, Schedule HTTP handlers in Appfabric Processor

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -79,6 +79,7 @@ import io.cdap.cdap.gateway.handlers.ProfileHttpHandler;
 import io.cdap.cdap.gateway.handlers.ProgramLifecycleHttpHandler;
 import io.cdap.cdap.gateway.handlers.ProgramLifecycleHttpHandlerInternal;
 import io.cdap.cdap.gateway.handlers.ProgramRuntimeHttpHandler;
+import io.cdap.cdap.gateway.handlers.ProgramScheduleHttpHandler;
 import io.cdap.cdap.gateway.handlers.ProvisionerHttpHandler;
 import io.cdap.cdap.gateway.handlers.SourceControlManagementHttpHandler;
 import io.cdap.cdap.gateway.handlers.TransactionHttpHandler;
@@ -157,6 +158,7 @@ import io.cdap.cdap.metadata.LocalPreferencesFetcherInternal;
 import io.cdap.cdap.metadata.PreferencesFetcher;
 import io.cdap.cdap.pipeline.PipelineFactory;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
+import io.cdap.cdap.scheduler.NoOpScheduler;
 import io.cdap.cdap.scheduler.Scheduler;
 import io.cdap.cdap.securestore.spi.SecretStore;
 import io.cdap.cdap.security.encryption.guice.DataStorageAeadEncryptionModule;
@@ -193,6 +195,9 @@ import org.quartz.spi.JobStore;
  */
 public final class AppFabricServiceRuntimeModule extends RuntimeModule {
 
+  /**
+   * Service type for App Fabric.
+   */
   public enum ServiceType {
     SERVER,
     PROCESSOR,
@@ -259,6 +264,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
               Multibinder<HttpHandler> handlerBinder = Multibinder.newSetBinder(
                   binder(), HttpHandler.class, Names.named(Constants.AppFabric.SERVER_HANDLERS_BINDING));
               handlerBinder.addBinding().to(ProgramRuntimeHttpHandler.class);
+              handlerBinder.addBinding().to(ProgramScheduleHttpHandler.class);
 
               // TODO: Uncomment after CDAP-7688 is resolved
               // servicesNamesBinder.addBinding().toInstance(Constants.Service.MESSAGING_SERVICE);
@@ -458,8 +464,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       bind(ProgramLifecycleService.class).in(Scopes.SINGLETON);
       bind(SystemAppManagementService.class).in(Scopes.SINGLETON);
       bind(OwnerAdmin.class).to(DefaultOwnerAdmin.class);
-      bind(CoreSchedulerService.class).in(Scopes.SINGLETON);
-      bind(Scheduler.class).to(CoreSchedulerService.class);
       install(new PrivateModule() {
         @Override
         protected void configure() {
@@ -556,11 +560,18 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
       }
 
       if (serviceTypes.contains(ServiceType.PROCESSOR)) {
+        bind(CoreSchedulerService.class).in(Scopes.SINGLETON);
+        bind(Scheduler.class).to(CoreSchedulerService.class);
+
         Multibinder<HttpHandler> processorHandlerBinder = Multibinder.newSetBinder(
             binder(), HttpHandler.class, Names.named(AppFabric.PROCESSOR_HANDLERS_BINDING));
         CommonHandlers.add(processorHandlerBinder);
         processorHandlerBinder.addBinding().to(ProgramRuntimeHttpHandler.class);
         processorHandlerBinder.addBinding().to(BootstrapHttpHandler.class);
+        processorHandlerBinder.addBinding().to(ProgramScheduleHttpHandler.class);
+      } else {
+        bind(NoOpScheduler.class).in(Scopes.SINGLETON);
+        bind(Scheduler.class).to(NoOpScheduler.class);
       }
     }
 

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramLifecycleHttpHandler.java
@@ -16,15 +16,9 @@
 
 package io.cdap.cdap.gateway.handlers;
 
-import com.google.common.base.Charsets;
-import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -49,21 +43,12 @@ import io.cdap.cdap.common.service.ServiceDiscoverable;
 import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
 import io.cdap.cdap.gateway.handlers.util.NamespaceHelper;
 import io.cdap.cdap.gateway.handlers.util.ProgramHandlerUtil;
-import io.cdap.cdap.internal.app.runtime.schedule.ProgramSchedule;
-import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleRecord;
-import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleStatus;
-import io.cdap.cdap.internal.app.runtime.schedule.SchedulerException;
-import io.cdap.cdap.internal.app.runtime.schedule.store.Schedulers;
-import io.cdap.cdap.internal.app.runtime.schedule.trigger.ProgramStatusTrigger;
 import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
-import io.cdap.cdap.internal.app.store.ApplicationMeta;
 import io.cdap.cdap.internal.app.store.RunRecordDetail;
-import io.cdap.cdap.internal.schedule.constraint.Constraint;
 import io.cdap.cdap.proto.BatchProgram;
 import io.cdap.cdap.proto.BatchProgramCount;
 import io.cdap.cdap.proto.BatchProgramHistory;
 import io.cdap.cdap.proto.BatchProgramResult;
-import io.cdap.cdap.proto.BatchProgramSchedule;
 import io.cdap.cdap.proto.BatchProgramStart;
 import io.cdap.cdap.proto.BatchProgramStatus;
 import io.cdap.cdap.proto.MRJobInfo;
@@ -71,43 +56,28 @@ import io.cdap.cdap.proto.ProgramHistory;
 import io.cdap.cdap.proto.ProgramRunStatus;
 import io.cdap.cdap.proto.ProgramStatus;
 import io.cdap.cdap.proto.ProgramType;
-import io.cdap.cdap.proto.ProtoTrigger;
 import io.cdap.cdap.proto.RunCountResult;
 import io.cdap.cdap.proto.RunRecord;
-import io.cdap.cdap.proto.ScheduleDetail;
-import io.cdap.cdap.proto.ScheduledRuntime;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ApplicationReference;
-import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.id.ProgramRunId;
-import io.cdap.cdap.proto.id.ScheduleId;
-import io.cdap.cdap.scheduler.ProgramScheduleService;
 import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
 import io.cdap.http.HttpResponder;
-import io.netty.buffer.ByteBufInputStream;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
-import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -120,7 +90,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@link io.cdap.http.HttpHandler} to manage program lifecycle for v3 REST APIs
+ * {@link io.cdap.http.HttpHandler} to manage program lifecycle for v3 REST APIs.
  */
 @Singleton
 @Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
@@ -132,11 +102,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   private static final Type BATCH_STARTS_TYPE = new TypeToken<List<BatchProgramStart>>() {
   }.getType();
 
-  private static final List<Constraint> NO_CONSTRAINTS = Collections.emptyList();
-
-  private static final String SCHEDULES = "schedules";
-
-  private final ProgramScheduleService programScheduleService;
   private final ProgramLifecycleService lifecycleService;
   private final DiscoveryServiceClient discoveryServiceClient;
   private final MRJobInfoFetcher mrJobInfoFetcher;
@@ -148,14 +113,12 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       DiscoveryServiceClient discoveryServiceClient,
       ProgramLifecycleService lifecycleService,
       MRJobInfoFetcher mrJobInfoFetcher,
-      NamespaceQueryAdmin namespaceQueryAdmin,
-      ProgramScheduleService programScheduleService) {
+      NamespaceQueryAdmin namespaceQueryAdmin) {
     this.store = store;
     this.discoveryServiceClient = discoveryServiceClient;
     this.lifecycleService = lifecycleService;
     this.mrJobInfoFetcher = mrJobInfoFetcher;
     this.namespaceQueryAdmin = namespaceQueryAdmin;
-    this.programScheduleService = programScheduleService;
   }
 
   /**
@@ -206,7 +169,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
-   * Returns status of a type specified by the type{flows,workflows,mapreduce,spark,services,schedules}.
+   * Returns status of a type specified by the type{flows,workflows,mapreduce,spark,services}.
    */
   @GET
   @Path("/apps/{app-id}/{program-type}/{program-id}/status")
@@ -220,8 +183,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
-   * Returns status of a type specified by the type{flows,workflows,mapreduce,spark,services,schedules}.
-   *
+   * Returns status of a type specified by the type{flows,workflows,mapreduce,spark,services}.
    * Deprecated: Only allowing program info retrieval for the latest app version (active app).
    */
   @Deprecated
@@ -234,22 +196,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       @PathParam("program-type") String type,
       @PathParam("program-id") String programId) throws Exception {
     ApplicationReference appReference = new ApplicationReference(namespaceId, appId);
-    if (SCHEDULES.equals(type)) {
-      JsonObject json = new JsonObject();
-      // ScheduleId is versionless (always "-SNAPSHOT")
-      ScheduleId scheduleId = appReference.app(ApplicationId.DEFAULT_VERSION).schedule(programId);
-      ApplicationSpecification appSpec = ApplicationId.DEFAULT_VERSION.equals(versionId)
-          ? Optional.ofNullable(store.getLatest(appReference)).map(ApplicationMeta::getSpec)
-          .orElse(null)
-          : store.getApplication(appReference.app(versionId));
-      if (appSpec == null) {
-        throw new NotFoundException(appReference);
-      }
-      json.addProperty("status", programScheduleService.getStatus(scheduleId).toString());
-      responder.sendJson(HttpResponseStatus.OK, json.toString());
-      return;
-    }
-
     ProgramType programType = ProgramType.valueOfCategoryName(type, BadRequestException::new);
     ProgramStatus programStatus;
     if (ApplicationId.DEFAULT_VERSION.equals(versionId)) {
@@ -328,12 +274,10 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
    * @param appVersion app version of the program
    * @param type type of the program
    * @param programId programId of the program
-   * @param action action to be performed. The value can be one of enable/disable/suspend/resume
-   *     for schedule and one of start/stop/debug for other program types. "debug" can only be
-   *     applied on type {@link ProgramType#SERVICE} and {@link ProgramType#WORKER}
+   * @param action action to be performed. The value can be one of start/stop/debug for other
+   *     program types. "debug" can only be applied on type {@link ProgramType#SERVICE} and
+   *     {@link ProgramType#WORKER}
    * @throws NotFoundException if action is an unknown action
-   * @throws BadRequestException if type is schedule and action is not any of
-   *     enable/disable/suspend/resume
    * @throws BadRequestException if action is "start" or "debug" and appVersion is not the
    *     latest version
    * @throws NotImplementedException if action is debug and type is not {@link
@@ -343,21 +287,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
       String appId,
       String appVersion, String type, String programId, String action) throws Exception {
     ApplicationId applicationId = new ApplicationId(namespaceId, appId, appVersion);
-    if (SCHEDULES.equals(type)) {
-      ScheduleId scheduleId = applicationId.schedule(programId);
-      if (action.equals("disable") || action.equals("suspend")) {
-        programScheduleService.suspend(scheduleId);
-      } else if (action.equals("enable") || action.equals("resume")) {
-        programScheduleService.resume(scheduleId);
-      } else {
-        throw new BadRequestException(
-            "Action for schedules may only be 'enable', 'disable', 'suspend', or 'resume' but is'"
-                + action + "'");
-      }
-      responder.sendJson(HttpResponseStatus.OK, "OK");
-      return;
-    }
-
     ProgramType programType = ProgramType.valueOfCategoryName(type, BadRequestException::new);
     ProgramReference programReference = new ProgramReference(namespaceId, appId, programType,
         programId);
@@ -706,606 +635,6 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
-   * Update schedules which were suspended between startTimeMillis and endTimeMillis
-   *
-   * @param startTimeMillis lower bound in millis of the update time for schedules (inclusive)
-   * @param endTimeMillis upper bound in millis of the update time for schedules (exclusive)
-   */
-  @PUT
-  @Path("schedules/re-enable")
-  public void reEnableSuspendedSchedules(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @QueryParam("start-time-millis") long startTimeMillis,
-      @QueryParam("end-time-millis") long endTimeMillis) throws Exception {
-    programScheduleService.reEnableSchedules(new NamespaceId(namespaceId), startTimeMillis,
-        endTimeMillis);
-    responder.sendStatus(HttpResponseStatus.OK);
-  }
-
-  /**
-   * Get schedules containing {@link ProgramStatusTrigger} filtered by triggering program, and
-   * optionally by triggering program statuses or schedule status
-   *
-   * @param triggerNamespaceId namespace of the triggering program in {@link
-   *     ProgramStatusTrigger}
-   * @param triggerAppName application name of the triggering program in {@link
-   *     ProgramStatusTrigger}
-   * @param triggerAppVersion application version of the triggering program in {@link
-   *     ProgramStatusTrigger}
-   * @param triggerProgramType program type of the triggering program in {@link
-   *     ProgramStatusTrigger}
-   * @param triggerProgramName program name of the triggering program in {@link
-   *     ProgramStatusTrigger}
-   * @param triggerProgramStatuses comma separated {@link ProgramStatus} in {@link
-   *     ProgramStatusTrigger}. Schedules with {@link ProgramStatusTrigger} triggered by none of the
-   *     {@link ProgramStatus} in triggerProgramStatuses will be filtered out. If not specified,
-   *     schedules will be returned regardless of triggering program status.
-   * @param scheduleStatus status of the schedule. Can only be one of "SCHEDULED" or
-   *     "SUSPENDED". If specified, only schedules with matching status will be returned.
-   */
-  @GET
-  @Path("schedules/trigger-type/program-status")
-  public void getProgramStatusSchedules(HttpRequest request, HttpResponder responder,
-      @QueryParam("trigger-namespace-id") String triggerNamespaceId,
-      @QueryParam("trigger-app-name") String triggerAppName,
-      @QueryParam("trigger-app-version") @DefaultValue(ApplicationId.DEFAULT_VERSION)
-          String triggerAppVersion,
-      @QueryParam("trigger-program-type") String triggerProgramType,
-      @QueryParam("trigger-program-name") String triggerProgramName,
-      @QueryParam("trigger-program-statuses") String triggerProgramStatuses,
-      @QueryParam("schedule-status") String scheduleStatus) throws Exception {
-    if (triggerNamespaceId == null) {
-      throw new BadRequestException("Must specify trigger-namespace-id as a query param");
-    }
-    if (triggerAppName == null) {
-      throw new BadRequestException("Must specify trigger-app-name as a query param");
-    }
-    if (triggerProgramType == null) {
-      throw new BadRequestException("Must specify trigger-program-type as a query param");
-    }
-    if (triggerProgramName == null) {
-      throw new BadRequestException("Must specify trigger-program-name as a query param");
-    }
-
-    ProgramType programType = ProgramType.valueOfCategoryName(triggerProgramType, BadRequestException::new);
-    ProgramScheduleStatus programScheduleStatus;
-    try {
-      programScheduleStatus =
-          scheduleStatus == null ? null : ProgramScheduleStatus.valueOf(scheduleStatus);
-    } catch (IllegalArgumentException e) {
-      throw new BadRequestException(
-          String.format("Invalid schedule status '%s'. Must be one of %s.",
-              scheduleStatus, Joiner.on(',').join(ProgramScheduleStatus.values())),
-          e);
-    }
-
-    ProgramId triggerProgramId = new NamespaceId(triggerNamespaceId)
-        .app(triggerAppName, triggerAppVersion)
-        .program(programType, triggerProgramName);
-
-    Set<io.cdap.cdap.api.ProgramStatus> queryProgramStatuses = new HashSet<>();
-    if (triggerProgramStatuses != null) {
-      try {
-        for (String status : triggerProgramStatuses.split(",")) {
-          queryProgramStatuses.add(io.cdap.cdap.api.ProgramStatus.valueOf(status));
-        }
-      } catch (Exception e) {
-        throw new BadRequestException(
-            String.format("Unable to parse program statuses '%s'. Must be comma separated "
-                    + "valid ProgramStatus names such as COMPLETED, FAILED, KILLED.",
-                triggerProgramStatuses), e);
-      }
-    } else {
-      // Query for schedules with all the statuses if no query status is specified
-      Collections.addAll(queryProgramStatuses, io.cdap.cdap.api.ProgramStatus.values());
-    }
-
-    List<ScheduleDetail> details = programScheduleService.findTriggeredBy(triggerProgramId,
-            queryProgramStatuses)
-        .stream()
-        .filter(record -> programScheduleStatus == null || record.getMeta().getStatus()
-            .equals(programScheduleStatus))
-        .map(ProgramScheduleRecord::toScheduleDetail)
-        .collect(Collectors.toList());
-    responder.sendJson(HttpResponseStatus.OK,
-        ProgramHandlerUtil.toJson(details, Schedulers.SCHEDULE_DETAILS_TYPE));
-  }
-
-  @GET
-  @Path("apps/{app-name}/schedules/{schedule-name}")
-  public void getSchedule(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @PathParam("app-name") String appName,
-      @PathParam("schedule-name") String scheduleName) throws Exception {
-    doGetSchedule(responder, namespaceId, appName, scheduleName);
-  }
-
-  /*
-  * Deprecated: Schedules are versionless.
-  * */
-  @Deprecated
-  @GET
-  @Path("apps/{app-name}/versions/{app-version}/schedules/{schedule-name}")
-  public void getScheduleVersioned(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @PathParam("app-name") String appName,
-      @PathParam("app-version") String appVersion,
-      @PathParam("schedule-name") String scheduleName) throws Exception {
-    doGetSchedule(responder, namespaceId, appName, scheduleName);
-  }
-
-  private void doGetSchedule(HttpResponder responder, String namespace, String app,
-      String scheduleName)
-      throws Exception {
-    ScheduleId scheduleId = new ApplicationId(namespace, app).schedule(scheduleName);
-    ProgramScheduleRecord record = programScheduleService.getRecord(scheduleId);
-    ScheduleDetail detail = record.toScheduleDetail();
-    responder.sendJson(HttpResponseStatus.OK, ProgramHandlerUtil.toJson(detail, ScheduleDetail.class));
-  }
-
-  /**
-   * See {@link #getAllSchedulesVersioned(HttpRequest, HttpResponder, String, String, String,
-   * String, String)}
-   */
-  @GET
-  @Path("apps/{app-name}/schedules")
-  public void getAllSchedules(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @PathParam("app-name") String appName,
-      @QueryParam("trigger-type") String triggerType,
-      @QueryParam("schedule-status") String scheduleStatus) throws Exception {
-    doGetSchedules(responder, new NamespaceId(namespaceId).app(appName), null, triggerType,
-        scheduleStatus);
-  }
-
-  /**
-   * Get schedules in a given application, optionally filtered by the given {@link
-   * io.cdap.cdap.proto.ProtoTrigger.Type}.
-   *
-   * @param namespaceId namespace of the application to get schedules from
-   * @param appName name of the application to get schedules from
-   * @param appVersion version of the application to get schedules from
-   * @param triggerType trigger type of returned schedules. If not specified, all schedules are
-   *     returned regardless of trigger type
-   * @param scheduleStatus the status of the schedule, must be values in {@link
-   *     ProgramScheduleStatus}.
-   *
-   * Deprecated : Schedules are versionless.
-   */
-  @Deprecated
-  @GET
-  @Path("apps/{app-name}/versions/{app-version}/schedules")
-  public void getAllSchedulesVersioned(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @PathParam("app-name") String appName,
-      @PathParam("app-version") String appVersion,
-      @QueryParam("trigger-type") String triggerType,
-      @QueryParam("schedule-status") String scheduleStatus) throws Exception {
-    doGetSchedules(responder, new NamespaceId(namespaceId).app(appName), null, triggerType,
-        scheduleStatus);
-  }
-
-  /**
-   * Get program schedules
-   */
-  @GET
-  @Path("/apps/{app-name}/{program-type}/{program-name}/schedules")
-  public void getProgramSchedules(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespace,
-      @PathParam("app-name") String application,
-      @PathParam("program-type") String type,
-      @PathParam("program-name") String program,
-      @QueryParam("trigger-type") String triggerType,
-      @QueryParam("schedule-status") String scheduleStatus) throws Exception {
-    getProgramSchedulesVersioned(request, responder, namespace, application,
-        ApplicationId.DEFAULT_VERSION,
-        type, program, triggerType, scheduleStatus);
-  }
-
-  /**
-   * Get Workflow schedules
-   *
-   * Deprecated : Schedules are versionless.
-   */
-  @Deprecated
-  @GET
-  @Path("/apps/{app-name}/versions/{app-version}/{program-type}/{program-name}/schedules")
-  public void getProgramSchedulesVersioned(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespace,
-      @PathParam("app-name") String application,
-      @PathParam("app-version") String appVersion,
-      @PathParam("program-type") String type,
-      @PathParam("program-name") String program,
-      @QueryParam("trigger-type") String triggerType,
-      @QueryParam("schedule-status") String scheduleStatus) throws Exception {
-    ProgramType programType = ProgramType.valueOfCategoryName(type, BadRequestException::new);
-    if (programType.getSchedulableType() == null) {
-      throw new BadRequestException("Program type " + programType + " cannot have schedule");
-    }
-
-    ProgramId programId = new ApplicationId(namespace, application).program(programType, program);
-    doGetSchedules(responder, new NamespaceId(namespace).app(application), programId,
-        triggerType, scheduleStatus);
-  }
-
-  private void doGetSchedules(HttpResponder responder, ApplicationId applicationId,
-      @Nullable ProgramId programId, @Nullable String triggerTypeStr,
-      @Nullable String statusStr) throws Exception {
-    ApplicationSpecification appSpec = Optional.ofNullable(
-            store.getLatest(applicationId.getAppReference()))
-        .map(ApplicationMeta::getSpec)
-        .orElse(null);
-    if (appSpec == null) {
-      throw new NotFoundException(applicationId);
-    }
-    ProgramScheduleStatus status;
-    try {
-      status = statusStr == null ? null : ProgramScheduleStatus.valueOf(statusStr);
-    } catch (IllegalArgumentException e) {
-      throw new BadRequestException(
-          String.format("Invalid schedule status '%s'. Must be one of %s.",
-              statusStr, Joiner.on(',').join(ProgramScheduleStatus.values())), e);
-    }
-
-    ProtoTrigger.Type triggerType;
-    try {
-      triggerType =
-          triggerTypeStr == null ? null : ProtoTrigger.Type.valueOfCategoryName(triggerTypeStr);
-    } catch (IllegalArgumentException e) {
-      throw new BadRequestException(e.getMessage(), e);
-    }
-
-    Predicate<ProgramScheduleRecord> predicate = record -> true;
-    if (status != null) {
-      predicate = predicate.and(record -> record.getMeta().getStatus().equals(status));
-    }
-    if (triggerType != null) {
-      predicate = predicate.and(
-          record -> record.getSchedule().getTrigger().getType().equals(triggerType));
-    }
-
-    Collection<ProgramScheduleRecord> schedules;
-    if (programId != null) {
-      if (!appSpec.getProgramsByType(programId.getType().getApiProgramType())
-          .contains(programId.getProgram())) {
-        throw new NotFoundException(programId);
-      }
-      schedules = programScheduleService.list(programId, predicate);
-    } else {
-      schedules = programScheduleService.list(applicationId, predicate);
-    }
-
-    List<ScheduleDetail> details = schedules.stream()
-        .map(ProgramScheduleRecord::toScheduleDetail)
-        .collect(Collectors.toList());
-    responder.sendJson(HttpResponseStatus.OK,
-        ProgramHandlerUtil.toJson(details, Schedulers.SCHEDULE_DETAILS_TYPE));
-  }
-
-  /**
-   * Returns the previous runtime when the scheduled program ran.
-   */
-  @GET
-  @Path("/apps/{app-name}/{program-type}/{program-name}/previousruntime")
-  public void getPreviousScheduledRunTime(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @PathParam("app-name") String appName,
-      @PathParam("program-type") String type,
-      @PathParam("program-name") String program) throws Exception {
-    ProgramType programType = ProgramType.valueOfCategoryName(type, BadRequestException::new);
-    ApplicationId appId = store.getLatestApp(new ApplicationReference(namespaceId, appName));
-    handleScheduleRunTime(responder, appId.program(programType, program), true);
-  }
-
-  /**
-   * Returns next scheduled runtime of a workflow.
-   */
-  @GET
-  @Path("/apps/{app-name}/{program-type}/{program-name}/nextruntime")
-  public void getNextScheduledRunTime(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @PathParam("app-name") String appName,
-      @PathParam("program-type") String type,
-      @PathParam("program-name") String program) throws Exception {
-    ProgramType programType = ProgramType.valueOfCategoryName(type, BadRequestException::new);
-    ApplicationId appId = store.getLatestApp(new ApplicationReference(namespaceId, appName));
-    handleScheduleRunTime(responder, appId.program(programType, program), false);
-  }
-
-  private void handleScheduleRunTime(HttpResponder responder, ProgramId programId,
-      boolean previousRuntimeRequested) throws Exception {
-    try {
-      lifecycleService.ensureProgramExists(programId);
-      responder.sendJson(HttpResponseStatus.OK,
-          ProgramHandlerUtil.toJson(getScheduledRunTimes(programId, previousRuntimeRequested)));
-    } catch (SecurityException e) {
-      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
-    }
-  }
-
-  /**
-   * Returns the previous scheduled run time for all programs that are passed into the data. The
-   * data is an array of JSON objects where each object must contain the following three elements:
-   * appId, programType, and programId (flow name, service name, etc.).
-   * <p>
-   * Example input:
-   * <pre><code>
-   * [{"appId": "App1", "programType": "Workflow", "programId": "WF1"},
-   * {"appId": "App1", "programType": "Workflow", "programId": "WF2"}]
-   * </code></pre>
-   * </p><p>
-   * The response will be an array of JsonObjects each of which will contain the three input
-   * parameters as well as a "schedules" field, which is a list of {@link ScheduledRuntime} object.
-   * </p><p>
-   * If an error occurs in the input (for the example above, App1 does not exist), then all
-   * JsonObjects for which the parameters have a valid status will have the status field but all
-   * JsonObjects for which the parameters do not have a valid status will have an error message and
-   * statusCode.
-   */
-  @POST
-  @Path("/previousruntime")
-  public void batchPreviousRunTimes(FullHttpRequest request,
-      HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId) throws Exception {
-    List<BatchProgram> batchPrograms = ProgramHandlerUtil.validateAndGetBatchInput(request, BATCH_PROGRAMS_TYPE);
-    responder.sendJson(HttpResponseStatus.OK,
-        ProgramHandlerUtil.toJson(batchRunTimes(namespaceId, batchPrograms, true)));
-  }
-
-  /**
-   * Returns the next scheduled run time for all programs that are passed into the data. The data is
-   * an array of JSON objects where each object must contain the following three elements: appId,
-   * programType, and programId (flow name, service name, etc.).
-   * <p>
-   * Example input:
-   * <pre><code>
-   * [{"appId": "App1", "programType": "Workflow", "programId": "WF1"},
-   * {"appId": "App1", "programType": "Workflow", "programId": "WF2"}]
-   * </code></pre>
-   * </p><p>
-   * The response will be an array of JsonObjects each of which will contain the three input
-   * parameters as well as a "schedules" field, which is a list of {@link ScheduledRuntime} object.
-   * </p><p>
-   * If an error occurs in the input (for the example above, App1 does not exist), then all
-   * JsonObjects for which the parameters have a valid status will have the status field but all
-   * JsonObjects for which the parameters do not have a valid status will have an error message and
-   * statusCode.
-   */
-  @POST
-  @Path("/nextruntime")
-  public void batchNextRunTimes(FullHttpRequest request,
-      HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId) throws Exception {
-    List<BatchProgram> batchPrograms = ProgramHandlerUtil.validateAndGetBatchInput(request, BATCH_PROGRAMS_TYPE);
-    responder.sendJson(HttpResponseStatus.OK,
-        ProgramHandlerUtil.toJson(batchRunTimes(namespaceId, batchPrograms, false)));
-  }
-
-  /**
-   * Fetches scheduled run times for a set of programs.
-   *
-   * @param namespace namespace of the programs
-   * @param programs the list of programs to fetch scheduled run times
-   * @param previous {@code true} to get the previous scheduled times; {@code false} to get the
-   *     next scheduled times
-   * @return a list of {@link BatchProgramSchedule} containing the result
-   * @throws SchedulerException if failed to fetch schedules
-   */
-  private List<BatchProgramSchedule> batchRunTimes(String namespace,
-      Collection<? extends BatchProgram> programs,
-      boolean previous) throws Exception {
-    List<ProgramReference> programReferences = programs.stream()
-        .map(p -> new ProgramReference(namespace, p.getAppId(), p.getProgramType(),
-            p.getProgramId()))
-        .collect(Collectors.toList());
-    Map<ProgramReference, ProgramId> programMap = store.getPrograms(programReferences);
-
-    List<BatchProgramSchedule> result = new ArrayList<>();
-    for (ProgramReference programReference : programReferences) {
-      if (programMap.containsKey(programReference)) {
-        ProgramId programId = programMap.get(programReference);
-        result.add(new BatchProgramSchedule(programId, HttpResponseStatus.OK.code(), null,
-            getScheduledRunTimes(programId, previous)));
-      } else {
-        result.add(new BatchProgramSchedule(programReference, HttpResponseStatus.NOT_FOUND.code(),
-            new NotFoundException(programReference).getMessage(), null));
-      }
-    }
-    return result;
-  }
-
-  /**
-   * Returns a list of {@link ScheduledRuntime} for the given program.
-   *
-   * @param programId the program to fetch schedules for
-   * @param previous {@code true} to get the previous scheduled times; {@code false} to get the
-   *     next scheduled times
-   * @return a list of {@link ScheduledRuntime}
-   * @throws SchedulerException if failed to fetch the schedule
-   */
-  private List<ScheduledRuntime> getScheduledRunTimes(ProgramId programId,
-      boolean previous) throws Exception {
-    if (programId.getType().getSchedulableType() == null) {
-      throw new BadRequestException("Program " + programId + " cannot have schedule");
-    }
-
-    if (previous) {
-      return programScheduleService.getPreviousScheduledRuntimes(programId);
-    } else {
-      return programScheduleService.getNextScheduledRuntimes(programId);
-    }
-  }
-
-  @PUT
-  @Path("apps/{app-name}/schedules/{schedule-name}")
-  @AuditPolicy(AuditDetail.REQUEST_BODY)
-  public void addSchedule(FullHttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @PathParam("app-name") String appName,
-      @PathParam("schedule-name") String scheduleName)
-      throws Exception {
-    doAddSchedule(request, responder, namespaceId, appName, scheduleName);
-  }
-
-  /*
-  * Deprecated : Schedules are versionless.
-  * */
-  @Deprecated
-  @PUT
-  @Path("apps/{app-name}/versions/{app-version}/schedules/{schedule-name}")
-  @AuditPolicy(AuditDetail.REQUEST_BODY)
-  public void addScheduleVersioned(FullHttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @PathParam("app-name") String appName,
-      @PathParam("app-version") String appVersion,
-      @PathParam("schedule-name") String scheduleName)
-      throws Exception {
-    // Schedules are versionless (all are "-SNAPSHOT" version)
-    doAddSchedule(request, responder, namespaceId, appName, scheduleName);
-  }
-
-  private void doAddSchedule(FullHttpRequest request, HttpResponder responder, String namespace,
-      String appName,
-      String scheduleName) throws Exception {
-
-    final ApplicationId applicationId = new ApplicationId(namespace, appName);
-    ScheduleDetail scheduleFromRequest = readScheduleDetailBody(request, scheduleName);
-
-    if (scheduleFromRequest.getProgram() == null) {
-      throw new BadRequestException("No program was specified for the schedule");
-    }
-    if (scheduleFromRequest.getProgram().getProgramType() == null) {
-      throw new BadRequestException("No program type was specified for the schedule");
-    }
-    if (scheduleFromRequest.getProgram().getProgramName() == null) {
-      throw new BadRequestException("No program name was specified for the schedule");
-    }
-    if (scheduleFromRequest.getTrigger() == null) {
-      throw new BadRequestException("No trigger was specified for the schedule");
-    }
-    ProgramType programType = ProgramType.valueOfSchedulableType(
-        scheduleFromRequest.getProgram().getProgramType());
-    String programName = scheduleFromRequest.getProgram().getProgramName();
-    ProgramId programId = applicationId.program(programType, programName);
-
-    // Schedules are versionless
-    lifecycleService.ensureLatestProgramExists(programId.getProgramReference());
-
-    String description = Objects.firstNonNull(scheduleFromRequest.getDescription(), "");
-    Map<String, String> properties = Objects.firstNonNull(scheduleFromRequest.getProperties(),
-        Collections.emptyMap());
-    List<? extends Constraint> constraints = Objects.firstNonNull(
-        scheduleFromRequest.getConstraints(), NO_CONSTRAINTS);
-    long timeoutMillis =
-        Objects.firstNonNull(scheduleFromRequest.getTimeoutMillis(),
-            Schedulers.JOB_QUEUE_TIMEOUT_MILLIS);
-    ProgramSchedule schedule = new ProgramSchedule(scheduleName, description, programId, properties,
-        scheduleFromRequest.getTrigger(), constraints, timeoutMillis);
-    programScheduleService.add(schedule);
-    responder.sendStatus(HttpResponseStatus.OK);
-  }
-
-  @POST
-  @Path("apps/{app-name}/schedules/{schedule-name}/update")
-  @AuditPolicy(AuditDetail.REQUEST_BODY)
-  public void updateSchedule(FullHttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @PathParam("app-name") String appName,
-      @PathParam("schedule-name") String scheduleName) throws Exception {
-    doUpdateSchedule(request, responder, namespaceId, appName, scheduleName);
-  }
-
-  /*
-   * Deprecated : Schedules are versionless.
-   * */
-  @Deprecated
-  @POST
-  @Path("apps/{app-name}/versions/{app-version}/schedules/{schedule-name}/update")
-  @AuditPolicy(AuditDetail.REQUEST_BODY)
-  public void updateScheduleVersioned(FullHttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @PathParam("app-name") String appName,
-      @PathParam("app-version") String appVersion,
-      @PathParam("schedule-name") String scheduleName) throws Exception {
-    doUpdateSchedule(request, responder, namespaceId, appName, scheduleName);
-  }
-
-  private void doUpdateSchedule(FullHttpRequest request, HttpResponder responder,
-      String namespaceId, String appId,
-      String scheduleName) throws Exception {
-
-    ScheduleId scheduleId = new ApplicationId(namespaceId, appId).schedule(scheduleName);
-    ScheduleDetail scheduleDetail = readScheduleDetailBody(request, scheduleName);
-
-    programScheduleService.update(scheduleId, scheduleDetail);
-    responder.sendStatus(HttpResponseStatus.OK);
-  }
-
-  private ScheduleDetail readScheduleDetailBody(FullHttpRequest request, String scheduleName)
-      throws BadRequestException, IOException {
-
-    JsonElement json;
-    try (Reader reader = new InputStreamReader(new ByteBufInputStream(request.content()),
-        Charsets.UTF_8)) {
-      // The schedule spec in the request body does not contain the program information
-      json = ProgramHandlerUtil.fromJson(reader, JsonElement.class);
-    } catch (IOException e) {
-      throw new IOException("Error reading request body", e);
-    } catch (JsonSyntaxException e) {
-      throw new BadRequestException("Request body is invalid json: " + e.getMessage());
-    }
-    if (!json.isJsonObject()) {
-      throw new BadRequestException(
-          "Expected a json object in the request body but received " + ProgramHandlerUtil.toJson(json));
-    }
-    ScheduleDetail scheduleDetail;
-    try {
-      scheduleDetail = ProgramHandlerUtil.fromJson(json, ScheduleDetail.class);
-    } catch (JsonSyntaxException e) {
-      throw new BadRequestException(
-          "Error parsing request body as a schedule specification: " + e.getMessage());
-    }
-
-    // If the schedule name is present in the request body, it should match the name in path params
-    if (scheduleDetail.getName() != null && !scheduleName.equals(scheduleDetail.getName())) {
-      throw new BadRequestException(String.format(
-          "Schedule name in the body of the request (%s) does not match the schedule name in the path parameter (%s)",
-          scheduleDetail.getName(), scheduleName));
-    }
-    return scheduleDetail;
-  }
-
-  @DELETE
-  @Path("apps/{app-name}/schedules/{schedule-name}")
-  public void deleteSchedule(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @PathParam("app-name") String appName,
-      @PathParam("schedule-name") String scheduleName) throws Exception {
-    doDeleteSchedule(responder, namespaceId, appName, scheduleName);
-  }
-
-  /*
-  * Deprecated : Schedules are versionless.
-  * */
-  @Deprecated
-  @DELETE
-  @Path("apps/{app-name}/versions/{app-version}/schedules/{schedule-name}")
-  public void deleteScheduleVersioned(HttpRequest request, HttpResponder responder,
-      @PathParam("namespace-id") String namespaceId,
-      @PathParam("app-name") String appName,
-      @PathParam("app-version") String appVersion,
-      @PathParam("schedule-name") String scheduleName) throws Exception {
-    doDeleteSchedule(responder, namespaceId, appName, scheduleName);
-  }
-
-  private void doDeleteSchedule(HttpResponder responder, String namespaceId, String appName,
-      String scheduleName) throws Exception {
-    ScheduleId scheduleId = new ApplicationId(namespaceId, appName).schedule(scheduleName);
-    programScheduleService.delete(scheduleId);
-    responder.sendStatus(HttpResponseStatus.OK);
-  }
-
-  /**
    * Returns the status for all programs that are passed into the data. The data is an array of JSON
    * objects where each object must contain the following three elements: appId, programType, and
    * programId (flow name, service name, etc.).
@@ -1628,7 +957,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
-   * Returns the count of the given program runs
+   * Returns the count of the given program runs.
    */
   @GET
   @Path("/apps/{app-name}/{program-type}/{program-name}/runcount")
@@ -1645,7 +974,7 @@ public class ProgramLifecycleHttpHandler extends AbstractAppFabricHttpHandler {
   }
 
   /**
-   * Returns the count of the given program runs
+   * Returns the count of the given program runs.
    */
   @GET
   @Path("/apps/{app-name}/versions/{app-version}/{program-type}/{program-name}/runcount")

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramScheduleHttpHandler.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/gateway/handlers/ProgramScheduleHttpHandler.java
@@ -1,0 +1,824 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.gateway.handlers;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.app.store.Store;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.security.AuditDetail;
+import io.cdap.cdap.common.security.AuditPolicy;
+import io.cdap.cdap.gateway.handlers.util.AbstractAppFabricHttpHandler;
+import io.cdap.cdap.gateway.handlers.util.ProgramHandlerUtil;
+import io.cdap.cdap.internal.app.runtime.schedule.ProgramSchedule;
+import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleRecord;
+import io.cdap.cdap.internal.app.runtime.schedule.ProgramScheduleStatus;
+import io.cdap.cdap.internal.app.runtime.schedule.SchedulerException;
+import io.cdap.cdap.internal.app.runtime.schedule.store.Schedulers;
+import io.cdap.cdap.internal.app.runtime.schedule.trigger.ProgramStatusTrigger;
+import io.cdap.cdap.internal.app.services.ProgramLifecycleService;
+import io.cdap.cdap.internal.app.store.ApplicationMeta;
+import io.cdap.cdap.internal.schedule.constraint.Constraint;
+import io.cdap.cdap.proto.BatchProgram;
+import io.cdap.cdap.proto.BatchProgramSchedule;
+import io.cdap.cdap.proto.ProgramStatus;
+import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.ProtoTrigger;
+import io.cdap.cdap.proto.ScheduleDetail;
+import io.cdap.cdap.proto.ScheduledRuntime;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ApplicationReference;
+import io.cdap.cdap.proto.id.NamespaceId;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ProgramReference;
+import io.cdap.cdap.proto.id.ScheduleId;
+import io.cdap.cdap.scheduler.ProgramScheduleService;
+import io.cdap.http.HttpResponder;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+
+/**
+ * {@link io.cdap.http.HttpHandler} to manage program schedule for v3 REST APIs.
+ */
+@Singleton
+@Path(Constants.Gateway.API_VERSION_3 + "/namespaces/{namespace-id}")
+public class ProgramScheduleHttpHandler extends AbstractAppFabricHttpHandler {
+
+  private static final Type BATCH_PROGRAMS_TYPE = new TypeToken<List<BatchProgram>>() {
+  }.getType();
+  private static final List<Constraint> NO_CONSTRAINTS = Collections.emptyList();
+
+  private final ProgramScheduleService programScheduleService;
+  private final ProgramLifecycleService lifecycleService;
+  private final Store store;
+
+  /**
+   * Constructor for ProgramScheduleHttpHandler.
+   * @param programScheduleService ProgramScheduleService
+   * @param lifecycleService ProgramLifecycleService
+   * @param store Store
+   */
+  @Inject
+  public ProgramScheduleHttpHandler(ProgramScheduleService programScheduleService,
+      ProgramLifecycleService lifecycleService,
+      Store store) {
+    this.programScheduleService = programScheduleService;
+    this.lifecycleService = lifecycleService;
+    this.store = store;
+  }
+
+  /**
+   * Returns status of a schedule.
+   */
+  @GET
+  @Path("/apps/{app-id}/schedules/{schedule-name}/status")
+  public void getStatus(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-id") String appId,
+      @PathParam("schedule-name") String scheduleName) throws Exception {
+    getStatusVersioned(request, responder, namespaceId, appId, ApplicationId.DEFAULT_VERSION, scheduleName);
+  }
+
+  /**
+   * Returns status of a schedule.
+   * Deprecated: Only schedule info retrieval for the latest app version (active app).
+   */
+  @Deprecated
+  @GET
+  @Path("/apps/{app-id}/versions/{version-id}/schedules/{schedule-name}/status")
+  public void getStatusVersioned(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-id") String appId,
+      @PathParam("version-id") String versionId,
+      @PathParam("schedule-name") String scheduleName) throws Exception {
+    ApplicationReference appReference = new ApplicationReference(namespaceId, appId);
+    JsonObject json = new JsonObject();
+    // ScheduleId is versionless (always "-SNAPSHOT")
+    ScheduleId scheduleId = appReference.app(ApplicationId.DEFAULT_VERSION).schedule(scheduleName);
+    ApplicationSpecification appSpec = ApplicationId.DEFAULT_VERSION.equals(versionId)
+        ? Optional.ofNullable(store.getLatest(appReference)).map(ApplicationMeta::getSpec)
+        .orElse(null)
+        : store.getApplication(appReference.app(versionId));
+    if (appSpec == null) {
+      throw new NotFoundException(appReference);
+    }
+    json.addProperty("status", programScheduleService.getStatus(scheduleId).toString());
+    responder.sendJson(HttpResponseStatus.OK, json.toString());
+  }
+
+  /**
+   * Perform an action on the latest version of a schedule.
+   */
+  @POST
+  @Path("/apps/{app-id}/schedules/{schedule-name}/{action}")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void performAction(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-id") String appId,
+      @PathParam("schedule-name") String scheduleName,
+      @PathParam("action") String action) throws Exception {
+    doPerformAction(responder, namespaceId, appId, ApplicationId.DEFAULT_VERSION, scheduleName, action);
+  }
+
+  /**
+   * Perform an action on the schedule of a specific {@code appVersion}.
+   */
+  @POST
+  @Path("/apps/{app-id}/versions/{app-version}/schedules/{schedule-name}/{action}")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void performActionVersioned(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-id") String appId,
+      @PathParam("app-version") String appVersion,
+      @PathParam("schedule-name") String scheduleName,
+      @PathParam("action") String action) throws Exception {
+    doPerformAction(responder, namespaceId, appId, appVersion, scheduleName, action);
+  }
+
+  /**
+   * Perform an action on the schedule of a specific {@code appVersion}.
+   *
+   * @param namespaceId namespace of the program
+   * @param appId appId of the program
+   * @param appVersion app version of the program
+   * @param programId programId of the program
+   * @param action action to be performed. The value can be one of enable/disable/suspend/resume
+   *     for schedule.
+   *
+   * @throws NotFoundException if action is an unknown action
+   * @throws BadRequestException if type is schedule and action is not any of
+   *     enable/disable/suspend/resume
+   * @throws BadRequestException if action is not supported.
+   */
+  private void doPerformAction(HttpResponder responder, String namespaceId,
+      String appId, String appVersion, String programId, String action) throws Exception {
+    ApplicationId applicationId = new ApplicationId(namespaceId, appId, appVersion);
+    ScheduleId scheduleId = applicationId.schedule(programId);
+    if (action.equals("disable") || action.equals("suspend")) {
+      programScheduleService.suspend(scheduleId);
+    } else if (action.equals("enable") || action.equals("resume")) {
+      programScheduleService.resume(scheduleId);
+    } else {
+      throw new BadRequestException(
+          "Action for schedules may only be 'enable', 'disable', 'suspend', or 'resume' but is'"
+              + action + "'");
+    }
+    responder.sendJson(HttpResponseStatus.OK, "OK");
+  }
+
+  /**
+   * Update schedules which were suspended between startTimeMillis and endTimeMillis.
+   *
+   * @param startTimeMillis lower bound in millis of the update time for schedules (inclusive)
+   * @param endTimeMillis upper bound in millis of the update time for schedules (exclusive)
+   */
+  @PUT
+  @Path("schedules/re-enable")
+  public void reEnableSuspendedSchedules(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @QueryParam("start-time-millis") long startTimeMillis,
+      @QueryParam("end-time-millis") long endTimeMillis) throws Exception {
+    programScheduleService.reEnableSchedules(new NamespaceId(namespaceId), startTimeMillis,
+        endTimeMillis);
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  /**
+   * Get schedules containing {@link ProgramStatusTrigger} filtered by triggering program, and
+   * optionally by triggering program statuses or schedule status.
+   *
+   * @param triggerNamespaceId namespace of the triggering program in {@link
+   *     ProgramStatusTrigger}
+   * @param triggerAppName application name of the triggering program in {@link
+   *     ProgramStatusTrigger}
+   * @param triggerAppVersion application version of the triggering program in {@link
+   *     ProgramStatusTrigger}
+   * @param triggerProgramType program type of the triggering program in {@link
+   *     ProgramStatusTrigger}
+   * @param triggerProgramName program name of the triggering program in {@link
+   *     ProgramStatusTrigger}
+   * @param triggerProgramStatuses comma separated {@link ProgramStatus} in {@link
+   *     ProgramStatusTrigger}. Schedules with {@link ProgramStatusTrigger} triggered by none of the
+   *     {@link ProgramStatus} in triggerProgramStatuses will be filtered out. If not specified,
+   *     schedules will be returned regardless of triggering program status.
+   * @param scheduleStatus status of the schedule. Can only be one of "SCHEDULED" or
+   *     "SUSPENDED". If specified, only schedules with matching status will be returned.
+   */
+  @GET
+  @Path("schedules/trigger-type/program-status")
+  public void getProgramStatusSchedules(HttpRequest request, HttpResponder responder,
+      @QueryParam("trigger-namespace-id") String triggerNamespaceId,
+      @QueryParam("trigger-app-name") String triggerAppName,
+      @QueryParam("trigger-app-version") @DefaultValue(ApplicationId.DEFAULT_VERSION)
+      String triggerAppVersion,
+      @QueryParam("trigger-program-type") String triggerProgramType,
+      @QueryParam("trigger-program-name") String triggerProgramName,
+      @QueryParam("trigger-program-statuses") String triggerProgramStatuses,
+      @QueryParam("schedule-status") String scheduleStatus) throws Exception {
+    if (triggerNamespaceId == null) {
+      throw new BadRequestException("Must specify trigger-namespace-id as a query param");
+    }
+    if (triggerAppName == null) {
+      throw new BadRequestException("Must specify trigger-app-name as a query param");
+    }
+    if (triggerProgramType == null) {
+      throw new BadRequestException("Must specify trigger-program-type as a query param");
+    }
+    if (triggerProgramName == null) {
+      throw new BadRequestException("Must specify trigger-program-name as a query param");
+    }
+
+    ProgramType programType = ProgramType.valueOfCategoryName(triggerProgramType, BadRequestException::new);
+    ProgramScheduleStatus programScheduleStatus;
+    try {
+      programScheduleStatus =
+          scheduleStatus == null ? null : ProgramScheduleStatus.valueOf(scheduleStatus);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(
+          String.format("Invalid schedule status '%s'. Must be one of %s.",
+              scheduleStatus, Joiner.on(',').join(ProgramScheduleStatus.values())),
+          e);
+    }
+
+    ProgramId triggerProgramId = new NamespaceId(triggerNamespaceId)
+        .app(triggerAppName, triggerAppVersion)
+        .program(programType, triggerProgramName);
+
+    Set<io.cdap.cdap.api.ProgramStatus> queryProgramStatuses = new HashSet<>();
+    if (triggerProgramStatuses != null) {
+      try {
+        for (String status : triggerProgramStatuses.split(",")) {
+          queryProgramStatuses.add(io.cdap.cdap.api.ProgramStatus.valueOf(status));
+        }
+      } catch (Exception e) {
+        throw new BadRequestException(
+            String.format("Unable to parse program statuses '%s'. Must be comma separated "
+                    + "valid ProgramStatus names such as COMPLETED, FAILED, KILLED.",
+                triggerProgramStatuses), e);
+      }
+    } else {
+      // Query for schedules with all the statuses if no query status is specified
+      Collections.addAll(queryProgramStatuses, io.cdap.cdap.api.ProgramStatus.values());
+    }
+
+    List<ScheduleDetail> details = programScheduleService.findTriggeredBy(triggerProgramId,
+            queryProgramStatuses)
+        .stream()
+        .filter(record -> programScheduleStatus == null || record.getMeta().getStatus()
+            .equals(programScheduleStatus))
+        .map(ProgramScheduleRecord::toScheduleDetail)
+        .collect(Collectors.toList());
+    responder.sendJson(HttpResponseStatus.OK,
+        ProgramHandlerUtil.toJson(details, Schedulers.SCHEDULE_DETAILS_TYPE));
+  }
+
+  /**
+   * Gets the schedule for the given {@code appName}.
+   */
+  @GET
+  @Path("apps/{app-name}/schedules/{schedule-name}")
+  public void getSchedule(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-name") String appName,
+      @PathParam("schedule-name") String scheduleName) throws Exception {
+    doGetSchedule(responder, namespaceId, appName, scheduleName);
+  }
+
+  /*
+   * Deprecated: Schedules are versionless.
+   * */
+  @Deprecated
+  @GET
+  @Path("apps/{app-name}/versions/{app-version}/schedules/{schedule-name}")
+  public void getScheduleVersioned(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-name") String appName,
+      @PathParam("app-version") String appVersion,
+      @PathParam("schedule-name") String scheduleName) throws Exception {
+    doGetSchedule(responder, namespaceId, appName, scheduleName);
+  }
+
+  private void doGetSchedule(HttpResponder responder, String namespace, String app,
+      String scheduleName)
+      throws Exception {
+    ScheduleId scheduleId = new ApplicationId(namespace, app).schedule(scheduleName);
+    ProgramScheduleRecord record = programScheduleService.getRecord(scheduleId);
+    ScheduleDetail detail = record.toScheduleDetail();
+    responder.sendJson(HttpResponseStatus.OK, ProgramHandlerUtil.toJson(detail, ScheduleDetail.class));
+  }
+
+  /**
+   * See {@link #getAllSchedulesVersioned(HttpRequest, HttpResponder, String, String, String,
+   * String, String)}.
+   */
+  @GET
+  @Path("apps/{app-name}/schedules")
+  public void getAllSchedules(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-name") String appName,
+      @QueryParam("trigger-type") String triggerType,
+      @QueryParam("schedule-status") String scheduleStatus) throws Exception {
+    doGetSchedules(responder, new NamespaceId(namespaceId).app(appName), null, triggerType,
+        scheduleStatus);
+  }
+
+  /**
+   * Get schedules in a given application, optionally filtered by the given {@link
+   *  io.cdap.cdap.proto.ProtoTrigger.Type}.
+   * Deprecated : Schedules are versionless.
+   * @param namespaceId namespace of the application to get schedules from
+   * @param appName name of the application to get schedules from
+   * @param appVersion version of the application to get schedules from
+   * @param triggerType trigger type of returned schedules. If not specified, all schedules are
+   *     returned regardless of trigger type
+   * @param scheduleStatus the status of the schedule, must be values in {@link
+   *     ProgramScheduleStatus}.
+   *
+   */
+  @Deprecated
+  @GET
+  @Path("apps/{app-name}/versions/{app-version}/schedules")
+  public void getAllSchedulesVersioned(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-name") String appName,
+      @PathParam("app-version") String appVersion,
+      @QueryParam("trigger-type") String triggerType,
+      @QueryParam("schedule-status") String scheduleStatus) throws Exception {
+    doGetSchedules(responder, new NamespaceId(namespaceId).app(appName), null, triggerType,
+        scheduleStatus);
+  }
+
+  /**
+   * Get program schedules.
+   */
+  @GET
+  @Path("/apps/{app-name}/{program-type}/{program-name}/schedules")
+  public void getProgramSchedules(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace,
+      @PathParam("app-name") String application,
+      @PathParam("program-type") String type,
+      @PathParam("program-name") String program,
+      @QueryParam("trigger-type") String triggerType,
+      @QueryParam("schedule-status") String scheduleStatus) throws Exception {
+    getProgramSchedulesVersioned(request, responder, namespace, application,
+        ApplicationId.DEFAULT_VERSION,
+        type, program, triggerType, scheduleStatus);
+  }
+
+  /**
+   * Get Workflow schedules.
+   * Deprecated : Schedules are versionless.
+   */
+  @Deprecated
+  @GET
+  @Path("/apps/{app-name}/versions/{app-version}/{program-type}/{program-name}/schedules")
+  public void getProgramSchedulesVersioned(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespace,
+      @PathParam("app-name") String application,
+      @PathParam("app-version") String appVersion,
+      @PathParam("program-type") String type,
+      @PathParam("program-name") String program,
+      @QueryParam("trigger-type") String triggerType,
+      @QueryParam("schedule-status") String scheduleStatus) throws Exception {
+    ProgramType programType = ProgramType.valueOfCategoryName(type, BadRequestException::new);
+    if (programType.getSchedulableType() == null) {
+      throw new BadRequestException("Program type " + programType + " cannot have schedule");
+    }
+
+    ProgramId programId = new ApplicationId(namespace, application).program(programType, program);
+    doGetSchedules(responder, new NamespaceId(namespace).app(application), programId,
+        triggerType, scheduleStatus);
+  }
+
+  private void doGetSchedules(HttpResponder responder, ApplicationId applicationId,
+      @Nullable ProgramId programId, @Nullable String triggerTypeStr,
+      @Nullable String statusStr) throws Exception {
+    ApplicationSpecification appSpec = Optional.ofNullable(
+            store.getLatest(applicationId.getAppReference()))
+        .map(ApplicationMeta::getSpec)
+        .orElse(null);
+    if (appSpec == null) {
+      throw new NotFoundException(applicationId);
+    }
+    ProgramScheduleStatus status;
+    try {
+      status = statusStr == null ? null : ProgramScheduleStatus.valueOf(statusStr);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(
+          String.format("Invalid schedule status '%s'. Must be one of %s.",
+              statusStr, Joiner.on(',').join(ProgramScheduleStatus.values())), e);
+    }
+
+    ProtoTrigger.Type triggerType;
+    try {
+      triggerType =
+          triggerTypeStr == null ? null : ProtoTrigger.Type.valueOfCategoryName(triggerTypeStr);
+    } catch (IllegalArgumentException e) {
+      throw new BadRequestException(e.getMessage(), e);
+    }
+
+    Predicate<ProgramScheduleRecord> predicate = record -> true;
+    if (status != null) {
+      predicate = predicate.and(record -> record.getMeta().getStatus().equals(status));
+    }
+    if (triggerType != null) {
+      predicate = predicate.and(
+          record -> record.getSchedule().getTrigger().getType().equals(triggerType));
+    }
+
+    Collection<ProgramScheduleRecord> schedules;
+    if (programId != null) {
+      if (!appSpec.getProgramsByType(programId.getType().getApiProgramType())
+          .contains(programId.getProgram())) {
+        throw new NotFoundException(programId);
+      }
+      schedules = programScheduleService.list(programId, predicate);
+    } else {
+      schedules = programScheduleService.list(applicationId, predicate);
+    }
+
+    List<ScheduleDetail> details = schedules.stream()
+        .map(ProgramScheduleRecord::toScheduleDetail)
+        .collect(Collectors.toList());
+    responder.sendJson(HttpResponseStatus.OK,
+        ProgramHandlerUtil.toJson(details, Schedulers.SCHEDULE_DETAILS_TYPE));
+  }
+
+  /**
+   * Returns the previous runtime when the scheduled program ran.
+   */
+  @GET
+  @Path("/apps/{app-name}/{program-type}/{program-name}/previousruntime")
+  public void getPreviousScheduledRunTime(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-name") String appName,
+      @PathParam("program-type") String type,
+      @PathParam("program-name") String program) throws Exception {
+    ProgramType programType = ProgramType.valueOfCategoryName(type, BadRequestException::new);
+    ApplicationId appId = store.getLatestApp(new ApplicationReference(namespaceId, appName));
+    handleScheduleRunTime(responder, appId.program(programType, program), true);
+  }
+
+  /**
+   * Returns next scheduled runtime of a workflow.
+   */
+  @GET
+  @Path("/apps/{app-name}/{program-type}/{program-name}/nextruntime")
+  public void getNextScheduledRunTime(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-name") String appName,
+      @PathParam("program-type") String type,
+      @PathParam("program-name") String program) throws Exception {
+    ProgramType programType = ProgramType.valueOfCategoryName(type, BadRequestException::new);
+    ApplicationId appId = store.getLatestApp(new ApplicationReference(namespaceId, appName));
+    handleScheduleRunTime(responder, appId.program(programType, program), false);
+  }
+
+  private void handleScheduleRunTime(HttpResponder responder, ProgramId programId,
+      boolean previousRuntimeRequested) throws Exception {
+    try {
+      lifecycleService.ensureProgramExists(programId);
+      responder.sendJson(HttpResponseStatus.OK,
+          ProgramHandlerUtil.toJson(getScheduledRunTimes(programId, previousRuntimeRequested)));
+    } catch (SecurityException e) {
+      responder.sendStatus(HttpResponseStatus.UNAUTHORIZED);
+    }
+  }
+
+  /**
+   * Adds a schedule for a given {@code appName}.
+   */
+  @PUT
+  @Path("apps/{app-name}/schedules/{schedule-name}")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void addSchedule(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-name") String appName,
+      @PathParam("schedule-name") String scheduleName)
+      throws Exception {
+    doAddSchedule(request, responder, namespaceId, appName, scheduleName);
+  }
+
+  /*
+   * Deprecated : Schedules are versionless.
+   */
+  @Deprecated
+  @PUT
+  @Path("apps/{app-name}/versions/{app-version}/schedules/{schedule-name}")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void addScheduleVersioned(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-name") String appName,
+      @PathParam("app-version") String appVersion,
+      @PathParam("schedule-name") String scheduleName)
+      throws Exception {
+    // Schedules are versionless (all are "-SNAPSHOT" version)
+    doAddSchedule(request, responder, namespaceId, appName, scheduleName);
+  }
+
+  private void doAddSchedule(FullHttpRequest request, HttpResponder responder, String namespace,
+      String appName,
+      String scheduleName) throws Exception {
+
+    final ApplicationId applicationId = new ApplicationId(namespace, appName);
+    ScheduleDetail scheduleFromRequest = readScheduleDetailBody(request, scheduleName);
+
+    if (scheduleFromRequest.getProgram() == null) {
+      throw new BadRequestException("No program was specified for the schedule");
+    }
+    if (scheduleFromRequest.getProgram().getProgramType() == null) {
+      throw new BadRequestException("No program type was specified for the schedule");
+    }
+    if (scheduleFromRequest.getProgram().getProgramName() == null) {
+      throw new BadRequestException("No program name was specified for the schedule");
+    }
+    if (scheduleFromRequest.getTrigger() == null) {
+      throw new BadRequestException("No trigger was specified for the schedule");
+    }
+    ProgramType programType = ProgramType.valueOfSchedulableType(
+        scheduleFromRequest.getProgram().getProgramType());
+    String programName = scheduleFromRequest.getProgram().getProgramName();
+    ProgramId programId = applicationId.program(programType, programName);
+
+    // Schedules are versionless
+    lifecycleService.ensureLatestProgramExists(programId.getProgramReference());
+
+    String description = Objects.firstNonNull(scheduleFromRequest.getDescription(), "");
+    Map<String, String> properties = Objects.firstNonNull(scheduleFromRequest.getProperties(),
+        Collections.emptyMap());
+    List<? extends Constraint> constraints = Objects.firstNonNull(
+        scheduleFromRequest.getConstraints(), NO_CONSTRAINTS);
+    long timeoutMillis =
+        Objects.firstNonNull(scheduleFromRequest.getTimeoutMillis(),
+            Schedulers.JOB_QUEUE_TIMEOUT_MILLIS);
+    ProgramSchedule schedule = new ProgramSchedule(scheduleName, description, programId, properties,
+        scheduleFromRequest.getTrigger(), constraints, timeoutMillis);
+    programScheduleService.add(schedule);
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  /**
+   * Updates the schedule for a given {@code appName}.
+   */
+  @POST
+  @Path("apps/{app-name}/schedules/{schedule-name}/update")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void updateSchedule(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-name") String appName,
+      @PathParam("schedule-name") String scheduleName) throws Exception {
+    doUpdateSchedule(request, responder, namespaceId, appName, scheduleName);
+  }
+
+  /*
+   * Deprecated : Schedules are versionless.
+   * */
+  @Deprecated
+  @POST
+  @Path("apps/{app-name}/versions/{app-version}/schedules/{schedule-name}/update")
+  @AuditPolicy(AuditDetail.REQUEST_BODY)
+  public void updateScheduleVersioned(FullHttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-name") String appName,
+      @PathParam("app-version") String appVersion,
+      @PathParam("schedule-name") String scheduleName) throws Exception {
+    doUpdateSchedule(request, responder, namespaceId, appName, scheduleName);
+  }
+
+  private void doUpdateSchedule(FullHttpRequest request, HttpResponder responder,
+      String namespaceId, String appId,
+      String scheduleName) throws Exception {
+
+    ScheduleId scheduleId = new ApplicationId(namespaceId, appId).schedule(scheduleName);
+    ScheduleDetail scheduleDetail = readScheduleDetailBody(request, scheduleName);
+
+    programScheduleService.update(scheduleId, scheduleDetail);
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  private ScheduleDetail readScheduleDetailBody(FullHttpRequest request, String scheduleName)
+      throws BadRequestException, IOException {
+
+    JsonElement json;
+    try (Reader reader = new InputStreamReader(new ByteBufInputStream(request.content()),
+        Charsets.UTF_8)) {
+      // The schedule spec in the request body does not contain the program information
+      json = ProgramHandlerUtil.fromJson(reader, JsonElement.class);
+    } catch (IOException e) {
+      throw new IOException("Error reading request body", e);
+    } catch (JsonSyntaxException e) {
+      throw new BadRequestException("Request body is invalid json: " + e.getMessage());
+    }
+    if (!json.isJsonObject()) {
+      throw new BadRequestException(
+          "Expected a json object in the request body but received " + ProgramHandlerUtil.toJson(json));
+    }
+    ScheduleDetail scheduleDetail;
+    try {
+      scheduleDetail = ProgramHandlerUtil.fromJson(json, ScheduleDetail.class);
+    } catch (JsonSyntaxException e) {
+      throw new BadRequestException(
+          "Error parsing request body as a schedule specification: " + e.getMessage());
+    }
+
+    // If the schedule name is present in the request body, it should match the name in path params
+    if (scheduleDetail.getName() != null && !scheduleName.equals(scheduleDetail.getName())) {
+      throw new BadRequestException(String.format(
+          "Schedule name in the body of the request (%s) does not match the schedule name in the path parameter (%s)",
+          scheduleDetail.getName(), scheduleName));
+    }
+    return scheduleDetail;
+  }
+
+  @DELETE
+  @Path("apps/{app-name}/schedules/{schedule-name}")
+  public void deleteSchedule(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-name") String appName,
+      @PathParam("schedule-name") String scheduleName) throws Exception {
+    doDeleteSchedule(responder, namespaceId, appName, scheduleName);
+  }
+
+  /*
+   * Deprecated : Schedules are versionless.
+   * */
+  @Deprecated
+  @DELETE
+  @Path("apps/{app-name}/versions/{app-version}/schedules/{schedule-name}")
+  public void deleteScheduleVersioned(HttpRequest request, HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId,
+      @PathParam("app-name") String appName,
+      @PathParam("app-version") String appVersion,
+      @PathParam("schedule-name") String scheduleName) throws Exception {
+    doDeleteSchedule(responder, namespaceId, appName, scheduleName);
+  }
+
+  private void doDeleteSchedule(HttpResponder responder, String namespaceId, String appName,
+      String scheduleName) throws Exception {
+    ScheduleId scheduleId = new ApplicationId(namespaceId, appName).schedule(scheduleName);
+    programScheduleService.delete(scheduleId);
+    responder.sendStatus(HttpResponseStatus.OK);
+  }
+
+  /**
+   * Returns the previous scheduled run time for all programs that are passed into the data. The
+   * data is an array of JSON objects where each object must contain the following three elements:
+   * appId, programType, and programId (flow name, service name, etc.).
+   * <p>
+   * Example input:
+   * <pre><code>
+   * [{"appId": "App1", "programType": "Workflow", "programId": "WF1"},
+   * {"appId": "App1", "programType": "Workflow", "programId": "WF2"}]
+   * </code></pre>
+   * </p>
+   * <p>The response will be an array of JsonObjects each of which will contain the three input
+   * parameters as well as a "schedules" field, which is a list of {@link ScheduledRuntime} object.
+   * </p>
+   * <p>If an error occurs in the input (for the example above, App1 does not exist), then all
+   * JsonObjects for which the parameters have a valid status will have the status field but all
+   * JsonObjects for which the parameters do not have a valid status will have an error message and
+   * statusCode.
+   */
+  @POST
+  @Path("/previousruntime")
+  public void batchPreviousRunTimes(FullHttpRequest request,
+      HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId) throws Exception {
+    List<BatchProgram> batchPrograms = ProgramHandlerUtil.validateAndGetBatchInput(request, BATCH_PROGRAMS_TYPE);
+    responder.sendJson(HttpResponseStatus.OK,
+        ProgramHandlerUtil.toJson(batchRunTimes(namespaceId, batchPrograms, true)));
+  }
+
+  /**
+   * Returns the next scheduled run time for all programs that are passed into the data. The data is
+   * an array of JSON objects where each object must contain the following three elements: appId,
+   * programType, and programId (flow name, service name, etc.).
+   * <p>
+   * Example input:
+   * <pre><code>
+   * [{"appId": "App1", "programType": "Workflow", "programId": "WF1"},
+   * {"appId": "App1", "programType": "Workflow", "programId": "WF2"}]
+   * </code></pre>
+   * </p>
+   * <p>The response will be an array of JsonObjects each of which will contain the three input
+   * parameters as well as a "schedules" field, which is a list of {@link ScheduledRuntime} object.
+   * </p>
+   * <p>If an error occurs in the input (for the example above, App1 does not exist), then all
+   * JsonObjects for which the parameters have a valid status will have the status field but all
+   * JsonObjects for which the parameters do not have a valid status will have an error message and
+   * statusCode.
+   */
+  @POST
+  @Path("/nextruntime")
+  public void batchNextRunTimes(FullHttpRequest request,
+      HttpResponder responder,
+      @PathParam("namespace-id") String namespaceId) throws Exception {
+    List<BatchProgram> batchPrograms = ProgramHandlerUtil.validateAndGetBatchInput(request, BATCH_PROGRAMS_TYPE);
+    responder.sendJson(HttpResponseStatus.OK,
+        ProgramHandlerUtil.toJson(batchRunTimes(namespaceId, batchPrograms, false)));
+  }
+
+  /**
+   * Fetches scheduled run times for a set of programs.
+   *
+   * @param namespace namespace of the programs
+   * @param programs the list of programs to fetch scheduled run times
+   * @param previous {@code true} to get the previous scheduled times; {@code false} to get the
+   *     next scheduled times
+   * @return a list of {@link BatchProgramSchedule} containing the result
+   * @throws SchedulerException if failed to fetch schedules
+   */
+  private List<BatchProgramSchedule> batchRunTimes(String namespace,
+      Collection<? extends BatchProgram> programs,
+      boolean previous) throws Exception {
+    List<ProgramReference> programReferences = programs.stream()
+        .map(p -> new ProgramReference(namespace, p.getAppId(), p.getProgramType(),
+            p.getProgramId()))
+        .collect(Collectors.toList());
+    Map<ProgramReference, ProgramId> programMap = store.getPrograms(programReferences);
+
+    List<BatchProgramSchedule> result = new ArrayList<>();
+    for (ProgramReference programReference : programReferences) {
+      if (programMap.containsKey(programReference)) {
+        ProgramId programId = programMap.get(programReference);
+        result.add(new BatchProgramSchedule(programId, HttpResponseStatus.OK.code(), null,
+            getScheduledRunTimes(programId, previous)));
+      } else {
+        result.add(new BatchProgramSchedule(programReference, HttpResponseStatus.NOT_FOUND.code(),
+            new NotFoundException(programReference).getMessage(), null));
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Returns a list of {@link ScheduledRuntime} for the given program.
+   *
+   * @param programId the program to fetch schedules for
+   * @param previous {@code true} to get the previous scheduled times; {@code false} to get the
+   *     next scheduled times
+   * @return a list of {@link ScheduledRuntime}
+   * @throws SchedulerException if failed to fetch the schedule
+   */
+  private List<ScheduledRuntime> getScheduledRunTimes(ProgramId programId,
+      boolean previous) throws Exception {
+    if (programId.getType().getSchedulableType() == null) {
+      throw new BadRequestException("Program " + programId + " cannot have schedule");
+    }
+
+    if (previous) {
+      return programScheduleService.getPreviousScheduledRuntimes(programId);
+    } else {
+      return programScheduleService.getNextScheduledRuntimes(programId);
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricProcessorService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricProcessorService.java
@@ -42,7 +42,6 @@ import io.cdap.cdap.internal.provision.ProvisioningService;
 import io.cdap.cdap.internal.sysapp.SystemAppManagementService;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.scheduler.CoreSchedulerService;
-import io.cdap.cdap.scheduler.ScheduleNotificationSubscriberService;
 import io.cdap.cdap.security.auth.AuditLogSubscriberService;
 import io.cdap.http.HttpHandler;
 import io.cdap.http.NettyHttpService;
@@ -80,7 +79,6 @@ public class AppFabricProcessorService extends AbstractIdleService {
   private final BootstrapService bootstrapService;
   private final SystemAppManagementService systemAppManagementService;
   private final OperationNotificationSubscriberService operationNotificationSubscriberService;
-  private final ScheduleNotificationSubscriberService scheduleNotificationSubscriberService;
   private final CConfiguration cConf;
   private final SConfiguration sConf;
   private final boolean sslEnabled;
@@ -112,8 +110,7 @@ public class AppFabricProcessorService extends AbstractIdleService {
       SystemAppManagementService systemAppManagementService,
       FlowControlService runRecordCounterService,
       RunDataTimeToLiveService runDataTimeToLiveService,
-      OperationNotificationSubscriberService operationNotificationSubscriberService,
-      ScheduleNotificationSubscriberService scheduleNotificationSubscriberService) {
+      OperationNotificationSubscriberService operationNotificationSubscriberService) {
     this.hostname = hostname;
     this.discoveryService = discoveryService;
     this.handlers = handlers;
@@ -136,7 +133,6 @@ public class AppFabricProcessorService extends AbstractIdleService {
     this.runRecordCounterService = runRecordCounterService;
     this.runDataTimeToLiveService = runDataTimeToLiveService;
     this.operationNotificationSubscriberService = operationNotificationSubscriberService;
-    this.scheduleNotificationSubscriberService = scheduleNotificationSubscriberService;
   }
 
   /**
@@ -166,7 +162,6 @@ public class AppFabricProcessorService extends AbstractIdleService {
         programStopSubscriberService.start(),
         runRecordCorrectorService.start(),
         programRunStatusMonitorService.start(),
-        scheduleNotificationSubscriberService.start(),
         coreSchedulerService.start(),
         runRecordCounterService.start(),
         runDataTimeToLiveService.start(),
@@ -200,7 +195,6 @@ public class AppFabricProcessorService extends AbstractIdleService {
   protected void shutDown() throws Exception {
     LOG.info("Stopping AppFabric processor service.");
     cancelHttpService.cancel();
-    scheduleNotificationSubscriberService.stopAndWait();
     coreSchedulerService.stopAndWait();
     bootstrapService.stopAndWait();
     systemAppManagementService.stopAndWait();

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricServer.java
@@ -43,7 +43,6 @@ import io.cdap.cdap.internal.credential.CredentialProviderService;
 import io.cdap.cdap.internal.namespace.credential.NamespaceCredentialProviderService;
 import io.cdap.cdap.internal.provision.ProvisioningService;
 import io.cdap.cdap.proto.id.NamespaceId;
-import io.cdap.cdap.scheduler.CoreSchedulerService;
 import io.cdap.cdap.sourcecontrol.RepositoryCleanupService;
 import io.cdap.cdap.sourcecontrol.operationrunner.SourceControlOperationRunner;
 import io.cdap.cdap.spi.data.transaction.TransactionRunner;
@@ -78,7 +77,6 @@ public class AppFabricServer extends AbstractIdleService {
   private final ApplicationLifecycleService applicationLifecycleService;
   private final Set<String> servicesNames;
   private final Set<String> handlerHookNames;
-  private final CoreSchedulerService coreSchedulerService;
   private final CredentialProviderService credentialProviderService;
   private final NamespaceCredentialProviderService namespaceCredentialProviderService;
   private final ProvisioningService provisioningService;
@@ -107,7 +105,6 @@ public class AppFabricServer extends AbstractIdleService {
       ApplicationLifecycleService applicationLifecycleService,
       @Named("appfabric.services.names") Set<String> servicesNames,
       @Named("appfabric.handler.hooks") Set<String> handlerHookNames,
-      CoreSchedulerService coreSchedulerService,
       CredentialProviderService credentialProviderService,
       NamespaceCredentialProviderService namespaceCredentialProviderService,
       ProvisioningService provisioningService,
@@ -126,7 +123,6 @@ public class AppFabricServer extends AbstractIdleService {
     this.handlerHookNames = handlerHookNames;
     this.applicationLifecycleService = applicationLifecycleService;
     this.sslEnabled = cConf.getBoolean(Constants.Security.SSL.INTERNAL_ENABLED);
-    this.coreSchedulerService = coreSchedulerService;
     this.credentialProviderService = credentialProviderService;
     this.namespaceCredentialProviderService = namespaceCredentialProviderService;
     this.provisioningService = provisioningService;
@@ -155,7 +151,6 @@ public class AppFabricServer extends AbstractIdleService {
         provisioningService.start(),
         applicationLifecycleService.start(),
         bootstrapService.start(),
-        coreSchedulerService.start(),
         credentialProviderService.start(),
         sourceControlOperationRunner.start(),
         repositoryCleanupService.start()
@@ -209,7 +204,6 @@ public class AppFabricServer extends AbstractIdleService {
 
   @Override
   protected void shutDown() throws Exception {
-    coreSchedulerService.stopAndWait();
     cancelHttpService.cancel();
     applicationLifecycleService.stopAndWait();
     bootstrapService.stopAndWait();

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/ExpectedNumberOfAuditPolicyPaths.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/ExpectedNumberOfAuditPolicyPaths.java
@@ -18,9 +18,9 @@
 package io.cdap.cdap.gateway.router;
 
 /**
- * Expected number of paths annotated with {@link io.cdap.cdap.common.security.AuditPolicy}
+ * Expected number of paths annotated with {@link io.cdap.cdap.common.security.AuditPolicy}.
  */
 public final class ExpectedNumberOfAuditPolicyPaths {
 
-  public static final int EXPECTED_PATH_NUMBER = 47;
+  public static final int EXPECTED_PATH_NUMBER = 49;
 }

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
@@ -18,14 +18,11 @@ package io.cdap.cdap.gateway.router;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableSet;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.common.conf.Constants.Gateway;
 import io.cdap.cdap.common.service.ServiceDiscoverable;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.http.AbstractHttpHandler;
 import io.netty.handler.codec.http.HttpRequest;
-import java.util.Set;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 
@@ -181,6 +178,35 @@ public final class RouterPathLookup extends AbstractHttpHandler {
     } else if (beginsWith(uriParts, "v3", "namespaces", null, "credentials")
         || beginsWith(uriParts, "v3", "credentials")) {
       return APP_FABRIC_HTTP;
+    } else if (beginsWith(uriParts, "v3", "namespaces", null, "schedules")
+        || beginsWith(uriParts, "v3", "namespaces", null, "apps", null, "schedules")
+        || beginsWith(uriParts, "v3", "namespaces", null, "apps", null, null, null, "schedules")
+        || beginsWith(uriParts, "v3", "namespaces", null, "apps", null, "versions", null, "schedules")
+        || beginsWith(uriParts, "v3", "namespaces", null, "apps", null, "versions", null, null, null, "schedules")
+        || beginsWith(uriParts, "v3", "namespaces", null, "previousruntime")
+        || beginsWith(uriParts, "v3", "namespaces", null, "nextruntime")
+        || beginsWith(uriParts, "v3", "namespaces", null, "apps", null, null, null, "previousruntime")
+        || beginsWith(uriParts, "v3", "namespaces", null, "apps", null, null, null, "nextruntime")) {
+      // Program Schedule handler paths:
+      // /v3/namespaces/{namespace-id}/apps/{app-name}/{program-type}/{program-name}/schedules
+      // /v3/namespaces/{namespace-id}/apps/{app-name}/versions/{app-version}/{program-type}/{program-name}/schedules
+      // /v3/namespaces/{namespace-id}/apps/{app-name}/schedules
+      // /v3/namespaces/{namespace-id}/apps/{app-name}/schedules/{schedule-name}
+      // /v3/namespaces/{namespace-id}/apps/{app-name}/schedules/{schedule-name}/update
+      // /v3/namespaces/{namespace-id}/apps/{app-id}/schedules/{schedule-name}/{action}
+      // /v3/namespaces/{namespace-id}/apps/{app-name}/versions/{app-version}/schedules
+      // /v3/namespaces/{namespace-id}/apps/{app-name}/versions/{app-version}/schedules/{schedule-name}
+      // /v3/namespaces/{namespace-id}/apps/{app-name}/versions/{app-version}/schedules/{schedule-name}/update
+      // /v3/namespaces/{namespace-id}/apps/{app-id}/versions/{version-id}/schedules/{schedule-name}/status
+      // /v3/namespaces/{namespace-id}/apps/{app-id}/versions/{app-version}/schedules/{schedule-name}/{action}
+      // /v3/namespaces/{namespace-id}/schedules/re-enable
+      // /v3/namespaces/{namespace-id}/schedules/trigger-type/program-status
+      // /v3/namespaces/{namespace-id}/apps/{app-name}/{program-type}/{program-name}/previousruntime
+      // /v3/namespaces/{namespace-id}/apps/{app-name}/{program-type}/{program-name}/nextruntime
+      // /v3/namespaces/{namespace-id}/previousruntime
+      // /v3/namespaces/{namespace-id}/nextruntime
+      // /v3/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/status
+      return APP_FABRIC_PROCESSOR;
     } else if ((uriParts.length >= 8 && uriParts[7].equals("logs"))
         || (uriParts.length >= 10 && (uriParts[9].equals("logs") || uriParts[9].equals("classify")))
         || (uriParts.length >= 6 && uriParts[5].equals("logs"))) {

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
@@ -288,8 +288,8 @@ public class RouterPathLookupTest {
     assertRouting("/v3/namespaces/default//artifacts/WordCount///versions/v1//metadata/properties",
                   RouterPathLookup.METADATA_SERVICE);
     // program metadata properties
-    assertRouting("/v3/namespaces/default//apps/WordCount/services/ServiceName/metadata/properties"
-      , RouterPathLookup.METADATA_SERVICE);
+    assertRouting("/v3/namespaces/default//apps/WordCount/services/ServiceName/metadata/properties",
+        RouterPathLookup.METADATA_SERVICE);
     // dataset metadata properties
     assertRouting("/v3/namespaces/default/////datasets/ds1/metadata/properties", RouterPathLookup.METADATA_SERVICE);
     // app metadata tags
@@ -456,6 +456,35 @@ public class RouterPathLookupTest {
     assertRouting("v3/namespaces//apps////runs//resetloglevels", RouterPathLookup.APP_FABRIC_PROCESSOR);
     assertRouting("v3/namespaces//apps//versions////runs//loglevels", RouterPathLookup.APP_FABRIC_PROCESSOR);
     assertRouting("v3/namespaces//apps//versions////runs//resetloglevels", RouterPathLookup.APP_FABRIC_PROCESSOR);
+  }
+
+  @Test
+  public void testProgramSchedulePaths() {
+    assertRouting("v3/namespaces/{ns}/apps/{app}/{ptype}/{pname}/schedules", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/versions/{ver}/{ptype}/{name}/schedules",
+        RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/schedules", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/schedules/", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/schedules/{sched}/update", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/schedules/{sched}/status", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/schedules/{sched}/{action}", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/versions/{ver}/schedules", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/versions/{ver}/schedules/{sched}",
+        RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/versions/{ver}/schedules/{sched}/update",
+        RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/versions/{ver}/schedules/{sched}/status",
+        RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/versions/{ver}/schedules/{sched}/{action}",
+        RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/schedules/re-enable", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/schedules/trigger-type/program-status", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/{ptype}/{pname}/previousruntime",
+        RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/apps/{app}/{ptype}/{pname}/nextruntime", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/previousruntime", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/nextruntime", RouterPathLookup.APP_FABRIC_PROCESSOR);
+    assertRouting("v3/namespaces/{ns}/instances", RouterPathLookup.APP_FABRIC_PROCESSOR);
   }
 
   @Test

--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -32,7 +32,6 @@ import io.cdap.cdap.app.guice.ProgramRunnerRuntimeModule;
 import io.cdap.cdap.app.store.ServiceStore;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
-import io.cdap.cdap.common.conf.Constants.SystemWorker;
 import io.cdap.cdap.common.guice.DFSLocationModule;
 import io.cdap.cdap.common.guice.SupplierProviderBridge;
 import io.cdap.cdap.common.logging.LoggingContext;
@@ -51,8 +50,6 @@ import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
 import io.cdap.cdap.internal.app.namespace.LocalStorageProviderNamespaceAdmin;
 import io.cdap.cdap.internal.app.namespace.StorageProviderNamespaceAdmin;
 import io.cdap.cdap.internal.app.services.AppFabricServer;
-import io.cdap.cdap.internal.app.worker.TaskWorkerServiceLauncher;
-import io.cdap.cdap.internal.app.worker.system.SystemWorkerServiceLauncher;
 import io.cdap.cdap.internal.events.EventPublishManager;
 import io.cdap.cdap.master.spi.environment.MasterEnvironment;
 import io.cdap.cdap.master.spi.environment.MasterEnvironmentContext;
@@ -66,7 +63,6 @@ import io.cdap.cdap.security.authorization.AuthorizationEnforcementModule;
 import io.cdap.cdap.security.guice.SecureStoreServerModule;
 import io.cdap.cdap.security.store.SecureStoreService;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -135,7 +131,6 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
       List<? super AutoCloseable> closeableResources,
       MasterEnvironment masterEnv, MasterEnvironmentContext masterEnvContext,
       EnvironmentOptions options) {
-    final CConfiguration cConf = injector.getInstance(CConfiguration.class);
     closeableResources.add(injector.getInstance(AccessControllerInstantiator.class));
     services.add(injector.getInstance(OperationalStatsService.class));
     services.add(injector.getInstance(SecureStoreService.class));
@@ -159,14 +154,6 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
     services.add(new RetryOnStartFailureService(
         () -> injector.getInstance(NamespaceInitializerService.class),
         RetryStrategies.exponentialDelay(200, 5000, TimeUnit.MILLISECONDS)));
-
-    if (cConf.getBoolean(Constants.TaskWorker.POOL_ENABLE)) {
-      services.add(injector.getInstance(TaskWorkerServiceLauncher.class));
-    }
-
-    if (cConf.getBoolean(SystemWorker.POOL_ENABLE)) {
-      services.add(injector.getInstance(SystemWorkerServiceLauncher.class));
-    }
 
     // Event publisher could rely on task workers for token generated for security enabled deployments
     services.add(injector.getInstance(EventPublishManager.class));


### PR DESCRIPTION
Cherry pick of PR: https://github.com/cdapio/cdap/pull/15844 from `develop` to `release/6.11` branch.