### PR TITLE
[CDAP-21096] Run dataset executor and service on appfabric processor only

### DIFF
--- a/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
+++ b/cdap-master/src/main/java/io/cdap/cdap/master/environment/k8s/AppFabricServiceMain.java
@@ -41,8 +41,6 @@ import io.cdap.cdap.common.service.RetryStrategies;
 import io.cdap.cdap.data.runtime.DataSetServiceModules;
 import io.cdap.cdap.data.runtime.DataSetsModules;
 import io.cdap.cdap.data2.audit.AuditModule;
-import io.cdap.cdap.data2.datafabric.dataset.service.DatasetService;
-import io.cdap.cdap.data2.datafabric.dataset.service.executor.DatasetOpExecutorService;
 import io.cdap.cdap.data2.metadata.writer.DefaultMetadataServiceClient;
 import io.cdap.cdap.data2.metadata.writer.MessagingMetadataPublisher;
 import io.cdap.cdap.data2.metadata.writer.MetadataPublisher;
@@ -134,7 +132,6 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
     closeableResources.add(injector.getInstance(AccessControllerInstantiator.class));
     services.add(injector.getInstance(OperationalStatsService.class));
     services.add(injector.getInstance(SecureStoreService.class));
-    services.add(injector.getInstance(DatasetOpExecutorService.class));
     services.add(injector.getInstance(ServiceStore.class));
 
     Binding<ZKClientService> zkBinding = injector.getExistingBinding(
@@ -148,8 +145,6 @@ public class AppFabricServiceMain extends AbstractServiceMain<EnvironmentOptions
         Constants.AppFabric.RemoteExecution.class));
     services.add(new TwillRunnerServiceWrapper(remoteTwillRunner));
     services.add(new TwillRunnerServiceWrapper(injector.getInstance(TwillRunnerService.class)));
-    services.add(new RetryOnStartFailureService(() -> injector.getInstance(DatasetService.class),
-        RetryStrategies.exponentialDelay(200, 5000, TimeUnit.MILLISECONDS)));
     services.add(injector.getInstance(AppFabricServer.class));
     services.add(new RetryOnStartFailureService(
         () -> injector.getInstance(NamespaceInitializerService.class),


### PR DESCRIPTION
[CDAP-21096] Run dataset executor and service on appfabric processor only

### Context

* Earlier dataset `DatasetService` and `DatasetOpExecutorService` were triggered and run on both appfabric server and processor.
* Sometimes due to concurrency issue, such errors were seen:
    * IllegalArgumentException: Requested dataset type is not available <module class path>
    * Could not instantiate instance of dataset module class <module class path> for module dataset_module:<module-name> using jarLocation null

### Change Description

Remove launch and run of `DatasetService` and `DatasetOpExecutorService` services from AppfabricServiceMain and let it run from `AppfabricProcessorService` to avoid concurrency issues.

### Verification

- [x] Unit Tests
- [x] CDAP Sandbox
- [x] Distributed docker image

[CDAP-21096]: https://cdap.atlassian.net/browse/CDAP-21096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