### PR TITLE
[cherry-pick][6.11][CDAP-21133] Making Dataproc 2.2 as default for 6.11

### DIFF
--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisioner.java
@@ -460,7 +460,7 @@ public class DataprocProvisioner extends AbstractDataprocProvisioner {
     String imageVersion = conf.getImageVersion();
     if (imageVersion == null) {
       // Dataproc 2.1 is the default version from 6.10.0 and later
-      imageVersion = "2.1";
+      imageVersion = "2.2";
     }
     return imageVersion;
   }

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/common/DataprocMetricTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/common/DataprocMetricTest.java
@@ -28,17 +28,17 @@ public class DataprocMetricTest {
   public void testImageVersion() {
     String metricName = "provisioner.createCluster.response.count";
     String region = "us-east1";
-    String imageVersion = "2.1.35-debian11";
+    String imageVersion = "2.2.35-debian11";
 
     DataprocMetric dataprocMetric =
         DataprocMetric.builder(metricName)
             .setRegion(region).setImageVersion(imageVersion).build();
-    Assert.assertEquals("2.1", dataprocMetric.getImageVersion());
+    Assert.assertEquals("2.2", dataprocMetric.getImageVersion());
 
-    imageVersion = "2.1";
+    imageVersion = "2.2";
     dataprocMetric = DataprocMetric.builder(metricName)
         .setRegion(region).setImageVersion(imageVersion).build();
-    Assert.assertEquals("2.1", dataprocMetric.getImageVersion());
+    Assert.assertEquals("2.2", dataprocMetric.getImageVersion());
 
     imageVersion = null;
     dataprocMetric = DataprocMetric.builder(metricName)

--- a/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
+++ b/cdap-runtime-ext-dataproc/src/test/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/DataprocProvisionerTest.java
@@ -272,20 +272,20 @@ public class DataprocProvisionerTest {
     ));
 
     context.setSparkCompat(SparkCompat.SPARK3_2_12);
-    Assert.assertEquals("2.1", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.2", provisioner.getImageVersion(context, defaultConf));
     Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
 
     context.setAppCDAPVersionInfo(new MockVersionInfo("6.5.0"));
-    Assert.assertEquals("2.1", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.2", provisioner.getImageVersion(context, defaultConf));
     Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
 
     context.setAppCDAPVersionInfo(new MockVersionInfo("6.4.0"));
-    Assert.assertEquals("2.1", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.2", provisioner.getImageVersion(context, defaultConf));
     Assert.assertEquals("explicit", provisioner.getImageVersion(context, explicitVersionConf));
 
     //Doublecheck we still get 2.1 for Spark 3 even with CDAP 6.4
     context.setSparkCompat(SparkCompat.SPARK3_2_12);
-    Assert.assertEquals("2.1", provisioner.getImageVersion(context, defaultConf));
+    Assert.assertEquals("2.2", provisioner.getImageVersion(context, defaultConf));
 
   }
 
@@ -313,7 +313,7 @@ public class DataprocProvisionerTest {
     Mockito.when(dataprocClient.getCluster("cdap-app-runId"))
         .thenReturn(Optional.empty());
     Mockito.when(dataprocClient.createCluster(Mockito.eq("cdap-app-runId"),
-            Mockito.eq("2.1"), addedLabelsCaptor.capture(), Mockito.eq(false),
+            Mockito.eq("2.2"), addedLabelsCaptor.capture(), Mockito.eq(false),
             Mockito.any()))
       .thenReturn(ClusterOperationMetadata.getDefaultInstance());
     Cluster expectedCluster = new Cluster(


### PR DESCRIPTION
Original PR : https://github.com/cdapio/cdap/pull/15869