### PR TITLE
[CDAP-21027] Add java dependency on common-io:2.12.0 in k8s profile of cdap-master/pom.xml

### DIFF
--- a/cdap-master/pom.xml
+++ b/cdap-master/pom.xml
@@ -943,6 +943,7 @@
     <profile>
       <id>k8s</id>
       <properties>
+        <commons-io.version>2.12.0</commons-io.version>
         <stage.hadoop.lib.dir>${stage.opt.dir}/lib/hadoop</stage.hadoop.lib.dir>
         <stage.master.environments.ext.dir>${stage.opt.dir}/ext/environments</stage.master.environments.ext.dir>
       </properties>
@@ -963,6 +964,11 @@
         <dependency>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-to-slf4j</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+          <version>${commons-io.version}</version>
         </dependency>
       </dependencies>
 


### PR DESCRIPTION
Add java dependency on common-io:2.12.0 in k8s profile of cdap-master/pom.xml

### Context

After the change https://github.com/cdapio/cdap/pull/15878, common-io:2.8.0 version was used by k8s profile. It caused exception in  [MasterEnvironmentMain.java#L110](https://github.com/cdapio/cdap/blob/2d51333c859f6b86e10c04387da66334aa0b5aea/cdap-app-fabric/src/main/java/io/cdap/cdap/master/environment/k8s/MasterEnvironmentMain.java#L110). This causes `file-localizer container` in TaskWorker and `PreviewRunner` pods to crash.

**Code:**

```java
FileUtils.copyDirectory(new File(options.getExtraConfPath()), new File("."));
```

**Error:**

```java
java.lang.reflect.InvocationTargetException: null
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at io.cdap.cdap.master.environment.k8s.MasterEnvironmentMain.main(MasterEnvironmentMain.java:78)
Caused by: java.io.IOException: Failed setLastModified on /config
        at org.apache.commons.io.FileUtils.setLastModified(FileUtils.java:2561)
        at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1361)
        at org.apache.commons.io.FileUtils.copyDirectory(FileUtils.java:733)
        at org.apache.commons.io.FileUtils.copyDirectory(FileUtils.java:659)
        at org.apache.commons.io.FileUtils.copyDirectory(FileUtils.java:555)
        at org.apache.commons.io.FileUtils.copyDirectory(FileUtils.java:521)
        at io.cdap.cdap.master.environment.k8s.MasterEnvironmentMain.doMain(MasterEnvironmentMain.java:110)
        ... 5 common frames omitted
```

### Change Description

Added explicit dependency on `common-io:2.12.0`.

This version has the probable fix: https://github.com/apache/commons-io/pull/377

### Verification

- [x] Unit Test
- [x] CDAP Sandbox
- [x] Distributed docker image