### PR TITLE
add pipeline filesize limit in cconf

### DIFF
--- a/cdap-common/src/main/resources/cdap-default.xml
+++ b/cdap-common/src/main/resources/cdap-default.xml
@@ -6593,4 +6593,13 @@
     </description>
   </property>
 
+  <property>
+    <name>app.cdap.file.max.size.bytes</name>
+    <value>2097152</value>
+    <description>
+      Maximum file size for pipelines. Restricts creation and import of pipelines where the
+      size of the json file exceeds the configured limit. Defaults to 2MB (2097152 bytes).
+    </description>
+  </property>
+
 </configuration>


### PR DESCRIPTION
Adds the filesize limit configuration for cdap pipelines (defaults to 2MB).