### PR TITLE
[CDAP-21144] Spanner Compression for String & bytes type fields

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -1270,6 +1270,16 @@
   </property>
 
   <property>
+    <name>data.storage.properties.gcp-spanner.compression.config</name>
+    <value>application_specs:application_data:SNAPPY,provisioner_data:provisioner_task_info:SNAPPY,destination_fields_table:destination_data:SNAPPY,summary_fields_table:destination_data:SNAPPY,run_records:run_record_data:SNAPPY</value>
+    <description>
+      Represents table_name:column_name:compressor_type which possibly can cross spanner cell limit
+      and will need compression to reduce size.
+      WARNING: Removing fields from here is a backward incompatible operation.
+    </description>
+  </property>
+
+  <property>
     <name>data.storage.properties.gcp-spanner.tx.runner.initial.delay.ms</name>
     <value>500</value>
     <description>

--- a/cdap-storage-ext-spanner/pom.xml
+++ b/cdap-storage-ext-spanner/pom.xml
@@ -77,6 +77,11 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>1.1.10.7</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerFieldValidator.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerFieldValidator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.storage.spanner;
+
+import io.cdap.cdap.spi.data.InvalidFieldException;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.FieldValidator;
+import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.storage.spanner.compression.CompressorType;
+import java.util.Collection;
+
+/**
+ * Spanner specific implementation of {@link FieldValidator}.
+ */
+public class SpannerFieldValidator extends FieldValidator {
+
+  private final SpannerStructuredTableSchema tableSchema;
+
+  /**
+   * Constructor for SpannerFieldValidator.
+   *
+   * @param tableSchema the {@link SpannerStructuredTableSchema} to be used.
+   */
+  public SpannerFieldValidator(SpannerStructuredTableSchema tableSchema) {
+    super(tableSchema);
+    this.tableSchema = tableSchema;
+  }
+
+  /**
+   * Validates the given {@link Range}.
+   *
+   * @param range the {@link Range} to validate.
+   * @throws InvalidFieldException if the range field is a compressed columns.
+   */
+  @Override
+  public void validateScanRange(Range range) throws InvalidFieldException {
+    super.validateScanRange(range);
+    for (Field field : range.getBegin()) {
+      CompressorType compressor = tableSchema.getCompressorType(field.getName());
+      if (compressor != null) {
+        throw new InvalidFieldException(tableSchema.getTableId(), field.getName(),
+            "is compression enabled for which range queries are not allowed");
+      }
+    }
+  }
+
+  /**
+   * Validates the given filter indexes.
+   *
+   * @param filterIndexes the filter indexes to validate.
+   * @throws InvalidFieldException if any filter index is a compressed column.
+   */
+  public void validateFilterIndexes(Collection<Field<?>> filterIndexes) {
+    for (Field field : filterIndexes) {
+      CompressorType compressor = tableSchema.getCompressorType(field.getName());
+      if (compressor != null) {
+        throw new InvalidFieldException(tableSchema.getTableId(), field.getName(),
+            "is compression enabled for which filter is not allowed");
+      }
+    }
+  }
+}

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStorageProvider.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStorageProvider.java
@@ -40,7 +40,7 @@ import java.util.Map;
  *   <li>data.storage.properties.gcp-spanner.database: &lt;Spanner database name&gt;</li>
  * </ul>>
  *
- * Optional configuration
+ * <p>Optional configuration
  * <ul>
  *   <li>data.storage.properties.gcp-spanner.credentials.path: &lt;GCP service account file&gt;</li>
  * </ul>
@@ -51,6 +51,7 @@ public class SpannerStorageProvider implements StorageProvider {
   static final String INSTANCE = "instance";
   static final String DATABASE = "database";
   static final String CREDENTIALS_PATH = "credentials.path";
+  public static final String COMPRESSION_CONFIG = "compression.config";
 
   private Spanner spanner;
   private SpannerStructuredTableAdmin admin;
@@ -89,7 +90,7 @@ public class SpannerStorageProvider implements StorageProvider {
         database);
 
     this.spanner = options.getService();
-    this.admin = new SpannerStructuredTableAdmin(spanner, databaseId);
+    this.admin = new SpannerStructuredTableAdmin(spanner, databaseId, conf.get(COMPRESSION_CONFIG));
     this.txRunner = new RetryingSpannerTransactionRunner(conf, admin);
   }
 

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredRow.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredRow.java
@@ -16,13 +16,18 @@
 
 package io.cdap.cdap.storage.spanner;
 
+import com.google.api.client.util.Throwables;
 import com.google.cloud.spanner.Struct;
 import io.cdap.cdap.spi.data.InvalidFieldException;
 import io.cdap.cdap.spi.data.StructuredRow;
-import io.cdap.cdap.spi.data.table.StructuredTableSchema;
+import io.cdap.cdap.spi.data.compression.Compressor;
 import io.cdap.cdap.spi.data.table.field.Field;
 import io.cdap.cdap.spi.data.table.field.FieldType;
 import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.storage.spanner.compression.CompressionConfig;
