### PR TITLE
Adding default namespace tag for authorization check metrics

### DIFF
--- a/cdap-security/src/main/java/io/cdap/cdap/security/authorization/SecurityMetricsService.java
+++ b/cdap-security/src/main/java/io/cdap/cdap/security/authorization/SecurityMetricsService.java
@@ -24,6 +24,7 @@ import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.metrics.ProgramTypeMetricTag;
 import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.id.ProgramRunId;
 import java.util.Collections;
@@ -55,7 +56,7 @@ public class SecurityMetricsService {
       return new NoopMetricsContext();
     }
     Map<String, String> tags = Collections.emptyMap();
-    if (metricsTagsEnabled && entityId != null) {
+    if (metricsTagsEnabled) {
       tags = createEntityIdMetricsTags(entityId);
     }
     return metricsCollectionService == null ? new NoopMetricsContext(tags)
@@ -67,8 +68,12 @@ public class SecurityMetricsService {
    */
   static Map<String, String> createEntityIdMetricsTags(EntityId entityId) {
     Map<String, String> tags = new HashMap<>();
-    for (EntityId currEntityId : entityId.getHierarchy()) {
-      addTagsForEntityId(tags, currEntityId);
+    // Adding default namespace tag
+    tags.put(Constants.Metrics.Tag.NAMESPACE, NamespaceId.SYSTEM.getNamespace());
+    if (entityId != null) {
+      for (EntityId currEntityId : entityId.getHierarchy()) {
+        addTagsForEntityId(tags, currEntityId);
+      }
     }
     return tags;
   }

--- a/cdap-security/src/test/java/io/cdap/cdap/security/authorization/DefaultAccessEnforcerTest.java
+++ b/cdap-security/src/test/java/io/cdap/cdap/security/authorization/DefaultAccessEnforcerTest.java
@@ -39,6 +39,7 @@ import io.cdap.cdap.proto.element.EntityType;
 import io.cdap.cdap.proto.id.ApplicationId;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.proto.id.EntityId;
+import io.cdap.cdap.proto.id.InstanceId;
 import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.id.ProgramId;
 import io.cdap.cdap.proto.security.Authorizable;
@@ -543,6 +544,16 @@ public class DefaultAccessEnforcerTest extends AuthorizationTestBase {
     expectedTags.put(Constants.Metrics.Tag.PROGRAM_TYPE,
         ProgramTypeMetricTag.getTagName(programId.getType()));
     Map<String, String> tags = SecurityMetricsService.createEntityIdMetricsTags(programId);
+    Assert.assertEquals(expectedTags, tags);
+  }
+
+  @Test
+  public void testDefaultNamespaceTagForEntityIdWithNoNamespace() {
+    Map<String, String> expectedTags = new HashMap<>();
+    expectedTags.put(Constants.Metrics.Tag.NAMESPACE, "system");
+    expectedTags.put(Constants.Metrics.Tag.INSTANCE_ID, "");
+    Map<String, String> tags = SecurityMetricsService.createEntityIdMetricsTags(InstanceId.SELF);
+
     Assert.assertEquals(expectedTags, tags);
   }
 }


### PR DESCRIPTION
Adding `system` namespace as default tag for auth check metrics

Tested by hitting the following CDAP endpoint:

```
metrics/search?target=metric&tag=namespace:system
```

And following metrics were present in the result:

```
"authorization.internal.check.success.count",
"authorization.internal.visibility.check.count",
"authorization.extension.check.success.count",
"authorization.extension.check.failure.count",
"authorization.extension.check.bypass.count"
```