### PR TITLE
[CDAP-21079] Fix guava version post updating google cloud library dependency version to 26.55.0

### DIFF
--- a/cdap-messaging-ext-spanner/pom.xml
+++ b/cdap-messaging-ext-spanner/pom.xml
@@ -27,6 +27,11 @@
   <name>CDAP Google Cloud Spanner Messaging Extension</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <guava.version>33.4.0-jre</guava.version>
+    <spanner.version>6.87.0</spanner.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/cdap-storage-ext-spanner/pom.xml
+++ b/cdap-storage-ext-spanner/pom.xml
@@ -29,6 +29,11 @@
   <name>CDAP Google Cloud Spanner Storage Extension</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <guava.version>33.4.0-jre</guava.version>
+    <spanner.version>6.87.0</spanner.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
Guava version specified in the pom file which was reverted during : https://github.com/cdapio/cdap/pull/15912 is required.