### PR TITLE
Consolidate Log Query and Log Saver Services

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -320,7 +320,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
               servicesNamesBinder.addBinding().toInstance(Constants.Service.APP_FABRIC_HTTP);
 
               // for PingHandler
-              servicesNamesBinder.addBinding().toInstance(Constants.Service.LOGSAVER);
               servicesNamesBinder.addBinding().toInstance(Constants.Service.TRANSACTION_HTTP);
               servicesNamesBinder.addBinding().toInstance(Constants.Service.RUNTIME);
 
@@ -330,7 +329,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
               handlerHookNamesBinder.addBinding().toInstance(Constants.Service.APP_FABRIC_HTTP);
 
               // for PingHandler
-              handlerHookNamesBinder.addBinding().toInstance(Constants.Service.LOGSAVER);
               handlerHookNamesBinder.addBinding().toInstance(Constants.Service.TRANSACTION_HTTP);
               handlerHookNamesBinder.addBinding().toInstance(Constants.Service.RUNTIME);
 

--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1402,6 +1402,7 @@ public final class Constants {
 
     public static final String LOG_SAVER_HANDLER = "log.saver.handler";
     public static final String ADDRESS = "log.saver.status.bind.address";
+    public static final String PORT = "log.saver.status.bind.port";
 
     public static final String SERVICE_DESCRIPTION = "Service to collect and store logs.";
 

--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -2245,6 +2245,13 @@
     </description>
   </property>
 
+  <property>
+    <name>log.saver.status.bind.port</name>
+    <value>0</value>
+    <description>
+      Log saver HTTP service bind port
+    </description>
+  </property>
 
   <!-- Market Configuration -->
 

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
@@ -49,8 +49,6 @@ public final class RouterPathLookup extends AbstractHttpHandler {
       Constants.Service.PREVIEW_HTTP);
   public static final RouteDestination TRANSACTION = new RouteDestination(
       Constants.Service.TRANSACTION_HTTP);
-  public static final RouteDestination LOG_QUERY = new RouteDestination(
-      Constants.Service.LOG_QUERY);
   public static final RouteDestination LOG_SAVER = new RouteDestination(Constants.Service.LOGSAVER);
   public static final RouteDestination DATASET_EXECUTOR = new RouteDestination(
       Constants.Service.DATASET_EXECUTOR);
@@ -123,7 +121,7 @@ public final class RouterPathLookup extends AbstractHttpHandler {
           uriParts[6]));
     } else if (beginsWith(uriParts, "v3", "system", "services", null, "logs")) {
       //Log Handler Path /v3/system/services/<service-id>/logs
-      return LOG_QUERY;
+      return LOG_SAVER;
     } else if (beginsWith(uriParts, "v3", "namespaces", null)
         && (endsWith(uriParts, "instances")
           || endsWith(uriParts, "live-info")
@@ -212,7 +210,7 @@ public final class RouterPathLookup extends AbstractHttpHandler {
       // /v3/namespaces/<namespaceid>/apps/<appid>/<programid-type>/<programid>/logs
       // /v3/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/runs/{run-id}/logs
       // /v3/namespaces/{namespace-id}/apps/{app-id}/{program-type}/{program-id}/runs/{run-id}/classify
-      return LOG_QUERY;
+      return LOG_SAVER;
     } else if (uriParts.length >= 2 && uriParts[1].equals("metrics")) {
       //Metrics Search Handler Path /v3/metrics
       return METRICS;

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/log/LogHttpHandlerTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/handlers/log/LogHttpHandlerTest.java
@@ -120,7 +120,7 @@ public class LogHttpHandlerTest {
   public static void setup() throws Exception {
     CConfiguration cConf = CConfiguration.create();
     cConf.set(Constants.CFG_LOCAL_DATA_DIR, TEMP_FOLDER.newFolder().getAbsolutePath());
-    cConf.set(Constants.LogQuery.ADDRESS, InetAddress.getLoopbackAddress().getHostAddress());
+    cConf.set(Constants.LogSaver.ADDRESS, InetAddress.getLoopbackAddress().getHostAddress());
 
     Injector injector = Guice.createInjector(Modules.override(
       new ConfigModule(cConf),
@@ -834,7 +834,7 @@ public class LogHttpHandlerTest {
    */
   private HttpResponse doGet(String path) throws IOException {
     Discoverable discoverable = new RandomEndpointStrategy(
-      () -> discoveryServiceClient.discover(Constants.Service.LOG_QUERY)).pick(10, TimeUnit.SECONDS);
+      () -> discoveryServiceClient.discover(Constants.Service.LOGSAVER)).pick(10, TimeUnit.SECONDS);
     Assert.assertNotNull(discoverable);
 
     URL url = URIScheme.createURI(discoverable, "%s", path).toURL();

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
@@ -83,7 +83,7 @@ public class RouterPathLookupTest {
     String path = "/v3/system/services/foo/logs";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), path);
     RouteDestination result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.LOG_QUERY, result);
+    Assert.assertEquals(RouterPathLookup.LOG_SAVER, result);
 
     path = "/v3/system/services/foo/live-info";
     httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), path);
@@ -145,17 +145,17 @@ public class RouterPathLookupTest {
     String path = "/v3/namespaces/default/apps//InvalidApp///services/ServiceName/logs/";
     HttpRequest httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), path);
     RouteDestination result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.LOG_QUERY, result);
+    Assert.assertEquals(RouterPathLookup.LOG_SAVER, result);
 
     path = "///v3/namespaces/default///apps/InvalidApp/services/ServiceName/////logs";
     httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("POST"), path);
     result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.LOG_QUERY, result);
