### PR TITLE
[CDAP-21096] Use RemoteScheduleManager to update TimeSchedulerService from Appfabric service

### DIFF
--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/guice/AppFabricServiceRuntimeModule.java
@@ -111,7 +111,10 @@ import io.cdap.cdap.internal.app.runtime.artifact.LocalPluginFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.schedule.DistributedTimeSchedulerService;
 import io.cdap.cdap.internal.app.runtime.schedule.ExecutorThreadPool;
+import io.cdap.cdap.internal.app.runtime.schedule.LocalScheduleManager;
 import io.cdap.cdap.internal.app.runtime.schedule.LocalTimeSchedulerService;
+import io.cdap.cdap.internal.app.runtime.schedule.RemoteScheduleManager;
+import io.cdap.cdap.internal.app.runtime.schedule.ScheduleManager;
 import io.cdap.cdap.internal.app.runtime.schedule.TimeSchedulerService;
 import io.cdap.cdap.internal.app.runtime.schedule.store.DatasetBasedTimeScheduleStore;
 import io.cdap.cdap.internal.app.runtime.schedule.store.TriggerMisfireLogger;
@@ -244,6 +247,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                 .in(Scopes.SINGLETON);
             bind(TimeSchedulerService.class).to(LocalTimeSchedulerService.class)
                 .in(Scopes.SINGLETON);
+            bind(ScheduleManager.class).to(LocalScheduleManager.class).in(Scopes.SINGLETON);
             bind(MRJobInfoFetcher.class).to(LocalMRJobInfoFetcher.class);
             bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
             bind(UGIProvider.class).toProvider(UgiProviderProvider.class);
@@ -265,6 +269,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                   binder(), HttpHandler.class, Names.named(Constants.AppFabric.SERVER_HANDLERS_BINDING));
               handlerBinder.addBinding().to(ProgramRuntimeHttpHandler.class);
               handlerBinder.addBinding().to(ProgramScheduleHttpHandler.class);
+              handlerBinder.addBinding().to(OperationsDashboardHttpHandler.class);
 
               // TODO: Uncomment after CDAP-7688 is resolved
               // servicesNamesBinder.addBinding().toInstance(Constants.Service.MESSAGING_SERVICE);
@@ -303,6 +308,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                 .in(Scopes.SINGLETON);
             bind(TimeSchedulerService.class).to(LocalTimeSchedulerService.class)
                 .in(Scopes.SINGLETON);
+            bind(ScheduleManager.class).to(LocalScheduleManager.class).in(Scopes.SINGLETON);
             bind(MRJobInfoFetcher.class).to(LocalMRJobInfoFetcher.class);
             bind(StorageProviderNamespaceAdmin.class).to(LocalStorageProviderNamespaceAdmin.class);
             bind(UGIProvider.class).toProvider(UgiProviderProvider.class);
@@ -367,6 +373,7 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
                 .in(Scopes.SINGLETON);
             bind(TimeSchedulerService.class).to(DistributedTimeSchedulerService.class)
                 .in(Scopes.SINGLETON);
+            bind(ScheduleManager.class).to(RemoteScheduleManager.class).in(Scopes.SINGLETON);
             bind(MRJobInfoFetcher.class).to(DistributedMRJobInfoFetcher.class);
             bind(StorageProviderNamespaceAdmin.class)
                 .to(DistributedStorageProviderNamespaceAdmin.class);
@@ -511,8 +518,6 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
         handlerBinder.addBinding().to(InstanceOperationHttpHandler.class);
         handlerBinder.addBinding().to(NamespaceHttpHandler.class);
         handlerBinder.addBinding().to(SourceControlManagementHttpHandler.class);
-        // TODO: [CDAP-13355] Move OperationsDashboardHttpHandler into report generation app
-        handlerBinder.addBinding().to(OperationsDashboardHttpHandler.class);
         handlerBinder.addBinding().to(PreferencesHttpHandler.class);
         handlerBinder.addBinding().to(PreferencesHttpHandlerInternal.class);
         handlerBinder.addBinding().to(ConsoleSettingsHttpHandler.class);
