### PR TITLE
[CDAP-21096] Separate bind and announce port configurations for appfabric server and processor for startupProbe

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricProcessorService.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/services/AppFabricProcessorService.java
@@ -26,6 +26,7 @@ import io.cdap.cdap.api.feature.FeatureFlagsProvider;
 import io.cdap.cdap.app.runtime.ProgramRuntimeService;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.AppFabric;
 import io.cdap.cdap.common.conf.Constants.Service;
 import io.cdap.cdap.common.conf.SConfiguration;
 import io.cdap.cdap.common.discovery.ResolvingDiscoverable;
@@ -182,7 +183,7 @@ public class AppFabricProcessorService extends AbstractIdleService {
             Constants.AppFabric.DEFAULT_BOSS_THREADS))
         .setWorkerThreadPoolSize(cConf.getInt(Constants.AppFabric.WORKER_THREADS,
             Constants.AppFabric.DEFAULT_WORKER_THREADS))
-        .setPort(cConf.getInt(Constants.AppFabric.SERVER_PORT));
+        .setPort(cConf.getInt(Constants.AppFabric.PROCESSOR_PORT));
     if (sslEnabled) {
       new HttpsEnabler().configureKeyStore(cConf, sConf).enable(httpServiceBuilder);
     }
@@ -217,7 +218,7 @@ public class AppFabricProcessorService extends AbstractIdleService {
 
     String announceAddress = cConf.get(Constants.Service.MASTER_SERVICES_ANNOUNCE_ADDRESS,
         httpService.getBindAddress().getHostName());
-    int announcePort = cConf.getInt(Constants.AppFabric.SERVER_ANNOUNCE_PORT,
+    int announcePort = cConf.getInt(AppFabric.PROCESSOR_ANNOUNCE_PORT,
         httpService.getBindAddress().getPort());
 
     final InetSocketAddress socketAddress = new InetSocketAddress(announceAddress, announcePort);

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -230,10 +230,17 @@ public final class Constants {
   public static final class AppFabric {
 
     /**
+     * App Fabric Processor.
+     */
+
+    public static final String PROCESSOR_PORT = "appfabric.processor.bind.port";
+    public static final String PROCESSOR_ANNOUNCE_PORT = "appfabric.processor.announce.port";
+
+    /**
      * App Fabric Server.
      */
-    public static final String SERVER_PORT = "app.bind.port";
-    public static final String SERVER_ANNOUNCE_PORT = "app.announce.port";
+    public static final String SERVER_PORT = "appfabric.bind.port";
+    public static final String SERVER_ANNOUNCE_PORT = "appfabric.announce.port";
     public static final String OUTPUT_DIR = "app.output.dir";
     public static final String TEMP_DIR = "app.temp.dir";
     public static final String REST_PORT = "app.rest.port";

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -514,10 +514,18 @@
   </property>
 
   <property>
-    <name>app.bind.port</name>
+    <name>appfabric.processor.bind.port</name>
     <value>0</value>
     <description>
-      App Fabric service bind port; if 0, binds to a random port
+      App Fabric processor bind port; if 0, binds to a random port
+    </description>
+  </property>
+
+  <property>
+    <name>appfabric.bind.port</name>
+    <value>0</value>
+    <description>
+      App Fabric server bind port; if 0, binds to a random port
     </description>
   </property>
 


### PR DESCRIPTION
[CDAP-21096] Add support for startupProbe in CDAP master

### Context

In addition to the rolling upgrade strategy, for high availability of APIs, startup probe need to be implemented to ensure that the CDAP service pods (eg. Appfabric) accepts requests only when the server has started.

CDAP services (eg. Appfabric) run on dynamic port and announces the port after the server has started. For this [command probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes) can be configured to check the status of system service using the URL ‘/v3/system/services/<service>/status’.

CDAP services will write the port to a temp file in the container after startup. Here is a code snippet for startup probe using the port written to the temp file:

```
startupProbe:
          exec:
            command:
            - sh
            - -c
            - curl -s -f -k https://localhost:<appfabric.bind.port>/v3/system/services/appfabric/status
          failureThreshold: 60
          periodSeconds: 2
          timeoutSeconds: 1
```

**NOTE**: Corresponding `cdapio/cdap-operator` PR: https://github.com/cdapio/cdap-operator/pull/132

### Change Description

* Segregate bind and announce port configurations for appfabric server and processor for startupProbe
* Renamed `"app.bind.port"` to `"appfabric.bind.port"` to make the config naming consistent with other services: `<service-name>.bind.port`. It makes it easy to configure startupProbe in cdap-operator.  

### Verification

- [x] Unit tests
- [x] CDAP Sandbox 
- [x] Docker image: deployed locally built docker image and edited the cdapmaster manifest to add startupProbe to appfabric spec.


[CDAP-21096]: https://cdap.atlassian.net/browse/CDAP-21096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