### PR TITLE
[CDAP-21027] upgrade hadoop to 3.3.6

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -943,7 +943,6 @@
     <profile>
       <id>k8s</id>
       <properties>
-        <hadoop.version>2.9.2</hadoop.version>
         <stage.hadoop.lib.dir>${stage.opt.dir}/lib/hadoop</stage.hadoop.lib.dir>
         <stage.master.environments.ext.dir>${stage.opt.dir}/ext/environments</stage.master.environments.ext.dir>
       </properties>


### PR DESCRIPTION
context:

```
Could not resolve dependencies for project io.cdap.cdap:cdap-master:jar:6.12.0-SNAPSHOT: Failed to collect dependencies at io.cdap.cdap:cdap-common:jar:6.12.0-SNAPSHOT -> io.cdap.twill:twill-yarn:jar:1.4.0 -> org.apache.hadoop:hadoop-common:jar:2.9.2 -> org.apache.hadoop:hadoop-auth:jar:2.9.2 -> com.nimbusds:nimbus-jose-jwt:jar:4.41.1 -> net.minidev:json-smart:jar:[1.3.1,2.3]
```

Successfully tested by deploying cdap image on a k8s cluster.