### PR TITLE
[CDAP-21115] Fix method used to base64 encode basic auth header

### DIFF
--- a/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
+++ b/cdap-app-templates/cdap-etl/cdap-data-pipeline-base/src/main/java/io/cdap/cdap/datapipeline/service/OAuthHandler.java
@@ -413,7 +413,7 @@ public class OAuthHandler extends AbstractSystemHttpServiceHandler {
 
   private String getBasicAuthHeader(OAuthClientCredentials clientCreds) {
     String authInfo = String.format("%s:%s", clientCreds.getClientId(), clientCreds.getClientSecret());
-    return String.format("Basic %s", Base64.getEncoder().encode(authInfo.getBytes()));
+    return String.format("Basic %s", Base64.getEncoder().encodeToString(authInfo.getBytes()));
   }
 
   private OAuthProvider getProvider(String provider) throws OAuthServiceException {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/997e93c6-e10c-4838-b67c-a4ed71d25ef5)