+import io.cdap.cdap.storage.spanner.compression.CompressorFactory;
+import io.cdap.cdap.storage.spanner.compression.CompressorType;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
@@ -33,11 +38,11 @@ import javax.annotation.Nullable;
  */
 public class SpannerStructuredRow implements StructuredRow {
 
-  private final StructuredTableSchema schema;
+  private final SpannerStructuredTableSchema schema;
   private final Struct struct;
   private volatile Collection<Field<?>> primaryKeys;
 
-  public SpannerStructuredRow(StructuredTableSchema schema, Struct struct) {
+  public SpannerStructuredRow(SpannerStructuredTableSchema schema, Struct struct) {
     this.schema = schema;
     this.struct = struct;
   }
@@ -63,7 +68,23 @@ public class SpannerStructuredRow implements StructuredRow {
   @Nullable
   @Override
   public String getString(String fieldName) throws InvalidFieldException {
-    return isNull(fieldName) ? null : struct.getString(fieldName);
+    if (isNull(fieldName)) {
+      return null;
+    }
+
+    String value = struct.getString(fieldName);
+    CompressorType compressorType = getCompressorType(fieldName);
+    if (value == null || compressorType == null) {
+      return value;
+    }
+
+    Compressor compressor = CompressorFactory.getCompressor(compressorType);
+    try {
+      value = compressor.decompress(value);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    return value;
   }
 
   @Nullable
@@ -81,7 +102,23 @@ public class SpannerStructuredRow implements StructuredRow {
   @Nullable
   @Override
   public byte[] getBytes(String fieldName) throws InvalidFieldException {
-    return isNull(fieldName) ? null : struct.getBytes(fieldName).toByteArray();
+    if (isNull(fieldName)) {
+      return null;
+    }
+
+    byte[] value = struct.getBytes(fieldName).toByteArray();
+    CompressorType compressorType = getCompressorType(fieldName);
+    if (value == null || compressorType == null) {
+      return value;
+    }
+
+    try {
+      Compressor compressor = CompressorFactory.getCompressor(compressorType);
+      value = compressor.decompress(value);
+    } catch (IOException e) {
+      throw Throwables.propagate(e);
+    }
+    return value;
   }
 
   @Override
@@ -126,6 +163,20 @@ public class SpannerStructuredRow implements StructuredRow {
       this.primaryKeys = primaryKeys;
       return primaryKeys;
     }
+  }
+
+  /**
+   * Returns compression status of the field stored in db, if the field is compression enabled.
+   */
+  private CompressorType getCompressorType(String fieldName) {
+    // First check if the field is compression enabled based on cConf.
+    if (schema.getCompressorType(fieldName) == null) {
+      return null;
+    }
+
+    // Use the compression status read from the db.
+    String compressorType = getString(fieldName + CompressionConfig.COMPRESSED_COLUMN_SUFFIX);
+    return compressorType == null ? null : CompressorType.fromString(compressorType);
   }
 
   @Override

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTable.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTable.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.storage.spanner;
 
+import com.google.api.client.util.Throwables;
 import com.google.cloud.ByteArray;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.KeyRange;
@@ -31,12 +32,14 @@ import io.cdap.cdap.spi.data.InvalidFieldException;
 import io.cdap.cdap.spi.data.SortOrder;
 import io.cdap.cdap.spi.data.StructuredRow;
 import io.cdap.cdap.spi.data.StructuredTable;
-import io.cdap.cdap.spi.data.table.StructuredTableSchema;
+import io.cdap.cdap.spi.data.compression.Compressor;
 import io.cdap.cdap.spi.data.table.field.Field;
 import io.cdap.cdap.spi.data.table.field.FieldType;
-import io.cdap.cdap.spi.data.table.field.FieldValidator;
 import io.cdap.cdap.spi.data.table.field.Fields;
 import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.cdap.storage.spanner.compression.CompressionConfig;
+import io.cdap.cdap.storage.spanner.compression.CompressorFactory;
+import io.cdap.cdap.storage.spanner.compression.CompressorType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -60,16 +63,27 @@ import org.slf4j.LoggerFactory;
 public class SpannerStructuredTable implements StructuredTable {
 
   private static final Logger LOG = LoggerFactory.getLogger(SpannerStructuredTable.class);
+  /**
+   * Spanner limit for string field in bytes.
+   */
+  private static final int STRING_LIMIT = 2621440;
+  /**
+   * Spanner limit for byte[] field in bytes.
+   */
+  private static final int BYTES_LIMIT = 10 * 1024 * 1024;
 
   private final TransactionContext transactionContext;
-  private final StructuredTableSchema schema;
-  private final FieldValidator fieldValidator;
+  private final SpannerStructuredTableSchema schema;
+  private final SpannerFieldValidator fieldValidator;
 
+  /**
+   * Constructor for {@link SpannerStructuredTable}.
+   */
   public SpannerStructuredTable(TransactionContext transactionContext,
-      StructuredTableSchema schema) {
+      SpannerStructuredTableSchema schema) {
     this.transactionContext = transactionContext;
     this.schema = schema;
-    this.fieldValidator = new FieldValidator(schema);
+    this.fieldValidator = new SpannerFieldValidator(schema);
   }
 
   @Override
@@ -110,6 +124,13 @@ public class SpannerStructuredTable implements StructuredTable {
         primaryKeyFields.add(field);
       } else {
         updateFields.add(field);
+        CompressorType compressorType = determineCompressorForField(field);
+        if (compressorType != null) {
+          Field<String> compressedField = Fields.stringField(
+              field.getName() + CompressionConfig.COMPRESSED_COLUMN_SUFFIX,
+              compressorType.name());
+          updateFields.add(compressedField);
+        }
       }
       fieldNames.add(field.getName());
     }
@@ -127,11 +148,16 @@ public class SpannerStructuredTable implements StructuredTable {
 
     LOG.trace("Updating row: {}", sql);
 
-    Statement statement = fields.stream()
-        .reduce(Statement.newBuilder(sql),
-            (builder, field) -> builder.bind(field.getName()).to(getValue(field)),
-            (builder1, builder2) -> builder1)
-        .build();
+    Statement.Builder builder = Statement.newBuilder(sql);
+    // Bind values for updateFields.
+    for (Field<?> field : updateFields) {
+      builder.bind(field.getName()).to(getValue(field));
+    }
+    // Bind values for primaryKeyFields.
+    for (Field<?> field : primaryKeyFields) {
+      builder.bind(field.getName()).to(getValue(field));
+    }
+    Statement statement = builder.build();
 
     transactionContext.executeUpdate(statement);
   }
@@ -224,6 +250,7 @@ public class SpannerStructuredTable implements StructuredTable {
       Collection<Field<?>> filterIndexes)
       throws InvalidFieldException {
     fieldValidator.validateScanRange(keyRange);
+    fieldValidator.validateFilterIndexes(filterIndexes);
     filterIndexes.forEach(fieldValidator::validateField);
     if (!schema.isIndexColumns(
         filterIndexes.stream().map(Field::getName).collect(Collectors.toList()))) {
@@ -442,6 +469,7 @@ public class SpannerStructuredTable implements StructuredTable {
   @Override
   public long count(Collection<Range> keyRanges, Collection<Field<?>> filterIndexes)
       throws InvalidFieldException, IOException {
+    fieldValidator.validateFilterIndexes(filterIndexes);
     try (ResultSet resultSet = transactionContext.executeQuery(
         getCountStatement(keyRanges, filterIndexes))) {
       if (!resultSet.next()) {
@@ -608,6 +636,13 @@ public class SpannerStructuredTable implements StructuredTable {
     for (Field<?> field : fields) {
       fieldValidator.validateField(field);
       insertFields.add(field);
+      CompressorType compressorType = determineCompressorForField(field);
+      if (compressorType != null) {
+        Field<String> compressedField = Fields.stringField(
+            field.getName() + CompressionConfig.COMPRESSED_COLUMN_SUFFIX,
+            compressorType.name());
+        insertFields.add(compressedField);
+      }
     }
 
     String sql = "INSERT INTO " + escapeName(schema.getTableId().getName()) + " ("
@@ -618,13 +653,34 @@ public class SpannerStructuredTable implements StructuredTable {
 
     LOG.trace("Inserting row: {}", sql);
 
-    Statement statement = fields.stream()
+    Statement statement = insertFields.stream()
         .reduce(Statement.newBuilder(sql),
             (builder, field) -> builder.bind(field.getName()).to(getValue(field)),
             (builder1, builder2) -> builder1)
         .build();
 
     transactionContext.executeUpdate(statement);
+  }
+
+  private CompressorType determineCompressorForField(Field field) {
+    Object value = field.getValue();
+    if (value == null) {
+      return null;
+    }
+
+    CompressorType compressor = schema.getCompressorType(field.getName());
+    if (compressor == null) {
+      return null;
+    }
+
+    switch (field.getFieldType()) {
+      case STRING:
+        return ((String) value).length() > STRING_LIMIT ? compressor : null;
+      case BYTES:
+        return ((byte[]) value).length > BYTES_LIMIT ? compressor : null;
+      default:
+        return null;
+    }
   }
 
   private Key createKey(Collection<Field<?>> fields) {
@@ -647,15 +703,44 @@ public class SpannerStructuredTable implements StructuredTable {
       case DOUBLE:
         return Value.float64((Double) value);
       case STRING:
-        return Value.string((String) value);
+        return Value.string(getStringValue(field));
       case BYTES:
-        return Value.bytes(value == null ? null : (ByteArray.copyFrom((byte[]) value)));
+        return Value.bytes(value == null ? null : getBytesValue(field));
       case BOOLEAN:
         return Value.bool((Boolean) value);
     }
 
     // This shouldn't happen
     throw new IllegalArgumentException("Unsupported field type " + field.getFieldType());
+  }
+
+
+  private String getStringValue(Field field) {
+    String val = (String) field.getValue();
+    CompressorType compressorType = determineCompressorForField(field);
+    if (compressorType != null) {
+      Compressor compressor = CompressorFactory.getCompressor(compressorType);
+      try {
+        val = compressor.compress(val);
+      } catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+    }
+    return val;
+  }
+
+  private ByteArray getBytesValue(Field field) {
+    byte[] val = (byte[]) field.getValue();
+    CompressorType compressorType = determineCompressorForField(field);
+    if (compressorType != null) {
+      Compressor compressor = CompressorFactory.getCompressor(compressorType);
+      try {
+        val = compressor.compress(val);
+      } catch (IOException e) {
+        throw Throwables.propagate(e);
+      }
+    }
+    return ByteArray.copyFrom(val);
   }
 
   /**
@@ -751,10 +836,10 @@ public class SpannerStructuredTable implements StructuredTable {
    */
   private static final class ResultSetIterator extends AbstractCloseableIterator<StructuredRow> {
 
-    private final StructuredTableSchema schema;
+    private final SpannerStructuredTableSchema schema;
     private final ResultSet resultSet;
 
-    ResultSetIterator(StructuredTableSchema schema, ResultSet resultSet) {
+    ResultSetIterator(SpannerStructuredTableSchema schema, ResultSet resultSet) {
       this.schema = schema;
       this.resultSet = resultSet;
     }

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableAdmin.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableAdmin.java
@@ -33,6 +33,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.common.util.concurrent.Uninterruptibles;
+import io.cdap.cdap.spi.data.InvalidFieldException;
 import io.cdap.cdap.spi.data.StructuredTableAdmin;
 import io.cdap.cdap.spi.data.TableAlreadyExistsException;
 import io.cdap.cdap.spi.data.TableDuplicateUpdateException;
@@ -42,11 +43,16 @@ import io.cdap.cdap.spi.data.table.StructuredTableId;
 import io.cdap.cdap.spi.data.table.StructuredTableSchema;
 import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
 import io.cdap.cdap.spi.data.table.field.FieldType;
+import io.cdap.cdap.spi.data.table.field.FieldType.Type;
+import io.cdap.cdap.storage.spanner.compression.CompressionConfig;
+import io.cdap.cdap.storage.spanner.compression.DatabaseCompressionConfig;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -64,7 +70,8 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
   private final DatabaseId databaseId;
   private final DatabaseAdminClient adminClient;
   private final DatabaseClient databaseClient;
-  private final LoadingCache<StructuredTableId, StructuredTableSchema> schemaCache;
+  private final DatabaseCompressionConfig databaseCompressionConfig;
+  private final LoadingCache<StructuredTableId, SpannerStructuredTableSchema> schemaCache;
 
   static String getIndexName(StructuredTableId tableId, String column) {
     return String.format("%s_%s_idx", tableId.getName(), column);
@@ -76,14 +83,16 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
    * @param spanner    the gcp Spanner service.
    * @param databaseId the ID of the Spanner instance database.
    */
-  public SpannerStructuredTableAdmin(Spanner spanner, DatabaseId databaseId) {
+  public SpannerStructuredTableAdmin(Spanner spanner, DatabaseId databaseId,
+      String databaseCompressionConfig) {
     this.databaseId = databaseId;
     this.adminClient = spanner.getDatabaseAdminClient();
     this.databaseClient = spanner.getDatabaseClient(databaseId);
+    this.databaseCompressionConfig = DatabaseCompressionConfig.parse(databaseCompressionConfig);
     this.schemaCache = CacheBuilder.newBuilder()
-        .build(new CacheLoader<StructuredTableId, StructuredTableSchema>() {
+        .build(new CacheLoader<StructuredTableId, SpannerStructuredTableSchema>() {
           @Override
-          public StructuredTableSchema load(StructuredTableId tableId) {
+          public SpannerStructuredTableSchema load(StructuredTableId tableId) {
             return loadSchema(tableId);
           }
         });
@@ -124,9 +133,9 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
 
   private List<String> getCreateTableStatements(StructuredTableSpecification spec) {
     List<String> statements = new ArrayList<>();
-    statements.add(getCreateTableStatement(spec));
+    StructuredTableSchema schema = createValidatedSchema(spec);
 
-    StructuredTableSchema schema = new StructuredTableSchema(spec);
+    statements.add(getCreateTableStatement(schema));
     spec.getIndexes()
         .forEach(idxColumn -> statements.add(getCreateIndexStatement(idxColumn, schema)));
 
@@ -145,6 +154,13 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
 
   @Override
   public StructuredTableSchema getSchema(StructuredTableId tableId) throws TableNotFoundException {
+    return getSpannerStructuredTableSchema(tableId);
+  }
+
+  /**
+   * Returns SpannerStructuredSchema for given tableId.
+   */
+  SpannerStructuredTableSchema getSpannerStructuredTableSchema(StructuredTableId tableId) {
     try {
       return schemaCache.get(tableId);
     } catch (ExecutionException | UncheckedExecutionException e) {
@@ -159,7 +175,7 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
       throws IOException, TableNotFoundException, TableSchemaIncompatibleException {
     StructuredTableId tableId = spec.getTableId();
     StructuredTableSchema cachedTableSchema = getSchema(tableId);
-    StructuredTableSchema newTableSchema = convertSpecToCompatibleSchema(spec);
+    StructuredTableSchema newTableSchema = createValidatedSchema(spec);
 
     if (newTableSchema.equals(cachedTableSchema)) {
       LOG.trace("The table schema is already up to date: {}", tableId);
@@ -197,8 +213,84 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
     }
   }
 
+
+  /**
+   * Converts a {@link StructuredTableSpecification} to a {@link SpannerStructuredTableSchema}.
+   * <p>
+   * This method processes the provided table specification to generate a corresponding Spanner
+   * schema. It includes the following steps:
+   * </p>
+   * <ol>
+   *   <li>Converts each field in the specification to a Spanner {@link FieldType}.</li>
+   *   <li>Retrieves the compression configurations associated with the table.</li>
+   *   <li>Validates and adds compressed fields to the schema if applicable.</li>
+   * </ol>
+   *
+   * @param spec the {@link StructuredTableSpecification} to be converted
+   * @return a {@link SpannerStructuredTableSchema} representing the converted schema
+   * @throws IllegalArgumentException if an error occurs during the conversion process, such as:
+   *                                  <ul>
+   *                                    <li>Attempting to compress a primary key field / index field.</li>
+   *                                    <li>Issues retrieving or processing compression configurations.</li>
+   *                                  </ul>
+   */
+  private SpannerStructuredTableSchema createValidatedSchema(StructuredTableSpecification spec) {
+    List<FieldType> convertedFieldTypes = new ArrayList<>();
+    Set<String> fieldNames = new HashSet<>();
+
+    // Convert each field in the specification to a Spanner FieldType
+    for (FieldType field : spec.getFieldTypes()) {
+      String spannerType = getSpannerType(field.getType());
+      FieldType.Type convertedType = fromSpannerType(spannerType);
+
+      convertedFieldTypes.add(new FieldType(field.getName(), convertedType));
+      fieldNames.add(field.getName());
+    }
+
+    // Retrieve compression configurations for the table.
+    Map<String, CompressionConfig> tableCompressionConfig = databaseCompressionConfig.get(
+        spec.getTableId().getName());
+
+    // Add compressed fields to field types if applicable.
+    if (tableCompressionConfig != null) {
+      addCompressedFields(spec, fieldNames, convertedFieldTypes, tableCompressionConfig);
+    }
+
+    return new SpannerStructuredTableSchema(spec.getTableId(), convertedFieldTypes,
+        spec.getPrimaryKeys(), spec.getIndexes(), tableCompressionConfig);
+  }
+
+  private void addCompressedFields(StructuredTableSpecification spec, Set<String> fieldNames,
+      List<FieldType> fieldTypes,
+      Map<String, CompressionConfig> tableCompressionConfig) {
+    Set<String> primaryKeys = new HashSet<>(spec.getPrimaryKeys());
+    Set<String> indexes = new HashSet<>(spec.getIndexes());
+
+    for (Map.Entry<String, CompressionConfig> entry : tableCompressionConfig.entrySet()) {
+      String fieldName = entry.getKey();
+      String compressedFieldName = fieldName + CompressionConfig.COMPRESSED_COLUMN_SUFFIX;
+
+      if (fieldNames.contains(fieldName) && !fieldNames.contains(compressedFieldName)) {
+        // Disallow having primary keys compressed as there is a slight chance of collision
+        // between compressed and uncompressed value.
+        if (primaryKeys.contains(fieldName)) {
+          throw new InvalidFieldException(spec.getTableId(), fieldName,
+              "Invalid attempt to compress primary key");
+        }
+        // Disallow having indexes on compressed columns.
+        if (indexes.contains(fieldName)) {
+          throw new InvalidFieldException(spec.getTableId(), fieldName,
+              "Invalid attempt to compress indexed column");
+        }
+
+        fieldTypes.add(new FieldType(compressedFieldName, Type.STRING));
+      }
+    }
+  }
+
   @VisibleForTesting
   static StructuredTableSchema convertSpecToCompatibleSchema(StructuredTableSpecification spec) {
+    // TODO: [CDAP-21101] Update unit tests to use non static method.
     List<FieldType> convertedFieldTypes =
         spec.getFieldTypes().stream()
             .map(
@@ -247,7 +339,7 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
     return databaseClient;
   }
 
-  private StructuredTableSchema loadSchema(StructuredTableId tableId)
+  private SpannerStructuredTableSchema loadSchema(StructuredTableId tableId)
       throws TableNotFoundException {
     // Query the information_schema to reconstruct the StructuredTableSchema
     // See https://cloud.google.com/spanner/docs/information-schema for details
@@ -293,22 +385,22 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
     // Primary Key fields can still be overly added when it's part of other index, exclude them
     Set<String> nonPrimaryKeyIndexes = Sets.difference(indexes, new HashSet<>(primaryKeys));
 
-    return new StructuredTableSchema(tableId, fields, primaryKeys, nonPrimaryKeyIndexes);
+    return new SpannerStructuredTableSchema(tableId, fields, primaryKeys, nonPrimaryKeyIndexes,
+        databaseCompressionConfig.get(tableId.getName()));
   }
 
-  private String getCreateTableStatement(StructuredTableSpecification spec) {
-    Set<String> primaryKeys = spec.getPrimaryKeys().stream()
+  private String getCreateTableStatement(StructuredTableSchema schema) {
+    Set<String> primaryKeys = schema.getPrimaryKeys().stream()
         .map(this::escapeName)
         .collect(Collectors.toCollection(LinkedHashSet::new));
 
-    String statement = spec.getFieldTypes().stream()
-        .map(f -> {
-          String fieldName = f.getName();
+    String statement = schema.getFieldNames().stream()
+        .map(fieldName -> {
           return escapeName(fieldName) + " "
-              + getSpannerType(f.getType())
+              + getSpannerType(Objects.requireNonNull(schema.getType(fieldName)))
               + (primaryKeys.contains(fieldName) ? " NOT NULL" : "");
         }).collect(Collectors.joining(", ",
-            "CREATE TABLE " + escapeName(spec.getTableId().getName()) + " (", ")"));
+            "CREATE TABLE " + escapeName(schema.getTableId().getName()) + " (", ")"));
 
     if (primaryKeys.isEmpty()) {
       return statement;
@@ -376,8 +468,9 @@ public class SpannerStructuredTableAdmin implements StructuredTableAdmin {
 
   private void createTable(StructuredTableSpecification spec) throws IOException {
     List<String> ddlStatements = new ArrayList<>();
-    ddlStatements.add(getCreateTableStatement(spec));
-    StructuredTableSchema schema = new StructuredTableSchema(spec);
+    StructuredTableSchema schema = createValidatedSchema(spec);
+
+    ddlStatements.add(getCreateTableStatement(schema));
     spec.getIndexes()
         .forEach(idxColumn -> ddlStatements.add(getCreateIndexStatement(idxColumn, schema)));
     executeDdlStatements(ddlStatements);

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableSchema.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerStructuredTableSchema.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.storage.spanner;
+
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+import io.cdap.cdap.spi.data.table.StructuredTableSchema;
+import io.cdap.cdap.spi.data.table.field.FieldType;
+import io.cdap.cdap.storage.spanner.compression.CompressionConfig;
+import io.cdap.cdap.storage.spanner.compression.CompressorType;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wrapper over {@link StructuredTableSchema} that stores spanner specific config related to
+ * compression along with the table schema.
+ */
+public class SpannerStructuredTableSchema extends StructuredTableSchema {
+
+  /**
+   * Map of column name and compression config.
+   */
+  private final Map<String, CompressionConfig> compressionConfigs;
+
+  /**
+   * Constructor for {@link SpannerStructuredTableSchema}.
+   */
+  SpannerStructuredTableSchema(StructuredTableId tableId,
+      List<FieldType> fields,
+      List<String> primaryKeys,
+      Collection<String> indexes,
+      Map<String, CompressionConfig> compressionConfigs) {
+    super(tableId, fields, primaryKeys, indexes);
+    this.compressionConfigs = compressionConfigs == null ? Collections.emptyMap()
+        : Collections.unmodifiableMap(compressionConfigs);
+  }
+
+  /**
+   * Retrieves compressor type for field.
+   *
+   * @param field column name for which compressor needs to be determined.
+   * @return compressor type set in cConf
+   */
+  CompressorType getCompressorType(String field) {
+    CompressionConfig config = compressionConfigs.get(field);
+    return config == null ? null : config.getCompressorType();
+  }
+}

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerTransactionRunner.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/SpannerTransactionRunner.java
@@ -37,7 +37,8 @@ public class SpannerTransactionRunner implements TransactionRunner {
   public void run(TxRunnable runnable) throws TransactionException {
     try {
       admin.getDatabaseClient().readWriteTransaction().allowNestedTransaction().run(context -> {
-        runnable.run(tableId -> new SpannerStructuredTable(context, admin.getSchema(tableId)));
+        runnable.run(tableId -> new SpannerStructuredTable(context,
+            admin.getSpannerStructuredTableSchema(tableId)));
         return null;
       });
     } catch (SpannerException e) {

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/compression/CompressionConfig.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/compression/CompressionConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.storage.spanner.compression;
+
+/**
+ * Configuration class for compression settings.
+ */
+public class CompressionConfig {
+
+  /**
+   * Suffix for compressed columns.
+   */
+  public static final String COMPRESSED_COLUMN_SUFFIX = "_compressor_type";
+
+  private final CompressorType compressorType;
+
+  /**
+   * Constructor for {@link CompressionConfig}.
+   *
+   * @param compressorType the {@link CompressorType} to be used.
+   */
+  public CompressionConfig(CompressorType compressorType) {
+    this.compressorType = compressorType;
+  }
+
+  /**
+   * Returns the {@link CompressorType}.
+   */
+  public CompressorType getCompressorType() {
+    return compressorType;
+  }
+}

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/compression/CompressorFactory.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/compression/CompressorFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.storage.spanner.compression;
+
+import com.google.common.collect.ImmutableMap;
+import io.cdap.cdap.spi.data.compression.Compressor;
+import java.util.Map;
+
+/**
+ * Factory class for creating and retrieving {@link Compressor} instances based on
+ * {@link CompressorType}.
+ */
+public class CompressorFactory {
+
+  private static final Map<CompressorType, Compressor> compressors = ImmutableMap.<CompressorType, Compressor>builder()
+      .put(CompressorType.SNAPPY, new SnappyCompressor()).build();
+
+  /**
+   * Method to retrieve the Compressor instance for a given CompressorType.
+   */
+  public static Compressor getCompressor(CompressorType type) {
+    Compressor compressor = compressors.get(type);
+    if (compressor == null) {
+      throw new IllegalArgumentException("Unsupported compression type: " + type);
+    }
+    return compressor;
+  }
+}

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/compression/CompressorType.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/compression/CompressorType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.storage.spanner.compression;
+
+/**
+ * Identifies the compressor type.
+ */
+public enum CompressorType {
+  SNAPPY;
+
+  /**
+   * Returns the {@link CompressorType} for the given string value.
+   *
+   * @param value the string value representing the compressor type
+   * @return the corresponding {@link CompressorType}, or {@code null} if the value is invalid
+   */
+  public static CompressorType fromString(String value) {
+    if (value == null || value.isEmpty()) {
+      return null;
+    }
+    return valueOf(value.toUpperCase());
+  }
+}

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/compression/DatabaseCompressionConfig.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/compression/DatabaseCompressionConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.storage.spanner.compression;
+
+import io.cdap.cdap.storage.spanner.SpannerStorageProvider;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class manages compression configurations for the Spanner database.
+ */
+public class DatabaseCompressionConfig {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DatabaseCompressionConfig.class);
+
+  private final Map<String, Map<String, CompressionConfig>> configs;
+
+  private DatabaseCompressionConfig(@Nonnull Map<String, Map<String, CompressionConfig>> configs) {
+    this.configs = Collections.unmodifiableMap(configs);
+  }
+
+  /**
+   * Parses the compression configuration string and creates a DatabaseCompressionConfig instance.
+   * The expected format is a comma-separated list of table:column:compressor, where table is the
+   * table name, column is the column name, and compressor is the compressor type (e.g.,
+   * "table_1:column_1:SNAPPY").
+   *
+   * @param compressionConfig compression config string fetched from {@link SpannerStorageProvider}
+   * @return parsed DatabaseCompressionConfig or empty configuration if the input is null or empty.
+   * @throws IllegalArgumentException if the compression configuration string has an invalid
+   *                                  format.
+   */
+  public static DatabaseCompressionConfig parse(String compressionConfig) {
+    Map<String, Map<String, CompressionConfig>> tableCompressionConfigs = new HashMap<>();
+
+    if (compressionConfig == null || compressionConfig.isEmpty()) {
+      LOG.warn("Spanner is being used without compression.");
+      return new DatabaseCompressionConfig(tableCompressionConfigs);
+    }
+
+    String[] configs = compressionConfig.split(",");
+    for (String config : configs) {
+      String[] parts = config.split(":");
+      if (parts.length == 3) {
+        String tableName = parts[0];
+        String columnName = parts[1];
+        CompressorType compressorType = CompressorType.fromString(parts[2]);
+        tableCompressionConfigs.computeIfAbsent(tableName, k -> new HashMap<>())
+            .put(columnName, new CompressionConfig(compressorType));
+      } else {
+        throw new IllegalArgumentException(
+            "Invalid format for Spanner property " + SpannerStorageProvider.COMPRESSION_CONFIG);
+      }
+    }
+    return new DatabaseCompressionConfig(tableCompressionConfigs);
+  }
+
+  /**
+   * Returns map of column names to CompressionConfig for the specified table, or {@code null} if no
+   * compression configuration exists for the table.
+   *
+   * @param tableName the name of the table for which to retrieve the compression configuration.
+   * @return map
+   */
+  public Map<String, CompressionConfig> get(String tableName) {
+    return configs.get(tableName);
+  }
+}

--- a/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/compression/SnappyCompressor.java
+++ b/cdap-storage-ext-spanner/src/main/java/io/cdap/cdap/storage/spanner/compression/SnappyCompressor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.storage.spanner.compression;
+
+import io.cdap.cdap.spi.data.compression.Compressor;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.annotation.Nonnull;
+import org.xerial.snappy.Snappy;
+
+/**
+ * A {@link Compressor} that uses Snappy for compression and decompression.
+ */
+public class SnappyCompressor implements Compressor {
+
+  @Nonnull
+  @Override
+  public String compress(@Nonnull String data) throws IOException {
+    return Base64.getEncoder()
+        .encodeToString(Snappy.compress(data.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Nonnull
+  @Override
+  public byte[] compress(@Nonnull byte[] data) throws IOException {
+    return Snappy.compress(data);
+  }
+
+  @Nonnull
+  @Override
+  public String decompress(@Nonnull String compressedData) throws IOException {
+    return new String(Snappy.uncompress(Base64.getDecoder().decode(compressedData)),
+        StandardCharsets.UTF_8);
+  }
+
+  @Nonnull
+  @Override
+  public byte[] decompress(@Nonnull byte[] compressedData) throws IOException {
+    return Snappy.uncompress(compressedData);
+  }
+}

--- a/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/compression/CompressorTypeTest.java
+++ b/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/compression/CompressorTypeTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.storage.spanner.compression;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link CompressorType}.
+ */
+public class CompressorTypeTest {
+
+  @Test
+  public void testFromString() {
+    Assert.assertNull(CompressorType.fromString(null));
+    Assert.assertNull(CompressorType.fromString(""));
+  }
+
+  @Test
+  public void testFromString_snappy() {
+    Assert.assertEquals(CompressorType.SNAPPY, CompressorType.fromString("SNAPPY"));
+    Assert.assertEquals(CompressorType.SNAPPY, CompressorType.fromString("snappy"));
+    Assert.assertEquals(CompressorType.SNAPPY, CompressorType.fromString("SnApPy"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFromString_InvalidType() {
+    CompressorType.fromString("INVALID");
+  }
+}

--- a/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/compression/SnappyCompressorTest.java
+++ b/cdap-storage-ext-spanner/src/test/java/io/cdap/cdap/storage/spanner/compression/SnappyCompressorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.storage.spanner.compression;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SnappyCompressor}.
+ */
+public class SnappyCompressorTest {
+
+  private final SnappyCompressor compressor = new SnappyCompressor();
+
+  @Test
+  public void testStringCompression() throws IOException {
+    String data = "This is a test string for Snappy compression.";
+    String compressed = compressor.compress(data);
+    String decompressed = compressor.decompress(compressed);
+    Assert.assertEquals(data, decompressed);
+  }
+
+  @Test
+  public void testStringCompression_EmptyString() throws IOException {
+    String data = "";
+    String compressed = compressor.compress(data);
+    String decompressed = compressor.decompress(compressed);
+    Assert.assertEquals(data, decompressed);
+  }
+
+  @Test(expected = IOException.class)
+  public void testStringDecompression_EmptyString() throws IOException {
+    String data = "";
+    compressor.decompress(data);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testStringCompression_NullString() throws IOException {
+    String data = null;
+    compressor.compress(data);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testStringDecompression_NullString() throws IOException {
+    String data = null;
+    compressor.decompress(data);
+  }
+
+  @Test
+  public void testBytesCompression() throws IOException {
+    byte[] data = "This is a test byte array for Snappy compression.".getBytes(
+        StandardCharsets.UTF_8);
+    byte[] compressed = compressor.compress(data);
+    byte[] decompressed = compressor.decompress(compressed);
+    Assert.assertArrayEquals(data, decompressed);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testBytesCompression_NullBytes() throws IOException {
+    byte[] data = null;
+    compressor.compress(data);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testBytesDecompression_NullBytes() throws IOException {
+    byte[] data = null;
+    compressor.decompress(data);
+  }
+
+  @Test(expected = IOException.class)
+  public void testInvalidCompressedData() throws IOException {
+    byte[] invalidData = new byte[0];
+    compressor.decompress(invalidData);
+  }
+}

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/compression/Compressor.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/compression/Compressor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2025 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.cdap.spi.data.compression;
+
+import java.io.IOException;
+
+/**
+ * An interface for compressing and decompressing data.
+ */
+public interface Compressor {
+
+  /**
+   * Compresses the given string data.
+   *
+   * @param data the string data to compress
+   * @return the compressed string data
+   * @throws IOException if there is an error during compression
+   */
+  String compress(String data) throws IOException;
+
+  /**
+   * Compresses the given byte array data.
+   *
+   * @param data the byte array data to compress
+   * @return the compressed byte array data
+   * @throws IOException if there is an error during compression
+   */
+  byte[] compress(byte[] data) throws IOException;
+
+  /**
+   * Decompresses the given compressed string data.
+   *
+   * @param compressedData the compressed string data
+   * @return the decompressed string data
+   * @throws IOException if there is an error during decompression
+   */
+  String decompress(String compressedData) throws IOException;
+
+  /**
+   * Decompresses the given compressed byte array data.
+   *
+   * @param compressedData the compressed byte array data
+   * @return the decompressed byte array data
+   * @throws IOException if there is an error during decompression
+   */
+  byte[] decompress(byte[] compressedData) throws IOException;
+}

--- a/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/field/FieldValidator.java
+++ b/cdap-storage-spi/src/main/java/io/cdap/cdap/spi/data/table/field/FieldValidator.java
@@ -28,7 +28,7 @@ import java.util.Set;
  * A field validator class which can be used to validate the given field.
  */
 @Beta
-public final class FieldValidator {
+public class FieldValidator {
 
   private final StructuredTableSchema tableSchema;
 


### PR DESCRIPTION
Columns to be compressed should be added to cConf
```table_name:column_name:compressor_type:(TO BE USED IN FUTURE)number_of_chunks```

All this would be part of the compressionConfig

**High level overview of changes:**
1. Specify the table.column in cConf that needs to be compressed
2. In Spanner implementation, at the time of table creation, if field is present in cConf, we create one more column : column_name.compression_type.
3. Based on the size, we compress (compression_type = null) or dont compress data for that particular field (compression_type = SNAPPY)

In case, we have any cx issue related to some new columns in future, we can append that column to the cConf property & thus enable compression.

**Testing evidences**
- Tested these changes using Distributed docker image
- Spanner table had the extra column
![image](https://github.com/user-attachments/assets/24f51133-a3e0-4823-9871-5dbb05504797)
- Update cconf post initial createTable
Alter table operations : 
![image](https://github.com/user-attachments/assets/6dcb5151-1972-4f5f-b90a-a05133a0ec8b)

- Primary keys part of cConf compression config throws error
![image](https://github.com/user-attachments/assets/a470237b-522a-4b9f-b064-16dbe8cb0097)


Unit tests to be added in follow up PR.