### PR TITLE
[CVE-2021-39144] Fixing vulnerability for xstream in cdap builds.

### DIFF
--- a/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
+++ b/cdap-docs/user-guide/source/pipelines/plugins/pom.xml
@@ -842,6 +842,13 @@
             <artifactId>nexus-staging-maven-plugin</artifactId>
             <version>1.6.2</version>
             <extensions>true</extensions>
+            <dependencies>
+              <dependency>
+                <groupId>com.thoughtworks.xstream</groupId>
+                <artifactId>xstream</artifactId>
+                <version>1.4.20</version>
+              </dependency>
+            </dependencies>
             <configuration>
               <nexusUrl>https://oss.sonatype.org</nexusUrl>
               <serverId>sonatype.release</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -1686,6 +1686,13 @@
           <artifactId>nexus-staging-maven-plugin</artifactId>
           <version>1.6.2</version>
           <extensions>true</extensions>
+          <dependencies>
+            <dependency>
+              <groupId>com.thoughtworks.xstream</groupId>
+              <artifactId>xstream</artifactId>
+              <version>1.4.20</version>
+            </dependency>
+          </dependencies>
           <configuration>
             <nexusUrl>https://oss.sonatype.org</nexusUrl>
             <serverId>sonatype.release</serverId>


### PR DESCRIPTION
com.thoughtworks.xstream:xstream has a [critical vulnerability](https://nvd.nist.gov/vuln/detail/cve-2021-39144) that is fixed 1.4.18 version onwards. 