+    Assert.assertEquals(RouterPathLookup.LOG_SAVER, result);
 
     path = "/v3/namespaces/default/apps/InvalidApp/service/ServiceName/runs/7e6adc79-0f5d-4252-70817ea47698/logs/";
     httpRequest = new DefaultHttpRequest(VERSION, new HttpMethod("GET"), path);
     result = pathLookup.getRoutingService(path, httpRequest);
-    Assert.assertEquals(RouterPathLookup.LOG_QUERY, result);
+    Assert.assertEquals(RouterPathLookup.LOG_SAVER, result);
   }
 
   @Test

--- a/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/LogsServiceMainTest.java
+++ b/cdap-master/src/test/java/io/cdap/cdap/master/environment/k8s/LogsServiceMainTest.java
@@ -95,7 +95,7 @@ public class LogsServiceMainTest extends MasterServiceMainTestBase {
     // Query the appended logs, we can not query logs for a given run because run record does not exist
     String url = "/v3/namespaces/default/apps/app1/workflows/myworkflow/logs?format=json";
     Tasks.waitFor(true, () -> {
-      HttpResponse response = doGet(url, client, Constants.Service.LOG_QUERY);
+      HttpResponse response = doGet(url, client, Constants.Service.LOGSAVER);
       if (response.getResponseCode() != 200) {
         LOG.warn("testLogsService get logs response non 200 response code: {} {} {}",
                  response.getResponseCode(), response.getResponseMessage(), response.getResponseBodyAsString());

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteLogsFetcher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteLogsFetcher.java
@@ -49,7 +49,7 @@ public class RemoteLogsFetcher implements LogsFetcher {
   @Inject
   public RemoteLogsFetcher(RemoteClientFactory remoteClientFactory) {
     this.remoteClient =
-        remoteClientFactory.createRemoteClient(Constants.Service.LOG_QUERY,
+        remoteClientFactory.createRemoteClient(Constants.Service.LOGSAVER,
             new DefaultHttpRequestConfig(false),
             Gateway.API_VERSION_3);
   }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/logbuffer/LogBufferService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/logbuffer/LogBufferService.java
@@ -127,8 +127,8 @@ public class LogBufferService extends AbstractIdleService {
             Constants.Service.LOGSAVER)
         .setHttpHandlers(handlers)
         .setExceptionHandler(new HttpExceptionHandler())
-        .setHost(cConf.get(Constants.LogBuffer.LOG_BUFFER_SERVER_BIND_ADDRESS))
-        .setPort(cConf.getInt(Constants.LogBuffer.LOG_BUFFER_SERVER_BIND_PORT));
+        .setHost(cConf.get(Constants.LogSaver.ADDRESS))
+        .setPort(cConf.getInt(Constants.LogSaver.PORT));
 
     if (cConf.getBoolean(Constants.Security.SSL.INTERNAL_ENABLED)) {
       new HttpsEnabler().configureKeyStore(cConf, sConf).enable(builder);

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/service/LogQueryService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/service/LogQueryService.java
@@ -51,10 +51,10 @@ public class LogQueryService extends AbstractIdleService {
       CommonNettyHttpServiceFactory commonNettyHttpServiceFactory) {
     this.discoveryService = discoveryService;
     NettyHttpService.Builder builder = commonNettyHttpServiceFactory.builder(
-            Constants.Service.LOG_QUERY)
+            Constants.Service.LOGSAVER)
         .setHttpHandlers(handlers)
-        .setHost(cConf.get(Constants.LogQuery.ADDRESS))
-        .setPort(cConf.getInt(Constants.LogQuery.PORT));
+        .setHost(cConf.get(Constants.LogSaver.ADDRESS))
+        .setPort(cConf.getInt(Constants.LogSaver.PORT));
 
     if (cConf.getBoolean(Constants.Security.SSL.INTERNAL_ENABLED)) {
       new HttpsEnabler().configureKeyStore(cConf, sConf).enable(builder);
@@ -68,11 +68,11 @@ public class LogQueryService extends AbstractIdleService {
   protected void startUp() throws Exception {
     LoggingContextAccessor.setLoggingContext(new ServiceLoggingContext(Id.Namespace.SYSTEM.getId(),
         Constants.Logging.COMPONENT_NAME,
-        Constants.Service.LOG_QUERY));
+        Constants.Service.LOGSAVER));
     httpServer.start();
     cancellable = discoveryService.register(
         ResolvingDiscoverable.of(
-            URIScheme.createDiscoverable(Constants.Service.LOG_QUERY, httpServer)));
+            URIScheme.createDiscoverable(Constants.Service.LOGSAVER, httpServer)));
 
   }
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/service/LogSaverStatusService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/service/LogSaverStatusService.java
@@ -55,7 +55,8 @@ public class LogSaverStatusService extends AbstractIdleService {
     NettyHttpService.Builder builder = commonNettyHttpServiceFactory.builder(
             Constants.Service.LOGSAVER)
         .setHttpHandlers(handlers)
-        .setHost(cConf.get(Constants.LogSaver.ADDRESS));
+        .setHost(cConf.get(Constants.LogSaver.ADDRESS))
+        .setPort(cConf.getInt(Constants.LogSaver.PORT));
 
     if (cConf.getBoolean(Constants.Security.SSL.INTERNAL_ENABLED)) {
       new HttpsEnabler().configureKeyStore(cConf, sConf).enable(builder);


### PR DESCRIPTION
The Log Query Service and Log Saver (Buffer) Service run on the same pod, allowing them to be merged into a single service. This consolidation helps free up a cluster IP.  

To minimize changes across multiple components, including the UI and documentation, the service name has been retained as **Log Saver**.  

### Changes  
- Merged the Log Query Service into **LogBufferService** by adding the necessary handlers (`LogQueryHandler`).  
- These handlers were previously bound in `LogQueryRuntimeModule#getRemoteModule`.  
- Now, they are directly bound within `LogsServiceMain`, alongside the existing `LogBufferService` handlers.  

### Testing  
- Built an image with the updated changes and successfully queried logs for pipeline runs and system services.  
- Verified logs from **Dataproc, CDF**, and other components.  
- Tested in **CDAP Sandbox** to confirm functionality.