@@ -569,6 +574,9 @@ public final class AppFabricServiceRuntimeModule extends RuntimeModule {
         processorHandlerBinder.addBinding().to(ProgramRuntimeHttpHandler.class);
         processorHandlerBinder.addBinding().to(BootstrapHttpHandler.class);
         processorHandlerBinder.addBinding().to(ProgramScheduleHttpHandler.class);
+        // TODO: [CDAP-13355] Move OperationsDashboardHttpHandler into report generation app
+        // TODO(CDAP-21134): Check feasibility of moving OperationsDashboardHttpHandler to Appfabric Server.
+        processorHandlerBinder.addBinding().to(OperationsDashboardHttpHandler.class);
       } else {
         bind(NoOpScheduler.class).in(Scopes.SINGLETON);
         bind(Scheduler.class).to(NoOpScheduler.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/app/preview/PreviewRunnerModule.java
@@ -53,6 +53,8 @@ import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepositoryReader;
 import io.cdap.cdap.internal.app.runtime.artifact.PluginFinder;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepositoryReaderWithLocalization;
 import io.cdap.cdap.internal.app.runtime.artifact.RemoteArtifactRepositoryWithLocalization;
+import io.cdap.cdap.internal.app.runtime.schedule.RemoteScheduleManager;
+import io.cdap.cdap.internal.app.runtime.schedule.ScheduleManager;
 import io.cdap.cdap.internal.app.runtime.workflow.BasicWorkflowStateWriter;
 import io.cdap.cdap.internal.app.runtime.workflow.WorkflowStateWriter;
 import io.cdap.cdap.internal.app.store.DefaultStore;
@@ -189,6 +191,7 @@ public class PreviewRunnerModule extends PrivateModule {
     expose(PreviewRunner.class);
 
     bind(Scheduler.class).to(NoOpScheduler.class);
+    bind(ScheduleManager.class).to(RemoteScheduleManager.class);
 
     bind(DataTracerFactory.class).to(DefaultDataTracerFactory.class);
     expose(DataTracerFactory.class);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/DeleteAndCreateSchedulesStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/DeleteAndCreateSchedulesStage.java
@@ -20,11 +20,11 @@ import com.google.common.reflect.TypeToken;
 import io.cdap.cdap.api.app.ApplicationSpecification;
 import io.cdap.cdap.api.schedule.Trigger;
 import io.cdap.cdap.internal.app.runtime.schedule.ProgramSchedule;
+import io.cdap.cdap.internal.app.runtime.schedule.ScheduleManager;
 import io.cdap.cdap.internal.schedule.ScheduleCreationSpec;
 import io.cdap.cdap.pipeline.AbstractStage;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.ProgramId;
-import io.cdap.cdap.scheduler.Scheduler;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -33,11 +33,11 @@ import java.util.Set;
  */
 public class DeleteAndCreateSchedulesStage extends AbstractStage<ApplicationWithPrograms> {
 
-  private final Scheduler programScheduler;
+  private final ScheduleManager scheduleManager;
 
-  public DeleteAndCreateSchedulesStage(Scheduler programScheduler) {
+  public DeleteAndCreateSchedulesStage(ScheduleManager scheduleManager) {
     super(TypeToken.of(ApplicationWithPrograms.class));
-    this.programScheduler = programScheduler;
+    this.scheduleManager = scheduleManager;
   }
 
   @Override
@@ -52,17 +52,17 @@ public class DeleteAndCreateSchedulesStage extends AbstractStage<ApplicationWith
     ApplicationId appId = input.getApplicationId();
     // Get a set of new schedules from the app spec
     Set<ProgramSchedule> newSchedules = getProgramScheduleSet(appId, input.getSpecification());
-    for (ProgramSchedule schedule : programScheduler.listSchedules(appId)) {
+    for (ProgramSchedule schedule : scheduleManager.listSchedules(appId)) {
       if (newSchedules.contains(schedule)) {
         newSchedules.remove(schedule); // Remove the existing schedule from the newSchedules
         continue;
       }
       // Delete the existing schedule if it is not present in newSchedules
-      programScheduler.deleteSchedule(schedule.getScheduleId());
+      scheduleManager.deleteSchedule(schedule.getScheduleId());
     }
 
     // Add new schedules
-    programScheduler.addSchedules(newSchedules);
+    scheduleManager.addSchedules(newSchedules);
 
     // Emit the input to next stage.
     emit(input);

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/deploy/pipeline/DeletedProgramHandlerStage.java
@@ -24,11 +24,11 @@ import io.cdap.cdap.app.store.Store;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.data2.metadata.writer.MetadataServiceClient;
 import io.cdap.cdap.internal.app.deploy.ProgramTerminator;
+import io.cdap.cdap.internal.app.runtime.schedule.ScheduleManager;
 import io.cdap.cdap.pipeline.AbstractStage;
 import io.cdap.cdap.proto.ProgramType;
 import io.cdap.cdap.proto.ProgramTypes;
 import io.cdap.cdap.proto.id.ProgramId;
-import io.cdap.cdap.scheduler.Scheduler;
 import io.cdap.cdap.spi.metadata.MetadataMutation;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -53,18 +53,18 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
   private final ProgramTerminator programTerminator;
   private final MetricsSystemClient metricsSystemClient;
   private final MetadataServiceClient metadataServiceClient;
-  private final Scheduler programScheduler;
+  private final ScheduleManager scheduleManager;
 
   public DeletedProgramHandlerStage(Store store, ProgramTerminator programTerminator,
       MetricsSystemClient metricsSystemClient,
       MetadataServiceClient metadataServiceClient,
-      Scheduler programScheduler) {
+      ScheduleManager scheduleManager) {
     super(TypeToken.of(ApplicationDeployable.class));
     this.store = store;
     this.programTerminator = programTerminator;
     this.metricsSystemClient = metricsSystemClient;
     this.metadataServiceClient = metadataServiceClient;
-    this.programScheduler = programScheduler;
+    this.scheduleManager = scheduleManager;
   }
 
   @Override
@@ -81,8 +81,8 @@ public class DeletedProgramHandlerStage extends AbstractStage<ApplicationDeploya
       ProgramType type = ProgramTypes.fromSpecification(spec);
       ProgramId programId = appSpec.getApplicationId().program(type, spec.getName());
       programTerminator.stop(programId);
-      programScheduler.deleteSchedules(programId);
-      programScheduler.modifySchedulesTriggeredByDeletedProgram(programId);
+      scheduleManager.deleteSchedules(programId);
+      scheduleManager.modifySchedulesTriggeredByDeletedProgram(programId);
 
       // Remove metadata for the deleted program
       metadataServiceClient.drop(new MetadataMutation.Drop(programId.toMetadataEntity()));

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/LocalScheduleManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/LocalScheduleManager.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.schedule;
+
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
+import io.cdap.cdap.common.AlreadyExistsException;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.ConflictException;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.ProfileConflictException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.internal.app.runtime.SystemArguments;
+import io.cdap.cdap.internal.app.runtime.schedule.queue.JobQueueTable;
+import io.cdap.cdap.internal.app.runtime.schedule.store.ProgramScheduleStoreDataset;
+import io.cdap.cdap.internal.app.runtime.schedule.store.Schedulers;
+import io.cdap.cdap.internal.app.store.profile.ProfileStore;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.proto.ProgramType;
+import io.cdap.cdap.proto.id.ProfileId;
+import io.cdap.cdap.proto.id.ScheduleId;
+import io.cdap.cdap.runtime.spi.profile.ProfileStatus;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@code ScheduleManager} to manage program schedules. This class is meant to be used by in-memory
+ * modules and tests.
+ */
+public class LocalScheduleManager extends ScheduleManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LocalScheduleManager.class);
+  private final TimeSchedulerService timeSchedulerService;
+
+  /**
+   * Parameterized constructor for LocalScheduleManager.
+   *
+   * @param transactionRunner TransactionRunner
+   * @param messagingService MessagingService
+   * @param cConf CConfiguration
+   * @param timeSchedulerService TimeSchedulerService
+   */
+  @Inject
+  public LocalScheduleManager(TransactionRunner transactionRunner, MessagingService messagingService,
+      CConfiguration cConf, TimeSchedulerService timeSchedulerService) {
+    super(transactionRunner, messagingService, cConf);
+    this.timeSchedulerService = timeSchedulerService;
+  }
+
+  @Override
+  public void addSchedules(Iterable<? extends ProgramSchedule> schedules)
+      throws BadRequestException, NotFoundException, IOException, ConflictException {
+    for (ProgramSchedule schedule : schedules) {
+      if (!schedule.getProgramId().getType().equals(ProgramType.WORKFLOW)) {
+        throw new BadRequestException(String.format(
+            "Cannot schedule program %s of type %s: Only workflows can be scheduled",
+            schedule.getProgramId().getProgram(), schedule.getProgramId().getType()));
+      }
+    }
+
+    try {
+      TransactionRunners.run(transactionRunner, context -> {
+        ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
+        ProfileStore profileStore = ProfileStore.get(context);
+        long updatedTime = store.addSchedules(schedules);
+        for (ProgramSchedule schedule : schedules) {
+          if (schedule.getProperties() != null) {
+            Optional<ProfileId> profile = SystemArguments.getProfileIdFromArgs(
+                schedule.getProgramId().getNamespaceId(), schedule.getProperties());
+            if (profile.isPresent()) {
+              ProfileId profileId = profile.get();
+              if (profileStore.getProfile(profileId).getStatus() == ProfileStatus.DISABLED) {
+                throw new ProfileConflictException(
+                    String.format("Profile %s in namespace %s is disabled. It cannot "
+                            + "be assigned to schedule %s",
+                        profileId.getProfile(), profileId.getNamespace(),
+                        schedule.getName()), profileId);
+              }
+            }
+          }
+          try {
+            timeSchedulerService.addProgramSchedule(schedule);
+          } catch (SchedulerException e) {
+            LOG.error("Exception occurs when adding schedule {}", schedule, e);
+            throw new RuntimeException(e);
+          }
+        }
+        for (ProgramSchedule schedule : schedules) {
+          ScheduleId scheduleId = schedule.getScheduleId();
+
+          // If the added properties contains profile assignment, add the assignment.
+          Optional<ProfileId> profileId = SystemArguments.getProfileIdFromArgs(
+              scheduleId.getNamespaceId(),
+              schedule.getProperties());
+          if (profileId.isPresent()) {
+            profileStore.addProfileAssignment(profileId.get(), scheduleId);
+          }
+        }
+        // Publish the messages at the end of transaction.
+        for (ProgramSchedule schedule : schedules) {
+          adminEventPublisher.publishScheduleCreation(schedule.getScheduleId(), updatedTime);
+        }
+        return null;
+      }, Exception.class);
+    } catch (NotFoundException | ProfileConflictException | AlreadyExistsException e) {
+      throw e;
+    } catch (Exception e) {
+      throw Throwables.propagate(e);
+    }
+  }
+
+  @Override
+  public void deleteSchedule(ScheduleId scheduleId)
+      throws NotFoundException, BadRequestException, IOException, ConflictException {
+    TransactionRunners.run(transactionRunner, context -> {
+      ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
+      ProfileStore profileStore = ProfileStore.get(context);
+      JobQueueTable queue = JobQueueTable.getJobQueue(context, cConf);
+      long deleteTime = System.currentTimeMillis();
+      List<ProgramSchedule> toNotify = new ArrayList<>();
+      ProgramSchedule schedule = store.getSchedule(scheduleId);
+      timeSchedulerService.deleteProgramSchedule(schedule);
+      queue.markJobsForDeletion(scheduleId, deleteTime);
+      toNotify.add(schedule);
+      // If the deleted schedule has properties with profile assignment, remove the assignment.
+      Optional<ProfileId> profileId = SystemArguments.getProfileIdFromArgs(
+          scheduleId.getNamespaceId(),
+          schedule.getProperties());
+      if (profileId.isPresent()) {
+        try {
+          profileStore.removeProfileAssignment(profileId.get(), scheduleId);
+        } catch (NotFoundException e) {
+          // This should not happen since the profile cannot be deleted if there is a schedule who is using it.
+          LOG.warn("Unable to find the profile {} when deleting schedule {}, "
+              + "skipping assignment deletion.", profileId.get(), scheduleId);
+        }
+      }
+      store.deleteSchedule(scheduleId);
+      toNotify.forEach(adminEventPublisher::publishScheduleDeletion);
+      return null;
+    }, NotFoundException.class);
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/RemoteScheduleManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/RemoteScheduleManager.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.schedule;
+
+import com.google.inject.Inject;
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.ConflictException;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.common.conf.Constants.Gateway;
+import io.cdap.cdap.common.http.DefaultHttpRequestConfig;
+import io.cdap.cdap.common.internal.remote.RemoteClient;
+import io.cdap.cdap.common.internal.remote.RemoteClientFactory;
+import io.cdap.cdap.gateway.handlers.util.ProgramHandlerUtil;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.proto.ScheduleDetail;
+import io.cdap.cdap.proto.id.ScheduleId;
+import io.cdap.cdap.security.spi.authorization.UnauthorizedException;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.common.http.HttpMethod;
+import io.cdap.common.http.HttpRequest;
+import io.cdap.common.http.HttpResponse;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+/**
+ * {@code ScheduleManager} to manage program schedules. This class uses remote client to communicate with
+ * {@code ProgramScheduleHttpHandler}.
+ */
+public class RemoteScheduleManager extends ScheduleManager {
+
+  private RemoteClient remoteClient;
+
+  /**
+   * Parameterized constructor for RemoteScheduleManager.
+   *
+   * @param transactionRunner TransactionRunner
+   * @param messagingService MessagingService
+   * @param cConf CConfiguration
+   * @param clientFactory RemoteClientFactory
+   */
+  @Inject
+  public RemoteScheduleManager(TransactionRunner transactionRunner, MessagingService messagingService,
+      CConfiguration cConf, RemoteClientFactory clientFactory) {
+    super(transactionRunner, messagingService, cConf);
+    this.remoteClient = clientFactory.createRemoteClient(Constants.Service.APP_FABRIC_PROCESSOR,
+        new DefaultHttpRequestConfig(false),
+        Gateway.API_VERSION_3);
+  }
+
+  @Override
+  public void addSchedules(Iterable<? extends ProgramSchedule> schedules)
+      throws BadRequestException, NotFoundException, IOException, ConflictException {
+    for (ProgramSchedule schedule : schedules) {
+      ScheduleId scheduleId = schedule.getScheduleId();
+      String url = String.format("namespaces/%s/apps/%s/schedules/%s",
+          scheduleId.getNamespace(),
+          scheduleId.getApplication(),
+          scheduleId.getSchedule());
+      HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.PUT, url);
+      ScheduleDetail scheduleDetail = schedule.toScheduleDetail();
+      requestBuilder.withBody(ProgramHandlerUtil.toJson(scheduleDetail, ScheduleDetail.class));
+      execute(requestBuilder.build());
+    }
+  }
+
+  @Override
+  public void deleteSchedule(ScheduleId scheduleId)
+      throws NotFoundException, BadRequestException, IOException, ConflictException {
+    String url = String.format("namespaces/%s/apps/%s/schedules/%s",
+        scheduleId.getNamespace(),
+        scheduleId.getApplication(),
+        scheduleId.getSchedule());
+    HttpRequest.Builder requestBuilder = remoteClient.requestBuilder(HttpMethod.DELETE, url);
+    execute(requestBuilder.build());
+  }
+
+  private HttpResponse execute(HttpRequest request)
+      throws IOException, NotFoundException, UnauthorizedException, BadRequestException, ConflictException {
+      HttpResponse httpResponse = remoteClient.execute(request);
+    switch (httpResponse.getResponseCode()) {
+      case HttpURLConnection.HTTP_OK:
+        return httpResponse;
+      case HttpURLConnection.HTTP_BAD_REQUEST:
+        throw new BadRequestException(httpResponse.getResponseBodyAsString());
+      case HttpURLConnection.HTTP_NOT_FOUND:
+        throw new NotFoundException(httpResponse.getResponseBodyAsString());
+      case HttpURLConnection.HTTP_CONFLICT:
+        throw new ConflictException(httpResponse.getResponseBodyAsString());
+      default:
+        throw new IOException(
+            String.format("Request failed %s", httpResponse.getResponseBodyAsString()));
+    }
+  }
+}

--- a/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/ScheduleManager.java
+++ b/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/schedule/ScheduleManager.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.internal.app.runtime.schedule;
+
+import io.cdap.cdap.common.BadRequestException;
+import io.cdap.cdap.common.ConflictException;
+import io.cdap.cdap.common.NotFoundException;
+import io.cdap.cdap.common.conf.CConfiguration;
+import io.cdap.cdap.internal.app.runtime.schedule.store.ProgramScheduleStoreDataset;
+import io.cdap.cdap.internal.app.runtime.schedule.store.Schedulers;
+import io.cdap.cdap.internal.app.runtime.schedule.trigger.ProgramStatusTrigger;
+import io.cdap.cdap.internal.profile.AdminEventPublisher;
+import io.cdap.cdap.messaging.context.MultiThreadMessagingContext;
+import io.cdap.cdap.messaging.spi.MessagingService;
+import io.cdap.cdap.proto.id.ApplicationId;
+import io.cdap.cdap.proto.id.ProgramId;
+import io.cdap.cdap.proto.id.ScheduleId;
+import io.cdap.cdap.spi.data.transaction.TransactionRunner;
+import io.cdap.cdap.spi.data.transaction.TransactionRunners;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Abstract class to manager program schedules.
+ */
+public abstract class ScheduleManager {
+
+  protected final CConfiguration cConf;
+  protected final TransactionRunner transactionRunner;
+  protected final AdminEventPublisher adminEventPublisher;
+
+  /**
+   * Parameterized constructor for ScheduleManager.
+   *
+   * @param transactionRunner TransactionRunner
+   * @param messagingService MessagingService
+   * @param cConf CConfiguration
+   */
+  public ScheduleManager(TransactionRunner transactionRunner,
+      MessagingService messagingService, CConfiguration cConf) {
+    this.cConf = cConf;
+    this.transactionRunner = transactionRunner;
+    MultiThreadMessagingContext messagingContext = new MultiThreadMessagingContext(messagingService);
+    this.adminEventPublisher = new AdminEventPublisher(cConf, messagingContext);
+  }
+
+  /**
+   * Add program schedules for the given collection of Program Schedules.
+   *
+   * @param schedules Collection of Program Schedules.
+   *
+   * @throws BadRequestException if the program type or not workflow.
+   * @throws NotFoundException if the program was not found.
+   * @throws IOException if there was an internal error in adding schedules.
+   * @throws ConflictException if the profile is disabled.
+   */
+  public abstract void addSchedules(Iterable<? extends ProgramSchedule> schedules)
+      throws Exception;
+
+  /**
+   * Deleted a program schedule for the given {@code scheduleId}.
+   *
+   * @param scheduleId for the schedule to be deleted.
+   *
+   * @throws NotFoundException if the schedule is not found.
+   * @throws IOException if an internal error occurred when deleting the schedule.
+   */
+  public abstract void deleteSchedule(ScheduleId scheduleId)
+      throws Exception;
+
+  /**
+   * Deletes all the schedules for the given {@code ApplicationId}.
+   *
+   * @param appId the {@code ApplicationId} whose schedules need to be deleted.
+   */
+  public void deleteSchedules(ApplicationId appId) {
+    TransactionRunners.run(transactionRunner, context -> {
+      ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
+      List<ProgramSchedule> programSchedules = store.listSchedules(appId);
+      for (ProgramSchedule programSchedule : programSchedules) {
+        deleteSchedule(programSchedule.getScheduleId());
+      }
+    }, RuntimeException.class);
+  }
+
+  /**
+   * Deletes all the schedules for the given {@code ProgramId}.
+   *
+   * @param programId the {@code ProgramId} whose schedules need to be deleted.
+   */
+  public void deleteSchedules(ProgramId programId) {
+    TransactionRunners.run(transactionRunner, context -> {
+      ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
+      List<ProgramSchedule> programSchedules = store.listSchedules(programId);
+      for (ProgramSchedule programSchedule : programSchedules) {
+        deleteSchedule(programSchedule.getScheduleId());
+      }
+    }, RuntimeException.class);
+  }
+
+  /**
+   * Update all schedules that can be triggered by the given deleted program. A schedule will be
+   * removed if the only {@link ProgramStatusTrigger} in it is triggered by the deleted program.
+   * Schedules with composite triggers will be updated if the composite trigger can still be
+   * satisfied after the program is deleted, otherwise the schedules will be deleted.
+   *
+   * @param programId the program id for which to delete the schedules.
+   */
+  public void modifySchedulesTriggeredByDeletedProgram(ProgramId programId) {
+    TransactionRunners.run(transactionRunner, context -> {
+      ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
+      List<ProgramSchedule> deletedSchedules = store.modifySchedulesTriggeredByDeletedProgram(programId);
+      deletedSchedules.forEach(adminEventPublisher::publishScheduleDeletion);
+    }, RuntimeException.class);
+  }
+
+  /**
+   * Lists all the schedules for the given {@code ApplicationId}.
+   *
+   * @param appId the {@code ApplicationId}.
+   *
+   * @return List of {@code ProgramSchedule}.
+   */
+  public List<ProgramSchedule> listSchedules(ApplicationId appId) {
+    return TransactionRunners.run(transactionRunner, context -> {
+      ProgramScheduleStoreDataset store = Schedulers.getScheduleStore(context);
+      return store.listSchedules(appId);
+    }, RuntimeException.class);
+  }
+}

--- a/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
+++ b/cdap-app-fabric/src/test/java/io/cdap/cdap/internal/app/services/http/handlers/AppLifecycleHttpHandlerTest.java
@@ -53,6 +53,7 @@ import io.cdap.cdap.internal.app.deploy.pipeline.AppDeploymentInfo;
 import io.cdap.cdap.internal.app.deploy.pipeline.ApplicationWithPrograms;
 import io.cdap.cdap.internal.app.runtime.SystemArguments;
 import io.cdap.cdap.internal.app.runtime.artifact.ArtifactRepository;
+import io.cdap.cdap.internal.app.runtime.schedule.ScheduleManager;
 import io.cdap.cdap.internal.app.services.ApplicationLifecycleService;
 import io.cdap.cdap.internal.app.services.http.AppFabricTestBase;
 import io.cdap.cdap.internal.app.store.state.AppStateKey;
@@ -75,7 +76,6 @@ import io.cdap.cdap.proto.id.ProfileId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramReference;
 import io.cdap.cdap.proto.profile.Profile;
-import io.cdap.cdap.scheduler.Scheduler;
 import io.cdap.cdap.security.impersonation.CurrentUGIProvider;
 import io.cdap.cdap.security.impersonation.Impersonator;
 import io.cdap.cdap.security.impersonation.OwnerAdmin;
@@ -136,7 +136,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
       @Provides
       @Singleton
       public ApplicationLifecycleService createLifeCycleService(CConfiguration cConf,
-          Store store, Scheduler scheduler, UsageRegistry usageRegistry,
+          Store store, ScheduleManager scheduleManager, UsageRegistry usageRegistry,
           PreferencesService preferencesService, MetricsSystemClient metricsSystemClient,
           OwnerAdmin ownerAdmin, ArtifactRepository artifactRepository,
           ManagerFactory<AppDeploymentInfo, ApplicationWithPrograms> managerFactory,
@@ -145,7 +145,7 @@ public class AppLifecycleHttpHandlerTest extends AppFabricTestBase {
           MessagingService messagingService, Impersonator impersonator,
           CapabilityReader capabilityReader) {
 
-        return Mockito.spy(new ApplicationLifecycleService(cConf, store, scheduler,
+        return Mockito.spy(new ApplicationLifecycleService(cConf, store, scheduleManager,
             usageRegistry, preferencesService, metricsSystemClient, ownerAdmin, artifactRepository,
             managerFactory, metadataServiceClient, accessEnforcer, authenticationContext,
             messagingService, impersonator, capabilityReader, new NoOpMetricsCollectionService()));

--- a/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
+++ b/cdap-gateway/src/main/java/io/cdap/cdap/gateway/router/RouterPathLookup.java
@@ -269,6 +269,8 @@ public final class RouterPathLookup extends AbstractHttpHandler {
       // we don't want to expose endpoints for direct metadata mutation from CDAP master
       // /v3/metadata-internals/{mutation-type}
       return DONT_ROUTE;
+    } else if ((uriParts.length == 2) && beginsWith(uriParts, "v3", "dashboard")) {
+      return APP_FABRIC_PROCESSOR;
     }
     return APP_FABRIC_HTTP;
   }

--- a/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
+++ b/cdap-gateway/src/test/java/io/cdap/cdap/gateway/router/RouterPathLookupTest.java
@@ -218,7 +218,7 @@ public class RouterPathLookupTest {
 
   @Test
   public void testOpsDashboardPath() {
-    assertRouting("/v3/dashboard", RouterPathLookup.APP_FABRIC_HTTP);
+    assertRouting("/v3/dashboard", RouterPathLookup.APP_FABRIC_PROCESSOR);
   }
 
   @Test


### PR DESCRIPTION
Use RemoteScheduleManager to update TimeSchedulerService from Appfabric service

### Issue

Appfabric service uses `NoOpScheduler`, and the `TimeSchedulerService` doesn't run in appfabric service. There are few flows (eg. DeployApp) where the default schedule needs to be created. Creation of default schedules is a no-op in the appfabric service and actually doesn't get created.

### Solution

* Introduced `RemoteScheduleManager` for managing schedules (in `TimeSchedulerService`) from the appfabric service.
* Similarly added `LocalScheduleManager` for in-memory modules and tests.
* Replaced all callers in appfabric service to use `RemoteScheduleManager`.

### Verification

- [x] Unit Tests
- [x] CDAP Sandbox
- [x] Distributed Docker image
