### PR TITLE
[CDAP-21128] Handle dataproc job failures in error management

### DIFF
--- a/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/ErrorUtils.java
+++ b/cdap-api-common/src/main/java/io/cdap/cdap/api/exception/ErrorUtils.java
@@ -125,6 +125,56 @@ public final class ErrorUtils {
         return new ActionErrorPair("Please ensure there are no network connectivity "
           + "issues between the proxy/gateway server and the upstream server or try again later.",
           ErrorType.SYSTEM);
+      case HttpURLConnection.HTTP_PROXY_AUTH:
+        return new ActionErrorPair("Proxy authentication required. Please check your "
+            + "proxy settings and provide valid credentials.", ErrorType.USER);
+      case HttpURLConnection.HTTP_NOT_ACCEPTABLE:
+        return new ActionErrorPair("Request cannot be processed in the requested format."
+            + " Please check the Accept headers.", ErrorType.USER);
+      case HttpURLConnection.HTTP_GONE:
+        return new ActionErrorPair("Requested resource is no longer available.",
+            ErrorType.USER);
+      case HttpURLConnection.HTTP_LENGTH_REQUIRED:
+        return new ActionErrorPair("Content-Length header is required. "
+            + "Please include it in your request.", ErrorType.USER);
+      case HttpURLConnection.HTTP_ENTITY_TOO_LARGE:
+        return new ActionErrorPair("Request entity too large. "
+            + "Please reduce payload size and try again.", ErrorType.USER);
+      case HttpURLConnection.HTTP_REQ_TOO_LONG: // 414
+        return new ActionErrorPair("Request URL is too long. "
+            + "Consider shortening the URL.", ErrorType.USER);
+      case HttpURLConnection.HTTP_UNSUPPORTED_TYPE:
+        return new ActionErrorPair("Unsupported media type. "
+            + "Please use a supported format and try again.", ErrorType.USER);
+      case 416: // HTTP 416 Requested Range Not Satisfiable
+        return new ActionErrorPair("Requested range is not satisfiable. "
+            + "Please adjust range headers and try again.", ErrorType.USER);
+      case 417: // HTTP 417 Expectation Failed
+        return new ActionErrorPair("Expectation failed. "
+            + "Server cannot meet Expect header requirements.", ErrorType.USER);
+      case 421: // HTTP 421 Misdirected Request
+        return new ActionErrorPair("Request was misdirected. "
+            + "Please try sending it to the correct server.", ErrorType.USER);
+      case 422: // HTTP 422 Unprocessable Entity
+        return new ActionErrorPair("Request cannot be processed due to semantic errors. "
+            + "Please check the request syntax and try again.", ErrorType.USER);
+      case 423: // HTTP 423 Locked
+        return new ActionErrorPair("Resource is locked. Please try again later.",
+            ErrorType.USER);
+      case 424: // HTTP 424 Failed Dependency
+        return new ActionErrorPair("Request failed due to a failed dependency. "
+            + "Please ensure related actions are successful.", ErrorType.USER);
+      case 426: // HTTP 426 Upgrade Required
+        return new ActionErrorPair("Upgrade required. "
+            + "Please use a newer protocol version.", ErrorType.USER);
+      case 428: // HTTP 428 Precondition Required
+        return new ActionErrorPair("Request requires preconditions. "
+            + "Please ensure headers are set correctly.", ErrorType.USER);
+      case 431: // HTTP 431 Request Header Fields Too Large
+        return new ActionErrorPair("Request headers are too large. "
+            + "Please reduce the number or size of headers.", ErrorType.USER);
+      case 451: // HTTP 451 Unavailable For Legal Reasons
+        return new ActionErrorPair("Content is restricted due to legal reasons.", ErrorType.USER);
       default:
         return new ActionErrorPair(String.format("Request failed with error code: %s", statusCode),
           ErrorType.UNKNOWN);

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/provisioner/dataproc/AbstractDataprocProvisioner.java
@@ -22,7 +22,6 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
-import io.cdap.cdap.api.exception.ErrorCategory;
 import io.cdap.cdap.runtime.spi.common.DataprocImageVersion;
 import io.cdap.cdap.runtime.spi.common.DataprocUtils;
 import io.cdap.cdap.runtime.spi.provisioner.Capabilities;
@@ -35,6 +34,7 @@ import io.cdap.cdap.runtime.spi.provisioner.ProvisionerSystemContext;
 import io.cdap.cdap.runtime.spi.runtimejob.DataprocClusterInfo;
 import io.cdap.cdap.runtime.spi.runtimejob.DataprocRuntimeJobDetail;
 import io.cdap.cdap.runtime.spi.runtimejob.DataprocRuntimeJobManager;
+import io.cdap.cdap.runtime.spi.runtimejob.ProgramRunFailureException;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobDetail;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobManager;
 import io.cdap.cdap.runtime.spi.runtimejob.RuntimeJobStatus;
@@ -127,8 +127,10 @@ public abstract class AbstractDataprocProvisioner implements Provisioner {
           // Status details is specific to dataproc jobs, so it was not added to RuntimeJobDetail spi.
           String statusDetails = ((DataprocRuntimeJobDetail) jobDetail).getJobStatusDetails();
           if (statusDetails != null) {
-            LOG.error("Dataproc job '{}' with the status details: {}",
-                jobDetail.getStatus().name(), statusDetails);
+            ProgramRunFailureException e = new ProgramRunFailureException(
+                String.format("Dataproc job '%s' status details: %s",
+                    ((DataprocRuntimeJobDetail) jobDetail).getJobId(), statusDetails));
+            LOG.error("Dataproc Job {}", jobDetail.getStatus(), e);
           }
         }
       } finally {

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobDetail.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobDetail.java
@@ -25,11 +25,13 @@ import java.util.Objects;
 public class DataprocRuntimeJobDetail extends RuntimeJobDetail {
 
   private final String jobStatusDetails;
+  private final String jobId;
 
   public DataprocRuntimeJobDetail(ProgramRunInfo runInfo, RuntimeJobStatus status,
-      String jobStatusDetails) {
+      String jobStatusDetails, String jobId) {
     super(runInfo, status);
     this.jobStatusDetails = jobStatusDetails;
+    this.jobId = jobId;
   }
 
   /**
@@ -37,6 +39,13 @@ public class DataprocRuntimeJobDetail extends RuntimeJobDetail {
    */
   public String getJobStatusDetails() {
     return jobStatusDetails;
+  }
+
+  /**
+   * Returns dataproc job id.
+   */
+  public String getJobId() {
+    return jobId;
   }
 
   @Override
@@ -49,11 +58,12 @@ public class DataprocRuntimeJobDetail extends RuntimeJobDetail {
     }
 
     DataprocRuntimeJobDetail that = (DataprocRuntimeJobDetail) o;
-    return Objects.equals(jobStatusDetails, that.jobStatusDetails);
+    return Objects.equals(jobStatusDetails, that.jobStatusDetails)
+        && Objects.equals(jobId, that.jobId);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(this.getRunInfo(), this.getStatus(), jobStatusDetails);
+    return Objects.hash(this.getRunInfo(), this.getStatus(), jobStatusDetails, jobId);
   }
 }

