### PR TITLE
[CDAP-21154] Retry socket timeout exception when launching pipelines to system workers

### DIFF
--- a/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteTaskExecutor.java
+++ b/cdap-common/src/main/java/io/cdap/cdap/common/internal/remote/RemoteTaskExecutor.java
@@ -46,6 +46,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.HttpURLConnection;
 import java.net.NoRouteToHostException;
+import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -64,7 +65,8 @@ public class RemoteTaskExecutor {
   private static final String TASK_WORKER_URL = "/worker/run";
   private static final String SYSTEM_WORKER_URL = "/system/run";
   private static final Predicate<Throwable> RETRYABLE_PREDICATE_SYSTEM_WORKER = throwable ->
-      (throwable instanceof RetryableException) || (throwable instanceof ServiceException);
+      (throwable instanceof RetryableException) || (throwable instanceof ServiceException)
+          || (throwable instanceof SocketTimeoutException);
   private static final Predicate<Throwable> RETRYABLE_PREDICATE_TASK_WORKER = throwable ->
       (throwable instanceof RetryableException);
   private final boolean compression;


### PR DESCRIPTION
This PR adds a retry on `SocketTimeoutException` to remote task executor. Therefore, if a `SocketTimeoutException` happens during pipeline launch, the task is retried.

Why: if an exception happens when a launching pipeline using a system worker pod, and given that submitting jobs to Dataproc (and k8s) is idempotent since 6.6, this PR retries to launch a pipeline if an exception occurs during the initial call.

```
java.net.SocketTimeoutException: connect timed out
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:607)
	at sun.security.ssl.SSLSocketImpl.connect(SSLSocketImpl.java:293)
	at sun.net.NetworkClient.doConnect(NetworkClient.java:175)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:463)
	at sun.net.www.http.HttpClient.openServer(HttpClient.java:558)
	at sun.net.www.protocol.https.HttpsClient.<init>(HttpsClient.java:264)
	at sun.net.www.protocol.https.HttpsClient.New(HttpsClient.java:367)
	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient(AbstractDelegateHttpsURLConnection.java:203)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect0(HttpURLConnection.java:1162)
	at sun.net.www.protocol.http.HttpURLConnection.plainConnect(HttpURLConnection.java:1056)
	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:189)
	at sun.net.www.protocol.https.HttpsURLConnectionImpl.connect(HttpsURLConnectionImpl.java:167)
	at io.cdap.common.http.HttpRequests.execute(HttpRequests.java:65)
	at io.cdap.cdap.common.internal.remote.RemoteClient.executeNonIdempotent(RemoteClient.java:163)
	at io.cdap.cdap.common.internal.remote.RemoteClient.execute(RemoteClient.java:143)
	at io.cdap.cdap.common.internal.remote.RemoteClient.execute(RemoteClient.java:117)
	at io.cdap.cdap.common.internal.remote.RemoteTaskExecutor.lambda$runTask$2(RemoteTaskExecutor.java:131)
	at io.cdap.cdap.common.service.Retries.callWithRetries(Retries.java:228)
	at io.cdap.cdap.common.internal.remote.RemoteTaskExecutor.runTask(RemoteTaskExecutor.java:120)
	at io.cdap.cdap.internal.app.deploy.RemoteProgramRunDispatcher.dispatchProgram(RemoteProgramRunDispatcher.java:128)
	at io.cdap.cdap.app.runtime.AbstractProgramRuntimeService.lambda$run$0(AbstractProgramRuntimeService.java:151)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
	Suppressed: io.cdap.cdap.api.retry.RetryFailedException: Retry failed. Encountered non retryable exception.
		at io.cdap.cdap.common.service.Retries.callWithRetries(Retries.java:236)
		... 6 common frames omitted
```