### PR TITLE
[CDAP-21123] Avoid double wrapping of failure details provider during starting state

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/conf/Constants.java
@@ -1554,7 +1554,6 @@ public final class Constants {
     public static final String USER_LOG_TAG_VALUE = "userLog";
     public static final String TAG_FAILED_STAGE = "failedStage";
     public static final String TAG_ERROR_CATEGORY = "errorCategory";
-    public static final String TAG_PARENT_ERROR_CATEGORY = "parentErrorCategory";
     public static final String TAG_ERROR_REASON = "errorReason";
     public static final String TAG_ERROR_TYPE = "errorType";
     public static final String TAG_DEPENDENCY = "dependency";

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/common/DataprocUtils.java
@@ -27,12 +27,14 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageBatch;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
 import io.cdap.cdap.api.exception.ErrorCategory;
 import io.cdap.cdap.api.exception.ErrorCodeType;
 import io.cdap.cdap.api.exception.ErrorType;
 import io.cdap.cdap.api.exception.ErrorUtils;
+import io.cdap.cdap.api.exception.FailureDetailsProvider;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerContext;
 import io.cdap.cdap.runtime.spi.provisioner.ProvisionerMetrics;
 import io.cdap.cdap.runtime.spi.provisioner.RetryableProvisionException;
@@ -584,6 +586,20 @@ public final class DataprocUtils {
         .withErrorCode(String.valueOf(statusCode))
         .withDependency(true)
         .build();
+  }
+
+  /**
+   * Returns a boolean true if {@link FailureDetailsProvider} is present in causal chain,
+   * otherwise false.
+   */
+  public static boolean isFailureDetailsProviderInCausalChain(Throwable e) {
+    List<Throwable> causalChain = Throwables.getCausalChain(e);
+    for (Throwable cause : causalChain) {
+      if (cause instanceof FailureDetailsProvider) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private DataprocUtils() {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -388,12 +388,17 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
             .withDependency(true)
             .build();
       }
-      throw new DataprocRuntimeException.Builder()
-          .withErrorMessage(e.getMessage())
-          .withErrorReason(errorReason)
-          .withErrorCategory(errorCategory)
-          .withCause(e)
-          .build();
+      if (DataprocUtils.isFailureDetailsProviderInCausalChain(e)) {
+        // avoid double wrapping
+        throw e;
+      } else {
+        throw new DataprocRuntimeException.Builder()
+            .withErrorMessage(e.getMessage())
+            .withErrorReason(errorReason)
+            .withErrorCategory(errorCategory)
+            .withCause(e)
+            .build();
+      }
     } finally {
       if (disableLocalCaching) {
         DataprocUtils.deleteDirectoryContents(tempDir);

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/ErrorLogsClassifier.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/ErrorLogsClassifier.java
@@ -317,6 +317,6 @@ public class ErrorLogsClassifier {
             .setErrorCodeType(mdc.get(Logging.TAG_ERROR_CODE_TYPE))
             .setErrorCode(mdc.get(Logging.TAG_ERROR_CODE))
             .setSupportedDocumentationUrl(mdc.get(Logging.TAG_SUPPORTED_DOC_URL)).build(),
-        mdc.get(Logging.TAG_PARENT_ERROR_CATEGORY), throwableProxy.getClassName(), null, null);
+        mdc.get(Logging.TAG_ERROR_CATEGORY), throwableProxy.getClassName(), null, null);
   }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/LogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/LogAppender.java
@@ -137,8 +137,6 @@ public abstract class LogAppender extends AppenderBase<ILoggingEvent> {
         }
         modifiableMdc.put(Constants.Logging.TAG_ERROR_CATEGORY,
             provider.getErrorCategory().getErrorCategory());
-        modifiableMdc.put(Constants.Logging.TAG_PARENT_ERROR_CATEGORY,
-            provider.getErrorCategory().getParentCategory().name());
         if (provider.getErrorReason() != null) {
           modifiableMdc.put(Constants.Logging.TAG_ERROR_REASON, provider.getErrorReason());
         }

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/ErrorLogsClassifierTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/ErrorLogsClassifierTest.java
@@ -148,7 +148,6 @@ public class ErrorLogsClassifierTest {
   private ILoggingEvent getEvent1() {
     Map<String, String> map = new HashMap<>();
     map.put(Constants.Logging.TAG_FAILED_STAGE, "stageName");
-    map.put(Constants.Logging.TAG_PARENT_ERROR_CATEGORY, "errorCategory");
     map.put(Constants.Logging.TAG_ERROR_CATEGORY, "errorCategory");
     map.put(Constants.Logging.TAG_ERROR_REASON, "errorReason");
     map.put(Constants.Logging.TAG_ERROR_TYPE, "errorType");
@@ -164,7 +163,6 @@ public class ErrorLogsClassifierTest {
   private ILoggingEvent getEvent2() {
     Map<String, String> map = new HashMap<>();
     map.put(Constants.Logging.TAG_FAILED_STAGE, "stageName");
-    map.put(Constants.Logging.TAG_PARENT_ERROR_CATEGORY, "errorCategory");
     map.put(Constants.Logging.TAG_ERROR_CATEGORY, "errorCategory");
     map.put(Constants.Logging.TAG_ERROR_REASON, "errorReason");
     map.put(Constants.Logging.TAG_ERROR_TYPE, "errorType");


### PR DESCRIPTION
context:
![image](https://github.com/user-attachments/assets/b9404380-a3e8-415d-b588-cd255cd57891)