--- a/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
+++ b/cdap-runtime-ext-dataproc/src/main/java/io/cdap/cdap/runtime/spi/runtimejob/DataprocRuntimeJobManager.java
@@ -417,8 +417,7 @@ public class DataprocRuntimeJobManager implements RuntimeJobManager {
           .setJobId(jobId)
           .build());
       return Optional.of(new DataprocRuntimeJobDetail(getProgramRunInfo(job),
-          getRuntimeJobStatus(job),
-          getJobStatusDetails(job)));
+          getRuntimeJobStatus(job), getJobStatusDetails(job), getJobId(programRunInfo)));
     } catch (ApiException e) {
       if (e.getStatusCode().getCode() != StatusCode.Code.NOT_FOUND) {
         int code = e.getStatusCode().getCode().getHttpStatusCode();

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/ErrorLogsClassifier.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/ErrorLogsClassifier.java
@@ -173,7 +173,7 @@ public class ErrorLogsClassifier {
           isFailureDetailsProviderInstancePresent = true;
           populateResponse(throwableProxy, mdc, stageName, responseMap, responseSet);
         } else if (!isFailureDetailsProviderInstancePresent) {
-          String errorReason = String.format("Program run '%s:%s:%s' failed,"
+          String errorReason = String.format("Program run '%s:%s:%s' failed. "
               + "View raw logs for more details.", namespace, appId, runId);
           ruleMatchedResponse = findMatchingRule(throwableProxy, ruleMatchedResponse, errorReason);
         }
@@ -277,7 +277,7 @@ public class ErrorLogsClassifier {
                 .setErrorReason(errorReason)
                 .setErrorMessage(errorMessage)
                 .setDependency(String.valueOf(rule.isDependency())).build(),
-            throwableProxy.getClassName(), ErrorCategoryEnum.OTHERS.name(), rule.getPriority(),
+            ErrorCategoryEnum.OTHERS.name(), throwableProxy.getClassName(), rule.getPriority(),
             rule.getId());
         break;
       }


### PR DESCRIPTION
Tested with rule:
```
{
    "id": "program_run_failure_exception",
    "description": "Program Run Failed",
    "priority": 100000,
    "exceptionClassRegex": "io.cdap.cdap.runtime.spi.runtimejob.ProgramRunFailureException",
    "errorType": "UNKNOWN",
    "dependency": true
}
```

![image](https://github.com/user-attachments/assets/d5855364-73ff-4ff7-8e7d-2bec9534a384)