### PR TITLE
[cherry-pick][CDAP-21079] Update google cloud library dependency version to 26.55.0 for Spanner storage and messaging extensions

### DIFF
--- a/cdap-messaging-ext-spanner/pom.xml
+++ b/cdap-messaging-ext-spanner/pom.xml
@@ -27,17 +27,12 @@
   <name>CDAP Google Cloud Spanner Messaging Extension</name>
   <packaging>jar</packaging>
 
-  <properties>
-    <guava.version>30.1.1-jre</guava.version>
-    <spanner.version>6.86.0</spanner.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>22.0.0</version>
+        <version>26.55.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/cdap-storage-ext-spanner/pom.xml
+++ b/cdap-storage-ext-spanner/pom.xml
@@ -29,17 +29,12 @@
   <name>CDAP Google Cloud Spanner Storage Extension</name>
   <packaging>jar</packaging>
 
-  <properties>
-    <guava.version>30.1.1-jre</guava.version>
-    <spanner.version>6.86.0</spanner.version>
-  </properties>
-
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>libraries-bom</artifactId>
-        <version>22.0.0</version>
+        <version>26.55.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Cherry pick for PR : https://github.com/cdapio/cdap/pull/15912