### PR TITLE
[CDAP-21136] Extracting namespace tag from URI

### DIFF
--- a/cdap-common/src/test/java/io/cdap/cdap/common/metrics/MetricsReporterHookTest.java
+++ b/cdap-common/src/test/java/io/cdap/cdap/common/metrics/MetricsReporterHookTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.api.metrics.MetricsContext;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -32,6 +33,7 @@ import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
+import java.util.Map;
 import org.junit.Test;
 
 public class MetricsReporterHookTest {
@@ -43,7 +45,13 @@ public class MetricsReporterHookTest {
     public void testReponseTimeCollection() throws InterruptedException {
         MetricsContext mockCollector = mock(MetricsContext.class);
         MetricsCollectionService mockCollectionService = mock(MetricsCollectionService.class);
-        when(mockCollectionService.getContext(anyMap())).thenReturn(mockCollector);
+        Map<String, String> tags = ImmutableMap.of(
+            "ns", "system",
+            "cmp", TESTSERVICENAME,
+            "hnd", "handler",
+            "mtd", TESTMETHODNAME
+        );
+        when(mockCollectionService.getContext(tags)).thenReturn(mockCollector);
 
         HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "http://ignore");
         HandlerInfo handlerInfo = new HandlerInfo(TESTHANDLERNAME, TESTMETHODNAME);
@@ -53,6 +61,58 @@ public class MetricsReporterHookTest {
         hook.preCall(request, null, handlerInfo);
         hook.postCall(request, HttpResponseStatus.OK, handlerInfo);
 
+        verify(mockCollector).event(eq("response.latency"), anyLong());
+    }
+
+    @Test
+    public void testNamespacesExtraction() throws InterruptedException {
+        MetricsContext mockCollector = mock(MetricsContext.class);
+        MetricsCollectionService mockCollectionService = mock(MetricsCollectionService.class);
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+            "http://ignore/namespaces/testNamespace");
+        HandlerInfo handlerInfo = new HandlerInfo(TESTHANDLERNAME, TESTMETHODNAME);
+        MetricsReporterHook hook = new MetricsReporterHook(CConfiguration.create(),
+            mockCollectionService, TESTSERVICENAME);
+
+        Map<String, String> tags = ImmutableMap.of(
+            "ns", "testNamespace",
+            "cmp", TESTSERVICENAME,
+            "hnd", "handler",
+            "mtd", TESTMETHODNAME
+        );
+        when(mockCollectionService.getContext(tags)).thenReturn(mockCollector);
+
+        hook.preCall(request, null, handlerInfo);
+        verify(mockCollector).increment("request.received", 1);
+
+        hook.postCall(request, HttpResponseStatus.OK, handlerInfo);
+        verify(mockCollector).increment("response.successful", 1);
+        verify(mockCollector).event(eq("response.latency"), anyLong());
+    }
+
+    @Test
+    public void testNoNamespaceToExtract() throws InterruptedException {
+        MetricsContext mockCollector = mock(MetricsContext.class);
+        MetricsCollectionService mockCollectionService = mock(MetricsCollectionService.class);
+        HttpRequest request = new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+            "http://ignore/namespaces");
+        HandlerInfo handlerInfo = new HandlerInfo(TESTHANDLERNAME, TESTMETHODNAME);
+        MetricsReporterHook hook = new MetricsReporterHook(CConfiguration.create(),
+            mockCollectionService, TESTSERVICENAME);
+
+        Map<String, String> tags = ImmutableMap.of(
+            "ns", "system",
+            "cmp", TESTSERVICENAME,
+            "hnd", "handler",
+            "mtd", TESTMETHODNAME
+        );
+        when(mockCollectionService.getContext(tags)).thenReturn(mockCollector);
+
+        hook.preCall(request, null, handlerInfo);
+        verify(mockCollector).increment("request.received", 1);
+
+        hook.postCall(request, HttpResponseStatus.OK, handlerInfo);
+        verify(mockCollector).increment("response.successful", 1);
         verify(mockCollector).event(eq("response.latency"), anyLong());
     }
 }


### PR DESCRIPTION
Fix for JIRA: [CDAP-21136](https://cdap.atlassian.net/browse/CDAP-21136)

Tested in CDAP Sandbox, when queried with following:

```
metrics/search?target=metric&tag=namespace:default
```

Got these metrics:

```
[
  "system.metrics.emitted.count",
  "system.request.received",
  "system.response.successful"
]
```

[CDAP-21136]: https://cdap.atlassian.net/browse/CDAP-21136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