### PR TITLE
[CDAP-21079] Update cloud spanner java lib version

### DIFF
--- a/cdap-messaging-ext-spanner/pom.xml
+++ b/cdap-messaging-ext-spanner/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <guava.version>30.1.1-jre</guava.version>
-    <spanner.version>6.12.2</spanner.version>
+    <spanner.version>6.86.0</spanner.version>
   </properties>
 
   <dependencyManagement>

--- a/cdap-storage-ext-spanner/pom.xml
+++ b/cdap-storage-ext-spanner/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <guava.version>30.1.1-jre</guava.version>
-    <spanner.version>6.12.2</spanner.version>
+    <spanner.version>6.86.0</spanner.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Updating to the latest version of the google-cloud-spanner Java library offers a range of benefits, including performance improvements, new features, enhanced stability, better compatibility and better internal spanner retry logic

There are no breaking changes.

Tested following scenarios:
- Pipeline run was successful
- Also tested for previous fix : https://github.com/cdapio/cdap/pull/15849 